### PR TITLE
Block editor extensions: add isSimpleSite helper

### DIFF
--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -14,6 +14,7 @@ import { withSelect } from '@wordpress/data';
 import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
 import getSiteFragment from '../../get-site-fragment';
+import isWpcomSite from '../../is-wpcom-site';
 import './store';
 
 import './style.scss';
@@ -62,7 +63,7 @@ export default compose( [
 		// The editor for CPTs has an `edit/` route fragment prefixed
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
-		const isWpcom = get( window, [ '_currentSiteType' ] ) === 'simple';
+		const isWpcom = isWpcomSite();
 
 		// Post-checkout: redirect back here
 		const redirect_to = isWpcom

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -14,7 +14,7 @@ import { withSelect } from '@wordpress/data';
 import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
 import getSiteFragment from '../../get-site-fragment';
-import isWpcomSite from '../../is-wpcom-site';
+import { isSimpleSite } from '../../site-type-utils';
 import './store';
 
 import './style.scss';
@@ -63,10 +63,8 @@ export default compose( [
 		// The editor for CPTs has an `edit/` route fragment prefixed
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
-		const isWpcom = isWpcomSite();
-
 		// Post-checkout: redirect back here
-		const redirect_to = isWpcom
+		const redirect_to = isSimpleSite()
 			? addQueryArgs(
 					'/' +
 						compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(

--- a/extensions/shared/is-wpcom-site.js
+++ b/extensions/shared/is-wpcom-site.js
@@ -1,3 +1,0 @@
-export default function isWpcomSite() {
-	return 'object' === typeof window ? window._currentSiteType === 'simple' : false;
-}

--- a/extensions/shared/is-wpcom-site.js
+++ b/extensions/shared/is-wpcom-site.js
@@ -1,0 +1,10 @@
+/**
+ * External Dependencies
+ */
+import { get } from 'lodash';
+
+export default function isWpcomSite() {
+	return (
+		get( 'object' === typeof window ? window : null, [ '_currentSiteType' ], null ) === 'simple'
+	);
+}

--- a/extensions/shared/is-wpcom-site.js
+++ b/extensions/shared/is-wpcom-site.js
@@ -5,6 +5,6 @@ import { get } from 'lodash';
 
 export default function isWpcomSite() {
 	return (
-		get( 'object' === typeof window ? window : null, [ '_currentSiteType' ], null ) === 'simple'
+		'object' === typeof window ? window._currentSiteType === 'simple' : false
 	);
 }

--- a/extensions/shared/is-wpcom-site.js
+++ b/extensions/shared/is-wpcom-site.js
@@ -1,10 +1,3 @@
-/**
- * External Dependencies
- */
-import { get } from 'lodash';
-
 export default function isWpcomSite() {
-	return (
-		'object' === typeof window ? window._currentSiteType === 'simple' : false
-	);
+	return 'object' === typeof window ? window._currentSiteType === 'simple' : false;
 }

--- a/extensions/shared/site-type-utils.js
+++ b/extensions/shared/site-type-utils.js
@@ -1,0 +1,19 @@
+/**
+ * Get the site type from environment
+ *
+ * @return {(string|null)} Site type
+ */
+function getSiteType() {
+	return 'object' === typeof window && typeof window._currentSiteType === 'string'
+		? window._currentSiteType
+		: null;
+}
+
+/**
+ * Check if environment is Simple site.
+ *
+ * @return {boolean} True for Simple sites.
+ */
+export function isSimpleSite() {
+	return getSiteType() === 'simple';
+}


### PR DESCRIPTION
Add `isWpcomSite` helper for block editor extensions. Just a step towards something better as described in https://github.com/Automattic/jetpack/pull/13512/files#r327466773

`window._currentSiteType` is available only for .com simple sites. For Jetpack sites, the helper returns `false.`

#### Changes proposed in this Pull Request:
- Add `isWpcomSite` helper and used it for upgrade nudges.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Modifies

#### Testing instructions:
* Have a free Jetpack site
* Enable filter: `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );`
* Insert simple payments block and observe that upgrade nudge includes correct editor URL as a redirect URL

* Build the bundle for .com simple sites (you can build to your sandbox with `yarn build-extensions --watch --output-path /PATH_TO_SANDBOX/wp-content/mu-plugins/jetpack/_inc/blocks/'`)
* Observe that helper returns `true` and redirect URL points to Calypso

#### Proposed changelog entry for your changes:
* 
