### PR TITLE
Jetpack Connection Banner: move the connection button

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -166,7 +166,7 @@ class Jetpack_Connection_Banner {
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 				'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
 				'buttonTextDefault'     => __( 'Set up Jetpack', 'jetpack' ),
-                'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
+				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
 			)
 		);
 	}
@@ -306,6 +306,17 @@ class Jetpack_Connection_Banner {
 					<h2 class="jp-connect-full__step-header-title"><?php esc_html_e( 'Activate essential WordPress security and performance tools by setting up Jetpack', 'jetpack' ) ?></h2>
 				</div>
 
+				<p class="jp-connect-full__tos-blurb">
+					<?php jetpack_render_tos_blurb(); ?>
+				</p>
+
+				<p class="jp-connect-full__button-container">
+					<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, $bottom_connect_url_from ) ); ?>"
+					   class="dops-button is-primary jp-connect-button">
+						<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
+					</a>
+				</p>
+
 				<div class="jp-connect-full__row">
 					<div class="jp-connect-full__slide">
 						<div class="jp-connect-full__slide-card illustration">
@@ -345,17 +356,6 @@ class Jetpack_Connection_Banner {
 					</div>
 				</div>
 
-				<p class="jp-connect-full__tos-blurb">
-					<?php jetpack_render_tos_blurb(); ?>
-				</p>
-
-				<p class="jp-connect-full__button-container">
-					<a href="<?php echo esc_url( Jetpack::init()->build_connect_url( true, false, $bottom_connect_url_from ) ); ?>"
-					   class="dops-button is-primary jp-connect-button">
-						<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
-					</a>
-				</p>
-
 				<?php if ( 'plugins' === $current_screen->base ) : ?>
 					<p class="jp-connect-full__dismiss-paragraph">
 						<a>
@@ -366,7 +366,7 @@ class Jetpack_Connection_Banner {
 					</p>
 				<?php endif; ?>
 			</div>
-        </div>
+		</div>
 		<?php
 	}
 

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -142,7 +142,7 @@
 
 .jp-connect-full__step-header {
 	max-width: 700px;
-	margin: 0 auto;
+	margin: 0 auto 40px auto;
 	line-height: 1.5;
 
 	h2 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes no known issues

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Moves the connection button above the fold.

Previously, it was here:

![Screen Shot 2019-08-21 at 5 50 50 PM](https://user-images.githubusercontent.com/2694219/63546450-dc176e00-c4f7-11e9-9a7a-4f051e0b67e4.png)

I'd like to put it here:

<img width="1547" alt="Screen Shot 2019-08-22 at 4 10 11 PM" src="https://user-images.githubusercontent.com/2694219/63546466-e3d71280-c4f7-11e9-9b7f-2aed7ccff3c4.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes the layout of an existing page in the Jetpack dashboard.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- On an unconnected Jetpack site, visit the main Jetpack dashboard to see the change

Bonus Points:

- set this constant on your unconnected jetpack site
`define ( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
- Try to connect the site via the main jetpack dashboard
- are any layout changes needed?

If that's too much for you, you can watch this[ brief screen cast.](https://cloudup.com/cglVLBVwwM2)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
