### PR TITLE
Recurring Payments: Use UpgradeNudge

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -146,30 +146,8 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
 	 */
 	public function get_status() {
-		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-			require_lib( 'memberships' );
-			$blog_id = get_current_blog_id();
-			return (array) get_memberships_settings_for_site( $blog_id );
-		} else {
-			$blog_id  = Jetpack_Options::get_option( 'id' );
-			$response = Client::wpcom_json_api_request_as_user(
-				"/sites/$blog_id/{$this->rest_base}/status",
-				'v2',
-				array(),
-				null
-			);
-			if ( is_wp_error( $response ) ) {
-				if ( $response->get_error_code() === 'missing_token' ) {
-					return new WP_Error( 'missing_token', __( 'Please connect your user account to WordPress.com', 'jetpack' ), 404 );
-				}
-				return new WP_Error( 'wpcom_connection_error', __( 'Could not connect to WordPress.com', 'jetpack' ), 404 );
-			}
-			$data = isset( $response['body'] ) ? json_decode( $response['body'], true ) : null;
-			if ( 200 !== $response['response']['code'] && $data['code'] && $data['message'] ) {
-				return new WP_Error( $data['code'], $data['message'], 401 );
-			}
-			return $data;
-		}
+		require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
+		return Jetpack_Memberships::get_connection_status( $this->rest_base );
 	}
 }
 

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -146,8 +146,30 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
 	 */
 	public function get_status() {
-		require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-		return Jetpack_Memberships::get_connection_status( $this->rest_base );
+		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+			require_lib( 'memberships' );
+			$blog_id = get_current_blog_id();
+			return (array) get_memberships_settings_for_site( $blog_id );
+		} else {
+			$blog_id  = Jetpack_Options::get_option( 'id' );
+			$response = Client::wpcom_json_api_request_as_user(
+				"/sites/$blog_id/{$this->rest_base}/status",
+				'v2',
+				array(),
+				null
+			);
+			if ( is_wp_error( $response ) ) {
+				if ( $response->get_error_code() === 'missing_token' ) {
+					return new WP_Error( 'missing_token', __( 'Please connect your user account to WordPress.com', 'jetpack' ), 404 );
+				}
+				return new WP_Error( 'wpcom_connection_error', __( 'Could not connect to WordPress.com', 'jetpack' ), 404 );
+			}
+			$data = isset( $response['body'] ) ? json_decode( $response['body'], true ) : null;
+			if ( 200 !== $response['response']['code'] && $data['code'] && $data['message'] ) {
+				return new WP_Error( $data['code'], $data['message'], 401 );
+			}
+			return $data;
+		}
 	}
 }
 

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -144,6 +144,7 @@ class Jetpack_Plan {
 
 		if ( in_array( $plan['product_slug'], $premium_plans, true ) ) {
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$supports[]    = 'simple-payments';
 			$supports[]    = 'vaultpress';
 			$supports[]    = 'videopress';
@@ -165,6 +166,7 @@ class Jetpack_Plan {
 
 		if ( in_array( $plan['product_slug'], $business_plans, true ) ) {
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$supports[]    = 'simple-payments';
 			$supports[]    = 'vaultpress';
 			$supports[]    = 'videopress';

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -130,6 +130,7 @@ class Jetpack_Plan {
 		if ( in_array( $plan['product_slug'], $personal_plans, true ) ) {
 			// special support value, not a module but a separate plugin.
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$plan['class'] = 'personal';
 		}
 

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -355,28 +355,6 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
-				{ this.state.shouldUpgrade && (
-					<div className="wp-block-jetpack-recurring-payments">
-						<Placeholder
-							icon={ <BlockIcon icon={ icon } /> }
-							label={ __( 'Recurring Payments', 'jetpack' ) }
-							notices={ notices }
-						>
-							<div className="components-placeholder__instructions">
-								<p>
-									{ __(
-										"You'll need to upgrade your plan to use the Recurring Payments button.",
-										'jetpack'
-									) }
-								</p>
-								<Button isDefault isLarge href={ this.state.upgradeURL } target="_blank">
-									{ __( 'Upgrade Your Plan', 'jetpack' ) }
-								</Button>
-								{ this.renderDisclaimer() }
-							</div>
-						</Placeholder>
-					</div>
-				) }
 				{ ( connected === API_STATE_LOADING ||
 					this.state.addingMembershipAmount === PRODUCT_FORM_SUBMITTED ) &&
 					! this.props.attributes.planId && (

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -42,7 +42,6 @@ class MembershipsButtonEdit extends Component {
 			connected: API_STATE_LOADING,
 			connectURL: null,
 			addingMembershipAmount: PRODUCT_NOT_ADDING,
-			shouldUpgrade: false,
 			upgradeURL: '',
 			products: [],
 			siteSlug: '',
@@ -84,14 +83,13 @@ class MembershipsButtonEdit extends Component {
 				const {
 					connect_url: connectURL,
 					products,
-					should_upgrade_to_access_memberships: shouldUpgrade,
 					upgrade_url: upgradeURL,
 					site_slug: siteSlug,
 				} = result;
 				const connected = result.connected_account_id
 					? API_STATE_CONNECTED
 					: API_STATE_NOTCONNECTED;
-				this.setState( { connected, connectURL, products, shouldUpgrade, upgradeURL, siteSlug } );
+				this.setState( { connected, connectURL, products, upgradeURL, siteSlug } );
 			},
 			result => {
 				const connectURL = null;
@@ -362,36 +360,33 @@ class MembershipsButtonEdit extends Component {
 							<Spinner />
 						</Placeholder>
 					) }
-				{ ! this.state.shouldUpgrade &&
-					! this.props.attributes.planId &&
-					connected === API_STATE_NOTCONNECTED && (
-						<div className="wp-block-jetpack-recurring-payments">
-							<Placeholder
-								icon={ <BlockIcon icon={ icon } /> }
-								label={ __( 'Recurring Payments', 'jetpack' ) }
-								notices={ notices }
-							>
-								<div className="components-placeholder__instructions">
-									<p>
-										{ __(
-											'In order to start selling Recurring Payments plans, you have to connect to Stripe:',
-											'jetpack'
-										) }
-									</p>
-									<Button isDefault isLarge href={ connectURL } target="_blank">
-										{ __( 'Connect to Stripe or set up an account', 'jetpack' ) }
-									</Button>
-									<br />
-									<Button isLink onClick={ this.apiCall }>
-										{ __( 'Re-check Connection', 'jetpack' ) }
-									</Button>
-									{ this.renderDisclaimer() }
-								</div>
-							</Placeholder>
-						</div>
-					) }
-				{ ! this.state.shouldUpgrade &&
-					! this.props.attributes.planId &&
+				{ ! this.props.attributes.planId && connected === API_STATE_NOTCONNECTED && (
+					<div className="wp-block-jetpack-recurring-payments">
+						<Placeholder
+							icon={ <BlockIcon icon={ icon } /> }
+							label={ __( 'Recurring Payments', 'jetpack' ) }
+							notices={ notices }
+						>
+							<div className="components-placeholder__instructions">
+								<p>
+									{ __(
+										'In order to start selling Recurring Payments plans, you have to connect to Stripe:',
+										'jetpack'
+									) }
+								</p>
+								<Button isDefault isLarge href={ connectURL } target="_blank">
+									{ __( 'Connect to Stripe or set up an account', 'jetpack' ) }
+								</Button>
+								<br />
+								<Button isLink onClick={ this.apiCall }>
+									{ __( 'Re-check Connection', 'jetpack' ) }
+								</Button>
+								{ this.renderDisclaimer() }
+							</div>
+						</Placeholder>
+					</div>
+				) }
+				{ ! this.props.attributes.planId &&
 					connected === API_STATE_CONNECTED &&
 					products.length === 0 && (
 						<div className="wp-block-jetpack-recurring-payments">
@@ -408,8 +403,7 @@ class MembershipsButtonEdit extends Component {
 							</Placeholder>
 						</div>
 					) }
-				{ ! this.state.shouldUpgrade &&
-					! this.props.attributes.planId &&
+				{ ! this.props.attributes.planId &&
 					this.state.addingMembershipAmount !== PRODUCT_FORM_SUBMITTED &&
 					connected === API_STATE_CONNECTED &&
 					products.length > 0 && (

--- a/extensions/blocks/recurring-payments/recurring-payments.php
+++ b/extensions/blocks/recurring-payments/recurring-payments.php
@@ -9,11 +9,5 @@
 
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-
-	jetpack_register_block(
-		'jetpack/recurring-payments',
-		array(
-			'render_callback' => array( Jetpack_Memberships::get_instance(), 'render_button' ),
-		)
-	);
+	Jetpack_Memberships::get_instance();
 }

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -341,14 +341,16 @@ class Jetpack_Memberships {
 	 * Register the Recurring Payments Gutenberg block
 	 */
 	public function register_gutenberg_block() {
-		if ( self::is_enabled_jetpack_recurring_payments() ) {
+		$is_enabled = self::is_enabled_jetpack_recurring_payments();
+
+		if ( true === $is_enabled ) {
 			jetpack_register_block(
 				'jetpack/recurring-payments',
 				array(
 					'render_callback' => array( $this, 'render_button' ),
 				)
 			);
-		} else {
+		} elseif ( false === $is_enabled ) {
 			Jetpack_Gutenberg::set_extension_unavailable(
 				'jetpack/recurring-payments',
 				'missing_plan',
@@ -356,6 +358,12 @@ class Jetpack_Memberships {
 					'required_feature' => 'memberships',
 					'required_plan'    => self::$required_plan,
 				)
+			);
+		} else { // $is_enabled is a WP_Error object.
+			Jetpack_Gutenberg::set_extension_unavailable(
+				'jetpack/recurring-payments',
+				'other_error',
+				$is_enabled
 			);
 		}
 	}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -6,8 +6,6 @@
  * @since      7.3.0
  */
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class Jetpack_Memberships
  * This class represents the Memberships functionality.
@@ -288,40 +286,6 @@ class Jetpack_Memberships {
 	 */
 	public static function get_connected_account_id() {
 		return get_option( self::$connected_account_id_option_name );
-	}
-
-	/**
-	 * Get a status of connection for the site. If this is Jetpack, pass the request to wpcom.
-	 *
-	 * @param string $rest_base - The REST API route base for requesting connection status on wpcom.
-	 *
-	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
-	 */
-	public static function get_connection_status( $rest_base = 'memberships' ) {
-		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-			require_lib( 'memberships' );
-			$blog_id = get_current_blog_id();
-			return (array) get_memberships_settings_for_site( $blog_id );
-		} else {
-			$blog_id  = Jetpack_Options::get_option( 'id' );
-			$response = Client::wpcom_json_api_request_as_user(
-				"/sites/$blog_id/{$rest_base}/status",
-				'v2',
-				array(),
-				null
-			);
-			if ( is_wp_error( $response ) ) {
-				if ( $response->get_error_code() === 'missing_token' ) {
-					return new WP_Error( 'missing_token', __( 'Please connect your user account to WordPress.com', 'jetpack' ), 404 );
-				}
-				return new WP_Error( 'wpcom_connection_error', __( 'Could not connect to WordPress.com', 'jetpack' ), 404 );
-			}
-			$data = isset( $response['body'] ) ? json_decode( $response['body'], true ) : null;
-			if ( 200 !== $response['response']['code'] && $data['code'] && $data['message'] ) {
-				return new WP_Error( $data['code'], $data['message'], 401 );
-			}
-			return $data;
-		}
 	}
 
 	/**

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -48,7 +48,7 @@ class Jetpack_Memberships {
 	 *
 	 * @var Jetpack_Memberships
 	 */
-	protected static $required_plan;
+	private static $required_plan;
 
 	/**
 	 * Classic singleton pattern

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -6,6 +6,8 @@
  * @since      7.3.0
  */
 
+use Automattic\Jetpack\Connection\Client;
+
 /**
  * Class Jetpack_Memberships
  * This class represents the Memberships functionality.
@@ -276,6 +278,40 @@ class Jetpack_Memberships {
 	 */
 	public static function get_connected_account_id() {
 		return get_option( self::$connected_account_id_option_name );
+	}
+
+	/**
+	 * Get a status of connection for the site. If this is Jetpack, pass the request to wpcom.
+	 *
+	 * @param string $rest_base - The REST API route base for requesting connection status on wpcom.
+	 *
+	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
+	 */
+	public static function get_connection_status( $rest_base = 'memberships' ) {
+		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+			require_lib( 'memberships' );
+			$blog_id = get_current_blog_id();
+			return (array) get_memberships_settings_for_site( $blog_id );
+		} else {
+			$blog_id  = Jetpack_Options::get_option( 'id' );
+			$response = Client::wpcom_json_api_request_as_user(
+				"/sites/$blog_id/{$rest_base}/status",
+				'v2',
+				array(),
+				null
+			);
+			if ( is_wp_error( $response ) ) {
+				if ( $response->get_error_code() === 'missing_token' ) {
+					return new WP_Error( 'missing_token', __( 'Please connect your user account to WordPress.com', 'jetpack' ), 404 );
+				}
+				return new WP_Error( 'wpcom_connection_error', __( 'Could not connect to WordPress.com', 'jetpack' ), 404 );
+			}
+			$data = isset( $response['body'] ) ? json_decode( $response['body'], true ) : null;
+			if ( 200 !== $response['response']['code'] && $data['code'] && $data['message'] ) {
+				return new WP_Error( $data['code'], $data['message'], 401 );
+			}
+			return $data;
+		}
 	}
 }
 Jetpack_Memberships::get_instance();

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -290,7 +290,7 @@ class Jetpack_Memberships {
 	}
 
 	/**
-	 * Whether Memberships (aka Recurring Payments) are enabled.
+	 * Whether Recurring Payments are enabled.
 	 *
 	 * @return bool
 	 */

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -71,7 +71,8 @@ class Jetpack_Memberships {
 		if ( ! self::$instance ) {
 			self::$instance = new self();
 			self::$instance->register_init_hook();
-			self::$required_plan = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'value_bundle' : 'jetpack_premium';
+			// Yes, `personal-bundle` with a dash, `jetpack_personal` with an underscore. Check the v1.5 endpoint to verify.
+			self::$required_plan = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'personal-bundle' : 'jetpack_personal';
 		}
 
 		return self::$instance;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add an UpgradeNudge to the Recurring Payments block to replace UI that's currently part of the block itself.

Step 1 for the the Recurring Payments block project. Next steps will include adding a nudge for connecting to Stripe, and improvements to the overall flow.

#### Caveat

We're planning to remove the upgrade nudge from Jetpack for the next release (see #13203 and #13228). However, this would mean that per this PR, the Recurring Payments block would be hidden altogether for users on a Free Plan. Our options (AFAICS):

1. Add back the in-block instructions, and some logic to determine whether to display those, or the Nudge. (Have the individual block check for whatever #13228 does.)
1. Finish work on D31489-code, and enable the Nudge for the next JP release.

####  Screenshots

##### Before

![image](https://user-images.githubusercontent.com/96308/63064516-c4d9ee80-bf01-11e9-870d-7fd844dd7b17.png)

##### After

![image](https://user-images.githubusercontent.com/96308/63064370-0fa73680-bf01-11e9-9370-8a57ec213947.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Nah.

#### Testing instructions:

- Switch to this branch locally, build Jetpack (`yarn build`), and start Docker (`yarn docker:up`)
- Make sure you're connected to WP.com, and on a free plan
- Start a new post, and insert the 'Recurring Payments' block
- Click the nudge's "Upgrade" CTA button
- Pay for the premium plan
- Verify that you're redirected back to where you came from (the wp-admin block editor) (without any intermediate redirects on WP.com)

#### Proposed changelog entry for your changes:

Add an UpgradeNudge to the Recurring Payments block to replace UI that's currently part of the block itself.