### PR TITLE
Jetpack Connection: do it via iframe

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -40,7 +40,7 @@ jQuery( document ).ready( function( $ ) {
 		},
 		receiveData: function( event ) {
 			if (
-				event.origin === 'https://jetpack.wordpress.com' &&
+				event.origin === jpConnect.jetpackApiDomain &&
 				event.source === jetpackConnectIframe.get( 0 ).contentWindow &&
 				event.data === 'close'
 			) {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -13,7 +13,6 @@ jQuery( document ).ready( function( $ ) {
 		handleClick: function() {
 			jetpackConnectButton.isRegistering = true;
 			$( '.jp-connect-button' ).text( jpConnect.buttonTextRegistering );
-			console.log( 'sending request to', jpConnect.apiBaseUrl + '/connection/register' );
 			$.ajax( {
 				url: jpConnect.apiBaseUrl + '/connection/register',
 				type: 'POST',

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -1,6 +1,57 @@
+/* global jpConnect */
+
 jQuery( document ).ready( function( $ ) {
 	$( '.jp-connect-button' ).click( function( event ) {
 		event.preventDefault();
-		alert( '❤️❤️❤️❤️❤️❤️❤️❤️❤️❤️' );
+		if ( ! jetpackConnectButton.isRegistering ) {
+			jetpackConnectButton.handleClick();
+		}
 	} );
+
+	var jetpackConnectButton = {
+		isRegistering: false,
+		handleClick: function() {
+			jetpackConnectButton.isRegistering = true;
+			$( '.jp-connect-button' ).text( jpConnect.buttonTextRegistering );
+			console.log( 'sending request to', jpConnect.apiBaseUrl + '/connection/register' );
+			$.ajax( {
+				url: jpConnect.apiBaseUrl + '/connection/register',
+				type: 'POST',
+				data: {
+					registration_nonce: jpConnect.registrationNonce,
+					_wpnonce: jpConnect.apiNonce,
+				},
+				error: function( error ) {
+					console.log( 'request failed' );
+					console.log( error );
+					jetpackConnectButton.isRegistering = false;
+				},
+				success: function( data ) {
+					console.log( 'request success' );
+					window.addEventListener( 'message', jetpackConnectButton.receiveData );
+					$( '.jp-connect-full__button-container' ).html(
+						'<iframe src="' + data.authorizeUrl + '" class="jp-jetpack-connect__iframe" />'
+					);
+				},
+			} );
+		},
+		receiveData: function( event ) {
+			if ( event.origin === 'https://jetpack.wordpress.com' ) {
+				console.log( 'got message', event );
+				// todo: && e.source === this.iframe.contentWindow
+				if ( event.data === 'close' ) {
+					window.removeEventListener( 'message', this.receiveData );
+					jetpackConnectButton.handleAuthorizationComplete();
+				}
+			}
+		},
+		handleAuthorizationComplete: function() {
+			console.log( 'finishing auth' );
+			jetpackConnectButton.isRegistering = false;
+			$( '.jp-connect-full__button-container' ).html(
+				'<p>' + jpConnect.buttonTextFinishing + '<p>'
+			);
+			location.reload();
+		},
+	};
 } );

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -42,7 +42,6 @@ jQuery( document ).ready( function( $ ) {
 			}
 		},
 		handleAuthorizationComplete: function() {
-			console.log( 'finishing auth' );
 			jetpackConnectButton.isRegistering = false;
 			$( '.jp-connect-full__button-container' ).html(
 				'<p>' + jpConnect.buttonTextFinishing + '<p>'

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -13,7 +13,10 @@ jQuery( document ).ready( function( $ ) {
 		isRegistering: false,
 		handleClick: function() {
 			jetpackConnectButton.isRegistering = true;
-			$( '.jp-connect-button' ).text( jpConnect.buttonTextRegistering );
+			$( '.jp-connect-button' )
+				.text( jpConnect.buttonTextRegistering )
+				.attr( 'disabled', true )
+				.blur();
 			$.ajax( {
 				url: jpConnect.apiBaseUrl + '/connection/register',
 				type: 'POST',
@@ -24,7 +27,9 @@ jQuery( document ).ready( function( $ ) {
 				error: function( error ) {
 					console.warn( error );
 					jetpackConnectButton.isRegistering = false;
-					$( '.jp-connect-button' ).text( jpConnect.buttonTextDefault );
+					$( '.jp-connect-button' )
+						.text( jpConnect.buttonTextDefault )
+						.removeAttr( 'disabled' );
 				},
 				success: function( data ) {
 					window.addEventListener( 'message', jetpackConnectButton.receiveData );
@@ -46,9 +51,6 @@ jQuery( document ).ready( function( $ ) {
 		},
 		handleAuthorizationComplete: function() {
 			jetpackConnectButton.isRegistering = false;
-			$( '.jp-connect-full__button-container' ).html(
-				'<p>' + jpConnect.buttonTextFinishing + '<p>'
-			);
 			location.reload();
 		},
 	};

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -21,7 +21,6 @@ jQuery( document ).ready( function( $ ) {
 					_wpnonce: jpConnect.apiNonce,
 				},
 				error: function( error ) {
-					console.log( 'request failed' );
 					console.log( error );
 					jetpackConnectButton.isRegistering = false;
 				},

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -34,7 +34,6 @@ jQuery( document ).ready( function( $ ) {
 		},
 		receiveData: function( event ) {
 			if ( event.origin === 'https://jetpack.wordpress.com' ) {
-				console.log( 'got message', event );
 				// todo: && e.source === this.iframe.contentWindow
 				if ( event.data === 'close' ) {
 					window.removeEventListener( 'message', this.receiveData );

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -25,7 +25,6 @@ jQuery( document ).ready( function( $ ) {
 					jetpackConnectButton.isRegistering = false;
 				},
 				success: function( data ) {
-					console.log( 'request success' );
 					window.addEventListener( 'message', jetpackConnectButton.receiveData );
 					$( '.jp-connect-full__button-container' ).html(
 						'<iframe src="' + data.authorizeUrl + '" class="jp-jetpack-connect__iframe" />'

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -7,6 +7,7 @@ jQuery( document ).ready( function( $ ) {
 			jetpackConnectButton.handleClick();
 		}
 	} );
+	var jetpackConnectIframe = $( '<iframe class="jp-jetpack-connect__iframe" />' );
 
 	var jetpackConnectButton = {
 		isRegistering: false,
@@ -21,20 +22,22 @@ jQuery( document ).ready( function( $ ) {
 					_wpnonce: jpConnect.apiNonce,
 				},
 				error: function( error ) {
-					console.log( error );
+					console.warn( error );
 					jetpackConnectButton.isRegistering = false;
+					$( '.jp-connect-button' ).text( jpConnect.buttonTextDefault );
 				},
 				success: function( data ) {
 					window.addEventListener( 'message', jetpackConnectButton.receiveData );
-					$( '.jp-connect-full__button-container' ).html(
-						'<iframe src="' + data.authorizeUrl + '" class="jp-jetpack-connect__iframe" />'
-					);
+					jetpackConnectIframe.attr( 'src', data.authorizeUrl );
+					$( '.jp-connect-full__button-container' ).html( jetpackConnectIframe );
 				},
 			} );
 		},
 		receiveData: function( event ) {
-			if ( event.origin === 'https://jetpack.wordpress.com' ) {
-				// todo: && e.source === this.iframe.contentWindow
+			if (
+				event.origin === 'https://jetpack.wordpress.com' &&
+				event.source === jetpackConnectIframe.get( 0 ).contentWindow
+			) {
 				if ( event.data === 'close' ) {
 					window.removeEventListener( 'message', this.receiveData );
 					jetpackConnectButton.handleAuthorizationComplete();

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -41,12 +41,11 @@ jQuery( document ).ready( function( $ ) {
 		receiveData: function( event ) {
 			if (
 				event.origin === 'https://jetpack.wordpress.com' &&
-				event.source === jetpackConnectIframe.get( 0 ).contentWindow
+				event.source === jetpackConnectIframe.get( 0 ).contentWindow &&
+				event.data === 'close'
 			) {
-				if ( event.data === 'close' ) {
-					window.removeEventListener( 'message', this.receiveData );
-					jetpackConnectButton.handleAuthorizationComplete();
-				}
+				window.removeEventListener( 'message', this.receiveData );
+				jetpackConnectButton.handleAuthorizationComplete();
 			}
 		},
 		handleAuthorizationComplete: function() {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1103,7 +1103,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Registers the Jetpack site
 	 *
 	 * @uses Jetpack::try_registration();
-	 * @since 4.3.0
+	 * @since 7.7.0
 	 *
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 *

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1111,7 +1111,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function register_site( $request ) {
 		if ( ! wp_verify_nonce( $request->get_param( 'registration_nonce' ), 'jetpack-registration-nonce' ) ) {
-			return new WP_Error( 'build_connect_url_failed', esc_html__( 'Unable to build the connect URL.  Please reload the page and try again.', 'jetpack' ), array( 'status' => 400 ) );
+			return new WP_Error( 'invalid_nonce', __( 'Unable to verify your request.', 'jetpack' ), array( 'status' => 403 ) );
 		}
 
 		$response = Jetpack::try_registration();

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -134,7 +134,7 @@ class Jetpack_Connection_Banner {
 		wp_enqueue_script(
 			'jetpack-connect-button',
 			Assets::get_file_url_for_environment(
-				'_inc/connect-button.js',
+				'_inc/connect-button.js', // TODO: minify
 				'_inc/connect-button.js'
 			),
 			array( 'jquery' ),
@@ -150,6 +150,7 @@ class Jetpack_Connection_Banner {
 			)
 		);
 
+		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 		wp_localize_script(
 			'jetpack-connect-button',
 			'jpConnect',
@@ -159,6 +160,7 @@ class Jetpack_Connection_Banner {
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 				'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
 				'buttonTextDefault'     => __( 'Set up Jetpack', 'jetpack' ),
+                'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
 			)
 		);
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -157,7 +157,6 @@ class Jetpack_Connection_Banner {
 				'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
 				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-				'buttonTextFinishing'   => __( 'Finishing up and reloading page.', 'jetpack' ),
 				'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
 				'buttonTextDefault'     => __( 'Set up Jetpack', 'jetpack' ),
 			)
@@ -184,7 +183,7 @@ class Jetpack_Connection_Banner {
 			<div class="jp-wpcom-connect__container-top-text">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
 				<span>
-			    <?php esc_html_e( 'You’re almost done. Set up Jetpack to enable powerful security and performance tools for WordPress.', 'jetpack' ); ?>
+					<?php esc_html_e( 'You’re almost done. Set up Jetpack to enable powerful security and performance tools for WordPress.', 'jetpack' ); ?>
 				</span>
 			</div>
 			<?php
@@ -254,14 +253,14 @@ class Jetpack_Connection_Banner {
 								?>
 							</p>
 
-                            <div class="jp-banner__button-container">
-                                <span class="jp-banner__tos-blurb"><?php jetpack_render_tos_blurb(); ?></span>
-                                <a
-                                        href="<?php echo esc_url( $this->build_connect_url_for_slide( '72' ) ); ?>"
-                                        class="dops-button is-primary jp-connect-button">
+							<div class="jp-banner__button-container">
+								<span class="jp-banner__tos-blurb"><?php jetpack_render_tos_blurb(); ?></span>
+								<a
+										href="<?php echo esc_url( $this->build_connect_url_for_slide( '72' ) ); ?>"
+										class="dops-button is-primary jp-connect-button">
 									<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
-                                </a>
-                            </div>
+								</a>
+							</div>
 
 						</div>
 					</div> <!-- end slide 1 -->
@@ -338,11 +337,11 @@ class Jetpack_Connection_Banner {
 					</div>
 				</div>
 
-                <p class="jp-connect-full__tos-blurb">
+				<p class="jp-connect-full__tos-blurb">
 					<?php jetpack_render_tos_blurb(); ?>
-                </p>
+				</p>
 
-                <p class="jp-connect-full__button-container">
+				<p class="jp-connect-full__button-container">
 					<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, $bottom_connect_url_from ) ); ?>"
 					   class="dops-button is-primary jp-connect-button">
 						<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -154,11 +154,12 @@ class Jetpack_Connection_Banner {
 			'jetpack-connect-button',
 			'jpConnect',
 			array(
-				'apiBaseUrl' => site_url('/wp-json/jetpack/v4'),
-				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
-                'apiNonce' => wp_create_nonce( 'wp_rest' ),
-                'buttonTextFinishing' => __( 'Finishing up and reloading page.', 'jetpack' ),
-                'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
+				'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
+				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
+				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
+				'buttonTextFinishing'   => __( 'Finishing up and reloading page.', 'jetpack' ),
+				'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
+				'buttonTextDefault'     => __( 'Set up Jetpack', 'jetpack' ),
 			)
 		);
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -259,7 +259,7 @@ class Jetpack_Connection_Banner {
 								<span class="jp-banner__tos-blurb"><?php jetpack_render_tos_blurb(); ?></span>
 								<a
 										href="<?php echo esc_url( $this->build_connect_url_for_slide( '72' ) ); ?>"
-										class="dops-button is-primary jp-connect-button">
+										class="dops-button is-primary">
 									<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
 								</a>
 							</div>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -134,12 +134,32 @@ class Jetpack_Connection_Banner {
 		wp_enqueue_script(
 			'jetpack-connect-button',
 			Assets::get_file_url_for_environment(
-				'_inc/connect-button.js', // TODO - minify?
+				'_inc/connect-button.js',
 				'_inc/connect-button.js'
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION,
 			true
+		);
+
+		wp_enqueue_style(
+			'jetpack-connect-button',
+			Assets::get_file_url_for_environment(
+				'css/jetpack-connect.min.css',
+				'css/jetpack-connect.css'
+			)
+		);
+
+		wp_localize_script(
+			'jetpack-connect-button',
+			'jpConnect',
+			array(
+				'apiBaseUrl' => site_url('/wp-json/jetpack/v4'),
+				'registrationNonce' => wp_create_nonce( 'jetpack-registration-nonce' ),
+                'apiNonce' => wp_create_nonce( 'wp_rest' ),
+                'buttonTextFinishing' => __( 'Finishing up and reloading page.', 'jetpack' ),
+                'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
+			)
 		);
 	}
 

--- a/scss/jetpack-connect.scss
+++ b/scss/jetpack-connect.scss
@@ -1,28 +1,46 @@
-// ==========================================================================
-// TOS Blurb
-// ==========================================================================
+@import '_inc/client/scss/variables/colors';
 
-.jp-jetpack-connect__tos-blurb {
-  font-size: .75rem;
-  margin-bottom: 2em;
-  text-align: left;
-
-  @media (min-width: 491px) {
-    text-align: center;
-  }
-}
-
-// ==========================================================================
+// =====================================================================
 // iFrame
 // ==========================================================================
 
 .jp-jetpack-connect__iframe {
-  height: 240px;
-  width: 380px;
-  max-width: 100%;
-  margin: 1rem auto 0;
+	height: 240px;
+	width: 380px;
+	max-width: 100%;
+	margin: 1rem auto 0;
 
-  @media (min-width: 491px) {
-    height: 290px;
-  }
+	@media (min-width: 491px) {
+		height: 290px;
+	}
+}
+
+// =====================================================================
+// Remove dops button override coming from jetpack-banner
+// ==========================================================================
+
+.jp-connect-full__button-container .dops-button.jp-connect-button.is-primary {
+	background: $blue-medium;
+	border-color: $blue-wordpress;
+	color: $white;
+
+	&:focus {
+		outline: 0;
+		border-color: $blue-medium;
+		box-shadow: 0 0 0 2px $blue-light;
+	}
+
+	&:hover,
+	&:focus {
+		background: $blue-medium;
+		border-color: $blue-dark;
+		color: $white;
+	}
+
+	&[disabled],
+	&:disabled {
+		background: tint( $blue-light, 50% );
+		border-color: tint( $blue-wordpress, 55% );
+		color: $white;
+	}
 }

--- a/scss/jetpack-connect.scss
+++ b/scss/jetpack-connect.scss
@@ -1,0 +1,28 @@
+// ==========================================================================
+// TOS Blurb
+// ==========================================================================
+
+.jp-jetpack-connect__tos-blurb {
+  font-size: .75rem;
+  margin-bottom: 2em;
+  text-align: left;
+
+  @media (min-width: 491px) {
+    text-align: center;
+  }
+}
+
+// ==========================================================================
+// iFrame
+// ==========================================================================
+
+.jp-jetpack-connect__iframe {
+  height: 240px;
+  width: 380px;
+  max-width: 100%;
+  margin: 1rem auto 0;
+
+  @media (min-width: 491px) {
+    height: 290px;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes no known issues

#### Changes proposed in this Pull Request:
If you have a constant set, you'll connect via iFrame within
wp-admin instead of being sent to WordPress.com

This is the last bit of #13112 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Master Thread: p1HpG7-7nj-p2

#### Testing instructions:
* Run this branch on an unconnected site
* In your wp-config.php, or somewhere similar, add this:
`define ( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
* Try connecting and notice the iframe-y newness!
* Connections without the constant should continue to work as usual

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
