### PR TITLE
Add Benefits Endpoint for Jetpack Disconnect Dialog

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -189,6 +189,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => array( $site_endpoint , 'can_request' ),
 		) );
 
+		// Get current site benefits
+		register_rest_route( 'jetpack/v4', '/site/benefits', array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => array( $site_endpoint, 'get_benefits' ),
+			'permission_callback' => array( $site_endpoint, 'can_request' ), // TODO: make better permission_callback
+		) );
+
 		// Get Activity Log data for this site.
 		register_rest_route( 'jetpack/v4', '/site/activity', array(
 			'methods' => WP_REST_Server::READABLE,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -193,7 +193,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', '/site/benefits', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => array( $site_endpoint, 'get_benefits' ),
-			'permission_callback' => array( $site_endpoint, 'can_request' ), // TODO: make better permission_callback
+			'permission_callback' => array( $site_endpoint, 'can_request' ),
 		) );
 
 		// Get Activity Log data for this site.

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -4,12 +4,12 @@ use Automattic\Jetpack\Connection\Client;
 
 /**
  * This is the endpoint class for `/site` endpoints.
- *
  */
 class Jetpack_Core_API_Site_Endpoint {
 
 	/**
 	 * Returns the result of `/sites/%s/features` endpoint call.
+	 *
 	 * @return object $features has 'active' and 'available' properties each of which contain feature slugs.
 	 *                  'active' is a simple array of slugs that are active on the current plan.
 	 *                  'available' is an object with keys that represent feature slugs and values are arrays
@@ -18,7 +18,7 @@ class Jetpack_Core_API_Site_Endpoint {
 	public static function get_features() {
 
 		// Make the API request
-		$request = sprintf( '/sites/%d/features', Jetpack_Options::get_option( 'id' ) );
+		$request  = sprintf( '/sites/%d/features', Jetpack_Options::get_option( 'id' ) );
 		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
 
 		// Bail if there was an error or malformed response
@@ -42,10 +42,11 @@ class Jetpack_Core_API_Site_Endpoint {
 			);
 		}
 
-		return rest_ensure_response( array(
-				'code' => 'success',
+		return rest_ensure_response(
+			array(
+				'code'    => 'success',
 				'message' => esc_html__( 'Site features correctly received.', 'jetpack' ),
-				'data' => wp_remote_retrieve_body( $response ),
+				'data'    => wp_remote_retrieve_body( $response ),
 			)
 		);
 	}
@@ -60,4 +61,197 @@ class Jetpack_Core_API_Site_Endpoint {
 	public static function can_request() {
 		return current_user_can( 'jetpack_manage_modules' );
 	}
+
+	public static function get_benefits() {
+		global $wpdb;
+
+		$benefits = [];
+
+		$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
+
+		// TODO: better threshold
+		if ( $stats->stats->visitors > 0 ) {
+			$benefits[] = [
+				'name'        => 'jetpack-stats',
+				'title'       => 'Jetpack Stats',
+				'description' => 'Visitors tracked by Jetpack this year',
+				'value'       => $stats->stats->visitors,
+			];
+		}
+
+		if ( Jetpack::is_module_active( 'protect' ) ) {
+			$protect = get_site_option( 'jetpack_protect_blocked_attempts' );
+			if ( $protect > 0 ) {
+				$benefits[] = [
+					'name'        => 'protect',
+					'title'       => 'Brute force protection',
+					'description' => 'The number of malicious login attempts blocked by Jetpack',
+					'value'       => $protect,
+				];
+			}
+		}
+
+		// TODO: are followers_blog and followers_comments unique?
+		$followers = $stats->stats->followers_blog; // + $stats->stats->followers_comments;
+		// TODO: better threshold
+		if ( $followers > 0 ) {
+			$benefits[] = [
+				'name'        => 'subscribers',
+				'title'       => 'Subscribers',
+				'description' => 'People subscribed to your updates through Jetpack',
+				'value'       => $followers,
+			];
+		}
+
+		$vaultpress = new VaultPress();
+		if ( $vaultpress->is_registered() ) {
+			$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
+			if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
+				$benefits[] = [
+					'name'        => 'jetpack-backup',
+					'title'       => 'Jetpack Backup',
+					'description' => 'The number of times Jetpack has backed up your site and kept it safe',
+					'value'       => $data->backups->stats->revisions,
+				];
+			}
+		}
+
+		if ( Jetpack::is_module_active( 'contact-form' ) ) {
+			$contact_form_count = array_sum( get_object_vars( wp_count_posts( 'feedback' ) ) );
+			if ( $contact_form_count > 0 ) {
+				$benefits[] = [
+					'name'        => 'contact-form-feedback',
+					'title'       => 'Contact Form Feedback',
+					'description' => 'Form submissions stored by Jetpack',
+					'value'       => $contact_form_count,
+				];
+			}
+		}
+
+		if ( Jetpack::is_module_active( 'photon' ) ) {
+			$photon_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type IN ('image/jpeg', 'image/png', 'image/gif')" );
+			if ( $photon_count > 0 ) {
+				$benefits[] = [
+					'name'        => 'image-hosting',
+					'title'       => 'Image Hosting',
+					'description' => 'Super-fast, mobile-ready images served by Jetpack',
+					'value'       => $photon_count,
+				];
+			}
+		}
+
+		$videopress_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type = 'video/videopress'" );
+		if ( $videopress_count > 0 ) {
+			$benefits[] = [
+				'name'        => 'video-hosting',
+				'title'       => 'Video Hosting',
+				'description' => 'Ad-free, lightning-fast videos delivered by Jetpack',
+				'value'       => $videopress_count,
+			];
+		}
+
+		if ( Jetpack::is_module_active( 'publicize' ) ) {
+			$publicize = new Publicize();
+
+			$connections           = $publicize->get_all_connections();
+			$number_of_connections = count( $connections );
+
+			if ( $number_of_connections > 0 ) {
+				$benefits[] = [
+					'name'        => 'publicize',
+					'title'       => 'Publicize',
+					'description' => 'Live social media site connections, powered by Jetpack',
+					'value'       => count( $connections ),
+				];
+			}
+		}
+
+		// TODO: test this value
+		// TODO: better threshold
+		if ( $stats->stats->shares > 0 ) {
+			$benefits[] = [
+				'name'        => 'sharing',
+				'title'       => 'Sharing',
+				'description' => 'The number of times visitors have shared your posts with the world using Jetpack',
+				'value'       => $stats->stats->shares,
+			];
+		}
+
+		// ***********************
+		// WPCOM data:
+		// ***********************
+		// $benefits[] = [
+		// 'name' => 'wordads',
+		// 'title' => 'WordAds',
+		// 'description' => 'The money you’ve earned by displaying Jetpack WordAds',
+		// 'value' => 'TODO: can be retrieved from wpcom endpoint /sites/%s/wordads/earnings'
+		// ];
+		// $benefits[] = [
+		// 'name' => 'likes',
+		// 'title' => 'Likes',
+		// 'description' => 'Jetpack-powered likes you’ve received on your posts',
+		// 'value' => 'TODO See wp-content/mu-plugins/likes/likes.php and public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-list-post-likes-endpoint.php'
+		// ];
+		// ***********************
+		// Will require input from others
+		// ***********************
+		// $benefits[] = [
+		// 'name' => 'paypal-payments',
+		// 'title' => 'Paypal Payments',
+		// 'description' => 'The money you’ve earned from your Jetpack-powered PayPal button',
+		// 'value' => 'TODO'
+		// ];
+		// ***********************
+		// Difficult data:
+		// ***********************
+		// $benefits[] = [
+		// 'name' => 'contact-forms',
+		// 'title' => 'Contact Forms',
+		// 'description' => 'Live Jetpack forms on your site right now',
+		// 'value' => 'TODO'
+		// ];
+		// $benefits[] = [
+		// 'name' => 'galleries',
+		// 'title' => 'Galleries',
+		// 'description' => 'Beautiful image galleries powered by Jetpack',
+		// 'value' => 'TODO'
+		// ***********************
+		// Might not exist
+		// ***********************
+		// $benefits[] = [
+		// 'name'        => 'jetpack-scan',
+		// 'title'       => 'Jetpack Scan',
+		// 'description' => 'The number of times Jetpack has scanned your site for viruses and malicious files',
+		// 'value'       => 'TODO',
+		// ];
+		return rest_ensure_response(
+			[
+				'code'    => 'success',
+				'message' => esc_html__( 'Site benefits correctly received.', 'jetpack' ),
+				'data'    => json_encode( $benefits ),
+			]
+		);
+	}
 }
+
+// Example of calling a wpcom API:
+// $response = Client::wpcom_json_api_request_as_user(
+// 'jetpack-user-tracking',
+// '2',
+// array(
+// 'method'  => 'GET',
+// 'headers' => array(
+// 'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+// ),
+// )
+// );
+//
+// if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+// return new WP_Error(
+// 'failed_to_fetch_data',
+// esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+// array( 'status' => 500 )
+// );
+// }
+//
+// $results = json_decode( $response['body'], true );

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -152,13 +152,17 @@ class Jetpack_Core_API_Site_Endpoint {
 			}
 		}
 
-			$videopress_count = wp_count_attachments( 'video/videopress' )->{ 'video/videopress' };
-		if ( $videopress_count > 0 ) {
+		// Fetch number of VideoPress videos on the site.
+		$videopress_attachments = wp_count_attachments( 'video/videopress' );
+		if (
+			isset( $videopress_attachments->{ 'video/videopress' } )
+			&& $videopress_attachments->{ 'video/videopress' } > 0
+		) {
 			$benefits[] = array(
 				'name'        => 'video-hosting',
 				'title'       => esc_html__( 'Video Hosting', 'jetpack' ),
 				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack', 'jetpack' ),
-				'value'       => $videopress_count,
+				'value'       => absint( $videopress_attachments->{ 'video/videopress' } ),
 			);
 		}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -93,7 +93,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( null !== $stats && $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
-				'title'       => esc_html__( 'Jetpack Stats', 'jetpack' ),
+				'title'       => esc_html__( 'Site Stats', 'jetpack' ),
 				'description' => esc_html__( 'Visitors tracked by Jetpack this year', 'jetpack' ),
 				'value'       => absint( $stats->stats->visitors ),
 			);

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -108,7 +108,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			);
 		}
 
-		$vaultpress = new VaultPress();
+		if ( Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) && class_exists( 'VaultPress' ) ) {
+			$vaultpress = new VaultPress();
 		if ( $vaultpress->is_registered() ) {
 			$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
 			if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -1,4 +1,9 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * List of /site core REST API endpoints used in Jetpack's dashboard.
+ *
+ * @package Jetpack
+ */
 
 use Automattic\Jetpack\Connection\Client;
 
@@ -17,11 +22,11 @@ class Jetpack_Core_API_Site_Endpoint {
 	 */
 	public static function get_features() {
 
-		// Make the API request
+		// Make the API request.
 		$request  = sprintf( '/sites/%d/features', Jetpack_Options::get_option( 'id' ) );
 		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
 
-		// Bail if there was an error or malformed response
+		// Bail if there was an error or malformed response.
 		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
 			return new WP_Error(
 				'failed_to_fetch_data',
@@ -30,10 +35,10 @@ class Jetpack_Core_API_Site_Endpoint {
 			);
 		}
 
-		// Decode the results
+		// Decode the results.
 		$results = json_decode( $response['body'], true );
 
-		// Bail if there were no results or plan details returned
+		// Bail if there were no results or plan details returned.
 		if ( ! is_array( $results ) ) {
 			return new WP_Error(
 				'failed_to_fetch_data',
@@ -121,7 +126,7 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) && class_exists( 'VaultPress' ) ) {
 			$vaultpress = new VaultPress();
 			if ( $vaultpress->is_registered() ) {
-				$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
+				$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 				if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
 					$benefits[] = array(
 						'name'        => 'jetpack-backup',

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -153,7 +153,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				}
 			}
 
-			$videopress_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type = 'video/videopress'" );
+			$videopress_count = wp_count_attachments( 'video/videopress' )->{ 'video/videopress' };
 			if ( $videopress_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'video-hosting',

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -69,7 +69,6 @@ class Jetpack_Core_API_Site_Endpoint {
 
 		$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
 
-		// TODO: better threshold
 		if ( $stats->stats->visitors > 0 ) {
 			$benefits[] = [
 				'name'        => 'jetpack-stats',
@@ -91,9 +90,7 @@ class Jetpack_Core_API_Site_Endpoint {
 			}
 		}
 
-		// TODO: are followers_blog and followers_comments unique?
-		$followers = $stats->stats->followers_blog; // + $stats->stats->followers_comments;
-		// TODO: better threshold
+		$followers = $stats->stats->followers_blog;
 		if ( $followers > 0 ) {
 			$benefits[] = [
 				'name'        => 'subscribers',
@@ -166,8 +163,6 @@ class Jetpack_Core_API_Site_Endpoint {
 			}
 		}
 
-		// TODO: test this value
-		// TODO: better threshold
 		if ( $stats->stats->shares > 0 ) {
 			$benefits[] = [
 				'name'        => 'sharing',
@@ -177,53 +172,6 @@ class Jetpack_Core_API_Site_Endpoint {
 			];
 		}
 
-		// ***********************
-		// WPCOM data:
-		// ***********************
-		// $benefits[] = [
-		// 'name' => 'wordads',
-		// 'title' => 'WordAds',
-		// 'description' => 'The money you’ve earned by displaying Jetpack WordAds',
-		// 'value' => 'TODO: can be retrieved from wpcom endpoint /sites/%s/wordads/earnings'
-		// ];
-		// $benefits[] = [
-		// 'name' => 'likes',
-		// 'title' => 'Likes',
-		// 'description' => 'Jetpack-powered likes you’ve received on your posts',
-		// 'value' => 'TODO See wp-content/mu-plugins/likes/likes.php and public.api/rest/wpcom-json-endpoints/class.wpcom-json-api-list-post-likes-endpoint.php'
-		// ];
-		// ***********************
-		// Will require input from others
-		// ***********************
-		// $benefits[] = [
-		// 'name' => 'paypal-payments',
-		// 'title' => 'Paypal Payments',
-		// 'description' => 'The money you’ve earned from your Jetpack-powered PayPal button',
-		// 'value' => 'TODO'
-		// ];
-		// ***********************
-		// Difficult data:
-		// ***********************
-		// $benefits[] = [
-		// 'name' => 'contact-forms',
-		// 'title' => 'Contact Forms',
-		// 'description' => 'Live Jetpack forms on your site right now',
-		// 'value' => 'TODO'
-		// ];
-		// $benefits[] = [
-		// 'name' => 'galleries',
-		// 'title' => 'Galleries',
-		// 'description' => 'Beautiful image galleries powered by Jetpack',
-		// 'value' => 'TODO'
-		// ***********************
-		// Might not exist
-		// ***********************
-		// $benefits[] = [
-		// 'name'        => 'jetpack-scan',
-		// 'title'       => 'Jetpack Scan',
-		// 'description' => 'The number of times Jetpack has scanned your site for viruses and malicious files',
-		// 'value'       => 'TODO',
-		// ];
 		return rest_ensure_response(
 			[
 				'code'    => 'success',
@@ -233,25 +181,3 @@ class Jetpack_Core_API_Site_Endpoint {
 		);
 	}
 }
-
-// Example of calling a wpcom API:
-// $response = Client::wpcom_json_api_request_as_user(
-// 'jetpack-user-tracking',
-// '2',
-// array(
-// 'method'  => 'GET',
-// 'headers' => array(
-// 'X-Forwarded-For' => Jetpack::current_user_ip( true ),
-// ),
-// )
-// );
-//
-// if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
-// return new WP_Error(
-// 'failed_to_fetch_data',
-// esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
-// array( 'status' => 500 )
-// );
-// }
-//
-// $results = json_decode( $response['body'], true );

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -80,8 +80,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
-				'title'       => 'Jetpack Stats',
-				'description' => 'Visitors tracked by Jetpack this year',
+				'title'       => esc_html__('Jetpack Stats'),
+				'description' => esc_html__('Visitors tracked by Jetpack this year'),
 				'value'       => $stats->stats->visitors,
 			);
 		}
@@ -91,8 +91,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $protect > 0 ) {
 				$benefits[] = array(
 					'name'        => 'protect',
-					'title'       => 'Brute force protection',
-					'description' => 'The number of malicious login attempts blocked by Jetpack',
+					'title'       => esc_html__('Brute force protection', 'jetpack'),
+					'description' => esc_html__('The number of malicious login attempts blocked by Jetpack'),
 					'value'       => $protect,
 				);
 			}
@@ -102,8 +102,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $followers > 0 ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
-				'title'       => 'Subscribers',
-				'description' => 'People subscribed to your updates through Jetpack',
+				'title'       => esc_html__('Subscribers'),
+				'description' => esc_html__('People subscribed to your updates through Jetpack'),
 				'value'       => $followers,
 			);
 		}
@@ -114,8 +114,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
 				$benefits[] = array(
 					'name'        => 'jetpack-backup',
-					'title'       => 'Jetpack Backup',
-					'description' => 'The number of times Jetpack has backed up your site and kept it safe',
+					'title'       => esc_html__('Jetpack Backup'),
+					'description' => esc_html__('The number of times Jetpack has backed up your site and kept it safe'),
 					'value'       => $data->backups->stats->revisions,
 				);
 			}
@@ -126,8 +126,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $contact_form_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'contact-form-feedback',
-					'title'       => 'Contact Form Feedback',
-					'description' => 'Form submissions stored by Jetpack',
+					'title'       => esc_html__('Contact Form Feedback'),
+					'description' => esc_html__('Form submissions stored by Jetpack'),
 					'value'       => $contact_form_count,
 				];
 			}
@@ -138,8 +138,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $photon_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'image-hosting',
-					'title'       => 'Image Hosting',
-					'description' => 'Super-fast, mobile-ready images served by Jetpack',
+					'title'       => esc_html__('Image Hosting'),
+					'description' => esc_html__('Super-fast, mobile-ready images served by Jetpack'),
 					'value'       => $photon_count,
 				);
 			}
