### PR TITLE
Fix mobile styles for filter menu on plugin install page

### DIFF
--- a/modules/calypsoify/style.scss
+++ b/modules/calypsoify/style.scss
@@ -612,6 +612,19 @@ body,
 	border-bottom: 2px solid $muriel-gray-700;
 }
 
+@media only screen and (max-width:480px) {
+	.filter-links,
+	.filter-links li,
+	.filter-links li a {
+		display: block;
+	}
+
+	.filter-links li > a {
+		font-size: 16px;
+	}
+}
+
+
 .count {
 	display: inline-block;
 	padding: 1px 6px;
@@ -789,6 +802,38 @@ div.mce-toolbar-grp,
 
 .wp-filter .search-form {
 	margin-right: 10px;
+
+	@media only screen and (max-width:1000px) {
+		margin-left: 10px;
+	}
+
+	@media only screen and (max-width: 782px) {
+		input[type="search"].wp-filter-search {
+			padding: 5px;
+		}
+	}
+
+	@media only screen and (max-width:480px) {
+		&.search-plugins {
+			align-items: center;
+			display: flex;
+
+			.wp-filter-search {
+				flex: 0 1 auto;
+				max-width: none;
+				width: 100%;
+			}
+		}
+
+		select {
+			flex-shrink: 0;
+		}
+
+		& > label {
+			flex: 1 1 auto;
+		}
+
+	}
 }
 
 // Shamelessly swiped from https://github.com/Automattic/wp-calypso/blob/59bdfeeb97eda4266ad39410cb0a074d2c88dbc8/client/components/forms/form-toggle


### PR DESCRIPTION
Changes the page navigation so links are shown in a vertical list instead of inline (for better readability), and fix the search box so it's always next to the dropdown and flexes with the browser window width.

Fixes Automattic/wp-calypso#32406

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes the Calypsoify filter menu on the Plugin install page

Before: 
![image](https://user-images.githubusercontent.com/4297811/64876492-e60a2980-d5ea-11e9-9549-19dae9a4acf3.png)

After:
![image](https://user-images.githubusercontent.com/4297811/64876545-fae6bd00-d5ea-11e9-929f-88b25bcd5911.png)

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a mobile view (screen width < 480px), enable Calypsoify on your local site (add `?calypsoify=1` to your site's URL)
* Visit the *Add Plugin* page, notice the filter links (Featured, Popular, Recommended, Favorites) are now in a vertical list instead of inline

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes the Calypso-ified mobile view of the filter menu on the Plugin install page
