### PR TITLE
More consistent naming for the Jetpack Search dashboard widget

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -107,7 +107,7 @@ class DashSearch extends Component {
 			return (
 				<div className="jp-dash-item">
 					<DashItem
-						label={ __( 'Search' ) }
+						label={ __( 'Jetpack Search' ) }
 						module="search"
 						support={ {
 							text: __(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13408

#### Changes proposed in this Pull Request:

Simply ensures that "Jetpack Search" title is consistent between enabled and disabled states. Previously it would show just "Search" when enabled, and "Jetpack Search" when disabled.
