### PR TITLE
Update is_fse_active to account for a8c_disable_full_site_editing filter

### DIFF
--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -197,7 +197,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	 * 
 	 * @since 7.7.0 
 	 * 
-	 * @return bool true is full site editing is currently active
+	 * @return bool true if full site editing is currently active
 	 */ 
 	function is_fse_active() {
 		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -188,12 +188,17 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_fse_active() {
-		$fse_enabled = Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' );
-		$has_method  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
-		if ( $fse_enabled && $has_method ) {
-			$fse  = \A8C\FSE\Full_Site_Editing::get_instance();
-			$slug = get_option( 'stylesheet' );
-			return $fse->is_supported_theme( $slug );
+		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {
+			return false;
+		}
+		if ( apply_filters( 'a8c_disable_full_site_editing', false ) ) {
+			return false;
+		}
+		$has_is_supported_theme_method  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
+		$has_normalize_theme_slug  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
+		if ( $has_is_supported_theme_method && $has_normalize_theme_slug ) {
+			$slug = \A8C\FSE\Full_Site_Editing::get_instance()->normalize_theme_slug( get_option( 'stylesheet' ) );
+			return \A8C\FSE\Full_Site_Editing::get_instance()->is_supported_theme( $slug );
 		}
 		return false;
 	}

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -187,27 +187,36 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return current_user_can( $role );
 	}
 
-	/** 
+	/**
 	 * Check if full site editing should be considered as currently active. Full site editing
 	 * requires the FSE plugin to be installed and activated, as well the current
-	 * theme to be FSE compatible. The plugin can also be explicitly disabled via the 
+	 * theme to be FSE compatible. The plugin can also be explicitly disabled via the
 	 * a8c_disable_full_site_editing filter.
-	 * 
-	 * @module json-api 
-	 * 
-	 * @since 7.7.0 
-	 * 
-	 * @return bool true if full site editing is currently active
-	 */ 
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return bool true if full site editing is currently active.
+	 */
 	function is_fse_active() {
 		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {
 			return false;
 		}
-		if ( apply_filters( 'a8c_disable_full_site_editing', false ) ) {
+		if (
+			/**
+			 * Allow disabling Full Site Editing, even when the FSE plugin is active.
+			 *
+			 * @module json-api
+			 *
+			 * @since 7.7.0
+			 *
+			 * @param bool $disable_fse Disable Full Site Editing. Defaults to false.
+			 */
+			apply_filters( 'a8c_disable_full_site_editing', false )
+		) {
 			return false;
 		}
-		$has_is_supported_theme_method  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
-		$has_normalize_theme_slug  = method_exists( '\A8C\FSE\Full_Site_Editing', 'normalize_theme_slug' );
+		$has_is_supported_theme_method = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
+		$has_normalize_theme_slug      = method_exists( '\A8C\FSE\Full_Site_Editing', 'normalize_theme_slug' );
 		if ( $has_is_supported_theme_method && $has_normalize_theme_slug ) {
 			$slug = \A8C\FSE\Full_Site_Editing::get_instance()->normalize_theme_slug( get_option( 'stylesheet' ) );
 			return \A8C\FSE\Full_Site_Editing::get_instance()->is_supported_theme( $slug );

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -187,6 +187,18 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return current_user_can( $role );
 	}
 
+	/** 
+	 * Check if full site editing should be considered as currently active. Full site editing
+	 * requires the FSE plugin to be installed and activated, as well the current
+	 * theme to be FSE compatible. The plugin can also be explicitly disabled via the 
+	 * a8c_disable_full_site_editing filter.
+	 * 
+	 * @module json-api 
+	 * 
+	 * @since 7.7.0 
+	 * 
+	 * @return bool true is full site editing is currently active
+	 */ 
 	function is_fse_active() {
 		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {
 			return false;
@@ -195,7 +207,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 			return false;
 		}
 		$has_is_supported_theme_method  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
-		$has_normalize_theme_slug  = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
+		$has_normalize_theme_slug  = method_exists( '\A8C\FSE\Full_Site_Editing', 'normalize_theme_slug' );
 		if ( $has_is_supported_theme_method && $has_normalize_theme_slug ) {
 			$slug = \A8C\FSE\Full_Site_Editing::get_instance()->normalize_theme_slug( get_option( 'stylesheet' ) );
 			return \A8C\FSE\Full_Site_Editing::get_instance()->is_supported_theme( $slug );


### PR DESCRIPTION
Sometimes we may want to disable full site editing flows in the page editor, but still have access to other features like the post list or start page templates. This is done with the following filter:
```
add_filter( 'a8c_disable_full_site_editing', '__return_true' );
```

Changes here update the /sites/mysite endpoint to return `site.is_fse_active` false when the `a8c_disable_full_site_editing` returns true.

<img width="992" alt="Screen Shot 2019-09-02 at 5 53 39 PM" src="https://user-images.githubusercontent.com/1270189/64137056-a487ac00-cdaa-11e9-9b98-41f450e39f97.png">

### Testing Instructions
- Create a new test site https://jurassic.ninja/create?branch=update/fse-is-actives&jetpack-beta
- Install the Full Site Editing Plugin, Gutenberg development plugin and activate both
- Install Modern Business from https://github.com/Automattic/themes/
- Verify that is_fse_active is true, and that Full Site Editing flows are available when editing a page.
<img width="1335" alt="Screen Shot 2019-09-02 at 5 59 31 PM" src="https://user-images.githubusercontent.com/1270189/64137175-72c31500-cdab-11e9-9d55-32de54dcbc1f.png">

Add the following filter to the site, can be done easily in the plugin editor:
```
add_filter( 'a8c_disable_full_site_editing', '__return_true' );
```
- site response should be is_fse_active false,
- FSE flows for the post editor are not available, but other features still are like Starter Page Templates and Recent Blog Posts

Notice no header/footer, just the plain block editor:
<img width="1284" alt="Screen Shot 2019-09-02 at 6 08 44 PM" src="https://user-images.githubusercontent.com/1270189/64137422-0fd27d80-cdad-11e9-97bc-5f475e622a54.png">

We still have access to Starter Page Templates
<img width="1277" alt="Screen Shot 2019-09-02 at 6 08 37 PM" src="https://user-images.githubusercontent.com/1270189/64137442-24167a80-cdad-11e9-9b23-cab391107bae.png">

With the filter added we see is_fse_active is false:
<img width="1276" alt="Screen Shot 2019-09-02 at 6 09 36 PM" src="https://user-images.githubusercontent.com/1270189/64137453-2d9fe280-cdad-11e9-9165-ad2b31a26bc8.png">

Part of fixing https://github.com/Automattic/wp-calypso/issues/35854

