### PR TITLE
Connection: Implement disconnect_user in the connection package

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\JITM;
 
 /**
@@ -1200,7 +1201,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Unlinks current user from the WordPress.com Servers.
 	 *
 	 * @since 4.3.0
-	 * @uses  Jetpack::unlink_user
+	 * @uses  Automattic\Jetpack\Connection\Manager::disconnect_user
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *
@@ -1212,7 +1213,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'invalid_param', esc_html__( 'Invalid Parameter', 'jetpack' ), array( 'status' => 404 ) );
 		}
 
-		if ( Jetpack::unlink_user() ) {
+		if ( Connection_Manager::disconnect_user() ) {
 			return rest_ensure_response(
 				array(
 					'code' => 'success'

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -3,6 +3,7 @@
 WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Queue;
@@ -227,7 +228,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				) );
 				break;
 			case 'user':
-				if ( Jetpack::unlink_user( $user->ID ) ) {
+				if ( Connection_Manager::disconnect_user( $user->ID ) ) {
 					Jetpack::log( 'unlink', $user->ID );
 					WP_CLI::success( __( 'User has been successfully disconnected.', 'jetpack' ) );
 				} else {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3256,38 +3256,17 @@ p {
 	}
 
 	/**
-	 * Unlinks the current user from the linked WordPress.com user
+	 * Unlinks the current user from the linked WordPress.com user.
+	 *
+	 * @deprecated since 7.7
+	 * @see Automattic\Jetpack\Connection\Manager::disconnect_user()
+	 *
+	 * @param Integer $user_id the user identifier.
+	 * @return Boolean Whether the disconnection of the user was successful.
 	 */
 	public static function unlink_user( $user_id = null ) {
-		if ( ! $tokens = Jetpack_Options::get_option( 'user_tokens' ) )
-			return false;
-
-		$user_id = empty( $user_id ) ? get_current_user_id() : intval( $user_id );
-
-		if ( Jetpack_Options::get_option( 'master_user' ) == $user_id )
-			return false;
-
-		if ( ! isset( $tokens[ $user_id ] ) )
-			return false;
-
-		Jetpack::load_xml_rpc_client();
-		$xml = new Jetpack_IXR_Client( compact( 'user_id' ) );
-		$xml->query( 'jetpack.unlink_user', $user_id );
-
-		unset( $tokens[ $user_id ] );
-
-		Jetpack_Options::update_option( 'user_tokens', $tokens );
-
-		/**
-		 * Fires after the current user has been unlinked from WordPress.com.
-		 *
-		 * @since 4.1.0
-		 *
-		 * @param int $user_id The current user's ID.
-		 */
-		do_action( 'jetpack_unlinked_user', $user_id );
-
-		return true;
+		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::disconnect_user' );
+		return Connection_Manager::disconnect_user( $user_id );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -597,9 +597,9 @@ class Jetpack {
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );
 
-		// Unlink user before deleting the user from .com
-		add_action( 'deleted_user', array( $this, 'unlink_user' ), 10, 1 );
-		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
+		// Unlink user before deleting the user from WP.com.
+		add_action( 'deleted_user', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
+		add_action( 'remove_user_from_blog', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 
 		if ( Jetpack::is_active() ) {
 			Jetpack_Heartbeat::init();
@@ -4052,7 +4052,7 @@ p {
 				$redirect = isset( $_GET['redirect'] ) ? $_GET['redirect'] : '';
 				check_admin_referer( 'jetpack-unlink' );
 				Jetpack::log( 'unlink' );
-				$this->unlink_user();
+				Connection_Manager::disconnect_user();
 				Jetpack::state( 'message', 'unlinked' );
 				if ( 'sub-unlink' == $redirect ) {
 					wp_safe_redirect( admin_url() );

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -794,7 +794,7 @@ class Jetpack_XMLRPC_Server {
 	 */
 	public function unlink_user() {
 		Jetpack::log( 'unlink' );
-		return Jetpack::unlink_user();
+		return Connection_Manager::disconnect_user();
 	}
 
 	/**

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -505,6 +505,8 @@ class Manager implements Manager_Interface {
 	/**
 	 * Get the wpcom user data of the current|specified connected user.
 	 *
+	 * @todo Refactor to properly load the XMLRPC client independently.
+	 *
 	 * @param Integer $user_id the user identifier.
 	 * @return Object the user object.
 	 */
@@ -558,6 +560,8 @@ class Manager implements Manager_Interface {
 	 *
 	 * @access public
 	 * @static
+	 *
+	 * @todo Refactor to properly load the XMLRPC client independently.
 	 *
 	 * @param Integer $user_id the user identifier.
 	 * @return Boolean Whether the disconnection of the user was successful.

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -567,14 +567,14 @@ class Manager implements Manager_Interface {
 	 * @return Boolean Whether the disconnection of the user was successful.
 	 */
 	public static function disconnect_user( $user_id = null ) {
-		$tokens = Jetpack_Options::get_option( 'user_tokens' );
+		$tokens = \Jetpack_Options::get_option( 'user_tokens' );
 		if ( ! $tokens ) {
 			return false;
 		}
 
 		$user_id = empty( $user_id ) ? get_current_user_id() : intval( $user_id );
 
-		if ( Jetpack_Options::get_option( 'master_user' ) === $user_id ) {
+		if ( \Jetpack_Options::get_option( 'master_user' ) === $user_id ) {
 			return false;
 		}
 
@@ -588,7 +588,7 @@ class Manager implements Manager_Interface {
 
 		unset( $tokens[ $user_id ] );
 
-		Jetpack_Options::update_option( 'user_tokens', $tokens );
+		\Jetpack_Options::update_option( 'user_tokens', $tokens );
 
 		/**
 		 * Fires after the current user has been unlinked from WordPress.com.

--- a/packages/connection/src/Manager_Interface.php
+++ b/packages/connection/src/Manager_Interface.php
@@ -51,9 +51,13 @@ interface Manager_Interface {
 	public function is_connection_owner( $user_id );
 
 	/**
-	 * Unlinks the current user from the linked WordPress.com user
+	 * Unlinks the current user from the linked WordPress.com user.
+	 *
+	 * @access public
+	 * @static
 	 *
 	 * @param Integer $user_id the user identifier.
+	 * @return Boolean Whether the disconnection of the user was successful.
 	 */
 	public static function disconnect_user( $user_id );
 


### PR DESCRIPTION
This PR implements the `disconnect_user` in the connection package. This method was previously implemented in the `Jetpack` class and wasn't yet implemented in the connection package.

We also update old method usage to use the new connection manager method, and deprecate the old method in favor of the new one.

#### Changes proposed in this Pull Request:
* Connection: Update docs of `Manager_Interface::disconnect_user`
* Connection: Implement `Manager::disconnect_user()`
* Connection: Deprecate `Jetpack::unlink_user` in favor of the connection package
* Connection: Add todos to refactor XMLRPC client loading
* Connection: Use `Manager::disconnect_user` in Jetpack class
* Connection: Use `Manager::disconnect_user` in Jetpack CLI
* Connection: Use `Manager::disconnect_user` in core REST API endpoints
* Connection: Use `Manager::disconnect_user` in XMLRPC server

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* A secondary user in this context is a user that is connected to WP.com but is not the master user / connection owner.
* Disconnect a secondary user from WP.com and make sure it goes correctly without any errors.
* Disconnect a secondary user from WP admin and make sure it goes correctly without any errors.
* Disconnect a secondary user using WP CLI and make sure it goes correctly without any errors.
* Make sure all tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Implement `Manager::disconnect_user()`
* Connection: Deprecate `Jetpack::unlink_user` in favor of the connection package
* Connection: Use `Manager::disconnect_user` instead of `Jetpack::unlink_user` everywhere.
