### PR TITLE
Twenty Twenty: Ensure full compatibility with upcoming default theme

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -24,6 +24,7 @@ module.exports = [
 	'modules/sharedaddy.php',
 	'modules/shortcodes/',
 	'modules/sitemaps/sitemaps.php',
+	'modules/theme-tools/compat/twentytwenty.php',
 	'modules/theme-tools/social-menu/',
 	'modules/verification-tools.php',
 	'modules/widgets/contact-info.php',

--- a/modules/theme-tools.php
+++ b/modules/theme-tools.php
@@ -34,13 +34,17 @@ function jetpack_load_theme_compat() {
 	 *
 	 * @param array Associative array of theme compat files to load.
 	 */
-	$compat_files = apply_filters( 'jetpack_theme_compat_files', array(
-		'twentyfourteen'   => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfourteen.php',
-		'twentyfifteen'    => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfifteen.php',
-		'twentysixteen'    => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentysixteen.php',
-		'twentyseventeen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyseventeen.php',
-		'twentynineteen'   => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentynineteen.php',
-	) );
+	$compat_files = apply_filters(
+		'jetpack_theme_compat_files',
+		array(
+			'twentyfourteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfourteen.php',
+			'twentyfifteen'   => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyfifteen.php',
+			'twentysixteen'   => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentysixteen.php',
+			'twentyseventeen' => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentyseventeen.php',
+			'twentynineteen'  => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentynineteen.php',
+			'twentytwenty'    => JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentytwenty.php',
+		)
+	);
 
 	_jetpack_require_compat_file( get_stylesheet(), $compat_files );
 

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -1,4 +1,6 @@
-/* Infinite scroll */
+/**
+ * Infinite scroll
+ */
 
 /* Globally hidden elements when Infinite Scroll is supported and in use. */
 .infinite-scroll .pagination-wrapper,
@@ -67,3 +69,28 @@
 #site-content .infinite-wrap .hentry:first-of-type {
 	padding: 4rem 0 0;
 }
+
+/**
+ * Sharing
+ */
+
+.entry-content div.sharedaddy h3.sd-title,
+.entry-content h3.sd-title {
+	color: #6d6d6d;
+	font-size: 1.6rem;
+	font-weight: 500;
+	letter-spacing: -0.016875em;
+	line-height: 1.5;
+}
+
+.entry-content div.sharedaddy h3.sd-title:before,
+.entry-content h3.sd-title:before {
+	border: 0 none;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font: normal 18px/1 'social-logos';
+	content:"\f415";
+	display: inline;
+	margin-right: 1rem;
+}
+

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -86,11 +86,4 @@
 .entry-content div.sharedaddy h3.sd-title:before,
 .entry-content h3.sd-title:before {
 	border: 0 none;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	font: normal 18px/1 'social-logos';
-	content:"\f415";
-	display: inline;
-	margin-right: 1rem;
 }
-

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -1,0 +1,69 @@
+/* Infinite scroll */
+
+/* Globally hidden elements when Infinite Scroll is supported and in use. */
+.infinite-scroll .pagination-wrapper,
+.infinite-scroll.neverending .footer-nav-widgets-wrapper,
+.infinite-scroll.neverending #site-footer {
+	/* Theme Footer (when set to scrolling) */
+	display: none;
+}
+
+ /* When Infinite Scroll has reached its end we need to re-display elements that were hidden (via .neverending) before. */
+.infinite-end.neverending .footer-nav-widgets-wrapper,
+.infinity-end.neverending #site-footer {
+	display: block;
+}
+
+.infinite-loader {
+	margin: calc(3 * 1rem) auto;
+}
+
+.infinite-loader .spinner {
+	margin: 0 auto;
+	left: inherit !important;
+}
+
+#site-content #infinite-handle {
+	margin: 0 auto;
+	max-width: 58rem;
+	width: calc(100% - 8rem);
+}
+
+#site-content #infinite-handle span {
+	background: transparent;
+	display: block;
+	font-size: 1.7rem;
+	text-align: center;
+}
+
+#site-content #infinite-handle span button,
+#site-content #infinite-handle span button:hover,
+#site-content #infinite-handle span button:focus {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	background: #cd2653;
+	border: none;
+	border-radius: 0;
+	color: #fff;
+	cursor: pointer;
+	display: inline-block;
+	font-size: 1.5rem;
+	font-weight: 600;
+	letter-spacing: 0.0333em;
+	line-height: 1.25;
+	margin: 0;
+	opacity: 1;
+	padding: 1.1em 1.44em;
+	text-align: center;
+	text-decoration: none;
+	text-transform: uppercase;
+	transition: opacity 0.15s linear;
+}
+
+#site-content #infinite-handle span button:hover {
+	text-decoration: underline;
+}
+
+#site-content .infinite-wrap .hentry:first-of-type {
+	padding: 4rem 0 0;
+}

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -71,11 +71,12 @@
 }
 
 /**
- * Sharing
+ * Sharing & Related Posts
  */
 
 .entry-content div.sharedaddy h3.sd-title,
