### PR TITLE
Prevent AMP validation errors from unnecessary code in responsive-videos module extra

### DIFF
--- a/modules/theme-tools/responsive-videos.php
+++ b/modules/theme-tools/responsive-videos.php
@@ -42,6 +42,11 @@ function jetpack_responsive_videos_embed_html( $html ) {
 		return $html;
 	}
 
+	// Short-circuit for AMP responses, since custom scripts are not allowed in AMP and videos are naturally responsive.
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		return $html;
+	}
+
 	// The customizer video widget wraps videos with a class of wp-video
 	// mejs as of 4.9 apparently resizes videos too which causes issues
 	// skip the video if it is wrapped in wp-video.
@@ -76,6 +81,11 @@ function jetpack_responsive_videos_embed_html( $html ) {
  */
 function jetpack_responsive_videos_maybe_wrap_oembed( $html, $url = null ) {
 	if ( empty( $html ) || ! is_string( $html ) || ! $url ) {
+		return $html;
+	}
+
+	// Short-circuit for AMP responses, since custom scripts are not allowed in AMP and videos are naturally responsive.
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		return $html;
 	}
 


### PR DESCRIPTION
The `responsive-videos` module extra can cause an AMP validation error (courtesy @amedina):

![image](https://user-images.githubusercontent.com/134745/62813155-1cb9c500-babe-11e9-87b6-91a2c77af72e.png)

Part of #9730.

#### Changes proposed in this Pull Request:

* Short-circuit logic in responsive-videos when generating AMP pages since AMP does not allow custom scripts and videos are inherently responsive in AMP.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Enhancement to AMP compatibility. See #9730.

#### Testing instructions:

* Install [official AMP plugin](https://wordpress.org/plugins/amp/).
* Activate Twenty Nineteen (or another theme that has `jetpack-responsive-videos` theme support)
* Switch to Standard or Transitional modes.
* Add a YouTube video embed block to post content.
* Click Save Draft.
* No validation error warning notice should appear, and the previous validation errors (above) should be cleared from the Validated URL screen (below).

![image](https://user-images.githubusercontent.com/134745/62813187-4246ce80-babe-11e9-9109-5d5bb5a3e45c.png)

#### Proposed changelog entry for your changes:

* Improve AMP compatibility by preventing unnecessary responsive-videos logic from running.
