### PR TITLE
Connection: Port JSON API auth to the connection package

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -799,8 +799,8 @@ class Jetpack_SSO {
 			) );
 
 			if ( $is_json_api_auth ) {
-				Jetpack::init()->verify_json_api_authorization_request( $json_api_auth_environment );
-				Jetpack::init()->store_json_api_authorization_token( $user->user_login, $user );
+				Jetpack::connection()->verify_json_api_authorization_request( $json_api_auth_environment );
+				Jetpack::connection()->store_json_api_authorization_token( $user->user_login, $user );
 
 			} else if ( ! $is_user_connected ) {
 				wp_safe_redirect(


### PR DESCRIPTION
Today I realized that in #12699 we forgot to port the JSON API auth functionality to the connection package 😱 You can see that there's a reference to `$this->login_form_json_api_authorization` in the connection manager, but that method doesn't exist 😕

This PR takes care of porting the methods to the connection package and deprecating the old methods, plus updating any usage. It also uses the chance to fix some PHPCS errors/warnings and add inline docs.

Question: Is this right @mdawaffe @zinigor? Does it feel this should live there? Do you have any other recommendations

#### Changes proposed in this Pull Request:
* Port all the JSON API auth methods to the connection package.
* Deprecate all the `Jetpack::` JSON API methods.
* Update any usage to use the new methods.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* https://developer.wordpress.com/docs/oauth2/
* Can anyone figure out better ways to test this?

#### Proposed changelog entry for your changes:
* Connection: Port JSON API auth to the connection package
