### PR TITLE
Adds webpack asset size warnings to dev builds.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,10 +83,14 @@ module.exports = [
 			filename: 'jp-search.bundle.js',
 		},
 		performance: isDevelopment
-			? {}
+			? {
+					maxAssetSize: 120000,
+					maxEntrypointSize: 120000,
+					hints: 'error',
+			  }
 			: {
-					maxAssetSize: 30000,
-					maxEntrypointSize: 30000,
+					maxAssetSize: 32000,
+					maxEntrypointSize: 32000,
 					hints: 'error',
 			  },
 	},


### PR DESCRIPTION
Before for Search bundle builds we were only generating warnings for production builds. This change adds asset size limits that pass both on development and production builds, but will alert us in case the bundles grow bigger. The most important part is that the alert will happen in both dev and prod environment, sparing us the surprise.

@gibrown I have specified these values as minimal that allow builds to pass, I'm not sure what values are best used here.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds search bundle size warnings to the development build environment.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Run `yarn build` and `yarn build-production-client`, you should see no warnings, the build should complete successfully.
* Try to tweak bundle sizes that are being changed in this PR to lower values, you should see the warnings when running both builds.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
