### PR TITLE
Stats: load rtl stylesheet for dashboard widget.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6516,6 +6516,7 @@ p {
 				array( __CLASS__, 'dashboard_widget' )
 			);
 			wp_enqueue_style( 'jetpack-dashboard-widget', plugins_url( 'css/dashboard-widget.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
+			wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
 
 			// If we're inactive and not in development mode, sort our box to the top.
 			if ( ! self::is_active() && ! self::is_development_mode() ) {


### PR DESCRIPTION
Fixes #13207

#### Changes proposed in this Pull Request:

* On RTL sites, load the correct stylesheet in the main dashboard.

#### Testing instructions:

* Start from a Jetpack site with an RTL language set, such as Hebrew.
* Activate Stats.
* Visit the main dashboard at `/wp-admin`
* Notice the broken widget title

![image](https://user-images.githubusercontent.com/426388/63332168-58af1e80-c337-11e9-96cf-db347bcaee4c.png)

* Apply this patch
* Notice the widget now looks better:

![image](https://user-images.githubusercontent.com/426388/63332206-682e6780-c337-11e9-92e6-a1849d4a08bd.png)


#### Proposed changelog entry for your changes:

* Stats: load RTL stylesheet for dashboard widget, to fix layout issues on RTL language sites.
