### PR TITLE
More readable tint for loading indicator

### DIFF
--- a/_inc/client/components/connect-button/style.scss
+++ b/_inc/client/components/connect-button/style.scss
@@ -4,14 +4,3 @@
 // Buttons
 // ==========================================================================
 
-.jp-jetpack-connect__button {
-	background: $green-primary;
-	border-color: $green-secondary;
-	color: $white;
-
-	&:hover, &:focus {
-		background: $green-secondary;
-		border-color: $green-dark;
-		color: $white;
-	}
-}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -164,7 +164,7 @@ class Jetpack_Connection_Banner {
 				'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
 				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-				'buttonTextRegistering' => __( 'Loading', 'jetpack' ),
+				'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
 				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
 			)
 		);

--- a/scss/jetpack-connect.scss
+++ b/scss/jetpack-connect.scss
@@ -39,8 +39,8 @@
 
 	&[disabled],
 	&:disabled {
-		background: tint( $blue-light, 50% );
-		border-color: tint( $blue-wordpress, 55% );
+		background: tint( $blue-medium, 40% );
+		border-color: tint( $blue-dark, 40% );
 		color: $white;
 	}
 }

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -168,21 +168,6 @@
 	}
 }
 
-.jp-connect-full__button-container {
-	margin: 0;
-	.dops-button.is-primary {
-		background: $green-primary;
-		border-color: $green-secondary;
-		padding-left: rem( 24px );
-		padding-right: rem( 24px );
-
-		&:hover, &:focus {
-			background: $green-secondary;
-			border-color: $green-dark;
-		}
-	}
-}
-
 .jp-connect-full__tos-blurb {
 	font-size: rem( 11px );
 	margin: 0 auto rem( 16px );


### PR DESCRIPTION
A style tweak suggested by @jeffgolenski : Don't grey out "loading" state of connect button as darkly, and add an ellipsis. This PR also simplifies some styles that were overriding each other in weird ways.

Before:

<img width="603" alt="loading-old" src="https://user-images.githubusercontent.com/51896/63626010-51e20f00-c5b6-11e9-854b-049dd51797ce.png">


After:

<img width="604" alt="loading-new" src="https://user-images.githubusercontent.com/51896/63625954-1b0bf900-c5b6-11e9-8dfa-4e9572fb82a3.png">




cc @roccotripaldi 