### PR TITLE
Add return for deprecated Jetpack_Sync_Settings functions

### DIFF
--- a/packages/compat/legacy/class.jetpack-sync-settings.php
+++ b/packages/compat/legacy/class.jetpack-sync-settings.php
@@ -61,12 +61,12 @@ class Jetpack_Sync_Settings {
 
 	static function is_importing() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
-		Settings::is_importing();
+		return Settings::is_importing();
 	}
 
 	static function is_sync_enabled() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
-		Settings::is_sync_enabled();
+		return Settings::is_sync_enabled();
 	}
 
 	static function set_doing_cron( $is_doing_cron ) {
@@ -76,7 +76,7 @@ class Jetpack_Sync_Settings {
 
 	static function is_doing_cron() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
-		Settings::is_doing_cron();
+		return Settings::is_doing_cron();
 	}
 
 	static function is_syncing() {
@@ -91,7 +91,7 @@ class Jetpack_Sync_Settings {
 
 	static function is_sending() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
-		Settings::is_sending();
+		return Settings::is_sending();
 	}
 
 	static function set_is_sending( $is_sending ) {


### PR DESCRIPTION
The deprecated functions in `Jetpack_Sync_Settings` that call the newly re-factored functions expect a returned value but do not return.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Certain Jetpack_Sync_Settings deprecated functions will now return

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Wp shell in
* Call one of the functions where it expects a returned value and see that it returns `NULL`:

```
wp> Jetpack_Sync_Settings::is_doing_cron();
=> phar:///root/roles/docker-container-vip-web/usr/local/bin/wp/vendor/wp-cli/shell-command/src/WP_CLI/Shell/REPL.php:52:
NULL
```
* Make change and call the function again:

```
wp> Jetpack_Sync_Settings::is_doing_cron();
bool(false)
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Deprecated functions in Jetpack_Sync_Settings with expected return values will return.
