### PR TITLE
Fix for empty namespaces. #13459

### DIFF
--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -179,8 +179,8 @@ class AutoloadGenerator extends BaseGenerator {
 					? $package['path']
 					: $basePath . '/' . $package['path']
 				);
-				$namespace = empty($namespace) ? NULL : $namespace;
-				$map = ClassMapGenerator::createMap( $dir, $blacklist, $this->io, $namespace );
+				$namespace = empty( $namespace ) ? null : $namespace;
+				$map       = ClassMapGenerator::createMap( $dir, $blacklist, $this->io, $namespace );
 
 				foreach ( $map as $class => $path ) {
 					$classCode       = var_export( $class, true );

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -179,6 +179,7 @@ class AutoloadGenerator extends BaseGenerator {
 					? $package['path']
 					: $basePath . '/' . $package['path']
 				);
+				$namespace = empty($namespace) ? NULL : $namespace;
 				$map = ClassMapGenerator::createMap( $dir, $blacklist, $this->io, $namespace );
 
 				foreach ( $map as $class => $path ) {


### PR DESCRIPTION
Fixes #13459

#### Changes proposed in this Pull Request:

If the namespace is an empty string then NULL is passed into `ClassMapGenerator::createMap()`.

#### Testing instructions:

Create a composer.json file with the following content:
```
{
    "description": "Tests automattic/jetpack-autoloader",
    "keywords": [
        "automatic jetpack autoloader"
    ],
    "repositories": [
        {
            "type": "path",
            "url": "/path/to/your/jetpack/packages/autoloader",
            "options": {
                "symlink": true
            }
        }
    ],
    "require": {
        "automattic/jetpack-autoloader": "@dev",
        "wp-cli/wp-cli": "^1.0"
    }
}
```
Then run `composer install`.

Once you see the bug, `rm -rf vendor composer.lock`, apply the patch above, and then run `composer install` again. The error should disappear.

#### Proposed changelog entry for your changes:

* General: avoid conflicts when using Jetpack alongside other plugins or services that rely on an Autoloader.