### PR TITLE
WP 5.3: Use modern wp_timezone

### DIFF
--- a/_inc/lib/icalendar-reader.php
+++ b/_inc/lib/icalendar-reader.php
@@ -90,17 +90,7 @@ class iCalendarReader {
 		}
 
 		// get timezone offset from the timezone name.
-		$timezone_name = get_option( 'timezone_string' );
-		if ( $timezone_name ) {
-			$timezone = new DateTimeZone( $timezone_name );
-			$timezone_offset_interval = false;
-		} else {
-			// If the timezone isn't set then the GMT offset must be set.
-			// generate a DateInterval object from the timezone offset
-			$gmt_offset = get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
-			$timezone_offset_interval = date_interval_create_from_date_string( "{$gmt_offset} seconds" );
-			$timezone = new DateTimeZone( 'UTC' );
-		}
+		$timezone = wp_timezone();
 
 		$offsetted_events = array();
 
@@ -114,11 +104,6 @@ class iCalendarReader {
 				$end_time = preg_replace( '/Z$/', '', $event['DTEND'] );
 				$end_time = new DateTime( $end_time, $this->timezone );
 				$end_time->setTimeZone( $timezone );
-
-				if ( $timezone_offset_interval ) {
-					$start_time->add( $timezone_offset_interval );
-					$end_time->add( $timezone_offset_interval );
-				}
 
 				$event['DTSTART'] = $start_time->format( 'YmdHis\Z' );
 				$event['DTEND'] = $end_time->format( 'YmdHis\Z' );

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1543,7 +1543,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 			// Check if it's already localized. Can't just check is_localtime because date_parse('oppossum') returns true; WTF, PHP.
 			if ( isset( $date_string_info['zone'] ) && true === $date_string_info['is_localtime'] ) {
 				$dt_utc   = new DateTime( $date_string );
-				$dt_local = $dt_utc;
+				$dt_local = clone $dt_utc;
 				$dt_utc->setTimezone( new DateTimeZone( 'UTC' ) );
 				return array(
 					(string) $dt_local->format( 'Y-m-d H:i:s' ),
@@ -1553,11 +1553,11 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 			// It's parseable but no TZ info so assume UTC.
 			$dt_utc   = new DateTime( $date_string, new DateTimeZone( 'UTC' ) );
-			$dt_local = new DateTime( $date_string, new DateTimeZone( 'UTC' ) );
+			$dt_local = clone $dt_utc;
 		} else {
 			// Could not parse time, use now in UTC.
 			$dt_utc   = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
-			$dt_local = $dt_utc;
+			$dt_local = clone $dt_utc;
 		}
 
 		$dt_local->setTimezone( wp_timezone() );

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1533,16 +1533,17 @@ abstract class WPCOM_JSON_API_Endpoint {
 	 * relative to now and will convert it to local time using either the
 	 * timezone set in the options table for the blog or the GMT offset.
 	 *
-	 * @param datetime string
+	 * @param datetime string $date_string Date to parse.
 	 *
 	 * @return array( $local_time_string, $gmt_time_string )
 	 */
-	function parse_date( $date_string ) {
+	public function parse_date( $date_string ) {
 		$date_string_info = date_parse( $date_string );
 		if ( is_array( $date_string_info ) && 0 === $date_string_info['error_count'] ) {
 			// Check if it's already localized. Can't just check is_localtime because date_parse('oppossum') returns true; WTF, PHP.
 			if ( isset( $date_string_info['zone'] ) && true === $date_string_info['is_localtime'] ) {
-				$dt_local = clone $dt_utc = new DateTime( $date_string );
+				$dt_utc   = new DateTime( $date_string );
+				$dt_local = $dt_utc;
 				$dt_utc->setTimezone( new DateTimeZone( 'UTC' ) );
 				return array(
 					(string) $dt_local->format( 'Y-m-d H:i:s' ),
@@ -1550,11 +1551,13 @@ abstract class WPCOM_JSON_API_Endpoint {
 				);
 			}
 
-			// It's parseable but no TZ info so assume UTC
-			$dt_local = clone $dt_utc = new DateTime( $date_string, new DateTimeZone( 'UTC' ) );
+			// It's parseable but no TZ info so assume UTC.
+			$dt_utc   = new DateTime( $date_string, new DateTimeZone( 'UTC' ) );
+			$dt_local = new DateTime( $date_string, new DateTimeZone( 'UTC' ) );
 		} else {
-			// Could not parse time, use now in UTC
-			$dt_local = clone $dt_utc = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			// Could not parse time, use now in UTC.
+			$dt_utc   = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+			$dt_local = $dt_utc;
 		}
 
 		$dt_local->setTimezone( wp_timezone() );
@@ -1562,7 +1565,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		return array(
 			(string) $dt_local->format( 'Y-m-d H:i:s' ),
 			(string) $dt_utc->format( 'Y-m-d H:i:s' ),
-			);
+		);
 	}
 
 	// Load the functions.php file for the current theme to get its post formats, CPTs, etc.

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1557,27 +1557,12 @@ abstract class WPCOM_JSON_API_Endpoint {
 			$dt_local = clone $dt_utc = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		}
 
-		// First try to use timezone as it's daylight savings aware.
-		$timezone_string = get_option( 'timezone_string' );
-		if ( $timezone_string ) {
-			$tz = timezone_open( $timezone_string );
-			if ( $tz ) {
-				$dt_local->setTimezone( $tz );
-				return array(
-					(string) $dt_local->format( 'Y-m-d H:i:s' ),
-					(string) $dt_utc->format( 'Y-m-d H:i:s' ),
-				);
-			}
-		}
+		$dt_local->setTimezone( wp_timezone() );
 
-		// Fallback to GMT offset (in hours)
-		// NOTE: TZ of $dt_local is still UTC, we simply modified the timestamp with an offset.
-		$gmt_offset_seconds = intval( get_option( 'gmt_offset' ) * 3600 );
-		$dt_local->modify( "+{$gmt_offset_seconds} seconds" );
 		return array(
 			(string) $dt_local->format( 'Y-m-d H:i:s' ),
 			(string) $dt_utc->format( 'Y-m-d H:i:s' ),
-		);
+			);
 	}
 
 	// Load the functions.php file for the current theme to get its post formats, CPTs, etc.

--- a/functions.global.php
+++ b/functions.global.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! function_exists( wp_timezone ) ) {
+if ( ! function_exists( 'wp_timezone' ) ) {
 	/**
 	 * Shim for WordPress 5.3's wp_timezone() function.
 	 *

--- a/functions.global.php
+++ b/functions.global.php
@@ -19,6 +19,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! function_exists( wp_timezone ) ) {
+	/**
+	 * Shim for WordPress 5.3's wp_timezone() function.
+	 *
+	 * This is a mix of wp_timezone(), which calls wp_timezone_string().
+	 * We don't need both in Jetpack, so providing only one function.
+	 *
+	 * @since 7.9.0
+	 * @todo Remove when WP 5.3 is Jetpack's minimum
+	 *
+	 * @return DateTimeZone Site's DateTimeZone
+	 */
+	function wp_timezone() {
+		$timezone_string = get_option( 'timezone_string' );
+
+		if ( $timezone_string ) {
+			return new DateTimeZone( $timezone_string );
+		}
+
+		$offset  = (float) get_option( 'gmt_offset' );
+		$hours   = (int) $offset;
+		$minutes = ( $offset - $hours );
+
+		$sign      = ( $offset < 0 ) ? '-' : '+';
+		$abs_hour  = abs( $hours );
+		$abs_mins  = abs( $minutes * 60 );
+		$tz_offset = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
+
+		return new DateTimeZone( $tz_offset );
+	}
+}
+
 /**
  * Set the admin language, based on user language.
  *

--- a/packages/sync/src/Functions.php
+++ b/packages/sync/src/Functions.php
@@ -1,12 +1,17 @@
 <?php
+/**
+ * Functions used for Jetpack Sync.
+ *
+ * @package Jetpack
+ */
 
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
-/*
+
+/**
  * Utility functions to generate data synced to wpcom
  */
-
 class Functions {
 	const HTTPS_CHECK_OPTION_PREFIX = 'jetpack_sync_https_history_';
 	const HTTPS_CHECK_HISTORY       = 5;
@@ -368,6 +373,10 @@ class Functions {
 	 * @return string
 	 */
 	public static function get_timezone() {
+		// @todo: Only return wp_timezone_string once WP 5.3 is the minimum version.
+		if ( function_exists( 'wp_timezone_string' ) ) {
+			return wp_timezone_string();
+		}
 		$timezone_string = get_option( 'timezone_string' );
 
 		if ( ! empty( $timezone_string ) ) {

--- a/packages/sync/src/Functions.php
+++ b/packages/sync/src/Functions.php
@@ -1,17 +1,12 @@
 <?php
-/**
- * Functions used for Jetpack Sync.
- *
- * @package Jetpack
- */
 
 namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Constants;
-
-/**
+/*
  * Utility functions to generate data synced to wpcom
  */
+
 class Functions {
 	const HTTPS_CHECK_OPTION_PREFIX = 'jetpack_sync_https_history_';
 	const HTTPS_CHECK_HISTORY       = 5;
@@ -370,13 +365,12 @@ class Functions {
 	 * 2. Check if `gmt_offset` is set, formats UTC-offset from it and return it.
 	 * 3. Default to "UTC+0" if nothing is set.
 	 *
+	 * Note: This function is specifically not using wp_timezone() to keep consistency with
+	 * the existing formatting of the timezone string.
+	 *
 	 * @return string
 	 */
 	public static function get_timezone() {
-		// @todo: Only return wp_timezone_string once WP 5.3 is the minimum version.
-		if ( function_exists( 'wp_timezone_string' ) ) {
-			return wp_timezone_string();
-		}
 		$timezone_string = get_option( 'timezone_string' );
 
 		if ( ! empty( $timezone_string ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Contributes to #13513 

#### Changes proposed in this Pull Request:
* WP 5.3 will add an unified Date/Time API to avoid the dance between the previous timezone OR GMT offset options defining a site's timezone. In Jetpack, let's use that!
* Since we still support older versions, we should ship a shim for now.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Run this PR while using the developer.wordpress.com/console against the site. Confirm the dates returned are the same before and after the PR.

#### Proposed changelog entry for your changes:
* Code Cleanup: Use new functionality available in WordPress 5.3.
