### PR TITLE
Ad block: bail early when we do not have any ad params.

### DIFF
--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -76,7 +76,12 @@ class Jetpack_WordAds_Gutenblock {
 		global $wordads;
 
 		/** This filter is already documented in modules/wordads/wordads.php `insert_ad()` */
-		if ( empty( $wordads ) || is_feed() || apply_filters( 'wordads_inpost_disable', false ) ) {
+		if (
+			empty( $wordads )
+			|| empty( $wordads->params )
+			|| is_feed()
+			|| apply_filters( 'wordads_inpost_disable', false )
+		) {
 			return '';
 		}
 


### PR DESCRIPTION
Fixes #13453

#### Changes proposed in this Pull Request:

* In some cases, we may not have any ad parameters. When that's the case, bail early to avoid fatals (see #13453).

#### Testing instructions:

* Start with a site on a Premium or Professional plan.
* Activate the Ads module
* Create a new post, and insert an ad block.
* Publish a post.
* Load your site's posts in Calypso: https://wordpress.com/posts/
* Watch the fatal in your logs. This happens because the WordAds Object returned when loading the posts looks like this:
```
(
    [params] =>
    [ads] => Array
        (
            [0] => Array
                (
                    [location] => gutenberg
                    [width] => 300
                    [height] => 250
                )

        )

)
```
* Apply patch.
* Notice the fatal does not appear anymore.

#### Proposed changelog entry for your changes:

* Ads Block: avoid PHP errors when loading posts via the WordPress.com interface.
