### PR TITLE
Removed an i18n override for Gutenberg.

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -642,30 +642,9 @@ class Jetpack_Gutenberg {
 			)
 		);
 
-		wp_set_script_translations( 'jetpack-blocks-editor', 'jetpack', plugins_url( 'languages/json', JETPACK__PLUGIN_FILE ) );
-
-		// Adding a filter late to allow every other filter to process the path, including the CDN.
-		add_filter( 'pre_load_script_translations', array( __CLASS__, 'filter_pre_load_script_translations' ), 1000, 3 );
+		wp_set_script_translations( 'jetpack-blocks-editor', 'jetpack' );
 
 		wp_enqueue_style( 'jetpack-blocks-editor', $editor_style, array(), $version );
-	}
-
-	/**
-	 * A workaround for setting i18n data for WordPress client-side i18n mechanism.
-	 * We are not yet using dotorg language packs for the editor file, so this short-circuits
-	 * the translation loading and feeds our JSON data directly into the translation getter.
-	 *
-	 * @param NULL   $null     not used.
-	 * @param String $file     the file path that is being loaded, ignored.
-	 * @param String $handle   the script handle.
-	 * @return NULL|String the translation data only if we're working with our handle.
-	 */
-	public static function filter_pre_load_script_translations( $null, $file, $handle ) {
-		if ( 'jetpack-blocks-editor' !== $handle ) {
-			return null;
-		}
-
-		return Jetpack::get_i18n_data_json();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #11491
Previously we were using our own generated files to provide translations for Gutenberg blocks. But since Core can already do it for us, we just remove the override mechanism and let blocks load translations from the Jetpack textdomain. This fixes broken block translations. Props to @jeherve for the find!

#### Changes proposed in this Pull Request:
* Removes an override filter added to use a JSON file shipped with the plugin for Gutenberg block translations.

#### Testing instructions:
* Switch to a language other than English.
* Open the post editor, add some Jetpack blocks.
* See that there are no translations available for the `master` branch.
* Apply this branch, update translations if you have that option in the updates section of the dashboard.
* Reload the post editor, see that the translations are there.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
