### PR TITLE
Connection: Implement is_connection_owner in the connection package

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1715,9 +1715,16 @@ class Jetpack {
 		return '';
 	}
 
-	function current_user_is_connection_owner() {
-		$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && get_current_user_id() === $user_token->external_user_id;
+	/**
+	 * Whether the current user is the connection owner.
+	 *
+	 * @deprecated since 7.7
+	 *
+	 * @return bool Whether the current user is the connection owner.
+	 */
+	public function current_user_is_connection_owner() {
+		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::is_connection_owner' );
+		return self::connection()->is_connection_owner();
 	}
 
 	/**

--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -78,7 +78,7 @@ class Jetpack_VideoPress {
 		}
 
 		// Connection owners are allowed to do all the things.
-		if ( $this->is_connection_owner( $user_id ) ) {
+		if ( Jetpack::connection()->is_connection_owner( $user_id ) ) {
 			return true;
 		}
 
@@ -100,15 +100,15 @@ class Jetpack_VideoPress {
 
 	/**
 	 * Returns true if the provided user is the Jetpack connection owner.
+	 *
+	 * @deprecated since 7.7
+	 *
+	 * @param Integer|Boolean $user_id the user identifier. False for current user.
+	 * @return bool Whether the current user is the connection owner.
 	 */
 	public function is_connection_owner( $user_id = false ) {
-		if ( ! $user_id ) {
-			$user_id = get_current_user_id();
-		}
-
-		$user_token = Jetpack_Data::get_access_token( JETPACK_MASTER_USER );
-
-		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
+		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::is_connection_owner' );
+		return Jetpack::connection()->is_connection_owner( $user_id );
 	}
 
 	/**

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -552,13 +552,20 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
-	 * Is the user the connection owner.
+	 * Returns true if the provided user is the Jetpack connection owner.
+	 * If user ID is not specified, the current user will be used.
 	 *
-	 * @param Integer $user_id the user identifier.
-	 * @return Boolean is the user the connection owner?
+	 * @param Integer|Boolean $user_id the user identifier. False for current user.
+	 * @return Boolean True the user the connection owner, false otherwise.
 	 */
-	public function is_connection_owner( $user_id ) {
-		return $user_id;
+	public function is_connection_owner( $user_id = false ) {
+		if ( ! $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		$user_token = $this->get_access_token( JETPACK_MASTER_USER );
+
+		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
 	}
 
 	/**


### PR DESCRIPTION
This PR implements the `is_connection_owner` in the connection package. This method was previously implemented in another class (`Jetpack_VideoPress`) and wasn't yet implemented in the connection package. 

We also update old methods usage to use the new connection manager method, and deprecate these old methods in favor of the new one.

#### Changes proposed in this Pull Request:
* Connection: Implement `is_connection_owner` method.
* VideoPress: Update usage to the new `is_connection_owner` method.
* VideoPress: Deprecate `is_connection_owner` in favor of the new method
* Jetpack: Update usage to the new `is_connection_owner` method the new method.
* Jetpack: Deprecate `current_user_is_connection_owner` in favor of the new method.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Make sure all tests still pass (affected methods don't seem to be in use).

#### Proposed changelog entry for your changes:
* Connection: Implement `is_connection_owner` method.
* VideoPress: Update usage to the new `is_connection_owner` method.
* VideoPress: Deprecate `is_connection_owner` in favor of the new method
* Jetpack: Update usage to the new `is_connection_owner` method the new method.
* Jetpack: Deprecate `current_user_is_connection_owner` in favor of the new method.
