### PR TITLE
Premium blocks: Add plan param to redirect URL - take 2 - simple sites

### DIFF
--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -85,8 +85,15 @@ export default compose( [
 
 		// Post-checkout: redirect back here
 		const redirect_to = isWpcom
-			? '/' +
-			  compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' )
+			? addQueryArgs(
+					'/' +
+						compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
+							'/'
+						),
+					{
+						plan_upgraded: 1,
+					}
+			  )
 			: addQueryArgs(
 					window.location.protocol +
 						`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13003 (partially)

Related: https://github.com/Automattic/wp-calypso/pull/35697

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Handles adding the `plan_upgraded=1` query param to simple site urls passed from the "upgrade nudge" in the `redirect_to` param. We (@simison primarily) spotted that in #13218 we were only handling jetpack self-hosted sites. Effectively this will be passed on redirection once a plan has been upgraded successfully after clicking on the "upgrade nudge".

---

The result after these changes is the user landing on the calypso block editor with a url of the form https://wordpress.com/block-editor/post/chriskmnds.wordpress.com/3?plan_upgraded=1

---

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It adds the foundation for showing a notification when the redirection happens after clicking an upgrade nudge.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the underlying diff to your sandbox.
* Load a non-premium non-jetpack wpcom site that is linked to your sandbox.
* Open a post and add the "simple payments" block.
* Click on the `upgrade nudge` and purchase a premium plan to enable simple payments.
* On redirection back to the editor, confirm that the URL contains the parameter `&plan_upgraded=1`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Doesn't need one I think?
