### PR TITLE
Renovate: Ignore PHPUnit packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,6 @@
 	"supportPolicy": [ "lts_latest" ],
 	"timezone": "UTC",
 	"schedule": [ "every weekend" ],
-	"updateNotScheduled": false
+	"updateNotScheduled": false,
+	"ignoreDeps": [ "mockery/mockery", "php-mock/php-mock", "phpunit/phpunit" ]
 }

--- a/.svnignore
+++ b/.svnignore
@@ -13,7 +13,6 @@ readme.md
 babel.config*
 phpunit.xml.dist
 dangerfile.js
-renovate.json
 bin/phpcs-whitelist.js
 bin/pre-commit-hook.js
 bin/prepare-built-branch.sh


### PR DESCRIPTION
Closes #13246

#### Changes proposed in this Pull Request:
* As mentioned in the above PR, the PHPUnit packages are intentionally left vague in order for Travis to works on multiple version of PHP.
* Once we're at PHP 7+, we can look at removing this.
* Moving to the .github folder to help keep root as clean as possible.

Ref: https://docs.renovatebot.com/configuration-options/#ignoredeps

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Not sure how to test Renovate rules without committing them.

#### Proposed changelog entry for your changes:
* n/a
