### PR TITLE
Deleting the connection owner? Think again (or transfer ownership.)

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -735,7 +735,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error True if user is able to change master user.
 	 */
 	public static function set_connection_owner_permission_callback() {
-		if ( get_current_user_id() === Jetpack_Options::get_option( 'master_user' ) ) {
+		if ( current_user_can( 'jetpack_connect' ) ) {
 			return true;
 		}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -735,7 +735,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error True if user is able to change master user.
 	 */
 	public static function set_connection_owner_permission_callback() {
-		if ( current_user_can( 'jetpack_connect' ) ) {
+		if ( current_user_can( 'jetpack_disconnect' ) ) {
 			return true;
 		}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -731,6 +731,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Check that user has permission to change the master user.
 	 *
 	 * @since 6.2.0
+	 * @since 7.7.0 Update so that any user with jetpack_disconnect privs can set owner.
 	 *
 	 * @return bool|WP_Error True if user is able to change master user.
 	 */

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -528,6 +528,31 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
+	 * Returns an array of user_id's that have user tokens for communicating with wpcom.
+	 * Able to select by specific capability.
+	 *
+	 * @param string The capability of the user
+	 * @return array Array of WP_User objects if found.
+	 */
+	public function get_connected_users( $capability = 'any' ) {
+		$connected_users    = array();
+		$connected_user_ids = array_keys( \Jetpack_Options::get_option( 'user_tokens' ) );
+
+		if ( ! empty( $connected_user_ids ) ) {
+			foreach ( $connected_user_ids as $id ) {
+				// Check for capability
+				if ( 'any' !== $capability && ! user_can( $id, $capability ) ) {
+					continue;
+				}
+
+				$connected_users[] = get_userdata( $id );
+			}
+		}
+
+		return $connected_users;
+	}
+
+	/**
 	 * Get the wpcom user data of the current|specified connected user.
 	 *
 	 * @todo Refactor to properly load the XMLRPC client independently.
@@ -560,6 +585,22 @@ class Manager implements Manager_Interface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Returns a user object of the connection owner.
+	 *
+	 * @return object|false False if no connection owner found.
+	 */
+	public function get_connection_owner() {
+		$user_token = $this->get_access_token( JETPACK_MASTER_USER );
+
+		$connection_owner = false;
+		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
+			$connection_owner = get_userdata( $user_token->external_user_id );
+		}
+
+		return $connection_owner;
 	}
 
 	/**

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -187,6 +187,11 @@ class JITM {
 			return;
 		}
 
+		// Bail if they're trying to delete themselves to avoid confusion.
+		if ( $connection_owner->ID == get_current_user_id() ) {
+			return;
+		}
+
 		$connection_manager = new Manager();
 		$connected_users    = $connection_manager->get_connected_users( 'jetpack_connect' );
 
@@ -237,7 +242,7 @@ class JITM {
 								'X-WP-Nonce': "<?php echo wp_create_nonce( 'wp_rest' ); ?>",
 							},
 							success: function() {
-								results.innerHTML = "Success! thank you.";
+								results.innerHTML = <?php esc_html_e( "Success!", 'jetpack' ); ?>;
 								setTimeout( function() {
 									$( '#jetpack-notice-switch-connection-owner' ).hide( 'slow' );
 								}, 1000 );

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -168,11 +168,6 @@ class JITM {
 			return;
 		}
 
-		// Get these from the URL params.
-		$user_ids = $_REQUEST['users'];
-
-		$deleting_connection_owner = false;
-
 		// Get connection owner or bail
 		$connection_manager = new Manager();
 		$connection_owner   = $connection_manager->get_connection_owner();
@@ -180,14 +175,9 @@ class JITM {
 			return;
 		}
 
-		// Are any of the users the connection owner?
-		foreach ( $user_ids as $user_id ) {
-			if ( $connection_owner->ID == $user_id ) {
-				$deleting_connection_owner = true;
-				break;
-			}
-		}
-
+		// Bail if we're not trying to delete connection owner.
+		$user_ids_to_delete        = $_REQUEST['users'];
+		$deleting_connection_owner = in_array( $connection_owner->ID, (array) $user_ids_to_delete );
 		if ( ! $deleting_connection_owner ) {
 			return;
 		}
@@ -224,11 +214,10 @@ class JITM {
 
 			submit_button( __( 'Set new connection owner', 'jetpack' ), 'primary', 'jp-switch-connection-owner-submit' );
 
-			_e( '<p>As always, feel free to <a href="https://jetpack.com/contact-support/?rel=support" target="_blank">contact our support team</a> if you have any questions.</p>', 'jetpack' );
+			_e( '<p>As always, feel free to <a href="https://jetpack.com/contact-support" target="_blank">contact our support team</a> if you have any questions.</p>', 'jetpack' );
 
 			echo "<div id='jp-switch-user-results'></div>";
 			echo '</form>';
-
 			?>
 			<script type="text/javascript">
 				jQuery( document ).ready( function( $ ) {
@@ -266,7 +255,7 @@ class JITM {
 			_e( '<p>Unfortunately, there are no other connected admins to transfer the connection to.</p>', 'jetpack' );
 			printf(
 				__( '<p>If you would like to be the new connection owner for this site, please connect to your WordPress.com account by clicking <a href="%s" target="_blank">this link</a>. Once you connect, you may refresh this page to see an option to change the connection owner.</p>', 'jetpack' ),
-				\Jetpack::init()->build_connect_url( false, false, 'delete_user_page' )
+				\Jetpack::init()->build_connect_url( false, false, 'connection_owner_notice' )
 			);
 			_e( '<p>If the site does not have a connection owner, it will be disconnected from Jetpack servers.</p>', 'jetpack' );
 		}

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -263,7 +263,7 @@ class JITM {
 		} else {
 			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ) . "</p>";
 			$connect_url = \Jetpack::init()->build_connect_url( false, false, 'connection_owner_notice' );
-			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to Wordpress.com' ) . "</a>";
+			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to WordPress.com', 'jetpack' ) . "</a>";
 		}
 
 		echo '<p>';

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -203,7 +203,7 @@ class JITM {
 
 		if ( ! empty( $connected_users ) && count( $connected_users ) > 1 ) {
 			echo '<form id="jp-switch-connection-owner" action="" method="post">';
-			echo "<label for='owner'>" . esc_html__( 'You can choose to transfer connection ownership to one of these already-connected admins: ', 'jetpack' ) . '</label>';
+			echo "<label for='owner'>" . esc_html__( 'You can choose to transfer connection ownership to one of these already-connected admins:', 'jetpack' ) . ' </label>';
 
 			$connected_user_ids = array_map(
 				function( $connected_user ) {
@@ -220,7 +220,10 @@ class JITM {
 				)
 			);
 
-			submit_button( __( 'Set new connection owner', 'jetpack' ), 'primary', 'jp-switch-connection-owner-submit' );
+			echo "<p>";
+			submit_button( esc_html__( 'Set new connection owner', 'jetpack' ), 'primary', 'jp-switch-connection-owner-submit', false );
+			echo "</p>";
+
 
 			echo "<div id='jp-switch-user-results'></div>";
 			echo '</form>';
@@ -242,7 +245,7 @@ class JITM {
 								'X-WP-Nonce': "<?php echo wp_create_nonce( 'wp_rest' ); ?>",
 							},
 							success: function() {
-								results.innerHTML = <?php esc_html_e( "Success!", 'jetpack' ); ?>;
+								results.innerHTML = "<?php esc_html_e( "Success!", 'jetpack' ); ?>";
 								setTimeout( function() {
 									$( '#jetpack-notice-switch-connection-owner' ).hide( 'slow' );
 								}, 1000 );
@@ -266,7 +269,7 @@ class JITM {
 		echo '<p>';
 		printf(
 			wp_kses(
-				__( "<a href='%1$1s' target='_blank' rel='noopener noreferrer'>Learn more</a> about the connection owner and what will break if you do not have one.", 'jetpack' ),
+				__( "<a href='%s' target='_blank' rel='noopener noreferrer'>Learn more</a> about the connection owner and what will break if you do not have one.", 'jetpack' ),
 				array(
 					'a' => array(
 						'href'   => true,
@@ -275,12 +278,13 @@ class JITM {
 					),
 				)
 			),
-			'https://jetpack.com/support/primary-user/',
-			esc_html( $connection_owner->data->user_login )
+			'https://jetpack.com/support/primary-user/'
 		);
 		echo '</p>';
-		echo '<p>' . wp_kses(
-				__( 'As always, feel free to <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer">contact our support team</a> if you have any questions.', 'jetpack' ),
+		echo '<p>';
+		printf(
+			wp_kses(
+				__( 'As always, feel free to <a href="%s" target="_blank" rel="noopener noreferrer">contact our support team</a> if you have any questions.', 'jetpack' ),
 				array(
 					'a' => array(
 						'href'   => true,
@@ -288,7 +292,10 @@ class JITM {
 						'rel'    => true,
 					),
 				)
-			) . '</p>';
+			),
+			'https://jetpack.com/contact-support'
+		);
+		echo "</p>";
 		echo '</div>';
 	}
 

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -169,11 +169,12 @@ class JITM {
 		}
 
 		// Get connection owner or bail
-		$connection_manager = new Manager();
-		$connection_owner   = $connection_manager->get_connection_owner();
-		if ( ! $connection_owner ) {
+		$connection_manager  = new Manager();
+		$connection_owner_id = $connection_manager->get_connection_owner_id();
+		if ( ! $connection_owner_id ) {
 			return;
 		}
+		$connection_owner_userdata = get_userdata( $connection_owner_id );
 
 		// Bail if we're not trying to delete connection owner.
 		$user_ids_to_delete = array();
@@ -182,13 +183,13 @@ class JITM {
 		} elseif ( isset( $_REQUEST['user'] ) ) {
 			$user_ids_to_delete[] = $_REQUEST['user'];
 		}
-		$deleting_connection_owner = in_array( $connection_owner->ID, (array) $user_ids_to_delete );
+		$deleting_connection_owner = in_array( $connection_owner_id, (array) $user_ids_to_delete );
 		if ( ! $deleting_connection_owner ) {
 			return;
 		}
 
 		// Bail if they're trying to delete themselves to avoid confusion.
-		if ( $connection_owner->ID == get_current_user_id() ) {
+		if ( $connection_owner_id == get_current_user_id() ) {
 			return;
 		}
 
@@ -199,7 +200,7 @@ class JITM {
 		echo '<h2>' . esc_html__( 'Important notice about your Jetpack connection:', 'jetpack' ) . '</h2>';
 		echo '<p>' . sprintf(
 			esc_html__( 'Warning! You are about to delete the Jetpack connection owner (%s) for this site, which may cause some of your Jetpack features to stop working.', 'jetpack' ),
-			esc_html( $connection_owner->data->user_login )
+			isset( $connection_owner_userdata ) ? esc_html( $connection_owner_userdata->data->user_login ) : ''
 		) . '</p>';
 
 		if ( ! empty( $connected_admins ) && count( $connected_admins ) > 1 ) {

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -200,7 +200,7 @@ class JITM {
 		echo '<h2>' . esc_html__( 'Important notice about your Jetpack connection:', 'jetpack' ) . '</h2>';
 		echo '<p>' . sprintf(
 			esc_html__( 'Warning! You are about to delete the Jetpack connection owner (%s) for this site, which may cause some of your Jetpack features to stop working.', 'jetpack' ),
-			isset( $connection_owner_userdata ) ? esc_html( $connection_owner_userdata->data->user_login ) : ''
+			is_a( $connection_owner_userdata, 'WP_User' ) ? esc_html( $connection_owner_userdata->data->user_login ) : ''
 		) . '</p>';
 
 		if ( ! empty( $connected_admins ) && count( $connected_admins ) > 1 ) {

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -217,7 +217,7 @@ class JITM {
 			wp_dropdown_users(
 				array(
 					'name'    => 'owner',
-					'include' => array_diff( $connected_admin_ids, array( $connection_owner->ID ) ),
+					'include' => array_diff( $connected_admin_ids, array( $connection_owner_id ) ),
 					'show'    => 'display_name_with_login',
 				)
 			);

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -192,22 +192,9 @@ class JITM {
 
 		echo "<div class='notice notice-warning' id='jetpack-notice-switch-connection-owner'>";
 		echo '<h2>' . esc_html__( 'Important notice about your Jetpack connection:', 'jetpack' ) . '</h2>';
-		echo '<p>';
-		printf(
-			wp_kses(
-				__( "Warning! You are about to delete the Jetpack <a href='%1\$1s' target='_blank' rel='noopener noreferrer'>connection owner</a> (%2\$2s) for this site, which may affect some of your features.", 'jetpack' ),
-				array(
-					'a' => array(
-						'href'   => true,
-						'target' => true,
-						'rel'    => true,
-					),
-				)
-			),
-			'https://jetpack.com/support/primary-user/',
+		echo '<p>' . sprintf( esc_html__( "Warning! You are about to delete the Jetpack connection owner (%s) for this site, which may cause some of your Jetpack features to stop working.", 'jetpack' ),
 			esc_html( $connection_owner->data->user_login )
-		);
-		echo '</p>';
+		) . '</p>';
 
 		if ( ! empty( $connected_users ) && count( $connected_users ) > 1 ) {
 			echo '<form id="jp-switch-connection-owner" action="" method="post">';
@@ -229,17 +216,6 @@ class JITM {
 			);
 
 			submit_button( __( 'Set new connection owner', 'jetpack' ), 'primary', 'jp-switch-connection-owner-submit' );
-
-			echo '<p>' . wp_kses(
-				__( 'As always, feel free to <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer">contact our support team</a> if you have any questions.', 'jetpack' ),
-				array(
-					'a' => array(
-						'href'   => true,
-						'target' => true,
-						'rel'    => true,
-					),
-				)
-			) . '</p>';
 
 			echo "<div id='jp-switch-user-results'></div>";
 			echo '</form>';
@@ -277,24 +253,37 @@ class JITM {
 			</script>
 			<?php
 		} else {
-			echo '<p><strong>' . esc_html__( 'If the site does not have a connection owner, some of your Jetpack features will stop working!', 'jetpack' ) . '</strong></p>';
-			echo '<p>';
-			printf(
-				wp_kses(
-					__( 'If you would like to be the new connection owner for this site, please connect to your WordPress.com account by clicking <a href="%s" target="_blank" rel="noopener noreferrer">this link</a>. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ),
-					array(
-						'a' => array(
-							'href'   => true,
-							'target' => true,
-							'rel'    => true,
-						),
-					)
-				),
-				\Jetpack::init()->build_connect_url( false, false, 'connection_owner_notice' )
-			);
-			echo '</p>';
+			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ) . "</p>";
+			$connect_url = \Jetpack::init()->build_connect_url( false, false, 'connection_owner_notice' );
+			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to Wordpress.com' ) . "</a>";
 		}
 
+		echo '<p>';
+		printf(
+			wp_kses(
+				__( "<a href='%1$1s' target='_blank' rel='noopener noreferrer'>Learn more</a> about the connection owner and what will break if you do not have one.", 'jetpack' ),
+				array(
+					'a' => array(
+						'href'   => true,
+						'target' => true,
+						'rel'    => true,
+					),
+				)
+			),
+			'https://jetpack.com/support/primary-user/',
+			esc_html( $connection_owner->data->user_login )
+		);
+		echo '</p>';
+		echo '<p>' . wp_kses(
+				__( 'As always, feel free to <a href="https://jetpack.com/contact-support" target="_blank" rel="noopener noreferrer">contact our support team</a> if you have any questions.', 'jetpack' ),
+				array(
+					'a' => array(
+						'href'   => true,
+						'target' => true,
+						'rel'    => true,
+					),
+				)
+			) . '</p>';
 		echo '</div>';
 	}
 

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -193,37 +193,37 @@ class JITM {
 		}
 
 		$connection_manager = new Manager();
-		$connected_users    = $connection_manager->get_connected_users( 'jetpack_connect' );
+		$connected_admins   = $connection_manager->get_connected_users( 'jetpack_disconnect' );
 
 		echo "<div class='notice notice-warning' id='jetpack-notice-switch-connection-owner'>";
 		echo '<h2>' . esc_html__( 'Important notice about your Jetpack connection:', 'jetpack' ) . '</h2>';
-		echo '<p>' . sprintf( esc_html__( "Warning! You are about to delete the Jetpack connection owner (%s) for this site, which may cause some of your Jetpack features to stop working.", 'jetpack' ),
+		echo '<p>' . sprintf(
+			esc_html__( 'Warning! You are about to delete the Jetpack connection owner (%s) for this site, which may cause some of your Jetpack features to stop working.', 'jetpack' ),
 			esc_html( $connection_owner->data->user_login )
 		) . '</p>';
 
-		if ( ! empty( $connected_users ) && count( $connected_users ) > 1 ) {
+		if ( ! empty( $connected_admins ) && count( $connected_admins ) > 1 ) {
 			echo '<form id="jp-switch-connection-owner" action="" method="post">';
 			echo "<label for='owner'>" . esc_html__( 'You can choose to transfer connection ownership to one of these already-connected admins:', 'jetpack' ) . ' </label>';
 
-			$connected_user_ids = array_map(
-				function( $connected_user ) {
-						return $connected_user->ID;
+			$connected_admin_ids = array_map(
+				function( $connected_admin ) {
+						return $connected_admin->ID;
 				},
-				$connected_users
+				$connected_admins
 			);
 
 			wp_dropdown_users(
 				array(
 					'name'    => 'owner',
-					'include' => array_diff( $connected_user_ids, array( $connection_owner->ID ) ),
+					'include' => array_diff( $connected_admin_ids, array( $connection_owner->ID ) ),
 					'show'    => 'display_name_with_login',
 				)
 			);
 
-			echo "<p>";
+			echo '<p>';
 			submit_button( esc_html__( 'Set new connection owner', 'jetpack' ), 'primary', 'jp-switch-connection-owner-submit', false );
-			echo "</p>";
-
+			echo '</p>';
 
 			echo "<div id='jp-switch-user-results'></div>";
 			echo '</form>';
@@ -245,7 +245,7 @@ class JITM {
 								'X-WP-Nonce': "<?php echo wp_create_nonce( 'wp_rest' ); ?>",
 							},
 							success: function() {
-								results.innerHTML = "<?php esc_html_e( "Success!", 'jetpack' ); ?>";
+								results.innerHTML = "<?php esc_html_e( 'Success!', 'jetpack' ); ?>";
 								setTimeout( function() {
 									$( '#jetpack-notice-switch-connection-owner' ).hide( 'slow' );
 								}, 1000 );
@@ -261,9 +261,9 @@ class JITM {
 			</script>
 			<?php
 		} else {
-			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ) . "</p>";
+			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ) . '</p>';
 			$connect_url = \Jetpack::init()->build_connect_url( false, false, 'connection_owner_notice' );
-			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to WordPress.com', 'jetpack' ) . "</a>";
+			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to WordPress.com', 'jetpack' ) . '</a>';
 		}
 
 		echo '<p>';
@@ -295,7 +295,7 @@ class JITM {
 			),
 			'https://jetpack.com/contact-support'
 		);
-		echo "</p>";
+		echo '</p>';
 		echo '</div>';
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -933,7 +933,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 
 		// Create a user and set it up as current.
 		$user = $this->create_and_get_user();
-		$user->add_cap( 'jetpack_connect_user' );
+		$user->add_cap( 'jetpack_disconnect' );
 		wp_set_current_user( $user->ID );
 
 		// Mock site already registered

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -928,20 +928,17 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * Test changing the master user.
 	 *
 	 * @since 6.2.0
+	 * @since 7.7.0 No longer need to be master user to update.
 	 */
 	public function test_change_owner() {
 
 		// Create a user and set it up as current.
-		$user = $this->create_and_get_user();
+		$user = $this->create_and_get_user( 'administrator' );
 		$user->add_cap( 'jetpack_disconnect' );
 		wp_set_current_user( $user->ID );
 
 		// Mock site already registered
 		Jetpack_Options::update_option( 'user_tokens', array( $user->ID => "honey.badger.$user->ID" ) );
-
-		// Attempt change, fail because not master user
-		$response = $this->create_and_get_request( 'connection/owner', array( 'owner' => 999 ), 'POST' );
-		$this->assertResponseStatus( 403, $response );
 
 		// Set up user as master user
 		Jetpack_Options::update_option( 'master_user', $user->ID );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Adds some new helper methods for getting info about the user connections.
- Modifies the permission callback for the `/connection/owner` endpoint.
- Adds a whole notice UI and logic during the delete user process with information and actions to take if the connection owner is being deleted.

**What this PR is intentionally not doing, and will be done in other PRs:**
- Add tracking
- Better copy/design

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* I wouldn't really call it a feature, more a preventative enhancement. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

There's a lot. 

**Test changing connection owner to secondary Admin**
1. Set up a new site. Connect Jetpack to whatever user - let's call it `User A`. 
2. Add a new admin user to the site - let'a call it `User B`.
3. In a separate (incognito?) window, log into the site as User B. 
4. Go to the Jetpack admin and connect User B to wordpress.com. 
5. Still logged in as User B, go to the users page. 
6. Click to delete User A. (Remember, User A should be the connection owner). You should be taken to a confirmation page to delete, where you should see this new notice: 
![image](https://user-images.githubusercontent.com/7129409/63655705-6ad6f580-c759-11e9-85a6-364e7c2c8b67.png)
7. Since you are logged in as a secondary connected user, you should see a dropdown with your name in it. 
8. Click the button to switch the connection to you! 
9. The notice should disappear. 

**Verify it worked**
After you did the above, you should be able to verify it "worked" by doing the following things: 
- In CLI: `wp jetpack options get master_user` - should be User B's ID returned.
- In wordpress.com NA: Visit the blog's report card. You should see User B's wpcom connected user as the new owner. 
- You should also see the connection owner has been updated in the blog's audit trail in wpcom. 

**Test when there are no other users connected**
Since we're only able to transfer ownership to another connected user, we needed a case to handle if there were none! So, you should expect to see a lot of text and a button to connect if this is the case when you're trying to delete the connection owner.  For this one, please verify: 
- That connection link works, and is done in a new tab. 
- The support links work and points to the right places. 
![image](https://user-images.githubusercontent.com/7129409/63655756-462f4d80-c75a-11e9-98aa-4b3f70b32baf.png)

**General things to check/verify**
- You should never see an option to transfer ownership to a non-admin
- You should never see an option to transfer ownership to another user that is not connected currently. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*General: Warn users that deleting the connection owner is going to break things.
