### PR TITLE
Apply calypso_env URL param to iframe login URL

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -56,8 +56,16 @@ jQuery( document ).ready( function( $ ) {
 			loadingText.text( jpConnect.buttonTextRegistering );
 			loadingText.appendTo( '.jp-connect-full__button-container' );
 
+			var registerUrl = jpConnect.apiBaseUrl + '/connection/register';
+
+			// detect Calypso Env and add to API URL
+			if ( window.Initial_State && window.Initial_State.calypsoEnv ) {
+				registerUrl =
+					registerUrl + '?' + $.param( { calypso_env: window.Initial_State.calypsoEnv } );
+			}
+
 			$.ajax( {
-				url: jpConnect.apiBaseUrl + '/connection/register',
+				url: registerUrl,
 				type: 'POST',
 				data: {
 					registration_nonce: jpConnect.registrationNonce,

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -296,7 +296,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'tracksUserData' => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'currentIp' => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false,
 			'lastPostUrl' => esc_url( $last_post ),
-			'externalServicesConnectUrls' => $this->get_external_services_connect_urls()
+			'externalServicesConnectUrls' => $this->get_external_services_connect_urls(),
+			'calypsoEnv' => Jetpack::get_calypso_env(),
 		);
 	}
 


### PR DESCRIPTION
Fixes an issue where appending `&calypso_env=development` to a Jetpack wp-admin URL would not use this Calypso environment for the wp-admin login flow.

`define( 'CALYPSO_ENV', 'development' );` currently works, so alternatively we could just stop supporting the URL parameter for setting the environment, if other folks aren't using it?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add calypso_env parameter to the `/connection/register` Jetpack endpoint, so that generated authorization URLs include the `calypso_env` param

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Modifies debugging/development code

#### Testing instructions:
* Ensure you are logged out of wordpress.com (e.g. in an incognito window)
* On an unconnected Jetpack, with `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`, head to the Jetpack->Dashboard link
* Add `calypso_env=development` to the URL params and reload the page
* Go through the connection flow
* Note that Calypso URLs start with "calypso.localhost:3000"
