### PR TITLE
Connection: Introduce a connect-in-place AB test

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Abtest;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Constants;
 
 class Jetpack_Connection_Banner {
 	/**
@@ -28,7 +29,10 @@ class Jetpack_Connection_Banner {
 		add_action( 'current_screen', array( $this, 'maybe_initialize_hooks' ) );
 
 		$abtest = new Abtest();
-		if ( 'in_place' === $abtest->get_variation( 'jetpack_connect_in_place' ) ) {
+		if (
+			'in_place' === $abtest->get_variation( 'jetpack_connect_in_place' ) ||
+			Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' )
+		) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_connect_button_scripts' ) );
 		}
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Abtest;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Assets;
 
@@ -26,7 +27,8 @@ class Jetpack_Connection_Banner {
 	private function __construct() {
 		add_action( 'current_screen', array( $this, 'maybe_initialize_hooks' ) );
 
-		if ( \Automattic\Jetpack\Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		$abtest = new Abtest();
+		if ( 'in_place' === $abtest->get_variation( 'jetpack_connect_in_place' ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_connect_button_scripts' ) );
 		}
 	}


### PR DESCRIPTION
Currently, to test the "connect in place" flow, you need to enable the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant.

This PR changes the logic so it relies on a new A/B test that is powered by WP.com.

#### Changes proposed in this Pull Request:
* Connection: Introduce a connect-in-place AB test instead of the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of p1HpG7-7nj-p2

#### Testing instructions:
* Follow instructions in PCYsg-2Fs-p2 to force the `jetpack_connect_in_place` test to be in either the `original` or the `in_place` variation.
* Verify both variations work well.

#### Proposed changelog entry for your changes:
* Connection: Introduce a connect-in-place AB test instead of the constant.
