### PR TITLE
Social Icons Widget: Add more common feed url components to supported icons

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -23,6 +23,7 @@ module.exports = [
 	'modules/sitemaps/sitemaps.php',
 	'modules/theme-tools/social-menu/',
 	'modules/verification-tools.php',
+	'modules/widgets/social-icons.php',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'packages',
 ];

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -1,6 +1,12 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Social Icons Widget.
+ */
 class Jetpack_Widget_Social_Icons extends WP_Widget {
 	/**
+	 * Default widget options.
+	 *
 	 * @var array Default widget options.
 	 */
 	protected $defaults;
@@ -52,8 +58,19 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 * Script & styles for admin widget form.
 	 */
 	public function enqueue_admin_scripts() {
-		wp_enqueue_script( 'jetpack-widget-social-icons-script', plugins_url( 'social-icons/social-icons-admin.js', __FILE__ ), array( 'jquery-ui-sortable' ), '20170506' );
-		wp_enqueue_style( 'jetpack-widget-social-icons-admin', plugins_url( 'social-icons/social-icons-admin.css', __FILE__ ), array(), '20170506' );
+		wp_enqueue_script(
+			'jetpack-widget-social-icons-script',
+			plugins_url( 'social-icons/social-icons-admin.js', __FILE__ ),
+			array( 'jquery-ui-sortable' ),
+			'20170506',
+			true
+		);
+		wp_enqueue_style(
+			'jetpack-widget-social-icons-admin',
+			plugins_url( 'social-icons/social-icons-admin.css', __FILE__ ),
+			array(),
+			'20170506'
+		);
 	}
 
 	/**
@@ -67,28 +84,28 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 * JavaScript for admin widget form.
 	 */
 	public function render_admin_js() {
-	?>
+		?>
 		<script type="text/html" id="tmpl-jetpack-widget-social-icons-template">
 			<?php self::render_icons_template(); ?>
 		</script>
-	<?php
+		<?php
 	}
 
 	/**
 	 * Add SVG definitions to the footer.
 	 */
 	public function include_svg_icons() {
-		// Define SVG sprite file in Jetpack
+		// Define SVG sprite file in Jetpack.
 		$svg_icons = dirname( dirname( __FILE__ ) ) . '/theme-tools/social-menu/social-menu.svg';
 
-		// Define SVG sprite file in WPCOM
+		// Define SVG sprite file in WPCOM.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			$svg_icons = dirname( dirname( __FILE__ ) ) . '/social-menu/social-menu.svg';
 		}
 
 		// If it exists, include it.
 		if ( is_file( $svg_icons ) ) {
-			require_once( $svg_icons );
+			require_once $svg_icons;
 		}
 	}
 
@@ -106,10 +123,10 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 
-		echo $args['before_widget'];
+		echo $args['before_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( ! empty( $title ) ) {
-			echo $args['before_title'] . esc_html( $title ) . $args['after_title'];
+			echo $args['before_title'] . esc_html( $title ) . $args['after_title']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		if ( ! empty( $instance['icons'] ) ) :
@@ -118,13 +135,13 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			$social_icons = $this->get_supported_icons();
 			$default_icon = $this->get_svg_icon( array( 'icon' => 'chain' ) );
 
-			// Set target attribute for the link
+			// Set target attribute for the link.
 			if ( true === $instance['new-tab'] ) {
 				$target = '_blank';
 			} else {
 				$target = '_self';
 			}
-		?>
+			?>
 
 			<ul class="jetpack-social-widget-list size-<?php echo esc_attr( $instance['icon-size'] ); ?>">
 
@@ -132,7 +149,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 
 					<?php if ( ! empty( $icon['url'] ) ) : ?>
 						<li class="jetpack-social-widget-item">
-							<a href="<?php echo esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ); ?>" target="<?php echo $target; ?>">
+							<a href="<?php echo esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ); ?>" target="<?php echo esc_attr( $target ); ?>">
 								<?php
 									$found_icon = false;
 
@@ -156,7 +173,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 								}
 
 								if ( ! $found_icon ) {
-									echo $default_icon;
+									echo $default_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								}
 								?>
 							</a>
@@ -167,10 +184,10 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 
 			</ul>
 
-		<?php
+			<?php
 		endif;
 
-		echo $args['after_widget'];
+		echo $args['after_widget']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		/** This action is documented in modules/widgets/gravatar-profile.php */
 		do_action( 'jetpack_stats_extra', 'widget_view', 'social_icons' );