-.entry-content h3.sd-title {
+.entry-content h3.sd-title,
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
 	color: #6d6d6d;
 	font-size: 1.6rem;
 	font-weight: 500;
@@ -86,4 +87,12 @@
 .entry-content div.sharedaddy h3.sd-title:before,
 .entry-content h3.sd-title:before {
 	border: 0 none;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline em:before {
+	border: 0 none;
+}
+
+.entry-content #jp-relatedposts h3.jp-relatedposts-headline em {
+	font-weight: 500;
 }

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -96,3 +96,21 @@
 .entry-content #jp-relatedposts h3.jp-relatedposts-headline em {
 	font-weight: 500;
 }
+
+/* EU cookie law */
+.widget_eu_cookie_law_widget #eu-cookie-law,
+.widget_eu_cookie_law_widget #eu-cookie-law .accept {
+	font-size: 1.8rem;
+    font-weight: 500;
+}
+
+.widget_eu_cookie_law_widget #eu-cookie-law .accept {
+	font-size: 1.5rem;
+	font-weight: 600;
+	letter-spacing: 0.0333em;
+	line-height: 1.25;
+	padding: 1.1em 1.44em;
+	text-decoration: none;
+	text-transform: uppercase;
+	transition: opacity 0.15s linear;
+}

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -97,6 +97,20 @@
 	font-weight: 500;
 }
 
+/* Authors widget */
+.widget_authors ul {
+	margin-left: 0;
+}
+
+.widget_authors li {
+	margin-top: 1rem;
+	list-style: none;
+}
+
+.widget_authors li:first-child {
+    margin-top: 2rem;
+}
+
 /* EU cookie law */
 .widget_eu_cookie_law_widget #eu-cookie-law,
 .widget_eu_cookie_law_widget #eu-cookie-law .accept {

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -108,14 +108,14 @@
 }
 
 .widget_authors li:first-child {
-    margin-top: 2rem;
+	margin-top: 2rem;
 }
 
 /* EU cookie law */
 .widget_eu_cookie_law_widget #eu-cookie-law,
 .widget_eu_cookie_law_widget #eu-cookie-law .accept {
 	font-size: 1.8rem;
-    font-weight: 500;
+	font-weight: 500;
 }
 
 .widget_eu_cookie_law_widget #eu-cookie-law .accept {

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -77,10 +77,18 @@
 .entry-content div.sharedaddy h3.sd-title,
 .entry-content h3.sd-title,
 .entry-content #jp-relatedposts h3.jp-relatedposts-headline {
-	font-size: 4rem;
+	font-size: 2.8rem;
 	font-weight: 700;
 	letter-spacing: -0.016875em;
 	line-height: 1.5;
+}
+
+@media (min-width: 700px) {
+	.entry-content div.sharedaddy h3.sd-title,
+	.entry-content h3.sd-title,
+	.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+		font-size: 4rem;
+	}
 }
 
 .entry-content div.sharedaddy h3.sd-title:before,
@@ -147,4 +155,9 @@
 #jp-relatedposts#jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
 	font-size: inherit;
 	line-height: 1.5;
+}
+
+/* Related Posts Block */
+.jp-related-posts-i2__post li {
+	margin: 0;
 }

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -111,12 +111,13 @@
 /* EU cookie law */
 .widget_eu_cookie_law_widget #eu-cookie-law,
 .widget_eu_cookie_law_widget #eu-cookie-law .accept {