@@ -149,8 +149,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $videopress_count > 0 ) {
 			$benefits[] = array(
 				'name'        => 'video-hosting',
-				'title'       => 'Video Hosting',
-				'description' => 'Ad-free, lightning-fast videos delivered by Jetpack',
+				'title'       => esc_html__('Video Hosting'),
+				'description' => esc_html__('Ad-free, lightning-fast videos delivered by Jetpack'),
 				'value'       => $videopress_count,
 			);
 		}
@@ -164,8 +164,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $number_of_connections > 0 ) {
 				$benefits[] = array(
 					'name'        => 'publicize',
-					'title'       => 'Publicize',
-					'description' => 'Live social media site connections, powered by Jetpack',
+					'title'       => esc_html__('Publicize'),
+					'description' => esc_html__('Live social media site connections, powered by Jetpack'),
 					'value'       => count( $connections ),
 				);
 			}
@@ -174,8 +174,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $stats->stats->shares > 0 ) {
 			$benefits[] = array(
 				'name'        => 'sharing',
-				'title'       => 'Sharing',
-				'description' => 'The number of times visitors have shared your posts with the world using Jetpack',
+				'title'       => esc_html__('Sharing'),
+				'description' => esc_html__('The number of times visitors have shared your posts with the world using Jetpack'),
 				'value'       => $stats->stats->shares,
 			);
 		}

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -110,88 +110,92 @@ class Jetpack_Core_API_Site_Endpoint {
 
 		if ( Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) && class_exists( 'VaultPress' ) ) {
 			$vaultpress = new VaultPress();
-		if ( $vaultpress->is_registered() ) {
-			$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
-			if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
-				$benefits[] = array(
-					'name'        => 'jetpack-backup',
-					'title'       => esc_html__( 'Jetpack Backup' ),
-					'description' => esc_html__( 'The number of times Jetpack has backed up your site and kept it safe' ),
-					'value'       => $data->backups->stats->revisions,
-				);
-			}
-		}
-
-		if ( Jetpack::is_module_active( 'contact-form' ) ) {
-			$contact_form_count = array_sum( get_object_vars( wp_count_posts( 'feedback' ) ) );
-			if ( $contact_form_count > 0 ) {
-				$benefits[] = array(
-					'name'        => 'contact-form-feedback',
-					'title'       => esc_html__( 'Contact Form Feedback' ),
-					'description' => esc_html__( 'Form submissions stored by Jetpack' ),
-					'value'       => $contact_form_count,
-				);
-			}
-		}
-
-		if ( Jetpack::is_module_active( 'photon' ) ) {
-			$photon_count = array_reduce(
-				get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif' ) ) ),
-				function( $i, $j ) {
-					return $i + $j;
+			if ( $vaultpress->is_registered() ) {
+				$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
+				if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
+					$benefits[] = array(
+						'name'        => 'jetpack-backup',
+						'title'       => esc_html__( 'Jetpack Backup' ),
+						'description' => esc_html__( 'The number of times Jetpack has backed up your site and kept it safe' ),
+						'value'       => $data->backups->stats->revisions,
+					);
 				}
-			);
-			if ( $photon_count > 0 ) {
+			}
+
+			if ( Jetpack::is_module_active( 'contact-form' ) ) {
+				$contact_form_count = array_sum( get_object_vars( wp_count_posts( 'feedback' ) ) );
+				if ( $contact_form_count > 0 ) {
+					$benefits[] = array(
+						'name'        => 'contact-form-feedback',
+						'title'       => esc_html__( 'Contact Form Feedback' ),
+						'description' => esc_html__( 'Form submissions stored by Jetpack' ),
+						'value'       => $contact_form_count,
+					);
+				}
+			}
+
+			if ( Jetpack::is_module_active( 'photon' ) ) {
+				$photon_count = array_reduce(
+					get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif' ) ) ),
+					function ( $i, $j ) {
+						return $i + $j;
+					}
+				);
+				if ( $photon_count > 0 ) {
+					$benefits[] = array(
+						'name'        => 'image-hosting',
+						'title'       => esc_html__( 'Image Hosting' ),
+						'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack' ),
+						'value'       => $photon_count,
+					);
+				}
+			}
+
+			$videopress_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type = 'video/videopress'" );
+			if ( $videopress_count > 0 ) {
 				$benefits[] = array(
-					'name'        => 'image-hosting',
-					'title'       => esc_html__( 'Image Hosting' ),
-					'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack' ),
-					'value'       => $photon_count,
+					'name'        => 'video-hosting',
+					'title'       => esc_html__( 'Video Hosting' ),
+					'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack' ),
+					'value'       => $videopress_count,
 				);
 			}
