### PR TITLE
Actions: auto-label all PRS modifying Packages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+"[Status] Needs Package Release":
+- 'packages/*'
+- 'packages/*/*'
+- 'packages/*/*/*'
+- 'packages/*/*/*/*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Whenever we make changes to package files in a PR, let's add a label to that PR to indicate that a new version of the package will need to be released.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* `1138708815542418/1139919027395387-as`

If this works:
1. We can do the same with other labels and stop relying on webhooks in a lot of cases.
2. As a step 2, we can release new package versions using GitHub actions. Let's start small though :)

#### Testing instructions:

* Not quite sure how to test actions yet.

#### Proposed changelog entry for your changes:

* None
