### PR TITLE
Ensure that file_data_option variable from transient is always an array

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2571,6 +2571,11 @@ class Jetpack {
 
 		$file_data_option = get_transient( $cache_key );
 
+		if ( ! is_array( $file_data_option ) ) {
+			delete_transient( $cache_key );
+			$file_data_option = false;
+		}
+
 		if ( false === $file_data_option ) {
 			$file_data_option = array();
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Related #13287 - we may keep this issue to find out why the transient was saved with wrong data type in the first place.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR will check if $file_data_option value from the transient is really an array, which is the data type we expect in the later code. If not, we delete the transient and force the later code to recreate the transient. 

#### Testing instructions:

* Open PHPMyAdmin or a similar database tool.
* In wp_options, look for option_name = `_transient_jetpack_file_data_x.y.z` while `x.y.z` is the current version of Jetpack. 
* Edit `option_value` of this row to a the value of `_transient_jetpack_file_data_7.6` in this file [wpstg0_options.csv.zip](https://github.com/Automattic/jetpack/files/3525688/wpstg0_options.csv.zip)
* In WP Admin -> Jetpack, try to visit different setting pages. 
* Try to deactivate then activate and reconnect Jetpack. 
* Make sure that you check PHP error logs (debug.log) and do not see any error like these: 

```
[19-Aug-2019 05:50:36 UTC] PHP Notice:  A non well formed numeric value encountered in /wp-content/plugins/jetpack/class.jetpack.php on line 2637
[19-Aug-2019 05:50:36 UTC] PHP Notice:  Array to string conversion in /wp-content/plugins/jetpack/class.jetpack.php on line 2637
[19-Aug-2019 05:50:36 UTC] PHP Warning:  Illegal string offset 'd0c5aa8400d364117d5fc89859781eca' in /wp-content/plugins/jetpack/class.jetpack.php on line 2637
```  

* Check option_name = `_transient_jetpack_file_data_x.y.z` above and make sure option_value is a serialized value instead of `a-simple-string. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* General: Ensure that `$file_data_option` is always an array to avoid warnings and fatal errors. 
