### PR TITLE
Update Prettier and reformat files

### DIFF
--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -75,9 +75,7 @@ export const settings = {
 			},
 			save: function( { attributes } ) {
 				return (
-					<RawHTML>{ `[jetpack_subscription_form show_subscribers_total="${
-						attributes.showSubscribersTotal
-					}" show_only_email_and_button="true"]` }</RawHTML>
+					<RawHTML>{ `[jetpack_subscription_form show_subscribers_total="${ attributes.showSubscribersTotal }" show_only_email_and_button="true"]` }</RawHTML>
 				);
 			},
 		},

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -133,7 +133,10 @@ export const icon = (
 export const settings = {
 	attributes: blockAttributes,
 	category: 'jetpack',
-	description: __( "Display multiple images in an elegantly organized tiled layout. Serves images using Jetpack's fast global network of servers.", 'jetpack' ),
+	description: __(
+		"Display multiple images in an elegantly organized tiled layout. Serves images using Jetpack's fast global network of servers.",
+		'jetpack'
+	),
 	icon,
 	keywords: [
 		_x( 'images', 'block search term', 'jetpack' ),

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -9,9 +9,7 @@ function getQuery() {
 
 function pushQueryString( queryString ) {
 	if ( history.pushState ) {
-		const newurl = `${ window.location.protocol }//${ window.location.host }${
-			window.location.pathname
-		}?${ queryString }`;
+		const newurl = `${ window.location.protocol }//${ window.location.host }${ window.location.pathname }?${ queryString }`;
 		window.history.pushState( { path: newurl }, '', newurl );
 	}
 }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
 		"mockery": "2.1.0",
 		"nock": "10.0.6",
 		"node-wp-i18n": "1.2.3",
-		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
+		"prettier": "npm:wp-prettier@1.18.2",
 		"puppeteer": "1.19.0",
 		"react-test-renderer": "16.8.6",
 		"sass-loader": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
 		"mockery": "2.1.0",
 		"nock": "10.0.6",
 		"node-wp-i18n": "1.2.3",
-		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz",
+		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz",
 		"puppeteer": "1.19.0",
 		"react-test-renderer": "16.8.6",
 		"sass-loader": "7.1.0",

--- a/packages/compat/composer.json
+++ b/packages/compat/composer.json
@@ -3,14 +3,15 @@
 	"description": "Compatibility layer with previous versions of Jetpack",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
-	"require": {
-	},
+	"require": {},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
 		"php-mock/php-mock": "^2.1"
 	},
 	"autoload": {
-		"files": [ "functions.php" ],
+		"files": [
+			"functions.php"
+		],
 		"classmap": [
 			"legacy"
 		]

--- a/yarn.lock
+++ b/yarn.lock
@@ -10201,9 +10201,9 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-"prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz":
-  version "1.17.0"
-  resolved "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz#6528e5a8579619dbf31bd511de4a5c6800674db3"
+"prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz":
+  version "1.18.2"
+  resolved "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz#8b1083de0e14e666e34b058d6a3e7f382d7dde67"
 
 pretty-format@^24.8.0:
   version "24.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10201,9 +10201,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-"prettier@https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz":
+"prettier@npm:wp-prettier@1.18.2":
   version "1.18.2"
-  resolved "https://github.com/Automattic/wp-prettier/releases/download/wp-1.18.2/wp-prettier-1.18.2.tgz#8b1083de0e14e666e34b058d6a3e7f382d7dde67"
+  resolved "https://registry.yarnpkg.com/wp-prettier/-/wp-prettier-1.18.2.tgz#d925869062173a217f4921d9a3d2ed59a78e2d9d"
+  integrity sha512-OvmJZJ6j6KF+CqnNGPLRupSLt6zlFG8/D9dJL21eVJwad1HHEq5cGgeXqboloxE7DjtglkKd/6CEvO1dvqfQdA==
 
 pretty-format@^24.8.0:
   version "24.8.0"


### PR DESCRIPTION
No functional changes.

#### Changes proposed in this Pull Request:
* Update version of our internal version of Prettier (see https://github.com/Automattic/wp-calypso/pull/36229 for exact changes)
* Install the wp-prettier fork as NPM alias rather than tarball download (see https://github.com/Automattic/wp-calypso/pull/36259)
* Run `yarn reformat-files`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

#### Testing instructions:
- Run `yarn` to confirm everything installs fine
- Run `yarn reformat-files` to confirm nothing was left out

#### Proposed changelog entry for your changes:
*
