### PR TITLE
Update: remove the php notice so that we give aksimet and vaultpress time to deprecate the method

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5173,7 +5173,8 @@ p {
 	 * @deprecated since 7.7.0
 	 */
 	public static function load_xml_rpc_client() {
-		_deprecated_function( __METHOD__, 'jetpack-7.7' );
+	    // Removed the php notice that shows up in order to give time to Akismet and VaultPress time to update.
+		// _deprecated_function( __METHOD__, 'jetpack-7.7' );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5173,7 +5173,7 @@ p {
 	 * @deprecated since 7.7.0
 	 */
 	public static function load_xml_rpc_client() {
-	    // Removed the php notice that shows up in order to give time to Akismet and VaultPress time to update.
+		// Removed the php notice that shows up in order to give time to Akismet and VaultPress time to update.
 		// _deprecated_function( __METHOD__, 'jetpack-7.7' );
 	}
 


### PR DESCRIPTION

Fixes a php notice that shows up in the akismet settings ui. 

#### Changes proposed in this Pull Request:


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:

* Go to the Akismet settings ui. Notice that the php notice is not visible any more. 

#### Proposed changelog entry for your changes:
* Suppress the php notice in akismet and vaultpress plugins. 
