### PR TITLE
Fix Upgrade and Subsite Registration Redirects

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -456,7 +456,7 @@ class Jetpack_Network {
 			return $result;
 		}
 
-		Jetpack::activate_default_modules();
+		Jetpack::activate_default_modules( false, false, array(), false );
 
 		restore_current_blog();
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2776,7 +2776,7 @@ class Jetpack {
 		$max_version = false,
 		$other_modules = array(),
 		$redirect = null,
-		$send_state_messages = true
+		$send_state_messages = null
 	) {
 		$jetpack = Jetpack::init();
 
@@ -2800,6 +2800,10 @@ class Jetpack {
 			}
 		}
 
+		if ( is_null( $send_state_messages ) ) {
+			$send_state_messages = current_user_can( 'jetpack_activate_modules' );
+		}
+
 		$modules = Jetpack::get_default_modules( $min_version, $max_version );
 		$modules = array_merge( $other_modules, $modules );
 
@@ -2821,7 +2825,9 @@ class Jetpack {
 		}
 
 		if ( $deactivated ) {
-			Jetpack::state( 'deactivated_plugins', join( ',', $deactivated ) );
+			if ( $send_state_messages ) {
+				Jetpack::state( 'deactivated_plugins', join( ',', $deactivated ) );
+			}
 
 			if ( $redirect ) {
 				$url = add_query_arg(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2800,18 +2800,20 @@ class Jetpack {
 			}
 		}
 
-		if ( $deactivated && $redirect ) {
+		if ( $deactivated ) {
 			Jetpack::state( 'deactivated_plugins', join( ',', $deactivated ) );
 
-			$url = add_query_arg(
-				array(
-					'action'   => 'activate_default_modules',
-					'_wpnonce' => wp_create_nonce( 'activate_default_modules' ),
-				),
-				add_query_arg( compact( 'min_version', 'max_version', 'other_modules' ), Jetpack::admin_url( 'page=jetpack' ) )
-			);
-			wp_safe_redirect( $url );
-			exit;
+			if ( $redirect ) {
+				$url = add_query_arg(
+					array(
+						'action'   => 'activate_default_modules',
+						'_wpnonce' => wp_create_nonce( 'activate_default_modules' ),
+					),
+					add_query_arg( compact( 'min_version', 'max_version', 'other_modules' ), Jetpack::admin_url( 'page=jetpack' ) )
+				);
+				wp_safe_redirect( $url );
+				exit;
+			}
 		}
 
 		/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2775,10 +2775,30 @@ class Jetpack {
 		$min_version = false,
 		$max_version = false,
 		$other_modules = array(),
-		$redirect = true,
+		$redirect = null,
 		$send_state_messages = true
 	) {
 		$jetpack = Jetpack::init();
+
+		if ( is_null( $redirect ) ) {
+			if (
+				( defined( 'REST_REQUEST' ) && REST_REQUEST )
+			||
+				( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+			||
+				( defined( 'WP_CLI' ) && WP_CLI )
+			||
+				( defined( 'DOING_CRON' ) && DOING_CRON )
+			||
+				( defined( 'DOING_AJAX' ) && DOING_AJAX )
+			) {
+				$redirect = false;
+			} elseif ( is_admin() ) {
+				$redirect = true;
+			} else {
+				$redirect = false;
+			}
+		}
 
 		$modules = Jetpack::get_default_modules( $min_version, $max_version );
 		$modules = array_merge( $other_modules, $modules );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2242,7 +2242,7 @@ class Jetpack {
 		);
 
 		Jetpack::state( 'message', 'modules_activated' );
-		Jetpack::activate_default_modules( $jetpack_version, JETPACK__VERSION, $reactivate_modules );
+		Jetpack::activate_default_modules( $jetpack_version, JETPACK__VERSION, $reactivate_modules, $redirect );
 
 		if ( $redirect ) {
 			$page = 'jetpack'; // make sure we redirect to either settings or the jetpack page


### PR DESCRIPTION
Fixes #5081.

#### Changes proposed in this Pull Request:

By default, `Jetpack::activate_default_modules()` redirects on error and queues an eventual redirect on success. This method is called in a few places where those redirects are not desired.

* Never redirect during automatic upgrades. Automatic upgrades can be triggered by any visitor on `init`.
* Never redirect during a `Jetpack_Network->do_subsiteregister()` call. Some of these calls are hooked to Core hooks, which can result in unexpected redirect behavior. Calls to `Jetpack_Network->do_subsiteregister()` should do their own error/success handling.
* Default to not redirecting during non-wp-admin/ requests.
* Default to not redirecting during REST, XML-RPC, AJAX, CRON, CLI requests.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: Bug fix.

#### Testing instructions:

It's a huge pain :(

For `do_subsiteregister()`, create a custom CLI command as in #5081.

For upgrade requests, you have to:
1. Deactivate the Protect module.
2. Set the "First Introduced" header in the Protect module to "7.6.5".
3. Open a new browser tab. In that browser tab, open the Network dev tools pane.
4. `wp jetpack options update version 7.6`
5. Quickly load the homepage (before some other request goes to your site).
6. Inspect the network request for the homepage load.

Prior to this PR, you'll see a `Location` header. Depending on what else is going on on your site, the request will 200, so there won't actually be a redirect, though you can still see the header. (It may 301 is some circumstances, in which case, you will see the redirect.)

After this PR, there's no `Location` header and no redirect.

#### Proposed changelog entry for your changes:

* Do not redirect during the automatic upgrades.