### PR TITLE
Tiled gallery: mention CDN in block description

### DIFF
--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -133,7 +133,7 @@ export const icon = (
 export const settings = {
 	attributes: blockAttributes,
 	category: 'jetpack',
-	description: __( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ),
+	description: __( "Display multiple images in an elegantly organized tiled layout. Serves images using Jetpack's fast global network of servers.", 'jetpack' ),
 	icon,
 	keywords: [
 		_x( 'images', 'block search term', 'jetpack' ),


### PR DESCRIPTION
Tiled gallery block always uses Photon CDN to load images. 

Follow up for https://github.com/Automattic/jetpack/pull/13471

See comment https://github.com/Automattic/jetpack/pull/13471#issuecomment-533008332:

> Should we update the block description to mention that it relies on our CDN? This would avoid confusion, and folks wouldn't have to contact support when they disable the Image CDN but keep seeing it being used in their galleries (this was a common issue back when tiled galleries were available as a single module).

#### Before
![image](https://user-images.githubusercontent.com/87168/65315737-48da6280-dba1-11e9-84b3-08ac00f1d76a.png)


#### After
![image](https://user-images.githubusercontent.com/87168/65315705-3f50fa80-dba1-11e9-9ab4-47fd699bd153.png)



#### Changes proposed in this Pull Request:
- Update block description

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

#### Testing instructions:
- build blocks: `yarn build-extensions`
- add tiled gallery block and see the new description in the sidebar

#### Proposed changelog entry for your changes:
