### PR TITLE
Add New Endpoint for Submitting Disconnect Survey to WordPress.com

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -81,6 +81,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		) );
 
+		register_rest_route( 'jetpack/v4', 'marketing/survey', array(
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => __CLASS__ . '::submit_survey',
+			// 'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
+
+		) );
+
 		register_rest_route( 'jetpack/v4', '/jitm', array(
 			'methods'  => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::get_jitm_message',
@@ -493,6 +500,35 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return $data;
+	}
+
+	public static function submit_survey( $request ) {
+
+		$wpcom_request = Client::wpcom_json_api_request_as_user(
+			'/marketing/survey',
+			'1.1',
+			array(
+				'method'  => 'POST',
+				'headers' => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+			),
+			[],
+			'rest'
+		);
+
+		$wpcom_request_body = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
+		if ( 200 === wp_remote_retrieve_response_code( $wpcom_request ) ) {
+			$data = $wpcom_request_body;
+		} else {
+			// something went wrong so we'll just return the response without caching
+			return $wpcom_request_body;
+		}
+
+		return $data;
+		// return $request;
+		// return new WP_Error( 'forbidden', __( 'Site endpoint is under construction.', 'jetpack' ) );
+		// return false;
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -84,7 +84,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', 'marketing/survey', array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => __CLASS__ . '::submit_survey',
-			// 'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
+			'permission_callback' => __CLASS__ . '::unlink_user_permission_callback',
 
 		) );
 
@@ -510,10 +510,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			array(
 				'method'  => 'POST',
 				'headers' => array(
+					'Content-Type'    => 'application/json',
 					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
 				),
 			),
-			[],
+			$request->get_body(),
 			'rest'
 		);
 
@@ -526,9 +527,6 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return $data;
-		// return $request;
-		// return new WP_Error( 'forbidden', __( 'Site endpoint is under construction.', 'jetpack' ) );
-		// return false;
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -84,7 +84,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', 'marketing/survey', array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => __CLASS__ . '::submit_survey',
-			'permission_callback' => __CLASS__ . '::unlink_user_permission_callback',
+			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback',
 
 		) );
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -506,7 +506,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$wpcom_request = Client::wpcom_json_api_request_as_user(
 			'/marketing/survey',
-			'1.1',
+			'v2',
 			array(
 				'method'  => 'POST',
 				'headers' => array(
@@ -514,8 +514,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
 				),
 			),
-			$request->get_body(),
-			'rest'
+			$request->get_json_params()
 		);
 
 		$wpcom_request_body = json_decode( wp_remote_retrieve_body( $wpcom_request ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Supporting PR for eventual new disconnect dialog ( see #13305 ). Survey results from that new dialog will be send to WordPress.com to be stored via this new endpoint.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `/marketing/survey` endpoint to submit surveys to WordPress.com
* **Requires D32171-code**

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Apply D32171-code and set `JETPACK__SANDBOX_DOMAIN`
2. Navigate to Jetpack Dashboard
3. Enter the following into the browser console:
```js
fetch( Initial_State.WP_API_root + 'jetpack/v4/marketing/survey', {
	credentials: 'same-origin',
	headers: {
		'X-WP-Nonce': Initial_State.WP_API_nonce,
        'Content-Type': 'application/json',
	},
    method: 'POST',
    body: JSON.stringify(
        {
            "survey_id": "calypso-disconnect-jetpack-july2019",
            "site_id": 150772522,
            "survey_responses": {
                "purchase": "jetpack_personal",
                "why-cancel": { "response": "other", "text": "a8c dev test" },
                "source": { "from": "Jetpack-Test" }
            }
        }
    )
} )
.then( function( response ) {
    return response.json();
} )
.then( function( myJson ) {
    console.log( JSON.stringify( myJson ) );
} );
```
4. Confirm the following is printed into the console `{"success":true,"err":null}`
5. Navigate to D32171-code and follow steps 4 & 5 from section v2 API to confirm survey submission


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Adds `jetpack/v4/marketing/survey` endpoint to submit surveys to WordPress.com
