### PR TITLE
Jetpack Connection Flow: no iframe variation for mobile folks

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -150,7 +150,7 @@ class Jetpack_Connection_Banner {
 
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 
-		if ( wp_is_mobile() ) {
+		if ( jetpack_is_mobile() ) {
 			$force_variation = 'original';
 		} else if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'in_place';

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -150,7 +150,9 @@ class Jetpack_Connection_Banner {
 
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 
-		if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		if ( wp_is_mobile() ) {
+			$force_variation = 'original';
+		} else if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'in_place';
 		} else if ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'original';


### PR DESCRIPTION
If someone is using a mobile device, we will always use the original connection flow.
There are currently too many bugs in the flow on mobile.

Fixes it so mobile users have a good connection experience no matter what.

#### Changes proposed in this Pull Request:
* If you are on a mobile device, you will always use the original connection flow.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhances the connection flow.

#### Testing instructions:
- Apply this patch to your jetpack site
- Disconnect the site from wordpress.com
- Set a constant `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
- On a mobile device try to connect
- You'd expect to get the new iframed connection flow because of the constant ^
- You should get the original flow

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
