### PR TITLE
Cast shortcode global to array. Some plugins may unset them completely.

### DIFF
--- a/packages/sync/src/Functions.php
+++ b/packages/sync/src/Functions.php
@@ -33,7 +33,7 @@ class Functions {
 
 	public static function get_shortcodes() {
 		global $shortcode_tags;
-		return array_keys( $shortcode_tags );
+		return array_keys( (array) $shortcode_tags );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

"Fixes" jpop-issue `4209`

I'm not convinced this "should" be fixed within Jetpack itself, but it's a defensive measure against other plugins/themes doing things in a strange way to avoid warnings. 

Copy-pasting my response from there with details about this: 

So Jetpack [assumes](https://github.com/Automattic/jetpack/blob/branch-7.6/packages/sync/src/Functions.php#L34-L37) that the `$shortcode_tags` global is an array, since it is by default in core. 

The SEO Framework plugin, on sitemap output, [unset's the entire global](https://github.com/WPPlugins/autodescription/blob/master/inc/classes/sitemaps.class.php#L226-L234), leaving no empty array. 

So any plugin that relies on any of these globals for the page view of the sitemaps will not get the default value of what they expect. I would open an issue in their repo to see what they say, as I believe it's not the best practice to override defaults as such, but I've also created a defensive Jetpack PR that gets rid of the warning.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Install The SEO Framework plugin 
- Enable their sitemap
- Disable Jetpack's sitemap
- Visit the sitemap as linked in the SEO Framework plugin's settings link
- See no warnings in debug.log 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*NA 