-		}
 
-		$videopress_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type = 'video/videopress'" );
-		if ( $videopress_count > 0 ) {
-			$benefits[] = array(
-				'name'        => 'video-hosting',
-				'title'       => esc_html__( 'Video Hosting' ),
-				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack' ),
-				'value'       => $videopress_count,
-			);
-		}
+			if ( Jetpack::is_module_active( 'publicize' ) && class_exists( 'Publicize' ) ) {
+				$publicize   = new Publicize();
+				$connections = $publicize->get_all_connections();
 
-		if ( Jetpack::is_module_active( 'publicize' ) && class_exists( 'Publicize' ) ) {
-			$publicize = new Publicize();
+				$number_of_connections = 0;
+				if ( is_array( $connections ) && ! empty( $connections ) ) {
+					$number_of_connections = count( $connections );
+				}
 
-			$connections           = $publicize->get_all_connections();
-			$number_of_connections = count( $connections );
+				if ( $number_of_connections > 0 ) {
+					$benefits[] = array(
+						'name'        => 'publicize',
+						'title'       => esc_html__( 'Publicize' ),
+						'description' => esc_html__( 'Live social media site connections, powered by Jetpack' ),
+						'value'       => count( $connections ),
+					);
+				}
+			}
 
-			if ( $number_of_connections > 0 ) {
+			if ( $stats->stats->shares > 0 ) {
 				$benefits[] = array(
-					'name'        => 'publicize',
-					'title'       => esc_html__( 'Publicize' ),
-					'description' => esc_html__( 'Live social media site connections, powered by Jetpack' ),
-					'value'       => count( $connections ),
+					'name'        => 'sharing',
+					'title'       => esc_html__( 'Sharing' ),
+					'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack' ),
+					'value'       => $stats->stats->shares,
 				);
 			}
-		}
 
