### PR TITLE
Connection: Update XMLRPC server to use connection package for the access token

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -315,7 +315,7 @@ class Jetpack_XMLRPC_Server {
 			);
 		}
 
-		if ( ! Jetpack_Options::get_option( 'id' ) || ! Jetpack_Data::get_access_token() || ! empty( $request['force'] ) ) {
+		if ( ! Jetpack_Options::get_option( 'id' ) || ! $this->connection->get_access_token() || ! empty( $request['force'] ) ) {
 			wp_set_current_user( $user->ID );
 
 			// This code mostly copied from Jetpack::admin_page_load.
@@ -740,7 +740,7 @@ class Jetpack_XMLRPC_Server {
 		error_log( "VERIFY: $verify" );
 		*/
 
-		$jetpack_token = Jetpack_Data::get_access_token( $user_id );
+		$jetpack_token = $this->connection->get_access_token( $user_id );
 
 		$api_user_code = get_user_meta( $user_id, "jetpack_json_api_$client_id", true );
 		if ( ! $api_user_code ) {
@@ -961,7 +961,7 @@ class Jetpack_XMLRPC_Server {
 			$token_key = $verified['token_key'];
 		}
 
-		$token = Jetpack_Data::get_access_token( $user_id, $token_key );
+		$token = $this->connection->get_access_token( $user_id, $token_key );
 		if ( ! $token || is_wp_error( $token ) ) {
 			return false;
 		}


### PR DESCRIPTION
This PR updates the XMLRPC server to use the `get_access_token` method from the connection package, instead of the one from `Jetpack_Data`. This makes sense for better isolation and is a step towards independence of the connection package, since the XMLRPC server is now part of the connection package.

#### Changes proposed in this Pull Request:
* Connection: Update XMLRPC server to use connection package for the access token

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the effort to make the connection package a standalone independent package.

#### Testing instructions:
* Verify tests still pass.

#### Proposed changelog entry for your changes:
* Connection: Update XMLRPC server to use connection package for the access token
