### PR TITLE
[WIP] VideoPress: Transcode all videos

### DIFF
--- a/modules/videopress/class.jetpack-videopress.php
+++ b/modules/videopress/class.jetpack-videopress.php
@@ -342,6 +342,14 @@ class Jetpack_VideoPress {
 		return $extensions;
 	}
 
+
+
+	/**
+	 * Request a VideoPress transcoding job by WordPress.com.
+	 *
+	 * @param int $attachment_id ID of a new attachment.
+	 * @return null
+	 */
 	public function transcode_video( $attachment_id ) {
 		// Bail if attachment is not a video.
 		if ( ! wp_attachment_is( 'video', $attachment_id ) ) {
@@ -359,7 +367,7 @@ class Jetpack_VideoPress {
 			sprintf( '/sites/%d/videopress/%d/transcode', $site_id, $attachment_id ),
 			'2',
 			array(
-				'method'  => 'POST',
+				'method' => 'POST',
 			),
 			null,
 			'wpcom'


### PR DESCRIPTION
Fixes #7073.
Fixes #11194.
Depends on D32307-code.

#### Changes proposed in this Pull Request:
Ensures that any new video attachment is transcoded by VideoPress if the module is active. 

Previously, only videos uploaded from within the media library in grid view mode were transcoded.

Now, we hook into the `add_attachment` action and perform a request to a WP.com endpoint that will transcode the video.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
paYKcK-f0-p2

#### Testing instructions:
* Apply D32307-code and sandbox the API.
* Apply this branch to your JP dev environment.
* Start from a Jetpack site with an active Professional upgrade.
* Go to Jetpack > Settings in your dashboard, and enable the VideoPress feature.
* Go to Media > Add New in your dashboard, and try to upload a video.
* Go to Media > Library in your dashboard, and verify the video has been transcoded.
* Repeat with videos uploaded from within the Media Library in list view mode or within a video block in the Gutenberg.

#### Proposed changelog entry for your changes:
* VideoPress: Transcode all videos
