### PR TITLE
Jetpack Sync: Do not do an initial sync if there is an ongoing full sync in progress

### DIFF
--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Sync;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -345,6 +346,12 @@ class Actions {
 	public static function do_initial_sync() {
 		// Lets not sync if we are not suppose to.
 		if ( ! self::sync_allowed() ) {
+			return false;
+		}
+
+		// Don't start new sync if a full sync is in process.
+		$full_sync_module = Modules::get_module( 'full-sync' );
+		if ( $full_sync_module && ( $full_sync_module->is_started() && ! $full_sync_module->is_finished() ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12548.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
`do_initial_sync()` will check if there is a current ongoing full sync before initializing the incremental sync.     

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Kick off a full sync in progress
2) Assuming your user isn't connected to JP yet, go to Jetpack > Dashboard
3) Scroll down to "Account Connection" and hit "Link to WordPress.com"
4) Current full sync will continue to sync without being overwritten

Alternatively, in lieu of steps 2) and 3), you could just call `Automattic\Jetpack\Sync\Actions::do_initial_sync();` in `wp shell`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add check for ongoing full sync in before do_initial_sync() initializes an incremental sync