### PR TITLE
Connection: Remove unnecessary non-implemented Manager methods

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -563,30 +563,6 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
-	 * Initializes a transport server, whatever it may be, saves into the object property.
-	 * Should be changed to be protected.
-	 */
-	public function initialize_server() {
-
-	}
-
-	/**
-	 * Checks if the current request is properly authenticated, bails if not.
-	 * Should be changed to be protected.
-	 */
-	public function require_authentication() {
-
-	}
-
-	/**
-	 * Verifies the correctness of the request signature.
-	 * Should be changed to be protected.
-	 */
-	public function verify_signature() {
-
-	}
-
-	/**
 	 * Returns the requested Jetpack API URL.
 	 *
 	 * @param String $relative_url the relative API path.

--- a/packages/connection/src/Manager_Interface.php
+++ b/packages/connection/src/Manager_Interface.php
@@ -58,24 +58,6 @@ interface Manager_Interface {
 	public static function disconnect_user( $user_id );
 
 	/**
-	 * Initializes a transport server, whatever it may be, saves into the object property.
-	 * Should be changed to be protected.
-	 */
-	public function initialize_server();
-
-	/**
-	 * Checks if the current request is properly authenticated, bails if not.
-	 * Should be changed to be protected.
-	 */
-	public function require_authentication();
-
-	/**
-	 * Verifies the correctness of the request signature.
-	 * Should be changed to be protected.
-	 */
-	public function verify_signature();
-
-	/**
 	 * Attempts Jetpack registration which sets up the site for connection. Should
 	 * remain public because the call to action comes from the current site, not from
 	 * WordPress.com.


### PR DESCRIPTION
This suggests removing 3 methods from the connection `Manager` and `Manager_Interface` that we don't seem to need:

* `initialize_server` - we seem to be doing the initialization in different places, so this one looks unnecessary.
* `require_authentication` - we already have `require_jetpack_authentication`, so this one could be removed.
* `verify_signature` - we already have `verify_xml_rpc_signature` implemented, and we might want to implement `verify_json_api_authorization_request` too, but this one will end up unused, unless I'm missing something. 

#### Changes proposed in this Pull Request:
* Connection: Remove unused non-implemented methods from connection manager.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Verify the removed methods aren't used.

#### Proposed changelog entry for your changes:
* Connection: Remove unused non-implemented methods from connection manager.
