### PR TITLE
Connection: Fix reference to connection manager in Jetpack class

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5741,7 +5741,7 @@ p {
 		$timestamp = (int) $environment['timestamp'];
 		$nonce     = stripslashes( (string) $environment['nonce'] );
 
-		if ( ! $this->connection->add_nonce( $timestamp, $nonce ) ) {
+		if ( ! $this->connection_manager->add_nonce( $timestamp, $nonce ) ) {
 			// De-nonce the nonce, at least for 5 minutes.
 			// We have to reuse this nonce at least once (used the first time when the initial request is made, used a second time when the login form is POSTed)
 			$old_nonce_time = get_option( "jetpack_nonce_{$timestamp}_{$nonce}" );


### PR DESCRIPTION
This fixes a wrong reference to the connection manager instance in the Jetpack class.

#### Changes proposed in this Pull Request:
* Connection: Fix reference to connection manager in Jetpack class

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Just a fix.

#### Testing instructions:
* Shouldn't be necessary.

#### Proposed changelog entry for your changes:
* Connection: Fix reference to connection manager in Jetpack class