@@ -187,15 +204,16 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 * @return array Updated safe values to be saved.
 	 */
 	public function update( $new_instance, $old_instance ) {
+		$instance = array();
+
 		$instance['title']     = sanitize_text_field( $new_instance['title'] );
 		$instance['icon-size'] = $this->defaults['icon-size'];
 
-		if ( in_array( $new_instance['icon-size'], array( 'small', 'medium', 'large' ) ) ) {
+		if ( in_array( $new_instance['icon-size'], array( 'small', 'medium', 'large' ), true ) ) {
 			$instance['icon-size'] = $new_instance['icon-size'];
 		}
 
 		$instance['new-tab'] = isset( $new_instance['new-tab'] ) ? (bool) $new_instance['new-tab'] : false;
-		$icon_count          = count( $new_instance['url-icons'] );
 		$instance['icons']   = array();
 
 		foreach ( $new_instance['url-icons'] as $url ) {
@@ -232,13 +250,13 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		?>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'jetpack' ); ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'icon-size' ); ?>"><?php esc_html_e( 'Size:', 'jetpack' ); ?></label>
-			<select class="widefat" name="<?php echo $this->get_field_name( 'icon-size' ); ?>">
+			<label for="<?php echo esc_attr( $this->get_field_id( 'icon-size' ) ); ?>"><?php esc_html_e( 'Size:', 'jetpack' ); ?></label>
+			<select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'icon-size' ) ); ?>">
 				<?php foreach ( $sizes as $value => $label ) : ?>
 					<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $value, $instance['icon-size'] ); ?>><?php echo esc_attr( $label ); ?></option>
 				<?php endforeach; ?>
@@ -246,8 +264,8 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		</p>
 
 		<div class="jetpack-social-icons-widget-list"
-			data-url-icon-id="<?php echo $this->get_field_id( 'url-icons' ); ?>"
-			data-url-icon-name="<?php echo $this->get_field_name( 'url-icons' ); ?>"
+			data-url-icon-id="<?php echo esc_attr( $this->get_field_id( 'url-icons' ) ); ?>"
+			data-url-icon-name="<?php echo esc_attr( $this->get_field_name( 'url-icons' ) ); ?>"
 		>
 
 			<?php
@@ -292,19 +310,19 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		</p>
 
 		<p>
-			<input type="checkbox" class="checkbox" id="<?php echo $this->get_field_id( 'new-tab' ); ?>" name="<?php echo $this->get_field_name( 'new-tab' ); ?>" <?php checked( $new_tab ); ?> />
-			<label for="<?php echo $this->get_field_id( 'new-tab' ); ?>"><?php esc_html_e( 'Open link in a new tab', 'jetpack' ); ?></label>
+			<input type="checkbox" class="checkbox" id="<?php echo esc_attr( $this->get_field_id( 'new-tab' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'new-tab' ) ); ?>" <?php checked( $new_tab ); ?> />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'new-tab' ) ); ?>"><?php esc_html_e( 'Open link in a new tab', 'jetpack' ); ?></label>
 		</p>
 
-	<?php
+		<?php
 	}
 
 	/**
 	 * Generates template to add icons.
 	 *
-	 * @param array $args Template arguments
+	 * @param array $args Template arguments.
 	 */
