### PR TITLE
Connection: Use generate_secrets from the package

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -382,7 +382,7 @@ class Jetpack_XMLRPC_Server {
 		// Generate secrets.
 		$roles   = new Roles();
 		$role    = $roles->translate_user_to_role( $user );
-		$secrets = Jetpack::init()->generate_secrets( 'authorize', $user->ID );
+		$secrets = $this->connection->generate_secrets( 'authorize', $user->ID );
 
 		$response = array(
 			'jp_version'   => JETPACK__VERSION,

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1047,7 +1047,7 @@ class Manager implements Manager_Interface {
 	 * @param Integer $user_id The user identifier.
 	 * @param Integer $exp     Expiration time in seconds.
 	 */
-	public function generate_secrets( $action, $user_id, $exp ) {
+	public function generate_secrets( $action, $user_id = false, $exp = 600 ) {
 		$callable = $this->get_secret_callable();
 
 		$secrets = \Jetpack_Options::get_raw_option(


### PR DESCRIPTION
As part of the effort to decouple the connection package from core Jetpack, this PR migrates the usage of `Jetpack::generate_secrets()` to the method from the package instead.

#### Changes proposed in this Pull Request:
* Connection: Use `generate_secrets` from the package.
* Connection: Add default values for `generate_secrets` arguments, to match the legacy method signature.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Verify the XMLRPC tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Use `generate_secrets` from the package.
* Connection: Add default values for `generate_secrets` arguments, to match the legacy method signature.
