### PR TITLE
Remove HTML tags in the description column of video sitemaps

### DIFF
--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -1320,6 +1320,10 @@ class Jetpack_Sitemap_Builder {
 		/** This filter is already documented in core/wp-includes/feed.php */
 		$content = apply_filters( 'the_content_feed', $content, 'rss2' );
 		
+		// Remove all HTML tags, keep only plain texts.
+		/** This filter is already documented in core/wp-includes/formatting.php */
+		$content = wp_strip_all_tags ( $content, true );
+
 		// Include thumbnails for VideoPress videos, use blank image for others
 		if ( 'complete' === get_post_meta( $post->ID, 'videopress_status', true ) && has_post_thumbnail( $post ) ) {
 			$video_thumbnail_url = get_the_post_thumbnail_url( $post );


### PR DESCRIPTION
Fixes #9546

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use wp_strip_all_tags() to remove all HTML tags. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Upload a new video to Media Libary
* Add the description of the video, which includes HTML tags like `<strong>Description</strong> with <a href="https://github.com/Automattic/jetpack/issues/9546">HTML tags</a>.`
* Check https://domain.com/video-sitemap-1.xml
* Make sure the description of this video is `Description with HTML tags.`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove HTML tags in the description column of video sitemaps
