### PR TITLE
Reduce Photon-resized AMP Story image max height from 1440 to 1280

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -397,7 +397,7 @@ class Jetpack_AMP_Support {
 			return $args;
 		}
 
-		$max_height = 1440; // See image size with the slug \AMP_Story_Post_Type::MAX_IMAGE_SIZE_SLUG.
+		$max_height = 1280; // See image size with the slug \AMP_Story_Post_Type::MAX_IMAGE_SIZE_SLUG.
 		$transform  = $details['transform_orig'];
 		$width      = $details['width_orig'];
 		$height     = $details['height_orig'];

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -984,7 +984,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$filtered_content = apply_filters( 'the_content', $content, $post->ID );
 
 		$this->assertContains(
-			'.wp.com/example.com/wp-content/uploads/2019/06/huge.jpg?h=1440&#038;ssl=1',
+			'.wp.com/example.com/wp-content/uploads/2019/06/huge.jpg?h=1280&#038;ssl=1',
 			$filtered_content
 		);
 


### PR DESCRIPTION
This is a follow up on #12821.

#### Changes proposed in this Pull Request:

* Reduce max height of Photon-resized images in `amp_story` post type from 1440px to 1280px to align with https://github.com/ampproject/amp-wp/pull/3006.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updates existing part of Jetpack

#### Testing instructions:

See testing instructions on https://github.com/Automattic/jetpack/pull/12821.

#### Proposed changelog entry for your changes:

* Reduce max height of Photon-resized images in `amp_story` post type from 1440px to 1280px to align with https://github.com/ampproject/amp-wp/pull/3006.