### PR TITLE
Connect Flow: ok for mobile

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -150,9 +150,7 @@ class Jetpack_Connection_Banner {
 
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 
-		if ( jetpack_is_mobile() ) {
-			$force_variation = 'original';
-		} else if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'in_place';
 		} else if ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'original';


### PR DESCRIPTION


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR will allow mobile users to use the new connect-in-place flow.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
p1HpG7-7nj-p2

#### Testing instructions:

* Get this potato running on a test site. 
* Set `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', false );`
* Disconnect your site
* Try visiting your site's wp-admin on a mobile device
* How does it feel connecting in place?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
