### PR TITLE
Sites Endpoint: Include launch_status in the v1.2 response

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -47,6 +47,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'jetpack_modules'   => '(array) A list of active Jetpack modules.',
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
+		'launch_status'     => '(string) A string describing the launch status of a site',
 	);
 
 


### PR DESCRIPTION
Merges r195407-wpcom
Differential Revision D31000-code

#### Changes proposed in this Pull Request:

While testing https://github.com/Automattic/wp-calypso/pull/35003, I would sometimes not have data on the site object as to whether the site was "unlaunched."
Since calypso is [calling](https://github.com/Automattic/wp-calypso/blob/a9a7969457752a2c3483a02d405b229bbad53dcd/client/state/sites/actions.js#L125) version 1.2 of the sites endpoint in the actions file, we want to return this value for all versions of the response format.


#### Testing instructions:

Follow test plan in https://github.com/Automattic/wp-calypso/pull/35003
ctrl+f the network inspector for sites/<insert site id here>
You should see launch_status in the response body

#### Proposed changelog entry for your changes:

* Sites Endpoint: Include launch_status in the v1.2 response
