### PR TITLE
Recurring Payments: Use Upgrade and Stripe Nudges

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -195,6 +195,9 @@ class Jetpack_Gutenberg {
 			 * Filter 'jetpack_block_editor_enable_upgrade_nudge' with `true` to enable or `false`
 			 * to disable paid feature upgrade nudges in the block editor.
 			 *
+			 * When this is changed to default to `true`, you should also update `modules/memberships/class-jetpack-memberships.php`
+			 * See https://github.com/Automattic/jetpack/pull/13394#pullrequestreview-293063378
+			 *
 			 * @since 7.7.0
 			 *
 			 * @param boolean

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -130,6 +130,7 @@ class Jetpack_Plan {
 		if ( in_array( $plan['product_slug'], $personal_plans, true ) ) {
 			// special support value, not a module but a separate plugin.
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$plan['class'] = 'personal';
 		}
 
@@ -144,6 +145,7 @@ class Jetpack_Plan {
 
 		if ( in_array( $plan['product_slug'], $premium_plans, true ) ) {
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$supports[]    = 'simple-payments';
 			$supports[]    = 'vaultpress';
 			$supports[]    = 'videopress';
@@ -165,6 +167,7 @@ class Jetpack_Plan {
 
 		if ( in_array( $plan['product_slug'], $business_plans, true ) ) {
 			$supports[]    = 'akismet';
+			$supports[]    = 'recurring-payments';
 			$supports[]    = 'simple-payments';
 			$supports[]    = 'vaultpress';
 			$supports[]    = 'videopress';

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -395,9 +395,11 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
-				{ ! this.state.shouldUpgrade && connected === API_STATE_NOTCONNECTED && (
-					<StripeNudge blockName="recurring-payments" stripeConnectUrl={ stripeConnectUrl } />
-				) }
+				{ ! this.hasUpgradeNudge &&
+					! this.state.shouldUpgrade &&
+					connected === API_STATE_NOTCONNECTED && (
+						<StripeNudge blockName="recurring-payments" stripeConnectUrl={ stripeConnectUrl } />
+					) }
 				{ ! this.hasUpgradeNudge && this.state.shouldUpgrade && (
 					<div className="wp-block-jetpack-recurring-payments">
 						<Placeholder

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -27,8 +27,9 @@ import { Fragment, Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { icon, SUPPORTED_CURRENCY_LIST } from '.';
+import analytics from '../../../_inc/client/lib/analytics';
 import StripeNudge from '../../shared/components/stripe-nudge';
+import { icon, SUPPORTED_CURRENCY_LIST } from '.';
 
 const API_STATE_LOADING = 0;
 const API_STATE_CONNECTED = 1;
@@ -539,6 +540,9 @@ export default compose( [
 			// Special handling if we're opening in _this_ window. Otherwise, just let the navigation happen.
 			if ( href && target !== '_blank' ) {
 				event.preventDefault();
+				analytics.tracks.recordEvent( 'jetpack_editor_block_stripe_connect_click', {
+					block: 'recurring-payments',
+				} );
 				await dispatch( 'core/editor' ).autosave();
 				// Using window.top to escape from the editor iframe on WordPress.com
 				window.top.location.href = href;

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -10,7 +10,6 @@ import formatCurrency, { getCurrencyDefaults } from '@automattic/format-currency
 import { addQueryArgs, getQueryArg, isURL } from '@wordpress/url';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-
 import {
 	Button,
 	ExternalLink,
@@ -59,14 +58,6 @@ class MembershipsButtonEdit extends Component {
 		};
 		this.timeout = null;
 
-		// FIXME: In Jetpack, we cannot yet support the 'new', Upgrade Nudge-based
-		// flow, since the post-checkout redirect skips the Jetpack Onboarding Checklist in Calypso,
-		// where Akismet and VaultPress installation is triggered.
-		// Instead, we continue to show the legacy, in-block prompt to upgrade the site's plan.
-		// This however means that we have to display the block also if the site's on a Free plan.
-		//
-		// Check p7rd6c-23C-p2 for details and progress. If ready, remove the line below, and replace all
-		// checks for `this.hasUpgradeNudge` with `false`.
 		const recurringPaymentsAvailability = getJetpackExtensionAvailability( 'recurring-payments' );
 		this.hasUpgradeNudge =
 			! recurringPaymentsAvailability.available &&

--- a/extensions/blocks/recurring-payments/editor.scss
+++ b/extensions/blocks/recurring-payments/editor.scss
@@ -1,4 +1,5 @@
 @import './view.scss';
+@import '../../shared/styles/gutenberg-colors.scss';
 @import '../../shared/styles/gutenberg-variables.scss';
 
 .wp-block-jetpack-recurring-payments {
@@ -39,7 +40,6 @@
 	}
 
 	.membership-button {
-		
 		&__add-amount {
 			margin-right: 4px;
 		}
@@ -56,7 +56,7 @@
 		&__field-button {
 			margin-right: 4px;
 		}
-	
+
 		&__field-currency {
 			width: 30%;
 		}
@@ -77,8 +77,23 @@
 		}
 	}
 
+	&.disclaimer-only {
+		box-sizing: content-box;
+		font-size: 13px;
+		margin: 0 -14px;
+		padding: 14px;
+		text-align: center;
+		transform: translateY( 14px );
+
+		// Use opacity to work in various editor styles.
+		background: $dark-opacity-light-200;
+
+		.is-dark-theme & {
+			background: $light-opacity-light-200;
+		}
+	}
+
 	.wp-block-jetpack-membership-button_notification {
 		display: block;
 	}
-
 }

--- a/extensions/blocks/recurring-payments/recurring-payments.php
+++ b/extensions/blocks/recurring-payments/recurring-payments.php
@@ -9,11 +9,5 @@
 
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-
-	jetpack_register_block(
-		'jetpack/recurring-payments',
-		array(
-			'render_callback' => array( Jetpack_Memberships::get_instance(), 'render_button' ),
-		)
-	);
+	Jetpack_Memberships::get_instance();
 }

--- a/extensions/blocks/recurring-payments/recurring-payments.php
+++ b/extensions/blocks/recurring-payments/recurring-payments.php
@@ -9,5 +9,5 @@
 
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
-	Jetpack_Memberships::get_instance();
+	Jetpack_Memberships::get_instance()->register_gutenberg_block();
 }

--- a/extensions/shared/components/stripe-nudge/index.jsx
+++ b/extensions/shared/components/stripe-nudge/index.jsx
@@ -30,9 +30,9 @@ export default ( { stripeConnectUrl } ) => (
 				block: blockName,
 			} )
 		}
-		title={ __( 'To use this block, connect to Stripe.', 'jetpack' ) }
+		title={ __( 'Connect to Stripe to use this block on your site', 'jetpack' ) }
 		subtitle={ __(
-			'Check if Stripe is available in your country, and sign up for an account.',
+			'This block will be hidden from your visitors until you connect to Stripe.',
 			'jetpack'
 		) }
 	/>

--- a/extensions/shared/components/stripe-nudge/index.jsx
+++ b/extensions/shared/components/stripe-nudge/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import GridiconStar from 'gridicons/dist/star';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import analytics from '../../../../_inc/client/lib/analytics';
+import BlockNudge from '../block-nudge';
+
+import './style.scss';
+
+export default ( { stripeConnectUrl } ) => (
+	<BlockNudge
+		buttonLabel={ __( 'Connect', 'jetpack' ) }
+		icon={
+			<GridiconStar
+				className="jetpack-stripe-nudge__icon"
+				size={ 18 }
+				aria-hidden="true"
+				role="img"
+				focusable="false"
+			/>
+		}
+		href={ stripeConnectUrl }
+		onClick={ blockName =>
+			void analytics.tracks.recordEvent( 'jetpack_editor_block_stripe_connect_click', {
+				block: blockName,
+			} )
+		}
+		title={ __( 'To use this block, connect to Stripe.', 'jetpack' ) }
+		subtitle={ __(
+			'Check if Stripe is available in your country, and sign up for an account.',
+			'jetpack'
+		) }
+	/>
+);

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -2,7 +2,7 @@
 
 .jetpack-stripe-nudge__icon {
 	align-self: center;
-	background: var( --color-wpcom );
+	background: var( --color-primary );
 	border-radius: 50%;
 	box-sizing: content-box;
 	color: $white;

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -1,0 +1,11 @@
+.jetpack-stripe-nudge__icon {
+	align-self: center;
+	background: var( --color-wpcom );
+	border-radius: 50%;
+	box-sizing: content-box;
+	color: var( --color-white );
+	fill: var( --color-white );
+	flex-shrink: 0;
+	margin-right: 16px;
+	padding: 6px;
+}

--- a/extensions/shared/components/stripe-nudge/style.scss
+++ b/extensions/shared/components/stripe-nudge/style.scss
@@ -1,10 +1,12 @@
+@import '../../styles/gutenberg-colors.scss';
+
 .jetpack-stripe-nudge__icon {
 	align-self: center;
 	background: var( --color-wpcom );
 	border-radius: 50%;
 	box-sizing: content-box;
-	color: var( --color-white );
-	fill: var( --color-white );
+	color: $white;
+	fill: $white;
 	flex-shrink: 0;
 	margin-right: 16px;
 	padding: 6px;

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -41,7 +41,7 @@ export const UpgradeNudge = ( { planName, trackEvent, upgradeUrl } ) => (
 				: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
 		}
 		subtitle={ __(
-			'You can try it out before upgrading, but only you will see it. It will be hidden from visitors until you upgrade.',
+			'You can try it out before upgrading, but only you will see it. It will be hidden from your visitors until you upgrade.',
 			'jetpack'
 		) }
 	/>

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -46,7 +46,7 @@ class Jetpack_Memberships {
 	/**
 	 * The minimum required plan for this Gutenberg block.
 	 *
-	 * @var Jetpack_Memberships
+	 * @var string Plan slug
 	 */
 	private static $required_plan;
 
@@ -61,6 +61,13 @@ class Jetpack_Memberships {
 	 * Jetpack_Memberships constructor.
 	 */
 	private function __construct() {}
+
+	/**
+	 * Track recurring payments block registration.
+	 *
+	 * @var boolean True if block registration has been executed.
+	 */
+	private static $has_registered_block = false;
 
 	/**
 	 * The actual constructor initializing the object.
@@ -313,6 +320,13 @@ class Jetpack_Memberships {
 	 * Register the Recurring Payments Gutenberg block
 	 */
 	public function register_gutenberg_block() {
+		// This gate was introduced to prevent duplicate registration. A race condition exists where
+		// the registration that happens via extensions/blocks/recurring-payments/recurring-payments.php
+		// was adding the registration action after the action had been run in some contexts.
+		if ( self::$has_registered_block ) {
+			return;
+		}
+
 		if ( self::is_enabled_jetpack_recurring_payments() ) {
 			jetpack_register_block(
 				'jetpack/recurring-payments',
@@ -330,6 +344,8 @@ class Jetpack_Memberships {
 				)
 			);
 		}
+
+		self::$has_registered_block = true;
 	}
 }
 Jetpack_Memberships::get_instance();

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -312,9 +312,10 @@ class Jetpack_Memberships {
 		//
 		// Check p7rd6c-23C-p2 for details and progress. If ready, uncomment the right-hand side of the line with the
 		// return statement below.
-		// phpcs:ignore
+
+		/** This filter is documented in class.jetpack-gutenberg.php */
 		return Jetpack::is_active() && (
-			! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) || // Remove when the default becomes `true`
+			! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) || // Remove when the default becomes `true`.
 			Jetpack_Plan::supports( 'recurring-payments' )
 		);
 	}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -302,19 +302,8 @@ class Jetpack_Memberships {
 		}
 
 		// For Jetpack sites.
-
-		// FIXME: We enable Recurring Payments on all Jetpack sites, including those on a Free plan.
-		// The reason is that in Jetpack, we cannot yet support the 'new', Upgrade and Stripe Nudge-based
-		// flow, since the post-checkout redirect skips the Jetpack Onboarding Checklist in Calypso,
-		// where Akismet and VaultPress installation is triggered.
-		// Instead, we continue to show the legacy, in-block prompts to upgrade the site's plan, and to
-		// connect Stripe. This however means that we have to display the block also if the site's on a Free plan.
-		//
-		// Check p7rd6c-23C-p2 for details and progress. If ready, uncomment the right-hand side of the line with the
-		// return statement below.
-
-		/** This filter is documented in class.jetpack-gutenberg.php */
 		return Jetpack::is_active() && (
+			/** This filter is documented in class.jetpack-gutenberg.php */
 			! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) || // Remove when the default becomes `true`.
 			Jetpack_Plan::supports( 'recurring-payments' )
 		);

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -313,7 +313,10 @@ class Jetpack_Memberships {
 		// Check p7rd6c-23C-p2 for details and progress. If ready, uncomment the right-hand side of the line with the
 		// return statement below.
 		// phpcs:ignore
-		return Jetpack::is_active(); // && Jetpack_Plan::supports( 'recurring-payments' ); // phpcs:ignore
+		return Jetpack::is_active() && (
+			! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ) || // Remove when the default becomes `true`
+			Jetpack_Plan::supports( 'recurring-payments' )
+		);
 	}
 
 	/**

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -51,6 +51,13 @@ class Jetpack_Memberships {
 	private static $required_plan;
 
 	/**
+	 * Track recurring payments block registration.
+	 *
+	 * @var boolean True if block registration has been executed.
+	 */
+	private static $has_registered_block = false;
+
+	/**
 	 * Classic singleton pattern
 	 *
 	 * @var Jetpack_Memberships
@@ -61,13 +68,6 @@ class Jetpack_Memberships {
 	 * Jetpack_Memberships constructor.
 	 */
 	private function __construct() {}
-
-	/**
-	 * Track recurring payments block registration.
-	 *
-	 * @var boolean True if block registration has been executed.
-	 */
-	private static $has_registered_block = false;
 
 	/**
 	 * The actual constructor initializing the object.

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -303,13 +303,7 @@ class Jetpack_Memberships {
 	 */
 	public static function is_enabled_jetpack_recurring_payments() {
 		// For WPCOM sites.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			// In some contexts (wp-cli), this function may not be defined. That should not make us
-			// fall into the Jetpack case, but instead fails the check.
-			if ( ! function_exists( 'has_any_blog_stickers' ) ) {
-				return false;
-			}
-
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'has_any_blog_stickers' ) ) {
 			$site_id = get_current_blog_id();
 			return has_any_blog_stickers( array( 'personal-plan', 'premium-plan', 'business-plan', 'ecommerce-plan' ), $site_id );
 		}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -303,7 +303,13 @@ class Jetpack_Memberships {
 	 */
 	public static function is_enabled_jetpack_recurring_payments() {
 		// For WPCOM sites.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'has_any_blog_stickers' ) ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// In some contexts (wp-cli), this function may not be defined. That should not make us
+			// fall into the Jetpack case, but instead fails the check.
+			if ( ! function_exists( 'has_any_blog_stickers' ) ) {
+				return false;
+			}
+
 			$site_id = get_current_blog_id();
 			return has_any_blog_stickers( array( 'personal-plan', 'premium-plan', 'business-plan', 'ecommerce-plan' ), $site_id );
 		}


### PR DESCRIPTION
**Fusion didn't work, so I generated the WP.com counterpart manually: D32570-code.**

Take Two of #13233, which was getting a bit noisy. This time, I'm also adding the Stripe Connect nudge since it's rather hard to do add each nudge in a separate PR, due to the block's UX. Thus, this PR is essentially implementing mockups from p8hgLy-1RC-p2 (with some limitations, see below).

The Stripe Nudge is used both on Jetpack and WP.com, wheras the Upgrade Nudge is only used when the relevant filter returns true (i.e. currently only on WP.com).

#### Changes proposed in this Pull Request:

Add an UpgradeNudge and a Stripe Connect Nudge to the Recurring Payments block to replace UI that's currently part of the block itself.

####  Screenshots

##### Before

![image](https://user-images.githubusercontent.com/96308/63064516-c4d9ee80-bf01-11e9-870d-7fd844dd7b17.png)

![image](https://user-images.githubusercontent.com/96308/64378912-099f0400-d02e-11e9-9f6a-369facfc4d47.png)

##### After

![image](https://user-images.githubusercontent.com/96308/64385879-ec6f3300-d037-11e9-86bd-0b2835b183b6.png)

![image](https://user-images.githubusercontent.com/96308/64388758-5db2e400-d040-11e9-9288-c551e1ec04be.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

The Recurring Payments block isn't new; we're just using the Upgrade Nudge, and introducing the Stripe Connect Nudge to replace some previously in-button messaging.

#### Testing instructions:

On Jetpack, verify that the Stripe Nudge is now shown if the site is on a paid plan, but not yet connected to Stripe; furthermore, the Recurring Payments button will be previewed inside the block in that case. The block's behavior should otherwise be unchanged.

- Switch to this branch locally, build Jetpack (`yarn build`), and start Docker (`yarn docker:up`)
- Make sure you're connected to WP.com, and on a free plan
- Start a new post, and insert the 'Recurring Payments' block
- Verify that it prompts you to upgrade to a paid plan (from within the block; no upgrade nudge)
- Upgrade to a paid plan
- Verify that post-checkout, you're redirected back to the block editor. You should now see the Upgrade Nudge, and an interactive preview of the Recurring Payments button inside of the block.

Test the WP.com counterpart:

- Apply D32570-code to your sandbox
- Make sure you're on a free plan
- Start a new post, and insert the 'Recurring Payments' block
- Verify that you can change the button's label and colors
- Click the nudge's "Upgrade" CTA button
- Pay for the premium plan
- Verify that you're redirected back to where you came from (the wp-admin block editor) (without any intermediate redirects on WP.com)
- Verify that you now see the Stripe Connect Nudge on top of the block
- Click the Connect button and connect to stripe (see the Field Guide for how to do this in sandbox mode)
- Manually return to the editor and verify that the nudges are gone

_You can also simulate the WP.com behavior in JP by adding `<?php add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );` to e.g. `docker/mu-plugins/0-gutenpack.php` and applying the following diff on top of this PR to your local JP Docker install:_

```diff
diff --git a/modules/memberships/class-jetpack-memberships.php b/modules/memberships/class-jetpack-memberships.php
index 52f9e92d2..e3e7b08ef 100644
--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -313,7 +313,7 @@ class Jetpack_Memberships {
 		// Check p7rd6c-23C-p2 for details and progress. If ready, uncomment the right-hand side of the line with the
 		// return statement below.
 		// phpcs:ignore
-		return Jetpack::is_active(); // && Jetpack_Plan::supports( 'recurring-payments' ); // phpcs:ignore
+		return Jetpack::is_active() && Jetpack_Plan::supports( 'recurring-payments' ); // phpcs:ignore
 	}
 
 	/**
```

#### Proposed changelog entry for your changes:

Add an Upgrade Nudge and a Stripe Connect Nudge to the Recurring Payments block to replace UI that's currently part of the block itself.

#### Differences from p8hgLy-1RC-p2

1. The Upgrade Nudge doesn't mention Stripe. For comparison, this is the mockup:
![rp-no-footer-4](https://user-images.githubusercontent.com/96308/64378497-21c25380-d02d-11e9-9e83-1d4e976f86e3.png)
The reason is that the Upgrade Nudge is currently generically added upon block registration. We'd have to move it to individual blocks in order to customize its message, but that will have us face another problem (similar to item 4. below).
2. In the Stripe Nudge message, there are no hyperlinks pointing to additional information. Again, see the mockup:
![connect-to-stripe-1](https://user-images.githubusercontent.com/96308/64378665-7960bf00-d02d-11e9-8a4d-2c66fe501b90.png)
The reason is that unlike `calypso-i18n`, it's not straight-forward to add hyperlinks to parts of a translated string within the framework of `@wordpress/i18n`. (There are a few ugly/fragile ways though.)
3. Post-checkout, the user continues to be redirected back to the editor (rather than showing them the success modal within Calypso). We've already added some logic both to Calypso and Jetpack to implement this behavior after some discussion. The feature hasn't been switched on in Jetpack yet, but once it is, it'll be hard to change the redirect behavior. We should make a very conscious decision here.
4. When the Stripe Nudge is shown, there's no border around the block (unless it becomes active by clicking into it). For the Upgrade Nudge, we add the filter by adding a class to the block container div that holds the block. This is done through a [filter](https://github.com/Automattic/jetpack/blob/005a488ce5de12631113665aa781fd6e2e7dd963/extensions/shared/register-jetpack-block.js#L53-L59) at block registration time since the block itself doesn't have direct access to the surrounding container. The same principle doesn't easily carry over to the Stripe Nudge, since unlike block availability and required plan, we only obtain information about Stripe connection status through a network request fired by the block.

I'd suggest we discuss each of these items separately to make a plan on how to proceed with them. I think that it's conceivable that we don't block this PR by them.