### PR TITLE
Add rudimentary support for filtering on post types

### DIFF
--- a/modules/search/instant-search/components/search-filter-post-types.jsx
+++ b/modules/search/instant-search/components/search-filter-post-types.jsx
@@ -3,18 +3,33 @@
 /**
  * External dependencies
  */
-import { h, Component } from 'preact';
+import { h, createRef, Component } from 'preact';
 import strip from 'strip';
+import { getCheckedInputNames } from '../lib/dom';
 
 export default class SearchFilterPostTypes extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { selected: this.props.initialValue };
+		this.filtersList = createRef();
+	}
+
+	toggleFilter = () => {
+		const selected = getCheckedInputNames( this.filtersList.current );
+		this.setState( { selected }, () => {
+			this.props.onChange( 'postTypes', selected );
+		} );
+	};
+
 	renderPostType = ( { key, doc_count: count } ) => {
-		const name = this.props.postTypes[ key ];
+		const name = key in this.props.postTypes ? this.props.postTypes[ key ] : key;
 		return (
 			<div>
 				<input
-					disabled
+					checked={ this.state.selected.includes( key ) }
 					id={ `jp-instant-search-filter-post-types-${ key }` }
 					name={ key }
+					onChange={ this.toggleFilter }
 					type="checkbox"
 				/>
 				<label htmlFor={ `jp-instant-search-filter-post-types-${ key }` }>
@@ -26,8 +41,10 @@ export default class SearchFilterPostTypes extends Component {
 	render() {
 		return (
 			<div>
-				<h4 className="jetpack-search-filters-widget__sub-heading">{ this.props.filter.name }</h4>
-				<ul className="jetpack-search-filters-widget__filter-list">
+				<h4 className="jetpack-search-filters-widget__sub-heading">
+					{ this.props.configuration.name }
+				</h4>
+				<ul className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
 					{ this.props.aggregation &&
 						'buckets' in this.props.aggregation &&
 						this.props.aggregation.buckets.map( this.renderPostType ) }

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -17,18 +17,22 @@ import SearchFilterTaxonomies from './search-filter-taxonomies';
 import SearchFilterPostTypes from './search-filter-post-types';
 
 export default class SearchFiltersWidget extends Component {
-	renderFilterComponent = ( { filter, results } ) => {
-		switch ( filter.type ) {
+	renderFilterComponent = ( { configuration, results } ) => {
+		switch ( configuration.type ) {
 			case 'date_histogram':
-				return results && <SearchFilterDates aggregation={ results } filter={ filter } />;
+				return results && <SearchFilterDates aggregation={ results } filter={ configuration } />;
 			case 'taxonomy':
-				return results && <SearchFilterTaxonomies aggregation={ results } filter={ filter } />;
+				return (
+					results && <SearchFilterTaxonomies aggregation={ results } filter={ configuration } />
+				);
 			case 'post_type':
 				return (
 					results && (
 						<SearchFilterPostTypes
 							aggregation={ results }
-							filter={ filter }
+							configuration={ configuration }
+							initialValue={ this.props.initialValues.postTypes }
+							onChange={ this.props.onChange }
 							postTypes={ this.props.postTypes }
 						/>
 					)
@@ -41,8 +45,10 @@ export default class SearchFiltersWidget extends Component {
 		return (
 			<div className="jetpack-instant-search__filters-widget">
 				{ get( this.props.widget, 'filters' )
-					.map( filter =>
-						aggregations ? { filter, results: aggregations[ filter.filter_id ] } : null
+					.map( configuration =>
+						aggregations
+							? { configuration, results: aggregations[ configuration.filter_id ] }
+							: null
 					)
 					.filter( data => !! data )
 					.filter(

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -9,13 +9,14 @@ import { h, render } from 'preact';
  * Internal dependencies
  */
 import SearchWidget from './components/search-widget';
-import { getSearchQuery } from './lib/query-string';
+import { getSearchQuery, getFilterQuery } from './lib/query-string';
 
-const injectSearchWidget = ( initialValue, grabFocus ) => {
+const injectSearchWidget = grabFocus => {
 	render(
 		<SearchWidget
 			grabFocus={ grabFocus }
-			initialValue={ initialValue }
+			initialFilters={ getFilterQuery() }
+			initialValue={ getSearchQuery() }
 			options={ window.JetpackInstantSearchOptions }
 		/>,
 		document.body
@@ -24,6 +25,6 @@ const injectSearchWidget = ( initialValue, grabFocus ) => {
 
 document.addEventListener( 'DOMContentLoaded', function() {
 	if ( !! window.JetpackInstantSearchOptions && 'siteId' in window.JetpackInstantSearchOptions ) {
-		injectSearchWidget( getSearchQuery() );
+		injectSearchWidget();
 	}
 } );

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -37,7 +37,21 @@ export function buildFilterAggregations( widgets = [] ) {
 	return aggregation;
 }
 
-export function search( siteId, query, aggregations, filter, resultFormat ) {
+function buildFilterObject( filterQuery ) {
+	if ( ! filterQuery ) {
+		return {};
+	}
+
+	const filter = { bool: { must: [] } };
+	if ( Array.isArray( filterQuery.postTypes ) && filterQuery.postTypes.length > 0 ) {
+		filterQuery.postTypes.forEach( postType => {
+			filter.bool.must.push( { term: { post_type: postType } } );
+		} );
+	}
+	return filter;
+}
+
+export function search( { aggregations, filter, query, resultFormat, siteId } ) {
 	let fields = [];
 	let highlight_fields = [];
 	switch ( resultFormat ) {
@@ -54,7 +68,7 @@ export function search( siteId, query, aggregations, filter, resultFormat ) {
 			aggregations,
 			fields,
 			highlight_fields,
-			filter,
+			filter: buildFilterObject( filter ),
 			query: encodeURIComponent( query ),
 		} )
 	);

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -10,3 +10,9 @@ export function hideSearchHeader() {
 		title.style.display = 'none';
 	}
 }
+
+export function getCheckedInputNames( parentDom ) {
+	return [ ...parentDom.querySelectorAll( 'input[type="checkbox"]' ).values() ]
+		.filter( input => input.checked )
+		.map( input => input.name );
+}

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -26,3 +26,30 @@ export function setSearchQuery( searchValue ) {
 	query.s = searchValue;
 	pushQueryString( encode( query ) );
 }
+
+function getFilterQueryByKey( filterKey ) {
+	const query = getQuery();
+	if ( ! ( filterKey in query ) ) {
+		return [];
+	}
+	if ( typeof query[ filterKey ] === 'string' ) {
+		return [ query[ filterKey ] ];
+	}
+	return query[ filterKey ];
+}
+
+export function getFilterQuery( filterKey ) {
+	if ( filterKey ) {
+		return getFilterQueryByKey( filterKey );
+	}
+
+	return {
+		postTypes: getFilterQueryByKey( 'postTypes' ),
+	};
+}
+
+export function setFilterQuery( filterKey, filterValue ) {
+	const query = getQuery();
+	query[ filterKey ] = filterValue;
+	pushQueryString( encode( query ) );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This enables filtering search results by post types checkboxes. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes, this adds post type filtering to a yet unreleased Instant Search.

#### Testing instructions:
* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and has Jetpack Search enabled.
* Add a Jetpack Search widget to the Search page sidebar.
* Add a post type filter to the Jetpack Search widget.
* Enter a query into a search widget. Alternatively, navigate to a search page like `/?s=privacy`.
* Ensure that you can select a post type filter checkbox.

#### Proposed changelog entry for your changes:
None necessary.