### PR TITLE
Media: Remove unnecessary XMLRPC/XHR checks from handlers

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -611,19 +611,7 @@ class Jetpack {
 		add_action( 'remove_user_from_blog', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 
 		// Initialize remote file upload request handlers.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_jetpack_xmlrpc_request = isset( $_GET['for'] ) && 'jetpack' === $_GET['for'] && Constants::get_constant( 'XMLRPC_REQUEST' );
-		if (
-			! $is_jetpack_xmlrpc_request
-			&& is_admin()
-			&& isset( $_POST['action'] ) // phpcs:ignore WordPress.Security.NonceVerification
-			&& (
-				'jetpack_upload_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
-				|| 'jetpack_update_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
-			)
-		) {
-			$this->add_remote_request_handlers();
-		}
+		$this->add_remote_request_handlers();
 
 		if ( Jetpack::is_active() ) {
 			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -610,7 +610,13 @@ class Jetpack {
 		add_action( 'deleted_user', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 
-		// Initialize remote file upload request handlers.
+		/**
+		 * Initialize remote file upload request handlers.
+		 * Remote file uploads require Jetpack authentication.
+		 *
+		 * @see Automattic\Jetpack\Connection\Manager::init()
+		 * @see Automattic\Jetpack\Connection\Manager::require_jetpack_authentication()
+		 */
 		$this->add_remote_request_handlers();
 
 		if ( Jetpack::is_active() ) {

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -67,6 +67,11 @@ class Manager implements Manager_Interface {
 				|| 'jetpack_update_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
 			)
 		) {
+			/**
+			 * Remote file uploads require Jetpack authentication.
+			 *
+			 * @see \Jetpack::add_remote_request_handlers()
+			 */
 			$this->require_jetpack_authentication();
 			return;
 		}


### PR DESCRIPTION
As suggested by @brbrr via Slack and documented via https://github.com/Automattic/jetpack/pull/13253/files#r315117316 we are hooking the remote file upload handlers with arbitrary checks that could be removed. This PR removes them.

Question: should we keep those for some reason? They were reintroduced in #13253 because they were removed in #12699, but it likely makes sense to clean them up now?

#### Changes proposed in this Pull Request:
* Media: Remove unnecessary XMLRPC/XHR checks from handlers

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* A continuation of https://github.com/Automattic/jetpack/pull/13253/

#### Testing instructions:
* Checkout this branch on a connected Jetpack site.
* Try uploading a file via Calypso.

#### Proposed changelog entry for your changes:
* Media: Remove unnecessary XMLRPC/XHR checks from handlers
