### PR TITLE
Check if the transient is an array before trying to access it by index in Jetpack::get_file_data

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2562,6 +2562,11 @@ class Jetpack {
 
 		$file_data_option = get_transient( $cache_key );
 
+		if  ( ! is_array( $file_data_option ) ) {
+			delete_transient( $cache_key );
+			$file_data_option = false; 
+		}
+
 		if ( false === $file_data_option ) {
 			$file_data_option = array();
 		}


### PR DESCRIPTION
This was generating the errors mentioned in
https://wordpress.org/support/topic/jetpack-error-prevents-loading-wordpress-admin/#post-11891380

Fixes 4225-gh-jpop-issues

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks if a transient is an array before trying to access it by index in `Jetpack::get_file_data`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:

Incoming

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed a bug by which an out of memory error was being thrown when accessing the site dashboard when Jetpack was acive. https://wordpress.org/support/topic/jetpack-error-prevents-loading-wordpress-admin/ 
