### PR TITLE
Instant Search: add filter api example

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -204,10 +204,23 @@ class Jetpack_Search {
 				$script_version = self::get_asset_version( $script_relative_path );
 				$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 				wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
-				$_blog_id = Jetpack::get_option( 'id' );
+
+				$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
+				$widgets = array();
+				foreach( $filters as $key => $filter ) {
+					if ( ! isset( $widgets[$filter[ 'widget_id' ]] ) ) {
+						$widgets[$filter[ 'widget_id' ]][ 'filters' ] = array();
+						$widgets[$filter[ 'widget_id' ]][ 'widget_id' ] = $filter[ 'widget_id' ];
+					}
+					$new_filter = $filter;
+					$new_filter[ 'filter_id' ] = $key;
+					$widgets[$filter[ 'widget_id' ]][ 'filters' ][] = $new_filter;
+				}
+
 				// This is probably a temporary filter for testing the prototype.
 				$options = array(
-					'siteId' => $_blog_id,
+					'siteId'  => Jetpack::get_option( 'id' ),
+					'widgets' => array_values( $widgets ),
 				);
 				/**
 				 * Customize Instant Search Options.
@@ -221,9 +234,7 @@ class Jetpack_Search {
 				$options = apply_filters( 'jetpack_instant_search_options', $options );
 
 				wp_localize_script(
-					'jetpack-instant-search',
-					'jetpack_instant_search_options',
-					$options
+					'jetpack-instant-search', 'JetpackInstantSearchOptions', $options
 				);
 			}
 

--- a/modules/search/instant-search/components/api.js
+++ b/modules/search/instant-search/components/api.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import fetch from 'unfetch';
+import { encode } from 'qss';
+import { flatten } from 'q-flat';
 
 const FIELDS = [
 	'author',
@@ -13,16 +15,50 @@ const FIELDS = [
 	'title_html',
 ];
 
-function stringifyArray( fieldName, array ) {
-	return array.map( ( element, index ) => `${ fieldName }[${ index }]=${ element }` ).join( '&' );
+export function buildFilterAggregations( widgets = [] ) {
+	const aggregation = {};
+	widgets.forEach( ( { filters: widgetFilters } ) =>
+		widgetFilters.forEach( filter => {
+			switch ( filter.type ) {
+				case 'date_histogram': {
+					const field = filter.field === 'post_date_gmt' ? 'date_gmt' : 'date';
+					aggregation[ filter.filter_id ] = {
+						date_histogram: { field, interval: filter.interval },
+					};
+					break;
+				}
+				case 'taxonomy': {
+					let field = `taxonomy.${ filter.taxonomy }.slug`;
+					if ( filter.taxonomy === 'post_tag' ) {
+						field = 'tag.slug';
+					} else if ( filter.type === 'category' ) {
+						field = 'category.slug';
+					}
+					aggregation[ filter.filter_id ] = { terms: { field, size: filter.count } };
+					break;
+				}
+				case 'post_type': {
+					aggregation[ filter.filter_id ] = { terms: { field: filter.type, size: filter.count } };
+					break;
+				}
+			}
+		} )
+	);
+	return aggregation;
 }
 
-function getAPIUrl( siteId, query ) {
-	return `https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?query=${ encodeURIComponent(
-		query
-	) }&${ stringifyArray( 'fields', FIELDS ) }`;
+function getAPIUrl( siteId, query, widgets ) {
+	const queryString = encode(
+		flatten( {
+			aggregations: buildFilterAggregations( widgets ),
+			fields: FIELDS,
+			query: encodeURIComponent( query ),
+		} )
+	);
+
+	return `https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?${ queryString }`;
 }
 
-export function search( siteId, query ) {
-	return fetch( getAPIUrl( siteId, query ) );
+export function search( siteId, query, widgets ) {
+	return fetch( getAPIUrl( siteId, query, widgets ) );
 }

--- a/modules/search/instant-search/components/search-filter-dates.jsx
+++ b/modules/search/instant-search/components/search-filter-dates.jsx
@@ -1,0 +1,42 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+import strip from 'strip';
+
+export default class SearchFilterDates extends Component {
+	render() {
+		return (
+			<div>
+				<h4 className="jetpack-search-filters-widget__sub-heading">{ this.props.filter.name }</h4>
+				<ul className="jetpack-search-filters-widget__filter-list">
+					{ this.props.aggregation &&
+						'buckets' in this.props.aggregation &&
+						[
+							...this.props.aggregation.buckets
+								// TODO: Remove this filter; API should only be sending buckets with document counts.
+								.filter( bucket => !! bucket && bucket.doc_count > 0 )
+								.map( bucket => (
+									<div>
+										<input
+											disabled
+											id={ `jp-instant-search-filter-dates-${ bucket.key_as_string }` }
+											name={ bucket.key }
+											type="checkbox"
+										/>
+										<label htmlFor={ `jp-instant-search-filter-dates-${ bucket.key_as_string }` }>
+											{ strip( bucket.key_as_string ) } ({ bucket.doc_count })
+										</label>
+									</div>
+								) ),
+						]
+							// TODO: Remove this reverse & slice when API adds filter count support
+							.reverse()
+							.slice( 0, 5 ) }
+				</ul>
+			</div>
+		);
+	}
+}

--- a/modules/search/instant-search/components/search-filter-post-types.jsx
+++ b/modules/search/instant-search/components/search-filter-post-types.jsx
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+import strip from 'strip';
+
+export default class SearchFilterPostTypes extends Component {
+	render() {
+		return (
+			<div>
+				<h4 className="jetpack-search-filters-widget__sub-heading">{ this.props.filter.name }</h4>
+				<ul className="jetpack-search-filters-widget__filter-list">
+					{ this.props.aggregation &&
+						'buckets' in this.props.aggregation &&
+						this.props.aggregation.buckets
+							// TODO: Remove this filter; API should only be sending buckets with document counts.
+							.filter( bucket => !! bucket && bucket.doc_count > 0 )
+							.map( bucket => (
+								<div>
+									<input
+										type="checkbox"
+										name=""
+										id={ `jp-instant-search-filter-post-types-${ bucket.key }` }
+										disabled
+									/>
+									<label htmlFor={ `jp-instant-search-filter-post-types-${ bucket.key }` }>
+										{ strip( bucket.key ) } ({ bucket.doc_count })
+									</label>
+								</div>
+							) ) }
+				</ul>
+			</div>
+		);
+	}
+}

--- a/modules/search/instant-search/components/search-filter-taxonomies.jsx
+++ b/modules/search/instant-search/components/search-filter-taxonomies.jsx
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+import strip from 'strip';
+
+export default class SearchFilterTaxonomies extends Component {
+	render() {
+		return (
+			<div>
+				<h4 className="jetpack-search-filters-widget__sub-heading">{ this.props.filter.name }</h4>
+				<ul className="jetpack-search-filters-widget__filter-list">
+					{ this.props.aggregation &&
+						'buckets' in this.props.aggregation &&
+						this.props.aggregation.buckets
+							// TODO: Remove this filter; API should only be sending buckets with document counts.
+							.filter( bucket => !! bucket && bucket.doc_count > 0 )
+							.map( bucket => (
+								<div>
+									<input
+										disabled
+										id={ `jp-instant-search-filter-taxonomies-${ bucket.key }` }
+										name={ bucket.key }
+										type="checkbox"
+									/>
+									<label htmlFor={ `jp-instant-search-filter-taxonomies-${ bucket.key }` }>
+										{ strip( bucket.key ) } ({ bucket.doc_count })
+									</label>
+								</div>
+							) ) }
+				</ul>
+			</div>
+		);
+	}
+}

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -1,0 +1,43 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+// NOTE: We only import the debounce package here for to reduced bundle size.
+//       Do not import the entire lodash library!
+// eslint-disable-next-line lodash/import-scope
+import get from 'lodash/get';
+
+/**
+ * Internal dependencies
+ */
+import SearchFilterDates from './search-filter-dates';
+import SearchFilterTaxonomies from './search-filter-taxonomies';
+import SearchFilterPostTypes from './search-filter-post-types';
+
+export default class SearchFiltersWidget extends Component {
+	renderFilterComponent( aggregations ) {
+		return filter => {
+			const results = aggregations ? aggregations[ filter.filter_id ] : null;
+			switch ( filter.type ) {
+				case 'date_histogram':
+					return <SearchFilterDates aggregation={ results } filter={ filter } />;
+				case 'taxonomy':
+					return <SearchFilterTaxonomies aggregation={ results } filter={ filter } />;
+				case 'post_type':
+					return <SearchFilterPostTypes aggregation={ results } filter={ filter } />;
+			}
+		};
+	}
+
+	render() {
+		return (
+			<div id={ `${ this.props.widget.widget_id }-wrapper` }>
+				{ get( this.props.widget, 'filters' ).map(
+					this.renderFilterComponent( get( this.props.results, 'aggregations' ) )
+				) }
+			</div>
+		);
+	}
+}

--- a/modules/search/instant-search/components/search-filters-widget.scss
+++ b/modules/search/instant-search/components/search-filters-widget.scss
@@ -1,0 +1,5 @@
+.jetpack-search-filters-widget__filter-list {
+	label {
+		display: inline-block;
+	}
+}

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -13,8 +13,6 @@ class SearchResult extends Component {
 			<div className="jetpack-instant-search__result">
 				<a
 					href={ `//${ this.props.result.fields[ 'permalink.url.raw' ] }` }
-					target="_blank"
-					rel="noopener noreferrer"
 					className="jetpack-instant-search__result-title"
 				>
 					{ strip( this.props.result.fields.title_html ) || 'Unknown Title' }
@@ -25,10 +23,12 @@ class SearchResult extends Component {
 						{ strip( this.props.result.fields.date ).split( ' ' )[ 0 ] }
 					</span>
 				</div>
-				<div className="jetpack-instant-search__result-excerpt">
-					{ strip( this.props.result.fields.excerpt_html ) }
-				</div>
-				<div>
+				{ this.props.result.fields.excerpt_html && (
+					<div className="jetpack-instant-search__result-excerpt">
+						{ strip( this.props.result.fields.excerpt_html ) }
+					</div>
+				) }
+				<div className="jetpack-instant-search__comment-count">
 					{ sprintf(
 						_n( '%d comment', '%d comments', this.props.result.fields.comment_count, 'jetpack' ),
 						this.props.result.fields.comment_count

--- a/modules/search/instant-search/components/search-result.scss
+++ b/modules/search/instant-search/components/search-result.scss
@@ -3,6 +3,11 @@
 .jetpack-instant-search__result {
 	padding: 0.125em 0;
 	margin: 1em 0;
+
+	&:first-child {
+		margin-top: 0;
+	}
+
 	a {
 		box-shadow: inset 0 0 0 rgba( black, 0 ), 0 1px 0 rgba( black, 1 );
 		transition: color 80ms ease-in, box-shadow 130ms ease-in-out;
@@ -14,7 +19,7 @@
 }
 
 .jetpack-instant-search__result-author-and-date {
-	margin: 0.5em 0;
+	margin: 0.25em 0;
 	display: flex;
 	justify-content: space-between;
 }
@@ -25,4 +30,8 @@
 
 .jetpack-instant-search__result-excerpt {
 	color: $gray;
+}
+
+.jetpack-instant-search__comment-count {
+	margin-top: 0.25em;
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -1,0 +1,3 @@
+.jetpack-instant-search__search-results > p {
+	margin-bottom: 1em;
+}

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -47,7 +47,7 @@ class SearchApp extends Component {
 			this.requestId++;
 			const requestId = this.requestId;
 
-			search( this.props.siteId, query )
+			search( this.props.siteId, query, this.props.widgets )
 				.then( response => response.json() )
 				.then( json => {
 					if ( this.requestId === requestId ) {

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -15,7 +15,7 @@ import debounce from 'lodash/debounce';
  */
 import SearchResults from './search-results';
 import SearchFiltersWidget from './search-filters-widget';
-import { search } from '../lib/api';
+import { search, buildFilter } from '../lib/api';
 import { setSearchQuery } from '../lib/query-string';
 import { removeChildren } from '../lib/dom';
 
@@ -27,6 +27,7 @@ class SearchApp extends Component {
 			query: this.props.initialValue,
 			results: {},
 		};
+		this.props.filter = buildFilter( this.props.options.filters ); //I guess should be added to state
 		this.getResults = debounce( this.getResults, 500 );
 		this.getResults( this.props.initialValue );
 	}
@@ -54,7 +55,7 @@ class SearchApp extends Component {
 			this.requestId++;
 			const requestId = this.requestId;
 
-			search( this.props.siteId, query, this.props.aggregations )
+			search( this.props.siteId, query, this.props.aggregations, this.props.filter )
 				.then( response => response.json() )
 				.then( json => {
 					if ( this.requestId === requestId ) {

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -9,13 +9,8 @@ import { h, render } from 'preact';
  * Internal dependencies
  */
 import SearchWidget from './components/search-widget';
+import { removeChildren } from './lib/dom';
 import { getSearchQuery } from './lib/query-string';
-
-function removeChildren( htmlElement ) {
-	while ( htmlElement.lastChild ) {
-		htmlElement.removeChild( htmlElement.lastChild );
-	}
-}
 
 const hideSearchHeader = () => {
 	const titleElements = document.getElementById( 'content' ).getElementsByClassName( 'page-title' );

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -9,6 +9,7 @@ import { h, render } from 'preact';
  * Internal dependencies
  */
 import SearchWidget from './components/search-widget';
+import { buildFilterAggregations } from './lib/api';
 import { removeChildren } from './lib/dom';
 import { getSearchQuery } from './lib/query-string';
 
@@ -22,8 +23,9 @@ const hideSearchHeader = () => {
 const injectSearchWidget = ( initialValue, target, grabFocus ) => {
 	render(
 		<SearchWidget
-			initialValue={ initialValue }
+			aggregations={ buildFilterAggregations( window.JetpackInstantSearchOptions.widgets ) }
 			grabFocus={ grabFocus }
+			initialValue={ initialValue }
 			siteId={ window.JetpackInstantSearchOptions.siteId }
 			widgets={ window.JetpackInstantSearchOptions.widgets }
 		/>,

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -24,24 +24,32 @@ const hideSearchHeader = () => {
 	}
 };
 
-const injectSearchWidget = ( initialValue, target, siteId, grabFocus ) => {
+const injectSearchWidget = ( initialValue, target, grabFocus ) => {
 	render(
-		<SearchWidget initialValue={ initialValue } grabFocus={ grabFocus } siteId={ siteId } />,
+		<SearchWidget
+			initialValue={ initialValue }
+			grabFocus={ grabFocus }
+			siteId={ window.JetpackInstantSearchOptions.siteId }
+			widgets={ window.JetpackInstantSearchOptions.widgets }
+		/>,
 		target
 	);
 };
 
 document.addEventListener( 'DOMContentLoaded', function() {
-	//This var is provided by wp_localize_script() so we have limited control
-	const options = jetpack_instant_search_options; // eslint-disable-line no-undef
-
-	if ( 'siteId' in options && document.body && document.body.classList.contains( 'search' ) ) {
+	if (
+		!! window.JetpackInstantSearchOptions &&
+		'siteId' in window.JetpackInstantSearchOptions &&
+		'widgets' in window.JetpackInstantSearchOptions &&
+		document.body &&
+		document.body.classList.contains( 'search' )
+	) {
 		const widget = document.querySelector( '.widget_search' );
 		if ( !! widget ) {
 			removeChildren( widget );
 			removeChildren( document.querySelector( 'main' ) );
 			hideSearchHeader();
-			injectSearchWidget( getSearchQuery(), widget, options.siteId );
+			injectSearchWidget( getSearchQuery(), widget );
 		}
 	}
 } );

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -1,2 +1,3 @@
 @import './components/search-results.scss';
 @import './components/search-result.scss';
+@import './components/search-filters-widget.scss';

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -1,1 +1,2 @@
+@import './components/search-results.scss';
 @import './components/search-result.scss';

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -47,10 +47,10 @@ export function buildFilterAggregations( widgets = [] ) {
 	return aggregation;
 }
 
-function getAPIUrl( siteId, query, widgets ) {
+function getAPIUrl( siteId, query, aggregations ) {
 	const queryString = encode(
 		flatten( {
-			aggregations: buildFilterAggregations( widgets ),
+			aggregations,
 			fields: FIELDS,
 			query: encodeURIComponent( query ),
 		} )
@@ -59,6 +59,6 @@ function getAPIUrl( siteId, query, widgets ) {
 	return `https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?${ queryString }`;
 }
 
-export function search( siteId, query, widgets ) {
-	return fetch( getAPIUrl( siteId, query, widgets ) );
+export function search( siteId, query, aggregations ) {
+	return fetch( getAPIUrl( siteId, query, aggregations ) );
 }

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -4,6 +4,7 @@
 import fetch from 'unfetch';
 import { encode } from 'qss';
 import { flatten } from 'q-flat';
+import { sprintf } from '@wordpress/i18n';
 
 const FIELDS = [
 	'author',
@@ -47,10 +48,95 @@ export function buildFilterAggregations( widgets = [] ) {
 	return aggregation;
 }
 
-function getAPIUrl( siteId, query, aggregations ) {
+export function buildFilter( query_params = {} ) {
+	if ( ! query_params ) {
+		return null;
+	}
+	let filter = {
+		bool: {
+			must: [],
+		},
+	};
+	let has_date = false;
+	for ( let p in query_params ) {
+		switch ( p ) {
+			case 'post_type':
+				filter.bool.must.push( {
+					term: { post_type: query_params[ p ] },
+				} );
+				break;
+			case 'year':
+			case 'monthnum':
+			case 'day':
+				has_date = true;
+				break;
+			case 'post_tag':
+				filter.bool.must.push( {
+					term: { 'tag.slug': query_params[ p ] },
+				} );
+				break;
+			case 'category':
+				filter.bool.must.push( {
+					term: { 'category.slug': query_params[ p ] },
+				} );
+				break;
+			default:
+				//assume this is a taxonomy for now
+				tax_name = 'taxonomy.' + p + '.slug';
+				filter.bool.must.push( {
+					term: { tax_name: query_params[ p ] },
+				} );
+				break;
+		}
+	}
+
+	if ( has_date ) {
+		let date_start;
+		let date_end;
+		if ( query_params[ 'year' ] ) {
+			if ( query_params[ 'monthnum' ] ) {
+				// Padding
+				const date_monthnum = sprintf( '%02d', query_params[ 'monthnum' ] );
+
+				if ( query_params[ 'day' ] ) {
+					// Padding
+					const date_day = sprintf( '%02d', query_params[ 'day' ] );
+
+					date_start = query_params[ 'year' ] + '-' + date_monthnum + '-' + date_day + ' 00:00:00';
+					date_end = query_params[ 'year' ] + '-' + date_monthnum + '-' + date_day + ' 23:59:59';
+				} else {
+					const days_in_month = new Date(
+						query_params[ 'year' ],
+						query_params[ 'monthnum' ],
+						14
+					).getDate(); // 14 = middle of the month so no chance of DST issues
+
+					date_start = query_params[ 'year' ] + '-' + date_monthnum + '-01 00:00:00';
+					date_end =
+						query_params[ 'year' ] + '-' + date_monthnum + '-' + days_in_month + ' 23:59:59';
+				}
+			} else {
+				date_start = query_params[ 'year' ] + '-01-01 00:00:00';
+				date_end = query_params[ 'year' ] + '-12-31 23:59:59';
+			}
+
+			filter.bool.must.push( {
+				range: {
+					field: 'date',
+					gte: date_start,
+					lte: date_end,
+				},
+			} );
+		}
+	}
+	return filter;
+}
+
+function getAPIUrl( siteId, query, aggregations, filter ) {
 	const queryString = encode(
 		flatten( {
 			aggregations,
+			filter,
 			fields: FIELDS,
 			query: encodeURIComponent( query ),
 		} )
@@ -59,6 +145,6 @@ function getAPIUrl( siteId, query, aggregations ) {
 	return `https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?${ queryString }`;
 }
 
-export function search( siteId, query, aggregations ) {
+export function search( siteId, query, aggregations, filter ) {
 	return fetch( getAPIUrl( siteId, query, aggregations ) );
 }

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -1,0 +1,5 @@
+export function removeChildren( htmlElement ) {
+	while ( htmlElement.lastChild ) {
+		htmlElement.removeChild( htmlElement.lastChild );
+	}
+}

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
 		"preact": "8.4.2",
 		"preact-portal": "1.1.3",
 		"prop-types": "15.7.2",
+		"q-flat": "1.0.7",
 		"qss": "2.0.3",
 		"react-pure-render": "1.0.2",
 		"react-redux": "6.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,8 +85,8 @@ module.exports = [
 		performance: isDevelopment
 			? {}
 			: {
-					maxAssetSize: 30000,
-					maxEntrypointSize: 30000,
+					maxAssetSize: 35000,
+					maxEntrypointSize: 35000,
 					hints: 'error',
 			  },
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -10307,6 +10307,11 @@ puppeteer@1.19.0:
     rimraf "^2.6.1"
     ws "^6.1.0"
 
+q-flat@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/q-flat/-/q-flat-1.0.7.tgz#4cf81aede99d2a9acbafcf503af0d0184a850d3d"
+  integrity sha512-Ug+B6yajVE5HF7eAszOvAcYmQ+DbYaDcQlxYuW9RaAqwZTRZQq+lHMGqHlnaxKP7CfuGCpXQXOb4qymRYMkYEQ==
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"


### PR DESCRIPTION
This code is just an initial example. If it is after Oct 1st 2019 this should almost certainly be deleted.

Unverified example code for building a filter for @jsnmoon. I was going to verify this code with something like this on my jp site:

```
function jp_instant_search_options( $options ) {
	if ( $_GET['blog_id'] ) {
		$options['siteId'] = (int) $_GET['blog_id'];
	}
	if ( $_GET['format'] ) {
		$options['resultFormat'] = sanitize_key( $_GET['format'] );
	}
	$options['filters'] = [
		'post_type' => 'page',
	];
	return $options;
}
add_filter( 'jetpack_instant_search_options', 'jp_instant_search_options' );
```

But we that doesn't work on the filters branch yet. But it seems like this is probably enough to get you going. We should really be taking these filters from the url anyways.
