### PR TITLE
Update is_fse_active to utilize FSE helper function

### DIFF
--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -201,27 +201,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {
 			return false;
 		}
-		if (
-			/**
-			 * Allow disabling Full Site Editing, even when the FSE plugin is active.
-			 *
-			 * @module json-api
-			 *
-			 * @since 7.7.0
-			 *
-			 * @param bool $disable_fse Disable Full Site Editing. Defaults to false.
-			 */
-			apply_filters( 'a8c_disable_full_site_editing', false )
-		) {
-			return false;
-		}
-		$has_is_supported_theme_method = method_exists( '\A8C\FSE\Full_Site_Editing', 'is_supported_theme' );
-		$has_normalize_theme_slug      = method_exists( '\A8C\FSE\Full_Site_Editing', 'normalize_theme_slug' );
-		if ( $has_is_supported_theme_method && $has_normalize_theme_slug ) {
-			$slug = \A8C\FSE\Full_Site_Editing::get_instance()->normalize_theme_slug( get_option( 'stylesheet' ) );
-			return \A8C\FSE\Full_Site_Editing::get_instance()->is_supported_theme( $slug );
-		}
-		return false;
+		return function_exists( '\A8C\FSE\is_full_site_editing_active' ) && \A8C\FSE\is_full_site_editing_active();
 	}
 
 	/**


### PR DESCRIPTION
This past week, we added a helper function to FSE which tells us when FSE is active on a site (which has now been deployed). I'm currently updating our API work to use this function, as it centralizes most of the logic needed! (Including all of the previous checks in this function.) Now we'll be able to update anything necessary without having to modify a bunch of API endpoints all the time. (yay!)

This is a bit of a followup to https://github.com/Automattic/jetpack/pull/13392. Testing instructions are practically the same as in that PR since behavior should be identical.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Uses `\A8C\FSE\is_full_site_editing_active();` to replace logic in `is_fse_active` endpoint.
* From the user's pov, there is no functional change with this PR. It simply improves code quality :)

#### Testing instructions:
1. Create a jurassic ninja site with this branch: `https://jurassic.ninja/create/?branch=update/use-fse-active-helper-function-in-plugin`. (also connect it to jetpack so you can see it in Calypso)
2. Before doing anything, [use the api console](https://developer.wordpress.com/docs/api/console/) to make sure that `is_fse_active` is false without the plugin installed. We're using the endpoint `/sites/abc.jurassic.ninja`
3. Install the Full Site Editing Plugin, Gutenberg development plugin and activate both
4. Check to make sure that `is_fse_active` is still false
5. Using calypso (URL like `https://wordpress.com/themes/abc.jurassic.ninja`), activate the "Maywood" theme
7. Now, in the console, `is_fse_active` should be true.
8. Verify that you can see the FSE editor by editing a page.
9. Add the following filter to the site, can be done easily in the plugin editor: `add_filter( 'a8c_disable_full_site_editing', '__return_true' );`
7. Now, in the console, `is_fse_active` should be false.
10. FSE flows for the post editor should not be available, but other features still are like Starter Page Templates (which you'll see creating a new page) and Recent Blog Posts

