### PR TITLE
Recurring Payments: Add postId to Stripe connection URL state param

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -349,19 +349,10 @@ class MembershipsButtonEdit extends Component {
 		const { align } = attributes;
 
 		const stripeConnectUrl = this.getConnectUrl();
-		/**
-		 * If we know the postId, assume we'll return to the editor and navigate away.
-		 * Otherwise, open a new window.
-		 *
-		 * If the block is mounted in an iframe, target the parent to navigate.
-		 */
-		let stripeConnectTarget = undefined;
-		if ( postId ) {
-			// Navigate the iframe parent or self if not iframed.
-			stripeConnectTarget = '_top';
-		} else {
-			stripeConnectTarget = '_blank';
-		}
+
+		// If we know the postId, assume we'll return to the editor. Navigate the top window.
+		// Otherwise, open a new window.
+		const stripeConnectTarget = postId ? '_top' : '_blank';
 
 		const inspectorControls = (
 			<InspectorControls>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -358,7 +358,7 @@ class MembershipsButtonEdit extends Component {
 		let stripeConnectTarget = undefined;
 		if ( postId ) {
 			// Navigate the iframe parent or self if not iframed.
-			stripeConnectTarget = '_parent';
+			stripeConnectTarget = '_top';
 		} else {
 			stripeConnectTarget = '_blank';
 		}

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -453,6 +453,7 @@ class MembershipsButtonEdit extends Component {
 										disabled={ ! stripeConnectUrl }
 										href={ stripeConnectUrl }
 										target={ stripeConnectTarget }
+										rel={ stripeConnectTarget === '_blank' ? 'noopener noreferrer' : undefined }
 										onClick={ this.props.autosaveAndNavigateToConnection }
 									>
 										{ __( 'Connect to Stripe or set up an account', 'jetpack' ) }


### PR DESCRIPTION
Companion to D32394-code

See p7rd6c-24Y-p2 for detailed discussion.

#### Changes proposed in this Pull Request:

- Save and navigate in the same window when starting Stripe connection.
- If we don't have a postId, open the connection in a new window without the postId added.
- Add the postId to the state so we can return after connection.
- Add `noopener noreferrer` if the link will open in a new window (`_blank`).

#### Testing instructions:
* If you apply D32394-code and sandbox `public-api.wordpress.com`, you should be able to follow the whole flow.
* For a Jetpack site with a paid plan
* Add a Recurring Payment block to the editor
* Click the Stripe conneciton button
  ![Screen Shot 2019-09-05 at 17 02 34](https://user-images.githubusercontent.com/841763/64354095-10625280-cfff-11e9-9065-5129f7de136e.png)
* The post should auto-save, then navigate to the strip connection.
* With D32394-code, you should return to the same post after connecting (or cancelling)
* Without D32394-code, you'll land at `/earn` on WordPress.com

The post id is base64 encoded in the `state` query param on the connection URL. You can grab it and inspect to verify that the post ID is correctly added.


#### Proposed changelog entry for your changes:

None.