### PR TITLE
Docker: Don't bind host 3306

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -65,7 +65,6 @@ You can control some of the behavior of Jetpack's Docker configuration with envi
 You can set the following variables on a per-command basis (`PORT_WORDPRESS=8000 yarn docker:up`) or, preferably, in a `./.env` file in Jetpack's root directory.
 
 * `PORT_WORDPRESS`: (default=`80`) The port on your host machine connected to the WordPress container's HTTP server.
-* `PORT_MYSQL`: (default=`3306`) The port on your host machine connected to the MySQL container's MySQL server.
 * `PORT_MAILDEV`: (default=`1080`) The port on your host machine connected to the MailDev container's MailDev HTTP server.
 * `PORT_SMTP`: (default=`25`) The port on your host machine connected to the MailDev container's SMTP server.
 * `PORT_SFTP`: (default=`1022`) The port on your host machine connected to the SFTP container's SFTP server.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     volumes:
       - ./data/mysql:/var/lib/mysql
     restart: always
-    ports:
-      - "${PORT_MYSQL:-3306}:3306"
     env_file:
       - default.env
       - .env


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

3306 is a common port and binding the host's 3306 can cause conflicts
with other docker applications.

Remove the host 3306 binding.

The tradeoff is that you can't access the db directly from the host, you'd need to connect to the container in some way. You won't be able to run `mysql …` commands from the host command line.

#### Testing instructions:

* Boot up the Jetpack docker build with this branch and ensure the WordPress install continues to function as expected.

#### Proposed changelog entry for your changes:
* None
