### PR TITLE
Gutenblocks: add new utility to get all classes for a given block

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -720,7 +720,7 @@ class Jetpack_Gutenberg {
 		}
 
 		// Add custom classes if provided in the block editor.
-		if ( isset( $attr['className'] ) ) {
+		if ( ! empty( $attr['className'] ) ) {
 			array_push( $classes, $attr['className'] );
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -696,8 +696,8 @@ class Jetpack_Gutenberg {
 	 * @since 7.7.0
 	 *
 	 * @param string $slug  Block slug.
-	 * @param array  $attr  Array containing the block attributes.
-	 * @param array  $extra Array of potential extra classes you may want to provide.
+	 * @param array  $attr  Block attributes.
+	 * @param array  $extra Potential extra classes you may want to provide.
 	 *
 	 * @return string $classes List of CSS classes for a block.
 	 */

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -689,4 +689,46 @@ class Jetpack_Gutenberg {
 			}
 		}
 	}
+
+	/**
+	 * Get CSS classes for a block.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param string $slug  Block slug.
+	 * @param array  $attr  Array containing the block attributes.
+	 * @param array  $extra Array of potential extra classes you may want to provide.
+	 *
+	 * @return string $classes List of CSS classes for a block.
+	 */
+	public static function block_classes( $slug = '', $attr, $extra = array() ) {
+		if ( empty( $slug ) ) {
+			return '';
+		}
+
+		// Basic block name class.
+		$classes = array(
+			'wp-block-jetpack-' . $slug,
+		);
+
+		// Add alignment if provided.
+		if (
+			! empty( $attr['align'] )
+			&& in_array( $attr['align'], array( 'left', 'center', 'right', 'wide', 'full' ), true )
+		) {
+			array_push( $classes, 'align' . $attr['align'] );
+		}
+
+		// Add custom classes if provided in the block editor.
+		if ( isset( $attr['className'] ) ) {
+			array_push( $classes, $attr['className'] );
+		}
+
+		// Add any extra classes.
+		if ( is_array( $extra ) && ! empty( $extra ) ) {
+			$classes = array_merge( $classes, $extra );
+		}
+
+		return implode( $classes, ' ' );
+	}
 }

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -32,17 +32,8 @@ function jetpack_gif_block_render( $attr ) {
 		return null;
 	}
 
-	/* TODO: replace with centralized block_class function */
-	$align   = isset( $attr['align'] ) ? $attr['align'] : 'center';
-	$type    = 'gif';
-	$classes = array(
-		'wp-block-jetpack-' . $type,
-		'align' . $align,
-	);
-	if ( isset( $attr['className'] ) ) {
-		array_push( $classes, $attr['className'] );
-	}
-	$classes     = implode( $classes, ' ' );
+	$classes = Jetpack_Gutenberg::block_classes( 'gif', $attr );
+
 	$placeholder = sprintf( '<a href="%s">%s</a>', esc_url( $giphy_url ), esc_attr( $search_text ) );
 
 	ob_start();

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -47,17 +47,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 
 	$values['submitButtonText'] = empty( $values['submitButtonText'] ) ? $defaults['submitButtonText'] : $values['submitButtonText'];
 
-	/* TODO: replace with centralized block_class function */
-	$align   = isset( $attr['align'] ) ? $attr['align'] : 'center';
-	$type    = 'mailchimp';
-	$classes = array(
-		'wp-block-jetpack-' . $type,
-		'align' . $align,
-	);
-	if ( isset( $attr['className'] ) ) {
-		array_push( $classes, $attr['className'] );
-	}
-	$classes = implode( $classes, ' ' );
+	$classes = Jetpack_Gutenberg::block_classes( 'mailchimp', $attr );
 
 	$button_styles = array();
 	if ( ! empty( $attr['customBackgroundButtonColor'] ) ) {

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -39,5 +39,5 @@ function jetpack_repeat_visitor_block_render( $attributes, $content ) {
 	}
 
 	// return an empty div so that view script increments the visit counter in the cookie.
-	return '<div class="' . $classes . '"></div>';
+	return '<div class="' . esc_attr( $classes ) . '"></div>';
 }

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -25,6 +25,8 @@ jetpack_register_block(
 function jetpack_repeat_visitor_block_render( $attributes, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( 'repeat-visitor' );
 
+	$classes = Jetpack_Gutenberg::block_classes( 'repeat-visitor', $attributes );
+
 	$count     = isset( $_COOKIE['jp-visit-counter'] ) ? intval( $_COOKIE['jp-visit-counter'] ) : 0;
 	$criteria  = isset( $attributes['criteria'] ) ? $attributes['criteria'] : 'after-visits';
 	$threshold = isset( $attributes['threshold'] ) ? intval( $attributes['threshold'] ) : 3;
@@ -37,5 +39,5 @@ function jetpack_repeat_visitor_block_render( $attributes, $content ) {
 	}
 
 	// return an empty div so that view script increments the visit counter in the cookie.
-	return '<div class="wp-block-jetpack-repeat-visitor"></div>';
+	return '<div class="' . $classes . '"></div>';
 }

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -208,17 +208,18 @@ class Jetpack_Memberships {
 			'powered_text' => __( 'Powered by WordPress.com', 'jetpack' ),
 		);
 
-		$classes = array(
-			'wp-block-button__link',
-			'components-button',
-			'is-primary',
-			'is-button',
-			'wp-block-jetpack-' . self::$button_block_name,
-			self::$css_classname_prefix . '-' . $data['id'],
+		$classes = Jetpack_Gutenberg::block_classes(
+			self::$button_block_name,
+			$attrs,
+			array(
+				'wp-block-button__link',
+				'components-button',
+				'is-primary',
+				'is-button',
+				self::$css_classname_prefix . '-' . $data['id'],
+			)
 		);
-		if ( isset( $attrs['className'] ) ) {
-			array_push( $classes, $attrs['className'] );
-		}
+
 		if ( isset( $attrs['submitButtonText'] ) ) {
 			$data['button_label'] = $attrs['submitButtonText'];
 		}
@@ -249,7 +250,7 @@ class Jetpack_Memberships {
 			esc_attr( $data['powered_text'] ),
 			esc_attr( $data['id'] ),
 			esc_attr( get_locale() ),
-			esc_attr( implode( $classes, ' ' ) ),
+			esc_attr( $classes ),
 			esc_attr( $button_styles ),
 			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button )
 		);


### PR DESCRIPTION
Fixes #13257

#### Changes proposed in this Pull Request:

* We previously fetched different classes in each block rendering function, from multiple places (the block's name, the block's alignment settings, the block's extra CSS classes that can be defined in the sidebar, and sometimes our own extra classes). This PR centralizes things into a common function that can be used by other blocks in the future.
* This PR also changes the default alignment for the Mailchimp and the GIF block. Until now we defaulted to a center alignment, which may not be the expected default. Thus this fixes #13257.

#### Testing instructions:

* You can test this PR by inserting a GIF, Recurring Payments, Mailchimp, and / or Repeat Visitor block in the block editor.
* After inserting the block, you can preview your post.
* You can check the block's markup and make sure the overall div container displays at least the main block class, `wp-block-jetpack-blockname`.
* You should **not** see an `aligncenter` class name by default.
* Back in the block editor, try making some changes to your block:
    * Add a custom class using the CSS class input field at the bottom of the editor sidebar when the block is selected.
    * Define an alignment for your block when it's offered.
* You will want to make sure those extra fields appear in the block markup in the preview.

#### Proposed changelog entry for your changes:

* Blocks: add new utility to get all classes for a given block.
