### PR TITLE
Consolidate use of `DOMContentLoaded` to wp-dom-ready package

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -1205,8 +1205,8 @@ class Jetpack_Photon {
 				'_inc/build/photon/photon.min.js',
 				'modules/photon/photon.js'
 			),
-			array(),
-			20190201,
+			array( 'wp-dom-ready' ),
+			20190901,
 			true
 		);
 	}

--- a/extensions/blocks/mailchimp/view.js
+++ b/extensions/blocks/mailchimp/view.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
  * Internal dependencies
  */
 import emailValidator from 'email-validator';
@@ -81,11 +86,6 @@ const initializeMailchimpBlocks = () => {
 	} );
 };
 
-if ( typeof window !== 'undefined' && typeof document !== 'undefined' ) {
-	// `DOMContentLoaded` may fire before the script has a chance to run
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initializeMailchimpBlocks );
-	} else {
-		initializeMailchimpBlocks();
-	}
+if ( typeof window !== 'undefined' ) {
+	domReady( initializeMailchimpBlocks );
 }

--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -1,6 +1,11 @@
 /* global tb_show, tb_remove */
 
 /**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
  * Internal dependencies
  */
 import './view.scss';
@@ -61,11 +66,6 @@ const initializeMembershipButtonBlocks = () => {
 	} );
 };
 
-if ( typeof window !== 'undefined' && typeof document !== 'undefined' ) {
-	// `DOMContentLoaded` may fire before the script has a chance to run
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', initializeMembershipButtonBlocks );
-	} else {
-		initializeMembershipButtonBlocks();
-	}
+if ( typeof window !== 'undefined' ) {
+	domReady( initializeMembershipButtonBlocks );
 }

--- a/extensions/blocks/slideshow/view.js
+++ b/extensions/blocks/slideshow/view.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { forEach } from 'lodash';
+import domReady from '@wordpress/dom-ready';
 import ResizeObserver from 'resize-observer-polyfill';
 
 /**
@@ -15,8 +16,8 @@ import {
 	swiperResize,
 } from './swiper-callbacks';
 
-typeof window !== 'undefined' &&
-	window.addEventListener( 'load', function() {
+if ( typeof window !== 'undefined' ) {
+	domReady( function() {
 		const slideshowBlocks = document.getElementsByClassName( 'wp-block-jetpack-slideshow' );
 		forEach( slideshowBlocks, slideshowBlock => {
 			const { autoplay, delay, effect } = slideshowBlock.dataset;
@@ -68,3 +69,4 @@ typeof window !== 'undefined' &&
 				} );
 		} );
 	} );
+}

--- a/extensions/blocks/tiled-gallery/view.js
+++ b/extensions/blocks/tiled-gallery/view.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
  * Internal dependencies
  */
 import './view.scss';
@@ -54,11 +59,6 @@ const observeGalleries = () => {
 	galleries.forEach( gallery => observer.observe( gallery ) );
 };
 
-if ( typeof window !== 'undefined' && typeof document !== 'undefined' ) {
-	// `DOMContentLoaded` may fire before the script has a chance to run
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', observeGalleries );
-	} else {
-		observeGalleries();
-	}
+if ( typeof window !== 'undefined' ) {
+	domReady( observeGalleries );
 }

--- a/modules/photon/photon.js
+++ b/modules/photon/photon.js
@@ -44,13 +44,8 @@
 	/**
 	 * Check both when page loads, and when IS is triggered.
 	 */
-	if ( typeof window !== 'undefined' && typeof document !== 'undefined' ) {
-		// `DOMContentLoaded` may fire before the script has a chance to run
-		if ( document.readyState === 'loading' ) {
-			document.addEventListener( 'DOMContentLoaded', restore_dims );
-		} else {
-			restore_dims();
-		}
+	if ( typeof window !== 'undefined' ) {
+		window.wp.domReady( restore_dims );
 	}
 
 	document.body.addEventListener( 'post-load', restore_dims );


### PR DESCRIPTION
Consolidates all various usages of `DOMContentLoaded` event to external [`@wordpress/dom-ready`](https://github.com/WordPress/gutenberg/tree/3406be8ed44294abff8bda74a0586be63d3081e2/packages/dom-ready) package.

I checked that it's shipped in WordPress 5.1.1 at least, maybe even earlier.

`domReady` [is super simple](https://github.com/WordPress/gutenberg/blob/821343191752d70c7ee898326c08e31e3087dc22/packages/dom-ready/src/index.js) but it does a couple important checks in case the code runs _after_ `DOMContentLoaded` event has already fired in case the script loads late. There are various ways to do this by checking `readyState` (or forgetting to check at all 😉) but like this we can ensure the same pattern everywhere.

This also saves a bit of code by sharing it from a package but that's not very significant. ;-) On the cons side it adds one network request but it'll get concatenated by caching plugins anyway.

#### Changes proposed in this Pull Request:
* Change Tiled gallery, Slideshow, Mailchimp and Recurring payments blocks to use `wp.domReady`. Enqueued dependencies for blocks are handled automatically so this will get loaded without manually adding it to anywhere.
* Change Photon.js to use `wp.domReady` and add package to dependencies.
* Fix previously unguarded use of `document.body.addEventListener` (`document` is in fact `window.document`)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Refactors existing features

#### Testing instructions:
##### Blocks
- Remember to build before testing (`yarn build`)
- Create a post with Tiled gallery, Slideshow, Mailchimp and Recurring payments blocks. For recurring payments block you'll need a site with paid plan.
- Look at the post from the frontend of the site — do blocks work as expected, are they interactive?
- Do pages with those blocks enqueue `wp-dom-ready` script? You can also confirm that `_inc/blocks/BLOCK_NAME/view.deps.json` file has `wp-dom-ready`

##### Photon
- Enable image CDN/photon
- Add an image to a post
- When `modules/photon/photon(.min).js` is loaded, does `restore_dims` function run? (maybe add console log to it to confirm?).

#### Proposed changelog entry for your changes:
–
