### PR TITLE
Connection: Remove unused initialize() from Manager

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -175,21 +175,6 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
-	 * Initializes all needed hooks and request handlers. Handles API calls, upload
-	 * requests, authentication requests. Also XMLRPC options requests.
-	 * Fallback XMLRPC is also a bridge, but probably can be a class that inherits
-	 * this one. Among other things it should strip existing methods.
-	 *
-	 * @param Array $methods an array of API method names for the Connection to accept and
-	 *                       pass on to existing callables. It's possible to specify whether
-	 *                       each method should be available for unauthenticated calls or not.
-	 * @see Jetpack::__construct
-	 */
-	public function initialize( $methods ) {
-		$methods;
-	}
-
-	/**
 	 * Since a lot of hosts use a hammer approach to "protecting" WordPress sites,
 	 * and just blanket block all requests to /xmlrpc.php, or apply other overly-sensitive
 	 * security/firewall policies, we provide our own alternate XML RPC API endpoint

--- a/packages/connection/src/Manager_Interface.php
+++ b/packages/connection/src/Manager_Interface.php
@@ -18,20 +18,6 @@ namespace Automattic\Jetpack\Connection;
  * to WordPress.com
  */
 interface Manager_Interface {
-
-	/**
-	 * Initializes all needed hooks and request handlers. Handles API calls, upload
-	 * requests, authentication requests. Also XMLRPC options requests.
-	 * Fallback XMLRPC is also a bridge, but probably can be a class that inherits
-	 * this one. Among other things it should strip existing methods.
-	 *
-	 * @param Array $methods an array of API method names for the Connection to accept and
-	 *                       pass on to existing callables. It's possible to specify whether
-	 *                       each method should be available for unauthenticated calls or not.
-	 * @see Jetpack::__construct
-	 */
-	public function initialize( $methods );
-
 	/**
 	 * Returns true if the current site is connected to WordPress.com.
 	 *


### PR DESCRIPTION
As we prepare the connection package for its v1, this PR is cleaning some unused code up. In particular, it takes care of the unused `initialize` method in the connection manager

#### Changes proposed in this Pull Request:
* Remove the unused `initialize` method from the connection manager and its interface

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:

* Start a new JN site (with debug log enabled) with this branch.
* Try to connect it.
* Make sure everything works well and there is nothing in the log.

#### Proposed changelog entry for your changes:
* Remove the unused `initialize` method from the connection manager and its interface
