### PR TITLE
Sync: do not sync comments made via Action Scheduler

### DIFF
--- a/packages/sync/src/modules/WooCommerce.php
+++ b/packages/sync/src/modules/WooCommerce.php
@@ -77,6 +77,9 @@ class WooCommerce extends Module {
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_new_order_item', array( $this, 'filter_order_item' ) );
 		add_filter( 'jetpack_sync_before_enqueue_woocommerce_update_order_item', array( $this, 'filter_order_item' ) );
 		add_filter( 'jetpack_sync_whitelisted_comment_types', array( $this, 'add_review_comment_types' ) );
+
+		// Blacklist Action Scheduler comment types.
+		add_filter( 'jetpack_sync_prevent_sending_comment_data', array( $this, 'filter_action_scheduler_comments' ), 10, 2 );
 	}
 
 	/**
@@ -324,6 +327,24 @@ class WooCommerce extends Module {
 			$comment_types[] = 'review';
 		}
 		return $comment_types;
+	}
+
+	/**
+	 * Stop comments from the Action Scheduler from being synced.
+	 * https://github.com/woocommerce/woocommerce/tree/e7762627c37ec1f7590e6cac4218ba0c6a20024d/includes/libraries/action-scheduler
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param boolean $can_sync Should we prevent comment data from bing synced to WordPress.com.
+	 * @param mixed   $comment  WP_COMMENT object.
+	 *
+	 * @return bool
+	 */
+	public function filter_action_scheduler_comments( $can_sync, $comment ) {
+		if ( isset( $comment->comment_agent ) && 'ActionScheduler' === $comment->comment_agent ) {
+			return true;
+		}
+		return $can_sync;
 	}
 
 	/**


### PR DESCRIPTION
Follow-up of #12830.

Fixes #13354

#### Changes proposed in this Pull Request:

Action Scheduler is used to schedule and run background jobs on WordPress, and is used extensively by WooCommerce and WooCommerce extensions.

The data is currently stored in a custom post type, and as such it appears in WordPress.com' activity log even though it does not provide a lot of value to site owners:

![image](https://user-images.githubusercontent.com/426388/60012848-425d4d00-967d-11e9-9986-65f946154d94.png)

In #12830, I stopped posts from that Post Type from being synchronized with WordPress.com, but that wasn't enough. This PR aims to stop the comments from being synchronized as well.

Here is an example of a comment we are trying to catch with this:

```
'WP_Comment Object
(
    [comment_ID] => 3468
    [comment_post_ID] => 25402
    [comment_author] => ActionScheduler
    [comment_author_email] =>
    [comment_author_url] =>
    [comment_author_IP] =>
    [comment_date] => 2019-08-28 18:33:41
    [comment_date_gmt] => 2019-08-28 09:33:41
    [comment_content] => action created
    [comment_karma] => 0
    [comment_approved] => 1
    [comment_agent] => ActionScheduler
    [comment_type] => action_log
    [comment_parent] => 0
    [user_id] => 0
    [children:protected] =>
    [populated_children:protected] =>
    [post_fields:protected] => Array
        (
            [0] => post_author
            [1] => post_date
            [2] => post_date_gmt
            [3] => post_content
            [4] => post_title
            [5] => post_excerpt
            [6] => post_status
            [7] => comment_status
            [8] => ping_status
            [9] => post_name
            [10] => to_ping
            [11] => pinged
            [12] => post_modified
            [13] => post_modified_gmt
            [14] => post_content_filtered
            [15] => post_parent
            [16] => guid
            [17] => menu_order
            [18] => post_type
            [19] => post_mime_type
            [20] => comment_count
        )

)
'
```
(matching blog ID is 114940227)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:

* Switch your Woo site to run that branch for a few days.
* You should spot no events from `ActionScheduler` in your activity log.
* You should still be able to use things like the Woo mobile app, or the Woo Store in Calypso.

#### Proposed changelog entry for your changes:

* Activity Log: avoid displaying events from the Action Scheduler.
