### PR TITLE
Connection: Deprecate Jetpack::setup_xmlrpc_handlers

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -735,7 +735,8 @@ class Jetpack {
 	/**
 	 * Sets up the XMLRPC request handlers.
 	 *
-	 * @todo Deprecate this method in favor of Automattic\\Jetpack\\Connection\\Manager::setup_xmlrpc_handlers().
+	 * @deprecated since 7.7.0
+	 * @see Automattic\Jetpack\Connection\Manager::setup_xmlrpc_handlers()
 	 *
 	 * @param Array                 $request_params Incoming request parameters.
 	 * @param Boolean               $is_active      Whether the connection is currently active.
@@ -748,6 +749,7 @@ class Jetpack {
 		$is_signed,
 		Jetpack_XMLRPC_Server $xmlrpc_server = null
 	) {
+		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::setup_xmlrpc_handlers' );
 		return $this->connection_manager->setup_xmlrpc_handlers(
 			$request_params,
 			$is_active,

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -980,7 +980,7 @@ EXPECTED;
 
 		$jetpack = new MockJetpack;
 		$xmlrpc_server = new MockJetpack_XMLRPC_Server( $user );
-		return $jetpack->setup_xmlrpc_handlers( $request_params, $is_active, $is_signed, $xmlrpc_server );
+		return $jetpack::connection()->setup_xmlrpc_handlers( $request_params, $is_active, $is_signed, $xmlrpc_server );
 	}
 
 	/**


### PR DESCRIPTION
We moved the `setup_xmlrpc_handlers` method to the connection package already, and updated any usage to it, but we still haven't deprecated `Jetpack::setup_xmlrpc_handlers()`. Also, the legacy method is used in the tests.

This PR updates the test usage to now use the new method from the connection package. It also deprecates the old method.

#### Changes proposed in this Pull Request:
* Connection: Deprecate `Jetpack::setup_xmlrpc_handlers`.
* Tests: Update to use `setup_xmlrpc_handlers` from the connection manager.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Verify tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Deprecate `Jetpack::setup_xmlrpc_handlers`.
* Tests: Update to use `setup_xmlrpc_handlers` from the connection manager.
