### PR TITLE
Connection: Perform A/B test requests after initial button click

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -5,14 +5,41 @@ jQuery( document ).ready( function( $ ) {
 	connectButton.click( function( event ) {
 		event.preventDefault();
 		if ( ! jetpackConnectButton.isRegistering ) {
-			jetpackConnectButton.handleClick();
+			if ( jpConnect.forceConnectInPlace === false ) {
+				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`.
+				jetpackConnectButton.handleOriginalFlow();
+			} else if ( jpConnect.forceConnectInPlace === true ) {
+				// Forcing new connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = true`.
+				jetpackConnectButton.handleConnectInPlaceFlow();
+			} else {
+				// Forcing A/B test driven connection flow variation, `JETPACK_SHOULD_USE_CONNECTION_IFRAME` not defined.
+				jetpackConnectButton.startConnectionFlow();
+			}
 		}
 	} );
 	var jetpackConnectIframe = $( '<iframe class="jp-jetpack-connect__iframe" />' );
 
 	var jetpackConnectButton = {
 		isRegistering: false,
-		handleClick: function() {
+		startConnectionFlow: function() {
+			var abTestName = 'jetpack_connect_in_place';
+			$.ajax( {
+				url: 'https://public-api.wordpress.com/wpcom/v2/abtest/' + abTestName,
+				type: 'GET',
+				error: jetpackConnectButton.handleConnectionError,
+				success: function( data ) {
+					if ( data && 'in_place' === data.variation ) {
+						jetpackConnectButton.handleConnectInPlaceFlow();
+						return;
+					}
+					jetpackConnectButton.handleOriginalFlow();
+				},
+			} );
+		},
+		handleOriginalFlow: function() {
+			window.location = connectButton.attr( 'href' );
+		},
+		handleConnectInPlaceFlow: function() {
 			jetpackConnectButton.isRegistering = true;
 			connectButton
 				.text( jpConnect.buttonTextRegistering )
@@ -25,11 +52,7 @@ jQuery( document ).ready( function( $ ) {
 					registration_nonce: jpConnect.registrationNonce,
 					_wpnonce: jpConnect.apiNonce,
 				},
-				error: function( error ) {
-					console.warn( 'Connection failed. Falling back to the regular flow', error );
-					jetpackConnectButton.isRegistering = false;
-					window.location = connectButton.attr( 'href' );
-				},
+				error: jetpackConnectButton.handleConnectionError,
 				success: function( data ) {
 					window.addEventListener( 'message', jetpackConnectButton.receiveData );
 					jetpackConnectIframe.attr( 'src', data.authorizeUrl );
@@ -50,6 +73,11 @@ jQuery( document ).ready( function( $ ) {
 		handleAuthorizationComplete: function() {
 			jetpackConnectButton.isRegistering = false;
 			location.reload();
+		},
+		handleConnectionError: function( error ) {
+			console.warn( 'Connection failed. Falling back to the regular flow', error );
+			jetpackConnectButton.isRegistering = false;
+			jetpackConnectButton.handleOriginalFlow();
 		},
 	};
 } );

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -4,12 +4,11 @@ jQuery( document ).ready( function( $ ) {
 	var connectButton = $( '.jp-connect-button' );
 	connectButton.click( function( event ) {
 		event.preventDefault();
-		console.log( jpConnect );
 		if ( ! jetpackConnectButton.isRegistering ) {
 			if ( 'original' === jpConnect.forceVariation ) {
 				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`.
 				jetpackConnectButton.handleOriginalFlow();
-			} else if ( 'iframe' === jpConnect.forceVariation ) {
+			} else if ( 'in_place' === jpConnect.forceVariation ) {
 				// Forcing new connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = true`.
 				jetpackConnectButton.handleConnectInPlaceFlow();
 			} else {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -1,15 +1,15 @@
-/* global _jpConnect */
+/* global jpConnect */
 
 jQuery( document ).ready( function( $ ) {
-	var jpConnect = _jpConnect._;
 	var connectButton = $( '.jp-connect-button' );
 	connectButton.click( function( event ) {
 		event.preventDefault();
+		console.log( jpConnect );
 		if ( ! jetpackConnectButton.isRegistering ) {
-			if ( jpConnect.forceConnectInPlace === false ) {
+			if ( 'original' === jpConnect.forceVariation ) {
 				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`.
 				jetpackConnectButton.handleOriginalFlow();
-			} else if ( jpConnect.forceConnectInPlace === true ) {
+			} else if ( 'iframe' === jpConnect.forceVariation ) {
 				// Forcing new connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = true`.
 				jetpackConnectButton.handleConnectInPlaceFlow();
 			} else {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -1,7 +1,7 @@
-/* global jpConnect */
+/* global _jpConnect */
 
 jQuery( document ).ready( function( $ ) {
-	var jpConnect = jpConnect.details;
+	var jpConnect = _jpConnect._;
 	var connectButton = $( '.jp-connect-button' );
 	connectButton.click( function( event ) {
 		event.preventDefault();

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -1,6 +1,7 @@
 /* global jpConnect */
 
 jQuery( document ).ready( function( $ ) {
+	var jpConnect = jpConnect.details;
 	var connectButton = $( '.jp-connect-button' );
 	connectButton.click( function( event ) {
 		event.preventDefault();

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -1,7 +1,7 @@
 <?php
 
-use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Constants;
 
 class Jetpack_Connection_Banner {
@@ -151,12 +151,12 @@ class Jetpack_Connection_Banner {
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 
 		if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
-		    $force_variation = 'iframe';
-        } else if ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
-		    $force_variation = 'original';
-        } else {
-		    $force_variation = null;
-        }
+			$force_variation = 'in_place';
+		} else if ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+			$force_variation = 'original';
+		} else {
+			$force_variation = null;
+		}
 
 		wp_localize_script(
 			'jetpack-connect-button',

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -1,6 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Abtest;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Constants;
@@ -27,14 +26,7 @@ class Jetpack_Connection_Banner {
 	 */
 	private function __construct() {
 		add_action( 'current_screen', array( $this, 'maybe_initialize_hooks' ) );
-
-		$abtest = new Abtest();
-		if (
-			'in_place' === $abtest->get_variation( 'jetpack_connect_in_place' ) ||
-			Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' )
-		) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_connect_button_scripts' ) );
-		}
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_connect_button_scripts' ) );
 	}
 
 	/**
@@ -166,6 +158,7 @@ class Jetpack_Connection_Banner {
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 				'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
 				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
+				'forceConnectInPlace'   => Constants::get_constant( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ),
 			)
 		);
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -151,9 +151,9 @@ class Jetpack_Connection_Banner {
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 		wp_localize_script(
 			'jetpack-connect-button',
-			'jpConnect',
+			'_jpConnect',
 			array(
-				'details' => array(
+				'_' => array(
 					'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
 					'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
 					'apiNonce'              => wp_create_nonce( 'wp_rest' ),

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -153,12 +153,14 @@ class Jetpack_Connection_Banner {
 			'jetpack-connect-button',
 			'jpConnect',
 			array(
-				'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
-				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
-				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-				'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
-				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
-				'forceConnectInPlace'   => Constants::get_constant( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ),
+				'details' => array(
+					'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
+					'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
+					'apiNonce'              => wp_create_nonce( 'wp_rest' ),
+					'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
+					'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
+					'forceConnectInPlace'   => Constants::get_constant( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ),
+				)
 			)
 		);
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -149,18 +149,25 @@ class Jetpack_Connection_Banner {
 		);
 
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
+
+		if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		    $force_variation = 'iframe';
+        } else if ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		    $force_variation = 'original';
+        } else {
+		    $force_variation = null;
+        }
+
 		wp_localize_script(
 			'jetpack-connect-button',
-			'_jpConnect',
+			'jpConnect',
 			array(
-				'_' => array(
-					'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
-					'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
-					'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-					'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
-					'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
-					'forceConnectInPlace'   => Constants::get_constant( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ),
-				)
+				'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
+				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
+				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
+				'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
+				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
+				'forceVariation'        => $force_variation,
 			)
 		);
 	}


### PR DESCRIPTION
This PR updates the connection flow so we don't request A/B test variations before the user has initially clicked the connection button. With this change, the A/B test variation request will be triggered as soon as the user clicks the "Set up Jetpack" button.

Based on the variation, the user will be presented with either the original flow, or the "in place" flow.

The `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant will still be considered and take precedence over the A/B test request:

* `true` will force the "connect in place" flow. A/B test request will be skipped.
* `false` will force the "original" connection flow. A/B test request will be skipped.
* Not defining it will fall back to the A/B test for deciding the flow.

#### Changes proposed in this Pull Request:
* Connection: Perform A/B test requests after initial button click.
* Connection: Update how the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant works.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the "Connect in place" project - p1HpG7-7nj-p2

#### Testing instructions:
* Checkout this branch.
* Run `yarn build`.
* Set `define ( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );` in your wp-config.
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Make sure you are always presented with the "connect in place" flow.
* Set `define ( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', false );` in your wp-config.
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Make sure you are always presented with the original connection flow.
* Remove the line that defines the constant completely.
* Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
* Make sure you are presented with the flow based on the variation coming from the A/B test (https://public-api.wordpress.com/wpcom/v2/abtest/jetpack_connect_in_place?)
* Make sure the original connection flow still works.
* Make sure the "connect in place" flow still works.

#### Proposed changelog entry for your changes:
* Connection: Perform A/B test requests after initial button click.
* Connection: Update how the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant works.
