### PR TITLE
Connection: Deprecate Manager interface

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -14,7 +14,7 @@ use Automattic\Jetpack\Tracking;
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com
  * and Jetpack.
  */
-class Manager implements Manager_Interface {
+class Manager {
 
 	const SECRETS_MISSING        = 'secrets_missing';
 	const SECRETS_EXPIRED        = 'secrets_expired';

--- a/packages/connection/src/Manager_Interface.php
+++ b/packages/connection/src/Manager_Interface.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * The Jetpack Connection Interface file.
+ * No longer used.
  *
  * @package automattic/jetpack-connection
  */
@@ -8,111 +9,9 @@
 namespace Automattic\Jetpack\Connection;
 
 /**
- * The Connection interface class file.
+ * This interface is no longer used and is now deprecated.
  *
- * @package automattic/jetpack-connection
- */
-
-/**
- * The interface that the Connection class must inherit in order to be used for connecting
- * to WordPress.com
+ * @deprecated since 7.8
  */
 interface Manager_Interface {
-	/**
-	 * Returns true if the current site is connected to WordPress.com.
-	 *
-	 * @return Boolean is the site connected?
-	 */
-	public function is_active();
-
-	/**
-	 * Returns true if the user with the specified identifier is connected to
-	 * WordPress.com.
-	 *
-	 * @param Integer $user_id the user identifier.
-	 * @return Boolean is the user connected?
-	 */
-	public function is_user_connected( $user_id );
-
-	/**
-	 * Get the wpcom user data of the current|specified connected user.
-	 *
-	 * @param Integer $user_id the user identifier.
-	 * @return Object the user object.
-	 */
-	public function get_connected_user_data( $user_id );
-
-	/**
-	 * Is the user the connection owner.
-	 *
-	 * @param Integer $user_id the user identifier.
-	 * @return Boolean is the user the connection owner?
-	 */
-	public function is_connection_owner( $user_id );
-
-	/**
-	 * Unlinks the current user from the linked WordPress.com user.
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @param Integer $user_id the user identifier.
-	 * @return Boolean Whether the disconnection of the user was successful.
-	 */
-	public static function disconnect_user( $user_id );
-
-	/**
-	 * Attempts Jetpack registration which sets up the site for connection. Should
-	 * remain public because the call to action comes from the current site, not from
-	 * WordPress.com.
-	 *
-	 * @return Integer zero on success, or a bitmask on failure.
-	 */
-	public function register();
-
-	/**
-	 * Creates two secret tokens and the end of life timestamp for them.
-	 *
-	 * Note these tokens are unique per call, NOT static per site for connecting.
-	 *
-	 * @param String  $action  The action name.
-	 * @param Integer $user_id The user identifier.
-	 * @return array
-	 */
-	public function get_secrets( $action, $user_id );
-
-	/**
-	 * Responds to a WordPress.com call to register the current site.
-	 * Should be changed to protected.
-	 *
-	 * @param array $registration_data Array of [ secret_1, user_id ].
-	 */
-	public function handle_registration( array $registration_data );
-
-	/**
-	 * Responds to a WordPress.com call to authorize the current user.
-	 * Should be changed to protected.
-	 */
-	public function handle_authorization();
-
-	/**
-	 * Builds a URL to the Jetpack connection auth page.
-	 * This needs rethinking.
-	 *
-	 * @param bool        $raw If true, URL will not be escaped.
-	 * @param bool|string $redirect If true, will redirect back to Jetpack wp-admin landing page after connection.
-	 *                              If string, will be a custom redirect.
-	 * @param bool|string $from If not false, adds 'from=$from' param to the connect URL.
-	 * @param bool        $register If true, will generate a register URL regardless of the existing token, since 4.9.0.
-	 *
-	 * @return string Connect URL
-	 */
-	public function build_connect_url( $raw, $redirect, $from, $register );
-
-	/**
-	 * Disconnects from the Jetpack servers.
-	 * Forgets all connection details and tells the Jetpack servers to do the same.
-	 */
-	public function disconnect_site();
 }
-

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -21,11 +21,6 @@ class ManagerTest extends TestCase {
 		Mock::disableAll();
 	}
 
-	function test_class_implements_interface() {
-		$manager = new Manager();
-		$this->assertInstanceOf( 'Automattic\Jetpack\Connection\Manager_Interface', $manager );
-	}
-
 	/**
 	 * @covers Automattic\Jetpack\Connection\Manager::is_active
 	 */


### PR DESCRIPTION
The connection manager interface is no longer necessary. This PR deprecates it.

#### Changes proposed in this Pull Request:
* Connection: Deprecate Manager interface

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is just a janitorial PR.

#### Testing instructions:
* Verify connection and disconnection still work.
* Verify tests pass.

#### Proposed changelog entry for your changes:
* Connection: Deprecate Manager interface
