### PR TITLE
Use Post ID instead of Post Object in current_user_can

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-endpoint.php
@@ -613,9 +613,9 @@ abstract class WPCOM_JSON_API_Post_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 */
 	function get_current_user_capabilities( $post ) {
 		return array(
-			'publish_post' => current_user_can( 'publish_post', $post ),
-			'delete_post'  => current_user_can( 'delete_post', $post ),
-			'edit_post'    => current_user_can( 'edit_post', $post )
+			'publish_post' => current_user_can( 'publish_post', $post->ID ),
+			'delete_post'  => current_user_can( 'delete_post', $post->ID ),
+			'edit_post'    => current_user_can( 'edit_post', $post->ID )
 		);
 	}
 

--- a/sal/class.json-api-post-base.php
+++ b/sal/class.json-api-post-base.php
@@ -182,9 +182,9 @@ abstract class SAL_Post {
 
 	public function get_current_user_capabilities() {
 		return array(
-			'publish_post' => current_user_can( 'publish_post', $this->post ),
-			'delete_post'  => current_user_can( 'delete_post', $this->post ),
-			'edit_post'    => current_user_can( 'edit_post', $this->post )
+			'publish_post' => current_user_can( 'publish_post', $this->post->ID ),
+			'delete_post'  => current_user_can( 'delete_post', $this->post->ID ),
+			'edit_post'    => current_user_can( 'edit_post', $this->post->ID )
 		);
 	}
 
@@ -458,7 +458,7 @@ abstract class SAL_Post {
 		if ( 0 == $this->post->post_author )
 			return null;
 
-		$show_email = $this->context === 'edit' && current_user_can( 'edit_post', $this->post );
+		$show_email = $this->context === 'edit' && current_user_can( 'edit_post', $this->post->ID );
 
 		$user = get_user_by( 'id', $this->post->post_author );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Similar to #13166, `current_user_can` only accepts object IDs as the optional second param; passing anything else (like an instance of Jetpack_Post like we did) will cause issues.

However, #13166 did not fix all wrong implementations so the same issue happens in 2184839-zen, then it was reported in 4206-gh-jpop-issues. 

This PR is to correct all wrong implementations. In fact, only changes in `sal/class.json-api-post-base.php` is enough to fix this fatal error. However, I've tried my best, then found out other wrong implementations in `json-endpoints/class.wpcom-json-api-post-endpoint.php`. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Connect your test site to WordPress.com.
- Install the Polylang plugin (it's OK to use the [free version](https://wordpress.org/plugins/polylang/) for replicate this issue)
- Add at least two languages
- Create the "Privacy" page in WP Admin -> Settings -> Privacy.
- Create a translation of the "Privacy" page
- Visit https://wordpress.com/pages/site.com
- Check PHP error log, make sure you do not see this fatal error: 

```
PHP Catchable fatal error: Object of class Jetpack_Post could not be converted to string in /wp-content/plugins/polylang-pro/include/filters.php on line 305 
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* WordPress.com API: avoid Fatal Errors, which are caused by current_user_can(), when fetching posts from the mobile apps
