### PR TITLE
Connection: Update XMLRPC server to use existing connection object

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -190,8 +190,7 @@ class Jetpack_XMLRPC_Server {
 			);
 		}
 
-		$connection = Jetpack::connection();
-		$user_token = $connection->get_access_token( $user->ID );
+		$user_token = $this->connection->get_access_token( $user->ID );
 
 		if ( $user_token ) {
 			list( $user_token_key ) = explode( '.', $user_token->secret );
@@ -654,7 +653,7 @@ class Jetpack_XMLRPC_Server {
 	 * @return \WP_User|bool
 	 */
 	public function login() {
-		Jetpack::connection()->require_jetpack_authentication();
+		$this->connection->require_jetpack_authentication();
 		$user = wp_authenticate( 'username', 'password' );
 		if ( is_wp_error( $user ) ) {
 			if ( 'authentication_failed' === $user->get_error_code() ) { // Generic error could mean most anything.
@@ -943,7 +942,7 @@ class Jetpack_XMLRPC_Server {
 		if ( $user_id ) {
 			$token_key = false;
 		} else {
-			$verified  = Jetpack::connection()->verify_xml_rpc_signature();
+			$verified  = $this->connection->verify_xml_rpc_signature();
 			$token_key = $verified['token_key'];
 		}
 


### PR DESCRIPTION
As part of the effort to decouple the connection package from core Jetpack, this PR migrates the usage of `Jetpack::connection()` to the object that lives in the class.

#### Changes proposed in this Pull Request:
* Connection: Update XMLRPC server to use existing connection object

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Verify the tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Update XMLRPC server to use existing connection object.