-		if ( $stats->stats->shares > 0 ) {
-			$benefits[] = array(
-				'name'        => 'sharing',
-				'title'       => esc_html__( 'Sharing' ),
-				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack' ),
-				'value'       => $stats->stats->shares,
+			return rest_ensure_response(
+				array(
+					'code'    => 'success',
+					'message' => esc_html__( 'Site benefits correctly received.', 'jetpack' ),
+					'data'    => json_encode( $benefits ),
+				)
 			);
 		}
-
-		return rest_ensure_response(
-			array(
-				'code'    => 'success',
-				'message' => esc_html__( 'Site benefits correctly received.', 'jetpack' ),
-				'data'    => json_encode( $benefits ),
-			)
-		);
 	}
 }

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -180,7 +180,7 @@ class Jetpack_Core_API_Site_Endpoint {
 					'name'        => 'publicize',
 					'title'       => esc_html__( 'Publicize', 'jetpack' ),
 					'description' => esc_html__( 'Live social media site connections, powered by Jetpack', 'jetpack' ),
-					'value'       => count( $connections ),
+					'value'       => absint( $number_of_connections ),
 				);
 			}
 		}

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -137,7 +137,7 @@ class Jetpack_Core_API_Site_Endpoint {
 
 		if ( Jetpack::is_module_active( 'photon' ) ) {
 			$photon_count = array_reduce(
-				get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif' ) ) ),
+				get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif', 'image/bmp' ) ) ),
 				function ( $i, $j ) {
 					return $i + $j;
 				}

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -134,7 +134,12 @@ class Jetpack_Core_API_Site_Endpoint {
 		}
 
 		if ( Jetpack::is_module_active( 'photon' ) ) {
-			$photon_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type IN ('image/jpeg', 'image/png', 'image/gif')" );
+			$photon_count = array_reduce(
+				get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif' ) ) ),
+				function( $i, $j ) {
+					return $i + $j;
+				}
+			);
 			if ( $photon_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'image-hosting',

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -161,7 +161,7 @@ class Jetpack_Core_API_Site_Endpoint {
 			);
 		}
 
-		if ( Jetpack::is_module_active( 'publicize' ) ) {
+		if ( Jetpack::is_module_active( 'publicize' ) && class_exists( 'Publicize' ) ) {
 			$publicize = new Publicize();
 
 			$connections           = $publicize->get_all_connections();

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -81,8 +81,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( null !== $stats && $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
-				'title'       => esc_html__( 'Jetpack Stats' ),
-				'description' => esc_html__( 'Visitors tracked by Jetpack this year' ),
+				'title'       => esc_html__( 'Jetpack Stats', 'jetpack' ),
+				'description' => esc_html__( 'Visitors tracked by Jetpack this year', 'jetpack' ),
 				'value'       => $stats->stats->visitors,
 			);
 		}
@@ -93,7 +93,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				$benefits[] = array(
 					'name'        => 'protect',
 					'title'       => esc_html__( 'Brute force protection', 'jetpack' ),
-					'description' => esc_html__( 'The number of malicious login attempts blocked by Jetpack' ),
+					'description' => esc_html__( 'The number of malicious login attempts blocked by Jetpack', 'jetpack' ),
 					'value'       => $protect,
 				);
 			}
@@ -102,8 +102,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( null !== $stats && $stats->stats->followers_blog > 0 && Jetpack::is_module_active( 'subscriptions' ) ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
-				'title'       => esc_html__( 'Subscribers' ),
-				'description' => esc_html__( 'People subscribed to your updates through Jetpack' ),
+				'title'       => esc_html__( 'Subscribers', 'jetpack' ),
+				'description' => esc_html__( 'People subscribed to your updates through Jetpack', 'jetpack' ),
 				'value'       => $stats->stats->followers_blog,
 			);
 		}
@@ -115,8 +115,8 @@ class Jetpack_Core_API_Site_Endpoint {
 				if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
 					$benefits[] = array(
 						'name'        => 'jetpack-backup',
-						'title'       => esc_html__( 'Jetpack Backup' ),
-						'description' => esc_html__( 'The number of times Jetpack has backed up your site and kept it safe' ),
+						'title'       => esc_html__( 'Jetpack Backup', 'jetpack' ),
+						'description' => esc_html__( 'The number of times Jetpack has backed up your site and kept it safe', 'jetpack' ),
 						'value'       => $data->backups->stats->revisions,
 					);
 				}
@@ -128,8 +128,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $contact_form_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'contact-form-feedback',
-					'title'       => esc_html__( 'Contact Form Feedback' ),
-					'description' => esc_html__( 'Form submissions stored by Jetpack' ),
+					'title'       => esc_html__( 'Contact Form Feedback', 'jetpack' ),
+					'description' => esc_html__( 'Form submissions stored by Jetpack', 'jetpack' ),
 					'value'       => $contact_form_count,
 				);
 			}
@@ -145,8 +145,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $photon_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'image-hosting',
-					'title'       => esc_html__( 'Image Hosting' ),
-					'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack' ),
+					'title'       => esc_html__( 'Image Hosting', 'jetpack' ),
+					'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack', 'jetpack' ),
 					'value'       => $photon_count,
 				);
 			}
