### PR TITLE
Connection: Use a hook for event log in package

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -623,6 +623,8 @@ class Jetpack {
 			}
 		}
 
+		add_action( 'jetpack_event_log', array( 'Jetpack', 'log' ), 10, 2 );
+
 		add_filter( 'determine_current_user', array( $this, 'wp_rest_authenticate' ) );
 		add_filter( 'rest_authentication_errors', array( $this, 'wp_rest_authentication_errors' ) );
 

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -779,7 +779,15 @@ class Jetpack_XMLRPC_Server {
 			wp_set_current_user( $this->user->ID );
 		}
 
-		Jetpack::log( 'disconnect' );
+		/**
+		 * Fired when we want to log an event to the Jetpack event log.
+		 *
+		 * @since 7.7.0
+		 *
+		 * @param string $code Unique name for the event.
+		 * @param string $data Optional data about the event.
+		 */
+		do_action( 'jetpack_event_log', 'disconnect' );
 		Jetpack::disconnect();
 
 		return true;
@@ -791,7 +799,15 @@ class Jetpack_XMLRPC_Server {
 	 * This will fail if called by the Master User.
 	 */
 	public function unlink_user() {
-		Jetpack::log( 'unlink' );
+		/**
+		 * Fired when we want to log an event to the Jetpack event log.
+		 *
+		 * @since 7.7.0
+		 *
+		 * @param string $code Unique name for the event.
+		 * @param string $data Optional data about the event.
+		 */
+		do_action( 'jetpack_event_log', 'unlink' );
 		return Connection_Manager::disconnect_user();
 	}
 


### PR DESCRIPTION
Currently, we're trying to decouple the connection package from the rest of Jetpack. As part of this effort, this PR suggests using a hook instead of `Jetpack::log()` in the connection package. That way, we could allow Jetpack to hook its logging mechanism, but if the package is used independently, no logging will be processed, unless someone else uses that hook.

#### Changes proposed in this Pull Request:
* Connection: Use a hook for event log in package

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a continuation of this effort: p1HpG7-7lI-p2

#### Testing instructions:
* Checkout this branch on your connected Jetpack site.
* Go to `https://wordpress.com/settings/manage-connection/:site` where `:site` is the slug of your Jetpack site.
* Click the button to disconnect, and confirm disconnection.
* In the root of your Jetpack dir, run `yarn docker:wp option get jetpack_log`.
* Verify you can see a `disconnect` event properly at the end of the log.

#### Proposed changelog entry for your changes:
* Connection: Use a hook for event log in package
