### PR TITLE
UpgradeNudge: Extract generic BlockNudge component

### DIFF
--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withDispatch } from '@wordpress/data';
+import { Warning } from '@wordpress/editor';
+
+import './style.scss';
+
+export const BlockNudge = ( { autosaveAndRedirect, buttonLabel, href, icon, subtitle, title } ) => (
+	<Warning
+		actions={
+			// Use href to determine whether or not to display the Upgrade button.
+			href && [
+				<Button
+					href={ href } // Only for server-side rendering, since onClick doesn't work there.
+					onClick={ autosaveAndRedirect }
+					target="_top"
+					isDefault
+				>
+					{ buttonLabel }
+				</Button>,
+			]
+		}
+		className="jetpack-block-nudge"
+	>
+		<span className="jetpack-block-nudge__info">
+			{ icon }
+			<span className="jetpack-block-nudge__text-container">
+				<span className="jetpack-block-nudge__title">{ title }</span>
+				<span className="jetpack-block-nudge__message">{ subtitle }</span>
+			</span>
+		</span>
+	</Warning>
+);
+
+export default compose( [
+	withDispatch( ( dispatch, { blockName, href, onClick } ) => ( {
+		autosaveAndRedirect: async event => {
+			event.preventDefault(); // Don't follow the href before autosaving
+			onClick( blockName );
+			await dispatch( 'core/editor' ).autosave();
+			// Using window.top to escape from the editor iframe on WordPress.com
+			window.top.location.href = href;
+		},
+	} ) ),
+] )( BlockNudge );

--- a/extensions/shared/components/block-nudge/style.scss
+++ b/extensions/shared/components/block-nudge/style.scss
@@ -1,0 +1,37 @@
+// Some styling here could inherit from Warning component, but is needed to
+// override some overzealous theme editor styling.
+
+.jetpack-block-nudge {
+	// Necessary extra specificity
+	&.editor-warning {
+		margin-bottom: 0;
+	}
+
+	.editor-warning__message {
+		margin: 13px 0;
+	}
+
+	.editor-warning__actions {
+		line-height: 1;
+	}
+
+	.jetpack-block-nudge__info {
+		font-size: 13px;
+		display: flex;
+		flex-direction: row;
+		line-height: 1.4;
+	}
+
+	.jetpack-block-nudge__text-container {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.jetpack-block-nudge__title {
+		font-size: 14px;
+	}
+
+	.jetpack-block-nudge__message {
+		color: var( --color-text-subtle );
+	}
+}

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -4,41 +4,24 @@
 import GridiconStar from 'gridicons/dist/star';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { Button } from '@wordpress/components';
 import { compact, get, startsWith } from 'lodash';
 import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { Warning } from '@wordpress/editor';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import analytics from '../../../../_inc/client/lib/analytics';
+import BlockNudge from '../block-nudge';
 import getSiteFragment from '../../get-site-fragment';
 import './store';
 
 import './style.scss';
 
-export const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName, upgradeUrl } ) => (
-	<Warning
-		actions={
-			// Use upgradeUrl to determine whether or not to display the Upgrade button.
-			// We tried setting autosaveAndRedirectToUpgrade to falsey in `withDispatch`,
-			// but it doesn't seem to be reliably updated after a `withSelect` update.
-			upgradeUrl && [
-				<Button
-					href={ upgradeUrl } // Only for server-side rendering, since onClick doesn't work there.
-					onClick={ autosaveAndRedirectToUpgrade }
-					target="_top"
-					isDefault
-				>
-					{ __( 'Upgrade', 'jetpack' ) }
-				</Button>,
-			]
-		}
-		className="jetpack-upgrade-nudge"
-	>
-		<span className="jetpack-upgrade-nudge__info">
+export const UpgradeNudge = ( { planName, trackEvent, upgradeUrl } ) => (
+	<BlockNudge
+		buttonLabel={ __( 'Upgrade', 'jetpack' ) }
+		icon={
 			<GridiconStar
 				className="jetpack-upgrade-nudge__icon"
 				size={ 18 }
@@ -46,23 +29,21 @@ export const UpgradeNudge = ( { autosaveAndRedirectToUpgrade, planName, upgradeU
 				role="img"
 				focusable="false"
 			/>
-			<span className="jetpack-upgrade-nudge__text-container">
-				<span className="jetpack-upgrade-nudge__title">
-					{ planName
-						? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
-								planName,
-						  } )
-						: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' ) }
-				</span>
-				<span className="jetpack-upgrade-nudge__message">
-					{ __(
-						'You can try it out before upgrading, but only you will see it. It will be hidden from visitors until you upgrade.',
-						'jetpack'
-					) }
-				</span>
-			</span>
-		</span>
-	</Warning>
+		}
+		href={ upgradeUrl }
+		onClick={ trackEvent }
+		title={
+			planName
+				? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
+						planName,
+				  } )
+				: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
+		}
+		subtitle={ __(
+			'You can try it out before upgrading, but only you will see it. It will be hidden from visitors until you upgrade.',
+			'jetpack'
+		) }
+	/>
 );
 
 export default compose( [
@@ -111,20 +92,13 @@ export default compose( [
 			} );
 
 		return {
+			trackEvent: blockName =>
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+					plan,
+					block: blockName,
+				} ),
 			planName: get( plan, [ 'product_name' ] ),
 			upgradeUrl,
 		};
 	} ),
