### PR TITLE
Connection Flow: hide TOS text

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -2,6 +2,7 @@
 
 jQuery( document ).ready( function( $ ) {
 	var connectButton = $( '.jp-connect-button' );
+	var tosText = $( '.jp-connect-full__tos-blurb' );
 	connectButton.click( function( event ) {
 		event.preventDefault();
 		if ( ! jetpackConnectButton.isRegistering ) {
@@ -42,6 +43,7 @@ jQuery( document ).ready( function( $ ) {
 		},
 		handleConnectInPlaceFlow: function() {
 			jetpackConnectButton.isRegistering = true;
+			tosText.hide();
 			connectButton
 				.text( jpConnect.buttonTextRegistering )
 				.attr( 'disabled', true )


### PR DESCRIPTION


Fixes #13370

#### Changes proposed in this Pull Request:
* If we are using the connection in place flow, we can hide the text after click

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
*A bug fix for an existing feature.

#### Testing instructions:

* Get this branch running on your testing site
* set `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
* disconnect your site from wordpress.com
* try to connect, and observe the TOS text disappear
* disconnect and set `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', false );` 
* try to connect, and the TOS should persist

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
