### PR TITLE
Heartbeat: Add stat about missing connection owner. 

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Manager;
+
 class Jetpack_Heartbeat {
 
 	/**
@@ -117,6 +119,10 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}identitycrisis"] = Jetpack::check_identity_crisis() ? 'yes' : 'no';
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 		$return["{$prefix}manage-enabled"] = true;
+
+		// Missing the connection owner?
+		$connection_manager = new Manager();
+		$return["{$prefix}missing-owner"] = $connection_manager->is_missing_connection_owner();
 
 		// is-multi-network can have three values, `single-site`, `single-network`, and `multi-network`
 		$return["{$prefix}is-multi-network"] = 'single-site';

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -483,6 +483,20 @@ class Manager implements Manager_Interface {
 	}
 
 	/**
+	 * Checks to see if the connection owner of the site is missing.
+	 *
+	 * @return bool
+	 */
+	public function is_missing_connection_owner() {
+		$connection_owner = $this->get_connection_owner_id();
+		if ( ! get_user_by( 'id', $connection_owner ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns true if the user with the specified identifier is connected to
 	 * WordPress.com.
 	 *
@@ -496,6 +510,21 @@ class Manager implements Manager_Interface {
 		}
 
 		return (bool) $this->get_access_token( $user_id );
+	}
+
+	/**
+	 * Returns the local user ID of the connection owner.
+	 *
+	 * @return string|int Returns the ID of the connection owner or False if no connection owner found.
+	 */
+	public function get_connection_owner_id() {
+		$user_token       = $this->get_access_token( JETPACK_MASTER_USER );
+		$connection_owner = false;
+		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
+			$connection_owner = $user_token->external_user_id;
+		}
+
+		return $connection_owner;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This adds a new heartbeat stat: `jetpack-v2-missing-owner`, which checks if the connection owner, according to the site token, still exists as a user on the local site. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not sure why I'm not seeing it. Maybe the stat takes a while to bump, but I was testing with this: 
- in CLI: `wp jetpack options delete last_heartbeat`
- In a functionality plugin: 

```
add_action( 'wp_loaded', function() {
	Jetpack_Heartbeat::init()->cron_exec();
} );
```

- Load some admin page

I can't figure out why it's not showing immediately :( 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*N/A
