### PR TITLE
SAL: use Post ID instead of Post Object in current_user_can

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -175,7 +175,7 @@ abstract class SAL_Site {
 
 		switch ( $context ) {
 		case 'edit' :
-			if ( ! current_user_can( 'edit_post', $post ) ) {
+			if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 				return new WP_Error( 'unauthorized', 'User cannot edit post', 403 );
 			}
 			break;


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

`current_user_can` only accepts object IDs as the optional second param; passing anything else (like an instance of `Jetpack_Post` like we did) will cause issues.

This was reported in 2184839-zen by a site owner using Polylang Pro.

#### Testing instructions:

I could not reproduce the Fatal myself, but something like this may help:

* Connect your test site to WordPress.com.
* Install the Polylang plugin.
* Add the site to your mobile WordPress app.
* Try to access the Posts screen in the app.
* Check your site's error logs and make sure you do not see any errors like those:

```
PHP Catchable fatal error: Object of class Jetpack_Post could not be converted to string in /wp-content/plugins/polylang-pro/include/filters.php on line 305 
```

#### Proposed changelog entry for your changes:

* WordPress.com API: avoid Fatal Errors when fetching posts from the mobile apps.
