### PR TITLE
Connection: adds a new `is_registered()` method

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -51,7 +51,6 @@ class Jetpack_Provision { //phpcs:ignore
 			);
 		}
 
-		$connection = new Connection();
 
 		if ( ! $connection->is_registered() || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// This code mostly copied from Jetpack::admin_page_load.

--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Actions;
+use Automattic\Jetpack\Connection\Manager as Connection;
 
 class Jetpack_Provision { //phpcs:ignore
 
@@ -51,10 +52,9 @@ class Jetpack_Provision { //phpcs:ignore
 			);
 		}
 
-		$blog_id    = Jetpack_Options::get_option( 'id' );
-		$blog_token = Jetpack_Data::get_access_token();
+		$connection = new Connection();
 
-		if ( ! $blog_id || ! $blog_token || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
+		if ( ! $connection->is_registered() || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// This code mostly copied from Jetpack::admin_page_load.
 			Jetpack::maybe_set_version_option();
 			$registered = Jetpack::try_registration();

--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -52,7 +52,7 @@ class Jetpack_Provision { //phpcs:ignore
 		}
 
 
-		if ( ! $connection->is_registered() || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
+		if ( ! Jetpack::connection()->is_registered() || ( isset( $named_args['force_register'] ) && intval( $named_args['force_register'] ) ) ) {
 			// This code mostly copied from Jetpack::admin_page_load.
 			Jetpack::maybe_set_version_option();
 			$registered = Jetpack::try_registration();

--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -3,7 +3,6 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Actions;
-use Automattic\Jetpack\Connection\Manager as Connection;
 
 class Jetpack_Provision { //phpcs:ignore
 

--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -61,9 +61,6 @@ class Jetpack_Provision { //phpcs:ignore
 			} elseif ( ! $registered ) {
 				return new WP_Error( 'registration_error', __( 'There was an unspecified error registering the site', 'jetpack' ) );
 			}
-
-			$blog_id    = Jetpack_Options::get_option( 'id' );
-			$blog_token = Jetpack_Data::get_access_token();
 		}
 
 		// If the user isn't specified, but we have a current master user, then set that to current user.

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -874,7 +874,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'isActive'     => Jetpack::is_active(),
 				'isStaging'    => Jetpack::is_staging_site(),
 				'isRegistered' => Jetpack::connection()->is_registered(),
-				'devMode'   => array(
+				'devMode'      => array(
 					'isActive' => Jetpack::is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1,7 +1,6 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager as Connection;
 use Automattic\Jetpack\JITM;
 
 /**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -872,7 +872,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function jetpack_connection_status() {
 		return rest_ensure_response( array(
 				'isActive'  => Jetpack::is_active(),
-				'isStaging' => Jetpack::is_staging_site(),
+				'isStaging'    => Jetpack::is_staging_site(),
 				'isRegistered' => Jetpack::connection()->is_registered(),
 				'devMode'   => array(
 					'isActive' => Jetpack::is_development_mode(),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -874,7 +874,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		return rest_ensure_response( array(
 				'isActive'  => Jetpack::is_active(),
 				'isStaging' => Jetpack::is_staging_site(),
-				'isRegistered' => $connection->is_registered(),
+				'isRegistered' => Jetpack::connection()->is_registered(),
 				'devMode'   => array(
 					'isActive' => Jetpack::is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection;
 use Automattic\Jetpack\JITM;
 
 /**
@@ -870,9 +871,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool True if site is connected
 	 */
 	public static function jetpack_connection_status() {
+		$connection = new Connection();
 		return rest_ensure_response( array(
 				'isActive'  => Jetpack::is_active(),
 				'isStaging' => Jetpack::is_staging_site(),
+				'isRegistered' => $connection->is_registered(),
 				'devMode'   => array(
 					'isActive' => Jetpack::is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -871,7 +871,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool True if site is connected
 	 */
 	public static function jetpack_connection_status() {
-		$connection = new Connection();
 		return rest_ensure_response( array(
 				'isActive'  => Jetpack::is_active(),
 				'isStaging' => Jetpack::is_staging_site(),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -871,7 +871,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function jetpack_connection_status() {
 		return rest_ensure_response( array(
-				'isActive'  => Jetpack::is_active(),
+				'isActive'     => Jetpack::is_active(),
 				'isStaging'    => Jetpack::is_staging_site(),
 				'isRegistered' => Jetpack::connection()->is_registered(),
 				'devMode'   => array(

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -487,6 +487,19 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
+	 * Returns true if the site has both a token and a blog id, which indicates a site has been registered.
+	 *
+	 * @access public
+	 *
+	 * @return bool
+	 */
+	public function is_registered() {
+		$blog_id   = \Jetpack_Options::get_option( 'id' );
+		$has_token = $this->is_active();
+		return $blog_id && $has_token;
+	}
+
+	/**
 	 * Returns true if the user with the specified identifier is connected to
 	 * WordPress.com.
 	 *

--- a/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -203,6 +203,9 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		$data     = $response->get_data();
 		$schema   = $data['schema'];
 
+		print_r( 'lezama ' );
+		print_r( $data );
+
 		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
 		$this->assertArrayHasKey( 'meta', $schema['properties'] );
 		$this->assertArrayHasKey( 'jetpack_publicize_message', $schema['properties']['meta']['properties'] );
@@ -212,6 +215,10 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		$request  = wp_rest_request( 'OPTIONS', '/wp/v2/example-with' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
+
+		print_r( 'lezama ' );
+		print_r( $data );
+
 		$schema   = $data['schema'];
 
 		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );

--- a/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -203,9 +203,6 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		$data     = $response->get_data();
 		$schema   = $data['schema'];
 
-		print_r( 'lezama ' );
-		print_r( $data );
-
 		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
 		$this->assertArrayHasKey( 'meta', $schema['properties'] );
 		$this->assertArrayHasKey( 'jetpack_publicize_message', $schema['properties']['meta']['properties'] );
@@ -215,9 +212,6 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		$request  = wp_rest_request( 'OPTIONS', '/wp/v2/example-with' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
-
-		print_r( 'lezama ' );
-		print_r( $data );
 
 		$schema   = $data['schema'];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes it so various parts of the code base can see if the current site has
been registered ( has an ID and a token ).

This is part of an effort of breaking #13112 into smaller bits.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new `is_registered()` method to the Connection Manager in the connection package
* refactors the Provision API to use the new method
* refactors the jetpack_connection_status API method to use the new method

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Enhances existing features.

#### Testing instructions:
* need to test the Provision flow ( ask for help from @ebinnion maybe )
* need to test the `jetpack_connection_status` ( ask for help from @zinigor maybe )

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
