### PR TITLE
REST API: Load theme plugins and functions in post list/count REST endpoints

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-post-counts-v1-1-endpoint.php
@@ -108,6 +108,10 @@ class WPCOM_JSON_API_GET_Post_Counts_V1_1_Endpoint extends WPCOM_JSON_API_Endpoi
 			return $blog_id;
 		}
 
+		if ( ! in_array( $post_type, array( 'post', 'revision', 'page', 'any' ) ) && defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->load_theme_functions();
+		}
+
 		if ( ! post_type_exists( $post_type ) ) {
 			return new WP_Error( 'unknown_post_type', __( 'Unknown post type requested.', 'jetpack' ), 404 );
 		}

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -85,6 +85,12 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			return new WP_Error( 'invalid_number',  'The NUMBER parameter must be less than or equal to 100.', 400 );
 		}
 
+		if ( isset( $args['type'] ) &&
+			   ! in_array( $args['type'], array( 'post', 'revision', 'page', 'any' ) ) &&
+			   defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->load_theme_functions();
+		}
+
 		if ( isset( $args['type'] ) && ! $site->is_post_type_allowed( $args['type'] ) ) {
 			return new WP_Error( 'unknown_post_type', 'Unknown post type', 404 );
 		}
@@ -122,12 +128,6 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			}
 			// clear it (AKA published only) because "any" includes protected
 			$status = array();
-		}
-
-		if ( isset( $args['type'] ) &&
-			   ! in_array( $args['type'], array( 'post', 'revision', 'page', 'any' ) ) &&
-			   defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->load_theme_functions();
 		}
 
 		// let's be explicit about defaulting to 'post'


### PR DESCRIPTION
Syncing a wpcom patch (D31026-code) that fixes Automattic/wp-calypso#15234 where custom post types registered by a theme would not load because `load_theme_functions` is not called (or called too late).

**Proposed changelog entry:**
All the modified code is behind `defined( 'IS_WPCOM' )` check, so there are no observable changes for Jetpack users.