### PR TITLE
Full Site Editing: add a `is_fse_active` property to the Site object in the REST API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -51,6 +51,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
+		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 	);
 
 	protected static $no_member_fields = array(
@@ -70,6 +71,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_following',
 		'meta',
 		'launch_status',
+		'is_fse_active',
 	);
 
 	protected static $site_options_format = array(
@@ -372,6 +374,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'launch_status' :
 				$response[ $key ] = $this->site->get_launch_status();
+				break;
+			case 'is_fse_active':
+				$response[ $key ] = $this->site->is_fse_active();
 				break;
 		}
 

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -48,6 +48,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
+		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 	);
 
 

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -187,6 +187,17 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return current_user_can( $role );
 	}
 
+	function is_fse_active() {
+		$fse_enabled = is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' );
+		$has_method = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
+		if ( $fse_enabled && $has_method ) {
+			$fse = \A8C\FSE\Full_Site_Editing::get_instance();
+			$slug = get_option( 'stylesheet' );
+			return $fse->is_supported_theme( $slug );
+		}
+		return false;
+	}
+
 	/**
 	 * Post functions
 	 */

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -188,10 +188,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_fse_active() {
-		$fse_enabled = is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' );
-		$has_method = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
+		$fse_enabled = Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' );
+		$has_method  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
 		if ( $fse_enabled && $has_method ) {
-			$fse = \A8C\FSE\Full_Site_Editing::get_instance();
+			$fse  = \A8C\FSE\Full_Site_Editing::get_instance();
 			$slug = get_option( 'stylesheet' );
 			return $fse->is_supported_theme( $slug );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Adding a property to the Site object since 1. the blog-stickers endpoint is only for automattians, and 2. to avoid duplicating theme support logic on the backend and in Calypso

Also introduce the `wpcom_is_full_site_editing_active` function and use it to hide the Customizer menu in wp-admin

Reviewers: #cylon_team, #serenity_team, helpingcat

Reviewed By: #serenity_team, helpingcat

Subscribers: helpingcat

Tags: #touches_jetpack_files

Differential Revision: D31148-code, D31319-code

This commit syncs r194971-wpcom and r195033-wpcom.

#### Testing instructions:

Instructions in https://github.com/Automattic/wp-calypso/pull/35106

also: the Customizer menu link should likewise be hidden under the same circumstance in wp-admin

#### Proposed changelog entry for your changes:
* WordPress.com API: add option to manage Full Site Editing.
