### PR TITLE
Add support for filtering on categories and tags

### DIFF
--- a/modules/search/instant-search/components/search-filter-post-types.jsx
+++ b/modules/search/instant-search/components/search-filter-post-types.jsx
@@ -17,7 +17,7 @@ export default class SearchFilterPostTypes extends Component {
 	toggleFilter = () => {
 		const selected = getCheckedInputNames( this.filtersList.current );
 		this.setState( { selected }, () => {
-			this.props.onChange( 'postTypes', selected );
+			this.props.onChange( 'post_types', selected );
 		} );
 	};
 

--- a/modules/search/instant-search/components/search-filter-taxonomies.jsx
+++ b/modules/search/instant-search/components/search-filter-taxonomies.jsx
@@ -3,30 +3,51 @@
 /**
  * External dependencies
  */
-import { h, Component } from 'preact';
+import { h, createRef, Component } from 'preact';
 import strip from 'strip';
+import { getCheckedInputNames } from '../lib/dom';
 
 export default class SearchFilterTaxonomies extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { selected: this.props.initialValue };
+		this.filtersList = createRef();
+	}
+
+	toggleFilter = () => {
+		const selected = getCheckedInputNames( this.filtersList.current );
+		this.setState( { selected }, () => {
+			this.props.onChange( this.props.configuration.taxonomy, selected );
+		} );
+	};
+
+	renderTaxonomy = ( { key, doc_count: count } ) => {
+		return (
+			<div>
+				<input
+					checked={ this.state.selected && this.state.selected.includes( key ) }
+					id={ `jp-instant-search-filter-taxonomies-${ key }` }
+					name={ key }
+					onChange={ this.toggleFilter }
+					type="checkbox"
+				/>
+				<label htmlFor={ `jp-instant-search-filter-taxonomies-${ key }` }>
+					{ strip( key ) } ({ count })
+				</label>
+			</div>
+		);
+	};
+
 	render() {
 		return (
 			<div>
-				<h4 className="jetpack-search-filters-widget__sub-heading">{ this.props.filter.name }</h4>
-				<ul className="jetpack-search-filters-widget__filter-list">
+				<h4 className="jetpack-search-filters-widget__sub-heading">
+					{ this.props.configuration.name }
+				</h4>
+				<ul className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
 					{ this.props.aggregation &&
 						'buckets' in this.props.aggregation &&
-						this.props.aggregation.buckets.map( bucket => (
-							<div>
-								<input
-									disabled
-									id={ `jp-instant-search-filter-taxonomies-${ bucket.key }` }
-									name={ bucket.key }
-									type="checkbox"
-								/>
-								<label htmlFor={ `jp-instant-search-filter-taxonomies-${ bucket.key }` }>
-									{ strip( bucket.key ) } ({ bucket.doc_count })
-								</label>
-							</div>
-						) ) }
+						this.props.aggregation.buckets.map( this.renderTaxonomy ) }
 				</ul>
 			</div>
 		);

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -31,7 +31,7 @@ export default class SearchFiltersWidget extends Component {
 						<SearchFilterPostTypes
 							aggregation={ results }
 							configuration={ configuration }
-							initialValue={ this.props.initialValues.postTypes }
+							initialValue={ this.props.initialValues.post_types }
 							onChange={ this.props.onChange }
 							postTypes={ this.props.postTypes }
 						/>

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -23,7 +23,14 @@ export default class SearchFiltersWidget extends Component {
 				return results && <SearchFilterDates aggregation={ results } filter={ configuration } />;
 			case 'taxonomy':
 				return (
-					results && <SearchFilterTaxonomies aggregation={ results } filter={ configuration } />
+					results && (
+						<SearchFilterTaxonomies
+							aggregation={ results }
+							configuration={ configuration }
+							initialValue={ this.props.initialValues[ configuration.taxonomy ] }
+							onChange={ this.props.onChange }
+						/>
+					)
 				);
 			case 'post_type':
 				return (

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -43,8 +43,8 @@ function buildFilterObject( filterQuery ) {
 	}
 
 	const filter = { bool: { must: [] } };
-	if ( Array.isArray( filterQuery.postTypes ) && filterQuery.postTypes.length > 0 ) {
-		filterQuery.postTypes.forEach( postType => {
+	if ( Array.isArray( filterQuery.post_types ) && filterQuery.post_types.length > 0 ) {
+		filterQuery.post_types.forEach( postType => {
 			filter.bool.must.push( { term: { post_type: postType } } );
 		} );
 	}

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -48,6 +48,11 @@ function buildFilterObject( filterQuery ) {
 			filter.bool.must.push( { term: { post_type: postType } } );
 		} );
 	}
+	if ( Array.isArray( filterQuery.post_tag ) && filterQuery.post_tag.length > 0 ) {
+		filterQuery.post_tag.forEach( tag => {
+			filter.bool.must.push( { term: { 'tag.slug': tag } } );
+		} );
+	}
 	return filter;
 }
 

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -44,6 +44,8 @@ export function getFilterQuery( filterKey ) {
 	}
 
 	return {
+		category: getFilterQueryByKey( 'category' ),
+		post_tag: getFilterQueryByKey( 'post_tag' ),
 		post_types: getFilterQueryByKey( 'post_types' ),
 	};
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -44,7 +44,7 @@ export function getFilterQuery( filterKey ) {
 	}
 
 	return {
-		postTypes: getFilterQueryByKey( 'postTypes' ),
+		post_types: getFilterQueryByKey( 'post_types' ),
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This enables filtering search results via search widget checkboxes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes, this adds categories and tags filtering to Jetpack Instant Search.

#### Testing instructions:
* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and has Jetpack Search enabled.
* Add a Jetpack Search widget to the Search page sidebar.
* Add a tags filter to the Jetpack Search widget. Also, add a category filter to the Jetpack Search widget. 
* Enter a query into a search widget. Alternatively, navigate to a search page like `/?s=privacy`.
* Ensure that you can select a category filter checkbox. 
* Ensure that you can select a tag filter checkbox.

#### Proposed changelog entry for your changes:
No changelog necessary. Instant Search has not yet been released.