### PR TITLE
Reduce Jetpack Admin page queries for connected users. 

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -219,6 +219,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 		}
 
+		$current_user_data = jetpack_current_user_data();
+
 		return array(
 			'WP_API_root' => esc_url_raw( rest_url() ),
 			'WP_API_nonce' => wp_create_nonce( 'wp_rest' ),
@@ -236,7 +238,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
 				'sandboxDomain' => JETPACK__SANDBOX_DOMAIN,
 			),
-			'connectUrl' => Jetpack::init()->build_connect_url( true, false, false ),
+			'connectUrl' => $current_user_data['isConnected'] == false ? Jetpack::init()->build_connect_url( true, false, false ) : '',
 			'dismissedNotices' => $this->get_dismissed_jetpack_notices(),
 			'isDevVersion' => Jetpack::is_development_version(),
 			'currentVersion' => JETPACK__VERSION,
@@ -258,7 +260,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'settings' => $this->get_flattened_settings( $modules ),
 			'userData' => array(
 //				'othersLinked' => Jetpack::get_other_linked_admins(),
-				'currentUser'  => jetpack_current_user_data(),
+				'currentUser'  => $current_user_data,
 			),
 			'siteData' => array(
 				'icon' => has_site_icon()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Related to #13463, we are unnecessarily passing the build_connect_url value on every page load of the Jetpack admin. The historical reason for this, is that we used to not reload the page after disconnecting. However, since the new full-screen modal required a page load after disconnect, we can be smarter about when we use the resources to build the url only when we need it. 

It prevents about 6-7 unnecessary queries when the current user is connected. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Faster Jetpack admin page load? 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check out query monitor or something similar. Note the queries for a connected user on page load of the main Jetpack Admin dashboard. 

Check it out with the patch applied as a connected user. There should be way fewer queries. 

Functional testing: 
0. From the main Jetpack dashboard: 
- Connect the site to wordpress.com. There should be no problem. 
- Disconnect, and then reconnect. There should be no problem. 
- Create a secondary user while the site is connected. 
- Visit the Jetpack admin page, and click to "create account" as that secondary user. There should be no problem. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Faster Jetpack admin page load? 
