### PR TITLE
Featured image: Add support for custom post types #13107

### DIFF
--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -98,10 +98,15 @@ function twentynineteen_override_post_thumbnail( $width ) {
 	$settings = array_merge( $settings, array(
 		'post-option'  => get_option( 'jetpack_content_featured_images_post', $settings['post-default'] ),
 		'page-option'  => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
+		'custom-option'  => get_option( 'jetpack_content_featured_images_custom', '' ),
 	) );
 
-	if ( ( ! $settings['post-option'] && is_single() )
-	|| ( ! $settings['page-option'] && is_singular() && is_page() ) ) {
+	$custom_posts = array_map('trim', explode( ',', $settings['custom-option']) ) ;
+	$current_post_type= get_post_type();
+
+	if ( ( ! $settings['post-option'] && is_singular('post') )
+	|| ( ! $settings['page-option'] && is_singular('page') )
+	|| in_array( $current_post_type, $custom_posts ) ) {
 		return false;
 	} else {
 		return ! post_password_required() && ! is_attachment() && has_post_thumbnail();

--- a/modules/theme-tools/content-options.php
+++ b/modules/theme-tools/content-options.php
@@ -95,6 +95,7 @@ function jetpack_featured_images_get_settings() {
 			'page-option'      => get_option( 'jetpack_content_featured_images_page', $settings['page-default'] ),
 			'portfolio-option' => get_option( 'jetpack_content_featured_images_portfolio', $settings['portfolio-default'] ),
 			'fallback-option'  => get_option( 'jetpack_content_featured_images_fallback', $settings['fallback-default'] ),
+			'custom-option'	   => get_option( 'jetpack_content_featured_images_custom', '' ),
 		)
 	);
 

--- a/modules/theme-tools/content-options/customizer.php
+++ b/modules/theme-tools/content-options/customizer.php
@@ -404,6 +404,27 @@ function jetpack_content_options_customize_register( $wp_customize ) {
 				)
 			);
 		}
+		
+		// Featured Images: All other custom post types
+		$wp_customize->add_setting(
+			'jetpack_content_featured_images_custom',
+			array(
+				'default'           => '',
+				'type'              => 'option',
+				'sanitize_callback' => 'wp_filter_nohtml_kses',
+			)
+		);
+
+		$wp_customize->add_control(
+			'jetpack_content_featured_images_custom',
+			array(
+				'section'         => 'jetpack_content_options',
+				'label'           => esc_html__( 'Hide on these custom post types', 'jetpack' ),
+				'description'	  => esc_html__( 'Enter comma separated list of custom post type slugs, where you want to hide featured images. Will display on all others by default', 'jetpack' ),
+				'type'            => 'text',
+				'active_callback' => 'jetpack_post_thumbnail_supports',
+			)
+		);
 	}
 }
 add_action( 'customize_register', 'jetpack_content_options_customize_register' );

--- a/modules/theme-tools/content-options/featured-images.php
+++ b/modules/theme-tools/content-options/featured-images.php
@@ -10,6 +10,28 @@ function jetpack_featured_images_remove_post_thumbnail( $metadata, $object_id, $
 		return $metadata;
 	}
 
+	// Check if it's custom post type other than post,page & portfolio)
+	if( $opts['custom-option'] != ''
+		&& is_singular()
+		&& !is_singular('post')
+		&& !is_page()
+		&& ! jetpack_is_product()
+		&& ( isset( $meta_key )
+		&& '_thumbnail_id' === $meta_key )
+		&& in_the_loop()
+	) {	
+		$custom_posts = array_map( 'trim', explode( ',', $opts['custom-option']) ) ;
+		$current_post_type= get_post_type();
+		
+		// Check if current post type is in the given list of custom types where featured image to be hidden.
+		if( in_array( $current_post_type, $custom_posts ) ) {
+			return false;
+		}
+		else {
+			return $metadata;
+		}
+	}
+	
 	// Return false if the archive option or singular option is unticked.
 	if (
 		( true === $opts['archive']


### PR DESCRIPTION
Fixes #13107

#### Changes proposed in this Pull Request:

Added text filed option to give comma separated list of custom post type slugs for which featured image to be hidden. All others will display it by default.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Yes, a new option is added in Content Options> featured images to hide featured image for custom post type.

#### Testing instructions:
- Should have at least couple of custom post types to test this.
- Go to customize >  Content Options> 'Hide on these custom post types'.
- Given a comma separated list of custom post type slugs for which you want to hide featured images.
- Now go to a single post page of that custom post type to test whether the featured image is visible or not. This option should work irrespective of other featured image settings in the same section.


#### Proposed changelog entry for your changes:
Featured image : Added text filed option to give comma separated list of custom post type slugs for which featured image to be hidden. All others will display it by default.