-	font-size: 1.8rem;
+	font-size: 1.6rem;
 	font-weight: 500;
+	padding: 2rem;
 }
 
 .widget_eu_cookie_law_widget #eu-cookie-law .accept {
-	font-size: 1.5rem;
+	font-size: 1.4rem;
 	font-weight: 600;
 	letter-spacing: 0.0333em;
 	line-height: 1.25;
@@ -124,4 +125,20 @@
 	text-decoration: none;
 	text-transform: uppercase;
 	transition: opacity 0.15s linear;
+}
+
+@media (max-width: 600px) {
+	.widget_eu_cookie_law_widget #eu-cookie-law {
+		font-size: 1.4rem;
+		padding: 1.5rem 1.5rem 6.5rem;
+	}
+
+	.widget_eu_cookie_law_widget #eu-cookie-law .accept {
+		font-size: 1.2rem;
+		bottom: 1.5rem;
+		right: auto;
+		left: 1.5rem;
+		padding: 1rem;
+		margin: 0;
+	}
 }

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -44,7 +44,9 @@
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	border: none;
+	background: #cd2653;
 	border-radius: 0;
+	color: #fff;
 	cursor: pointer;
 	display: inline-block;
 	font-size: 1.5rem;
@@ -75,6 +77,7 @@
 .entry-content div.sharedaddy h3.sd-title,
 .entry-content h3.sd-title,
 .entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+	color: #6d6d6d;
 	font-size: 1.6rem;
 	font-weight: 500;
 	letter-spacing: -0.016875em;

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -43,10 +43,8 @@
 #site-content #infinite-handle span button:focus {
 	-webkit-appearance: none;
 	-moz-appearance: none;
-	background: #cd2653;
 	border: none;
 	border-radius: 0;
-	color: #fff;
 	cursor: pointer;
 	display: inline-block;
 	font-size: 1.5rem;
@@ -77,7 +75,6 @@
 .entry-content div.sharedaddy h3.sd-title,
 .entry-content h3.sd-title,
 .entry-content #jp-relatedposts h3.jp-relatedposts-headline {
-	color: #6d6d6d;
 	font-size: 1.6rem;
 	font-weight: 500;
 	letter-spacing: -0.016875em;

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -77,9 +77,8 @@
 .entry-content div.sharedaddy h3.sd-title,
 .entry-content h3.sd-title,
 .entry-content #jp-relatedposts h3.jp-relatedposts-headline {
-	color: #6d6d6d;
-	font-size: 1.6rem;
-	font-weight: 500;
+	font-size: 4rem;
+	font-weight: 700;
 	letter-spacing: -0.016875em;
 	line-height: 1.5;
 }
@@ -91,10 +90,6 @@
 
 .entry-content #jp-relatedposts h3.jp-relatedposts-headline em:before {
 	border: 0 none;
-}
-
-.entry-content #jp-relatedposts h3.jp-relatedposts-headline em {
-	font-weight: 500;
 }
 
 /* Authors widget */
@@ -144,4 +139,12 @@
 		padding: 1rem;
 		margin: 0;
 	}