@@ -156,8 +156,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $videopress_count > 0 ) {
 			$benefits[] = array(
 				'name'        => 'video-hosting',
-				'title'       => esc_html__( 'Video Hosting' ),
-				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack' ),
+				'title'       => esc_html__( 'Video Hosting', 'jetpack' ),
+				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack', 'jetpack' ),
 				'value'       => $videopress_count,
 			);
 		}
@@ -174,8 +174,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $number_of_connections > 0 ) {
 				$benefits[] = array(
 					'name'        => 'publicize',
-					'title'       => esc_html__( 'Publicize' ),
-					'description' => esc_html__( 'Live social media site connections, powered by Jetpack' ),
+					'title'       => esc_html__( 'Publicize', 'jetpack' ),
+					'description' => esc_html__( 'Live social media site connections, powered by Jetpack', 'jetpack' ),
 					'value'       => count( $connections ),
 				);
 			}
@@ -184,8 +184,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( null !== $stats && $stats->stats->shares > 0 ) {
 			$benefits[] = array(
 				'name'        => 'sharing',
-				'title'       => esc_html__( 'Sharing' ),
-				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack' ),
+				'title'       => esc_html__( 'Sharing', 'jetpack' ),
+				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack', 'jetpack' ),
 				'value'       => $stats->stats->shares,
 			);
 		}

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -71,8 +71,6 @@ class Jetpack_Core_API_Site_Endpoint {
 	 * @return WP_REST_Response
 	 */
 	public static function get_benefits() {
-		global $wpdb;
-
 		$benefits = array();
 
 		$stats = null;

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -80,8 +80,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
-				'title'       => esc_html__('Jetpack Stats'),
-				'description' => esc_html__('Visitors tracked by Jetpack this year'),
+				'title'       => esc_html__( 'Jetpack Stats' ),
+				'description' => esc_html__( 'Visitors tracked by Jetpack this year' ),
 				'value'       => $stats->stats->visitors,
 			);
 		}
@@ -91,8 +91,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $protect > 0 ) {
 				$benefits[] = array(
 					'name'        => 'protect',
-					'title'       => esc_html__('Brute force protection', 'jetpack'),
-					'description' => esc_html__('The number of malicious login attempts blocked by Jetpack'),
+					'title'       => esc_html__( 'Brute force protection', 'jetpack' ),
+					'description' => esc_html__( 'The number of malicious login attempts blocked by Jetpack' ),
 					'value'       => $protect,
 				);
 			}
