### PR TITLE
Recurring Payments: change alignment

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -316,7 +316,7 @@ class MembershipsButtonEdit extends Component {
 	render = () => {
 		const { className, notices } = this.props;
 		const { connected, connectURL, products } = this.state;
-
+		const align = this.props.attributes.align;
 		const inspectorControls = (
 			<InspectorControls>
 				<PanelBody title={ __( 'Product', 'jetpack' ) }>
@@ -343,6 +343,7 @@ class MembershipsButtonEdit extends Component {
 			'components-button',
 			'is-primary',
 			'is-button',
+			`align${ align }`,
 		] );
 		const blockContent = (
 			<SubmitButton

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -314,9 +314,9 @@ class MembershipsButtonEdit extends Component {
 	};
 
 	render = () => {
-		const { className, notices } = this.props;
+		const { className, notices, attributes } = this.props;
 		const { connected, connectURL, products } = this.state;
-		const align = this.props.attributes.align;
+		const { align } = attributes;
 		const inspectorControls = (
 			<InspectorControls>
 				<PanelBody title={ __( 'Product', 'jetpack' ) }>

--- a/extensions/blocks/recurring-payments/editor.scss
+++ b/extensions/blocks/recurring-payments/editor.scss
@@ -3,6 +3,7 @@
 
 .wp-block-jetpack-recurring-payments {
 	font-family: $default-font;
+	width: 100%;
 
 	.components-base-control__label {
 		text-align: left;

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -46,7 +46,6 @@ export const settings = {
 		},
 		align: {
 			type: 'string',
-			default: 'center',
 		},
 	},
 	edit,

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -44,9 +44,17 @@ export const settings = {
 		customTextButtonColor: {
 			type: 'string',
 		},
+		align: {
+			type: 'string',
+			default: 'left',
+		},
 	},
 	edit,
 	save: () => null,
+	supports: {
+		html: false,
+		align: true,
+	},
 };
 
 // These are Stripe Settlement currencies https://stripe.com/docs/currencies since memberships supports only Stripe ATM.

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -46,7 +46,7 @@ export const settings = {
 		},
 		align: {
 			type: 'string',
-			default: 'left',
+			default: 'center',
 		},
 	},
 	edit,


### PR DESCRIPTION


<img width="722" alt="Zrzut ekranu 2019-09-3 o 11 40 24" src="https://user-images.githubusercontent.com/3775068/64162989-aa2fd100-ce40-11e9-93ee-be36115d8f86.png">
<img width="657" alt="Zrzut ekranu 2019-09-3 o 11 39 51" src="https://user-images.githubusercontent.com/3775068/64162993-ab60fe00-ce40-11e9-9f97-ef29f49ba2fc.png">


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduce the align menu to choose left/right/center alignment for the block.

#### Testing instructions:

* Choose a site with Recurring Payments set up (full instructions in https://github.com/Automattic/jetpack/pull/9802)
* Insert new button
* Change alignment to center
* Publish
* See that your new button is in the center

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* You can now change the alignment of your recurring payments button. If you want to have it display in the middle of your page - that's an option now!
