### PR TITLE
Yarn watch: Fix looping

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -21,7 +21,11 @@ const meta = require( './package.json' );
 import frontendcss from './tools/builder/frontend-css';
 import admincss from './tools/builder/admin-css';
 import { watch as react_watch, build as react_build } from './tools/builder/react';
-import { watch as sass_watch, build as sass_build } from './tools/builder/sass';
+import {
+	watch as sass_watch,
+	build as sass_build,
+	watchPackages as sass_watch_packages,
+} from './tools/builder/sass';
 
 gulp.task( 'old-styles:watch', function() {
 	return gulp.watch( 'scss/**/*.scss', gulp.parallel( 'old-styles' ) );
@@ -209,19 +213,22 @@ gulp.task( 'languages:extract', function( done ) {
 		} );
 } );
 
-gulp.task( 'old-styles', gulp.parallel( frontendcss, admincss, 'sass:old', 'sass:packages:rtl' ) );
+gulp.task( 'old-styles', gulp.parallel( frontendcss, admincss, 'sass:old', 'sass:packages' ) );
 
 // Default task
 gulp.task(
 	'default',
 	gulp.series( gulp.parallel( react_build, 'old-styles', 'php:module-headings' ), sass_build )
 );
-gulp.task( 'watch', gulp.parallel( react_watch, sass_watch, 'old-styles:watch' ) );
+gulp.task(
+	'watch',
+	gulp.parallel( react_watch, sass_watch, sass_watch_packages, 'old-styles:watch' )
+);
 
 // Keeping explicit task names to allow for individual runs
 gulp.task( 'sass:build', sass_build );
 gulp.task( 'react:build', react_build );
-gulp.task( 'sass:watch', sass_watch );
+gulp.task( 'sass:watch', gulp.parallel( sass_watch, sass_watch_packages ) );
 gulp.task( 'react:watch', react_watch );
 
 gulp.task(

--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -233,18 +233,19 @@ gulp.task(
 export const build = gulp.parallel(
 	gulp.series( 'sass:dashboard', 'sass:calypsoify', 'sass:instant-search' ),
 	'sass:old',
-	'sass:packages:rtl'
+	'sass:packages'
 );
 
 export const watch = function() {
 	return gulp.watch(
 		[ './**/*.scss', ...alwaysIgnoredPaths ],
-		gulp.parallel(
-			'sass:dashboard',
-			'sass:instant-search',
-			'sass:calypsoify',
-			'sass:old',
-			'sass:packages:rtl'
-		)
+		gulp.series( 'sass:dashboard', 'sass:instant-search', 'sass:calypsoify', 'sass:old' )
+	);
+};
+
+export const watchPackages = function() {
+	return gulp.watch(
+		[ './packages/jitm/assets/*.scss', ...alwaysIgnoredPaths ],
+		gulp.parallel( 'sass:packages:rtl' )
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13198 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

I separated the entire packages watch function into it's own function. 

I honestly never figured out exactly what was causing it, but I know it has something to do with the wildcard paths using `**/`. 

See how the `watch` function is watching `[ './**/*.scss', ...alwaysIgnoredPaths ],`? Well, the `sass:packages:rtl` task is watching a different wildcard path `packages/**/assets/*.css`. I do not know if/how recursive wildcards behave differently if you append a static dir name, such as being done for `assets`, but some conflict here is what's causing the loop. 

If someone has a better idea on how to fix, let me know.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. `yarn watch`
2. While it's watching, modify some code in `jetpack-admin-jitm.scss`
3. `watch` should do it's thing, and you should see the changes reflected in all the auto-generated files. 
4. Ensure that no other files were created. 
5. Ensure that watch doesn't keep going forever.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
NA