@@ -102,8 +102,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $followers > 0 ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
-				'title'       => esc_html__('Subscribers'),
-				'description' => esc_html__('People subscribed to your updates through Jetpack'),
+				'title'       => esc_html__( 'Subscribers' ),
+				'description' => esc_html__( 'People subscribed to your updates through Jetpack' ),
 				'value'       => $followers,
 			);
 		}
@@ -114,8 +114,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
 				$benefits[] = array(
 					'name'        => 'jetpack-backup',
-					'title'       => esc_html__('Jetpack Backup'),
-					'description' => esc_html__('The number of times Jetpack has backed up your site and kept it safe'),
+					'title'       => esc_html__( 'Jetpack Backup' ),
+					'description' => esc_html__( 'The number of times Jetpack has backed up your site and kept it safe' ),
 					'value'       => $data->backups->stats->revisions,
 				);
 			}
@@ -126,10 +126,10 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $contact_form_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'contact-form-feedback',
-					'title'       => esc_html__('Contact Form Feedback'),
-					'description' => esc_html__('Form submissions stored by Jetpack'),
+					'title'       => esc_html__( 'Contact Form Feedback' ),
+					'description' => esc_html__( 'Form submissions stored by Jetpack' ),
 					'value'       => $contact_form_count,
-				];
+				);
 			}
 		}
 
@@ -138,8 +138,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $photon_count > 0 ) {
 				$benefits[] = array(
 					'name'        => 'image-hosting',
-					'title'       => esc_html__('Image Hosting'),
-					'description' => esc_html__('Super-fast, mobile-ready images served by Jetpack'),
+					'title'       => esc_html__( 'Image Hosting' ),
+					'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack' ),
 					'value'       => $photon_count,
 				);
 			}
@@ -149,8 +149,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $videopress_count > 0 ) {
 			$benefits[] = array(
 				'name'        => 'video-hosting',
-				'title'       => esc_html__('Video Hosting'),
-				'description' => esc_html__('Ad-free, lightning-fast videos delivered by Jetpack'),
+				'title'       => esc_html__( 'Video Hosting' ),
+				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack' ),
 				'value'       => $videopress_count,
 			);
 		}
@@ -164,8 +164,8 @@ class Jetpack_Core_API_Site_Endpoint {
 			if ( $number_of_connections > 0 ) {
 				$benefits[] = array(
 					'name'        => 'publicize',
-					'title'       => esc_html__('Publicize'),
-					'description' => esc_html__('Live social media site connections, powered by Jetpack'),
+					'title'       => esc_html__( 'Publicize' ),
+					'description' => esc_html__( 'Live social media site connections, powered by Jetpack' ),
 					'value'       => count( $connections ),
 				);
 			}
@@ -174,8 +174,8 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( $stats->stats->shares > 0 ) {
 			$benefits[] = array(
 				'name'        => 'sharing',
-				'title'       => esc_html__('Sharing'),
-				'description' => esc_html__('The number of times visitors have shared your posts with the world using Jetpack'),
+				'title'       => esc_html__( 'Sharing' ),
+				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack' ),
 				'value'       => $stats->stats->shares,
 			);
 		}

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -101,7 +101,7 @@ class Jetpack_Core_API_Site_Endpoint {
 			}
 		}
 
-		if ( null !== $stats && $stats->stats->followers_blog > 0 ) {
+		if ( null !== $stats && $stats->stats->followers_blog > 0 && Jetpack::is_module_active( 'subscriptions' ) ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
 				'title'       => esc_html__( 'Subscribers' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -194,7 +194,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				array(
 					'code'    => 'success',
 					'message' => esc_html__( 'Site benefits correctly received.', 'jetpack' ),
-					'data'    => json_encode( $benefits ),
+					'data'    => wp_json_encode( $benefits ),
 				)
 			);
 	}

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -83,7 +83,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				'name'        => 'jetpack-stats',
 				'title'       => esc_html__( 'Jetpack Stats', 'jetpack' ),
 				'description' => esc_html__( 'Visitors tracked by Jetpack this year', 'jetpack' ),
-				'value'       => $stats->stats->visitors,
+				'value'       => absint( $stats->stats->visitors ),
 			);
 		}
 
@@ -94,7 +94,7 @@ class Jetpack_Core_API_Site_Endpoint {
 					'name'        => 'protect',
 					'title'       => esc_html__( 'Brute force protection', 'jetpack' ),
 					'description' => esc_html__( 'The number of malicious login attempts blocked by Jetpack', 'jetpack' ),
-					'value'       => $protect,
+					'value'       => absint( $protect ),
 				);
 			}
 		}
@@ -104,7 +104,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				'name'        => 'subscribers',
 				'title'       => esc_html__( 'Subscribers', 'jetpack' ),
 				'description' => esc_html__( 'People subscribed to your updates through Jetpack', 'jetpack' ),
-				'value'       => $stats->stats->followers_blog,
+				'value'       => absint( $stats->stats->followers_blog ),
 			);
 		}
 
@@ -117,7 +117,7 @@ class Jetpack_Core_API_Site_Endpoint {
 						'name'        => 'jetpack-backup',
 						'title'       => esc_html__( 'Jetpack Backup', 'jetpack' ),
 						'description' => esc_html__( 'The number of times Jetpack has backed up your site and kept it safe', 'jetpack' ),
-						'value'       => $data->backups->stats->revisions,
+						'value'       => absint( $data->backups->stats->revisions ),
 					);
 				}
 			}
@@ -130,7 +130,7 @@ class Jetpack_Core_API_Site_Endpoint {
 					'name'        => 'contact-form-feedback',
 					'title'       => esc_html__( 'Contact Form Feedback', 'jetpack' ),
 					'description' => esc_html__( 'Form submissions stored by Jetpack', 'jetpack' ),
-					'value'       => $contact_form_count,
+					'value'       => absint( $contact_form_count ),
 				);
 			}
 		}
@@ -147,7 +147,7 @@ class Jetpack_Core_API_Site_Endpoint {
 					'name'        => 'image-hosting',
 					'title'       => esc_html__( 'Image Hosting', 'jetpack' ),
 					'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack', 'jetpack' ),
-					'value'       => $photon_count,
+					'value'       => absint( $photon_count ),
 				);
 			}
 		}
@@ -190,7 +190,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				'name'        => 'sharing',
 				'title'       => esc_html__( 'Sharing', 'jetpack' ),
 				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack', 'jetpack' ),
