### PR TITLE
Enqueue connect-in-place JS and CSS only when needed

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -69,6 +69,7 @@ abstract class Jetpack_Admin_Page {
 			&& ! Jetpack::is_development_mode()
 		) {
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_banner_scripts' ) );
+			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
 			add_action( 'admin_print_styles', array( Jetpack::init(), 'admin_banner_styles' ) );
 			add_action( 'admin_notices', array( 'Jetpack_Connection_Banner', 'render_connect_prompt_full_screen' ) );
 			delete_transient( 'activated_jetpack' );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -26,7 +26,6 @@ class Jetpack_Connection_Banner {
 	 */
 	private function __construct() {
 		add_action( 'current_screen', array( $this, 'maybe_initialize_hooks' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_connect_button_scripts' ) );
 	}
 
 	/**
@@ -128,6 +127,11 @@ class Jetpack_Connection_Banner {
 		);
 	}
 
+	/**
+	 * Enqueues JavaScript and CSS for new connect-in-place flow.
+	 *
+	 * @since 7.2
+	 */
 	public static function enqueue_connect_button_scripts() {
 		wp_enqueue_script(
 			'jetpack-connect-button',

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -130,7 +130,7 @@ class Jetpack_Connection_Banner {
 	/**
 	 * Enqueues JavaScript and CSS for new connect-in-place flow.
 	 *
-	 * @since 7.2
+	 * @since 7.7
 	 */
 	public static function enqueue_connect_button_scripts() {
 		wp_enqueue_script(


### PR DESCRIPTION
Currently connect-in-place JS and CSS assets are enqueued globally in `wp-admin`. With this update they are going to be included only where they are actually needed - on the Jetpack connect page.

Fixes no known issue.

#### Changes proposed in this Pull Request:
* Enqueue connect-in-place JS and CSS only when needed.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p1HpG7-7nj-p2

#### Testing instructions:
* Check out this branch.
* Disconnect from Jetpack.
* Check if the `connect-button[.min].js` and `jetpack-connect[.min].css` are present on the page.
* Confirm those files are not present on any other admin page.
* Go through the connection flow and confirm the aforementioned assets are not present anywhere in the `wp-admin`.

![Screen Shot on 2019-09-06 at 16:36:03](https://user-images.githubusercontent.com/478735/64436346-7369ed00-d0c4-11e9-9b33-a6f6dc283d9e.png)

![Screen Shot on 2019-09-06 at 16:34:54](https://user-images.githubusercontent.com/478735/64436267-4e757a00-d0c4-11e9-96a4-cc6436c454ef.png)

#### Proposed changelog entry for your changes:
* Enqueue connect-in-place JS and CSS only when needed.
