### PR TITLE
when in debug mode, reduce sitemap cache duration

### DIFF
--- a/modules/sitemaps/sitemap-constants.php
+++ b/modules/sitemaps/sitemap-constants.php
@@ -10,7 +10,7 @@
 /**
  * Number of seconds between sitemap and news updates in development code.
  *
- * @since 5.x.x
+ * @since 7.7.0
  */
 if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
 	define( 'JP_SITEMAP_INTERVAL', 60 );

--- a/modules/sitemaps/sitemap-constants.php
+++ b/modules/sitemaps/sitemap-constants.php
@@ -8,6 +8,16 @@
  */
 
 /**
+ * Number of seconds between sitemap and news updates in development code.
+ *
+ * @since 5.x.x
+ */
+if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
+	define( 'JP_SITEMAP_INTERVAL', 60 );
+	define( 'JP_NEWS_SITEMAP_INTERVAL', 60 );
+}
+
+/**
  * Maximum size (in bytes) of a sitemap xml file.
  * Max is 716800 = 700kb to avoid potential failures for default memcached limits (1MB)
  *
@@ -77,7 +87,7 @@ if ( ! defined( 'JP_SITEMAP_LOCK_INTERVAL' ) ) {
 }
 
 /**
- * Cache lifetime of news sitemap (in seconds).
+ * Number of seconds between news sitemap updates.
  *
  * @since 4.8.0
  */

--- a/modules/sitemaps/sitemap-constants.php
+++ b/modules/sitemaps/sitemap-constants.php
@@ -8,13 +8,19 @@
  */
 
 /**
- * Number of seconds between sitemap and news updates in development code.
+ * Number of seconds between sitemap and news sitemap updates in development code.
+ * In production, sitemaps are cached for 12 hours.
+ * In development, sitemaps are cache for 1 minute.
  *
  * @since 5.x.x
  */
 if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
-	define( 'JP_SITEMAP_INTERVAL', 60 );
-	define( 'JP_NEWS_SITEMAP_INTERVAL', 60 );
+	if ( ! defined( 'JP_SITEMAP_INTERVAL') ) {
+		define( 'JP_SITEMAP_INTERVAL', 60 );
+	}
+	if ( ! defined( 'JP_NEWS_SITEMAP_INTERVAL') ) {
+		define( 'JP_NEWS_SITEMAP_INTERVAL', 60 );
+	}
 }
 
 /**


### PR DESCRIPTION
When in debug mode, reduce JP_SITEMAP_INTERVAL and JP_NEWS_SITEMAP_INTERVAL times.

Fixes #11232

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
* Go to /sitemap.xml
* Change an article
* Wait 61 seconds
* See that sitemap has update

#### Proposed changelog entry for your changes:
* In debug mode, reduce length of sitemap cache times to 60 seconds.
