### PR TITLE
Stats: Update method for inserting JavaScript - Removed fallback / workaround for themes without wp_footer

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -231,12 +231,13 @@ function stats_build_view_data() {
  * @return void
  */
 function stats_footer() {
-    $data = stats_build_view_data();
-    if ( Jetpack_AMP_Support::is_amp_request() ) {
-        stats_render_amp_footer( $data );
-    } else {
-        stats_render_footer( $data );
-    }
+	$data = stats_build_view_data();
+	if ( Jetpack_AMP_Support::is_amp_request() ) {
+		stats_render_amp_footer( $data );
+	} else {
+		stats_render_footer( $data );
+	}
+	
 }
 
 function stats_render_footer( $data ) {

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -169,7 +169,7 @@ function stats_map_meta_caps( $caps, $cap, $user_id ) {
  * @return void
  */
 function stats_template_redirect() {
-	global $current_user, $rendered_stats_footer;
+	global $current_user;
 
 	if ( is_feed() || is_robots() || is_trackback() || is_preview() || jetpack_is_dnt_enabled() ) {
 		return;
@@ -184,9 +184,7 @@ function stats_template_redirect() {
 	}
 
 	add_action( 'wp_footer', 'stats_footer', 101 );
-	add_action( 'wp_head', 'stats_add_shutdown_action' );
 
-	$rendered_stats_footer = false;
 }
 
 
@@ -225,16 +223,6 @@ function stats_build_view_data() {
 	return compact( 'v', 'j', 'blog', 'post', 'tz', 'srv' );
 }
 
-/**
- * Stats Add Shutdown Action.
- *
- * @access public
- * @return void
- */
-function stats_add_shutdown_action() {
-	// Just in case wp_footer isn't in your theme.
-	add_action( 'shutdown',  'stats_footer', 101 );
-}
 
 /**
  * Stats Footer.
@@ -243,17 +231,12 @@ function stats_add_shutdown_action() {
  * @return void
  */
 function stats_footer() {
-	global $rendered_stats_footer;
-
-	if ( ! $rendered_stats_footer ) {
-		$data = stats_build_view_data();
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
-			stats_render_amp_footer( $data );
-		} else {
-			stats_render_footer( $data );
-		}
-		$rendered_stats_footer = true;
-	}
+    $data = stats_build_view_data();
+    if ( Jetpack_AMP_Support::is_amp_request() ) {
+        stats_render_amp_footer( $data );
+    } else {
+        stats_render_footer( $data );
+    }
 }
 
 function stats_render_footer( $data ) {


### PR DESCRIPTION
After discussion on Github issue "Stats: Update method for inserting JavaScript #3763" it was considered that it was a safe assumption to make that a theme would always have a `wp_footer` action.

This update removes and modifies code which was used to provide a fallback / workaround in the case of themes that did not contain a `wp_footer` action.

The workaround consisted of setting a global variable `$rendered_stats_footer` which would get set to true if the `wp_footer` call was successful, if not successful then the WP Stats JS code would get set via a `wp_head` action instead.

<!-- Would you like this feature to be tested by Beta testers?
The changes made by the removal and modification of this code should not affect existing functionality as the original could was only intended to deal with an edge-case of themes without a `wp_footer` action. The `stats_footer` function that was modified also has an AMP-specific output so testing could be done to check that this is outputting correctly on all themes that do have a `wp_footer` action.

Fixes #
* Removed a function `stats_add_shutdown_action()`
* Removed a line that called the above function: `add_action( 'wp_head', 'stats_add_shutdown_action' );` 
* Removed the use of a global variable `$rendered_stats_footer`, this was used as part of the fallback process, if there was no `wp_footer` in the theme then this global variable would be false and this would cause the `add_action( 'wp_head', 'stats_add_shutdown_action' );` action to trigger the `stats_footer()` function and the stats would be loaded in `wp_head` instead.

#### Changes proposed in this Pull Request:
* This update removes a fallback / workaround in the case of themes that did not contain a `wp_footer` action, as per discussion on issue #3763 it was considered safe to remove this.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This removes old workaround / fallback code on an existing feature.

#### Testing instructions:
Primary testing of this change would be to check that the Jetpack stats JavaScript is being correctly output into the footer of the site. This should look something along the lines of appearing somewhere prior to the closing body tag and not within the <head> of your site:

`<script type="text/javascript" src="https://stats.wp.com/e-201932.js" async="async" defer="defer"></script>
<script type="text/javascript">
	_stq = window._stq || [];
	_stq.push([ 'view', {v:'ext',j:'1:7.5.3',blog:'TRACKINGIDNUMBERHERE',post:'0',tz:'1',srv:'YOURDOMAINHERE'} ]);
	_stq.push([ 'clickTrackerInit', 'TRACKINGIDNUMBERHERE', '0' ]);
</script>`

(Note that the numbers in "e-******.js" will likely be different than the above).

Additionally testing that the AMP Pixel is being correctly output when viewing an AMP-generated page. The amp pixel is something along the lines of:

`<amp-pixel src="PIXELGIFURLHERE"></amp-pixel>`

To test this will require enabling [the AMP plugin for WordPress](https://wordpress.org/plugins/amp/) and then checking the AMP formatted output contains the AMP pixel.


* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* This update modifies code used to load the Jetpack Stats JavaScript and removes an outdated fallback in the case that a theme did not call `wp_footer`.