### PR TITLE
Add support for AMP Dev Mode in Notes module

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -104,8 +104,6 @@ class Jetpack_Notifications {
 
 	function styles_and_scripts() {
 		$is_rtl = is_rtl();
-		$style_handles  = array();
-		$script_handles = array();
 
 		if ( Jetpack::is_module_active( 'masterbar' ) ) {
 			/**
@@ -121,18 +119,17 @@ class Jetpack_Notifications {
 		}
 
 		if ( ! $is_rtl ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 		}
-		$style_handles[] = 'wpcom-notes-admin-bar';
 
-		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
-		$style_handles[] = 'noticons';
+		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 
 		$this->print_js();
 
 		// attempt to use core or plugin libraries if registered
+		$script_handles = array();
 		if ( !wp_script_is( 'mustache', 'registered' ) ) {
 			wp_register_script( 'mustache', $this->wpcom_static_url( '/wp-content/js/mustache.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
 		}
@@ -160,18 +157,6 @@ class Jetpack_Notifications {
 				function ( $tag, $handle ) use ( $script_handles ) {
 					if ( in_array( $handle, $script_handles, true ) ) {
 						$tag = preg_replace( '/(?<=<script)(?=\s|>)/i', ' data-ampdevmode', $tag );
-					}
-					return $tag;
-				},
-				10,
-				2
-			);
-
-			add_filter(
-				'style_loader_tag',
-				function ( $tag, $handle ) use ( $style_handles ) {
-					if ( in_array( $handle, $style_handles, true ) ) {
-						$tag = preg_replace( '/(?<=<link)(?=\s|>)/i', ' data-ampdevmode', $tag );
 					}
 					return $tag;
 				},

--- a/modules/notes.php
+++ b/modules/notes.php
@@ -104,8 +104,8 @@ class Jetpack_Notifications {
 
 	function styles_and_scripts() {
 		$is_rtl = is_rtl();
-		$style_handles  = [];
-		$script_handles = [];
+		$style_handles  = array();
+		$script_handles = array();
 
 		if ( Jetpack::is_module_active( 'masterbar' ) ) {
 			/**

--- a/modules/notes.php
+++ b/modules/notes.php
@@ -104,6 +104,8 @@ class Jetpack_Notifications {
 
 	function styles_and_scripts() {
 		$is_rtl = is_rtl();
+		$style_handles  = [];
+		$script_handles = [];
 
 		if ( Jetpack::is_module_active( 'masterbar' ) ) {
 			/**
@@ -123,7 +125,10 @@ class Jetpack_Notifications {
 		} else {
 			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		}
+		$style_handles[] = 'wpcom-notes-admin-bar';
+
 		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+		$style_handles[] = 'noticons';
 
 		$this->print_js();
 
@@ -131,15 +136,49 @@ class Jetpack_Notifications {
 		if ( !wp_script_is( 'mustache', 'registered' ) ) {
 			wp_register_script( 'mustache', $this->wpcom_static_url( '/wp-content/js/mustache.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
 		}
+		$script_handles[] = 'mustache';
 		if ( !wp_script_is( 'underscore', 'registered' ) ) {
 			wp_register_script( 'underscore', $this->wpcom_static_url( '/wp-includes/js/underscore.min.js' ), null, JETPACK_NOTES__CACHE_BUSTER );
 		}
+		$script_handles[] = 'underscore';
 		if ( !wp_script_is( 'backbone', 'registered' ) ) {
 			wp_register_script( 'backbone', $this->wpcom_static_url( '/wp-includes/js/backbone.min.js' ), array( 'underscore' ), JETPACK_NOTES__CACHE_BUSTER );
 		}
+		$script_handles[] = 'backbone';
 
 		wp_register_script( 'wpcom-notes-common', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/notes-common-v2.js' ), array( 'jquery', 'underscore', 'backbone', 'mustache' ), JETPACK_NOTES__CACHE_BUSTER );
+		$script_handles[] = 'wpcom-notes-common';
+		$script_handles[] = 'jquery';
+		$script_handles[] = 'jquery-migrate';
+		$script_handles[] = 'jquery-core';
 		wp_enqueue_script( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.js' ), array( 'wpcom-notes-common' ), JETPACK_NOTES__CACHE_BUSTER );
+		$script_handles[] = 'wpcom-notes-admin-bar';
+
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			add_filter(
+				'script_loader_tag',
+				function ( $tag, $handle ) use ( $script_handles ) {
+					if ( in_array( $handle, $script_handles, true ) ) {
+						$tag = preg_replace( '/(?<=<script)(?=\s|>)/i', ' data-ampdevmode', $tag );
+					}
+					return $tag;
+				},
+				10,
+				2
+			);
+
+			add_filter(
+				'style_loader_tag',
+				function ( $tag, $handle ) use ( $style_handles ) {
+					if ( in_array( $handle, $style_handles, true ) ) {
+						$tag = preg_replace( '/(?<=<link)(?=\s|>)/i', ' data-ampdevmode', $tag );
+					}
+					return $tag;
+				},
+				10,
+				2
+			);
+		}
 	}
 
 	function admin_bar_menu() {
@@ -180,7 +219,7 @@ class Jetpack_Notifications {
 	function print_js() {
 		$link_accounts_url = is_user_logged_in() && !Jetpack::is_user_connected() ? Jetpack::admin_url() : false;
 ?>
-<script type="text/javascript">
+<script data-ampdevmode type="text/javascript">
 /* <![CDATA[ */
 	var wpNotesIsJetpackClient = true;
 	var wpNotesIsJetpackClientV2 = true;

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -832,7 +832,7 @@ function stats_admin_bar_head() {
 	add_action( 'admin_bar_menu', 'stats_admin_bar_menu', 100 );
 ?>
 
-<style type='text/css'>
+<style data-ampdevmode type='text/css'>
 #wpadminbar .quicklinks li#wp-admin-bar-stats {
 	height: 32px;
 }
@@ -878,14 +878,10 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
 	$title = esc_attr( __( 'Views over 48 hours. Click for more Site Stats.', 'jetpack' ) );
 
 	$menu = array(
-		'id'   => 'stats',
-		'href' => $url,
+		'id'    => 'stats',
+		'href'  => $url,
+		'title' => "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>",
 	);
-	if ( Jetpack_AMP_Support::is_amp_request() ) {
-		$menu['title'] = "<amp-img src='$img_src_2x' width=112 height=24 layout=fixed alt='$alt' title='$title'></amp-img>";
-	} else {
-		$menu['title'] = "<div><img src='$img_src' srcset='$img_src 1x, $img_src_2x 2x' width='112' height='24' alt='$alt' title='$title'></div>";
-	}
 
 	$wp_admin_bar->add_menu( $menu );
 }


### PR DESCRIPTION
As noted in https://github.com/ampproject/amp-wp/issues/1921, AMP now supports a dev mode (https://github.com/ampproject/amphtml/issues/20974, https://github.com/ampproject/amp-wp/pull/3187) which allows a document to mark certain elements as being excluded for AMP validation. This is exactly what the AMP plugin has needed to allow the admin bar without fighting against the 50KB CSS limit. It also opens up the door to using scripts on AMP pages to add interactivity to the admin bar without worrying about AMP compatibility. This is exactly what Jetpack has needed for its admin bar integration on AMP pages (e.g. Stats and Notes).

This PR begins to implement support for that. Any markup that is being added by Jetpack to the frontend which is used by an authenticated user for administration should be amended with the `data-ampdevmode` attribute to each element. The elements in the admin bar items will get this automatically, so the primary concern is the `script`, `link`, and `style` elements that are output to extend on the frontend admin bar.

For more information on this, see [Integrating with AMP Dev Mode in WordPress](https://weston.ruter.net/2019/09/24/integrating-with-amp-dev-mode-in-wordpress/).

Part of #9730. This revisits/reverts aspects of #10945.

Support implemented in these modules:

- **Stats**: Reverts now-[unnecessary change](https://github.com/Automattic/jetpack/pull/10945/files#diff-f3b7c7c56cbf7524138248379aa9b949L986-R994) in #10945.
- **Notes**

Before:

<img width="417" alt="Screen Shot 2019-10-02 at 09 02 04" src="https://user-images.githubusercontent.com/134745/66060999-71445400-e4f3-11e9-92de-ee202c8801fc.png">

<img width="1088" alt="Screen Shot 2019-10-02 at 09 02 24" src="https://user-images.githubusercontent.com/134745/66061011-77d2cb80-e4f3-11e9-8249-170e0af3d255.png">

After:

<img width="402" alt="Screen Shot 2019-10-02 at 09 00 13" src="https://user-images.githubusercontent.com/134745/66061029-7e614300-e4f3-11e9-9be3-069862228b9e.png">

<img width="833" alt="Screen Shot 2019-10-02 at 08 59 22" src="https://user-images.githubusercontent.com/134745/66061039-828d6080-e4f3-11e9-95f5-6c6b27cb4553.png">

Notice the Notes admin menu item is not broken any longer after the changes are applied.

To revisit later:

- Likes (Note that the Like button does not yet work in AMP: https://github.com/Automattic/jetpack/issues/9555)
- Calypsoify
- Masterbar

#### Changes proposed in this Pull Request:

* Add support for AMP Dev Mode in Notes module, eliminating the need to deactivate the module to prevent AMP validation errors in Standard/Transitional modes of the AMP plugin. Revert now-[unnecessary change](https://github.com/Automattic/jetpack/pull/10945/files#diff-f3b7c7c56cbf7524138248379aa9b949L986-R994) in #10945.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Existing

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the AMP plugin v1.3.
* Check out this branch.
* There should not be validation errors from the Stats or Notes modules.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added support for AMP Dev Mode in Notes module, eliminating the need to deactivate the module to prevent AMP validation errors in Standard/Transitional modes of the AMP plugin.
