### PR TITLE
Build Workflow: rely on COMPOSER_MIRROR_PATH_REPOS for packages

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Jetpack
         uses: actions/checkout@master
       - name: Build production files
-        run: yarn build-production
+        run: COMPOSER_MIRROR_PATH_REPOS=1 yarn run build-production
       - name: Purge dev files
         run: $GITHUB_WORKSPACE/bin/prepare-built-branch.sh
       - name: Push to built branch


### PR DESCRIPTION
Related: #12480
#### Changes proposed in this Pull Request:

* When buidling the production version of the plugin, make sure we do not mirror the packages, but pull them.


#### Testing instructions:

* The workflow should work.

#### Proposed changelog entry for your changes:

* None
