### PR TITLE
Connection: Use Manager for retrieving token in Client

### DIFF
--- a/packages/connection/src/Client.php
+++ b/packages/connection/src/Client.php
@@ -45,7 +45,8 @@ class Client {
 			$args['auth_location'] = 'query_string';
 		}
 
-		$token = \Jetpack_Data::get_access_token( $args['user_id'] );
+		$connection = new Manager();
+		$token      = $connection->get_access_token( $args['user_id'] );
 		if ( ! $token ) {
 			return new \WP_Error( 'missing_token' );
 		}


### PR DESCRIPTION
This PR updates the connection client to use the connection manager for retrieving the access token.

This is part of the effort to decouple the connection package from the rest of Jetpack.

#### Changes proposed in this Pull Request:
* Connection: Use Manager for retrieving token in Client

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Go to `/wp-admin/admin.php?page=jetpack#/plans`
* Verify plans load correctly.

#### Proposed changelog entry for your changes:
* Connection: Use Manager for retrieving token in Client
