### PR TITLE
Dashboard: do not display tabs to Plans for unconnected users.

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -18,7 +18,7 @@ import {
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 } from 'state/initial-state';
-import { isDevMode } from 'state/connection';
+import { isCurrentUserLinked, isDevMode } from 'state/connection';
 
 export class Navigation extends React.Component {
 	trackNavClick = target => {
@@ -52,7 +52,7 @@ export class Navigation extends React.Component {
 					>
 						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
 					</NavItem>
-					{ ! this.props.isDevMode && (
+					{ ! this.props.isDevMode && this.props.isLinked && (
 						<NavItem
 							path="#/my-plan"
 							onClick={ this.trackMyPlanClick }
@@ -61,7 +61,7 @@ export class Navigation extends React.Component {
 							{ __( 'My Plan', { context: 'Navigation item.' } ) }
 						</NavItem>
 					) }
-					{ ! this.props.isDevMode && (
+					{ ! this.props.isDevMode && this.props.isLinked && (
 						<NavItem
 							path="#/plans"
 							onClick={ this.trackPlansClick }
@@ -103,5 +103,6 @@ export default connect( state => {
 		userCanViewStats: _userCanViewStats( state ),
 		isModuleActivated: module_name => _isModuleActivated( state, module_name ),
 		isDevMode: isDevMode( state ),
+		isLinked: isCurrentUserLinked( state ),
 	};
 } )( Navigation );

--- a/_inc/client/components/navigation/test/component.js
+++ b/_inc/client/components/navigation/test/component.js
@@ -66,12 +66,12 @@ describe( 'Navigation', () => {
 
 		const wrapperManage = shallow( <Navigation { ...testProps } /> );
 
-		it( 'renders 3 NavItem components', () => {
-			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 3 );
+		it( 'renders 1 NavItem component', () => {
+			expect( wrapperManage.find( 'NavItem' ) ).to.have.length( 1 );
 		} );
 
-		it( 'renders tabs with At a Glance, My Plan, Plans', () => {
-			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance,My Plan,Plans' );
+		it( 'renders At a Glance tab', () => {
+			expect( wrapperManage.find( 'NavItem' ).children().map( item => item.text() ).join() ).to.be.equal( 'At a Glance' );
 		} );
 
 	} );


### PR DESCRIPTION
Fixes #13415

#### Changes proposed in this Pull Request:

* When an admin has not linked their account to their wpcom account yet, they will not be able to pick a plan or visit any of the site's pages in Calypso.
Let's consequently not show them the "My Plan" or "Plans" pages in the Jetpack dashboard.

#### Testing instructions:

0. Connect your site to wordpress.com
1. Create a secondary admin user on the site
2. Log in as secondary admin in a separate browser/incognito
3. navigate to the Jetpack dashboard.
4. You should not see any links to the "My Plan" or "Plans" page in the masthead.

![image](https://user-images.githubusercontent.com/426388/64258617-d96d3d80-cf27-11e9-8d90-2bd2a50a2338.png)

#### Proposed changelog entry for your changes:

* Dashboard: do not display Plans page to non-connected admins.
