### PR TITLE
Upgrade Nudge: Fix redirect_to for Jetpack wp-admin

### DIFF
--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -86,11 +86,13 @@ class Jetpack_Components {
 			$site_slug = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
 		}
 
+		$redirect_to = '/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) );
+
 		$upgrade_url =
 			$plan_path_slug
 			? add_query_arg(
 				'redirect_to',
-				'/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) ),
+				$redirect_to,
 				"https://wordpress.com/checkout/${site_slug}/${plan_path_slug}"
 			) : '';
 

--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -86,6 +86,7 @@ class Jetpack_Components {
 			$site_slug = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
 		}
 
+		// Post-checkout: redirect back to the editor.
 		$redirect_to = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
 			? '/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) )
 			: add_query_arg(

--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -86,7 +86,15 @@ class Jetpack_Components {
 			$site_slug = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
 		}
 
-		$redirect_to = '/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) );
+		$redirect_to = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			? '/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) )
+			: add_query_arg(
+				array(
+					'action' => 'edit',
+					'post'   => $post_id,
+				),
+				admin_url( 'post.php' )
+			);
 
 		$upgrade_url =
 			$plan_path_slug

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -81,13 +81,17 @@ export default compose( [
 		// The editor for CPTs has an `edit/` route fragment prefixed
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
+		// Post-checkout: redirect back here
+		const redirect_to =
+			'/' +
+			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' );
+
 		const upgradeUrl =
 			planPathSlug &&
 			addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
-				redirect_to:
-					'/' +
-					compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' ),
+				redirect_to,
 			} );
+
 		return {
 			planName: get( plan, [ 'product_name' ] ),
 			upgradeUrl,

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -87,10 +87,16 @@ export default compose( [
 		const redirect_to = isWpcom
 			? '/' +
 			  compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' )
-			: addQueryArgs( `//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`, {
-					action: 'edit',
-					post: postId,
-			  } );
+			: addQueryArgs(
+					`${ window.location.protocol }//${ getSiteFragment().replace(
+						'::',
+						'/'
+					) }/wp-admin/post.php`,
+					{
+						action: 'edit',
+						post: postId,
+					}
+			  );
 
 		const upgradeUrl =
 			planPathSlug &&

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -81,10 +81,16 @@ export default compose( [
 		// The editor for CPTs has an `edit/` route fragment prefixed
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
+		const isWpcom = true; // TODO
+
 		// Post-checkout: redirect back here
-		const redirect_to =
-			'/' +
-			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' );
+		const redirect_to = isWpcom
+			? '/' +
+			  compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' )
+			: addQueryArgs( `//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`, {
+					action: 'edit',
+					post: postId,
+			  } );
 
 		const upgradeUrl =
 			planPathSlug &&

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -88,10 +88,8 @@ export default compose( [
 			? '/' +
 			  compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' )
 			: addQueryArgs(
-					`${ window.location.protocol }//${ getSiteFragment().replace(
-						'::',
-						'/'
-					) }/wp-admin/post.php`,
+					window.location.protocol +
+						`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
 					{
 						action: 'edit',
 						post: postId,

--- a/extensions/shared/upgrade-nudge/index.jsx
+++ b/extensions/shared/upgrade-nudge/index.jsx
@@ -81,7 +81,7 @@ export default compose( [
 		// The editor for CPTs has an `edit/` route fragment prefixed
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
-		const isWpcom = true; // TODO
+		const isWpcom = get( window, [ '_currentSiteType' ] ) === 'simple';
 
 		// Post-checkout: redirect back here
 		const redirect_to = isWpcom


### PR DESCRIPTION
Required for #13081, and implementing musings found at https://github.com/Automattic/jetpack/pull/13081#issuecomment-516379126. Related: https://github.com/Automattic/wp-calypso/pull/35027.

#### Changes proposed in this Pull Request:

Change the post-checkout redirect target to the wp-admin block editor for Jetpack sites, both in the editor (JS), and the frontend (PHP).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Modifies the existing UpgradeNudge.

#### Testing instructions:

- Switch to this branch locally, build Jetpack (`yarn build`), and start Docker (`yarn docker:up`)
- Now add the following line to any file in `docker/mu-plugins`, e.g. a newly created `0-blocks-upgrade.php` (needs to start with `<?php`): `define ( 'JETPACK_SHOW_BLOCK_UPGRADE_NUDGE', true );`
- Make sure you're connected to WP.com, and on a free plan
- Start a new post, and insert the 'Simple Payments' block
- Select the block, and enter some information into its text fields.
- Click the nudge's "Upgrade" CTA button
- Pay for the premium plan
- Verify that you're redirected back to where you came from (the wp-admin block editor) (without any intermediate redirects on WP.com)

Verify that on WP.com, the redirect target is still the iframed Gutenberg editor (well, if you have enabled it, see PCYsg-hNB-p2):
- Apply the WP.com counterpart patch (D31062-code) to your sandbox
- Make sure your sandbox is on a free plan, and that you have enabled it to use Gutenberg
- Open the block editor for your sandbox site from within Calypso
- Insert the 'Simple Payments' block
- Click the nudge's "Upgrade" CTA button
- Pay for the premium plan
- Verify that you're redirected back to where you came from (the iframed Gutenberg editor in Calypso)

#### Proposed changelog entry for your changes:

N/A (The UpgradeNudge hasn't been enabled in any previous JP version, so no need to add a ChangeLog entry.)