### PR TITLE
Map Block AMP Compatibility Alternate Approach

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -171,7 +171,10 @@ export class Map extends Component {
 		const { map } = this.state;
 		const mapEl = this.mapRef.current;
 		const blockWidth = mapEl.offsetWidth;
-		const maxHeight = window.innerHeight * 0.8;
+		const maxHeight =
+			window.location.search.indexOf( 'map-block-counter' ) > -1
+				? window.innerHeight
+				: window.innerHeight * 0.8;
 		const blockHeight = Math.min( blockWidth * ( 3 / 4 ), maxHeight );
 		mapEl.style.height = blockHeight + 'px';
 		map.resize();

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -47,8 +47,8 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		return sprintf(
 			'<amp-iframe src="%s" width="%d" height="%d" layout="responsive" allowfullscreen sandbox="allow-scripts">%s</amp-iframe>',
 			esc_url( $iframe_url ),
-			absint( Jetpack::get_content_width() ),
-			absint( Jetpack::get_content_width() * 0.75 ),
+			4,
+			3,
 			$placeholder
 		);
 	}

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -72,6 +72,10 @@ function jetpack_map_block_render_single_block_page() {
 	/* Create an array of all root-level DIVs that are Map Blocks */
 	$post = get_post( $map_block_post_id );
 
+	if ( ! class_exists( 'DOMDocument' ) ) {
+		return;
+	}
+
 	$post_html = new DOMDocument();
 	$content   = apply_filters( 'the_content', $post->post_content );
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -74,7 +74,12 @@ function jetpack_map_block_render_single_block_page() {
 
 	$post_html = new DOMDocument();
 	$content   = apply_filters( 'the_content', $post->post_content );
+
+	/* Suppress warnings */
+	libxml_use_internal_errors( true );
 	$post_html->loadHTML( $content );
+	libxml_use_internal_errors( false );
+
 	$xpath     = new DOMXPath( $post_html );
 	$container = $xpath->query( '//div[ contains( @class, "wp-block-jetpack-map" ) ]' )->item( $map_block_counter - 1 );
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -26,7 +26,6 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		global $wp;
 		static $map_block_counter = [];
 
 		$id = get_the_ID();
@@ -35,7 +34,13 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		}
 		$map_block_counter[ $id ]++;
 
-		$iframe_url = home_url( $wp->request ) . '?map-block-counter=' . $map_block_counter[ $id ] . '&map-block-post-id=' . get_the_ID();
+		$iframe_url = add_query_arg(
+			array(
+				'map-block-counter' => $map_block_counter[ get_the_ID() ],
+				'map-block-post-id' => get_the_ID(),
+			),
+			get_permalink()
+		);
 
 		$placeholder = preg_replace( '/(?<=<div\s)/', 'placeholder ', $content );
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -32,6 +32,8 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		}
 		$iframe_url = home_url( $wp->request ) . '?map-block-counter=' . $map_block_counter;
 
+		$map_block_counter++;
+
 		$placeholder = preg_replace( '/(?<=<div\s)/', 'placeholder ', $content );
 
 		// @todo Is intrinsic size right? Is content_width the right dimensions?

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -39,12 +39,11 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 
 		$placeholder = preg_replace( '/(?<=<div\s)/', 'placeholder ', $content );
 
