### PR TITLE
Post Images: look for images in inner blocks.

### DIFF
--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -340,7 +340,7 @@ class Jetpack_PostImages {
 		 * @to-do: instead of looping manually (that's a lot of if and loops), search recursively instead.
 		 */
 		foreach ( $blocks as $block ) {
-			if ( ! self::is_nested_block( $block ) ) {
+			if ( ! self::is_nested_block( $block ) || 'core/media-text' === $block['blockName'] ) {
 				$images = self::get_images_from_block( $images, $block, $html_info, $width, $height );
 			} else {
 				foreach ( $block['innerBlocks'] as $inner_block ) {
@@ -793,6 +793,8 @@ class Jetpack_PostImages {
 	 * @param array $html_info Info about the post where the block is found.
 	 * @param int   $width     Desired image width.
 	 * @param int   $height    Desired image height.
+	 *
+	 * @return array Array of images found.
 	 */
 	private static function get_images_from_block( $images, $block, $html_info, $width, $height ) {
 		/**
@@ -806,13 +808,16 @@ class Jetpack_PostImages {
 			&& ! empty( $block['attrs']['id'] )
 		) {
 			$images[] = self::get_attachment_data( $block['attrs']['id'], $html_info['post_url'], $width, $height );
-		}
-
-		/**
-		 * Parse content from Core Gallery blocks as well from Jetpack's Tiled Gallery and Slideshow blocks.
-		 * Gallery blocks include the ID of each one of the images in the gallery.
-		 */
-		if (
+		} elseif (
+			'core/media-text' === $block['blockName']
+			&& ! empty( $block['attrs']['mediaId'] )
+		) {
+			$images[] = self::get_attachment_data( $block['attrs']['mediaId'], $html_info['post_url'], $width, $height );
+		} elseif (
+			/**
+			 * Parse content from Core Gallery blocks as well from Jetpack's Tiled Gallery and Slideshow blocks.
+			 * Gallery blocks include the ID of each one of the images in the gallery.
+			 */
 			in_array( $block['blockName'], array( 'core/gallery', 'jetpack/tiled-gallery', 'jetpack/slideshow' ), true )
 			&& ! empty( $block['attrs']['ids'] )
 		) {

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -332,29 +332,25 @@ class Jetpack_PostImages {
 			return $images;
 		}
 
+		/*
+		 * Let's loop through our blocks.
+		 * Some blocks may include some other blocks. Let's go 2 levels deep to look for blocks
+		 * that we support and that may include images (see get_images_from_block)
+		 *
+		 * @to-do: instead of looping manually (that's a lot of if and loops), search recursively instead.
+		 */
 		foreach ( $blocks as $block ) {
-			/**
-			 * Parse content from Core Image blocks.
-			 * If it is an image block for an image hosted on our site, it will have an ID.
-			 * If it does not have an ID, let `from_html` parse that content later,
-			 * and extract an image if it has size parameters.
-			 */
-			if (
-				'core/image' === $block['blockName']
-				&& ! empty( $block['attrs']['id'] )
-			) {
-				$images[] = self::get_attachment_data( $block['attrs']['id'], $html_info['post_url'], $width, $height );
-			}
-
-			/**
-			 * Parse content from Core Gallery blocks as well from Jetpack's Tiled Gallery and Slideshow blocks.
-			 * Gallery blocks include the ID of each one of the images in the gallery.
-			 */
-			if ( in_array( $block['blockName'], array( 'core/gallery', 'jetpack/tiled-gallery', 'jetpack/slideshow' ) )
-				&& ! empty( $block['attrs']['ids'] )
-			) {
-				foreach ( $block['attrs']['ids'] as $img_id ) {
-					$images[] = self::get_attachment_data( $img_id, $html_info['post_url'], $width, $height );
+			if ( ! self::is_nested_block( $block ) ) {
+				$images = self::get_images_from_block( $images, $block, $html_info, $width, $height );
+			} else {
+				foreach ( $block['innerBlocks'] as $inner_block ) {
+					if ( ! self::is_nested_block( $inner_block ) ) {
+						$images = self::get_images_from_block( $images, $inner_block, $html_info, $width, $height );
+					} else {
+						foreach ( $inner_block['innerBlocks'] as $inner_inner_block ) {
+							$images = self::get_images_from_block( $images, $inner_inner_block, $html_info, $width, $height );
+						}
+					}
 				}
 			}
 		}
@@ -785,5 +781,63 @@ class Jetpack_PostImages {
 	 */
 	public static function get_alt_text( $attachment_id ) {
 		return get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+	}
+
+	/**
+	 * Get an image from a block.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @param array $images    Images found.
+	 * @param array $block     Block and its attributes.
+	 * @param array $html_info Info about the post where the block is found.
+	 * @param int   $width     Desired image width.
+	 * @param int   $height    Desired image height.
+	 */
+	private static function get_images_from_block( $images, $block, $html_info, $width, $height ) {
+		/**
+		 * Parse content from Core Image blocks.
+		 * If it is an image block for an image hosted on our site, it will have an ID.
+		 * If it does not have an ID, let `from_html` parse that content later,
+		 * and extract an image if it has size parameters.
+		 */
+		if (
+			'core/image' === $block['blockName']
+			&& ! empty( $block['attrs']['id'] )
+		) {
+			$images[] = self::get_attachment_data( $block['attrs']['id'], $html_info['post_url'], $width, $height );
+		}
+
+		/**
+		 * Parse content from Core Gallery blocks as well from Jetpack's Tiled Gallery and Slideshow blocks.
+		 * Gallery blocks include the ID of each one of the images in the gallery.
+		 */
+		if (
+			in_array( $block['blockName'], array( 'core/gallery', 'jetpack/tiled-gallery', 'jetpack/slideshow' ), true )
+			&& ! empty( $block['attrs']['ids'] )
+		) {
+			foreach ( $block['attrs']['ids'] as $img_id ) {
+				$images[] = self::get_attachment_data( $img_id, $html_info['post_url'], $width, $height );
+			}
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Check if a block has inner blocks.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @param array $block Block and its attributes.
+	 *
+	 * @return bool
+	 */
+	private static function is_nested_block( $block ) {
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/tests/php/media/test-class.jetpack-post-images.php
+++ b/tests/php/media/test-class.jetpack-post-images.php
@@ -300,4 +300,108 @@ class WP_Test_Jetpack_PostImages extends WP_UnitTestCase {
 		// Testing the width condition.
 		$this->assertEquals( false, Jetpack_PostImages::get_attachment_data( $post['post_id'], '', PHP_INT_MAX, 200 ) );
 	}
+
+	/**
+	 * Create a post with a columns block that includes an image block, and some text.
+	 *
+	 * @since 7.8.0
+	 *
+	 * @return array $post_info {
+	 * An array of information about our post.
+	 * 	@type int $post_id Post ID.
+	 * 	@type string $img_url Image URL we'll look to extract.
+	 * }
+	 */
+	protected function get_post_with_columns_block() {
+		$img_name       = 'image.jpg';
+		$alt_text       = 'Alt Text.';
+		$img_dimensions = array( 'width' => 250, 'height' => 250 );
+
+		$post_id       = $this->factory->post->create();
+		$attachment_id = $this->factory->attachment->create_object( $img_name, $post_id, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_type'      => 'attachment'
+		) );
+		wp_update_attachment_metadata( $attachment_id, $img_dimensions );
+		update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+
+		$img_url = wp_get_attachment_url( $attachment_id );
+
+		// Create another post with that picture.
+		$post_html = sprintf(
+			'<!-- wp:columns --><div class="wp-block-columns has-2-columns"><!-- wp:column --><div class="wp-block-column"><!-- wp:image {"id":%2$d} --><figure class="wp-block-image"><img src="%1$s" alt="" class="wp-image-%2$d"/></figure><!-- /wp:image --></div><!-- /wp:column --><!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Some text</p><!-- /wp:paragraph --></div><!-- /wp:column --></div><!-- /wp:columns -->',
+			$img_url,
+			$attachment_id
+		);
+
+		$second_post_id = $this->factory->post->create( array(
+			'post_content' => $post_html,
+		) );
+
+		return array(
+			'post_id'  => $second_post_id,
+			'img_url'  => $img_url,
+			'alt_text' => $alt_text,
+		);
+	}
+
+	/**
+	 * Test if an array of images can be extracted from column blocks in the new block editor.
+	 *
+	 * @covers Jetpack_PostImages::from_blocks
+	 *
+	 * @since 7.8.0
+	 */
+	public function test_from_columns_block_from_post_id_is_array() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return;
+		}
+
+		$post_info = $this->get_post_with_columns_block();
+
+		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
+
+		$this->assertEquals( count( $images ), 1 );
+	}
+
+	/**
+	 * Test if the array extracted from Colunms blocks include the image URL and alt text.
+	 *
+	 * @covers Jetpack_PostImages::from_blocks
+	 *
+	 * @since 7.8.0
+	 */
+	public function test_from_columns_block_from_post_id_is_correct_array() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return;
+		}
+
+		$post_info = $this->get_post_with_columns_block();
+
+		$images = Jetpack_PostImages::from_blocks( $post_info['post_id'] );
+
+		$this->assertEquals( $post_info['img_url'], $images[ 0 ][ 'src' ] );
+		$this->assertEquals( $post_info['alt_text'], $images[ 0 ][ 'alt_text' ] );
+	}
+
+	/**
+	 * Test if a Colunms block with an externally hosted image is not extracted by Post Images.
+	 *
+	 * @covers Jetpack_PostImages::from_blocks
+	 * @since 6.9.0
+	 */
+	public function test_from_columns_block_from_html_is_empty_array() {
+		if ( ! function_exists( 'parse_blocks' ) ) {
+			$this->markTestSkipped( 'parse_blocks not available. Block editor not available' );
+			return;
+		}
+
+		$html = '<!-- wp:columns --><div class="wp-block-columns has-2-columns"><!-- wp:column --><div class="wp-block-column"><!-- wp:image --><figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/></figure><!-- /wp:image --></div><!-- /wp:column --><!-- wp:column --><div class="wp-block-column"><!-- wp:paragraph --><p>Some text</p><!-- /wp:paragraph --></div><!-- /wp:column --></div><!-- /wp:columns -->';
+
+		$images = Jetpack_PostImages::from_blocks( $html );
+
+		$this->assertEmpty( $images );
+	}
 } // end class


### PR DESCRIPTION
Fixes #13338

#### Changes proposed in this Pull Request:

Until now, we only parsed blocks that included images right away. However, some blocks may include some other, inner, blocks.
Let's go 2 levels deep to look for blocks that we support and that may include images.

This allows us to support, for example, a colunms block that would include an image block as well as a text block.

#### Testing instructions:

* Start on a site without this patch, with the Sharing module active.
* In a new post, add an image block and upload a large image. Publish your post.
* View the post, and view source.
* Search for an `og:image` meta tag. It should list your image.
* Now start a new post.
* Insert a Columns block. In that block, insert a Paragraph block as well as an image block. Add the same image as before to your image block.
* Publish the post, view it, view source.
* Search for an `og:image` meta tag. Your image is not listed.
* Apply the patch.
* Note that `og:image` meta tags now work even with posts with columns blocks.

You can repeat this with Gallery blocks, tiled galleries, slideshows, all inside columns blocks.

You can also try installing the Kadence Blocks – Gutenberg Page Builder Toolkit plugin, and insert a Row layout block instead of a columns block. See that everything keeps working.

#### Proposed changelog entry for your changes:

* Post Images: look for representative images in inner blocks.
