### PR TITLE
Twitter: change the way the @wordpressdotcom handle is added.

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -233,11 +233,8 @@ class Jetpack_Twitter_Cards {
             trim( get_option( 'twitter_via' ) ) :
             Jetpack_Options::get_option_and_ensure_autoload( 'jetpack-twitter-cards-site-tag', '' );
 		if ( empty( $site_tag ) ) {
-			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-				return 'wordpressdotcom';
-			} else {
-				return;
-			}
+			/** This action is documented in modules/sharedaddy/sharing-sources.php */
+			return apply_filters( 'jetpack_sharing_twitter_via', '', null );
 		}
 		return $site_tag;
 	}


### PR DESCRIPTION
Differential Revision: D31369-code
This commit syncs r195657-wpcom.

#### Changes proposed in this Pull Request:

* Nothing should change on the Jetpack-end. This is just changing the way the @wordpressdotcom handle is added to wpcom simple sites by default. This is now done via the `jetpack_sharing_twitter_via` filter instead of hardcoded in the function.

#### Testing instructions:

* You can check the use of that handle in a few places.
* Activate the Sharing module and add a Sharing button to your site.
* In any post, click on the sharing button and make sure that nothing is added to the end of the Twitter message (no `via @....`)
* If you view source and search for `twitter:` meta tags, you should see no site or creator tag added.
* Now go to Settings > Sharing and add your Twitter handle in the settings.
* That handle should now be used in the places I mentioned above.
* Go back to Settings > Sharing and remove that Twitter handle from the settings.
* Activate Publicize, and connect your site to your Twitter account.
* Publish a new post. 
* Repeat the testing steps above: the twitter account you've connected to Publicize should now be used everywhere.
* Add the following code snippet to your site: 
```php
function jetpackcom_custom_twitter_via() {
    return 'jakelikesonions';
}
add_filter( 'jetpack_sharing_twitter_via', 'jetpackcom_custom_twitter_via' );
```
* Make sure that handle is used instead of yours.

#### Proposed changelog entry for your changes:

* None
