### PR TITLE
Premium blocks: Add plan param to post-checkout redirect URL

### DIFF
--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -93,7 +93,7 @@ export default compose( [
 					{
 						action: 'edit',
 						post: postId,
-						plan: 'updated',
+						plan_upgraded: 1,
 					}
 			  );
 

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -93,6 +93,7 @@ export default compose( [
 					{
 						action: 'edit',
 						post: postId,
+						plan: 'updated',
 					}
 			  );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13003 (partially)

Requires backend diff: https://github.com/Automattic/wp-calypso/pull/35308

Related: https://github.com/Automattic/jetpack/pull/13209

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds a ~`plan`~ `plan_upgraded` URL parameter to the post-checkout redirect url. Effectively this will be passed on redirection from WPCOM once a plan has been upgraded successfully after clicking on the "upgrade nudge".

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes & no. It adds the foundation for showing a notification when the redirection happens after clicking an upgrade nudge.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout the underlying branch.
* Load a non-premium jetpack site.
* Add the "simple payments" block and click on the `upgrade nudge`.
* On redirection back to the editor, confirm that the URL contains the parameter `&plan_upgraded=1`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Doesn't need one I think?
