### PR TITLE
Docs: Unify usage of @package phpdoc tags in packages

### DIFF
--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -2,7 +2,7 @@
 /**
  * Autoloader Generator.
  *
- * @package Automattic\Jetpack\Autoloader
+ * @package automattic/jetpack-autoloader
  */
 
 // phpcs:disable PHPCompatibility.Keywords.NewKeywords.t_useFound
@@ -174,7 +174,7 @@ class AutoloadGenerator extends BaseGenerator {
 		// Scan the PSR-4 and classmap directories for class files, and add them to the class map.
 		foreach ( $autoloads['psr-4'] as $namespace => $packages_info ) {
 			foreach ( $packages_info as $package ) {
-				$dir = $filesystem->normalizePath(
+				$dir       = $filesystem->normalizePath(
 					$filesystem->isAbsolutePath( $package['path'] )
 					? $package['path']
 					: $basePath . '/' . $package['path']

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -2,7 +2,7 @@
 /**
  * Custom Autoloader Composer Plugin, hooks into composer events to generate the custom autoloader.
  *
- * @package Automattic\Jetpack\Autoloader
+ * @package automattic/jetpack-autoloader
  */
 
 // phpcs:disable PHPCompatibility.Keywords.NewKeywords.t_useFound
@@ -24,7 +24,7 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 /**
  * Class CustomAutoloaderPlugin.
  *
- * @package Automattic\Jetpack\Autoloader
+ * @package automattic/jetpack-autoloader
  */
 class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterface {
 

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -5,7 +5,7 @@
  * From your plugin include this file with:
  * require_once . plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
  *
- * @package Automattic\Jetpack\Autoloader
+ * @package automattic/jetpack-autoloader
  */
 
 // phpcs:disable PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound

--- a/packages/autoloader/tests/php/path_to_class.php
+++ b/packages/autoloader/tests/php/path_to_class.php
@@ -3,15 +3,13 @@
  * This is a very much a dummy class that is used for a test.
  * To see if we are able to load it via the autoloader.
  *
- * @package jetpack
+ * @package automattic/jetpack-autoloader
  */
 
 namespace Jetpack\TestCase_ABC;
 
 /**
  * Class className_ABC.
- *
- * @package Jetpack\TestCase_ABC
  */
 class className_ABC {
 

--- a/packages/compat/functions.php
+++ b/packages/compat/functions.php
@@ -2,7 +2,7 @@
 /**
  * Legacy global scope functions.
  *
- * @package global-functions
+ * @package automattic/jetpack-compat
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/packages/compat/legacy/class.jetpack-client.php
+++ b/packages/compat/legacy/class.jetpack-client.php
@@ -4,8 +4,8 @@
  *
  * Deprecated methods for Jetpack to act as client with wpcom, provided for back-compatibility.
  *
- * @category   Connection
- * @package    Client
+ * @category Connection
+ * @package  automattic/jetpack-compat
  */
 
 use Automattic\Jetpack\Connection\Client;

--- a/packages/compat/legacy/class.jetpack-sync-actions.php
+++ b/packages/compat/legacy/class.jetpack-sync-actions.php
@@ -2,7 +2,7 @@
 /**
  * A compatibility shim for the sync actions class.
  *
- * @package jetpack-compat
+ * @package automattic/jetpack-compat
  */
 
 use Automattic\Jetpack\Sync\Actions;

--- a/packages/compat/legacy/class.jetpack-sync-modules.php
+++ b/packages/compat/legacy/class.jetpack-sync-modules.php
@@ -2,7 +2,7 @@
 /**
  * A compatibility shim for the sync modules class.
  *
- * @package jetpack-compat
+ * @package automattic/jetpack-compat
  */
 
 use Automattic\Jetpack\Sync\Modules;

--- a/packages/connection/src/Client.php
+++ b/packages/connection/src/Client.php
@@ -2,7 +2,7 @@
 /**
  * The Connection Client class file.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 namespace Automattic\Jetpack\Connection;

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -2,7 +2,7 @@
 /**
  * The Jetpack Connection manager class file.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 namespace Automattic\Jetpack\Connection;

--- a/packages/connection/src/Manager_Interface.php
+++ b/packages/connection/src/Manager_Interface.php
@@ -2,7 +2,7 @@
 /**
  * The Jetpack Connection Interface file.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 namespace Automattic\Jetpack\Connection;
@@ -10,7 +10,7 @@ namespace Automattic\Jetpack\Connection;
 /**
  * The Connection interface class file.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 /**

--- a/packages/connection/src/REST_Connector.php
+++ b/packages/connection/src/REST_Connector.php
@@ -2,7 +2,7 @@
 /**
  * Sets up the Connection REST API endpoints.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 namespace Automattic\Jetpack\Connection;

--- a/packages/connection/src/XMLRPC_Connector.php
+++ b/packages/connection/src/XMLRPC_Connector.php
@@ -2,7 +2,7 @@
 /**
  * Sets up the Connection XML-RPC methods.
  *
- * @package jetpack-connection
+ * @package automattic/jetpack-connection
  */
 
 namespace Automattic\Jetpack\Connection;

--- a/packages/constants/src/Constants.php
+++ b/packages/constants/src/Constants.php
@@ -2,7 +2,7 @@
 /**
  * A constants manager for Jetpack.
  *
- * @package jetpack-constants
+ * @package automattic/jetpack-constants
  */
 
 namespace Automattic\Jetpack;

--- a/packages/error/src/Error.php
+++ b/packages/error/src/Error.php
@@ -4,7 +4,7 @@
  *
  * @see https://codex.wordpress.org/Class_Reference/WP_Error
  *
- * @package jetpack-error
+ * @package automattic/jetpack-error
  */
 
 namespace Automattic\Jetpack;

--- a/packages/logo/src/Logo.php
+++ b/packages/logo/src/Logo.php
@@ -2,7 +2,7 @@
 /**
  * A logo for Jetpack.
  *
- * @package jetpack-logo
+ * @package automattic/jetpack-logo
  */
 
 namespace Automattic\Jetpack\Assets;

--- a/packages/roles/src/Roles.php
+++ b/packages/roles/src/Roles.php
@@ -2,7 +2,7 @@
 /**
  * A user roles class for Jetpack.
  *
- * @package jetpack-roles
+ * @package automattic/jetpack-roles
  */
 
 namespace Automattic\Jetpack;

--- a/packages/status/src/Status.php
+++ b/packages/status/src/Status.php
@@ -2,7 +2,7 @@
 /**
  * A status class for Jetpack.
  *
- * @package jetpack-status
+ * @package automattic/jetpack-status
  */
 
 namespace Automattic\Jetpack;

--- a/packages/sync/src/Main.php
+++ b/packages/sync/src/Main.php
@@ -2,7 +2,7 @@
 /**
  * This class hooks the main sync actions.
  *
- * @package jetpack-sync
+ * @package automattic/jetpack-sync
  */
 
 namespace Automattic\Jetpack\Sync;

--- a/packages/tracking/src/Tracking.php
+++ b/packages/tracking/src/Tracking.php
@@ -2,7 +2,7 @@
 /**
  * Nosara Tracks for Jetpack
  *
- * @package jetpack-tracking
+ * @package automattic/jetpack-tracking
  */
 
 namespace Automattic\Jetpack;


### PR DESCRIPTION
Currently, inside our packages, we have a mixed syntax usage for the `@package` phpdocs tag. This PR updates these usages to the prevailing syntax, which is `@automattic/jetpack-package-name`. This conveniently corresponds to both the GitHub repo path, and the composer package identifier.

#### Changes proposed in this Pull Request:
* Docs: Unify usage of `@package` phpdoc tags in packages

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is just a janitorial PR

#### Testing instructions:
* Shouldn't be necessary - changes affect only comments.

#### Proposed changelog entry for your changes:
* Docs: Unify usage of `@package` phpdoc tags in packages
