### PR TITLE
Move fix_url_for_bad_hosts from Jetpack class to Connection pa…

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -7,7 +7,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Status;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 
 /**
  * Class Jetpack_Cxn_Tests contains all of the actual tests.
@@ -335,7 +335,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
 
-		$testsite_url = Connection_Manager::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
+		$testsite_url = Connection_Utils::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
 
 		add_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 /**
  * Class Jetpack_Cxn_Tests contains all of the actual tests.
@@ -334,7 +335,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
 
-		$testsite_url = Jetpack::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
+		$testsite_url = Connection_Manager::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
 
 		add_filter( 'http_request_timeout', array( 'Jetpack_Debugger', 'jetpack_increase_timeout' ) );
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -1,7 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
 
@@ -233,7 +233,7 @@ class Jetpack_Client_Server {
 				'Accept' => 'application/json',
 			),
 		);
-		$response = Client::_wp_remote_request( Manager::fix_url_for_bad_hosts( Jetpack::connection()->api_url( 'token' ) ), $args );
+		$response = Client::_wp_remote_request( Connection_Utils::fix_url_for_bad_hosts( Jetpack::connection()->api_url( 'token' ) ), $args );
 
 		if ( is_wp_error( $response ) ) {
 			return new Jetpack_Error( 'token_http_request_failed', $response->get_error_message() );

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
 
@@ -232,7 +233,7 @@ class Jetpack_Client_Server {
 				'Accept' => 'application/json',
 			),
 		);
-		$response = Client::_wp_remote_request( Jetpack::fix_url_for_bad_hosts( Jetpack::connection()->api_url( 'token' ) ), $args );
+		$response = Client::_wp_remote_request( Manager::fix_url_for_bad_hosts( Jetpack::connection()->api_url( 'token' ) ), $args );
 
 		if ( is_wp_error( $response ) ) {
 			return new Jetpack_Error( 'token_http_request_failed', $response->get_error_message() );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3533,7 +3533,7 @@ p {
 			$args       = array();
 			$connection = self::connection();
 			Client::_wp_remote_request(
-				self::fix_url_for_bad_hosts( $connection->api_url( 'test' ) ),
+				Connection_Manager::fix_url_for_bad_hosts( $connection->api_url( 'test' ) ),
 				$args,
 				true
 			);
@@ -4816,23 +4816,13 @@ endif;
 	}
 
 	/**
+	 * @deprecated 7.8 Use Automattic\Jetpack\Connection\Manager::fix_url_for_bad_hosts() instead.
+     *
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requsets
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {
-		if ( 0 !== strpos( $url, 'https://' ) ) {
-			return $url;
-		}
-
-		switch ( JETPACK_CLIENT__HTTPS ) {
-			case 'ALWAYS':
-				return $url;
-			case 'NEVER':
-				return set_url_scheme( $url, 'http' );
-			// default : case 'AUTO' :
-		}
-
-		// we now return the unmodified SSL URL by default, as a security precaution
-		return $url;
+		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\Jetpack\Connection\Manager' );
+		return Connection_Manager::fix_url_for_bad_hosts( $url );
 	}
 
 	public static function verify_onboarding_token( $token_data, $token, $request_data ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4822,7 +4822,7 @@ endif;
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requsets
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {
-		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\Jetpack\Connection\Utils::fix_url_for_bad_hosts' );
+		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\\Jetpack\\Connection\\Utils::fix_url_for_bad_hosts' );
 		return Connection_Utils::fix_url_for_bad_hosts( $url );
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5,6 +5,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\REST_Connector as REST_Connector;
 use Automattic\Jetpack\Connection\XMLRPC_Connector as XMLRPC_Connector;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
@@ -3533,7 +3534,7 @@ p {
 			$args       = array();
 			$connection = self::connection();
 			Client::_wp_remote_request(
-				Connection_Manager::fix_url_for_bad_hosts( $connection->api_url( 'test' ) ),
+				Connection_Utils::fix_url_for_bad_hosts( $connection->api_url( 'test' ) ),
 				$args,
 				true
 			);
@@ -4816,13 +4817,13 @@ endif;
 	}
 
 	/**
-	 * @deprecated 7.8 Use Automattic\Jetpack\Connection\Manager::fix_url_for_bad_hosts() instead.
+	 * @deprecated 8.0 Use Automattic\Jetpack\Connection\Utils::fix_url_for_bad_hosts() instead.
      *
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requsets
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {
-		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\Jetpack\Connection\Manager' );
-		return Connection_Manager::fix_url_for_bad_hosts( $url );
+		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\Jetpack\Connection\Utils::fix_url_for_bad_hosts' );
+		return Connection_Utils::fix_url_for_bad_hosts( $url );
 	}
 
 	public static function verify_onboarding_token( $token_data, $token, $request_data ) {

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -13,6 +13,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
 
@@ -865,7 +866,7 @@ class Jetpack_Protect_Module {
 		}
 
 		//Check to see if we can use SSL
-		$this->api_endpoint = Jetpack::fix_url_for_bad_hosts( JETPACK_PROTECT__API_HOST );
+		$this->api_endpoint = Connection_Manager::fix_url_for_bad_hosts( JETPACK_PROTECT__API_HOST );
 
 		return $this->api_endpoint;
 	}

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -13,7 +13,7 @@
  */
 
 use Automattic\Jetpack\Constants;
