### PR TITLE
Masterbar: limit access to Stats and Plan menu items

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -861,7 +861,7 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		// Stats.
-		if ( Jetpack::is_module_active( 'stats' ) ) {
+		if ( Jetpack::is_module_active( 'stats' ) && current_user_can( 'view_stats' ) ) {
 			$wp_admin_bar->add_menu(
 				array(
 					'parent' => 'blog',
@@ -890,7 +890,7 @@ class A8C_WPCOM_Masterbar {
 		}
 
 		// Add Calypso plans link and plan type indicator.
-		if ( is_user_member_of_blog( $current_user->ID ) ) {
+		if ( is_user_member_of_blog( $current_user->ID ) && current_user_can( 'manage_options' ) ) {
 			$plans_url = 'https://wordpress.com/plans/' . esc_attr( $this->primary_site_slug );
 			$label     = esc_html__( 'Plan', 'jetpack' );
 			$plan      = Jetpack_Plan::get();


### PR DESCRIPTION
Fixes #13113

#### Changes proposed in this Pull Request:

* Not every wpcom-connected user should be able to see those 2 menu items. You should only see them if you have access to them on WordPress.com.

#### Testing instructions:

* Start with a site with 2 users: an admin, that you've used to connect the site to WordPress.com, and an editor, that you've connected to WordPress.com afterwards using a different WordPress.com account.
* Go to Jetpack > Settings while connected as the admin, and enable the WordPress.com toolbar.
* In a different browser, log in with the editor. You'll see the masterbar, but the 2 menu items are now gone.

**Before**

![image](https://user-images.githubusercontent.com/426388/62381558-0b1b6f00-b54c-11e9-9dd9-f1cbafc081b5.png)


**After**

![image](https://user-images.githubusercontent.com/426388/62381512-f212be00-b54b-11e9-94e0-413eb5b206b2.png)


#### Proposed changelog entry for your changes:

* WordPress.com Toolbar: limit access to Stats and Plan menu items
