### PR TITLE
Connection: Fix A/B test endpoint CORS request to be with credentials

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -29,6 +29,10 @@ jQuery( document ).ready( function( $ ) {
 				url: 'https://public-api.wordpress.com/wpcom/v2/abtest/' + abTestName,
 				type: 'GET',
 				error: jetpackConnectButton.handleConnectionError,
+				xhrFields: {
+					withCredentials: true,
+				},
+				crossDomain: true,
 				success: function( data ) {
 					if ( data && 'in_place' === data.variation ) {
 						jetpackConnectButton.handleConnectInPlaceFlow();


### PR DESCRIPTION
Currently, when requesting A/B test variation for the "connect in place" flow, we perform an AJAX request to the dedicated public WP.com REST API endpoint. However, since the AJAX request is a cross-domain one, browsers would not store cookies on the remote domain that were created during those requests for security reasons. Because the cookie was not set in those cases, the A/B test identity was being lost.

To fix this issue, we simply have to declare the request as a cross-domain one, and enable `withCredentials` for the XHR2 request (see [this article](https://stackoverflow.com/questions/14221722/set-cookie-on-browser-with-ajax-request-via-cors) for more info).

#### Changes proposed in this Pull Request:
* Connection: Fix A/B test endpoint CORS request to be with credentials

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of p1HpG7-7nj-p2.

#### Testing instructions:
* Inspect the cookies of `public-api.wordpress.com`. If you have a `SSE_jetpack_connect_in_place_20190821` cookie, delete it.
* Checkout Jetpack `master`.
* Run `yarn build`.
* In case you have `JETPACK_SHOULD_USE_CONNECTION_IFRAME` defined, comment/remove it. This should NOT be defined for the A/B test variation to be requested.
* Disconnect the site if it's connected.
* Navigate to the Jetpack dashboard, and attempt to connect by clicking the "Set up Jetpack" button.
* Inspect the cookies of `public-api.wordpress.com`. 
* Verify you don't have a `SSE_jetpack_connect_in_place_20190821` cookie.
* Now checkout this branch.
* Run `yarn build`.
* Make sure the site is still disconnected.
* Navigate to the Jetpack dashboard, and attempt to connect by clicking the "Set up Jetpack" button.
* Inspect the cookies of `public-api.wordpress.com`. 
* Verify you have a `SSE_jetpack_connect_in_place_20190821` cookie with a variation of either `original` or `in_place`.

Note: To inspect the cookies of a domain, you can open https://public-api.wordpress.com/wpcom/v2/plans/mobile/ and use the "Application" -> "Cookies" section for Chrome. 

#### Proposed changelog entry for your changes:
* Connection: Fix A/B test endpoint CORS request to be with credentials
