### PR TITLE
Components Lib: Use `get_edit_post_link()` to build `$redirect_to`

### DIFF
--- a/_inc/lib/components.php
+++ b/_inc/lib/components.php
@@ -87,21 +87,12 @@ class Jetpack_Components {
 		}
 
 		// Post-checkout: redirect back to the editor.
-		$redirect_to = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-			? add_query_arg(
-				array(
-					'plan_upgraded' => 1,
-				),
-				'/' . implode( '/', array_filter( array( $post_type_editor_route_prefix, $post_type, $site_slug, $post_id ) ) )
-			)
-			: add_query_arg(
-				array(
-					'action'        => 'edit',
-					'post'          => $post_id,
-					'plan_upgraded' => 1,
-				),
-				admin_url( 'post.php' )
-			);
+		$redirect_to = add_query_arg(
+			array(
+				'plan_upgraded' => 1,
+			),
+			get_edit_post_link( $post_id )
+		);
 
 		$upgrade_url =
 			$plan_path_slug


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This uses a unified function call to `get_edit_post_link()` rather than the previous ternary that would redirect to Calypso in the WP.com case, and to wp-admin for Jetpack.

The idea is that `get_edit_post_link()` expresses better what we _want_ to do here (and have been discussing for a while): Give us a link to the correct editor in the given environment.

This is evidenced by the fact that WP.com uses the `get_edit_post_link` to change it contextually. (Try searching in the WP.com codebase, and note e.g. how it's used by the `gutenberg-wpcom` plugin to change its return value to either Gutenberg or the classic editor.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Existing part.

#### Testing instructions:

##### Jetpack:

You need to test the Upgrade Nudge which is currently disabled in Jetpack. To enable, add the following line to a file in `docker/mu-plugins/`, e.g. `docker/mu-plugins/0-gutenpack.php`:

```
add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
```

- Make sure your Jetpack site is connected to WP.com, and on a Free plan.
- Start a new post, and insert a Simple Payments block. Publish and view the site.
- Check the target of the Upgrade Nudge's 'Upgrade' button.
- Verify that it would still redirect you back to the wp-admin editor. (The query arg order might have changed.)

```diff
- https://wordpress.com/checkout/example.com/premium?redirect_to=http://example.com/wp-admin/post.php?action=edit&post=309&plan_upgraded=1
+ https://wordpress.com/checkout/example.com/premium?redirect_to=http://example.com/wp-admin/post.php?post=309&action=edit&plan_upgraded=1
```

##### WP.com:

Test the WP.com counterpart of this PR (D33061-code) by applying it to your sandbox and verifying that the Upgrade Nudge button redirect still takes you back to Calypso. The only difference is that the redirect link now includes the `https://wordpress.com` part.

```diff
- https://wordpress.com/checkout/example.wordpress.com/premium?redirect_to=/post/example.wordpress.com/123?plan_upgraded=1
+ https://wordpress.com/checkout/example.wordpress.com/premium?redirect_to=https://wordpress.com/post/example.wordpress.com/123?plan_upgraded=1
```
#### Proposed changelog entry for your changes:

Components Lib: Use `get_edit_post_link()` to build `$redirect_to` link

#### Open questions

- The code modified in here is just the PHP/server side equivalent for some existing client-side JS code. However, I don't think there's an equivalent JS function for `get_edit_post_link()`.
 - Are we fine that things are diverging here, with a more semantic implementation used on the server side?
 - If we use this, then we do so in order to have more accurate values for the redirect link on the server side, because they're e.g. informed by filters. The JS side is ignorant of that, and thus can possibly return a different value. How do we go about this?
  - Core PR to add a JS version of this function and filter?
- FYI, @sirreal and I were coming across this while discussing using `get_edit_post_link()` for D32394-code, where `get_edit_post_link()` curiously doesn't work, see D32394-code#654197.

#### TODO

Don't double-escape `get_edit_post_link`'s ampersands (`add_query_arg` does that!)