### PR TITLE
Sync: Move sync_object XML-RPC method from connection to sync

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -83,7 +83,6 @@ class Jetpack_XMLRPC_Server {
 					'jetpack.featuresEnabled'   => array( $this, 'features_enabled' ),
 					'jetpack.disconnectBlog'    => array( $this, 'disconnect_blog' ),
 					'jetpack.unlinkUser'        => array( $this, 'unlink_user' ),
-					'jetpack.syncObject'        => array( $this, 'sync_object' ),
 					'jetpack.idcUrlValidation'  => array( $this, 'validate_urls_for_idc_mitigation' ),
 				)
 			);
@@ -814,16 +813,15 @@ class Jetpack_XMLRPC_Server {
 	/**
 	 * Returns any object that is able to be synced.
 	 *
+	 * @deprecated since 7.8.0
+	 * @see Automattic\Jetpack\Sync\Sender::sync_object()
+	 *
 	 * @param array $args the synchronized object parameters.
+	 * @return string Encoded sync object.
 	 */
 	public function sync_object( $args ) {
-		// For example: posts, post, 5.
-		list( $module_name, $object_type, $id ) = $args;
-
-		$sync_module = Modules::get_module( $module_name );
-		$codec       = Sender::get_instance()->get_codec();
-
-		return $codec->encode( $sync_module->get_object_by_id( $object_type, $id ) );
+		_deprecated_function( __METHOD__, 'jetpack-7.8', 'Automattic\\Jetpack\\Sync\\Sender::sync_object' );
+		return Sender::get_instance()->sync_object( $args );
 	}
 
 	/**

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -543,10 +543,7 @@ class Sender {
 	 * @return array Filtered XML-RPC methods.
 	 */
 	public function register_jetpack_xmlrpc_methods( $jetpack_methods, $core_methods, $user ) {
-		if ( $user ) {
-			$jetpack_methods['jetpack.syncObject'] = array( $this, 'sync_object' );
-		}
-
+		$jetpack_methods['jetpack.syncObject'] = array( $this, 'sync_object' );
 		return $jetpack_methods;
 	}
 

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -186,7 +186,7 @@ class Sender {
 	private function init() {
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_set_user_from_token' ), 1 );
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_clear_user_from_token' ), 20 );
-		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'register_jetpack_xmlrpc_methods' ), 10, 3 );
+		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'register_jetpack_xmlrpc_methods' ) );
 		foreach ( Modules::get_modules() as $module ) {
 			$module->init_before_send();
 		}
