### PR TITLE
Instant Search: Allow overriding wpcom blog_id

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -204,7 +204,11 @@ class Jetpack_Search {
 				$script_version = self::get_asset_version( $script_relative_path );
 				$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 				wp_enqueue_script( 'jetpack-search', $script_path, array(), $script_version, true );
-				wp_add_inline_script( 'jetpack-search', 'window.JetpackInstantSearchOptions = { siteId: ' . Jetpack::get_option( 'id' ) .'}', 'before' );
+				$_blog_id = Jetpack::get_option( 'id' );
+				if ( $_GET['blog_id'] ) {
+					$_blog_id = (int) $_GET['blog_id'];
+				}
+				wp_add_inline_script( 'jetpack-search', 'window.JetpackInstantSearchOptions = { siteId: ' . $_blog_id .'}', 'before' );
 			}
 
 			$style_relative_path = '_inc/build/instant-search/instant-search.min.css';

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -208,7 +208,7 @@ class Jetpack_Search {
 				// This is probably a temporary filter for testing the prototype.
 				$options = array(
 					'siteId' => $_blog_id,
-				];
+				);
 				$options = apply_filters( 'jetpack_instant_search_options', $options );
 
 				wp_localize_script(

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -206,7 +206,7 @@ class Jetpack_Search {
 				wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 				$_blog_id = Jetpack::get_option( 'id' );
 				// This is probably a temporary filter for testing the prototype.
-				$options = [
+				$options = array(
 					'siteId' => $_blog_id,
 				];
 				$options = apply_filters( 'jetpack_instant_search_options', $options );

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -203,19 +203,26 @@ class Jetpack_Search {
 			if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
 				$script_version = self::get_asset_version( $script_relative_path );
 				$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-				wp_enqueue_script( 'jetpack-search', $script_path, array(), $script_version, true );
+				wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 				$_blog_id = Jetpack::get_option( 'id' );
-				if ( $_GET['blog_id'] ) {
-					$_blog_id = (int) $_GET['blog_id'];
-				}
-				wp_add_inline_script( 'jetpack-search', 'window.JetpackInstantSearchOptions = { siteId: ' . $_blog_id .'}', 'before' );
+				//this is probably a temporary filter for testing the prototype
+				$options = [
+					'siteId' => $_blog_id,
+				];
+				$options = apply_filters( 'jetpack_instant_search_options', $options );
+
+				wp_localize_script(
+					'jetpack-instant-search',
+					'jetpack_instant_search_options',
+					$options
+				);
 			}
 
 			$style_relative_path = '_inc/build/instant-search/instant-search.min.css';
 			if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
 				$style_version = self::get_asset_version( $style_relative_path );
 				$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-				wp_enqueue_style( 'jetpack-search', $style_path, array(), $style_version );
+				wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
 			}
 		}
 	}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -209,6 +209,15 @@ class Jetpack_Search {
 				$options = array(
 					'siteId' => $_blog_id,
 				);
+				/**
+				 * Customize Instant Search Options.
+				 *
+				 * @module search
+				 *
+				 * @since 7.7.0
+				 *
+				 * @param array $options Array of parameters used in Instant Search queries.
+				 */
 				$options = apply_filters( 'jetpack_instant_search_options', $options );
 
 				wp_localize_script(

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -205,7 +205,7 @@ class Jetpack_Search {
 				$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 				wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 				$_blog_id = Jetpack::get_option( 'id' );
-				//this is probably a temporary filter for testing the prototype
+				// This is probably a temporary filter for testing the prototype.
 				$options = [
 					'siteId' => $_blog_id,
 				];

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -24,29 +24,24 @@ const hideSearchHeader = () => {
 	}
 };
 
-const injectSearchWidget = ( initialValue, target, grabFocus ) => {
+const injectSearchWidget = ( initialValue, target, siteId, grabFocus ) => {
 	render(
-		<SearchWidget
-			initialValue={ initialValue }
-			grabFocus={ grabFocus }
-			siteId={ window.JetpackInstantSearchOptions.siteId }
-		/>,
+		<SearchWidget initialValue={ initialValue } grabFocus={ grabFocus } siteId={ siteId } />,
 		target
 	);
 };
 
 document.addEventListener( 'DOMContentLoaded', function() {
-	if (
-		'siteId' in window.JetpackInstantSearchOptions &&
-		document.body &&
-		document.body.classList.contains( 'search' )
-	) {
+	//This var is provided by wp_localize_script() so we have limited control
+	const options = jetpack_instant_search_options; // eslint-disable-line no-undef
+
+	if ( 'siteId' in options && document.body && document.body.classList.contains( 'search' ) ) {
 		const widget = document.querySelector( '.widget_search' );
 		if ( !! widget ) {
 			removeChildren( widget );
 			removeChildren( document.querySelector( 'main' ) );
 			hideSearchHeader();
-			injectSearchWidget( getSearchQuery(), widget );
+			injectSearchWidget( getSearchQuery(), widget, options.siteId );
 		}
 	}
 } );


### PR DESCRIPTION
This adds a filter that allows all of the options for instant search to be adjusted.

I am then testing it with:

```
function jp_instant_search_options( $options ) {
	if ( $_GET['blog_id'] ) {
		$options['siteId'] = (int) $_GET['blog_id'];
	}
	return $options;
}
add_filter( 'jetpack_instant_search_options', 'jp_instant_search_options' );
```

This then allows me to build a demo site which can run the search against any site.

To test:
- load up this PR on any test site that has 2015 theme running
- add the above filter (or whatever filter you want)
- visit the site with the `blog_id` set in the query params. e.g. `?s=search&orderby=relevance&order=DESC&blog_id=20115252`
- you should now see search results from a different site. The blog_id here is for jetpack.com

This will only work for sites that are in the new index: business, pro, vip, and blue flag.

I decided to add filtering by any option since I can think of a few other things we may want to experiment with setting and this gives an easy mechanism for doing so.
