### PR TITLE
Connect in Place: Add a loading text instead of loading button

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -50,9 +50,12 @@ jQuery( document ).ready( function( $ ) {
 			jetpackConnectButton.isRegistering = true;
 			tosText.hide();
 			connectButton
-				.text( jpConnect.buttonTextRegistering )
-				.attr( 'disabled', true )
-				.blur();
+				.hide()
+				.after(
+					'<span class="jp-connect-full__button-container-loading">' +
+						jpConnect.buttonTextRegistering +
+						'</span>'
+				);
 
 			$.ajax( {
 				url: jpConnect.apiBaseUrl + '/connection/register',
@@ -66,7 +69,12 @@ jQuery( document ).ready( function( $ ) {
 					jetpackConnectButton.fetchPlanType();
 					window.addEventListener( 'message', jetpackConnectButton.receiveData );
 					jetpackConnectIframe.attr( 'src', data.authorizeUrl );
-					$( '.jp-connect-full__button-container' ).html( jetpackConnectIframe );
+					jetpackConnectIframe.load( function() {
+						jetpackConnectIframe.show();
+						$( '.jp-connect-full__button-container' ).hide();
+					} );
+					jetpackConnectIframe.hide();
+					$( '.jp-connect-full__button-container' ).after( jetpackConnectIframe );
 				},
 			} );
 		},
@@ -104,7 +112,6 @@ jQuery( document ).ready( function( $ ) {
 			window.location.reload( true );
 		},
 		handleConnectionError: function( error ) {
-			console.warn( 'Connection failed. Falling back to the regular flow', error );
 			jetpackConnectButton.isRegistering = false;
 			jetpackConnectButton.handleOriginalFlow();
 		},

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -53,7 +53,6 @@ jQuery( document ).ready( function( $ ) {
 
 			var loadingText = $( '<span>' );
 			loadingText.addClass( 'jp-connect-full__button-container-loading' );
-			loadingText.css( { marginTop: '84px', display: 'block' } );
 			loadingText.text( jpConnect.buttonTextRegistering );
 			loadingText.appendTo( '.jp-connect-full__button-container' );
 

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -49,13 +49,13 @@ jQuery( document ).ready( function( $ ) {
 		handleConnectInPlaceFlow: function() {
 			jetpackConnectButton.isRegistering = true;
 			tosText.hide();
-			connectButton
-				.hide()
-				.after(
-					'<span class="jp-connect-full__button-container-loading">' +
-						jpConnect.buttonTextRegistering +
-						'</span>'
-				);
+			connectButton.hide();
+
+			var loadingText = $( '<span>' );
+			loadingText.addClass( 'jp-connect-full__button-container-loading' );
+			loadingText.css( { marginTop: '84px', display: 'block' } );
+			loadingText.text( jpConnect.buttonTextRegistering );
+			loadingText.appendTo( '.jp-connect-full__button-container' );
 
 			$.ajax( {
 				url: jpConnect.apiBaseUrl + '/connection/register',

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -65,18 +65,19 @@ jQuery( document ).ready( function( $ ) {
 					_wpnonce: jpConnect.apiNonce,
 				},
 				error: jetpackConnectButton.handleConnectionError,
-				success: function( data ) {
-					jetpackConnectButton.fetchPlanType();
-					window.addEventListener( 'message', jetpackConnectButton.receiveData );
-					jetpackConnectIframe.attr( 'src', data.authorizeUrl );
-					jetpackConnectIframe.load( function() {
-						jetpackConnectIframe.show();
-						$( '.jp-connect-full__button-container' ).hide();
-					} );
-					jetpackConnectIframe.hide();
-					$( '.jp-connect-full__button-container' ).after( jetpackConnectIframe );
-				},
+				success: jetpackConnectButton.handleConnectionSuccess,
 			} );
+		},
+		handleConnectionSuccess: function( data ) {
+			jetpackConnectButton.fetchPlanType();
+			window.addEventListener( 'message', jetpackConnectButton.receiveData );
+			jetpackConnectIframe.attr( 'src', data.authorizeUrl );
+			jetpackConnectIframe.on( 'load', function() {
+				jetpackConnectIframe.show();
+				$( '.jp-connect-full__button-container' ).hide();
+			} );
+			jetpackConnectIframe.hide();
+			$( '.jp-connect-full__button-container' ).after( jetpackConnectIframe );
 		},
 		fetchPlanType: function() {
 			$.ajax( {

--- a/scss/jetpack-connect.scss
+++ b/scss/jetpack-connect.scss
@@ -6,13 +6,17 @@
 
 .jp-jetpack-connect__iframe {
 	height: 240px;
-	width: 380px;
-	max-width: 100%;
+	width: 100%;
 	margin: 1rem auto 0;
 
 	@media (min-width: 491px) {
 		height: 290px;
 	}
+}
+
+.jp-connect-full__button-container-loading {
+	margin-top: 84px;
+	display: block;
 }
 
 // =====================================================================


### PR DESCRIPTION
Update the button that says loading into a plain text. See https://cloudup.com/ceUX9fXWbx5

#### Changes proposed in this Pull Request:
* Replace the button into plain text. 
* Also makes sure that the loading text displays as long as the iframe is not loaded yet. so that we don't see a noticeable blank screen while the iframe is loading.

#### Testing instructions:
1. Have the flowing constant in your wp-config.php 
2. Go to the jetpack admin dashboard and connect your jetpack site. 
3. Notice that the button is gone once you click Setup Jetpack and is replaced by text. 

#### Proposed changelog entry for your changes:
* nothing this a minor change. 
