### PR TITLE
Update: Remove the promotional copy on Jetpack Setup

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -5,7 +5,7 @@ jQuery( document ).ready( function( $ ) {
 	var tosText = $( '.jp-connect-full__tos-blurb' );
 	connectButton.click( function( event ) {
 		event.preventDefault();
-		$('#jetpack-connection-cards').fadeOut(100);
+		$( '#jetpack-connection-cards' ).fadeOut( 600 );
 		if ( ! jetpackConnectButton.isRegistering ) {
 			if ( 'original' === jpConnect.forceVariation ) {
 				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`.

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -5,6 +5,7 @@ jQuery( document ).ready( function( $ ) {
 	var tosText = $( '.jp-connect-full__tos-blurb' );
 	connectButton.click( function( event ) {
 		event.preventDefault();
+		$('#jetpack-connection-cards').fadeOut(100);
 		if ( ! jetpackConnectButton.isRegistering ) {
 			if ( 'original' === jpConnect.forceVariation ) {
 				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`.

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -321,7 +321,7 @@ class Jetpack_Connection_Banner {
 					</a>
 				</p>
 
-				<div class="jp-connect-full__row">
+				<div class="jp-connect-full__row" id="jetpack-connection-cards">
 					<div class="jp-connect-full__slide">
 						<div class="jp-connect-full__slide-card illustration">
 							<img


### PR DESCRIPTION
Fixes #13410. 

The main reason we are doing this is so that we can then increase the iframe size and not have too much of a gap between the promotional copy and the iframe.

#### Changes proposed in this Pull Request:
Fade out the promotional instructions when the user clicks the Setup Jetpack button.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?


#### Testing instructions:
Add the constant `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );` to you wp-config.php

* Go to Jetpack admin to connect jetpack for the first time. 
* Notice that the promotional copy fades away after you click on thee `Setup Jetpack` button. 

#### Proposed changelog entry for your changes:
* Remove the promiotional copy when in the jetpack setup process.
