### PR TITLE
Connection: Use is_active and is_user_connected from the package

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -232,7 +232,7 @@ class Jetpack_XMLRPC_Server {
 			return $this->error( new Jetpack_Error( 'user_unknown', 'User not found.', 404 ), 'jpc_remote_authorize_fail' );
 		}
 
-		if ( Jetpack::is_active() && Jetpack::is_user_connected( $request['state'] ) ) {
+		if ( $this->connection->is_active() && $this->connection->is_user_connected( $request['state'] ) ) {
 			return $this->error( new Jetpack_Error( 'already_connected', 'User already connected.', 400 ), 'jpc_remote_authorize_fail' );
 		}
 
@@ -364,7 +364,7 @@ class Jetpack_XMLRPC_Server {
 
 		$site_icon = get_site_icon_url();
 
-		$auto_enable_sso = ( ! Jetpack::is_active() || Jetpack::is_module_active( 'sso' ) );
+		$auto_enable_sso = ( ! $this->connection->is_active() || Jetpack::is_module_active( 'sso' ) );
 
 		/** This filter is documented in class.jetpack-cli.php */
 		if ( apply_filters( 'jetpack_start_enable_sso', $auto_enable_sso ) ) {
@@ -392,7 +392,7 @@ class Jetpack_XMLRPC_Server {
 			'user_login'   => $user->user_login,
 			'scope'        => Jetpack::sign_role( $role, $user->ID ),
 			'secret'       => $secrets['secret_1'],
-			'is_active'    => Jetpack::is_active(),
+			'is_active'    => $this->connection->is_active(),
 		);
 
 		if ( $site_icon ) {
@@ -416,7 +416,7 @@ class Jetpack_XMLRPC_Server {
 	 * @return mixed
 	 */
 	public function remote_connect( $request, $ixr_client = false ) {
-		if ( Jetpack::is_active() ) {
+		if ( $this->connection->is_active() ) {
 			return $this->error(
 				new WP_Error(
 					'already_connected',
@@ -480,7 +480,7 @@ class Jetpack_XMLRPC_Server {
 
 		$this->do_post_authorization();
 
-		return Jetpack::is_active();
+		return $this->connection->is_active();
 	}
 
 	/**


### PR DESCRIPTION
As part of the effort to decouple the connection package from core Jetpack, this PR migrates the usage of `Jetpack::is_active()` and `Jetpack::is_user_connected()` to the methods from the package instead.

#### Changes proposed in this Pull Request:
* Connection: Use `is_active` and `is_user_connected` from the package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Checkout this branch.
* Try connecting a user that's not connected via WP.com, make sure it still works well.
* Try connecting a user that's already connected via WP.com, make sure you get a proper message.
* Verify tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Use `is_active` and `is_user_connected` from the package.