-use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 
 include_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
 
@@ -866,7 +866,7 @@ class Jetpack_Protect_Module {
 		}
 
 		//Check to see if we can use SSL
-		$this->api_endpoint = Connection_Manager::fix_url_for_bad_hosts( JETPACK_PROTECT__API_HOST );
+		$this->api_endpoint = Connection_Utils::fix_url_for_bad_hosts( JETPACK_PROTECT__API_HOST );
 
 		return $this->api_endpoint;
 	}

--- a/packages/compat/legacy/class.jetpack-client.php
+++ b/packages/compat/legacy/class.jetpack-client.php
@@ -76,7 +76,7 @@ class Jetpack_Client {
 	 * The option is checked on each request.
 	 *
 	 * @internal
-	 * @see Jetpack::fix_url_for_bad_hosts()
+	 * @see Manager::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
 	 * @param Array   $args request arguments.

--- a/packages/compat/legacy/class.jetpack-client.php
+++ b/packages/compat/legacy/class.jetpack-client.php
@@ -76,7 +76,7 @@ class Jetpack_Client {
 	 * The option is checked on each request.
 	 *
 	 * @internal
-	 * @see Manager::fix_url_for_bad_hosts()
+	 * @see Utils::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
 	 * @param Array   $args request arguments.

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -291,7 +291,7 @@ class Jetpack_XMLRPC_Server {
 		$nonce = sanitize_text_field( $request['nonce'] );
 		unset( $request['nonce'] );
 
-		$api_url  = Jetpack::fix_url_for_bad_hosts(
+		$api_url  = Connection_Manager::fix_url_for_bad_hosts(
 			$this->connection->api_url( 'partner_provision_nonce_check' )
 		);
 		$response = Client::_wp_remote_request(

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Functions;
@@ -291,7 +292,7 @@ class Jetpack_XMLRPC_Server {
 		$nonce = sanitize_text_field( $request['nonce'] );
 		unset( $request['nonce'] );
 
-		$api_url  = Connection_Manager::fix_url_for_bad_hosts(
+		$api_url  = Connection_Utils::fix_url_for_bad_hosts(
 			$this->connection->api_url( 'partner_provision_nonce_check' )
 		);
 		$response = Client::_wp_remote_request(

--- a/packages/connection/src/Client.php
+++ b/packages/connection/src/Client.php
@@ -131,7 +131,7 @@ class Client {
 		}
 
 		$url = add_query_arg( urlencode_deep( $url_args ), $args['url'] );
-		$url = \Jetpack::fix_url_for_bad_hosts( $url );
+		$url = Manager::fix_url_for_bad_hosts( $url );
 
 		$signature = $jetpack_signature->sign_request( $token_key, $timestamp, $nonce, $body_hash, $method, $url, $body, false );
 
@@ -171,7 +171,7 @@ class Client {
 	 * The option is checked on each request.
 	 *
 	 * @internal
-	 * @see Jetpack::fix_url_for_bad_hosts()
+	 * @see Manager::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
 	 * @param Array   $args request arguments.

--- a/packages/connection/src/Client.php
+++ b/packages/connection/src/Client.php
@@ -131,7 +131,7 @@ class Client {
 		}
 
 		$url = add_query_arg( urlencode_deep( $url_args ), $args['url'] );
-		$url = Manager::fix_url_for_bad_hosts( $url );
+		$url = Utils::fix_url_for_bad_hosts( $url );
 
 		$signature = $jetpack_signature->sign_request( $token_key, $timestamp, $nonce, $body_hash, $method, $url, $body, false );
 
@@ -171,7 +171,7 @@ class Client {
 	 * The option is checked on each request.
 	 *
 	 * @internal
-	 * @see Manager::fix_url_for_bad_hosts()
+	 * @see Utils::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
 	 * @param Array   $args request arguments.

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1775,4 +1775,24 @@ class Manager {
 
 		return $role . ':' . hash_hmac( 'md5', "{$role}|{$user_id}", $token->secret );
 	}
+
+	/**
+	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requsets
+	 */
+	public static function fix_url_for_bad_hosts( $url ) {
+		if ( 0 !== strpos( $url, 'https://' ) ) {
+			return $url;
+		}
+
+		switch ( JETPACK_CLIENT__HTTPS ) {
+			case 'ALWAYS':
+				return $url;
+			case 'NEVER':
+				return set_url_scheme( $url, 'http' );
+			// default : case 'AUTO' :
+		}
+
+		// we now return the unmodified SSL URL by default, as a security precaution
+		return $url;
+	}
 }

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1789,7 +1789,6 @@ class Manager {
 				return $url;
 			case 'NEVER':
 				return set_url_scheme( $url, 'http' );
-			// default : case 'AUTO' :
 		}
 
 		// we now return the unmodified SSL URL by default, as a security precaution

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1775,23 +1775,4 @@ class Manager {
 
 		return $role . ':' . hash_hmac( 'md5', "{$role}|{$user_id}", $token->secret );
 	}
-
-	/**
-	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requsets
-	 */
-	public static function fix_url_for_bad_hosts( $url ) {
-		if ( 0 !== strpos( $url, 'https://' ) ) {
-			return $url;
-		}
-
-		switch ( JETPACK_CLIENT__HTTPS ) {
-			case 'ALWAYS':
-				return $url;
-			case 'NEVER':
-				return set_url_scheme( $url, 'http' );
-		}
-
-		// we now return the unmodified SSL URL by default, as a security precaution
-		return $url;
-	}
 }

--- a/packages/connection/src/Utils.php
+++ b/packages/connection/src/Utils.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * The Jetpack Connection package Utils class file.
+ *
+ * @package jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Constants;
+
+/**
+ * Provides utility methods for the Connection package.
+ */
+class Utils {
+
+	/**
+	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requests.
+	 * This method sets the URL scheme to HTTP when HTTPS requests can't be made.
+	 *
+	 * @param String $url The url.
+	 * @return String The url with the required URL scheme.
+	 */
+	public static function fix_url_for_bad_hosts( $url ) {
+		// If we receive an http url, return it.
+		if ( 'http' === wp_parse_url( $url, PHP_URL_SCHEME ) ) {
+			return $url;
+		}
+
+		// If the url should never be https, ensure it isn't https.
+		if ( 'NEVER' === Constants::get_constant( 'JETPACK_CLIENT__HTTPS' ) ) {
+			return set_url_scheme( $url, 'http' );
+		}
+
+		// Otherwise, return the https url.
+		return $url;
+	}
+}

--- a/packages/connection/src/Utils.php
+++ b/packages/connection/src/Utils.php
@@ -1,8 +1,8 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * The Jetpack Connection package Utils class file.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 namespace Automattic\Jetpack\Connection;


### PR DESCRIPTION
This PR moved fix_url_for_bad_hosts from Jetpack class to Connection package so that we can make the Connection package more independent. It deprecates the old method.

#### Testing instructions:
Ensure all tests continue to pass after this refactoring.

#### Proposed changelog entry for your changes:
Moved Jetpack::fix_url_for_bad_hosts to Connection package
