### PR TITLE
Carousel: improve detection of containers where we should add data

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -542,6 +542,11 @@ class Jetpack_Carousel {
 			$extra_data = apply_filters( 'jp_carousel_add_data_to_container', $extra_data );
 
 			foreach ( (array) $extra_data as $data_key => $data_values ) {
+				// Do not go any further if DOMDocument is disabled on the server.
+				if ( ! class_exists( 'DOMDocument' ) ) {
+					return $html;
+				}
+
 				// Let's grab all containers from the HTML.
 				$dom_doc = new DOMDocument();
 

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -554,9 +554,11 @@ class Jetpack_Carousel {
 				 * The @ is not enough to suppress errors when dealing with libxml,
 				 * we have to tell it directly how we want to handle errors.
 				 */
-				$old_libxml_use_internal_errors = libxml_use_internal_errors( true );
+				$old_libxml_disable_entity_loader = libxml_disable_entity_loader( true );
+				$old_libxml_use_internal_errors   = libxml_use_internal_errors( true );
 				@$dom_doc->loadHTML( $html ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 				libxml_use_internal_errors( $old_libxml_use_internal_errors );
+				libxml_disable_entity_loader( $old_libxml_disable_entity_loader );
 
 				// Let's look for lists and divs.
 				$ul_tags  = $dom_doc->getElementsByTagName( 'ul' );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -554,9 +554,9 @@ class Jetpack_Carousel {
 				 * The @ is not enough to suppress errors when dealing with libxml,
 				 * we have to tell it directly how we want to handle errors.
 				 */
-				libxml_use_internal_errors( true );
+				$old_libxml_use_internal_errors = libxml_use_internal_errors( true );
 				@$dom_doc->loadHTML( $html ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-				libxml_use_internal_errors( false );
+				libxml_use_internal_errors( $old_libxml_use_internal_errors );
 
 				// Let's look for lists and divs.
 				$ul_tags  = $dom_doc->getElementsByTagName( 'ul' );

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -566,7 +566,7 @@ class Jetpack_Carousel {
 				foreach ( $ul_tags as $ul_tag ) {
 					if ( false !== strpos( $ul_tag->getAttribute( 'class' ), 'wp-block-gallery' ) ) {
 						$ul_tag->setAttribute(
-							esc_attr( $data_key ),
+							$data_key,
 							wp_json_encode( $data_values )
 						);
 					}
@@ -583,7 +583,7 @@ class Jetpack_Carousel {
 						|| false !== strpos( $div_tag->getAttribute( 'class' ), 'gallery' )
 					) {
 						$div_tag->setAttribute(
-							esc_attr( $data_key ),
+							$data_key,
 							wp_json_encode( $data_values )
 						);
 					}


### PR DESCRIPTION
Fixes #13428

#### Changes proposed in this Pull Request:

Until now we would rely on 2 str_replace to add Carousel data to div and ul containers in post content.
This worked, but wasn't smart enough to know to ignore specific divs like Columns blocks.

By using DOMDocument, we can go through the post content in a more readable way, to detect gallery blocks as well as regular galleries and images.

#### Testing instructions:

* In a new post, insert a variety of blocks:
	- A classic block with a gallery
	- A classic block with a tiled gallery
	- A classic block with a single image  (still testing, but I think this may not work, neither with my branch or on the latest stable).
	- An image block (still testing, but I think this may not work, neither with my branch or on the latest stable).
	- A gallery block
	- A Tiled Gallery block
	- A column block with some text
	- A column block with a gallery block in it.
* Publish your post
* When moving your mouse over each block, make sure the cursor only becomes a pointer when the element can be expanded to a Carousel modal.

#### Proposed changelog entry for your changes:

* Carousel: improve detection of containers where we should add the Carousel modal.
