### PR TITLE
Autoloader: Cover scenarios where composer/autoload_files.php might not exist.

### DIFF
--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -263,8 +263,11 @@ function enqueue_packages_$suffix() {
 	foreach ( \$class_map as \$class_name => \$class_info ) {
 		enqueue_package_class( \$class_name, \$class_info['version'], \$class_info['path'] );
 	}
-	
-	\$includeFiles = require __DIR__ . '/composer/autoload_files.php';
+
+	\$autoload_file = __DIR__ . '/composer/autoload_files.php';
+	\$includeFiles = file_exists( \$autoload_file )
+	    ? require \$autoload_file
+	    : [];
 
 	foreach ( \$includeFiles as \$fileIdentifier => \$file ) {
 		if ( empty( \$GLOBALS['__composer_autoload_files'][ \$fileIdentifier ] ) ) {

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -266,8 +266,8 @@ function enqueue_packages_$suffix() {
 
 	\$autoload_file = __DIR__ . '/composer/autoload_files.php';
 	\$includeFiles = file_exists( \$autoload_file )
-	    ? require \$autoload_file
-	    : [];
+		? require \$autoload_file
+		: [];
 
 	foreach ( \$includeFiles as \$fileIdentifier => \$file ) {
 		if ( empty( \$GLOBALS['__composer_autoload_files'][ \$fileIdentifier ] ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Adds a check for if `autoload_files.php` exists before including.

This surfaced in failing tests in travis in the WooCommerce Blocks repo after bumping the package version requirement (see [example build fail here](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block/jobs/237671098)).

- It looks like it was introduced in 2962a2c (from #12857).

There are scenarios where `composer install --no-dev` will result in no `vendor/composer/autoload_files.php` file so there needs to be a safety check before including it.

#### Testing instructions:

Testing involves

- Create a composer config basic entries in `composer_require` and with a PS4 autoloader config. 
Example (note I forked the mirror to my own repo and cherry-picked in the fix for the purpose of this test):

```
       "repositories": [
	  {
	    "type": "vcs",
	    "url": "https://github.com/nerrad/jetpack-autoloader"
	  }
	],
	"require": {
		"composer/installers": "1.7.0",
		"automattic/jetpack-autoloader": "dev-test-autoloader_files-fix"
	},
```
- Run `composer install --no-dev` (there should be no `autoload_files.php` file in `vendor/composer/`)
- Verify php app runs without errors.

(Note: I tested the fork with the cherry-picked commit and here's the resulting travis build: https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block/builds/128563691).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Check for `composer/autoload_files.php` before including.
