### PR TITLE
Media: Unify remote file upload handler registration logic

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3603,7 +3603,7 @@ p {
 		}
 
 		// Require Jetpack authentication for the remote file upload AJAX requests.
-		self::connection()->require_jetpack_authentication();
+		$this->connection_manager->require_jetpack_authentication();
 
 		// Register the remote file upload AJAX handlers.
 		foreach ( $remote_request_actions as $action ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -611,19 +611,7 @@ class Jetpack {
 		add_action( 'remove_user_from_blog', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 
 		// Initialize remote file upload request handlers.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_jetpack_xmlrpc_request = isset( $_GET['for'] ) && 'jetpack' === $_GET['for'] && Constants::get_constant( 'XMLRPC_REQUEST' );
-		if (
-			! $is_jetpack_xmlrpc_request
-			&& is_admin()
-			&& isset( $_POST['action'] ) // phpcs:ignore WordPress.Security.NonceVerification
-			&& (
-				'jetpack_upload_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
-				|| 'jetpack_update_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
-			)
-		) {
-			$this->add_remote_request_handlers();
-		}
+		$this->add_remote_request_handlers();
 
 		if ( Jetpack::is_active() ) {
 			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );
@@ -3592,12 +3580,43 @@ p {
 		}
 	}
 
-	function add_remote_request_handlers() {
-		add_action( 'wp_ajax_nopriv_jetpack_upload_file', array( $this, 'remote_request_handlers' ) );
-		add_action( 'wp_ajax_nopriv_jetpack_update_file', array( $this, 'remote_request_handlers' ) );
+	/**
+	 * Register the remote file upload request handlers, if needed.
+	 *
+	 * @access public
+	 */
+	public function add_remote_request_handlers() {
+		// Remote file uploads are allowed only via AJAX requests.
+		if ( ! is_admin() || ! Constants::get_constant( 'DOING_AJAX' ) ) {
+			return;
+		}
+
+		// Remote file uploads are allowed only for a set of specific AJAX actions.
+		$remote_request_actions = array(
+			'jetpack_upload_file',
+			'jetpack_update_file',
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! isset( $_POST['action'] ) || ! in_array( $_POST['action'], $remote_request_actions, true ) ) {
+			return;
+		}
+
+		// Require Jetpack authentication for the remote file upload AJAX requests.
+		self::connection()->require_jetpack_authentication();
+
+		// Register the remote file upload AJAX handlers.
+		foreach ( $remote_request_actions as $action ) {
+			add_action( "wp_ajax_nopriv_{$action}", array( $this, 'remote_request_handlers' ) );
+		}
 	}
 
-	function remote_request_handlers() {
+	/**
+	 * Handler for Jetpack remote file uploads.
+	 *
+	 * @access public
+	 */
+	public function remote_request_handlers() {
 		$action = current_filter();
 
 		switch ( current_filter() ) {

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -50,26 +50,11 @@ class Manager implements Manager_Interface {
 	 * @todo Implement a proper nonce verification.
 	 */
 	public function init() {
-
-		$is_jetpack_xmlrpc_request = $this->setup_xmlrpc_handlers(
-			$_GET,
+		$this->setup_xmlrpc_handlers(
+			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$this->is_active(),
 			$this->verify_xml_rpc_signature()
 		);
-
-		// All the XMLRPC functionality has been moved into setup_xmlrpc_handlers.
-		if (
-			! $is_jetpack_xmlrpc_request
-			&& is_admin()
-			&& isset( $_POST['action'] ) // phpcs:ignore WordPress.Security.NonceVerification
-			&& (
-				'jetpack_upload_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
-				|| 'jetpack_update_file' === $_POST['action']  // phpcs:ignore WordPress.Security.NonceVerification
-			)
-		) {
-			$this->require_jetpack_authentication();
-			return;
-		}
 
 		if ( $this->is_active() ) {
 			add_filter( 'xmlrpc_methods', array( $this, 'public_xmlrpc_methods' ) );


### PR DESCRIPTION
As suggested by @mdawaffe, in https://github.com/Automattic/jetpack/pull/13256#discussion_r315850786 the logic we introduced in #13253 for splitting the remote media upload handler registration and the jetpack auth didn't make much sense. This follows his advice to unify the handler registration logic, and make it clear that the Jetpack auth is needed specifically by the remote file upload requests.

#### Changes proposed in this Pull Request:
* Media: Unify remote file upload handler registration logic

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Alternative to #13256.

#### Testing instructions:
* Checkout this branch on a connected Jetpack site.
* Try uploading a file via Calypso and make sure it works correctly.

#### Proposed changelog entry for your changes:
* Media: Unify remote file upload handler registration logic
