### PR TITLE
Add initial AMP-compatibility to the Map block

### DIFF
--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -25,7 +25,80 @@ jetpack_register_block(
 function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
-	Jetpack_Gutenberg::load_assets_as_required( 'map' );
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 
-	return preg_replace( '/<div /', '<div data-api-key="' . esc_attr( $api_key ) . '" ', $content, 1 );
+		$attr['api_key'] = $api_key;
+		$attr['content'] = $content;
+
+		$attr = wp_json_encode( $attr );
+		$hmac = wp_hash( $attr );
+
+		$src = add_query_arg(
+			array(
+				'jetpack_map_block_attr' => rawurlencode( $attr ),
+				'jetpack_map_block_hmac' => rawurlencode( $hmac ),
+			),
+			home_url( '/' )
+		);
+
+		$placeholder = preg_replace( '/(?<=<div\s)/', 'placeholder ', $content );
+
+		// @todo Is intrinsic size right? Is content_width the right dimensions?
+		return sprintf(
+			'<amp-iframe src="%s" width="%d" height="%d" layout="intrinsic" allowfullscreen sandbox="allow-scripts">%s</amp-iframe>',
+			esc_url( $src ),
+			Jetpack::get_content_width(),
+			Jetpack::get_content_width(),
+			$placeholder
+		);
+
+	} else {
+		Jetpack_Gutenberg::load_assets_as_required( 'map' );
+
+		return preg_replace( '/(?<=<div\s)/', 'data-api-key="' . esc_attr( $api_key ) . '" ', $content, 1 );
+	}
 }
+
+/**
+ * Render standalone document for a map block, for use inside an iframe (such as on an AMP page).
+ */
+function jetpack_map_block_render_standalone() {
+	if ( ! isset( $_GET['jetpack_map_block_attr'] ) || ! isset( $_GET['jetpack_map_block_hmac'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+	$hmac = wp_unslash( $_GET['jetpack_map_block_hmac'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$attr = wp_unslash( $_GET['jetpack_map_block_attr'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( wp_hash( $attr ) !== $hmac ) {
+		wp_die( 'HMAC failure' );
+	}
+	$attr = json_decode( $attr, true );
+	if ( ! is_array( $attr ) ) {
+		wp_die( 'Parse error in jetpack_map_block JSON.' );
+	}
+	remove_theme_support( 'amp' ); // Prevent page from being served as AMP on standard-mode sites.
+	?>
+	<!DOCTYPE html>
+	<html>
+		<head>
+			<style>
+				html, body { margin: 0; padding: 0; }
+				/* @todo Map Box isn't actually stretching to the bottom of the div here.  */
+				body > div { position: absolute; top: 0; bottom: 0; left: 0; right: 0; }
+			</style>
+		</head>
+		<body>
+			<?php Jetpack_Gutenberg::load_assets_as_required( 'map' ); ?>
+			<?php
+			echo preg_replace( '/(?<=<div\s)/', 'data-api-key="' . esc_attr( $attr['api_key'] ) . '" ', $attr['content'], 1 ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+			// @todo Are there non-required dependencies being added?
+			wp_styles()->do_items();
+			wp_scripts()->do_items();
+			?>
+		</body>
+	</html>
+	<?php
+	exit;
+
+}
+add_action( 'wp', 'jetpack_map_block_render_standalone', 0 );

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -82,8 +82,6 @@ function jetpack_map_block_render_standalone() {
 		<head>
 			<style>
 				html, body { margin: 0; padding: 0; }
-				/* @todo Map Box isn't actually stretching to the bottom of the div here.  */
-				body > div { position: absolute; top: 0; bottom: 0; left: 0; right: 0; }
 			</style>
 		</head>
 		<body>


### PR DESCRIPTION
This adds initial AMP-compatibility to the Map block. In reality, it would be better to use `amp-script` for this rather than `amp-iframe`, but using `amp-iframe` is more straightforward at the moment.

Note: if there are multiple map blocks on a given page it may be more performant to disable AMP for that page, since otherwise each iframe has to have a separate copy of all scripts.

See #9730

Todo:

- [ ] Address doubled placeholders.
- [ ] Improve map height inside of iframe.
- [ ] Determine if width/height of `amp-iframe` are correct, and whether `intrinsic` or `responsive` layout should be used.
- [ ] Make sure only the required scripts and styles are being printed in the iframe.

#### Changes proposed in this Pull Request:

* On AMP pages, embed an `amp-iframe` that loads a new endpoint page that contains the map block in isolation.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds AMP compatibility to Map block.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate AMP plugin.
* Add Map block to content.
* View post/page in AMP.
* Verify Map block still renders on a valid AMP page.

#### Proposed changelog entry for your changes:

* Add AMP-compatibility to the Map block.
