### PR TITLE
Add medium_large size to images that are Photonized

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -1124,6 +1124,11 @@ class Jetpack_Photon {
 					'height' => intval( get_option( 'medium_size_h' ) ),
 					'crop'   => false
 				),
+				'medium_large' => array(
+						'width'  => intval( get_option( 'medium_large_size_w' ) ),
+						'height' => intval( get_option( 'medium_large_size_h' ) ),
+						'crop'   => false
+				),
 				'large'  => array(
 					'width'  => intval( get_option( 'large_size_w' ) ),
 					'height' => intval( get_option( 'large_size_h' ) ),

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -325,6 +325,26 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	}
 
 	/**
+	 * @author emilyatmobtown
+	 * @covers Jetpack_Photon::filter_image_downsize
+	 */
+	public function test_photon_return_medium_large_size_dimensions() {
+		global $content_width;
+		$content_width = 0;
+
+		$test_image = $this->_get_image();
+
+		// Using the default "Large" size with a soft crop.
+		$this->assertEquals(
+			'fit=768%2C576',
+			$this->_get_query( Jetpack_Photon::instance()->filter_image_downsize( false, $test_image, 'medium_large' ) )
+		);
+
+		wp_delete_attachment( $test_image );
+		$this->_remove_image_sizes();
+	}
+
+	/**
 	 * @author kraftbj
 	 * @covers Jetpack_Photon::filter_image_downsize
 	 * @since 3.8.2
@@ -985,10 +1005,13 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$this->assertArrayHasKey( 'media_details', $data );
 		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
 		$this->assertArrayHasKey( 'full', $data['media_details']['sizes'] );
+		$this->assertArrayHasKey( 'medium_large', $data['media_details']['sizes'] );
 		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['full'] );
+		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['medium_large'] );
 
 		$this->assertContains( '?', $data['media_details']['sizes']['full']['source_url'] );
-	}
+		$this->assertContains( '?', $data['media_details']['sizes']['medium_large']['source_url'] );
+		}
 
 	/**
 	 * @group rest-api
@@ -1007,9 +1030,12 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$this->assertArrayHasKey( 'media_details', $data );
 		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
 		$this->assertArrayHasKey( 'full', $data['media_details']['sizes'] );
+		$this->assertArrayHasKey( 'medium_large', $data['media_details']['sizes'] );
 		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['full'] );
+		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['medium_large'] );
 
 		$this->assertNotContains( '?', $data['media_details']['sizes']['full']['source_url'] );
+		$this->assertNotContains( '?', $data['media_details']['sizes']['medium_large']['source_url'] );
 
 
 		// Subsequent ?context=view requests should still be Photonized
@@ -1021,8 +1047,11 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$this->assertArrayHasKey( 'media_details', $data );
 		$this->assertArrayHasKey( 'sizes', $data['media_details'] );
 		$this->assertArrayHasKey( 'full', $data['media_details']['sizes'] );
+		$this->assertArrayHasKey( 'medium_large', $data['media_details']['sizes'] );
 		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['full'] );
+		$this->assertArrayHasKey( 'source_url', $data['media_details']['sizes']['medium_large'] );
 
 		$this->assertContains( '?', $data['media_details']['sizes']['full']['source_url'] );
-	}
+		$this->assertContains( '?', $data['media_details']['sizes']['medium_large']['source_url'] );
+		}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #5383

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the Jetpack_Photon class to include medium_large in the image sizes that are provided.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Dashboard > Performance and activate "Image Performance". 
* Upload an image to the Media Library.
* Go to <your-site-url>/wp-json/wp/v2/media to see the JSON data for images on the site.
* Search and find "medium_large" in the data to find the first medium_large image size.
* Under medium_large, see that the source_url shows the CDN as the base URL rather than your site URL. This will appear as i0.wp.com, i1.wp.com or i2.wp.com.

Before (showing the test site base URL):
![AwesomeScreenshot-els-jetpack-dev-ngrok-io-wp-json-wp-v2-media-2019-07-29-16-07-59](https://user-images.githubusercontent.com/24902269/62079256-5c5df280-b21c-11e9-9166-d1f572beeade.png)

After (showing the CDN base URL):
![AwesomeScreenshot-els-jetpack-dev-ngrok-io-wp-json-wp-v2-media-2019-07-29-16-07-93](https://user-images.githubusercontent.com/24902269/62079289-70095900-b21c-11e9-8571-9b3a900187a0.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed Photon so that it includes the medium_large image size with the images that are accelerated.