### PR TITLE
Connection: Move remote file upload handlers back to Jetpack class

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -610,6 +610,21 @@ class Jetpack {
 		add_action( 'deleted_user', array( $this, 'unlink_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( $this, 'unlink_user' ), 10, 1 );
 
+		// Initialize remote file upload request handlers.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_jetpack_xmlrpc_request = isset( $_GET['for'] ) && 'jetpack' === $_GET['for'] && Constants::get_constant( 'XMLRPC_REQUEST' );
+		if (
+			! $is_jetpack_xmlrpc_request
+			&& is_admin()
+			&& isset( $_POST['action'] ) // phpcs:ignore WordPress.Security.NonceVerification
+			&& (
+				'jetpack_upload_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
+				|| 'jetpack_update_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
+			)
+		) {
+			$this->add_remote_request_handlers();
+		}
+
 		if ( Jetpack::is_active() ) {
 			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );
 

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -68,7 +68,6 @@ class Manager implements Manager_Interface {
 			)
 		) {
 			$this->require_jetpack_authentication();
-			$this->add_remote_request_handlers();
 			return;
 		}
 


### PR DESCRIPTION
In #12699 we didn't port the remote media upload functionality to the connection package, but we moved a call to the responsible method in the connection manager 😱 You can see that there's a reference to `$this->add_remote_request_handlers` in the connection manager, but that method doesn't exist 😕

This PR puts the remote media upload initialization back to the Jetpack class where it belongs, as the method we're using still lives there. This is similar to what #13235 did for the JSON API auth.

Kudos to @brbrr for reporting that.

#### Changes proposed in this Pull Request:
* Connection: Move remote file upload handlers back to Jetpack class

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Apply this patch to your Jetpack on a connected site.
* Try uploading a file from Calypso to your site.

#### Proposed changelog entry for your changes:
* Connection: Move remote file upload handlers back to Jetpack class
