### PR TITLE
Premium blocks: update frontend nudge with plan_upgraded redirect param

### DIFF
--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -88,11 +88,17 @@ class Jetpack_Components {
 
 		// Post-checkout: redirect back to the editor.
 		$redirect_to = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-			? '/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) )
+			? add_query_arg(
+				array(
+					'plan_upgraded' => 1,
+				),
+				'/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) )
+			)
 			: add_query_arg(
 				array(
-					'action' => 'edit',
-					'post'   => $post_id,
+					'action'        => 'edit',
+					'post'          => $post_id,
+					'plan_upgraded' => 1,
 				),
 				admin_url( 'post.php' )
 			);


### PR DESCRIPTION
Fixes #13003 (partially)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Continues from https://github.com/Automattic/jetpack/pull/13281 to add the redirect parameter to the public facing pages (as per https://github.com/Automattic/jetpack/pull/13281#issuecomment-524288746).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
It adds the foundation for showing a notification when the redirection happens after clicking an upgrade nudge.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Simple site** 

* Load the respective diff to your sandbox, point to it with a free site.
* Create a new post and add "Simple Payments" block.
* Go to the public url (while logged into WP) and observe that "plan_upgraded" is added to the Upgrade button.

<img width="1440" alt="Screenshot 2019-08-27 at 4 22 47 PM" src="https://user-images.githubusercontent.com/1705499/63775785-bec41480-c8e8-11e9-8961-74054eb2d234.png">

**Self hosted**

Same process, but checkout PR and load ngrok site over it.

<img width="1440" alt="Screenshot 2019-08-27 at 4 19 55 PM" src="https://user-images.githubusercontent.com/1705499/63775805-c5eb2280-c8e8-11e9-888d-7b153828f15d.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Doesn't need one I think?