### PR TITLE
Store "Assumed site creation date" in transient

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4719,7 +4719,6 @@ endif;
 
 		$tracks          = new Tracking();
 		$tracks_identity = $tracks->tracks_get_identity( get_current_user_id() );
-		$connection      = new Connection_Manager();
 
 		$args = urlencode_deep(
 			array(
@@ -4780,7 +4779,7 @@ endif;
 	 * @return string Assumed site creation date and time.
 	 */
 	public static function get_assumed_site_creation_date() {
-		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\Jetpack\Connection\Manager' );
+		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\\Jetpack\\Connection\\Manager' );
 		return self::connection()->get_assumed_site_creation_date();
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4719,6 +4719,7 @@ endif;
 
 		$tracks          = new Tracking();
 		$tracks_identity = $tracks->tracks_get_identity( get_current_user_id() );
+		$connection      = new Connection_Manager();
 
 		$args = urlencode_deep(
 			array(
@@ -4748,7 +4749,7 @@ endif;
 				'site_lang'     => get_locale(),
 				'_ui'           => $tracks_identity['_ui'],
 				'_ut'           => $tracks_identity['_ut'],
-				'site_created'  => self::get_assumed_site_creation_date(),
+				'site_created'  => $connection->get_assumed_site_creation_date(),
 			)
 		);
 
@@ -4778,35 +4779,8 @@ endif;
 	 * @return string Assumed site creation date and time.
 	 */
 	public static function get_assumed_site_creation_date() {
-		$earliest_registered_users  = get_users(
-			array(
-				'role'    => 'administrator',
-				'orderby' => 'user_registered',
-				'order'   => 'ASC',
-				'fields'  => array( 'user_registered' ),
-				'number'  => 1,
-			)
-		);
-		$earliest_registration_date = $earliest_registered_users[0]->user_registered;
-
-		$earliest_posts = get_posts(
-			array(
-				'posts_per_page' => 1,
-				'post_type'      => 'any',
-				'post_status'    => 'any',
-				'orderby'        => 'date',
-				'order'          => 'ASC',
-			)
-		);
-
-		// If there are no posts at all, we'll count only on user registration date.
-		if ( $earliest_posts ) {
-			$earliest_post_date = $earliest_posts[0]->post_date;
-		} else {
-			$earliest_post_date = PHP_INT_MAX;
-		}
-
-		return min( $earliest_registration_date, $earliest_post_date );
+		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\\Jetpack\\Connection\\Manager' );
+		return self::connection()->get_assumed_site_creation_date();
 	}
 
 	public static function apply_activation_source_to_args( &$args ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4749,7 +4749,7 @@ endif;
 				'site_lang'     => get_locale(),
 				'_ui'           => $tracks_identity['_ui'],
 				'_ut'           => $tracks_identity['_ut'],
-				'site_created'  => $connection->get_assumed_site_creation_date(),
+				'site_created'  => self::connection()->get_assumed_site_creation_date(),
 			)
 		);
 
@@ -4775,11 +4775,12 @@ endif;
 	 * - Earliest date of post of any post type.
 	 *
 	 * @since 7.2.0
+	 * @deprecated since 7.8.0
 	 *
 	 * @return string Assumed site creation date and time.
 	 */
 	public static function get_assumed_site_creation_date() {
-		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\\Jetpack\\Connection\\Manager' );
+		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\Jetpack\Connection\Manager' );
 		return self::connection()->get_assumed_site_creation_date();
 	}
 

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1024,6 +1024,11 @@ class Manager implements Manager_Interface {
 	 * @return string Assumed site creation date and time.
 	 */
 	public function get_assumed_site_creation_date() {
+		$cached_date = get_transient( 'jetpack_assumed_site_creation_date' );
+		if ( ! empty( $cached_date ) ) {
+			return $cached_date;
+		}
+
 		$earliest_registered_users  = get_users(
 			array(
 				'role'    => 'administrator',
@@ -1052,7 +1057,10 @@ class Manager implements Manager_Interface {
 			$earliest_post_date = PHP_INT_MAX;
 		}
 
-		return min( $earliest_registration_date, $earliest_post_date );
+		$assumed_date = min( $earliest_registration_date, $earliest_post_date );
+		set_transient( 'jetpack_assumed_site_creation_date', $assumed_date );
+
+		return $assumed_date;
 	}
 
 	/**

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -801,7 +801,8 @@ EXPECTED;
 			'post_date' => '1995-01-01 00:00:00',
 		) );
 
-		$this->assertEquals( '1990-01-01 00:00:00', Jetpack::get_assumed_site_creation_date() );
+		$jetpack = new MockJetpack();
+		$this->assertEquals( '1990-01-01 00:00:00', $jetpack::connection()->get_assumed_site_creation_date() );
 
 		wp_delete_user( $user_id );
 		wp_delete_post( $post_id, true );
@@ -820,7 +821,8 @@ EXPECTED;
 			'post_date' => '1991-01-01 00:00:00',
 		) );
 
-		$this->assertEquals( '1991-01-01 00:00:00', Jetpack::get_assumed_site_creation_date() );
+		$jetpack = new MockJetpack();
+		$this->assertEquals( '1991-01-01 00:00:00', $jetpack::connection()->get_assumed_site_creation_date() );
 
 		wp_delete_user( $user_id );
 		wp_delete_post( $post_id, true );

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -842,7 +842,8 @@ EXPECTED;
 			'user_registered' => '1992-01-01 00:00:00',
 		) );
 
-		$this->assertEquals( '1994-01-01 00:00:00', Jetpack::get_assumed_site_creation_date() );
+		$jetpack = new MockJetpack();
+		$this->assertEquals( '1994-01-01 00:00:00', $jetpack::connection()->get_assumed_site_creation_date() );
 
 		wp_delete_user( $admin_id );
 		wp_delete_user( $editor_id );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR does two things: 
1. Removes the duplicate `Jetpack::get_assumed_site_creation_date()` in the main Jetpack class, and replaces it with the package method. 
2. Caches the date in a transient. 

This method is called on every Jetpack Admin page load, because it's used in the build_connect_url() method that is passed into the initial state. We don't even need it in most cases (like if the user is already connected) - unless I guess if the user wants to disconnect/reconnect without a page load, so it could be further improved to not pass at all in that case, but not worth the extra complication. 

I'm not sure if there was a reason for not caching, but it seems like something that only needs to be checked and stored once. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Slightly improves 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

You can check with a plugin such as Query monitor: 
- Before applying patch, load the Jetpack admin page and note the number of queries. 
- After applying the patch, load the admin page. The first page load may not see signs of improvement, but subsequent page loads will be making fewer queries. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Slight performance increase in the admin area? Maybe not worth mentioning? 
