### PR TITLE
Connection: Move out the JSON API auth hooking

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -602,6 +602,8 @@ class Jetpack {
 		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
 
 		if ( Jetpack::is_active() ) {
+			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );
+
 			Jetpack_Heartbeat::init();
 			if ( Jetpack::is_module_active( 'stats' ) && Jetpack::is_module_active( 'search' ) ) {
 				require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.jetpack-search-performance-logger.php';

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -73,7 +73,6 @@ class Manager implements Manager_Interface {
 		}
 
 		if ( $this->is_active() ) {
-			add_action( 'login_form_jetpack_json_api_authorization', array( &$this, 'login_form_json_api_authorization' ) );
 			add_filter( 'xmlrpc_methods', array( $this, 'public_xmlrpc_methods' ) );
 		} else {
 			add_action( 'rest_api_init', array( $this, 'initialize_rest_api_registration_connector' ) );


### PR DESCRIPTION
In #12699 we forgot to port the JSON API auth functionality to the connection package 😱 You can see that there's a reference to `$this->login_form_json_api_authorization` in the connection manager, but that method doesn't exist 😕

This PR puts it back to the Jetpack class where it belongs, as the method we're using still lives there.

This is a better alternative than the approach initially suggested in #13224.

#### Changes proposed in this Pull Request:
* Connection: Move out the JSON API auth hooking.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* https://developer.wordpress.com/docs/oauth2/
* Can anyone figure out better ways to test this?

#### Proposed changelog entry for your changes:
* Connection: Move out the JSON API auth hooking bit