+}
+
+/* Related Posts */
+
+#jp-relatedposts#jp-relatedposts .jp-relatedposts-items p,
+#jp-relatedposts#jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
+	font-size: inherit;
+	line-height: 1.5;
 }

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -40,8 +40,9 @@ add_action( 'after_setup_theme', 'twentytwenty_jetpack_setup' );
  */
 function twentytwenty_infinite_scroll_render() {
 	while ( have_posts() ) {
+		echo '<hr class="post-separator styled-separator is-style-wide section-inner" aria-hidden="true" />';
 		the_post();
-		get_template_part( 'template-parts/content' );
+		get_template_part( 'template-parts/content', get_post_type() );
 	}
 }
 

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Jetpack Compatibility File
+ * See: https://jetpack.com/
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Add Jetpack extra functionality to Twenty Twenty.
+ */
+function twentytwenty_jetpack_setup() {
+	/**
+	 * Add theme support for Infinite Scroll.
+	 */
+	add_theme_support(
+		'infinite-scroll',
+		array(
+			'type'      => 'click',
+			'container' => 'main',
+			'render'    => 'twentytwenty_infinite_scroll_render',
+			'footer'    => 'page',
+		)
+	);
+
+	/**
+	 * Add theme support for Responsive Videos.
+	 */
+	add_theme_support( 'jetpack-responsive-videos' );
+
+	/**
+	 * Add theme support for geo-location.
+	 */
+	add_theme_support( 'jetpack-geo-location' );
+}
+add_action( 'after_setup_theme', 'twentytwenty_jetpack_setup' );
+
+/**
+ * Custom render function for Infinite Scroll.
+ */
+function twentytwenty_infinite_scroll_render() {
+	while ( have_posts() ) {
+		the_post();
+		get_template_part( 'template-parts/content' );
+	}
+}
+
+/**
+ * Remove Sharing buttons and Likes from excerpts that are used as intro on single post views.
+ */
+function twentytwenty_no_sharing_on_excerpts() {
+	if ( is_single() ) {
+		// Remove sharing buttons.
+		remove_filter( 'the_excerpt', 'sharing_display', 19 );
+
+		// Remove Likes.
+		if ( class_exists( 'Jetpack_Likes' ) ) {
+			remove_filter( 'the_excerpt', array( Jetpack_Likes::init(), 'post_likes' ), 30, 1 );
+		}
+	}
+}
+add_action( 'loop_start', 'twentytwenty_no_sharing_on_excerpts' );
+
+/**
+ * Disable Ads in post excerpts, that are used as intro on single post views.
+ */
+add_filter( 'wordads_excerpt_disable', '__return_true' );
+
+/**
+ * Add our compat CSS file for Infinite Scroll and custom widget stylings and such.
+ * Set the version equal to filemtime for development builds, and the JETPACK__VERSION for production
+ * or skip it entirely for wpcom.
+ */
+function twentytwenty_enqueue_jetpack_style() {
+	$version = Jetpack::is_development_version()
+		? filemtime( JETPACK__PLUGIN_DIR . 'modules/theme-tools/compat/twentytwenty.css' )
+		: JETPACK__VERSION;
+
+	wp_enqueue_style( 'twentytwenty-jetpack', plugins_url( 'twentytwenty.css', __FILE__ ), array(), $version );
+	wp_style_add_data( 'twentytwenty-jetpack', 'rtl', 'replace' );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwenty_enqueue_jetpack_style' );
+

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -17,9 +17,9 @@ function twentytwenty_jetpack_setup() {
 		'infinite-scroll',
 		array(
 			'type'      => 'click',
-			'container' => 'main',
+			'container' => 'site-content',
 			'render'    => 'twentytwenty_infinite_scroll_render',
-			'footer'    => 'page',
+			'footer'    => 'site-content',
 		)
 	);
 

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -63,6 +63,22 @@ function twentytwenty_no_sharing_on_excerpts() {
 add_action( 'loop_start', 'twentytwenty_no_sharing_on_excerpts' );
 
 /**
+ * We do not need to display the Likes Heading here.
+ *
+ * @param string $heading Headline structure.
+ * @param string $title   Title.
+ * @param string $module  Module name.
+ */
+function twentytwenty_no_likes_heading( $heading, $title, $module ) {
+	if ( 'likes' === $module ) {
+		return '';
+	}
+
+	return $heading;
+}
+add_filter( 'jetpack_sharing_headline_html', 'twentytwenty_no_likes_heading', 10, 3 );
+
+/**
  * Disable Ads in post excerpts, that are used as intro on single post views.
  */
 add_filter( 'wordads_excerpt_disable', '__return_true' );

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -24,11 +24,6 @@ function twentytwenty_jetpack_setup() {
 	);
 
 	/**
-	 * Add theme support for Responsive Videos.
-	 */
-	add_theme_support( 'jetpack-responsive-videos' );
-
-	/**
 	 * Add theme support for geo-location.
 	 */
 	add_theme_support( 'jetpack-geo-location' );

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -99,14 +99,13 @@ add_action( 'wp_enqueue_scripts', 'twentytwenty_enqueue_jetpack_style' );
 function twentytwenty_infinity_accent_color_css() {
 	// Bail early if no custom color was set.
 	if (
-		! 'custom' === get_theme_mod( 'accent_hue_active' )
+		'custom' !== get_theme_mod( 'accent_hue_active' )
 		|| empty( get_theme_mod( 'accent_accessible_colors' ) )
 	) {
 		return;
 	}
 
 	$color_info = get_theme_mod( 'accent_accessible_colors' );
-
 	$custom_css = sprintf(
 		'
 		.infinite-scroll #site-content #infinite-handle span button,

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -109,15 +109,15 @@ function twentytwenty_infinity_accent_color_css() {
 
 	$custom_css = sprintf(
 		'
-		#site-content #infinite-handle span button,
-		#site-content #infinite-handle span button:hover,
-		#site-content #infinite-handle span button:focus {
+		.infinite-scroll #site-content #infinite-handle span button,
+		.infinite-scroll #site-content #infinite-handle span button:hover,
+		.infinite-scroll #site-content #infinite-handle span button:focus {
 			background: %1$s;
 			color: %2$s;
 		}
-		.entry-content div.sharedaddy h3.sd-title,
-		.entry-content h3.sd-title,
-		.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+		#site-content .entry-content div.sharedaddy h3.sd-title,
+		#site-content .entry-content h3.sd-title,
+		#site-content .entry-content #jp-relatedposts h3.jp-relatedposts-headline {
 			color: %3$s;
 		}
 		',

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -93,3 +93,41 @@ function twentytwenty_enqueue_jetpack_style() {
 }
 add_action( 'wp_enqueue_scripts', 'twentytwenty_enqueue_jetpack_style' );
 
+/**
+ * Add inline custom CSS with custom accent color if there is any set.
+ */
+function twentytwenty_infinity_accent_color_css() {
+	// Bail early if no custom color was set.
+	if (
+		! 'custom' === get_theme_mod( 'accent_hue_active' )
+		|| empty( get_theme_mod( 'accent_accessible_colors' ) )
+	) {
+		return;
+	}
+
+	$color_info = get_theme_mod( 'accent_accessible_colors' );
+
+	$custom_css = sprintf(
+		'
+		#site-content #infinite-handle span button,
+		#site-content #infinite-handle span button:hover,
+		#site-content #infinite-handle span button:focus {
+			background: %1$s;
+			color: %2$s;
+		}
+		.entry-content div.sharedaddy h3.sd-title,
+		.entry-content h3.sd-title,
+		.entry-content #jp-relatedposts h3.jp-relatedposts-headline {
+			color: %3$s;
+		}
+		',
+		$color_info['content']['accent'],
+		$color_info['content']['background'],
+		$color_info['content']['secondary']
+	);
+
+	// Add our custom style to the existing Twenty Twenty CSS compat file.
+	wp_add_inline_style( 'twentytwenty-jetpack', $custom_css );
+}
+add_action( 'wp_enqueue_scripts', 'twentytwenty_infinity_accent_color_css' );
+

--- a/tools/builder/frontend-css.js
+++ b/tools/builder/frontend-css.js
@@ -64,6 +64,7 @@ const separate_list = [
 	'modules/shortcodes/css/recipes-print.css',
 	'modules/tiled-gallery/tiled-gallery/tiled-gallery.css',
 	'modules/theme-tools/compat/twentynineteen.css',
+	'modules/theme-tools/compat/twentytwenty.css',
 ];
 
 const cwd = process.cwd() + '/';


### PR DESCRIPTION
Fixes #13511, #13718

#### Changes proposed in this Pull Request:

* This PR adds a set of compat files to make sure Jetpack is fully compatible with the future WordPress default theme.

This will then be ported to WordPress.com in D33027-code.

Still to do / check

- [x] Authors Widget
- [x] RSS widget
- [x] Jetpack Search Widget
- [x] Review other widgets
- [x] Review existing CSS in https://github.com/Automattic/jetpack/blob/3a18e3fa5485281dc41aa33fa7c2f891000d195c/modules/theme-tools/compat/twentytwenty.css

#### Testing instructions:

* Enable the Twenty Twenty Theme on your site. https://github.com/wordpress/twentytwenty
(You'll want to clone the repo, or download a zip, unzip it, remove `-master` from the unzipped directory, rezip it, and upload it to your site).
* Make sure it behaves properly, with all Jetpack features on and when using lots of widgets

#### Proposed changelog entry for your changes:

* Twenty Twenty: Ensure full compatibility with upcoming default theme
