### PR TITLE
Delete user connection owner: Add tracking to notice view and switch user action

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\JITM;
+use Automattic\Jetpack\Tracking;
 
 /**
  * Register WP REST API endpoints for Jetpack.
@@ -1232,6 +1233,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		if ( $updated && ! $xml->isError() ) {
+
+			// Track it
+			if ( class_exists( 'Automattic\Jetpack\Tracking' ) ) {
+				$tracking = new Tracking();
+				$tracking->record_user_event( 'set_connection_owner_success' );
+			}
+
 			return rest_ensure_response(
 				array(
 					'code' => 'success',

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -243,14 +243,6 @@ class JITM {
 
 						submitBtn.disabled = true;
 
-						// Track it
-						if ( typeof window.jpTracksAJAX.record_ajax_event === "function" ) {
-							window.jpTracksAJAX.record_ajax_event(
-								'delete_user_notice_switch_owner',
-								'click'
-							);
-						}
-
 						$.ajax( {
 							type        : "POST",
 							url         : "<?php echo get_rest_url() . 'jetpack/v4/connection/owner'; ?>",

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -193,6 +193,11 @@ class JITM {
 			return;
 		}
 
+		// Track it!
+		if ( method_exists( $this->tracking, 'record_user_event' ) ) {
+			$this->tracking->record_user_event( 'delete_connection_owner_notice_view' );
+		}
+
 		$connection_manager = new Manager();
 		$connected_admins   = $connection_manager->get_connected_users( 'jetpack_disconnect' );
 
@@ -238,6 +243,14 @@ class JITM {
 
 						submitBtn.disabled = true;
 
+						// Track it
+						if ( typeof window.jpTracksAJAX.record_ajax_event === "function" ) {
+							window.jpTracksAJAX.record_ajax_event(
+								'delete_user_notice_switch_owner',
+								'click'
+							);
+						}
+
 						$.ajax( {
 							type        : "POST",
 							url         : "<?php echo get_rest_url() . 'jetpack/v4/connection/owner'; ?>",
@@ -263,7 +276,7 @@ class JITM {
 			<?php
 		} else {
 			echo '<p>' . esc_html__( 'Every Jetpack site needs at least one connected admin for the features to work properly. Please connect to your WordPress.com account via the button below. Once you connect, you may refresh this page to see an option to change the connection owner.', 'jetpack' ) . '</p>';
-			$connect_url = \Jetpack::init()->build_connect_url( false, false, 'connection_owner_notice' );
+			$connect_url = \Jetpack::init()->build_connect_url( false, false, 'delete_connection_owner_notice' );
 			echo "<a href='" . esc_url( $connect_url ) . "' target='_blank' rel='noopener noreferrer' class='button-primary'>" . esc_html__( 'Connect to WordPress.com', 'jetpack' ) . '</a>';
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adds Tracks events to the notice view, and also an event in the `set_connection_owner` endpoint callback. 

View event name: `delete_connection_owner_notice_view`
Switch user event name: `set_connection_owner_success`

The connection button already is passing a `from` parameter, which we're automatically tracking. 

I did not add Tracks to the learn more nor the contact links, but would do so if asked. These are the most important actions IMO. 

Since it's so late in the cycle, I've written it a bit defensive :) 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
See above. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- ~set `localStorage.setItem( 'debug', 'dops:analytics' );` in your browser console~ No loner needed
- Add a secondary user (admin) and link them to wordpress.com
- Logged in as that secondary user, go to the users page and try to delete the current connection owner. 
- See the notice
- Click to switch the owner

These events will not come through the console. To see that, you need to watch the live tracks evetns come through in MC. This may have a 5-10 minute delay. 

ALSO: 
- Please verify that the Calypso UI for switching owner still works, since it also relies on this endpoint. 
- Remember when searching for these events, that they are prefixed with `jetpack_`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
n/a