@@ -537,12 +537,10 @@ class Sender {
 	 * @access public
 	 * @since 7.8
 	 *
-	 * @param array    $jetpack_methods XML-RPC methods available to the Jetpack Server.
-	 * @param array    $core_methods    Available core XML-RPC methods.
-	 * @param \WP_User $user            Information about a given WordPress user.
+	 * @param array $jetpack_methods XML-RPC methods available to the Jetpack Server.
 	 * @return array Filtered XML-RPC methods.
 	 */
-	public function register_jetpack_xmlrpc_methods( $jetpack_methods, $core_methods, $user ) {
+	public function register_jetpack_xmlrpc_methods( $jetpack_methods ) {
 		$jetpack_methods['jetpack.syncObject'] = array( $this, 'sync_object' );
 		return $jetpack_methods;
 	}

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -186,6 +186,7 @@ class Sender {
 	private function init() {
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_set_user_from_token' ), 1 );
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_clear_user_from_token' ), 20 );
+		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'register_jetpack_xmlrpc_methods' ), 10, 3 );
 		foreach ( Modules::get_modules() as $module ) {
 			$module->init_before_send();
 		}
@@ -510,6 +511,43 @@ class Sender {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Returns any object that is able to be synced.
+	 *
+	 * @access public
+	 *
+	 * @param array $args the synchronized object parameters.
+	 * @return string Encoded sync object.
+	 */
+	public function sync_object( $args ) {
+		// For example: posts, post, 5.
+		list( $module_name, $object_type, $id ) = $args;
+
+		$sync_module = Modules::get_module( $module_name );
+		$codec       = $this->get_codec();
+
+		return $codec->encode( $sync_module->get_object_by_id( $object_type, $id ) );
+	}
+
+	/**
+	 * Register additional sync XML-RPC methods available to Jetpack for authenticated users.
+	 *
+	 * @access public
+	 * @since 7.8
+	 *
+	 * @param array    $jetpack_methods XML-RPC methods available to the Jetpack Server.
+	 * @param array    $core_methods    Available core XML-RPC methods.
+	 * @param \WP_User $user            Information about a given WordPress user.
+	 * @return array Filtered XML-RPC methods.
+	 */
+	public function register_jetpack_xmlrpc_methods( $jetpack_methods, $core_methods, $user ) {
+		if ( $user ) {
+			$jetpack_methods['jetpack.syncObject'] = array( $this, 'sync_object' );
+		}
+
+		return $jetpack_methods;
 	}
 
 	/**

--- a/tests/php/general/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/general/test_class.jetpack-xmlrpc-server.php
@@ -22,42 +22,6 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		$this->assertTrue( in_array( 'publicize', $response ) );
 	}
 
-	function test_xmlrpc_get_sync_object_for_post() {
-		$post_id = $this->factory->post->create();
-
-		$server = new Jetpack_XMLRPC_Server();
-		$response = $server->sync_object( array( 'posts', 'post', $post_id ) );
-
-		$codec = Sender::get_instance()->get_codec();
-		$decoded_object = $codec->decode( $response );
-
-		$this->assertEquals( $post_id, $decoded_object->ID );
-	}
-
-	function test_xmlrpc_sync_object_returns_false_if_missing() {
-		$server = new Jetpack_XMLRPC_Server();
-		$response = $server->sync_object( array( 'posts', 'post', 1000 ) );
-
-		$codec = Sender::get_instance()->get_codec();
-		$decoded_object = $codec->decode( $response );
-
-		$this->assertFalse( $decoded_object );
-	}
-
-	function test_xmlrpc_get_sync_object_for_user() {
-		$user_id = $this->factory->user->create();
-
-		$server = new Jetpack_XMLRPC_Server();
-		$response = $server->sync_object( array( 'users', 'user', $user_id ) );
-
-		$codec = Sender::get_instance()->get_codec();
-		$decoded_object = $codec->decode( $response );
-
-		$this->assertFalse( isset( $decoded_object->user_pass ) );
-
-		$this->assertEquals( $user_id, $decoded_object->ID );
-	}
-
 	function test_xmlrpc_get_user_by_id() {
 		$user = get_user_by( 'id', self::$xmlrpc_admin );
 		$server = new Jetpack_XMLRPC_Server();

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -3,7 +3,6 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Sync\Sender;
 
 // Extend with a public constructor so that can be mocked in tests
 class MockJetpack extends Jetpack {
@@ -34,8 +33,6 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 		self::$admin_id = self::factory()->user->create( array(
 			'role' => 'administrator',
 		) );
-
-		Sender::get_instance();
 	}
 
 	public function tearDown() {
@@ -1042,8 +1039,9 @@ EXPECTED;
 			'jetpack.featuresEnabled',
 			'jetpack.disconnectBlog',
 			'jetpack.unlinkUser',
-			'jetpack.syncObject',
 			'jetpack.idcUrlValidation',
+
+			'jetpack.syncObject',
 		];
 
 		// It's OK if these module-added methods are present. (Module active in tests.)
@@ -1081,11 +1079,12 @@ EXPECTED;
 			'jetpack.featuresEnabled',
 			'jetpack.disconnectBlog',
 			'jetpack.unlinkUser',
-			'jetpack.syncObject',
 			'jetpack.idcUrlValidation',
 
 			'metaWeblog.newMediaObject',
 			'jetpack.updateAttachmentParent',
+
+			'jetpack.syncObject',
 		];
 
 		// It's OK if these module-added methods are present. (Module active in tests.)

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Sync\Sender;
 
 // Extend with a public constructor so that can be mocked in tests
 class MockJetpack extends Jetpack {
@@ -33,6 +34,8 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 		self::$admin_id = self::factory()->user->create( array(
 			'role' => 'administrator',
 		) );
+
+		Sender::get_instance();
 	}
 
 	public function tearDown() {

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -432,6 +432,39 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $sync_queue->has_any_items() ,"We didn't empty the queue" );
 	}
 
+	function test_sender_get_sync_object_for_post() {
+		$post_id = $this->factory->post->create();
+
+		$response = $this->sender->sync_object( array( 'posts', 'post', $post_id ) );
+
+		$codec = $this->sender->get_codec();
+		$decoded_object = $codec->decode( $response );
+
+		$this->assertEquals( $post_id, $decoded_object->ID );
+	}
+
+	function test_sender_sync_object_returns_false_if_missing() {
+		$response = $this->sender->sync_object( array( 'posts', 'post', 1000 ) );
+
+		$codec = $this->sender->get_codec();
+		$decoded_object = $codec->decode( $response );
+
+		$this->assertFalse( $decoded_object );
+	}
+
+	function test_sender_get_sync_object_for_user() {
+		$user_id = $this->factory->user->create();
+
+		$response = $this->sender->sync_object( array( 'users', 'user', $user_id ) );
+
+		$codec = $this->sender->get_codec();
+		$decoded_object = $codec->decode( $response );
+
+		$this->assertFalse( isset( $decoded_object->user_pass ) );
+
+		$this->assertEquals( $user_id, $decoded_object->ID );
+	}
+
 	function run_filter( $data ) {
 		$this->filter_ran = true;
 		return $data;


### PR DESCRIPTION
This PR moves the `sync_object` method and its registration as a XML-RPC endpoint to the sync sender, where it belongs, deprecates the original method, and moves the tests. Previously it was in the XMLRPC server that is currently in the connection package. However, that no longer made sense, as the connection doesn't require sync as a dependency, so any sync functionality should be provided by the sync package.

#### Changes proposed in this Pull Request:
* Sync: Move sync_object() and XMLRPC registration to Sender
* Connection: Deprecate Jetpack_XMLRPC_Server::sync_object()
* Tests: Move sync_object tests to sync sender tests

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the work on making the connection package independent.

#### Testing instructions:
* Verify tests pass.

#### Proposed changelog entry for your changes:
* Sync: Move sync_object XML-RPC method from connection to sync
