### PR TITLE
Connection: Add "connect in place" A/B test to plugins and dashboard

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -262,11 +262,14 @@ class Jetpack_Connection_Banner {
 
 							<div class="jp-banner__button-container">
 								<span class="jp-banner__tos-blurb"><?php jetpack_render_tos_blurb(); ?></span>
-								<a
+								<div class="jp-connect-full__button-container is-compact">
+									<a
 										href="<?php echo esc_url( $this->build_connect_url_for_slide( '72' ) ); ?>"
-										class="dops-button is-primary">
-									<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
-								</a>
+										class="dops-button is-primary jp-connect-button"
+									>
+										<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
+									</a>
+								</div>
 							</div>
 
 						</div>

--- a/scss/jetpack-connect.scss
+++ b/scss/jetpack-connect.scss
@@ -44,3 +44,9 @@
 		color: $white;
 	}
 }
+
+.jp-connect-full__button-container.is-compact {
+	.jp-jetpack-connect__iframe {
+		margin-left: -40px;
+	}
+}

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -15,13 +15,6 @@
 
 	.jp-banner__button-container {
 		padding: rem( 32px ) 0 0;
-		flex-direction: row-reverse;
-		align-items: center;
-		justify-content: flex-end;
-
-		@include minbreakpoint(phablet) {
-			display: flex;
-		}
 	}
 
 	.jp-banner__tos-blurb {
@@ -30,9 +23,6 @@
 		line-height: 1.5;
 		font-size: rem( 11px );
 		color: $gray-dark;
-		@include minbreakpoint(phablet) {
-			margin-left: rem(18px);
-		}
 
 		a {
 			color: inherit;


### PR DESCRIPTION
We've already implemented the "connect in place" A/B test in the general connection button on the Jetpack dashboard.

This PR adds the A/B test for the connection banner that appears on the plugins page and the WP admin dashboard.

#### Changes proposed in this Pull Request:
* Connection: Add "connect in place" A/B test to plugins and dashboard

Preview of how it works in that banner:

![](https://cldup.com/BD9feyOWRr.png)

![](https://cldup.com/ScXsjyw2PU.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the "Connect in place" project - p1HpG7-7nj-p2

#### Testing instructions:
* Checkout this branch.
* Run `yarn build` or `yarn watch`.
* Disconnect the site if it's already connected.
* Enable the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant locally.
* Go to `/wp-admin/plugins.php` and try the connection flow.
* Make sure you're able to connect.
* Disable the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant locally.
* Make sure the old connect button still works and looks well in all locations (wp admin dashboard, plugins dashboard, Jetpack dashboard)

#### Proposed changelog entry for your changes:
* Connection: Add "connect in place" A/B test to plugins and dashboard.
