### PR TITLE
Markdown block: remove module dependency

### DIFF
--- a/extensions/blocks/markdown/markdown.php
+++ b/extensions/blocks/markdown/markdown.php
@@ -7,14 +7,4 @@
  * @package Jetpack
  */
 
-/**
- * The block depends on the Markdown module to be active for now.
- * Related discussion: https://github.com/Automattic/jetpack/issues/10294
- */
-if (
-	( defined( 'IS_WPCOM' ) && IS_WPCOM )
-	|| ( method_exists( 'Jetpack', 'is_module_active' ) && Jetpack::is_module_active( 'markdown' ) )
-) {
-	jetpack_register_block( 'jetpack/markdown' );
-}
-
+jetpack_register_block( 'jetpack/markdown' );


### PR DESCRIPTION
Currently, Markdown block requires the Markdown module to be present, although we don't rely on the module technically.

Markdown block renders Markdown using a frontend library instead of relying on the PHP module.

UI where you need to go to turn on a separate toggle in settings page just to allow a feature showing up in the block picker is not great. From the user perspective, the act of choosing Markdown block from the block picker is de-factor "turning a feature on".

Module toggle itself is still useful for allowing writing Markdown on classic editor pages and the toggle could be hidden for sites using Gutenberg, but that's outside the scope in here.

This PR removes module dependency, making the block always available in the block picker.

<img src="https://user-images.githubusercontent.com/87168/64923260-2feb3f00-d7a6-11e9-8be4-8d38704eeb59.png" alt="" width="200"/>

Similar question to Tiled gallery's Photon module dependency; https://github.com/Automattic/jetpack/pull/13471

#### Changes proposed in this Pull Request:
- Remove markdown module check when registering markdown block

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Modify existing.

#### Testing instructions:
- Have a Jetpack site (e.g. via https://jurassic.ninja/)
- Confirm that Markdown block is available in block editor only when Markdown module is active. You can activate/disable it via "Writing -> Write posts or pages in plain-text Markdown syntax" toggle in Jetpack settings:
    ![image](https://user-images.githubusercontent.com/87168/64924125-071b7780-d7af-11e9-995d-aa0421024f63.png)
- In this branch, the block should be available when the module is off (test e.g. via https://jurassic.ninja/create?jetpack-beta&branch=update/markdown-module-dep&wp-debug-log)

#### Proposed changelog entry for your changes:
- Show Markdown block in the block picker even if the Markdown module is disabled