### PR TITLE
Connection Flow: fix calypso_env

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4542,6 +4542,13 @@ p {
 			if( is_network_admin() ) {
 				$url = add_query_arg( 'is_multisite', network_admin_url( 'admin.php?page=jetpack-settings' ), $url );
 			}
+
+			$calypso_env = self::get_calypso_env();
+
+			if ( ! empty( $calypso_env ) ) {
+				$args['calypso_env'] = $calypso_env;
+			}
+
 		} else {
 
 			// Let's check the existing blog token to see if we need to re-register. We only check once per minute

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4655,7 +4655,7 @@ p {
 		$calypso_env = self::get_calypso_env();
 
 		if ( ! empty( $calypso_env ) ) {
-		    $args['calypso_env'] = $calypso_env;
+			$args['calypso_env'] = $calypso_env;
 		}
 
 		$api_url = $iframe ? $connection->api_url( 'authorize_iframe' ) : $connection->api_url( 'authorize' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4576,12 +4576,6 @@ p {
 		// Get affiliate code and add it to the URL
 		$url = Jetpack_Affiliate::init()->add_code_as_query_arg( $url );
 
-		$calypso_env = $this->get_calypso_env();
-
-		if ( ! empty( $calypso_env ) ) {
-			$url = add_query_arg( 'calypso_env', $calypso_env, $url );
-		}
-
 		return $raw ? esc_url_raw( $url ) : esc_url( $url );
 	}
 
@@ -4657,6 +4651,12 @@ p {
 		self::apply_activation_source_to_args( $args );
 
 		$connection = self::connection();
+
+		$calypso_env = self::get_calypso_env();
+
+		if ( ! empty( $calypso_env ) ) {
+		    $args['calypso_env'] = $calypso_env;
+		}
 
 		$api_url = $iframe ? $connection->api_url( 'authorize_iframe' ) : $connection->api_url( 'authorize' );
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4546,7 +4546,7 @@ p {
 			$calypso_env = self::get_calypso_env();
 
 			if ( ! empty( $calypso_env ) ) {
-				$args['calypso_env'] = $calypso_env;
+				$url = add_query_arg( 'calypso_env', $calypso_env, $url );
 			}
 
 		} else {


### PR DESCRIPTION
This moves the calypso_evn logic from the connection url method and into
the authorization url method. This allows the logic to be shared between
different connection flows.

For example, the new ifram connection flow will now respect the calypso_env parameter
and allow us to test the flow in different calypso environments.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes issues where the new iframe connection flow can only be tested with `production` calypso environments.

#### Changes proposed in this Pull Request:
* A refactor which moves logic from one place to an other.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhancement to the connection flow.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your jetpack testing site.
* Disconnect the site.
* Set these constants:
```
define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );
define( 'CALYPSO_ENV', 'development' );
```
* Try to connect while logged out from wordpress.com
* The wordpress login popup should attempt to open a calypso.localhost:3000 URL
* Try the same steps with :
`define( 'CALYPSO_ENV', 'horizon' );`
* The wordpress login popup should attempt to open a horizon.wordpress.com URL

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
