### PR TITLE
Connection: Move Jetpack::sign_role() to the package

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -101,7 +101,7 @@ class Jetpack_Provision { //phpcs:ignore
 			// Role.
 			$roles       = new Roles();
 			$role        = $roles->translate_current_user_to_role();
-			$signed_role = Jetpack::sign_role( $role );
+			$signed_role = Jetpack::connection()->sign_role( $role );
 
 			$secrets = Jetpack::init()->generate_secrets( 'authorize' );
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -268,7 +268,7 @@ class Jetpack_Client_Server {
 			return new Jetpack_Error( 'scope', 'Malformed Scope', $code );
 		}
 
-		if ( Jetpack::sign_role( $role ) !== $json->scope ) {
+		if ( Jetpack::connection()->sign_role( $role ) !== $json->scope ) {
 			return new Jetpack_Error( 'scope', 'Invalid Scope', $code );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4531,7 +4531,7 @@ p {
 
 		$roles       = new Roles();
 		$role        = $roles->translate_current_user_to_role();
-		$signed_role = self::sign_role( $role );
+		$signed_role = self::connection()->sign_role( $role );
 
 		$user = wp_get_current_user();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4431,23 +4431,24 @@ p {
 		return $roles->translate_role_to_cap( $role );
 	}
 
-	static function sign_role( $role, $user_id = null ) {
-		if ( empty( $user_id ) ) {
-			$user_id = (int) get_current_user_id();
-		}
-
-		if ( ! $user_id  ) {
-			return false;
-		}
-
-		$token = Jetpack_Data::get_access_token();
-		if ( ! $token || is_wp_error( $token ) ) {
-			return false;
-		}
-
-		return $role . ':' . hash_hmac( 'md5', "{$role}|{$user_id}", $token->secret );
+	/**
+	 * Sign a user role with the master access token.
+	 * If not specified, will default to the current user.
+	 *
+	 * @deprecated since 7.7
+	 * @see Automattic\Jetpack\Connection\Manager::sign_role()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $role    User role.
+	 * @param int    $user_id ID of the user.
+	 * @return string Signed user role.
+	 */
+	public static function sign_role( $role, $user_id = null ) {
+		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::sign_role' );
+		return self::connection()->sign_role( $role, $user_id );
 	}
-
 
 	/**
 	 * Builds a URL to the Jetpack connection auth page

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -389,7 +389,7 @@ class Jetpack_XMLRPC_Server {
 			'user_id'      => $user->ID,
 			'user_email'   => $user->user_email,
 			'user_login'   => $user->user_login,
-			'scope'        => Jetpack::sign_role( $role, $user->ID ),
+			'scope'        => $this->connection->sign_role( $role, $user->ID ),
 			'secret'       => $secrets['secret_1'],
 			'is_active'    => $this->connection->is_active(),
 		);

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1622,4 +1622,31 @@ class Manager implements Manager_Interface {
 	public function reset_saved_auth_state() {
 		$this->xmlrpc_verification = null;
 	}
+
+	/**
+	 * Sign a user role with the master access token.
+	 * If not specified, will default to the current user.
+	 *
+	 * @access public
+	 *
+	 * @param string $role    User role.
+	 * @param int    $user_id ID of the user.
+	 * @return string Signed user role.
+	 */
+	public function sign_role( $role, $user_id = null ) {
+		if ( empty( $user_id ) ) {
+			$user_id = (int) get_current_user_id();
+		}
+
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$token = $this->get_access_token();
+		if ( ! $token || is_wp_error( $token ) ) {
+			return false;
+		}
+
+		return $role . ':' . hash_hmac( 'md5', "{$role}|{$user_id}", $token->secret );
+	}
 }

--- a/packages/sync/src/Users.php
+++ b/packages/sync/src/Users.php
@@ -101,7 +101,7 @@ class Users {
 	 * @return string Signed role of the user.
 	 */
 	public static function get_signed_role( $user_id ) {
-		return \Jetpack::sign_role( self::get_role( $user_id ), $user_id );
+		return \Jetpack::connection()->sign_role( self::get_role( $user_id ), $user_id );
 	}
 
 	/**


### PR DESCRIPTION
This PR moves the `Jetpack::sign_role()` method to the connection package. This makes sense to me, because the method will sign a role with the access token, and the access token is an artifact that the connection manager from that package currently supplies. 

In addition to moving the method, this PR suggests deprecating the old method, and updating all existing usages to the new one.

#### Changes proposed in this Pull Request:

* Connection: Move `Jetpack::sign_role()` to the package
* Connection: Deprecate `Jetpack::sign_role()`
* Connection: Use `sign_role()` from package everywhere

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Checkout this branch.
* Verify connecting Jetpack to WP.com still works well.
* Verify changing the role of a user sync properly to the cache site.
* Verify all tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Move `Jetpack::sign_role()` to the package
* Connection: Deprecate `Jetpack::sign_role()`
* Connection: Use `sign_role()` from package everywhere
