### PR TITLE
Woo Analytics: use core WP function to enqueue script

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -83,6 +83,15 @@ class Jetpack {
 	);
 
 	/**
+	 * The handles of scripts that can be loaded asynchronously.
+	 *
+	 * @var array
+	 */
+	public $async_script_handles = array(
+		'woocommerce-analytics',
+	);
+
+	/**
 	 * Contains all assets that have had their URL rewritten to minified versions.
 	 *
 	 * @var array
@@ -719,6 +728,11 @@ class Jetpack {
 		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
 			add_action( 'shutdown', array( $this, 'push_stats' ) );
 		}
+
+		/*
+		 * Load some scripts asynchronously.
+		 */
+		add_action( 'script_loader_tag', array( $this, 'script_add_async' ), 10, 3 );
 	}
 
 	function setup_xmlrpc_handlers( $request_params, $is_active, $is_signed, Jetpack_XMLRPC_Server $xmlrpc_server = null ) {
@@ -6690,6 +6704,24 @@ p {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 				$tag = "<!-- `" . esc_html( $handle ) . "` is included in the concatenated jetpack.css -->\r\n";
 			}
+		}
+
+		return $tag;
+	}
+
+	/**
+	 * Add an async attribute to scripts that can be loaded asynchronously.
+	 * https://www.w3schools.com/tags/att_script_async.asp
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param string $tag    The <script> tag for the enqueued script.
+	 * @param string $handle The script's registered handle.
+	 * @param string $src    The script's source URL.
+	 */
+	public function script_add_async( $tag, $handle, $src ) {
+		if ( in_array( $handle, $this->async_script_handles, true ) ) {
+			return preg_replace( '/^<script /i', '<script async ', $tag );
 		}
 
 		return $tag;

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -28,8 +28,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		// add to carts from non-product pages or lists (search, store etc.)
 		add_action( 'wp_head', array( $this, 'loop_session_events' ), 2 );
 
-		// loading s.js
-		add_action( 'wp_head', array( $this, 'wp_head_bottom' ), 999999 );
+		// loading s.js.
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracking_script' ) );
 
 		// Capture cart events
 		add_action( 'woocommerce_add_to_cart', array( $this, 'capture_add_to_cart' ), 10, 6 );
@@ -64,12 +64,16 @@ class Jetpack_WooCommerce_Analytics_Universal {
 
 
 	/**
-	 * Place script to call s.js, Store Analytics
+	 * Place script to call s.js, Store Analytics.
 	 */
-	public function wp_head_bottom() {
-		$filename   = 's-' . gmdate( 'YW' ) . '.js';
-		$async_code = "<script async src='https://stats.wp.com/" . $filename . "'></script>";
-		echo "$async_code\r\n";
+	public function enqueue_tracking_script() {
+		$filename = sprintf(
+			'https://stats.wp.com/s-%d.js',
+			gmdate( 'YW' )
+		);
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_enqueue_script( 'woocommerce-analytics', esc_url( $filename ), array(), null, false );
 	}
 
 	/**


### PR DESCRIPTION
Related: #13039

#### Changes proposed in this Pull Request:

* For third-parties to be able to interact with our tracking script, it is easier if it is registered using core WP functions instead of just added to `wp_head`.

Using `wp_enqueue_script` makes it easier to dequeue the file if needed, or modify its output with the `script_loader_tag` filter (one could add an async parameter for example, or add extra data attributes like the Cookiebot plugin.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* @psealock I'd appreciate your review on this, to be sure I am not missing anything obvious with this enqueue. Thank you!

#### Testing instructions:

* Install and activate the WooCommerce plugin on your site.
* Connect Jetpack to WordPress.com
* With or without this patch, you should see the same file being enqueued in the `head`: `<script type='text/javascript' src='https://stats.wp.com/s-201931.js'></script>` (note that the exact filename changes week after week).

#### Proposed changelog entry for your changes:

* WooCommerce Analytics: use core WP function to enqueue script
