### PR TITLE
Handle connection errors on the Jetpack side gracefully

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -1,7 +1,8 @@
 /* global jpConnect */
 
 jQuery( document ).ready( function( $ ) {
-	$( '.jp-connect-button' ).click( function( event ) {
+	var connectButton = $( '.jp-connect-button' );
+	connectButton.click( function( event ) {
 		event.preventDefault();
 		if ( ! jetpackConnectButton.isRegistering ) {
 			jetpackConnectButton.handleClick();
@@ -13,7 +14,7 @@ jQuery( document ).ready( function( $ ) {
 		isRegistering: false,
 		handleClick: function() {
 			jetpackConnectButton.isRegistering = true;
-			$( '.jp-connect-button' )
+			connectButton
 				.text( jpConnect.buttonTextRegistering )
 				.attr( 'disabled', true )
 				.blur();
@@ -25,11 +26,9 @@ jQuery( document ).ready( function( $ ) {
 					_wpnonce: jpConnect.apiNonce,
 				},
 				error: function( error ) {
-					console.warn( error );
+					console.warn( 'Connection failed. Falling back to the regular flow', error );
 					jetpackConnectButton.isRegistering = false;
-					$( '.jp-connect-button' )
-						.text( jpConnect.buttonTextDefault )
-						.removeAttr( 'disabled' );
+					window.location = connectButton.attr( 'href' );
 				},
 				success: function( data ) {
 					window.addEventListener( 'message', jetpackConnectButton.receiveData );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -165,7 +165,6 @@ class Jetpack_Connection_Banner {
 				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 				'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
-				'buttonTextDefault'     => __( 'Set up Jetpack', 'jetpack' ),
 				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
 			)
 		);


### PR DESCRIPTION
When it's impossible to initiate the registration on the Jetpack side using the connect in place feature, we should fall back to the regular flow, i.e. redirect to Calypso flow.

Fixes no known issues.

#### Changes proposed in this Pull Request:
* Fall back to the regular registration flow if the ajax request made by the connect-in-place feature fails.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Master Thread: p1HpG7-7nj-p2

#### Testing instructions:
* Test on an un-connected site running this branch.
* Ensure you can connect using the new connect-in-place flow.
* Disconnect from WP.com.
* Force a connection error, e.g. by changing the `url` param in the `$.ajax` call to something inexistent. 
* Ensure you can still connect using the regular Calypso flow.

#### Proposed changelog entry for your changes:
* None needed
