### PR TITLE
DO NOT MERGE: A/B test package playground

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,6 +1,8 @@
 <?php
 include_once( 'class.jetpack-admin-page.php' );
 
+use Automattic\Jetpack\Abtest;
+
 // Builds the landing page and its menu
 class Jetpack_React_Page extends Jetpack_Admin_Page {
 
@@ -219,6 +221,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 		}
 
+		$abtest = new Abtest();
+
 		return array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
 			'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
@@ -294,7 +298,13 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false,
 			'lastPostUrl' => esc_url( $last_post ),
-			'externalServicesConnectUrls' => $this->get_external_services_connect_urls()
+			'externalServicesConnectUrls' => $this->get_external_services_connect_urls(),
+			'abtests' => array(
+				'post_streak_notification' => $abtest->get_variation( 'post_streak_notification' ),
+				'unexisting_test'          => $abtest->get_variation( 'unexisting_test' ),
+				'wrong-abtest-name'        => $abtest->get_variation( 'wrong-abtest-name' ),
+				'example'                  => $abtest->get_variation( null ),
+			),
 		);
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-error": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-roles": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
 	},
 	"require": {
 		"ext-openssl": "*",
+		"automattic/jetpack-abtest": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-logo": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44ae72e6d5f99c2118b037d797886467",
+    "content-hash": "e107ddbf5e4b493a152a728ca84fe70b",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -12,17 +12,28 @@
             "dist": {
                 "type": "path",
                 "url": "./packages/abtest",
-                "reference": "ab5b09dd20ff636b228785d56a04229e53dbe1af",
+                "reference": "b873be98786907a49ac5cd21836167f662212aa0",
                 "shasum": null
             },
             "require": {
-                "automattic/jetpack-connection": "@dev"
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-error": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "Automattic\\Jetpack\\": "src/"
                 }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -195,6 +206,35 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way."
+        },
+        {
+            "name": "automattic/jetpack-error",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "./packages/error",
+                "reference": "1707cf33a92fc66f1635dfe1e4215819101e9bb4",
+                "shasum": null
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack Error - a wrapper around WP_Error."
         },
         {
             "name": "automattic/jetpack-jitm",
@@ -794,6 +834,7 @@
         "automattic/jetpack-options": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-constants": 20,
+        "automattic/jetpack-error": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-roles": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "56dc3d84ef0f2644bbee524c63ee1a4d",
+    "content-hash": "44ae72e6d5f99c2118b037d797886467",
     "packages": [
         {
+            "name": "automattic/jetpack-abtest",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "./packages/abtest",
+                "reference": "ab5b09dd20ff636b228785d56a04229e53dbe1af",
+                "shasum": null
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Provides an interface to the WP.com A/B tests."
+        },
+        {
             "name": "automattic/jetpack-assets",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
@@ -41,7 +64,7 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
@@ -76,7 +99,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -109,7 +132,7 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
@@ -146,7 +169,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -175,7 +198,7 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
@@ -214,7 +237,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -244,7 +267,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -271,7 +294,7 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
@@ -301,7 +324,7 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
@@ -331,7 +354,7 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
@@ -359,7 +382,7 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-update/sync-use-roles-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
@@ -766,6 +789,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-abtest": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-options": 20,
         "automattic/jetpack-logo": 20,

--- a/packages/abtest/README.md
+++ b/packages/abtest/README.md
@@ -1,0 +1,18 @@
+# Jetpack A/B Test
+
+Provides an interface to the WP.com A/B tests.
+
+Used to retrieve the variation of a valid, active A/B test running on WP.com for the current user.
+
+### Usage
+
+Retrieve the A/B test variation of the current user for the `example_abtest_name` A/B test:
+
+```php
+use Automattic\Jetpack\Abtest;
+
+$abtest = new Abtest();
+$variation = $abtest->get_variation( 'example_abtest_name' );
+```
+
+Will return `null` if the A/B test is invalid or is currently inactive.

--- a/packages/abtest/composer.json
+++ b/packages/abtest/composer.json
@@ -1,0 +1,33 @@
+{
+	"name": "automattic/jetpack-abtest",
+	"description": "Provides an interface to the WP.com A/B tests.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-error": "@dev"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
+	},
+	"autoload": {
+		"psr-4": {
+			"Automattic\\Jetpack\\": "src/"
+		}
+	},
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		]
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../*"
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true
+}

--- a/packages/abtest/phpunit.xml.dist
+++ b/packages/abtest/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/packages/abtest/src/Abtest.php
+++ b/packages/abtest/src/Abtest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * A class that interacts with WP.com A/B tests.
+ *
+ * @package automattic/jetpack-abtest
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Error;
+
+/**
+ * This class provides an interface to the WP.com A/B tests.
+ */
+class Abtest {
+	/**
+	 * A variable to hold the tests we fetched, and their variations for the current user.
+	 *
+	 * @access private
+	 *
+	 * @var array
+	 */
+	private $tests = array();
+
+	/**
+	 * Retrieve the test variation for a provided A/B test.
+	 *
+	 * @access public
+	 *
+	 * @param string $test_name Name of the A/B test.
+	 * @return mixed|null A/B test variation, or null on failure.
+	 */
+	public function get_variation( $test_name ) {
+		$variation = $this->fetch_variation( $test_name );
+
+		// If there was an error retrieving a variation, conceal the error for the consumer.
+		if ( is_wp_error( $variation ) ) {
+			return null;
+		}
+
+		return $variation;
+	}
+
+	/**
+	 * Fetch and cache the test variation for a provided A/B test from WP.com.
+	 *
+	 * @access protected
+	 *
+	 * @param string $test_name Name of the A/B test.
+	 * @return mixed|Automattic\Jetpack\Error A/B test variation, or Automattic\Jetpack\Error on failure.
+	 */
+	protected function fetch_variation( $test_name ) {
+		// Make sure test name exists.
+		if ( ! $test_name ) {
+			return new Error( 'test_name_not_provided', 'A/B test name has not been provided.' );
+		}
+
+		// Make sure test name is a valid one.
+		if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $test_name ) ) {
+			return new Error( 'invalid_test_name', 'Invalid A/B test name.' );
+		}
+
+		// Return cached test variations.
+		if ( isset( $this->tests[ $test_name ] ) ) {
+			return $this->tests[ $test_name ];
+		}
+
+		// Make the request to the WP.com API.
+		$response = $this->request_variation( $test_name );
+
+		// Bail if there was an error or malformed response.
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return new Error( 'failed_to_fetch_data', 'Unable to fetch the requested data.' );
+		}
+
+		// Decode the results.
+		$results = json_decode( $response['body'], true );
+
+		// Bail if there were no results or there is no test variation returned.
+		if ( ! is_array( $results ) || empty( $results['variation'] ) ) {
+			return new Error( 'unexpected_data_format', 'Data was not returned in the expected format.' );
+		}
+
+		// Store the variation in our internal cache.
+		$this->tests[ $test_name ] = $results['variation'];
+
+		return $results['variation'];
+	}
+
+	/**
+	 * Perform the request for a variation of a provided A/B test from WP.com.
+	 *
+	 * @access protected
+	 *
+	 * @param string $test_name Name of the A/B test.
+	 * @return mixed|Automattic\Jetpack\Error A/B test variation, or Automattic\Jetpack\Error on failure.
+	 */
+	protected function request_variation( $test_name ) {
+		return Client::wpcom_json_api_request_as_blog( sprintf( '/abtest/%s', $test_name ), '2', array(), null, 'wpcom' );
+	}
+}

