### PR TITLE
JSON API: Don't set `WP_Query`'s `search` parameter if the search string is empty

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-endpoint.php
@@ -153,7 +153,7 @@ class WPCOM_JSON_API_List_Posts_Endpoint extends WPCOM_JSON_API_Post_Endpoint {
 			'post_status'    => $status,
 			'post_parent'    => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
 			'author'         => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
-			's'              => isset( $args['search'] ) ? $args['search'] : null,
+			's'              => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
 			'fields'         => 'ids',
 		);
 

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -162,7 +162,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			'post_status'    => $status,
 			'post_parent'    => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
 			'author'         => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
-			's'              => isset( $args['search'] ) ? $args['search'] : null,
+			's'              => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
 			'fields'         => 'ids',
 		);
 

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -155,7 +155,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 			'post_status'    => $status,
 			'post_parent'    => isset( $args['parent_id'] ) ? $args['parent_id'] : null,
 			'author'         => isset( $args['author'] ) && 0 < $args['author'] ? $args['author'] : null,
-			's'              => isset( $args['search'] ) ? $args['search'] : null,
+			's'              => isset( $args['search'] ) && '' !== $args['search'] ? $args['search'] : null,
 			'fields'         => 'ids',
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Setting `WP_Query`'s `search` parameter can cause conflicts with other plugins since WordPress will set `->is_search` to true even if it's empty.

https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/class-wp-query.php#L811-L813

These requests with empty search strings are used in Calypso.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: bug fix.

#### Testing instructions:
1. Install and Activate [Search Everything](https://wordpress.org/plugins/search-everything/).
2. `curl -is 'https://public-api.wordpress.com/rest/v1.1/sites/YOUR_SITE/posts/`. See your posts.
3. `curl -is 'https://public-api.wordpress.com/rest/v1.1/sites/YOUR_SITE/posts/?search=`.

Prior to this patch, see no posts. With this patch, see the expected posts.

#### Proposed changelog entry for your changes:
Improved compatibility with plugins that alter the behavior of search queries.