-	static function render_icons_template( $args = array() ) {
+	private static function render_icons_template( $args = array() ) {
 		$defaults = array(
 			'url-icon-id'   => '',
 			'url-icon-name' => '',

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -498,28 +498,28 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			),
 			array(
 				'url'   => array(
-					'/feed/',        // WordPress default feed url.
-					'/feeds/',       // Blogspot and others.
-					'/blog/feed',    // No trailing space WordPress feed, could use /feed but may match unexpectedly.
-					'format=RSS',    // Squarespace and others.
-					'/rss',          // Tumblr.
-					'/.rss',         // Reddit.
-					'/rss.xml',      // Moveable Type, Typepad.
-					'http://rss',
-					'https://rss',
+					'/feed/',         // WordPress default feed url.
+					'/feeds/',        // Blogspot and others.
+					'/blog/feed',     // No trailing slash WordPress feed, could use /feed but may match unexpectedly.
+					'format=RSS',     // Squarespace and others.
+					'/rss',           // Tumblr.
+					'/.rss',          // Reddit.
+					'/rss.xml',       // Moveable Type, Typepad.
+					'http://rss.',    // Old custom format.
+					'https://rss.',   // Old custom format.
 					'rss=1',
-					'/feed=rss',     // Catches feed=rss / feed=rss2.
-					'?feed=rss',     // WordPress non-permalink - Catches feed=rss / feed=rss2.
-					'?feed=rdf',     // WordPress non-permalink.
-					'?feed=atom',    // WordPress non-permalink.
-					'http://feeds',  // FeedBurner.
-					'https://feeds', // FeedBurner.
-					'/feed.xml',     // Feedburner Alias, and others.
-					'/index.xml',    // Moveable Type, and others.
-					'/atom.xml',     // Typepad, Squarespace.
-					'.atom',         // Shopify blog.
-					'/atom',         // Some non-WordPress feeds.
-					'index.rdf',     // Typepad.
+					'/feed=rss',      // Catches feed=rss / feed=rss2.
+					'?feed=rss',      // WordPress non-permalink - Catches feed=rss / feed=rss2.
+					'?feed=rdf',      // WordPress non-permalink.
+					'?feed=atom',     // WordPress non-permalink.
+					'http://feeds.',  // FeedBurner.
+					'https://feeds.', // FeedBurner.
+					'/feed.xml',      // Feedburner Alias, and others.
+					'/index.xml',     // Moveable Type, and others.
+					'/atom.xml',      // Typepad, Squarespace.
+					'.atom',          // Shopify blog.
+					'/atom',          // Some non-WordPress feeds.
+					'index.rdf',      // Typepad.
 				),
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -138,7 +138,8 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 
 								foreach ( $social_icons as $social_icon ) {
 									
-									// Check if the $social_icon['url'] is an array ('Feed' url is provided as an array of url components)
+									// All $social_icon['url'] elements are now provided as an array even if there is only one item,
+									// but we'll check if the $social_icon['url'] is an array anyway
 									if ( is_array( $social_icon['url'] ) ) {
 										// If array then we loop over the array to do the stripos match using each array item
 										foreach ( $social_icon['url'] as $url_fragment ) {
@@ -150,14 +151,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 											}
 										}
 										
-									} else {
-										// If not array then we can do a regular stripos match using $social_icon['url']
-										if ( false !== stripos( $icon['url'], $social_icon['url'] ) ) {
-											echo '<span class="screen-reader-text">' . esc_attr( $social_icon['label'] ) . '</span>';
-											echo $this->get_svg_icon( array( 'icon' => esc_attr( $social_icon['icon'] ) ) );
-											$found_icon = true;
-											break;
-										}
 									}
 								}
 
@@ -404,272 +397,272 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	public function get_supported_icons() {
 		$social_links_icons = array(
 			array(
-				'url'   => '500px.com',
+				'url'   => array( '500px.com' ),
 				'icon'  => '500px',
 				'label' => '500px',
 			),
 			array(
-				'url'   => 'amazon.cn',
+				'url'   => array( 'amazon.cn' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.in',
+				'url'   => array( 'amazon.in' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.fr',
+				'url'   => array( 'amazon.fr' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.de',
+				'url'   => array( 'amazon.de' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.it',
+				'url'   => array( 'amazon.it' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.nl',
+				'url'   => array( 'amazon.nl' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.es',
+				'url'   => array( 'amazon.es' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.co',
+				'url'   => array( 'amazon.co' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.ca',
+				'url'   => array( 'amazon.ca' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'amazon.com',
+				'url'   => array( 'amazon.com' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
 			array(
-				'url'   => 'apple.com',
+				'url'   => array( 'apple.com' ),
 				'icon'  => 'apple',
 				'label' => 'Apple',
 			),
 			array(
-				'url'   => 'itunes.com',
+				'url'   => array( 'itunes.com' ),
 				'icon'  => 'apple',
 				'label' => 'iTunes',
 			),
 			array(
-				'url'   => 'bandcamp.com',
+				'url'   => array( 'bandcamp.com' ),
 				'icon'  => 'bandcamp',
 				'label' => 'Bandcamp',
 			),
 			array(
-				'url'   => 'behance.net',
+				'url'   => array( 'behance.net' ),
 				'icon'  => 'behance',
 				'label' => 'Behance',
 			),
 			array(
-				'url'   => 'codepen.io',
+				'url'   => array( 'codepen.io' ),
 				'icon'  => 'codepen',
 				'label' => 'CodePen',
 			),
 			array(
-				'url'   => 'deviantart.com',
+				'url'   => array( 'deviantart.com' ),
 				'icon'  => 'deviantart',
 				'label' => 'DeviantArt',
 			),
 			array(
-				'url'   => 'digg.com',
+				'url'   => array( 'digg.com' ),
 				'icon'  => 'digg',
 				'label' => 'Digg',
 			),
 			array(
-				'url'   => 'discord.gg',
+				'url'   => array( 'discord.gg' ),
 				'icon'  => 'discord',
 				'label' => 'Discord',
 			),
 			array(
-				'url'   => 'discordapp.com',
+				'url'   => array( 'discordapp.com' ),
 				'icon'  => 'discord',
 				'label' => 'Discord',
 			),
 			array(
-				'url'   => 'dribbble.com',
+				'url'   => array( 'dribbble.com' ),
 				'icon'  => 'dribbble',
 				'label' => 'Dribbble',
 			),
 			array(
-				'url'   => 'dropbox.com',
+				'url'   => array( 'dropbox.com' ),
 				'icon'  => 'dropbox',
 				'label' => 'Dropbox',
 			),
 			array(
-				'url'   => 'etsy.com',
+				'url'   => array( 'etsy.com' ),
 				'icon'  => 'etsy',
 				'label' => 'Etsy',
 			),
 			array(
-				'url'   => 'facebook.com',
+				'url'   => array( 'facebook.com' ),
 				'icon'  => 'facebook',
 				'label' => 'Facebook',
 			),
 			array(
-				'url'   => 'flickr.com',
+				'url'   => array( 'flickr.com' ),
 				'icon'  => 'flickr',
 				'label' => 'Flickr',
 			),
 			array(
-				'url'   => 'foursquare.com',
+				'url'   => array( 'foursquare.com' ),
 				'icon'  => 'foursquare',
 				'label' => 'Foursquare',
 			),
 			array(
-				'url'   => 'goodreads.com',
+				'url'   => array( 'goodreads.com' ),
 				'icon'  => 'goodreads',
 				'label' => 'Goodreads',
 			),
 			array(
-				'url'   => 'google.com',
+				'url'   => array( 'google.com' ),
 				'icon'  => 'google',
 				'label' => 'Google',
 			),
 			array(
-				'url'   => 'github.com',
+				'url'   => array( 'github.com' ),
 				'icon'  => 'github',
 				'label' => 'GitHub',
 			),
 			array(
-				'url'   => 'instagram.com',
+				'url'   => array( 'instagram.com' ),
 				'icon'  => 'instagram',
 				'label' => 'Instagram',
 			),
 			array(
-				'url'   => 'linkedin.com',
+				'url'   => array( 'linkedin.com' ),
 				'icon'  => 'linkedin',
 				'label' => 'LinkedIn',
 			),
 			array(
-				'url'   => 'mailto:',
+				'url'   => array( 'mailto:' ),
 				'icon'  => 'mail',
 				'label' => __( 'Email', 'jetpack' ),
 			),
 			array(
-				'url'   => 'meetup.com',
+				'url'   => array( 'meetup.com' ),
 				'icon'  => 'meetup',
 				'label' => 'Meetup',
 			),
 			array(
-				'url'   => 'medium.com',
+				'url'   => array( 'medium.com' ),
 				'icon'  => 'medium',
 				'label' => 'Medium',
 			),
 			array(
-				'url'   => 'pinterest.',
+				'url'   => array( 'pinterest.' ),
 				'icon'  => 'pinterest',
 				'label' => 'Pinterest',
 			),
 			array(
-				'url'   => 'getpocket.com',
+				'url'   => array( 'getpocket.com' ),
 				'icon'  => 'pocket',
 				'label' => 'Pocket',
 			),
 			array(
-				'url'   => 'reddit.com',
+				'url'   => array( 'reddit.com' ),
 				'icon'  => 'reddit',
 				'label' => 'Reddit',
 			),
 			array(
-				'url'   => 'skype.com',
+				'url'   => array( 'skype.com' ),
 				'icon'  => 'skype',
 				'label' => 'Skype',
 			),
 			array(
-				'url'   => 'skype:',
+				'url'   => array( 'skype:' ),
 				'icon'  => 'skype',
 				'label' => 'Skype',
 			),
 			array(
-				'url'   => 'slideshare.net',
+				'url'   => array( 'slideshare.net' ),
 				'icon'  => 'slideshare',
 				'label' => 'SlideShare',
 			),
 			array(
-				'url'   => 'snapchat.com',
+				'url'   => array( 'snapchat.com' ),
 				'icon'  => 'snapchat',
 				'label' => 'Snapchat',
 			),
 			array(
-				'url'   => 'soundcloud.com',
+				'url'   => array( 'soundcloud.com' ),
 				'icon'  => 'soundcloud',
 				'label' => 'SoundCloud',
 			),
 			array(
-				'url'   => 'spotify.com',
+				'url'   => array( 'spotify.com' ),
 				'icon'  => 'spotify',
 				'label' => 'Spotify',
 			),
 			array(
-				'url'   => 'stackoverflow.com',
+				'url'   => array( 'stackoverflow.com' ),
 				'icon'  => 'stackoverflow',
 				'label' => 'Stack Overflow',
 			),
 			array(
-				'url'   => 'stumbleupon.com',
+				'url'   => array( 'stumbleupon.com' ),
 				'icon'  => 'stumbleupon',
 				'label' => 'StumbleUpon',
 			),
 			array(
-				'url'   => 'tumblr.com',
+				'url'   => array( 'tumblr.com' ),
 				'icon'  => 'tumblr',
 				'label' => 'Tumblr',
 			),
 			array(
-				'url'   => 'twitch.tv',
+				'url'   => array( 'twitch.tv' ),
 				'icon'  => 'twitch',
 				'label' => 'Twitch',
 			),
 			array(
-				'url'   => 'twitter.com',
+				'url'   => array( 'twitter.com' ),
 				'icon'  => 'twitter',
 				'label' => 'Twitter',
 			),
 			array(
-				'url'   => 'vimeo.com',
+				'url'   => array( 'vimeo.com' ),
 				'icon'  => 'vimeo',
 				'label' => 'Vimeo',
 			),
 			array(
-				'url'   => 'vk.com',
+				'url'   => array( 'vk.com' ),
 				'icon'  => 'vk',
 				'label' => 'VK',
 			),
 			array(
-				'url'   => 'wordpress.com',
+				'url'   => array( 'wordpress.com' ),
 				'icon'  => 'wordpress',
 				'label' => 'WordPress.com',
 			),
 			array(
-				'url'   => 'wordpress.org',
+				'url'   => array( 'wordpress.org' ),
 				'icon'  => 'wordpress',
 				'label' => 'WordPress',
 			),
 			array(
-				'url'   => 'yelp.com',
+				'url'   => array( 'yelp.com' ),
 				'icon'  => 'yelp',
 				'label' => 'Yelp',
 			),
 			array(
-				'url'   => 'youtube.com',
+				'url'   => array( 'youtube.com' ),
 				'icon'  => 'youtube',
 				'label' => 'YouTube',
 			),

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -402,52 +402,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => '500px',
 			),
 			array(
-				'url'   => array( 'amazon.cn' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.in' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.fr' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.de' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.it' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.nl' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.es' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.co' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.ca' ),
-				'icon'  => 'amazon',
-				'label' => 'Amazon',
-			),
-			array(
-				'url'   => array( 'amazon.com' ),
+				'url'   => array( 'amazon.cn', 'amazon.in', 'amazon.fr', 'amazon.de', 'amazon.it', 'amazon.nl', 'amazon.es', 'amazon.co', 'amazon.ca', 'amazon.com' ),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
@@ -487,12 +442,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'Digg',
 			),
 			array(
-				'url'   => array( 'discord.gg' ),
-				'icon'  => 'discord',
-				'label' => 'Discord',
-			),
-			array(
-				'url'   => array( 'discordapp.com' ),
+				'url'   => array( 'discord.gg', 'discordapp.com' ),
 				'icon'  => 'discord',
 				'label' => 'Discord',
 			),
@@ -532,7 +482,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'Goodreads',
 			),
 			array(
-				'url'   => array( 'google.com' ),
+				'url'   => array( 'google.com', 'google.co.uk', 'google.ca', 'google.cn', 'google.it' ),
 				'icon'  => 'google',
 				'label' => 'Google',
 			),
@@ -647,12 +597,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'VK',
 			),
 			array(
-				'url'   => array( 'wordpress.com' ),
-				'icon'  => 'wordpress',
-				'label' => 'WordPress.com',
-			),
-			array(
-				'url'   => array( 'wordpress.org' ),
+				'url'   => array( 'wordpress.com', 'wordpress.org' ),
 				'icon'  => 'wordpress',
 				'label' => 'WordPress',
 			),

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -508,17 +508,22 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'Facebook',
 			),
 			array(
-				'url'   => '/feed/',
+				'url'   => '/feed/', // WordPress default feed url
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/feeds/',
+				'url'   => '/feeds/', // Blogspot, and others
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => 'format=RSS',
+				'url'   => '/blog/feed', // No trailing space WordPress feed, could use /feed but may match unexpectedly
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'format=RSS', // Squarespace feed url, and others
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
@@ -527,13 +532,13 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
-            array(
+			array(
 				'url'   => '/.rss', // Yep, Reddit uses this
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/rss.xml',
+				'url'   => '/rss.xml', // Moveable Type, Typepad
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
@@ -558,57 +563,57 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '?feed=rss', // Catches feed=rss / feed=rss2
+				'url'   => '?feed=rss', // WordPress non-permalink - Catches feed=rss / feed=rss2
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '?feed=rdf',
+				'url'   => '?feed=rdf', // WordPress non-permalink
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '?feed=atom',
+				'url'   => '?feed=atom', // WordPress non-permalink
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => 'http://feeds',
+				'url'   => 'http://feeds', // FeedBurner 
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => 'https://feeds',
+				'url'   => 'https://feeds', // FeedBurner 
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/feed.xml',
+				'url'   => '/feed.xml', // Alias used with Feedburner, and others
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/index.xml',
+				'url'   => '/index.xml', // Moveable Type, and others
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/blog/feed',
+				'url'   => '/atom.xml', // Typepad
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/atom.xml',
+				'url'   => '.atom', // Shopify blogs
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '.atom',
+				'url'   => '/atom', // Some non-WordPress feeds
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
-				'url'   => '/atom',
+				'url'   => 'index.rdf', // Typepad
 				'icon'  => 'feed',
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -513,6 +513,106 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
+				'url'   => '/feeds/',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'format=RSS',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/rss', // Used by Tumblr
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+            array(
+				'url'   => '/.rss', // Yep, Reddit uses this
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/rss.xml',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'http://rss',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'https://rss',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'rss=1',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/feed=rss', // Catches feed=rss / feed=rss2
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '?feed=rss', // Catches feed=rss / feed=rss2
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '?feed=rdf',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '?feed=atom',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'http://feeds',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => 'https://feeds',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/feed.xml',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/index.xml',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/blog/feed',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/atom.xml',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '.atom',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
+				'url'   => '/atom',
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
+			),
+			array(
 				'url'   => 'flickr.com',
 				'icon'  => 'flickr',
 				'label' => 'Flickr',

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -137,20 +137,21 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 									$found_icon = false;
 
 								foreach ( $social_icons as $social_icon ) {
-									
-									// All $social_icon['url'] elements are now provided as an array even if there is only one item,
-									// but we'll check if the $social_icon['url'] is an array anyway
-									if ( is_array( $social_icon['url'] ) ) {
-										// If array then we loop over the array to do the stripos match using each array item
-										foreach ( $social_icon['url'] as $url_fragment ) {
-											if ( false !== stripos( $icon['url'], $url_fragment ) ) {
-												echo '<span class="screen-reader-text">' . esc_attr( $social_icon['label'] ) . '</span>';
-												echo $this->get_svg_icon( array( 'icon' => esc_attr( $social_icon['icon'] ) ) );
-												$found_icon = true;
-												break;
-											}
+									foreach ( $social_icon['url'] as $url_fragment ) {
+										if ( false !== stripos( $icon['url'], $url_fragment ) ) {
+											printf(
+												'<span class="screen-reader-text">%1$s</span>%2$s',
+												esc_attr( $social_icon['label'] ),
+												// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+												$this->get_svg_icon(
+													array(
+														'icon' => esc_attr( $social_icon['icon'] ),
+													)
+												)
+											);
+											$found_icon = true;
+											break;
 										}
-										
 									}
 								}
 

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -402,7 +402,18 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => '500px',
 			),
 			array(
-				'url'   => array( 'amazon.cn', 'amazon.in', 'amazon.fr', 'amazon.de', 'amazon.it', 'amazon.nl', 'amazon.es', 'amazon.co', 'amazon.ca', 'amazon.com' ),
+				'url'   => array(
+					'amazon.cn',
+					'amazon.in',
+					'amazon.fr',
+					'amazon.de',
+					'amazon.it',
+					'amazon.nl',
+					'amazon.es',
+					'amazon.co',
+					'amazon.ca',
+					'amazon.com',
+				),
 				'icon'  => 'amazon',
 				'label' => 'Amazon',
 			),
@@ -465,6 +476,34 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'url'   => array( 'facebook.com' ),
 				'icon'  => 'facebook',
 				'label' => 'Facebook',
+			),
+			array(
+				'url'   => array(
+					'/feed/',        // WordPress default feed url.
+					'/feeds/',       // Blogspot and others.
+					'/blog/feed',    // No trailing space WordPress feed, could use /feed but may match unexpectedly.
+					'format=RSS',    // Squarespace and others.
+					'/rss',          // Tumblr.
+					'/.rss',         // Reddit.
+					'/rss.xml',      // Moveable Type, Typepad.
+					'http://rss',
+					'https://rss',
+					'rss=1',
+					'/feed=rss',     // Catches feed=rss / feed=rss2.
+					'?feed=rss',     // WordPress non-permalink - Catches feed=rss / feed=rss2.
+					'?feed=rdf',     // WordPress non-permalink.
+					'?feed=atom',    // WordPress non-permalink.
+					'http://feeds',  // FeedBurner.
+					'https://feeds', // FeedBurner.
+					'/feed.xml',     // Feedburner Alias, and others.
+					'/index.xml',    // Moveable Type, and others.
+					'/atom.xml',     // Typepad, Squarespace.
+					'.atom',         // Shopify blog.
+					'/atom',         // Some non-WordPress feeds.
+					'index.rdf',     // Typepad.
+				),
+				'icon'  => 'feed',
+				'label' => __( 'RSS Feed', 'jetpack' ),
 			),
 			array(
 				'url'   => array( 'flickr.com' ),
@@ -612,43 +651,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'YouTube',
 			),
 		);
-		
-		/*
-		 * There are many possible RSS Feed url formats
-		 * 
-		 * This array of common feed url parameters is used to try and match a variety of feed urls in order to correctly display them as Feeds
-		 */
-		$feed_url_formats = array(
-			'url'   => array(
-				'/feed/', // WordPress default feed url
-				'/feeds/', // Blogspot, and others
-				'/blog/feed', // No trailing space WordPress feed, could use /feed but may match unexpectedly
-				'format=RSS', // Squarespace feed url, and others
-				'/rss', // Used by Tumblr
-				'/.rss', // Yep, Reddit uses this
-				'/rss.xml', // Moveable Type, Typepad
-				'http://rss',
-				'https://rss',
-				'rss=1',
-				'/feed=rss', // Catches feed=rss / feed=rss2
-				'?feed=rss', // WordPress non-permalink - Catches feed=rss / feed=rss2
-				'?feed=rdf', // WordPress non-permalink
-				'?feed=atom', // WordPress non-permalink
-				'http://feeds', // FeedBurner 
-				'https://feeds', // FeedBurner 
-				'/feed.xml', // Alias used with Feedburner, and others
-				'/index.xml', // Moveable Type, and others
-				'/atom.xml', // Typepad, Squarespace
-				'.atom', // Shopify blog
-				'/atom', // Some non-WordPress feeds
-				'index.rdf', // Typepad
-			),
-			'icon'  => 'feed',
-			'label' => __( 'RSS Feed', 'jetpack' ),
-		);
-		
-		// Push the $feed_url_formats onto the main $social_links_icons array
-		array_push( $social_links_icons, $feed_url_formats );
 
 		return $social_links_icons;
 	}

--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -137,11 +137,27 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 									$found_icon = false;
 
 								foreach ( $social_icons as $social_icon ) {
-									if ( false !== stripos( $icon['url'], $social_icon['url'] ) ) {
-										echo '<span class="screen-reader-text">' . esc_attr( $social_icon['label'] ) . '</span>';
-										echo $this->get_svg_icon( array( 'icon' => esc_attr( $social_icon['icon'] ) ) );
-										$found_icon = true;
-										break;
+									
+									// Check if the $social_icon['url'] is an array ('Feed' url is provided as an array of url components)
+									if ( is_array( $social_icon['url'] ) ) {
+										// If array then we loop over the array to do the stripos match using each array item
+										foreach ( $social_icon['url'] as $url_fragment ) {
+											if ( false !== stripos( $icon['url'], $url_fragment ) ) {
+												echo '<span class="screen-reader-text">' . esc_attr( $social_icon['label'] ) . '</span>';
+												echo $this->get_svg_icon( array( 'icon' => esc_attr( $social_icon['icon'] ) ) );
+												$found_icon = true;
+												break;
+											}
+										}
+										
+									} else {
+										// If not array then we can do a regular stripos match using $social_icon['url']
+										if ( false !== stripos( $icon['url'], $social_icon['url'] ) ) {
+											echo '<span class="screen-reader-text">' . esc_attr( $social_icon['label'] ) . '</span>';
+											echo $this->get_svg_icon( array( 'icon' => esc_attr( $social_icon['icon'] ) ) );
+											$found_icon = true;
+											break;
+										}
 									}
 								}
 
@@ -508,116 +524,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'Facebook',
 			),
 			array(
-				'url'   => '/feed/', // WordPress default feed url
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/feeds/', // Blogspot, and others
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/blog/feed', // No trailing space WordPress feed, could use /feed but may match unexpectedly
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'format=RSS', // Squarespace feed url, and others
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/rss', // Used by Tumblr
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/.rss', // Yep, Reddit uses this
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/rss.xml', // Moveable Type, Typepad
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'http://rss',
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'https://rss',
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'rss=1',
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/feed=rss', // Catches feed=rss / feed=rss2
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '?feed=rss', // WordPress non-permalink - Catches feed=rss / feed=rss2
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '?feed=rdf', // WordPress non-permalink
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '?feed=atom', // WordPress non-permalink
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'http://feeds', // FeedBurner 
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'https://feeds', // FeedBurner 
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/feed.xml', // Alias used with Feedburner, and others
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/index.xml', // Moveable Type, and others
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/atom.xml', // Typepad
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '.atom', // Shopify blogs
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => '/atom', // Some non-WordPress feeds
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
-				'url'   => 'index.rdf', // Typepad
-				'icon'  => 'feed',
-				'label' => __( 'RSS Feed', 'jetpack' ),
-			),
-			array(
 				'url'   => 'flickr.com',
 				'icon'  => 'flickr',
 				'label' => 'Flickr',
@@ -768,6 +674,43 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 				'label' => 'YouTube',
 			),
 		);
+		
+		/*
+		 * There are many possible RSS Feed url formats
+		 * 
+		 * This array of common feed url parameters is used to try and match a variety of feed urls in order to correctly display them as Feeds
+		 */
+		$feed_url_formats = array(
+			'url'   => array(
+				'/feed/', // WordPress default feed url
+				'/feeds/', // Blogspot, and others
+				'/blog/feed', // No trailing space WordPress feed, could use /feed but may match unexpectedly
+				'format=RSS', // Squarespace feed url, and others
+				'/rss', // Used by Tumblr
+				'/.rss', // Yep, Reddit uses this
+				'/rss.xml', // Moveable Type, Typepad
+				'http://rss',
+				'https://rss',
+				'rss=1',
+				'/feed=rss', // Catches feed=rss / feed=rss2
+				'?feed=rss', // WordPress non-permalink - Catches feed=rss / feed=rss2
+				'?feed=rdf', // WordPress non-permalink
+				'?feed=atom', // WordPress non-permalink
+				'http://feeds', // FeedBurner 
+				'https://feeds', // FeedBurner 
+				'/feed.xml', // Alias used with Feedburner, and others
+				'/index.xml', // Moveable Type, and others
+				'/atom.xml', // Typepad, Squarespace
+				'.atom', // Shopify blog
+				'/atom', // Some non-WordPress feeds
+				'index.rdf', // Typepad
+			),
+			'icon'  => 'feed',
+			'label' => __( 'RSS Feed', 'jetpack' ),
+		);
+		
+		// Push the $feed_url_formats onto the main $social_links_icons array
+		array_push( $social_links_icons, $feed_url_formats );
 
 		return $social_links_icons;
 	}


### PR DESCRIPTION
As an improvement based on the issue #10662 "Social Icons Widget: allow for alternate feed URLs" this adds some more common feed url components to the get_supported_icons() function. The existing version only matches the existence of "/feed/" in the url being added, as such many other feed URL formats would end up showing with the default link icon instead. Whilst it may still not catch all possible feed url formats it will catch many commonly used formats as well as non-permalink versions of WordPress feeds.

This feature could be tested by beta testers to see if more feed urls are correctly recognised and shown with the RSS feed icon instead of the generic link icon.

Fixes #10662

#### Changes proposed in this Pull Request:
* This PR adds in approximately 20 additional items to an array `$social_links_icons` which is used to match components of any url added to the Social Icons widget, the additions expand upon the existing `/feed/` array item which is intended to show an RSS feed icon if matched. Whilst this works for the standard WordPress permalink feed format it doesn't work for non-permalink WordPress feed urls and also many other common RSS feed url formats.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds features to the `get_supported_icons()` function which matches urls added to the Social Icons widget to specific icons for the URL. This addition provides more items to the `$social_links_icons` array which match other common RSS feed url structures.

#### Testing instructions:
To test this please try adding additional RSS feed urls to the Social Icons widget, the standard WordPress url for `somedomain.com/feed/` is already supported so try some more unusual formats such as those generated by other CMS or blogging platforms. Here are some suggested urls to try:
* http://blogs.adobe.com/jkost/atom.xml
* http://feeds.feedburner.com/clickontyler
* http://daringfireball.net/index.xml
* http://ranchero.com/xml/rss.xml
* http://usefulmac.com/rss
* http://rss.macworld.com/macworld/feeds/main

If these are correctly parsed then you should see an RSS feed icon instead of the default 'chain link' icon.

#### Proposed changelog entry for your changes:
* This improves the likelihood that RSS Feed urls that are added to the Social Icons widget are correctly recognised and displayed using the RSS feed icon rather than the default link icon. 