### PR TITLE
Connect-in-place: resize the IFRAME whenever a request is being sent

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -80,12 +80,20 @@ jQuery( document ).ready( function( $ ) {
 		},
 		receiveData: function( event ) {
 			if (
-				event.origin === jpConnect.jetpackApiDomain &&
-				event.source === jetpackConnectIframe.get( 0 ).contentWindow &&
-				event.data === 'close'
+				event.origin !== jpConnect.jetpackApiDomain ||
+				event.source !== jetpackConnectIframe.get( 0 ).contentWindow
 			) {
-				window.removeEventListener( 'message', this.receiveData );
-				jetpackConnectButton.handleAuthorizationComplete();
+				return;
+			}
+
+			var type = event.data.type || 'close';
+			switch ( type ) {
+				case 'close':
+					window.removeEventListener( 'message', this.receiveData );
+					jetpackConnectButton.handleAuthorizationComplete();
+					break;
+				case 'resize':
+					jetpackConnectIframe.height( event.data.height );
 			}
 		},
 		handleAuthorizationComplete: function() {


### PR DESCRIPTION
This PR adds a support for `iframe` resizing whenever a request is being sent from it.
This needs D32432-code to be checked out in order to work as expected.

Fixes no known issues.

#### Changes proposed in this Pull Request:
* Resize the `iframe` whenever a request is being sent from it.

#### Testing instructions:
* Check out D32432-code
* Make sure to set the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant to `true`.
* Disconnect from Jetpack.
* Go through the connect in place flow and observe the `iframe` size changes at different stages. This may be best visible when you encounter an error in the connection flow inside the `iframe`. 