### PR TITLE
Connection: Make sure port is an integer

### DIFF
--- a/packages/connection/legacy/class.jetpack-signature.php
+++ b/packages/connection/legacy/class.jetpack-signature.php
@@ -75,6 +75,7 @@ class Jetpack_Signature {
 		}
 
 		$host_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? $_SERVER['HTTP_X_FORWARDED_PORT'] : $_SERVER['SERVER_PORT'];
+		$host_port = intval( $host_port );
 
 		/**
 		 * Note: This port logic is tested in the Jetpack_Cxn_Tests->test__server_port_value() test.


### PR DESCRIPTION
Sometimes `HTTP_X_FORWARDED_PORT` can be a string, which after #13489 will cause issues with signature generation. This PR converts those ports to integer, to ensure proper comparison.

#### Changes proposed in this Pull Request:
* Connection: Make sure port is an integer

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Just a bugfix

#### Testing instructions:
* cc @brbrr for testing - this should be fixing the connection e2e tests.

#### Proposed changelog entry for your changes:
* Connection: Make sure port is an integer
