### PR TITLE
Slideshow block: Add image size selector

### DIFF
--- a/extensions/blocks/simple-payments/featured-media.js
+++ b/extensions/blocks/simple-payments/featured-media.js
@@ -5,7 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { BlockControls, MediaPlaceholder, MediaUpload } from '@wordpress/editor';
 import { Fragment } from '@wordpress/element';
 import { get } from 'lodash';
-import { IconButton, Toolbar, ToolbarButton } from '@wordpress/components';
+import { Toolbar, ToolbarButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import EditButton from '../../shared/edit-button';
 
 const onSelectMedia = setAttributes => media =>
 	setAttributes( {
@@ -39,12 +44,7 @@ export default ( { featuredMediaId, featuredMediaUrl, featuredMediaTitle, setAtt
 							allowedTypes={ [ 'image' ] }
 							value={ featuredMediaId }
 							render={ ( { open } ) => (
-								<IconButton
-									className="components-toolbar__control"
-									label={ __( 'Edit Image', 'jetpack' ) }
-									icon="edit"
-									onClick={ open }
-								/>
+								<EditButton label={ __( 'Edit Image', 'jetpack' ) } onClick={ open } />
 							) }
 						/>
 						<ToolbarButton

--- a/extensions/blocks/slideshow/controls.js
+++ b/extensions/blocks/slideshow/controls.js
@@ -3,7 +3,6 @@
  */
 import { BlockControls, InspectorControls, MediaUpload } from '@wordpress/editor';
 import {
-	IconButton,
 	PanelBody,
 	RangeControl,
 	SelectControl,
@@ -13,6 +12,11 @@ import {
 import { __, _x } from '@wordpress/i18n';
 import { isEmpty } from 'lodash';
 import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import EditButton from '../../shared/edit-button';
 
 export default ( {
 	allowedMediaTypes,
@@ -94,12 +98,7 @@ export default ( {
 							gallery
 							value={ images.map( img => img.id ) }
 							render={ ( { open } ) => (
-								<IconButton
-									className="components-toolbar__control"
-									label={ __( 'Edit Slideshow', 'jetpack' ) }
-									icon="edit"
-									onClick={ open }
-								/>
+								<EditButton label={ __( 'Edit Slideshow', 'jetpack' ) } onClick={ open } />
 							) }
 						/>
 					</Toolbar>

--- a/extensions/blocks/slideshow/controls.js
+++ b/extensions/blocks/slideshow/controls.js
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { BlockControls, InspectorControls, MediaUpload } from '@wordpress/editor';
+import {
+	IconButton,
+	PanelBody,
+	RangeControl,
+	SelectControl,
+	ToggleControl,
+	Toolbar,
+} from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import { isEmpty } from 'lodash';
+import { Fragment } from '@wordpress/element';
+
+export default ( {
+	allowedMediaTypes,
+	attributes: { autoplay, delay, effect, images, sizeSlug },
+	imageSizeOptions,
+	onChangeImageSize,
+	onSelectImages,
+	setAttributes,
+} ) => {
+	const prefersReducedMotion =
+		typeof window !== 'undefined' &&
+		window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+
+	const effectOptions = [
+		{ label: _x( 'Slide', 'Slideshow transition effect', 'jetpack' ), value: 'slide' },
+		{ label: _x( 'Fade', 'Slideshow transition effect', 'jetpack' ), value: 'fade' },
+	];
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<PanelBody title={ __( 'Autoplay', 'jetpack' ) }>
+					<ToggleControl
+						label={ __( 'Autoplay', 'jetpack' ) }
+						help={ __( 'Autoplay between slides', 'jetpack' ) }
+						checked={ autoplay }
+						onChange={ value => {
+							setAttributes( { autoplay: value } );
+						} }
+					/>
+					{ autoplay && (
+						<RangeControl
+							label={ __( 'Delay between transitions (in seconds)', 'jetpack' ) }
+							value={ delay }
+							onChange={ value => {
+								setAttributes( { delay: value } );
+							} }
+							min={ 1 }
+							max={ 5 }
+						/>
+					) }
+					{ autoplay && prefersReducedMotion && (
+						<span>
+							{ __(
+								'The Reduce Motion accessibility option is selected, therefore autoplay will be disabled in this browser.',
+								'jetpack'
+							) }
+						</span>
+					) }
+				</PanelBody>
+				<PanelBody title={ __( 'Effects', 'jetpack' ) }>
+					<SelectControl
+						label={ __( 'Transition effect', 'jetpack' ) }
+						value={ effect }
+						onChange={ value => {
+							setAttributes( { effect: value } );
+						} }
+						options={ effectOptions }
+					/>
+				</PanelBody>
+				{ ! isEmpty( images ) && ! isEmpty( imageSizeOptions ) && (
+					<PanelBody title={ __( 'Image Settings', 'jetpack' ) }>
+						<SelectControl
+							label={ __( 'Image Size', 'jetpack' ) }
+							value={ sizeSlug }
+							options={ imageSizeOptions }
+							onChange={ onChangeImageSize }
+						/>
+					</PanelBody>
+				) }
+			</InspectorControls>
+			<BlockControls>
+				{ !! images.length && (
+					<Toolbar>
+						<MediaUpload
+							onSelect={ onSelectImages }
+							allowedTypes={ allowedMediaTypes }
+							multiple
+							gallery
+							value={ images.map( img => img.id ) }
+							render={ ( { open } ) => (
+								<IconButton
+									className="components-toolbar__control"
+									label={ __( 'Edit Slideshow', 'jetpack' ) }
+									icon="edit"
+									onClick={ open }
+								/>
+							) }
+						/>
+					</Toolbar>
+				) }
+			</BlockControls>
+		</Fragment>
+	);
+};

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -60,6 +60,8 @@ class SlideshowEdit extends Component {
 	componentDidMount() {
 		const { ids, sizeSlug } = this.props.attributes;
 		if ( ! sizeSlug ) {
+			// Blocks inserted before the image size selector was available were using full size images. After including
+			// the image selector, blocks will use large size images by default.
 			this.setAttributes( { sizeSlug: ids.length ? 'full' : 'large' } );
 		}
 	}

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -39,8 +39,10 @@ class SlideshowEdit extends Component {
 	componentDidMount() {
 		const { ids, sizeSlug } = this.props.attributes;
 		if ( ! sizeSlug ) {
-			// Blocks inserted before the image size selector was available were using full size images. After including
-			// the image selector, blocks will use large size images by default.
+			// To improve the performance, we use large size images by default except for blocks inserted before the
+			// image size attribute was added, since they were loading full size images. The presence or lack of images
+			// in a block determines when it has been inserted (before or after we added the image size attribute),
+			// given that now it is not possible to have a block with images and no size.
 			this.setAttributes( { sizeSlug: ids.length ? 'full' : 'large' } );
 		}
 	}

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -1,45 +1,24 @@
 /**
  * External dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
-import { filter, get, isEmpty, map, pick } from 'lodash';
+import { filter, get, map, pick } from 'lodash';
 import { isBlobURL } from '@wordpress/blob';
 import { withDispatch, withSelect } from '@wordpress/data';
-import {
-	BlockControls,
-	BlockIcon,
-	InspectorControls,
-	MediaPlaceholder,
-	MediaUpload,
-	mediaUpload,
-} from '@wordpress/editor';
-import {
-	DropZone,
-	FormFileUpload,
-	IconButton,
-	PanelBody,
-	RangeControl,
-	SelectControl,
-	ToggleControl,
-	Toolbar,
-	withNotices,
-} from '@wordpress/components';
+import { BlockIcon, MediaPlaceholder, mediaUpload } from '@wordpress/editor';
+import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { icon } from '.';
+import Controls from './controls';
 import Slideshow from './slideshow';
 import './editor.scss';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
-
-const effectOptions = [
-	{ label: _x( 'Slide', 'Slideshow transition effect', 'jetpack' ), value: 'slide' },
-	{ label: _x( 'Fade', 'Slideshow transition effect', 'jetpack' ), value: 'fade' },
-];
 
 export const pickRelevantMediaFiles = ( image, sizeSlug ) => {
 	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
@@ -138,94 +117,19 @@ class SlideshowEdit extends Component {
 		this.setAttributes( { images, sizeSlug } );
 	};
 	render() {
-		const {
-			attributes,
-			className,
-			isSelected,
-			noticeOperations,
-			noticeUI,
-			setAttributes,
-		} = this.props;
-		const { align, autoplay, delay, effect, images, sizeSlug } = attributes;
-		const prefersReducedMotion =
-			typeof window !== 'undefined' &&
-			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches;
+		const { attributes, className, isSelected, noticeOperations, noticeUI } = this.props;
+		const { align, autoplay, delay, effect, images } = attributes;
+
 		const imageSizeOptions = this.getImageSizeOptions();
 		const controls = (
-			<Fragment>
-				<InspectorControls>
-					<PanelBody title={ __( 'Autoplay', 'jetpack' ) }>
-						<ToggleControl
-							label={ __( 'Autoplay', 'jetpack' ) }
-							help={ __( 'Autoplay between slides', 'jetpack' ) }
-							checked={ autoplay }
-							onChange={ value => {
-								setAttributes( { autoplay: value } );
-							} }
-						/>
-						{ autoplay && (
-							<RangeControl
-								label={ __( 'Delay between transitions (in seconds)', 'jetpack' ) }
-								value={ delay }
-								onChange={ value => {
-									setAttributes( { delay: value } );
-								} }
-								min={ 1 }
-								max={ 5 }
-							/>
-						) }
-						{ autoplay && prefersReducedMotion && (
-							<span>
-								{ __(
-									'The Reduce Motion accessibility option is selected, therefore autoplay will be disabled in this browser.',
-									'jetpack'
-								) }
-							</span>
-						) }
-					</PanelBody>
-					<PanelBody title={ __( 'Effects', 'jetpack' ) }>
-						<SelectControl
-							label={ __( 'Transition effect', 'jetpack' ) }
-							value={ effect }
-							onChange={ value => {
-								setAttributes( { effect: value } );
-							} }
-							options={ effectOptions }
-						/>
-					</PanelBody>
-					{ ! isEmpty( images ) && ! isEmpty( imageSizeOptions ) && (
-						<PanelBody title={ __( 'Image Settings', 'jetpack' ) }>
-							<SelectControl
-								label={ __( 'Image Size', 'jetpack' ) }
-								value={ sizeSlug }
-								options={ imageSizeOptions }
-								onChange={ this.updateImagesSize }
-							/>
-						</PanelBody>
-					) }
-				</InspectorControls>
-				<BlockControls>
-					{ !! images.length && (
-						<Toolbar>
-							<MediaUpload
-								onSelect={ this.onSelectImages }
-								allowedTypes={ ALLOWED_MEDIA_TYPES }
-								multiple
-								gallery
-								value={ images.map( img => img.id ) }
-								render={ ( { open } ) => (
-									<IconButton
-										className="components-toolbar__control"
-										label={ __( 'Edit Slideshow', 'jetpack' ) }
-										icon="edit"
-										onClick={ open }
-									/>
-								) }
-							/>
-						</Toolbar>
-					) }
-				</BlockControls>
-			</Fragment>
+			<Controls
+				allowedMediaTypes={ ALLOWED_MEDIA_TYPES }
+				attributes={ attributes }
+				imageSizeOptions={ imageSizeOptions }
+				onChangeImageSize={ this.updateImagesSize }
+				onSelectImages={ this.onSelectImages }
+				setAttributes={ this.setAttributes }
+			/>
 		);
 
 		if ( images.length === 0 ) {

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -57,6 +57,12 @@ class SlideshowEdit extends Component {
 			selectedImage: null,
 		};
 	}
+	componentDidMount() {
+		const { ids, sizeSlug } = this.props.attributes;
+		if ( ! sizeSlug ) {
+			this.setAttributes( { sizeSlug: ids.length ? 'full' : 'large' } );
+		}
+	}
 	setAttributes( attributes ) {
 		if ( attributes.ids ) {
 			throw new Error(

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -128,7 +128,7 @@ class SlideshowEdit extends Component {
 				imageSizeOptions={ imageSizeOptions }
 				onChangeImageSize={ this.updateImagesSize }
 				onSelectImages={ this.onSelectImages }
-				setAttributes={ this.setAttributes }
+				setAttributes={ attrs => this.setAttributes( attrs ) }
 			/>
 		);
 

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -106,17 +106,18 @@ class SlideshowEdit extends Component {
 		const { images } = this.props.attributes;
 		const { resizedImages } = this.props;
 
-		images.forEach( image => {
+		const updatedImages = images.map( image => {
 			const resizedImage = resizedImages.find(
 				( { id } ) => parseInt( id, 10 ) === parseInt( image.id, 10 )
 			);
 			const url = get( resizedImage, [ 'sizes', sizeSlug, 'source_url' ] );
-			if ( url ) {
-				image.url = url;
-			}
+			return {
+				...image,
+				...( url && { url } ),
+			};
 		} );
 
-		this.setAttributes( { images, sizeSlug } );
+		this.setAttributes( { images: updatedImages, sizeSlug } );
 	};
 	render() {
 		const { attributes, className, isSelected, noticeOperations, noticeUI } = this.props;

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -77,7 +77,6 @@ const attributes = {
 	},
 	sizeSlug: {
 		type: 'string',
-		default: 'large',
 	},
 };
 

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -75,6 +75,10 @@ const attributes = {
 		type: 'string',
 		default: 'slide',
 	},
+	sizeSlug: {
+		type: 'string',
+		default: 'large',
+	},
 };
 
 const exampleAttributes = {

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -15,7 +15,6 @@ import {
 import {
 	DropZone,
 	FormFileUpload,
-	IconButton,
 	PanelBody,
 	RangeControl,
 	SelectControl,
@@ -31,6 +30,7 @@ import Layout from './layout';
 import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES, MAX_COLUMNS } from './constants';
 import { getActiveStyleName } from '../../shared/block-styles';
 import { icon } from '.';
+import EditButton from '../../shared/edit-button';
 
 const linkOptions = [
 	{ value: 'attachment', label: __( 'Attachment Page', 'jetpack' ) },
@@ -182,12 +182,7 @@ class TiledGalleryEdit extends Component {
 								gallery
 								value={ images.map( img => img.id ) }
 								render={ ( { open } ) => (
-									<IconButton
-										className="components-toolbar__control"
-										label={ __( 'Edit Gallery', 'jetpack' ) }
-										icon="edit"
-										onClick={ open }
-									/>
+									<EditButton label={ __( 'Edit Gallery', 'jetpack' ) } onClick={ open } />
 								) }
 							/>
 						</Toolbar>

--- a/extensions/shared/edit-button.js
+++ b/extensions/shared/edit-button.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { IconButton } from '@wordpress/components';
+
+export default ( { label, onClick } ) => (
+	<IconButton
+		className="components-toolbar__control"
+		label={ label }
+		icon="edit"
+		onClick={ onClick }
+	/>
+);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add an image size selector to the slideshow block that allows users to choose the image size for the gallery inserted in the block.

<img width="296" alt="Screen Shot 2019-09-03 at 10 17 42" src="https://user-images.githubusercontent.com/1233880/64137610-49020080-ce34-11e9-8fd8-933a2451d081.png">

The selector defaults to `large` size. Previously, all the images were loaded in `full` size. This should improve the performance when visiting a page, since the `large` size will be enough for most users, making necessary to download less MB.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Improvement for the Slideshow block.

#### Testing instructions:
- Start creating a new post.
- Insert a slideshow block.
- Add some images.
- Make sure you can resize the images with the image size selector.
- Make sure the selector defaults to `large`.
- Publish the post.
- Verify on the frontend the images are loaded with the selected size.
- Load an existing post containing a slideshow block (created before applying this branch).
- Make sure the image size selector has a `full` value (since the post was created before the image selector was available).

#### Proposed changelog entry for your changes:
Slideshow block: Add image size selector
