### PR TITLE
Markdown: add explanation that the toggle is for Classic only

### DIFF
--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -78,7 +78,10 @@ export class Composing extends React.Component {
 					module={ markdown }
 					support={ {
 						text: __(
-							'Allows you to compose content with links, lists, and other styles using the Markdown syntax.'
+							'Allows you to compose content with links, lists, ' +
+								'and other styles using the Markdown syntax. ' +
+								'This setting will allow you to write with the help of Markdown ' +
+								'in the Classic Editor or within a Classic Editor block.'
 						),
 						link: 'https://jetpack.com/support/markdown/',
 					} }
@@ -101,13 +104,6 @@ export class Composing extends React.Component {
 						>
 							<span className="jp-form-toggle-explanation">{ markdown.description }</span>
 						</ModuleToggle>
-					</FormFieldset>
-					<FormFieldset>
-						<p className="jp-form-setting-explanation">
-							{ __(
-								'This only applies to the Classic Editor because there is a Markdown block available in new editor.'
-							) }
-						</p>
 					</FormFieldset>
 				</SettingsGroup>
 			),

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -49,7 +49,6 @@ export class Composing extends React.Component {
 			latex = this.props.module( 'latex' ),
 			copyPost = this.props.module( 'copy-post' ),
 			shortcodes = this.props.module( 'shortcodes' ),
-
 			copyPostSettings = (
 				<SettingsGroup
 					module={ copyPost }
@@ -102,6 +101,13 @@ export class Composing extends React.Component {
 						>
 							<span className="jp-form-toggle-explanation">{ markdown.description }</span>
 						</ModuleToggle>
+					</FormFieldset>
+					<FormFieldset>
+						<p className="jp-form-setting-explanation">
+							{ __(
+								'This only applies to the Classic Editor because there is a Markdown block available in new editor.'
+							) }
+						</p>
 					</FormFieldset>
 				</SettingsGroup>
 			),


### PR DESCRIPTION
Fixes #10294

#### Changes proposed in this Pull Request:

This is one potential approach to clarify that toggling the feature on and off in the Jetpack settings will not impact the block appearing in the block editor (it will always be available, regardless of the status of the toggle in settings). Here is what that approach looks like:
![image](https://user-images.githubusercontent.com/426388/65250004-2428b100-daf5-11e9-922e-0e0ad36c71c6.png)

Another alternative would be this for example:
![image](https://user-images.githubusercontent.com/426388/65249985-1c690c80-daf5-11e9-87d1-a91ed1f6cf3b.png)

I'd be happy to have some feedback on the wording and the placement of the explanation.

Another completely different approach that we could take would be to auto-activate the module on all new sites, and not display any settings in Jetpack > Settings.

#### Testing instructions:

* Go to Jetpack > Settings > Writing in your dashboard.
* Review the section about Markdown.

#### Proposed changelog entry for your changes:

* None
