### PR TITLE
Core XML-RPC: Add test for extensions to wp.getOptions

### DIFF
--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1160,4 +1160,15 @@ EXPECTED;
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}
 
+	/**
+	 * https://github.com/Automattic/jetpack/pull/13514
+	 *
+	 * @group xmlrpc
+	 */
+	public function test_wp_getOptions_hook_in_place() {
+		$options = apply_filters( 'xmlrpc_blog_options', array() );
+
+		$this->assertArrayHasKey( 'jetpack_version', $options );
+	}
+
 } // end class


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/13514

#### Changes proposed in this Pull Request:
Tests that `Manager::xmlrpc_options()` has been attached to core's `xmlrpc_blog_options` filter.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: Bug fix.

#### Testing instructions:
1. Check out this PR.
2. `git reset --hard c6672042e438ea5c10d4d5d46863ae7367e71e52` (to set your git clone's HEAD to just before https://github.com/Automattic/jetpack/pull/13514)
3. `git cherry-pick 64ac751cf199b0d76b21401943c1de5481023b19` (to bring in this PR's one commit).
4. `phpunit --group=xmlrpc --filter=WP_Test_Jetpack::`
5. See that the tests fail for the old code.
6. `git reset --hard c6672042e438ea5c10d4d5d46863ae7367e71e52 && git pull` (to set your git clone's HEAD back to this PR, which includes https://github.com/Automattic/jetpack/pull/13514).
7. `phpunit --group=xmlrpc --filter=WP_Test_Jetpack::`
8. See that the tests pass for the new code from https://github.com/Automattic/jetpack/pull/13514.

#### Proposed changelog entry for your changes:
* Improves testing of Jetpack's extensions to Core's XML-RPC methods.