-		// @todo Is intrinsic size right? Is content_width the right dimensions?
 		return sprintf(
-			'<amp-iframe src="%s" width="%d" height="%d" layout="intrinsic" allowfullscreen sandbox="allow-scripts">%s</amp-iframe>',
+			'<amp-iframe src="%s" width="%d" height="%d" layout="responsive" allowfullscreen sandbox="allow-scripts">%s</amp-iframe>',
 			esc_url( $iframe_url ),
-			Jetpack::get_content_width(),
-			Jetpack::get_content_width(),
+			absint( Jetpack::get_content_width() ),
+			absint( Jetpack::get_content_width() * 0.75 ),
 			$placeholder
 		);
 	}

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -26,10 +26,9 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		global $wp, $map_block_counter;
-		if ( ! $map_block_counter ) {
-			$map_block_counter = array();
-		}
+		global $wp;
+		static $map_block_counter = [];
+
 		$id = get_the_ID();
 		if ( ! $map_block_counter[ $id ] ) {
 			$map_block_counter[ $id ] = 0;

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -64,6 +64,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 function jetpack_map_block_render_single_block_page() {
 	$map_block_counter = (int) filter_input( INPUT_GET, 'map-block-counter', FILTER_SANITIZE_NUMBER_INT );
 	$map_block_post_id = (int) filter_input( INPUT_GET, 'map-block-post-id', FILTER_SANITIZE_NUMBER_INT );
+
 	if ( ! $map_block_counter || ! $map_block_post_id ) {
 		return;
 	}
@@ -73,11 +74,11 @@ function jetpack_map_block_render_single_block_page() {
 
 	$post_html = new DOMDocument();
 	$post_html->loadHTML( $post->post_content );
-	$xpath          = new DOMXPath( $post_html );
-	$map_block_divs = $xpath->query( '//div[ contains( @class, "wp-block-jetpack-map" ) ]' );
+	$xpath     = new DOMXPath( $post_html );
+	$container = $xpath->query( '//div[ contains( @class, "wp-block-jetpack-map" ) ]' )->item( $map_block_counter - 1 );
 
 	/* Check that we have a block matching the counter position */
-	if ( ! isset( $map_block_divs[ $map_block_counter - 1 ] ) ) {
+	if ( ! $container ) {
 		return;
 	}
 
@@ -95,7 +96,7 @@ function jetpack_map_block_render_single_block_page() {
 	$head_content = ob_get_clean();
 
 	/* Put together a new complete document containing only the requested block markup and the scripts/styles needed to render it */
-	$block_markup = $post_html->saveHTML( $map_block_divs[ $map_block_counter - 1 ] );
+	$block_markup = $post_html->saveHTML( $container );
 	$api_key      = Jetpack_Options::get_option( 'mapbox_api_key' );
 	$page_html    = sprintf(
 		'<!DOCTYPE html><head><style>html, body { margin: 0; padding: 0; }</style>%s</head><body>%s</body>',

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -25,7 +25,83 @@ jetpack_register_block(
 function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		global $wp, $map_block_counter;
+		if ( ! $map_block_counter ) {
+			$map_block_counter = 0;
+		}
+		$iframe_url = home_url( $wp->request ) . '?map-block-counter=' . $map_block_counter;
+
+		$placeholder = preg_replace( '/(?<=<div\s)/', 'placeholder ', $content );
+
+		// @todo Is intrinsic size right? Is content_width the right dimensions?
+		return sprintf(
+			'<amp-iframe src="%s" width="%d" height="%d" layout="intrinsic" allowfullscreen sandbox="allow-scripts">%s</amp-iframe>',
+			esc_url( $iframe_url ),
+			Jetpack::get_content_width(),
+			Jetpack::get_content_width(),
+			$placeholder
+		);
+	}
+
 	Jetpack_Gutenberg::load_assets_as_required( 'map' );
 
 	return preg_replace( '/<div /', '<div data-api-key="' . esc_attr( $api_key ) . '" ', $content, 1 );
 }
+
+/**
+ * Render a page containing only a single Map block.
+ */
+function jetpack_map_block_render_single_block_page() {
+	$map_block_counter_as_string = filter_input( INPUT_GET, 'map-block-counter', FILTER_SANITIZE_STRING );
+	if ( strlen( $map_block_counter_as_string ) < 1 ) {
+		return;
+	}
+	$map_block_counter = intval( $map_block_counter_as_string );
+
+	/* Create an array of all root-level DIVs that are Map Blocks */
+	global $post;
+
+	$post_html = new DOMDocument();
+	$post_html->loadHTML( $post->post_content );
+	$divs = $post_html->getElementsByTagName( 'div' );
+
+	$map_block_divs = array();
+	foreach ( $divs as $div ) {
+		$classes = explode( ' ', $div->getAttribute( 'class' ) );
+		if ( in_array( 'wp-block-jetpack-map', $classes, true ) ) {
+			$map_block_divs[] = $div;
+		}
+	}
+
+	/* Check that we have a block matching the counter position */
+	if ( ! isset( $map_block_divs[ $map_block_counter ] ) ) {
+		return;
+	}
+
+	/* Compile scripts and styles */
+	ob_start();
+
+	add_filter( 'jetpack_is_amp_request', '__return_false' );
+
+	Jetpack_Gutenberg::load_assets_as_required( 'map' );
+	wp_scripts()->do_items();
+	wp_styles()->do_items();
+
+	add_filter( 'jetpack_is_amp_request', '__return_true' );
+
+	$head_content = ob_get_clean();
+
+	/* Put together a new complete document containing only the requested block markup and the scripts/styles needed to render it */
+	$block_markup = $post_html->saveHTML( $map_block_divs[ $map_block_counter ] );
+	$api_key      = Jetpack_Options::get_option( 'mapbox_api_key' );
+	$page_html    = sprintf(
+		'<!DOCTYPE html><head><style>html, body { margin: 0; padding: 0; }</style>%s</head><body>%s</body>',
+		$head_content,
+		preg_replace( '/(?<=<div\s)/', 'data-api-key="' . esc_attr( $api_key ) . '" ', $block_markup, 1 )
+	);
+	echo $page_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit;
+}
+
+add_action( 'wp', 'jetpack_map_block_render_single_block_page' );

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -62,8 +62,10 @@ function jetpack_map_block_load_assets( $attr, $content ) {
  * Render a page containing only a single Map block.
  */
 function jetpack_map_block_render_single_block_page() {
-	$map_block_counter = (int) filter_input( INPUT_GET, 'map-block-counter', FILTER_SANITIZE_NUMBER_INT );
-	$map_block_post_id = (int) filter_input( INPUT_GET, 'map-block-post-id', FILTER_SANITIZE_NUMBER_INT );
+	// phpcs:ignore WordPress.Security.NonceVerification
+	$map_block_counter = isset( $_GET, $_GET['map-block-counter'] ) ? absint( $_GET['map-block-counter'] ) : null;
+	// phpcs:ignore WordPress.Security.NonceVerification
+	$map_block_post_id = isset( $_GET, $_GET['map-block-post-id'] ) ? absint( $_GET['map-block-post-id'] ) : null;
 
 	if ( ! $map_block_counter || ! $map_block_post_id ) {
 		return;

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -28,7 +28,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		global $wp, $map_block_counter;
 		if ( ! $map_block_counter ) {
-			$map_block_counter = 0;
+			$map_block_counter = 1;
 		}
 		$iframe_url = home_url( $wp->request ) . '?map-block-counter=' . $map_block_counter;
 
@@ -55,11 +55,10 @@ function jetpack_map_block_load_assets( $attr, $content ) {
  * Render a page containing only a single Map block.
  */
 function jetpack_map_block_render_single_block_page() {
-	$map_block_counter_as_string = filter_input( INPUT_GET, 'map-block-counter', FILTER_SANITIZE_STRING );
-	if ( strlen( $map_block_counter_as_string ) < 1 ) {
+	$map_block_counter = (int) filter_input( INPUT_GET, 'map-block-counter', FILTER_SANITIZE_NUMBER_INT );
+	if ( ! $map_block_counter ) {
 		return;
 	}
-	$map_block_counter = intval( $map_block_counter_as_string );
 
 	/* Create an array of all root-level DIVs that are Map Blocks */
 	global $post;
@@ -77,7 +76,7 @@ function jetpack_map_block_render_single_block_page() {
 	}
 
 	/* Check that we have a block matching the counter position */
-	if ( ! isset( $map_block_divs[ $map_block_counter ] ) ) {
+	if ( ! isset( $map_block_divs[ $map_block_counter - 1 ] ) ) {
 		return;
 	}
 
@@ -95,7 +94,7 @@ function jetpack_map_block_render_single_block_page() {
 	$head_content = ob_get_clean();
 
 	/* Put together a new complete document containing only the requested block markup and the scripts/styles needed to render it */
-	$block_markup = $post_html->saveHTML( $map_block_divs[ $map_block_counter ] );
+	$block_markup = $post_html->saveHTML( $map_block_divs[ $map_block_counter - 1 ] );
 	$api_key      = Jetpack_Options::get_option( 'mapbox_api_key' );
 	$page_html    = sprintf(
 		'<!DOCTYPE html><head><style>html, body { margin: 0; padding: 0; }</style>%s</head><body>%s</body>',

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -73,7 +73,8 @@ function jetpack_map_block_render_single_block_page() {
 	$post = get_post( $map_block_post_id );
 
 	$post_html = new DOMDocument();
-	$post_html->loadHTML( $post->post_content );
+	$content   = apply_filters( 'the_content', $post->post_content );
+	$post_html->loadHTML( $content );
 	$xpath     = new DOMXPath( $post_html );
 	$container = $xpath->query( '//div[ contains( @class, "wp-block-jetpack-map" ) ]' )->item( $map_block_counter - 1 );
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -65,15 +65,8 @@ function jetpack_map_block_render_single_block_page() {
 
 	$post_html = new DOMDocument();
 	$post_html->loadHTML( $post->post_content );
-	$divs = $post_html->getElementsByTagName( 'div' );
-
-	$map_block_divs = array();
-	foreach ( $divs as $div ) {
-		$classes = explode( ' ', $div->getAttribute( 'class' ) );
-		if ( in_array( 'wp-block-jetpack-map', $classes, true ) ) {
-			$map_block_divs[] = $div;
-		}
-	}
+	$xpath          = new DOMXPath( $post_html );
+	$map_block_divs = $xpath->query( '//div[ contains( @class, "wp-block-jetpack-map" ) ]' );
 
 	/* Check that we have a block matching the counter position */
 	if ( ! isset( $map_block_divs[ $map_block_counter - 1 ] ) ) {

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -28,11 +28,15 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		global $wp, $map_block_counter;
 		if ( ! $map_block_counter ) {
-			$map_block_counter = 1;
+			$map_block_counter = array();
 		}
-		$iframe_url = home_url( $wp->request ) . '?map-block-counter=' . $map_block_counter;
+		$id = get_the_ID();
+		if ( ! $map_block_counter[ $id ] ) {
+			$map_block_counter[ $id ] = 0;
+		}
+		$map_block_counter[ $id ]++;
 
-		$map_block_counter++;
+		$iframe_url = home_url( $wp->request ) . '?map-block-counter=' . $map_block_counter[ $id ] . '&map-block-post-id=' . get_the_ID();
 
 		$placeholder = preg_replace( '/(?<=<div\s)/', 'placeholder ', $content );
 
@@ -56,12 +60,13 @@ function jetpack_map_block_load_assets( $attr, $content ) {
  */
 function jetpack_map_block_render_single_block_page() {
 	$map_block_counter = (int) filter_input( INPUT_GET, 'map-block-counter', FILTER_SANITIZE_NUMBER_INT );
-	if ( ! $map_block_counter ) {
+	$map_block_post_id = (int) filter_input( INPUT_GET, 'map-block-post-id', FILTER_SANITIZE_NUMBER_INT );
+	if ( ! $map_block_counter || ! $map_block_post_id ) {
 		return;
 	}
 
 	/* Create an array of all root-level DIVs that are Map Blocks */
-	global $post;
+	$post = get_post( $map_block_post_id );
 
 	$post_html = new DOMDocument();
 	$post_html->loadHTML( $post->post_content );

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -26,7 +26,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		static $map_block_counter = [];
+		static $map_block_counter = array();
 
 		$id = get_the_ID();
 		if ( ! $map_block_counter[ $id ] ) {

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -29,7 +29,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		static $map_block_counter = array();
 
 		$id = get_the_ID();
-		if ( ! $map_block_counter[ $id ] ) {
+		if ( ! isset( $map_block_counter[ $id ] ) ) {
 			$map_block_counter[ $id ] = 0;
 		}
 		$map_block_counter[ $id ]++;

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -79,11 +79,12 @@ function jetpack_map_block_render_single_block_page() {
 	}
 
 	$post_html = new DOMDocument();
-	$content   = apply_filters( 'the_content', $post->post_content );
+	/** This filter is already documented in core/wp-includes/post-template.php */
+	$content = apply_filters( 'the_content', $post->post_content );
 
 	/* Suppress warnings */
 	libxml_use_internal_errors( true );
-	$post_html->loadHTML( $content );
+	@$post_html->loadHTML( $content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	libxml_use_internal_errors( false );
 
 	$xpath     = new DOMXPath( $post_html );

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -36,8 +36,8 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 
 		$iframe_url = add_query_arg(
 			array(
-				'map-block-counter' => $map_block_counter[ get_the_ID() ],
-				'map-block-post-id' => get_the_ID(),
+				'map-block-counter' => absint( $map_block_counter[ $id ] ),
+				'map-block-post-id' => $id,
 			),
 			get_permalink()
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR is an alternate approach to https://github.com/Automattic/jetpack/pull/13321, which came about due to problems described in https://github.com/Automattic/jetpack/pull/13321#issuecomment-527246542. In this approach, a URL param  (`map-block-counter`) will cause page requests to render a complete document containing only a single Map block. The value of `map-block-counter` determines the ordinal of the block to render. If no block at the provided value is found, the page renders normally. In AMP requests, Map block will render as an iFrame using the special URL as the `src`. This approach replaces the `srcdoc` attribute and length/browser compatibility constraints associated with it. `DOMDocument` is used to extract the desired block markup from the post content.

TODO:

- [x] Improve map height inside of iframe.
- [x] Determine if width/height of amp-iframe are correct, and whether intrinsic or responsive layout should be used.
- [x] How to sanitize the full page output?
- [x] If problematic, there may be viable alternatives to ordinal, for example a hash of the Map block markup.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds AMP compatibility to Map block.

#### Testing instructions:
* Activate AMP plugin.
* Add Map block to content.
* View post/page in AMP.
* Verify Map block still renders on a valid AMP page.
* Verify Map block renders in the loop, e.g. on homepage.
* Verify pages  with multiple Map blocks render correctly.
* Inspect page and copy the `src`  of the `amp-iframe`s.  Load these URLs in separate browser windows. Make sure they render correctly.
* Alter the value of `map-block-post-id` and/or `map-block-counter` query params. This should cause the full page to load rather than the block alone.

#### Proposed changelog entry for your changes:
* Add AMP-compatibility to the Map block.
