### PR TITLE
Make use of a minified JS file in connect-in-place feature

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -132,7 +132,7 @@ class Jetpack_Connection_Banner {
 		wp_enqueue_script(
 			'jetpack-connect-button',
 			Assets::get_file_url_for_environment(
-				'_inc/connect-button.js', // TODO: minify
+				'_inc/build/connect-button.min.js',
 				'_inc/connect-button.js'
 			),
 			array( 'jquery' ),


### PR DESCRIPTION
Fixes no known issue.

#### Changes proposed in this Pull Request:
* Make use of a minified `connect-button` JS file.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
* Make sure you're not connected to wp.com
* Make sure the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant is defined
* Go to Jetpack dashboard and initiate a new connection. A connect in place feature should be triggered.
* Observe dev tools Network tab - make sure `connect-button.min.js` is used.