### PR TITLE
Jetpack Search: Use full namespace for class_exists check for authenticated_requests to work

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -368,7 +368,7 @@ class Jetpack_Search {
 
 		$do_authenticated_request = false;
 
-		if ( class_exists( 'Client' ) &&
+		if ( class_exists( 'Automattic\Jetpack\Connection\Client' ) &&
 			isset( $es_args['authenticated_request'] ) &&
 			true === $es_args['authenticated_request'] ) {
 			$do_authenticated_request = true;

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -368,7 +368,7 @@ class Jetpack_Search {
 
 		$do_authenticated_request = false;
 
-		if ( class_exists( 'Automattic\Jetpack\Connection\Client' ) &&
+		if ( class_exists( 'Automattic\\Jetpack\\Connection\\Client' ) &&
 			isset( $es_args['authenticated_request'] ) &&
 			true === $es_args['authenticated_request'] ) {
 			$do_authenticated_request = true;


### PR DESCRIPTION
Fixes #13243.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Per https://www.php.net/manual/en/function.class-exists.php:

> If you are using aliasing to import namespaced classes, take care that class_exists will not work using the short, aliased class name - apparently whenever a class name is used as string, only the full-namespace version can be used

Therefore, `class_exists( 'Client' )` will always return `false`.  Instead, we should use the full namespace `Automattic\Jetpack\Connection\Client`.

Introduced in https://github.com/Automattic/jetpack/commit/3ed3de86a58730377bbc29f8b7df7aa7729f28ce during re-factoring.

Since JP autoloads classes now, I think we might be able to just remove the check?  Happy to re-commit the change if so.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Assuming JP Search module is enabled, add filter to enable authenticated requests via JP:
```
add_filter( 'jetpack_search_es_query_args', function( $es_query_args ) {
    $es_query_args['authenticated_request'] = true;
 
    return $es_query_args;
} );
```
2) Ensure es args have non-public content in search (e.g. drafts for post_type)
3) Perform search
4) Apply patch
5) Perform search again and see results

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Bugfix: Authenticated requests to search will now display non-public content
