### PR TITLE
PWA: hide the module from the module list when it is not active.

### DIFF
--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -92,6 +92,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
 				if ( item === undefined ) return;
+				if ( 'pwa' == item.module && ! item.activated ) return;
 				if ( 'manage' == item.module && item.activated ) return; #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When the module is active, we want to offer folks the chance to deactivate it.
When it is not active, however, let's not show it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Internal reference: p1HpG7-7uS-p2

#### Testing instructions:

* Before you apply this patch, go to `/wp-admin/admin.php?page=jetpack_modules` on your site and enable the Progressive Web Apps module.
* Apply this patch.
* The module should still be there on the list.
* Now deactivate the module.
* The module should be gone from the list.

#### Proposed changelog entry for your changes:

* None
