### PR TITLE
Related Posts: Fix bug that prevents related posts from displaying in AMP view

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -176,7 +176,7 @@ class Jetpack_RelatedPosts {
 			return $content;
 		}
 
-		if ( ! $this->_found_shortcode ) {
+		if ( ! $this->_found_shortcode && ! doing_filter( 'get_the_excerpt' ) ) {
 			if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 				$content .= "\n" . $this->get_server_rendered_html();
 			} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13260

This fixes a bug that prevents related posts from displaying in AMP view when the Sharing or Publicize modules are enabled. This bug is also present when the Yoast SEO plugin is activated.

In AMP view, the related posts are displayed by using a filter, `filter_add_target_to_dom()`, on the `the_content` hook [here](https://github.com/Automattic/jetpack/blob/4297f466117d7bd32a865a08674ec236ee3b8a49/modules/related-posts/jetpack-related-posts.php#L1670). 

That filter is removed in the [`render_block` function](https://github.com/Automattic/jetpack/blob/4297f466117d7bd32a865a08674ec236ee3b8a49/modules/related-posts/jetpack-related-posts.php#L378) So, `filter_add_target_to_dom()` will only be called the first time that `the_content` filters are applied.

In the Publicize and Sharing modules, filters are applied to the `get_the_excerpt` hook early, and those filters apply the `the_content` filters.  This causes the `filter_add_target_to_dom()` filter to be applied to the `the_content` hook before the content is actually being prepared. Then the filter is removed, so the filter isn't applied when it's needed.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
 * Fix this issue by preventing `filter_add_target_to_dom()` from calling `render_block()` when `get_the_excerpt` is in `$wp_current_filter`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes a bug in the existing Related Posts module.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test on a site that has related posts.

1. Enable the Related Posts module.
2. Install and activate the AMP plugin.
3. In the AMP settings, select 'Transitional'.
4. Look at a post that has related posts in AMP view by adding ?amp to the URL. Observe that the related posts are displayed.
5. Enable the Sharing module.
6. Reload the post from step 4 and observe that the related posts are still displayed.
7. Enable the Publicize module.
8. Reload the post from step 4 and observe that the related posts are still displayed.
9. Install and activate the Yoast SEO plugin.
10. Reload the posts from step 4 and observe that the related posts are still displayed.

Steps 3 to 10 should be repeated with the Standard AMP mode.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix a bug that prevents Related Posts from displaying in AMP view.
