### PR TITLE
Moves unreachable code to where it would be run.

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -77,6 +77,8 @@ class Manager {
 		$is_signed,
 		\Jetpack_XMLRPC_Server $xmlrpc_server = null
 	) {
+		add_filter( 'xmlrpc_blog_options', array( $this, 'xmlrpc_options' ), 1000, 2 );
+
 		if (
 			! isset( $request_params['for'] )
 			|| 'jetpack' !== $request_params['for']
@@ -137,8 +139,6 @@ class Manager {
 			}
 		}
 
-		add_filter( 'xmlrpc_blog_options', array( $this, 'xmlrpc_options' ) );
-
 		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
 		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
@@ -146,7 +146,6 @@ class Manager {
 
 		// Now that no one can authenticate, and we're whitelisting all XML-RPC methods, force enable_xmlrpc on.
 		add_filter( 'pre_option_enable_xmlrpc', '__return_true' );
-
 		return true;
 	}
 


### PR DESCRIPTION
After being refactored, the filter line has become unreachable for cases when an XMLRPC is made to a regular WordPress endpoint, without using the  query parameter. This change moves the line back to a reachable place so that Jetpack can add additional parameters to an XMLRPC  request.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moved a line of code to where it would be reachable in a regular XMLRPC request.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Issue a regular XMLRPC `getOptions` call to your test site with Jetpack installed but not connected. You can use `curl` for that, thanks @planarvoid for [the request command](https://gist.github.com/zinigor/b7320a3eb28e4a7d7e2c4ebb77fc01be#file-gistfile1-txt). Make sure to edit the command with your site URL, user name and password.
* See that the `jetpack_client_id` is not returned as part of the response.
* Use this PR.
* See that the `jetpack_client_id` is now present and set to 0.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed a regression in regular XMLRPC requests with Jetpack enabled.
