### PR TITLE
Masterbar setting: fix typo

### DIFF
--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -40,7 +40,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						<p>
 							{ __(
 								'The WordPress.com toolbar replaces the default WordPress admin toolbar. ' +
-									'It offers one-click access to notifcations, your WordPress.com ' +
+									'It offers one-click access to notifications, your WordPress.com ' +
 									'profile and your other Jetpack and WordPress.com websites. ' +
 									'You can also catch up on the sites you follow in the Reader.'
 							) }


### PR DESCRIPTION
Fixes typo in masterbar settings.

Kudos @nagpai for spotting at Calypso side https://github.com/Automattic/wp-calypso/pull/35266




#### Changes proposed in this Pull Request:
-

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
-

#### Testing instructions:
Open `/wp-admin/admin.php?page=jetpack#/writing`

<img width="1080" alt="image" src="https://user-images.githubusercontent.com/87168/62758153-3ccd9200-ba86-11e9-916a-7ae94c8a1543.png">


#### Proposed changelog entry for your changes:
-