### PR TITLE
Remove deprecated module stubs

### DIFF
--- a/modules/blocks.php
+++ b/modules/blocks.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/debug.php
+++ b/modules/debug.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/gplus-authorship.php
+++ b/modules/gplus-authorship.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/holiday-snow.php
+++ b/modules/holiday-snow.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer included in Jetpack.
- *
- * @package Jetpack
- */

--- a/modules/omnisearch.php
+++ b/modules/omnisearch.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/random-redirect.php
+++ b/modules/random-redirect.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/site-icon.php
+++ b/modules/site-icon.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed. Site Icons are in Core. 
- *
- * @package Jetpack
- */

--- a/modules/social-links.php
+++ b/modules/social-links.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/tonesque.php
+++ b/modules/tonesque.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */

--- a/modules/wpcc.php
+++ b/modules/wpcc.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * Deprecated. No longer needed.
- *
- * @package Jetpack
- */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

All of these files have been left as stubs when they were removed, as an attempt to fight against incomplete upgrades and stale file cache that were still `require`ing them. 

The dates of removal below: 
- `modules/blocks.php`: Feb 2019 #11312
- `modules/holiday-snow.php`: Mar, 2018 #9019
- `modules/omnisearch.php`: Aug 2017 #7590
- `modules/site-icon.php`: Nov 2016 #3156
- `modules/random-redirect.php`: Dec 2013 46bacdd
- `modules/social-links.php`: Dec 2013 46bacdd
- `modules/tonesque.php`: Dec 2013 46bacdd
- `modules/debug.php`: Aug 2013 8c3790d8cb1463a687a250b6b3d687c03a0365ca
- `modules/gplus-authorship.php`: Oct 2014 e9cb5f0e468abba56a00ed706606dadb6b7a8cf2
- `modules/wpcc.php`: Oct 2013 ddc65e1

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
See above

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Make sure these are not referenced anywhere else in code. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
