### PR TITLE
Regen asset CDN paths, which were stale

### DIFF
--- a/bin/build-asset-cdn-json.php
+++ b/bin/build-asset-cdn-json.php
@@ -19,6 +19,7 @@ $ignore_paths = array(
 	'tests/',
 	'tools/',
 	'vendor/',
+	'packages/',
 );
 
 $manifest = array();


### PR DESCRIPTION
This updates the file `modules/photon-cdn/jetpack-manifest.php`. I also updated `bin/build-asset-cdn-json.php`, which generates the file, to exclude the `packages` directory.

I had noticed while doing other work that this file contained some stale assets, so it seemed worth regenerating.

I also noticed that it explicitly ignores the `vendor/` directory. That may not be a good thing, depending on how many assets we include directly from built packages.