### PR TITLE
Connect in Place: revert setting the alt. connection flow as the default

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -49,9 +49,6 @@ defined( 'JETPACK__DEBUGGER_PUBLIC_KEY' )    || define(
 defined( 'JETPACK_SIGNATURE__HTTP_PORT' )  || define( 'JETPACK_SIGNATURE__HTTP_PORT', 80 );
 defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) || define( 'JETPACK_SIGNATURE__HTTPS_PORT', 443 );
 
-// TODO: delete before next release
-defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) || define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );
-
 /**
  * Check if the version of WordPress in use on the site is supported by Jetpack.
  */


### PR DESCRIPTION
This reverts commit 005a488ce5de12631113665aa781fd6e2e7dd963.

Fixes #13435

#### Changes proposed in this Pull Request:

* Connect in Place: revert setting the alt. connection flow as the default

#### Testing instructions:

* Spin up a new site running this branch.
* Connect to WordPress.com.
* You should be seeing the standard connection flow that brings you to WordPress.com.

#### Proposed changelog entry for your changes:

* None
