### PR TITLE
Premium blocks: Plan upgrade notif, show current plan.

### DIFF
--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -22,7 +22,7 @@ import { isSimpleSite } from './site-type-utils';
 function getPlanUrl() {
 	if ( undefined !== typeof window && window.location ) {
 		if ( isSimpleSite() ) {
-			return `https://wordpress.com/plans/my-plan/${ getSiteFragment().replace( '::', '/' ) }`;
+			return `https://wordpress.com/plans/my-plan/${ getSiteFragment() }`;
 		}
 		// Potentially a JP site may have a wordpress root: https//foo.com/custom/wp/root
 		// Unlikely, but technically also possible: https//foo.com/custom/wp/wp-admin/root

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -40,24 +40,25 @@ function getPlanUrl() {
 ( async () => {
 	if ( undefined !== typeof window && window.location ) {
 		const { query } = parseUrl( window.location.href, true );
+		let planName = null;
 
 		if ( query.plan_upgraded ) {
-			let planName = 'a paid plan';
-
-			updatePlanNameFromApi: try {
+			getPlanNameFromApi: try {
 				// not updating if simple site
 				if ( isSimpleSite() ) {
-					break updatePlanNameFromApi;
+					break getPlanNameFromApi;
 				}
 
 				const jetpackSiteInfo = await apiFetch( { path: '/jetpack/v4/site' } );
 				const data = JSON.parse( jetpackSiteInfo.data );
 
-				planName = `the ${ data.plan.product_name } plan`;
+				planName = data.plan.product_name;
 			} finally {
 				dispatch( 'core/notices' ).createNotice(
 					'success',
-					__( `Congratulations! Your site is now on ${ planName }.`, 'jetpack' ),
+					planName
+						? __( `Congratulations! Your site is now on the ${ planName } plan.`, 'jetpack' )
+						: __( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
 					{
 						isDismissible: true,
 						actions: [

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -8,6 +8,11 @@ import '@wordpress/notices';
 import { parse as parseUrl } from 'url';
 
 /**
+ * Internal dependencies
+ */
+import { getSiteFragment } from 'extensions/shared/get-site-fragment';
+
+/**
  * Shows a notification when a plan is marked as purchased
  * after redirection from WPCOM.
  */
@@ -16,11 +21,12 @@ if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		const planUrl = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
+		const planUrl = `https://wordpress.com/plans/my-plan/${ getSiteFragment() }`;
 
-		apiFetch( { path: '/jetpack/v4/site', parse: true } )
+		apiFetch( { path: '/jetpack/v4/site' } )
 			.then( response => {
-				const planName = response.data.plan.product_name;
+				const data = JSON.parse( response.data );
+				const planName = data.plan.product_name;
 
 				dispatch( 'core/notices' ).createNotice(
 					'success',

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -8,11 +8,6 @@ import '@wordpress/notices';
 import { parse as parseUrl } from 'url';
 
 /**
- * Internal dependencies
- */
-import { isSimpleSite } from './site-type-utils';
-
-/**
  * Shows a notification when a plan is marked as purchased
  * after redirection from WPCOM.
  */
@@ -21,15 +16,11 @@ if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		const path = isSimpleSite() ? `/rest/v1.2/sites/${ window.location.host }` : '/jetpack/v4/site';
+		const planUrl = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
 
-		// apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/rest/v1.2' ) );
-
-		apiFetch( { path } )
+		apiFetch( { path: '/jetpack/v4/site', parse: true } )
 			.then( response => {
-				const data = JSON.parse( response.data );
-				const planName = data.plan.product_name;
-				const planUrl = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
+				const planName = response.data.plan.product_name;
 
 				dispatch( 'core/notices' ).createNotice(
 					'success',
@@ -48,7 +39,16 @@ if ( undefined !== typeof window && window.location ) {
 			.catch( () => {
 				dispatch( 'core/notices' ).createNotice(
 					'success',
-					__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' )
+					__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
+					{
+						isDismissible: true,
+						actions: [
+							{
+								url: planUrl,
+								label: __( 'View my plan', 'jetpack' ),
+							},
+						],
+					}
 				);
 			} );
 	}

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -39,20 +39,9 @@ if ( undefined !== typeof window && window.location ) {
 				);
 			} )
 			.catch( () => {
-				const viewSitePlanlink = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
-
 				dispatch( 'core/notices' ).createNotice(
 					'success',
-					__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
-					{
-						isDismissible: true,
-						actions: [
-							{
-								url: viewSitePlanlink,
-								label: __( '[View my plan]', 'jetpack' ),
-							},
-						],
-					}
+					__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' )
 				);
 			} );
 	}

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -17,7 +17,7 @@ import { isSimpleSite } from './site-type-utils';
  * Returns a URL where the current site's plan can be viewed from.
  * [Relative to current domain for JP sites]
  *
- * @return {string} A URL where the current site plan is viewable.
+ * @return {string|null} A URL where the current site plan is viewable - null if not retrievable.
  */
 function getPlanUrl() {
 	if ( undefined !== typeof window && window.location ) {
@@ -31,6 +31,7 @@ function getPlanUrl() {
 			'/'
 		) }/wp-admin/admin.php?page=jetpack#/my-plan`;
 	}
+	return null;
 }
 
 /**

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -20,13 +20,9 @@ import { isSimpleSite } from './site-type-utils';
  * @return {string|null} A URL where the current site plan is viewable - null if not retrievable.
  */
 function getPlanUrl() {
-	if ( undefined !== typeof window && window.location ) {
-		const siteFragment = getSiteFragment();
+	const siteFragment = getSiteFragment();
 
-		if ( ! siteFragment ) {
-			return null;
-		}
-
+	if ( undefined !== typeof window && window.location && siteFragment ) {
 		if ( isSimpleSite() ) {
 			return `https://wordpress.com/plans/my-plan/${ siteFragment }`;
 		}

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -21,17 +21,14 @@ if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		const path = isSimpleSite() ? `sites/${ window.location.host }` : '/jetpack/v4/site';
+		const path = isSimpleSite() ? `/rest/v1.2/sites/${ window.location.host }` : '/jetpack/v4/site';
 
-		if ( isSimpleSite() ) {
-			apiFetch.use(
-				apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/rest/v1.2/' )
-			);
-		}
+		// apiFetch.use( apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/rest/v1.2' ) );
 
-		apiFetch( { path, parse: true } )
+		apiFetch( { path } )
 			.then( response => {
-				const planName = response.data.plan.product_name;
+				const data = JSON.parse( response.data );
+				const planName = data.plan.product_name;
 				const planUrl = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
 
 				dispatch( 'core/notices' ).createNotice(

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import '@wordpress/notices';
 import { parse as parseUrl } from 'url';
 
@@ -57,9 +57,13 @@ function getPlanUrl() {
 			} finally {
 				dispatch( 'core/notices' ).createNotice(
 					'success',
+					/* translators: %s is the plan name, such as Jetpack Premium. */
 					planName
-						? __( `Congratulations! Your site is now on the ${ planName } plan.`, 'jetpack' )
-						: __( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
+						? sprintf(
+								__( 'Congratulations! Your site is now on the %s plan.', 'jetpack' ),
+								planName
+						  )
+						: __( 'Congratulations! Your site is now on a paid plan.', 'jetpack' ),
 					{
 						isDismissible: true,
 						actions: [

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import '@wordpress/notices';
@@ -15,9 +16,44 @@ if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		dispatch( 'core/notices' ).createNotice(
-			'success',
-			__( 'Plan upgraded. You may use premium blocks now.', 'jetpack' )
-		);
+		const path = '/jetpack/v4/site';
+
+		apiFetch( { path } )
+			.then( response => {
+				const data = JSON.parse( response.data );
+				const productName = data.plan.product_name;
+				const viewSitePlanlink = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
+
+				dispatch( 'core/notices' ).createNotice(
+					'success',
+					__( `Congratulations! Your site is now on the ${ productName } plan.`, 'jetpack' ),
+					{
+						isDismissible: true,
+						actions: [
+							{
+								url: viewSitePlanlink,
+								label: __( 'View my plan', 'jetpack' ),
+							},
+						],
+					}
+				);
+			} )
+			.catch( () => {
+				const viewSitePlanlink = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
+
+				dispatch( 'core/notices' ).createNotice(
+					'success',
+					__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
+					{
+						isDismissible: true,
+						actions: [
+							{
+								url: viewSitePlanlink,
+								label: __( '[View my plan]', 'jetpack' ),
+							},
+						],
+					}
+				);
+			} );
 	}
 }

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -38,32 +38,15 @@ function getPlanUrl() {
 	}
 }
 
-if ( undefined !== typeof window && window.location ) {
-	const { query } = parseUrl( window.location.href, true );
+( function() {
+	if ( undefined !== typeof window && window.location ) {
+		const { query } = parseUrl( window.location.href, true );
 
-	if ( query.plan_upgraded ) {
-		const planUrl = getPlanUrl();
+		if ( query.plan_upgraded ) {
+			const planUrl = getPlanUrl();
 
-		apiFetch( { path: '/jetpack/v4/site' } )
-			.then( response => {
-				const data = JSON.parse( response.data );
-				const planName = data.plan.product_name;
-
-				dispatch( 'core/notices' ).createNotice(
-					'success',
-					__( `Congratulations! Your site is now on the ${ planName } plan.`, 'jetpack' ),
-					{
-						isDismissible: true,
-						actions: [
-							{
-								url: planUrl,
-								label: __( 'View my plan', 'jetpack' ),
-							},
-						],
-					}
-				);
-			} )
-			.catch( () => {
+			// Simple/WPCOM sites
+			if ( isSimpleSite() ) {
 				dispatch( 'core/notices' ).createNotice(
 					'success',
 					__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
@@ -77,6 +60,45 @@ if ( undefined !== typeof window && window.location ) {
 						],
 					}
 				);
-			} );
+
+				return;
+			}
+
+			// Self-hosted/Jetpack sites
+			apiFetch( { path: '/jetpack/v4/site' } )
+				.then( response => {
+					const data = JSON.parse( response.data );
+					const planName = data.plan.product_name;
+
+					dispatch( 'core/notices' ).createNotice(
+						'success',
+						__( `Congratulations! Your site is now on the ${ planName } plan.`, 'jetpack' ),
+						{
+							isDismissible: true,
+							actions: [
+								{
+									url: planUrl,
+									label: __( 'View my plan', 'jetpack' ),
+								},
+							],
+						}
+					);
+				} )
+				.catch( () => {
+					dispatch( 'core/notices' ).createNotice(
+						'success',
+						__( `Congratulations! Your site is now on a paid plan.`, 'jetpack' ),
+						{
+							isDismissible: true,
+							actions: [
+								{
+									url: planUrl,
+									label: __( 'View my plan', 'jetpack' ),
+								},
+							],
+						}
+					);
+				} );
+		}
 	}
-}
+} )();

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -59,6 +59,8 @@ function getPlanUrl() {
 
 				planName = data.plan.product_name;
 			} finally {
+				const planUrl = getPlanUrl();
+
 				dispatch( 'core/notices' ).createNotice(
 					'success',
 					/* translators: %s is the plan name, such as Jetpack Premium. */
@@ -70,12 +72,14 @@ function getPlanUrl() {
 						: __( 'Congratulations! Your site is now on a paid plan.', 'jetpack' ),
 					{
 						isDismissible: true,
-						actions: [
-							{
-								url: getPlanUrl(),
-								label: __( 'View my plan', 'jetpack' ),
-							},
-						],
+						...( planUrl && {
+							actions: [
+								{
+									url: getPlanUrl(),
+									label: __( 'View my plan', 'jetpack' ),
+								},
+							],
+						} ),
 					}
 				);
 			}

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -8,6 +8,11 @@ import '@wordpress/notices';
 import { parse as parseUrl } from 'url';
 
 /**
+ * Internal dependencies
+ */
+import { isSimpleSite } from './site-type-utils';
+
+/**
  * Shows a notification when a plan is marked as purchased
  * after redirection from WPCOM.
  */
@@ -16,22 +21,22 @@ if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		const path = '/jetpack/v4/site';
+		const path = isSimpleSite() ? `/sites/${ window.location.host }` : '/jetpack/v4/site';
 
 		apiFetch( { path } )
 			.then( response => {
 				const data = JSON.parse( response.data );
-				const productName = data.plan.product_name;
-				const viewSitePlanlink = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
+				const planName = data.plan.product_name;
+				const planUrl = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
 
 				dispatch( 'core/notices' ).createNotice(
 					'success',
-					__( `Congratulations! Your site is now on the ${ productName } plan.`, 'jetpack' ),
+					__( `Congratulations! Your site is now on the ${ planName } plan.`, 'jetpack' ),
 					{
 						isDismissible: true,
 						actions: [
 							{
-								url: viewSitePlanlink,
+								url: planUrl,
 								label: __( 'View my plan', 'jetpack' ),
 							},
 						],

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -53,7 +53,7 @@ function getPlanUrl() {
 				const jetpackSiteInfo = await apiFetch( { path: '/jetpack/v4/site' } );
 				const data = JSON.parse( jetpackSiteInfo.data );
 
-				planName = `the ${ data.plan.product_name } plan.`;
+				planName = `the ${ data.plan.product_name } plan`;
 			} finally {
 				dispatch( 'core/notices' ).createNotice(
 					'success',

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -21,12 +21,17 @@ if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		const path = isSimpleSite() ? `/sites/${ window.location.host }` : '/jetpack/v4/site';
+		const path = isSimpleSite() ? `sites/${ window.location.host }` : '/jetpack/v4/site';
 
-		apiFetch( { path } )
+		if ( isSimpleSite() ) {
+			apiFetch.use(
+				apiFetch.createRootURLMiddleware( 'https://public-api.wordpress.com/rest/v1.2/' )
+			);
+		}
+
+		apiFetch( { path, parse: true } )
 			.then( response => {
-				const data = JSON.parse( response.data );
-				const planName = data.plan.product_name;
+				const planName = response.data.plan.product_name;
 				const planUrl = `https://wordpress.com/plans/my-plan/${ window.location.host }`;
 
 				dispatch( 'core/notices' ).createNotice(

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -21,16 +21,24 @@ import { isSimpleSite } from './site-type-utils';
  */
 function getPlanUrl() {
 	if ( undefined !== typeof window && window.location ) {
-		if ( isSimpleSite() ) {
-			return `https://wordpress.com/plans/my-plan/${ getSiteFragment() }`;
+		const siteFragment = getSiteFragment();
+
+		if ( ! siteFragment ) {
+			return null;
 		}
+
+		if ( isSimpleSite() ) {
+			return `https://wordpress.com/plans/my-plan/${ siteFragment }`;
+		}
+
 		// Potentially a JP site may have a wordpress root: https//foo.com/custom/wp/root
 		// Unlikely, but technically also possible: https//foo.com/custom/wp/wp-admin/root
-		return `${ window.location.protocol }//${ getSiteFragment().replace(
+		return `${ window.location.protocol }//${ siteFragment.replace(
 			'::',
 			'/'
 		) }/wp-admin/admin.php?page=jetpack#/my-plan`;
 	}
+
 	return null;
 }
 

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -10,18 +10,39 @@ import { parse as parseUrl } from 'url';
 /**
  * Internal dependencies
  */
-import { getSiteFragment } from 'extensions/shared/get-site-fragment';
+import getSiteFragment from './get-site-fragment';
+import { isSimpleSite } from './site-type-utils';
 
 /**
  * Shows a notification when a plan is marked as purchased
  * after redirection from WPCOM.
  */
 
+/**
+ * Returns a URL where the current site's plan can be viewed from.
+ * [Relative to current domain for JP sites]
+ *
+ * @return {string} A URL where the current site plan is viewable.
+ */
+function getPlanUrl() {
+	if ( undefined !== typeof window && window.location ) {
+		if ( isSimpleSite() ) {
+			return `https://wordpress.com/plans/my-plan/${ getSiteFragment().replace( '::', '/' ) }`;
+		}
+		// Potentially a JP site may have a wordpress root: https//foo.com/custom/wp/root
+		// Unlikely, but technically also possible: https//foo.com/custom/wp/wp-admin/root
+		return `${ window.location.protocol }//${ getSiteFragment().replace(
+			'::',
+			'/'
+		) }/wp-admin/admin.php?page=jetpack#/my-plan`;
+	}
+}
+
 if ( undefined !== typeof window && window.location ) {
 	const { query } = parseUrl( window.location.href, true );
 
 	if ( query.plan_upgraded ) {
-		const planUrl = `https://wordpress.com/plans/my-plan/${ getSiteFragment() }`;
+		const planUrl = getPlanUrl();
 
 		apiFetch( { path: '/jetpack/v4/site' } )
 			.then( response => {

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -45,9 +45,10 @@ function getPlanUrl() {
 ( async () => {
 	if ( undefined !== typeof window && window.location ) {
 		const { query } = parseUrl( window.location.href, true );
-		let planName = null;
 
 		if ( query.plan_upgraded ) {
+			let planName = null;
+
 			getPlanNameFromApi: try {
 				// not updating if simple site
 				if ( isSimpleSite() ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13309

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the current plan to the notification shown when user upgraded and redirected back to editor.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Existing

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Currently only really functional for jetpack sites.

* Go to `http://chriskmnds.eu.ngrok.io/wp-admin/post.php?post=1&action=edit&plan_upgraded=1` (jetpack site on Jetpack Free)
* Observe that the notification shown looks like this:

<img width="1680" alt="Screenshot 2019-09-23 at 4 05 06 PM" src="https://user-images.githubusercontent.com/1705499/65427973-2a33d000-de1c-11e9-9562-28d2cfe4e96d.png">

* For anything else, including network errors, the notification should look like:

<img width="1680" alt="Screenshot 2019-09-23 at 4 08 35 PM" src="https://user-images.githubusercontent.com/1705499/65428110-6ebf6b80-de1c-11e9-8c46-0ce40bdcb6ac.png">

#### TODO:

- [x]  Get the simple/wpcom site link and plan shown.
