### PR TITLE
Upgrade nudge: Add filter to control block-editor upgrade nudges

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -199,9 +199,7 @@ class Jetpack_Gutenberg {
 		if ( 'missing_plan' === $reason && ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) ) {
 			// The block editor applies an upgrade nudge if `missing_plan` is the reason.
 			// Add a suffix to disable and provide informative reason.
-			if ( 'missing_plan' === $reason ) {
-				$reason .= '__upgrade_disabled';
-			}
+			$reason .= '__nudge_disabled';
 		}
 
 		self::$availability[ self::remove_extension_prefix( $slug ) ] = array(

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -201,7 +201,7 @@ class Jetpack_Gutenberg {
 			 */
 			&& ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
 		) {
-			// The block editor applies an upgrade nudge if `missing_plan` is the reason.
+			// The block editor may apply an upgrade nudge if `missing_plan` is the reason.
 			// Add a descriptive suffix to disable behavior but provide informative reason.
 			$reason .= '__nudge_disabled';
 		}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -188,6 +188,22 @@ class Jetpack_Gutenberg {
 	 * @param array  $details A free-form array containing more information on why the extension is unavailable.
 	 */
 	public static function set_extension_unavailable( $slug, $reason, $details = array() ) {
+		/**
+		 * Filter 'jetpack_block_editor_enable_upgrade_nudge' with `true` to enable or `false`
+		 * to disable paid feature upgrade nudges in the block editor.
+		 *
+		 * @since 7.7.0
+		 *
+		 * @param boolean
+		 */
+		if ( 'missing_plan' === $reason && ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) ) {
+			// The block editor applies an upgrade nudge if `missing_plan` is the reason.
+			// Add a suffix to disable and provide informative reason.
+			if ( 'missing_plan' === $reason ) {
+				$reason .= '__upgrade_disabled';
+			}
+		}
+
 		self::$availability[ self::remove_extension_prefix( $slug ) ] = array(
 			'reason'  => $reason,
 			'details' => $details,

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -188,17 +188,21 @@ class Jetpack_Gutenberg {
 	 * @param array  $details A free-form array containing more information on why the extension is unavailable.
 	 */
 	public static function set_extension_unavailable( $slug, $reason, $details = array() ) {
-		/**
-		 * Filter 'jetpack_block_editor_enable_upgrade_nudge' with `true` to enable or `false`
-		 * to disable paid feature upgrade nudges in the block editor.
-		 *
-		 * @since 7.7.0
-		 *
-		 * @param boolean
-		 */
-		if ( 'missing_plan' === $reason && ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) ) {
+		if (
+			// Extensions that require a plan may be eligible for upgrades.
+			'missing_plan' === $reason
+			/**
+			 * Filter 'jetpack_block_editor_enable_upgrade_nudge' with `true` to enable or `false`
+			 * to disable paid feature upgrade nudges in the block editor.
+			 *
+			 * @since 7.7.0
+			 *
+			 * @param boolean
+			 */
+			&& ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
+		) {
 			// The block editor applies an upgrade nudge if `missing_plan` is the reason.
-			// Add a suffix to disable and provide informative reason.
+			// Add a descriptive suffix to disable behavior but provide informative reason.
 			$reason .= '__nudge_disabled';
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The new `jetpack_block_editor_enable_upgrade_nudge` filter can be used
to enable or disable the feature.

Fixes https://github.com/Automattic/jetpack/issues/13203

#### Testing instructions:
With a site on the free plan, open the editor and try to add a Simple Payments block.

* By default, no nudges are shown and the block is unavailable.
* Use `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );` to enable.
* Use `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_false' );` to disable.

When disabled in development, you'll see a console message like:

> register-jetpack-block.js:65 Block simple-payments couldn't be registered because it is unavailable (missing_plan__nudge_disabled).

When enabled, the upgrade nudge is shown and works as expected.

#### Proposed changelog entry for your changes:

Add filter `jetpack_block_editor_enable_upgrade_nudge` to control upgrade nudges in the block editor.
