### PR TITLE
Connection: Return the correct error when the verification secrets do not exist

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1166,11 +1166,27 @@ class Manager implements Manager_Interface {
 			);
 		}
 
-		if ( ! $stored_secrets ) {
+		if ( self::SECRETS_MISSING === $stored_secrets ) {
 			return $return_error(
 				new \WP_Error(
 					'verify_secrets_missing',
 					__( 'Verification secrets not found', 'jetpack' ),
+					400
+				)
+			);
+		} elseif ( self::SECRETS_EXPIRED === $stored_secrets ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secrets_expired',
+					__( 'Verification took too long', 'jetpack' ),
+					400
+				)
+			);
+		} elseif ( ! $stored_secrets ) {
+			return $return_error(
+				new \WP_Error(
+					'verify_secrets_empty',
+					__( 'Verification secrets are empty', 'jetpack' ),
 					400
 				)
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When the requested secrets do not exist, `->get_secrets()` returns a string now instead of `false`. Test that condition in the calling code.

This also adds a new error code, `verify_secrets_empty`, which should never happen (ha!) to distinguish the expected error return value from `->get_secrets()` and a strange falsey one.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: bug fix.

#### Testing instructions:
1. Disconnect a site.
2. Use the Jetpack Debugger on that site: https://jetpack.com/support/debug/
3. Look at the HTTP response for the "test unauthenticated xmlrpc request for jetpack works" test.

Prior to this patch, you'll see `verify_secrets_incomplete`.

After this patch, you should see `verify_secrets_missing`.

#### Proposed changelog entry for your changes:
None needed.