-	withDispatch( ( dispatch, { blockName, plan, upgradeUrl } ) => ( {
-		autosaveAndRedirectToUpgrade: async event => {
-			event.preventDefault(); // Don't follow the href before autosaving
-			analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
-				plan,
-				block: blockName,
-			} );
-			await dispatch( 'core/editor' ).autosave();
-			// Using window.top to escape from the editor iframe on WordPress.com
-			window.top.location.href = upgradeUrl;
-		},
-	} ) ),
 ] )( UpgradeNudge );

--- a/extensions/shared/components/upgrade-nudge/style.scss
+++ b/extensions/shared/components/upgrade-nudge/style.scss
@@ -1,49 +1,11 @@
-// Some styling here could inherit from Warning component, but is needed to
-// override some overzealous theme editor styling.
-
-.jetpack-upgrade-nudge {
-	// Necessary extra specificity
-	&.editor-warning {
-		margin-bottom: 0;
-	}
-
-	.editor-warning__message {
-		margin: 13px 0;
-	}
-
-	.editor-warning__actions {
-		line-height: 1;
-	}
-
-	.jetpack-upgrade-nudge__info {
-		font-size: 13px;
-		display: flex;
-		flex-direction: row;
-		line-height: 1.4;
-	}
-
-	.jetpack-upgrade-nudge__icon {
-		align-self: center;
-		background: var( --color-plan-premium );
-		border-radius: 50%;
-		box-sizing: content-box;
-		color: var( --color-white );
-		fill: var( --color-white );
-		flex-shrink: 0;
-		margin-right: 16px;
-		padding: 6px;
-	}
-
-	.jetpack-upgrade-nudge__text-container {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.jetpack-upgrade-nudge__title {
-		font-size: 14px;
-	}
-
-	.jetpack-upgrade-nudge__message {
-		color: var( --color-text-subtle );
-	}
+.jetpack-upgrade-nudge__icon {
+	align-self: center;
+	background: var( --color-plan-premium );
+	border-radius: 50%;
+	box-sizing: content-box;
+	color: var( --color-white );
+	fill: var( --color-white );
+	flex-shrink: 0;
+	margin-right: 16px;
+	padding: 6px;
 }


### PR DESCRIPTION
Extracted from #13394, to make that PR smaller.

#### Changes proposed in this Pull Request:

* Extract a more generic `BlockNudge` component from `UpgradeNudge`, and implement the latter by using it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Nope.

#### Testing instructions:

Use the Simple Payments block to verify that the Upgrade Nudge works as before:

- Switch to this branch locally, build Jetpack (`yarn build`), and start Docker (`yarn docker:up`)
- Now add the following line to any file in `docker/mu-plugins`, e.g. a newly created `0-blocks-upgrade.php` (needs to start with `<?php`): `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );`
- Make sure you're connected to WP.com, and on a free plan
- Start a new post, and insert the 'Simple Payments' block
- Select the block, and enter some information into its text fields.
- Click the nudge's "Upgrade" CTA button
- Pay for the premium plan
- Verify that you're redirected back to where you came from (the wp-admin block editor) (without any intermediate redirects on WP.com)

#### Proposed changelog entry for your changes:

* Extract a more generic `BlockNudge` component from `UpgradeNudge`, and implement the latter by using it.