### PR TITLE
Sync: Check if IXR client is there to prevent errors when updating

### DIFF
--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -291,6 +291,15 @@ class Actions {
 
 		$url = add_query_arg( $query_args, \Jetpack::xmlrpc_api_url() );
 
+		// If we're currently updating to Jetpack 7.7, the IXR client may be missing briefly
+		// because since 7.7 it's being autoloaded with Composer.
+		if ( ! class_exists( '\\Jetpack_IXR_Client' ) ) {
+			return new \WP_Error(
+				'ixr_client_missing',
+				esc_html__( 'Sync has been aborted because the IXR client is missing.', 'jetpack' )
+			);
+		}
+
 		$rpc = new \Jetpack_IXR_Client(
 			array(
 				'url'     => $url,


### PR DESCRIPTION
This introduces a check for IXR client when performing sync data sending. It will prevent from fatal errors caused by sync sending items during an update of Jetpack to 7.7 (see #13421 for more details).

Fixes #13421

#### Changes proposed in this Pull Request:
* Sync: Check if IXR client is there to prevent errors when updating

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is just a fix.

#### Testing instructions:
* Checkout this branch.
* Make sure full sync and incremental sync are still working well.
* Verify tests still pass.

#### Proposed changelog entry for your changes:
* Sync: Check if IXR client is there to prevent errors when updating
