### PR TITLE
Connection banner: use `rest_url` instead of hardcoded path

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -164,7 +164,7 @@ class Jetpack_Connection_Banner {
 			'jetpack-connect-button',
 			'jpConnect',
 			array(
-				'apiBaseUrl'            => esc_url_raw( rest_url( 'jetpack/v4') ),
+				'apiBaseUrl'            => esc_url_raw( rest_url( 'jetpack/v4' ) ),
 				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 				'apiSiteDataNonce'      => wp_create_nonce( 'wp_rest' ),

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -164,7 +164,7 @@ class Jetpack_Connection_Banner {
 			'jetpack-connect-button',
 			'jpConnect',
 			array(
-				'apiBaseUrl'            => site_url( '/wp-json/jetpack/v4' ),
+				'apiBaseUrl'            => esc_url_raw( rest_url( 'jetpack/v4') ),
 				'registrationNonce'     => wp_create_nonce( 'jetpack-registration-nonce' ),
 				'apiNonce'              => wp_create_nonce( 'wp_rest' ),
 				'apiSiteDataNonce'      => wp_create_nonce( 'wp_rest' ),


### PR DESCRIPTION
account for different permalink setups, hattip @enejb and @oskosk

Fixes #

Connect in place doesn't work when using the 'plain' permalink setting. (reported by @enejb on Slack)

#### Changes proposed in this Pull Request:
use `rest_url` as suggested by @oskosk 

#### Testing instructions:
* Set `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
* Set permalinks to plain
* Try to connect the site