-				'value'       => $stats->stats->shares,
+				'value'       => absint( $stats->stats->shares ),
 			);
 		}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -62,6 +62,14 @@ class Jetpack_Core_API_Site_Endpoint {
 		return current_user_can( 'jetpack_manage_modules' );
 	}
 
+
+	/**
+	 * Gets an array of data that show how Jetpack is currently being used to benefit the site.
+	 *
+	 * @since 7.7
+	 *
+	 * @return WP_REST_Response
+	 */
 	public static function get_benefits() {
 		global $wpdb;
 

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -123,73 +123,74 @@ class Jetpack_Core_API_Site_Endpoint {
 					);
 				}
 			}
+		}
 
-			if ( Jetpack::is_module_active( 'contact-form' ) ) {
-				$contact_form_count = array_sum( get_object_vars( wp_count_posts( 'feedback' ) ) );
-				if ( $contact_form_count > 0 ) {
-					$benefits[] = array(
-						'name'        => 'contact-form-feedback',
-						'title'       => esc_html__( 'Contact Form Feedback' ),
-						'description' => esc_html__( 'Form submissions stored by Jetpack' ),
-						'value'       => $contact_form_count,
-					);
-				}
-			}
-
-			if ( Jetpack::is_module_active( 'photon' ) ) {
-				$photon_count = array_reduce(
-					get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif' ) ) ),
-					function ( $i, $j ) {
-						return $i + $j;
-					}
+		if ( Jetpack::is_module_active( 'contact-form' ) ) {
+			$contact_form_count = array_sum( get_object_vars( wp_count_posts( 'feedback' ) ) );
+			if ( $contact_form_count > 0 ) {
+				$benefits[] = array(
+					'name'        => 'contact-form-feedback',
+					'title'       => esc_html__( 'Contact Form Feedback' ),
+					'description' => esc_html__( 'Form submissions stored by Jetpack' ),
+					'value'       => $contact_form_count,
 				);
-				if ( $photon_count > 0 ) {
-					$benefits[] = array(
-						'name'        => 'image-hosting',
-						'title'       => esc_html__( 'Image Hosting' ),
-						'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack' ),
-						'value'       => $photon_count,
-					);
-				}
 			}
+		}
+
+		if ( Jetpack::is_module_active( 'photon' ) ) {
+			$photon_count = array_reduce(
+				get_object_vars( wp_count_attachments( array( 'image/jpeg', 'image/png', 'image/gif' ) ) ),
+				function ( $i, $j ) {
+					return $i + $j;
+				}
+			);
+			if ( $photon_count > 0 ) {
+				$benefits[] = array(
+					'name'        => 'image-hosting',
+					'title'       => esc_html__( 'Image Hosting' ),
+					'description' => esc_html__( 'Super-fast, mobile-ready images served by Jetpack' ),
+					'value'       => $photon_count,
+				);
+			}
+		}
 
 			$videopress_count = wp_count_attachments( 'video/videopress' )->{ 'video/videopress' };
-			if ( $videopress_count > 0 ) {
+		if ( $videopress_count > 0 ) {
+			$benefits[] = array(
+				'name'        => 'video-hosting',
+				'title'       => esc_html__( 'Video Hosting' ),
+				'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack' ),
+				'value'       => $videopress_count,
+			);
+		}
+
+		if ( Jetpack::is_module_active( 'publicize' ) && class_exists( 'Publicize' ) ) {
+			$publicize   = new Publicize();
+			$connections = $publicize->get_all_connections();
+
+			$number_of_connections = 0;
+			if ( is_array( $connections ) && ! empty( $connections ) ) {
+				$number_of_connections = count( $connections );
+			}
+
+			if ( $number_of_connections > 0 ) {
 				$benefits[] = array(
-					'name'        => 'video-hosting',
-					'title'       => esc_html__( 'Video Hosting' ),
-					'description' => esc_html__( 'Ad-free, lightning-fast videos delivered by Jetpack' ),
-					'value'       => $videopress_count,
+					'name'        => 'publicize',
+					'title'       => esc_html__( 'Publicize' ),
+					'description' => esc_html__( 'Live social media site connections, powered by Jetpack' ),
+					'value'       => count( $connections ),
 				);
 			}
+		}
 
-			if ( Jetpack::is_module_active( 'publicize' ) && class_exists( 'Publicize' ) ) {
-				$publicize   = new Publicize();
-				$connections = $publicize->get_all_connections();
-
-				$number_of_connections = 0;
-				if ( is_array( $connections ) && ! empty( $connections ) ) {
-					$number_of_connections = count( $connections );
-				}
-
-				if ( $number_of_connections > 0 ) {
-					$benefits[] = array(
-						'name'        => 'publicize',
-						'title'       => esc_html__( 'Publicize' ),
-						'description' => esc_html__( 'Live social media site connections, powered by Jetpack' ),
-						'value'       => count( $connections ),
-					);
-				}
-			}
-
-			if ( null !== $stats && $stats->stats->shares > 0 ) {
-				$benefits[] = array(
-					'name'        => 'sharing',
-					'title'       => esc_html__( 'Sharing' ),
-					'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack' ),
-					'value'       => $stats->stats->shares,
-				);
-			}
+		if ( null !== $stats && $stats->stats->shares > 0 ) {
+			$benefits[] = array(
+				'name'        => 'sharing',
+				'title'       => esc_html__( 'Sharing' ),
+				'description' => esc_html__( 'The number of times visitors have shared your posts with the world using Jetpack' ),
+				'value'       => $stats->stats->shares,
+			);
+		}
 
 			return rest_ensure_response(
 				array(
@@ -198,6 +199,5 @@ class Jetpack_Core_API_Site_Endpoint {
 					'data'    => json_encode( $benefits ),
 				)
 			);
-		}
 	}
 }

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -75,9 +75,12 @@ class Jetpack_Core_API_Site_Endpoint {
 
 		$benefits = array();
 
-		$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
+		$stats = null;
+		if ( function_exists( 'stats_get_from_restapi' ) ) {
+			$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
+		}
 
-		if ( $stats->stats->visitors > 0 ) {
+		if ( null !== $stats && $stats->stats->visitors > 0 ) {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
 				'title'       => esc_html__( 'Jetpack Stats' ),
@@ -98,13 +101,12 @@ class Jetpack_Core_API_Site_Endpoint {
 			}
 		}
 
-		$followers = $stats->stats->followers_blog;
-		if ( $followers > 0 ) {
+		if ( null !== $stats && $stats->stats->followers_blog > 0 ) {
 			$benefits[] = array(
 				'name'        => 'subscribers',
 				'title'       => esc_html__( 'Subscribers' ),
 				'description' => esc_html__( 'People subscribed to your updates through Jetpack' ),
-				'value'       => $followers,
+				'value'       => $stats->stats->followers_blog,
 			);
 		}
 
@@ -180,7 +182,7 @@ class Jetpack_Core_API_Site_Endpoint {
 				}
 			}
 
-			if ( $stats->stats->shares > 0 ) {
+			if ( null !== $stats && $stats->stats->shares > 0 ) {
 				$benefits[] = array(
 					'name'        => 'sharing',
 					'title'       => esc_html__( 'Sharing' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -73,58 +73,58 @@ class Jetpack_Core_API_Site_Endpoint {
 	public static function get_benefits() {
 		global $wpdb;
 
-		$benefits = [];
+		$benefits = array();
 
 		$stats = stats_get_from_restapi( array( 'fields' => 'stats' ) );
 
 		if ( $stats->stats->visitors > 0 ) {
-			$benefits[] = [
+			$benefits[] = array(
 				'name'        => 'jetpack-stats',
 				'title'       => 'Jetpack Stats',
 				'description' => 'Visitors tracked by Jetpack this year',
 				'value'       => $stats->stats->visitors,
-			];
+			);
 		}
 
 		if ( Jetpack::is_module_active( 'protect' ) ) {
 			$protect = get_site_option( 'jetpack_protect_blocked_attempts' );
 			if ( $protect > 0 ) {
-				$benefits[] = [
+				$benefits[] = array(
 					'name'        => 'protect',
 					'title'       => 'Brute force protection',
 					'description' => 'The number of malicious login attempts blocked by Jetpack',
 					'value'       => $protect,
-				];
+				);
 			}
 		}
 
 		$followers = $stats->stats->followers_blog;
 		if ( $followers > 0 ) {
-			$benefits[] = [
+			$benefits[] = array(
 				'name'        => 'subscribers',
 				'title'       => 'Subscribers',
 				'description' => 'People subscribed to your updates through Jetpack',
 				'value'       => $followers,
-			];
+			);
 		}
 
 		$vaultpress = new VaultPress();
 		if ( $vaultpress->is_registered() ) {
 			$data = json_decode( base64_decode( $vaultpress->contact_service( 'plugin_data' ) ) );
 			if ( $data->features->backups && $data->backups->stats->revisions > 0 ) {
-				$benefits[] = [
+				$benefits[] = array(
 					'name'        => 'jetpack-backup',
 					'title'       => 'Jetpack Backup',
 					'description' => 'The number of times Jetpack has backed up your site and kept it safe',
 					'value'       => $data->backups->stats->revisions,
-				];
+				);
 			}
 		}
 
 		if ( Jetpack::is_module_active( 'contact-form' ) ) {
 			$contact_form_count = array_sum( get_object_vars( wp_count_posts( 'feedback' ) ) );
 			if ( $contact_form_count > 0 ) {
-				$benefits[] = [
+				$benefits[] = array(
 					'name'        => 'contact-form-feedback',
 					'title'       => 'Contact Form Feedback',
 					'description' => 'Form submissions stored by Jetpack',
@@ -136,23 +136,23 @@ class Jetpack_Core_API_Site_Endpoint {
 		if ( Jetpack::is_module_active( 'photon' ) ) {
 			$photon_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type IN ('image/jpeg', 'image/png', 'image/gif')" );
 			if ( $photon_count > 0 ) {
-				$benefits[] = [
+				$benefits[] = array(
 					'name'        => 'image-hosting',
 					'title'       => 'Image Hosting',
 					'description' => 'Super-fast, mobile-ready images served by Jetpack',
 					'value'       => $photon_count,
-				];
+				);
 			}
 		}
 
 		$videopress_count = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_mime_type = 'video/videopress'" );
 		if ( $videopress_count > 0 ) {
-			$benefits[] = [
+			$benefits[] = array(
 				'name'        => 'video-hosting',
 				'title'       => 'Video Hosting',
 				'description' => 'Ad-free, lightning-fast videos delivered by Jetpack',
 				'value'       => $videopress_count,
-			];
+			);
 		}
 
 		if ( Jetpack::is_module_active( 'publicize' ) ) {
@@ -162,30 +162,30 @@ class Jetpack_Core_API_Site_Endpoint {
 			$number_of_connections = count( $connections );
 
 			if ( $number_of_connections > 0 ) {
-				$benefits[] = [
+				$benefits[] = array(
 					'name'        => 'publicize',
 					'title'       => 'Publicize',
 					'description' => 'Live social media site connections, powered by Jetpack',
 					'value'       => count( $connections ),
-				];
+				);
 			}
 		}
 
 		if ( $stats->stats->shares > 0 ) {
-			$benefits[] = [
+			$benefits[] = array(
 				'name'        => 'sharing',
 				'title'       => 'Sharing',
 				'description' => 'The number of times visitors have shared your posts with the world using Jetpack',
 				'value'       => $stats->stats->shares,
-			];
+			);
 		}
 
 		return rest_ensure_response(
-			[
+			array(
 				'code'    => 'success',
 				'message' => esc_html__( 'Site benefits correctly received.', 'jetpack' ),
 				'data'    => json_encode( $benefits ),
-			]
+			)
 		);
 	}
 }

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -10,6 +10,7 @@ module.exports = [
 	'_inc/lib/admin-pages/class-jetpack-about-page.php',
 	'_inc/lib/class.jetpack-password-checker.php',
 	'_inc/lib/components.php',
+	'_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php',
 	'_inc/lib/core-api/wpcom-endpoints/memberships.php',
 	'_inc/lib/debugger/',
 	'_inc/lib/plans.php',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The disconnect dialog project (see parBdM-fY-p2) needs an endpoint to return information about which benefits to highlight in the disconnect dialog. This PR adds a new endpoint at /site/benefits that calculates a list of benefits based on which features in Jetpack are currently being used. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
New feature, see parBdM-fY-p2 and https://github.com/Automattic/jetpack/pull/13118.

#### Testing instructions:

* Check out the branch
* Use Postman or something similar to make a request to https://:site/wp-json/jetpack/v4/site/benefits
* Verify that each of the items returned by the API is returned correctly.
* Verify that the data is only retrieved if the user is logged in and able to manage Jetpack.

#### Proposed changelog entry for your changes:
* Added an endpoint at wp-json/jetpack/v4/site/benefits for showing how Jetpack is being used on the site.
