### PR TITLE
Sync: Ensure we properly compare numbers when querying for object counts

### DIFF
--- a/packages/sync/src/Replicastore.php
+++ b/packages/sync/src/Replicastore.php
@@ -120,11 +120,11 @@ class Replicastore implements Replicastore_Interface {
 			$where = '1=1';
 		}
 
-		if ( null !== $min_id ) {
+		if ( ! empty( $min_id ) ) {
 			$where .= ' AND ID >= ' . intval( $min_id );
 		}
 
-		if ( null !== $max_id ) {
+		if ( ! empty( $max_id ) ) {
 			$where .= ' AND ID <= ' . intval( $max_id );
 		}
 
@@ -301,11 +301,11 @@ class Replicastore implements Replicastore_Interface {
 			$where = '1=1';
 		}
 
-		if ( null !== $min_id ) {
+		if ( ! empty( $min_id ) ) {
 			$where .= ' AND comment_ID >= ' . intval( $min_id );
 		}
 
-		if ( null !== $max_id ) {
+		if ( ! empty( $max_id ) ) {
 			$where .= ' AND comment_ID <= ' . intval( $max_id );
 		}
 
@@ -1450,11 +1450,11 @@ ENDSQL;
 	private function meta_count( $table, $where_sql, $min_id, $max_id ) {
 		global $wpdb;
 
-		if ( null !== $min_id ) {
+		if ( ! empty( $min_id ) ) {
 			$where_sql .= ' AND meta_id >= ' . intval( $min_id );
 		}
 
-		if ( null !== $max_id ) {
+		if ( ! empty( $max_id ) ) {
 			$where_sql .= ' AND meta_id <= ' . intval( $max_id );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes  an issues where checksum queries with no ranges will fail.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changes the logic for finding object counts when a zero-value is specified in the range.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updates an existing part of Jetpack: p7rcWF-14b-p2

#### Testing instructions:


* Use with D31256-code

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