--- a/packages/abtest/tests/php/bootstrap.php
+++ b/packages/abtest/tests/php/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/packages/abtest/tests/php/test_Abtest.php
+++ b/packages/abtest/tests/php/test_Abtest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Abtest;
+use PHPUnit\Framework\TestCase;
+use phpmock\Mock;
+use phpmock\MockBuilder;
+
+class Test_Abtest extends TestCase {
+	/**
+	 * Test setup.
+	 */
+	public function setUp() {
+		$this->abtest = $this->getMockBuilder( 'Automattic\\Jetpack\\Abtest' )
+					 ->setMethods( [ 'request_variation' ] )
+					 ->getMock();
+
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( 'is_wp_error' )
+			->setFunction( function( $object ) {
+				return is_a( $object, __NAMESPACE__ . '\\Error' );
+			} );
+		$mock = $builder->build();
+		$mock->enable();
+	}
+
+	/**
+	 * Test teardown.
+	 */
+	public function tearDown() {
+		Mock::disableAll();
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Abtest::get_variation
+	 */
+	public function test_with_no_test_name_provided() {
+		$result = $this->abtest->get_variation( null );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Abtest::get_variation
+	 */
+	public function test_with_incorrect_test_name_provided() {
+		$result = $this->abtest->get_variation( 'example-test' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Abtest::get_variation
+	 */
+	public function test_when_test_inactive_or_does_not_exist() {
+		$this->abtest->expects( $this->once() )
+			 ->method( 'request_variation' )
+			 ->willReturn( [
+				'body' => json_encode( [
+					'code'    => 'incorrect_test_name',
+					'message' => 'This A/B test does not exist or is currently inactive.',
+				] ),
+			] );
+
+		$result = $this->abtest->get_variation( 'example_test' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Abtest::get_variation
+	 */
+	public function test_when_error_or_malformed_response() {
+		$this->abtest->expects( $this->once() )
+			 ->method( 'request_variation' )
+			 ->willReturn( [
+				'status' => 500,
+			] );
+
+		$result = $this->abtest->get_variation( 'some_test' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Abtest::get_variation
+	 */
+	public function test_when_response_in_unexpected_format() {
+		$this->abtest->expects( $this->once() )
+			 ->method( 'request_variation' )
+			 ->willReturn( [
+				'body' => json_encode( [
+					'foo' => 'bar',
+				] ),
+			] );
+
+		$result = $this->abtest->get_variation( 'some_test' );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Abtest::get_variation
+	 */
+	public function test_with_valid_active_test() {
+		$variation = 'original';
+		$this->abtest->expects( $this->once() )
+			 ->method( 'request_variation' )
+			 ->willReturn( [
+				'body' => json_encode( [
+					'variation' => $variation,
+				] ),
+			] );
+
+		$result = $this->abtest->get_variation( 'some_test' );
+		$this->assertEquals( $variation, $result );
+
+		// Try again to verify we're caching the value instead of requesting it with `request_variation()` again.
+		$result = $this->abtest->get_variation( 'some_test' );
+		$this->assertEquals( $variation, $result );
+	}
+}
+
+/**
+ * We're declaring this class to mock Automattic\Jetpack\Error in the tests.
+ */
+class Error {
+
+}


### PR DESCRIPTION
DO NOT MERGE - this is just for testing purposes.

In D31517-code we introduce a new A/B test endpoint on the WP.com side, and in #13226 we are introducing a package to work with it.

This PR contains #13226 and adds a basic usage of the new package (see https://github.com/Automattic/jetpack/commit/58c9662833a70e43413d9d2b9cad55ce77895c73 to see what the actual usage is).

#### Changes proposed in this Pull Request:
* Contains #13226 (can be rebased after it lands).
* Adds example usage of the new `abtest` package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Connect in Place project - See p1HpG7-7nj-p2
* See D31517-code that introduces the new endpoint.
* See #13226 that introduces the new abtest package.

#### Testing instructions:
* Sandbox `public-api.wordpress.com`.
* Apply D31517-code to your WP.com sandbox.
* Checkout this branch.
* Run `composer install`.
* Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard` of your Jetpack site.
* In the browser console, type `Initial_State.abtests`
* Verify you can see what is shown on the following screenshot:

![](https://cldup.com/BTSh_5Dmqi.png)

#### Proposed changelog entry for your changes:
* Not needed, this should not be merged.
