### PR TITLE
Add Stats to XML-RPC Errors

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -120,6 +120,12 @@ class Jetpack_Heartbeat {
 		$return["{$prefix}plugins"]        = implode( ',', Jetpack::get_active_plugins() );
 		$return["{$prefix}manage-enabled"] = true;
 
+		$xmlrpc_errors = Jetpack_Options::get_option( 'xmlrpc_errors', array() );
+		if ( $xmlrpc_errors ) {
+			$return["{$prefix}xmlrpc-errors"] = implode( ',', array_keys( $xmlrpc_errors ) );
+			Jetpack_Options::delete_option( 'xmlrpc_errors' );
+		}
+
 		// Missing the connection owner?
 		$connection_manager = new Manager();
 		$return["{$prefix}missing-owner"] = $connection_manager->is_missing_connection_owner();

--- a/packages/options/legacy/class.jetpack-options.php
+++ b/packages/options/legacy/class.jetpack-options.php
@@ -61,6 +61,7 @@ class Jetpack_Options {
 					'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.
 					'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
+					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 				);
 
 			case 'private':


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Track unique XML-RPC authentication error codes in a new Jetpack Option.
* Send those error codes as part of the heartbeat.

Sending a stat for each failed XML-RPC request might not scale for sites with too many errors. Sending a stat for each failed XML-RPC request might not scale for the stats system :)

Using the heartbeat makes it impossible to gauge how many XML-RPC errors occur, but it does allow us to determine how many sites experience XML-RPC errors, which is probably more useful for us.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No: improved telemetry.

#### Testing instructions:

1. Break your XML-RPC authentication :) For example, with the patch below.
2. Do something that will generate XML-RPC requests to your site. (API Dev Console, Calypso, …)
3. `wp jetpack options get xmlrpc_errors` - see the error code in the option
4. `wp jetpack options update last_heartbeat 0` - to trick Jetpack into running the heartbeat on command.
5. `wp cron event run jetpack_v2_heartbeat` - to run the heartbeat on command.
6. `wp jetpack options get xmlrpc_errors` - see the option has been removed.
7. Wait a minute, then check that the stat has bumped. (If multiple people happen to be testing this around the same time, you may have to wait up to 5 minutes to see the stat bump results.)

```diff
diff --git a/packages/connection/src/Manager.php b/packages/connection/src/Manager.php
index b3d9b4ea9..dd7ea6eab 100644
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -350,6 +350,7 @@ class Manager implements Manager_Interface {
 			$user_id = (int) $user_id;
 
 			$user = new \WP_User( $user_id );
+$user = false;
 			if ( ! $user || ! $user->exists() ) {
 				return new \WP_Error(
 					'unknown_user',
```

#### Proposed changelog entry for your changes:

* Improved error reporting for sites having connection trouble.