### PR TITLE
Enable Tiled Gallery Block on VIP Go

### DIFF
--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -44,6 +44,10 @@ class Jetpack_Tiled_Gallery_Block {
 
 		$is_squareish_layout = self::is_squareish_layout( $attr );
 
+		$jetack_plan = Jetpack_Plan::get();
+
+		wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetack_plan ) );
+
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {
 			/**
 			 * This block processes all of the images that are found and builds $find and $replace.

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -165,6 +165,7 @@ class Jetpack_Tiled_Gallery_Block {
 
 if (
 	( defined( 'IS_WPCOM' ) && IS_WPCOM )
+	|| defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV
 	|| class_exists( 'Jetpack_Photon' ) && Jetpack::is_module_active( 'photon' )
 ) {
 	Jetpack_Tiled_Gallery_Block::register();

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -44,9 +44,9 @@ class Jetpack_Tiled_Gallery_Block {
 
 		$is_squareish_layout = self::is_squareish_layout( $attr );
 
-		$jetack_plan = Jetpack_Plan::get();
+		$jetpack_plan = Jetpack_Plan::get();
 
-		wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetack_plan ) );
+		wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
 
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {
 			/**

--- a/extensions/blocks/tiled-gallery/utils/index.js
+++ b/extensions/blocks/tiled-gallery/utils/index.js
@@ -108,7 +108,7 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 }
 function isVIP() {
 	/*global jetpack_plan*/
-	if ( typeof jetpack_plan !== 'undefined' && jetpack_plan.data.product_slug === 'vip' ) {
+	if ( typeof jetpack_plan !== 'undefined' && jetpack_plan.data === 'vip' ) {
 		return true;
 	}
 }

--- a/extensions/blocks/tiled-gallery/utils/index.js
+++ b/extensions/blocks/tiled-gallery/utils/index.js
@@ -46,7 +46,8 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 	const { height, width } = img;
 	const { layoutStyle } = galleryAtts;
 
-	const photonImplementation = isWpcomFilesUrl( url ) ? photonWpcomImage : photon;
+	const photonImplementation =
+		isWpcomFilesUrl( url ) || true === isVIP() ? photonWpcomImage : photon;
 
 	/**
 	 * Build the `src`
@@ -105,7 +106,12 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 
 	return Object.assign( { src }, srcSet && { srcSet } );
 }
-
+function isVIP() {
+	/*global jetpack_plan*/
+	if ( typeof jetpack_plan !== 'undefined' && jetpack_plan.data.product_slug === 'vip' ) {
+		return true;
+	}
+}
 function isWpcomFilesUrl( url ) {
 	const { host } = parseUrl( url );
 	return /\.files\.wordpress\.com$/.test( host );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

On VIP Go, we don’t load the Photon module by default because we use our analogous Files Service which works with Tiled Galleries.

This PR adds a check to make sure the Tiled Gallery Block will be available on VIP Go environments.

#### Testing instructions:
- Spin up a VIP Go environment
- Make sure Gutenberg is enabled with `wpcom_vip_load_gutenberg()`
- Verify that the `Tiled Gallery Block` is not present.
- Apply this PR and see it show up!

#### Proposed changelog entry for your changes:
* Add VIP Go Environment check for registering Tiled Gallery Block
