### PR TITLE
Dependencies: Update `eslint-plugin-lodash`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
 		"@babel/core": "7.4.0",
 		"@babel/register": "7.4.4",
 		"@wordpress/browserslist-config": "2.5.0",
-		"@wordpress/i18n": "3.5.0",
 		"@wordpress/element": "2.5.0",
+		"@wordpress/i18n": "3.5.0",
 		"babel-loader": "8.0.6",
 		"bounding-client-rect": "1.0.5",
 		"classnames": "2.2.6",
@@ -177,7 +177,7 @@
 		"eslint-plugin-es5": "1.4.1",
 		"eslint-plugin-jest": "22.8.0",
 		"eslint-plugin-jsx-a11y": "6.2.3",
-		"eslint-plugin-lodash": "5.1.0",
+		"eslint-plugin-lodash": "6.0.0",
 		"eslint-plugin-react": "7.14.2",
 		"eslint-plugin-wpcalypso": "4.1.0",
 		"glob": "7.1.4",
@@ -197,9 +197,6 @@
 		"sinon-chai": "3.3.0",
 		"style-loader": "0.23.1",
 		"url-loader": "1.1.2"
-	},
-	"resolutions": {
-		"eslint-plugin-lodash/lodash": "4.17.14"
 	},
 	"engines": {
 		"node": ">=10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4610,12 +4610,12 @@ eslint-plugin-jsx-a11y@6.2.3, eslint-plugin-jsx-a11y@^6.2.1:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-lodash@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-5.1.0.tgz#f7dc6c14f104cacb169a18d17c27d9c015a53924"
-  integrity sha512-mMKmf1OMLS8VExtaHCcrwBmsYIiOVYEibnAFDzXrbJdtFGOcLEw37tryN/WGYKBiJy6nAIGC43i5Wh3KA9lO2g==
+eslint-plugin-lodash@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-6.0.0.tgz#70fa487ab632e62627ecf01ad3e85c228e3ab9d3"
+  integrity sha512-iuxToisjIYAJdxWtW8OamFyc3yAsGCjU5WokvuBfTc/k5XdWOp9fAmzw+aFjj520/QXspCc8//xJpqkhYUj4qw==
   dependencies:
-    lodash "4.17.11"
+    lodash "^4.17.15"
 
 eslint-plugin-react-hooks@^1.6.0:
   version "1.6.1"
@@ -7842,12 +7842,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@4.17.14, lodash@^4.0.0, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.11, lodash@~4.17.10:
-  version "4.17.14"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
-  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@4.17.15, lodash@^4.17.10:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.1.1, lodash@^4.13.1, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.11, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

5.1.0 -> 6.0.0

The change from 5.1.0 -> 5.1.1 updates the `lodash` dependency, which
allows us to get rid of the `resolutions` property in package.json.

The only change from 5.x -> 6.x is removal of Node 6 support:
https://github.com/wix/eslint-plugin-lodash/compare/v5.1.1...v6.0.0

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No.

#### Testing instructions:

1. `yarn build`
2. Poke around.

#### Proposed changelog entry for your changes:

None required.