### PR TITLE
Protect: Improve Network Activated Jetpack check

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -141,7 +141,7 @@ class Jetpack_Protect_Module {
 				require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
 			}
 
-			if ( ! ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) || is_plugin_active_for_network( 'jetpack-dev/jetpack.php' ) ) ) {
+			if ( ! is_plugin_active_for_network( plugin_basename( JETPACK__PLUGIN_FILE ) ) ) {
 				add_action( 'load-index.php', array ( $this, 'prepare_jetpack_protect_multisite_notice' ) );
 			}
 		}


### PR DESCRIPTION
Previously, Jetpack Protect would complain that the plugin was not network activated even if the plugin *was* network activated but installed in a non-standard directory.

#### Changes proposed in this Pull Request:
* Use `plugin_basename()` to always look in the right place.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: bug fix.

#### Testing instructions:
1. Create a multisite.
2. Install the Jetpack plugin in wp-content/plugins/nice-jetpack
3. Network Activate Jetpack.
4. Go to any single site's wp-admin/ Dashboard.

Prior to this PR: See the warning about Network Activation.

After this PR: See no warning.

#### Proposed changelog entry for your changes:
* Improve Network Activation detection for Jetpack Protect admin notice.