### PR TITLE
Fix analyzer crash on function like `$myarray['dim']()`

### DIFF
--- a/packages/analyzer/src/Invocations/Visitor.php
+++ b/packages/analyzer/src/Invocations/Visitor.php
@@ -34,7 +34,7 @@ class Visitor extends NodeVisitorAbstract {
 			if ( $node->name instanceof Node\Expr\Variable ) {
 				$function_name = '$' . Utils::maybe_stringify( $node->name->name );
 			} elseif ( $node->name instanceof Node\Expr\ArrayDimFetch ) {
-				$function_name = '$' . Utils::maybe_stringify( $node->name->var->name ) . '[' . Utils::maybe_stringify( $node->name->dim->name ) . ']';
+				$function_name = '$' . Utils::maybe_stringify( $node->name->var->name ) . '[' . Utils::maybe_stringify( $node->name->dim->value ) . ']';
 			} else {
 				$function_name = implode( '\\', $node->name->parts );
 			}

--- a/packages/analyzer/src/Invocations/Visitor.php
+++ b/packages/analyzer/src/Invocations/Visitor.php
@@ -33,6 +33,8 @@ class Visitor extends NodeVisitorAbstract {
 			// TODO - args
 			if ( $node->name instanceof Node\Expr\Variable ) {
 				$function_name = '$' . Utils::maybe_stringify( $node->name->name );
+			} elseif ( $node->name instanceof Node\Expr\ArrayDimFetch ) {
+				$function_name = '$' . Utils::maybe_stringify( $node->name->var->name ) . '[' . Utils::maybe_stringify( $node->name->dim->name ) . ']';
 			} else {
 				$function_name = implode( '\\', $node->name->parts );
 			}

--- a/packages/analyzer/src/Utils.php
+++ b/packages/analyzer/src/Utils.php
@@ -57,7 +57,7 @@ class Utils {
 			}
 		}
 
-		if ( $class_name  === '\\self' && ! is_null( $class_for_self ) ) {
+		if ( $class_name === '\\self' && ! is_null( $class_for_self ) ) {
 			$class_name = $class_for_self;
 		}
 
@@ -75,6 +75,10 @@ class Utils {
 
 		if ( $is_stringifiable ) {
 			return (string) $object;
+		}
+
+		if ( is_null( $object ) ) {
+			return '';
 		}
 
 		// Objects that need additional recursion to properly stringify


### PR DESCRIPTION
Fixes an issue analyzing invocations on array members, like this:

`$myarray['field']()`

#### Testing instructions:

This issue arose running analysis on a private repo, so I can't give complete instructions to repro here. However, finding invocations on any code with the syntactic structure shown above should trigger the following error on master:

```
Warning: implode(): Invalid arguments passed in /some-path/jetpack-analyzer/src/Invocations/Visitor.php on line 40
```

This patch should make that error go away.

