### PR TITLE
Add doc for remote debugging in vscode

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -463,7 +463,7 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 
 You'll need:
 
-- [PHP Debug](https://github.com/felixfbecker/vscode-php-debug) plugin installed in VSCode
+- [PHP Debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) plugin installed in VSCode
 - Install "Xdebug Helper" extension for Google Chrome 
 - Install "The easiest Xdebug" extension for Mozilla Firefox.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -500,7 +500,7 @@ You'll need to set up the XDEBUG_CONFIG environment variable to enable remote de
 
     XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1
 
-You will also have to configure the IDE key for the Chrome/ Mozilla extension. In the `php.ini` file, add:
+You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In the `php.ini` file, add:
 
     xdebug.idekey = VSCODE
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -502,11 +502,15 @@ You'll need to set up the `XDEBUG_CONFIG` environment variable to enable remote 
 
 `XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1`
 
-You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In the `php.ini` file, add:
+You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In your `php.ini` file (you'll find that file at `docker/config/php.ini` in the Docker environment), add:
 
 `xdebug.idekey = VSCODE`
 
-Now, in the Xdebug Helper for Chrome, under IDE Key, select 'Other' and add 'VSCODE' as the key, and save.
+Now, in your browser's Xdebug Helper preferences, look for the IDE Key setting:
+
+1. Select 'Other'
+2. Add `VSCODE` as the key.
+3. Save.
 
 ##### Run the debugger
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -458,3 +458,60 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 1. Back in the main configuration window, click 'Apply' then 'Ok'.
 
 1. You can now start a debug session by clicking 'Run -> Debug' in the main menu
+
+#### Remote Debugging with VSCode
+
+You'll need:
+
+- PHP Debug plugin installed in VSCode
+- Xdebug Helper for Google Chrome 
+- The easiest Xdebug for Mozilla Firefox.
+
+#### Set up the Debugging Task
+
+In the debug panel in VSCode, select Add Configuration. Since you have PHP Debug installed, you'll have the option to select "PHP" from the list. This will create a `.vscode` folder in the project root with a `launch.json` file in it.
+
+You will need to supply a pathMappings value to the `launch.json` configuration. This value connects the debugger to the volume in Docker with the Jetpack code. Your `launch.json` file should have this configuration when you're done.
+
+    {
+      "version": "0.2.0",
+      "configurations": [
+        {
+          "name": "Listen for XDebug",
+          "type": "php",
+          "request": "launch",
+          "port": 9000,
+          "pathMappings": {
+            "/var/www/html/wp-content/plugins/jetpack": "${workspaceRoot}"
+          }
+        },
+        {
+          "name": "Launch currently open script",
+          "type": "php",
+          "request": "launch",
+          "program": "${file}",
+          "cwd": "${fileDirname}",
+          "port": 9000
+        }
+      ]
+    }
+
+You'll need to set up the XDEBUG_CONFIG environment variable to enable remote debugging, and set the address and the port that the PHP Xdebug extension will use to connect to the debugger running in VSCode. Add the variable to your `.env` file.
+
+    XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1
+
+You will also have to configure the IDE key for the Chrome/ Mozilla extension. In the `php.ini` file, add:
+
+    xdebug.idekey = VSCODE
+
+Now, in the XDebug Helper for Chrome, under IDE Key, select 'Other' and add 'VSCODE' as the key, and save.
+
+Run the debugger
+
+- Set a break point in a php file, for example in the init() function of class.jetpack.php.
+
+- Select 'Debug' on the browser extension.
+- Click 'play' in VSCode's debug panel
+- Refresh the page at localhost
+
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -464,8 +464,8 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 You'll need:
 
 - [PHP Debug](https://marketplace.visualstudio.com/items?itemName=felixfbecker.php-debug) plugin installed in VSCode
-- Install "Xdebug Helper" extension for Google Chrome 
-- Install "The easiest Xdebug" extension for Mozilla Firefox.
+- If you use Google Chrome, install the [Xdebug Helper](https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en) extension.
+- If you use Firefox, install [Xdebug Helper](https://addons.mozilla.org/en-GB/firefox/addon/xdebug-helper-for-firefox/) add-on.
 
 ##### Set up the Debugging Task
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -500,7 +500,7 @@ You'll need to set up the XDEBUG_CONFIG environment variable to enable remote de
 
     XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1
 
-You will also have to configure the IDE key for the Chrome/ Mozilla extension. In the `php.ini` file, add:
+You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In the `php.ini` file, add:
 
     xdebug.idekey = VSCODE
 
@@ -514,4 +514,4 @@ Run the debugger
 - Click 'play' in VSCode's debug panel
 - Refresh the page at localhost
 
-
+For more context on remote debugging PHP with VSCode, see [this article](https://medium.com/@jasonterando/debugging-with-visual-studio-code-xdebug-and-docker-on-windows-b63a10b0dec).

--- a/docker/README.md
+++ b/docker/README.md
@@ -467,7 +467,7 @@ You'll need:
 - Install "Xdebug Helper" extension for Google Chrome 
 - Install "The easiest Xdebug" extension for Mozilla Firefox.
 
-#### Set up the Debugging Task
+##### Set up the Debugging Task
 
 In the debug panel in VSCode, select Add Configuration. Since you have PHP Debug installed, you'll have the option to select "PHP" from the list. This will create a `.vscode` folder in the project root with a `launch.json` file in it.
 
@@ -498,7 +498,7 @@ You will need to supply a pathMappings value to the `launch.json` configuration.
 	}
 ```
 
-You'll need to set up the XDEBUG_CONFIG environment variable to enable remote debugging, and set the address and the port that the PHP Xdebug extension will use to connect to the debugger running in VSCode. Add the variable to your `.env` file.
+You'll need to set up the `XDEBUG_CONFIG` environment variable to enable remote debugging, and set the address and the port that the PHP Xdebug extension will use to connect to the debugger running in VSCode. Add the variable to your `.env` file.
 
 `XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1`
 
@@ -508,10 +508,9 @@ You [will also have to configure the IDE key](https://github.com/mac-cain13/xdeb
 
 Now, in the Xdebug Helper for Chrome, under IDE Key, select 'Other' and add 'VSCODE' as the key, and save.
 
-Run the debugger
+##### Run the debugger
 
-- Set a break point in a php file, for example in the init() function of class.jetpack.php.
-
+- Set a breakpoint in a php file, for example in the `init()` function of `class.jetpack.php`.
 - Select 'Debug' on the browser extension.
 - Click 'play' in VSCode's debug panel
 - Refresh the page at localhost

--- a/docker/README.md
+++ b/docker/README.md
@@ -500,7 +500,7 @@ You'll need to set up the XDEBUG_CONFIG environment variable to enable remote de
 
     XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1
 
-You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In the `php.ini` file, add:
+You will also have to configure the IDE key for the Chrome/ Mozilla extension. In the `php.ini` file, add:
 
     xdebug.idekey = VSCODE
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -473,36 +473,38 @@ In the debug panel in VSCode, select Add Configuration. Since you have PHP Debug
 
 You will need to supply a pathMappings value to the `launch.json` configuration. This value connects the debugger to the volume in Docker with the Jetpack code. Your `launch.json` file should have this configuration when you're done.
 
-    {
-      "version": "0.2.0",
-      "configurations": [
-        {
-          "name": "Listen for XDebug",
-          "type": "php",
-          "request": "launch",
-          "port": 9000,
-          "pathMappings": {
-            "/var/www/html/wp-content/plugins/jetpack": "${workspaceRoot}"
-          }
-        },
-        {
-          "name": "Launch currently open script",
-          "type": "php",
-          "request": "launch",
-          "program": "${file}",
-          "cwd": "${fileDirname}",
-          "port": 9000
-        }
-      ]
-    }
+```json
+	{
+		"version": "0.2.0",
+		"configurations": [
+			{
+				"name": "Listen for XDebug",
+				"type": "php",
+				"request": "launch",
+				"port": 9000,
+				"pathMappings": {
+					"/var/www/html/wp-content/plugins/jetpack": "${workspaceRoot}"
+				}
+			},
+			{
+				"name": "Launch currently open script",
+				"type": "php",
+				"request": "launch",
+				"program": "${file}",
+				"cwd": "${fileDirname}",
+				"port": 9000
+			}
+		]
+	}
+```
 
 You'll need to set up the XDEBUG_CONFIG environment variable to enable remote debugging, and set the address and the port that the PHP Xdebug extension will use to connect to the debugger running in VSCode. Add the variable to your `.env` file.
 
-    XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1
+`XDEBUG_CONFIG=remote_host=host.docker.internal remote_port=9000 remote_enable=1`
 
 You [will also have to configure the IDE key](https://github.com/mac-cain13/xdebug-helper-for-chrome/issues/89) for the Chrome/ Mozilla extension. In the `php.ini` file, add:
 
-    xdebug.idekey = VSCODE
+`xdebug.idekey = VSCODE`
 
 Now, in the Xdebug Helper for Chrome, under IDE Key, select 'Other' and add 'VSCODE' as the key, and save.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -463,9 +463,9 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 
 You'll need:
 
-- PHP Debug plugin installed in VSCode
-- Xdebug Helper for Google Chrome 
-- The easiest Xdebug for Mozilla Firefox.
+- [PHP Debug](https://github.com/felixfbecker/vscode-php-debug) plugin installed in VSCode
+- Install "Xdebug Helper" extension for Google Chrome 
+- Install "The easiest Xdebug" extension for Mozilla Firefox.
 
 #### Set up the Debugging Task
 
@@ -504,7 +504,7 @@ You [will also have to configure the IDE key](https://github.com/mac-cain13/xdeb
 
     xdebug.idekey = VSCODE
 
-Now, in the XDebug Helper for Chrome, under IDE Key, select 'Other' and add 'VSCODE' as the key, and save.
+Now, in the Xdebug Helper for Chrome, under IDE Key, select 'Other' and add 'VSCODE' as the key, and save.
 
 Run the debugger
 


### PR DESCRIPTION
Fixes #

Related to #13180 

docker/Readme.md

Add documentation for remote debugging in VSCode.