### PR TITLE
Tests: Core now caches API Endpoint Schemas. Flush that cache.

### DIFF
--- a/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -118,21 +118,42 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		// phpunit --group=rest-api
 		$this->publicize = publicize_init();
 		$this->publicize->register_post_meta();
+
+		$GLOBALS['wp_rest_server']->override_by_default = true;
+		foreach ( get_post_types() as $post_type ) {
+			if ( ! $this->publicize->post_type_is_publicizeable( $post_type ) ) {
+				continue;
+			}
+
+			$controller = new WP_REST_Posts_Controller( $post_type );
+			$controller->register_routes();
+		}
+		$GLOBALS['wp_rest_server']->override_by_default = false;
 	}
 
 	public function tearDown() {
 		$this->teardown_fields();
+
+		$publicizeable_post_types = [];
+		$GLOBALS['wp_rest_server']->override_by_default = true;
+		foreach ( get_post_types() as $post_type ) {
+			if ( ! $this->publicize->post_type_is_publicizeable( $post_type ) ) {
+				continue;
+			}
+
+			$publicizeable_post_types[] = $post_type;
+
+			$controller = new WP_REST_Posts_Controller( $post_type );
+			$controller->register_routes();
+		}
+		$GLOBALS['wp_rest_server']->override_by_default = false;
 
 		parent::tearDown();
 
 		wp_delete_post( $this->draft_id, true );
 
 		// Clean up custom meta from publicizeable post types
-		foreach ( get_post_types() as $post_type ) {
-			if ( ! $this->publicize->post_type_is_publicizeable( $post_type ) ) {
-				continue;
-			}
-
+		foreach ( $publicizeable_post_types as $post_type ) {
 			unregister_meta_key( 'post', $this->publicize->POST_MESS, $post_type );
 		}
 	}

--- a/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -180,6 +180,8 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		$schema   = $data['schema'];
 
 		$this->assertArrayHasKey( 'jetpack_publicize_connections', $schema['properties'] );
+		$this->assertArrayHasKey( 'meta', $schema['properties'] );
+		$this->assertArrayHasKey( 'jetpack_publicize_message', $schema['properties']['meta']['properties'] );
 	}
 
 	public function test_register_fields_custom_post_type_with_custom_fields_support() {

--- a/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
+++ b/tests/php/core-api/wpcom-fields/test-post-fields-publicize-connections.php
@@ -119,6 +119,8 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 		$this->publicize = publicize_init();
 		$this->publicize->register_post_meta();
 
+		// Flush the schema cache for those Posts Controllers that need it.
+		// https://core.trac.wordpress.org/changeset/45811/
 		$GLOBALS['wp_rest_server']->override_by_default = true;
 		foreach ( get_post_types() as $post_type ) {
 			if ( ! $this->publicize->post_type_is_publicizeable( $post_type ) ) {
@@ -132,30 +134,31 @@ class Test_WPCOM_REST_API_V2_Post_Publicize_Connections_Field extends WP_Test_Je
 	}
 
 	public function tearDown() {
-		$this->teardown_fields();
-
 		$publicizeable_post_types = [];
-		$GLOBALS['wp_rest_server']->override_by_default = true;
+		// Clean up custom meta from publicizeable post types
 		foreach ( get_post_types() as $post_type ) {
 			if ( ! $this->publicize->post_type_is_publicizeable( $post_type ) ) {
 				continue;
 			}
 
 			$publicizeable_post_types[] = $post_type;
+			unregister_meta_key( 'post', $this->publicize->POST_MESS, $post_type );
+		}
 
+		// Flush the schema cache for those Posts Controllers that need it.
+		// https://core.trac.wordpress.org/changeset/45811/
+		$GLOBALS['wp_rest_server']->override_by_default = true;
+		foreach ( $publicizeable_post_types as $post_type ) {
 			$controller = new WP_REST_Posts_Controller( $post_type );
 			$controller->register_routes();
 		}
 		$GLOBALS['wp_rest_server']->override_by_default = false;
 
+		$this->teardown_fields();
+
 		parent::tearDown();
 
 		wp_delete_post( $this->draft_id, true );
-
-		// Clean up custom meta from publicizeable post types
-		foreach ( $publicizeable_post_types as $post_type ) {
-			unregister_meta_key( 'post', $this->publicize->POST_MESS, $post_type );
-		}
 	}
 
 	private function setup_fields() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As of https://core.trac.wordpress.org/changeset/45811/, Core now caches API Endpoints' Schemas, but does not flush that cache between individual tests.

Our tests sometimes change the expected schema.

To flush the cache, we user Core's method of re-instantiating the entire Controller object.
 
#### Is this a new feature or does it add/remove features to an existing part of Jetpack?


No - bug fix.

#### Testing instructions:

1. Ensure you're running a version of core Core that includes at least [r45811](https://core.trac.wordpress.org/changeset/45811/). As of today, the latest nightly works.
   * If you're using the docker image: `yarn docker:wp core update --version=nightly`
2. `phpunit --group=publicize`
   * If you're using the docker image: `yarn docker:phpunit --group=publicize`

Prior to this patch, you'd see a couple errors about the `jetpack_publicize_message` key being missing.

After this patch, there are no errors.

#### Proposed changelog entry for your changes:

None needed? Only affects tests.