### PR TITLE
Gutenberg extensions: Stripe connection notices

### DIFF
--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -4,6 +4,7 @@
 import './shared/public-path';
 import './shared/block-category';
 import './shared/plan-upgrade-notification';
+import './shared/stripe-connection-notification';
 import analytics from '../_inc/client/lib/analytics';
 
 // @TODO Please make a shared analytics solution and remove this!

--- a/extensions/shared/stripe-connection-notification.js
+++ b/extensions/shared/stripe-connection-notification.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import '@wordpress/notices';
+import { parse as parseUrl } from 'url';
+
+/**
+ * Shows a notification when a Stripe has been connected
+ * after redirection from WPCOM.
+ */
+if ( undefined !== typeof window && window.location ) {
+	const { query } = parseUrl( window.location.href, true );
+
+	if ( query.stripe_connect_success ) {
+		dispatch( 'core/notices' ).createNotice(
+			'success',
+			__(
+				'Congrats! Your site is now connected to Stripe. You can start making money by adding your first subscription!',
+				'jetpack'
+			)
+		);
+	} else if ( query.stripe_connect_cancelled ) {
+		dispatch( 'core/notices' ).createNotice(
+			'error',
+			__( 'You cancelled connecting your site to Stripe.', 'jetpack' )
+		);
+	}
+}

--- a/extensions/shared/stripe-connection-notification.js
+++ b/extensions/shared/stripe-connection-notification.js
@@ -7,8 +7,8 @@ import '@wordpress/notices';
 import { parse as parseUrl } from 'url';
 
 /**
- * Shows a notification when a Stripe has been connected
- * after redirection from WPCOM.
+ * Shows a notification when a Stripe has been connected or
+ * connection has been cancelled after redirection from WPCOM.
  */
 if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );


### PR DESCRIPTION
Adds success notices for successful and canceled Stripe connections.

Note that copy is now Recurring payments specific since that's the only feature using Stripe like this; in future, if there are multiple features utilizing Stripe, the copy would need to be modified.

Companion for D32394-code and https://github.com/Automattic/jetpack/pull/13398

<img width="1019" alt="Screenshot 2019-09-06 at 16 58 33" src="https://user-images.githubusercontent.com/87168/64433773-cd1fe680-d0c7-11e9-8355-839696c3bb19.png">
<img width="1123" alt="Screenshot 2019-09-06 at 16 58 11" src="https://user-images.githubusercontent.com/87168/64433796-d9a43f00-d0c7-11e9-8816-c21d667033eb.png">


#### Changes proposed in this Pull Request:
–

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Updates. paObgF-qE-p2

#### Testing instructions:
Instead of testing the full flow with other patches, you can just test the _contract_:

- When creating a new post and saving it...
- Then re-loading the page with `?stripe_connect_success=1` or `?stripe_connect_cancelled=1` URL arguments, you should see corresponding notices respectively.

#### Proposed changelog entry for your changes:
*
