### PR TITLE
Admin Page: Move to Core translation functions -- PART 1

### DIFF
--- a/_inc/client/at-a-glance/activity.jsx
+++ b/_inc/client/at-a-glance/activity.jsx
@@ -4,16 +4,15 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import DashItem from 'components/dash-item';
-import Card from 'components/card';
-import { translate as __ } from 'i18n-calypso';
-// import { get, includes } from 'lodash';
 import classNames from 'classnames';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
+import DashItem from 'components/dash-item';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getSitePlan } from 'state/site';
 import { isDevMode } from 'state/connection';
 //import { PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_VIP } from 'lib/plans/constants';
@@ -50,13 +49,14 @@ class DashActivity extends Component {
 
 		// @todo: update this to use rewind text/CTA when available
 		const activityLogOnlyText = __(
-			'Jetpack keeps a complete record of everything that happens on your site, taking the guesswork out of site management, debugging, and repair.'
+			'Jetpack keeps a complete record of everything that happens on your site, taking the guesswork out of site management, debugging, and repair.',
+			'jetpack'
 		);
 
 		return (
 			<div className="jp-dash-item__interior">
 				<DashItem
-					label={ __( 'Activity' ) }
+					label={ __( 'Activity', 'jetpack' ) }
 					isModule={ false }
 					className={ classNames( {
 						'jp-dash-item__is-inactive': inDevMode,
@@ -64,7 +64,7 @@ class DashActivity extends Component {
 					pro={ false }
 				>
 					<p className="jp-dash-item__description">
-						{ inDevMode ? __( 'Unavailable in Dev Mode.' ) : activityLogOnlyText }
+						{ inDevMode ? __( 'Unavailable in Dev Mode.', 'jetpack' ) : activityLogOnlyText }
 					</p>
 				</DashItem>
 				<Card
@@ -73,7 +73,7 @@ class DashActivity extends Component {
 					compact
 					href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 				>
-					{ __( 'View site activity' ) }
+					{ __( 'View site activity', 'jetpack' ) }
 				</Card>
 			</div>
 		);

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { connect } from 'react-redux';
 import { numberFormat } from 'i18n-calypso';
 import { __, _x } from '@wordpress/i18n';
@@ -77,7 +77,7 @@ class DashAkismet extends Component {
 		};
 
 		const getAkismetUpgradeBanner = () => {
-			const description = createInterpolateElement(
+			const description = jetpackCreateInterpolateElement(
 				__( 'Already have a key? <a>Activate Akismet</a>', 'jetpack' ),
 				{
 					a: <a href="javascript:void(0)" onClick={ this.onActivateClick } />,

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -4,7 +4,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { numberFormat, translate as __ } from 'i18n-calypso';
+import { numberFormat } from 'i18n-calypso';
+import { __, _x } from '@wordpress/i18n';
+import interpolateComponents from 'interpolate-components';
 import { get } from 'lodash';
 import getRedirectUrl from 'lib/jp-redirect';
 
@@ -61,20 +63,22 @@ class DashAkismet extends Component {
 
 	getContent() {
 		const akismetData = this.props.akismetData;
-		const labelName = __( 'Anti-spam' );
+		const labelName = __( 'Anti-spam', 'jetpack' );
 		const isSiteOnFreePlan =
 			'jetpack_free' === get( this.props.sitePlan, 'product_slug', 'jetpack_free' );
 
 		const support = {
 			text: __(
-				'Jetpack Anti-spam powered by Akismet. Comments and contact form submissions are checked against our global database of spam.'
+				'Jetpack Anti-spam powered by Akismet. Comments and contact form submissions are checked against our global database of spam.',
+				'jetpack'
 			),
 			link: 'https://akismet.com/',
 			privacyLink: 'https://automattic.com/privacy/',
 		};
 
 		const getAkismetUpgradeBanner = () => {
-			const description = __( 'Already have a key? {{a}}Activate Akismet{{/a}}', {
+			const description = interpolateComponents( {
+				mixedString: __( 'Already have a key? {{a}}Activate Akismet{{/a}}', 'jetpack' ),
 				components: {
 					a: <a href="javascript:void(0)" onClick={ this.onActivateClick } />,
 				},
@@ -82,9 +86,10 @@ class DashAkismet extends Component {
 
 			return (
 				<JetpackBanner
-					callToAction={ __( 'Upgrade' ) }
+					callToAction={ __( 'Upgrade', 'jetpack' ) }
 					title={ __(
-						'Automatically clear spam from your comments and forms so you can get back to your business.'
+						'Automatically clear spam from your comments and forms so you can get back to your business.',
+						'jetpack'
 					) }
 					description={ description }
 					disableHref="false"
@@ -100,7 +105,7 @@ class DashAkismet extends Component {
 		if ( 'N/A' === akismetData ) {
 			return (
 				<DashItem label={ labelName } module="akismet" support={ support } pro={ true }>
-					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
+					<p className="jp-dash-item__description">{ __( 'Loading…', 'jetpack' ) }</p>
 				</DashItem>
 			);
 		}
@@ -160,7 +165,8 @@ class DashAkismet extends Component {
 					pro={ true }
 				>
 					{ __(
-						"Your Jetpack plan provides anti-spam protection through Akismet. Click 'set up' to enable it on your site."
+						"Your Jetpack plan provides anti-spam protection through Akismet. Click 'set up' to enable it on your site.",
+						'jetpack'
 					) }
 				</DashItem>
 			);
@@ -177,9 +183,7 @@ class DashAkismet extends Component {
 			>
 				<h2 className="jp-dash-item__count">{ numberFormat( akismetData.all.spam ) }</h2>
 				<p className="jp-dash-item__description">
-					{ __( 'Spam comments blocked.', {
-						context: 'Example: "412 Spam comments blocked"',
-					} ) }
+					{ _x( 'Spam comments blocked.', 'Example: "412 Spam comments blocked"', 'jetpack' ) }
 				</p>
 			</DashItem>,
 			! this.props.isDevMode && (
@@ -189,7 +193,7 @@ class DashAkismet extends Component {
 					compact
 					href={ getRedirectUrl( 'calypso-comments-all', { site: this.props.siteRawUrl } ) }
 				>
-					{ __( 'Moderate comments' ) }
+					{ __( 'Moderate comments', 'jetpack' ) }
 				</Card>
 			),
 		];

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -3,10 +3,10 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { createInterpolateElement } from '@wordpress/element';
 import { connect } from 'react-redux';
 import { numberFormat } from 'i18n-calypso';
 import { __, _x } from '@wordpress/i18n';
-import interpolateComponents from 'interpolate-components';
 import { get } from 'lodash';
 import getRedirectUrl from 'lib/jp-redirect';
 
@@ -77,12 +77,12 @@ class DashAkismet extends Component {
 		};
 
 		const getAkismetUpgradeBanner = () => {
-			const description = interpolateComponents( {
-				mixedString: __( 'Already have a key? {{a}}Activate Akismet{{/a}}', 'jetpack' ),
-				components: {
+			const description = createInterpolateElement(
+				__( 'Already have a key? <a>Activate Akismet</a>', 'jetpack' ),
+				{
 					a: <a href="javascript:void(0)" onClick={ this.onActivateClick } />,
-				},
-			} );
+				}
+			);
 
 			return (
 				<JetpackBanner

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -4,10 +4,10 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { createInterpolateElement } from '@wordpress/element';
 import DashItem from 'components/dash-item';
-import { translate as __ } from 'i18n-calypso';
 import { get, isEmpty, noop } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import { getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
@@ -30,11 +31,12 @@ import { getUpgradeUrl, showBackups } from 'state/initial-state';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Backup' ) }
+		label={ __( 'Backup', 'jetpack' ) }
 		module={ props.feature || 'backups' }
 		support={ {
 			text: __(
-				'Jetpack Backups allow you to easily restore or download a backup from a specific moment.'
+				'Jetpack Backups allow you to easily restore or download a backup from a specific moment.',
+				'jetpack'
 			),
 			link: getRedirectUrl( 'jetpack-support-backup' ),
 		} }
@@ -88,16 +90,14 @@ class DashBackups extends Component {
 					<span>
 						{ get( vaultPressData, 'message', '' ) }
 						&nbsp;
-						{ __( '{{a}}View backup details{{/a}}.', {
-							components: {
-								a: (
-									<a
-										href={ getRedirectUrl( 'vaultpress-dashboard' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
+						{ createInterpolateElement( __( '<a>View backup details</a>.', 'jetpack' ), {
+							a: (
+								<a
+									href={ getRedirectUrl( 'vaultpress-dashboard' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						} ) }
 					</span>
 				),
@@ -110,21 +110,22 @@ class DashBackups extends Component {
 				return renderCard( {
 					className: 'jp-dash-item__is-inactive',
 					status: isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled',
-					content: __(
-						'To automatically back up your entire site, please {{a}}install and activate{{/a}} VaultPress.',
+					content: createInterpolateElement(
+						__(
+							'To automatically back up your entire site, please <a>install and activate</a> VaultPress.',
+							'jetpack'
+						),
 						{
-							components: {
-								a: (
-									<a
-										href={ getRedirectUrl( 'calypso-plugins-setup', {
-											site: siteRawUrl,
-											query: 'only=backups',
-										} ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
+							a: (
+								<a
+									href={ getRedirectUrl( 'calypso-plugins-setup', {
+										site: siteRawUrl,
+										query: 'only=backups',
+									} ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						}
 					),
 				} );
@@ -135,9 +136,10 @@ class DashBackups extends Component {
 				status: 'no-pro-uninstalled-or-inactive',
 				overrideContent: (
 					<JetpackBanner
-						callToAction={ __( 'Upgrade' ) }
+						callToAction={ __( 'Upgrade', 'jetpack' ) }
 						title={ __(
-							'Never worry about losing your site – automatic backups keep your content safe.'
+							'Never worry about losing your site – automatic backups keep your content safe.',
+							'jetpack'
 						) }
 						disableHref="false"
 						href={ this.props.upgradeUrl }
@@ -153,7 +155,7 @@ class DashBackups extends Component {
 		return renderCard( {
 			className: '',
 			status: '',
-			content: __( 'Loading…' ),
+			content: __( 'Loading…', 'jetpack' ),
 		} );
 	}
 
@@ -176,32 +178,32 @@ class DashBackups extends Component {
 			case 'provisioning':
 				return (
 					<React.Fragment>
-						{ buildCard( __( "We are configuring your site's backups." ) ) }
+						{ buildCard( __( "We are configuring your site's backups.", 'jetpack' ) ) }
 					</React.Fragment>
 				);
 			case 'awaiting_credentials':
 				return (
 					<React.Fragment>
 						{ buildCard(
-							__( "You need to enter your server's credentials to finish the setup." )
+							__( "You need to enter your server's credentials to finish the setup.", 'jetpack' )
 						) }
 						{ buildAction(
 							getRedirectUrl( 'calypso-settings-security', { site: siteRawUrl } ),
-							__( 'Enter credentials' )
+							__( 'Enter credentials', 'jetpack' )
 						) }
 					</React.Fragment>
 				);
 			case 'active':
 				const message = [ 'is-business-plan', 'is-realtime-backup-plan' ].includes( planClass )
-					? __( 'We are backing up your site in real-time.' )
-					: __( 'We are backing up your site daily.' );
+					? __( 'We are backing up your site in real-time.', 'jetpack' )
+					: __( 'We are backing up your site daily.', 'jetpack' );
 
 				return (
 					<React.Fragment>
 						{ buildCard( message ) }
 						{ buildAction(
 							getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl, query: 'group=rewind' } ),
-							__( "View your site's backups" )
+							__( "View your site's backups", 'jetpack' )
 						) }
 					</React.Fragment>
 				);
@@ -221,7 +223,7 @@ class DashBackups extends Component {
 					{ renderCard( {
 						className: 'jp-dash-item__is-inactive',
 						status: 'no-pro-uninstalled-or-inactive',
-						content: __( 'Unavailable in Dev Mode.' ),
+						content: __( 'Unavailable in Dev Mode.', 'jetpack' ),
 					} ) }
 				</div>
 			);

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import DashItem from 'components/dash-item';
 import { get, isEmpty, noop } from 'lodash';
 import { __ } from '@wordpress/i18n';
@@ -90,7 +90,7 @@ class DashBackups extends Component {
 					<span>
 						{ get( vaultPressData, 'message', '' ) }
 						&nbsp;
-						{ createInterpolateElement( __( '<a>View backup details</a>.', 'jetpack' ), {
+						{ jetpackCreateInterpolateElement( __( '<a>View backup details</a>.', 'jetpack' ), {
 							a: (
 								<a
 									href={ getRedirectUrl( 'vaultpress-dashboard' ) }
@@ -110,7 +110,7 @@ class DashBackups extends Component {
 				return renderCard( {
 					className: 'jp-dash-item__is-inactive',
 					status: isVaultPressInstalled ? 'pro-inactive' : 'pro-uninstalled',
-					content: createInterpolateElement(
+					content: jetpackCreateInterpolateElement(
 						__(
 							'To automatically back up your entire site, please <a>install and activate</a> VaultPress.',
 							'jetpack'

--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { __, sprintf, _x } from '@wordpress/i18n';
 
 /**
@@ -141,7 +141,10 @@ export class DashConnections extends Component {
 			cardContent = (
 				<div>
 					<div className="jp-connection-settings__info">
-						{ __( 'Link your account to WordPress.com to get the most out of Jetpack.', 'jetpack' ) }
+						{ __(
+							'Link your account to WordPress.com to get the most out of Jetpack.',
+							'jetpack'
+						) }
 					</div>
 					<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
 				</div>
@@ -160,7 +163,7 @@ export class DashConnections extends Component {
 							src={ this.props.wpComConnectedUser.avatar }
 						/>
 						<div className="jp-connection-settings__text">
-							{ createInterpolateElement(
+							{ jetpackCreateInterpolateElement(
 								sprintf(
 									/* translators: Placeholder is the WordPress user login name. */
 									__( 'Connected as <span>%s</span>', 'jetpack' ),

--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -4,9 +4,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
-import DashItem from 'components/dash-item';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -27,6 +26,8 @@ import {
 } from 'state/initial-state';
 import QueryUserConnectionData from 'components/data/query-user-connection';
 import ConnectButton from 'components/connect-button';
+import DashItem from 'components/dash-item';
+import Gridicon from 'components/gridicon';
 import MobileMagicLink from 'components/mobile-magic-link';
 
 export class DashConnections extends Component {
@@ -55,7 +56,8 @@ export class DashConnections extends Component {
 					) }
 					<div className="jp-connection-settings__text">
 						{ __(
-							'Your site is in Development Mode, so it can not be connected to WordPress.com.'
+							'Your site is in Development Mode, so it can not be connected to WordPress.com.',
+							'jetpack'
 						) }
 					</div>
 				</div>
@@ -76,11 +78,11 @@ export class DashConnections extends Component {
 							<Gridicon icon="globe" size={ 64 } />
 						) }
 						<div className="jp-connection-settings__text">
-							{ __( 'Your site is connected to WordPress.com.' ) }
+							{ __( 'Your site is connected to WordPress.com.', 'jetpack' ) }
 							{ this.props.userIsMaster && (
 								<span className="jp-connection-settings__is-owner">
 									<br />
-									<em>{ __( 'You are the Jetpack owner.' ) }</em>
+									<em>{ __( 'You are the Jetpack owner.', 'jetpack' ) }</em>
 								</span>
 							) }
 						</div>
@@ -126,7 +128,10 @@ export class DashConnections extends Component {
 						<Gridicon icon="user" size={ 64 } />
 					) }
 					<div className="jp-connection-settings__text">
-						{ __( 'The site is in Development Mode, so you can not connect to WordPress.com.' ) }
+						{ __(
+							'The site is in Development Mode, so you can not connect to WordPress.com.',
+							'jetpack'
+						) }
 					</div>
 				</div>
 			);
@@ -136,13 +141,13 @@ export class DashConnections extends Component {
 			cardContent = (
 				<div>
 					<div className="jp-connection-settings__info">
-						{ __( 'Link your account to WordPress.com to get the most out of Jetpack.' ) }
+						{ __( 'Link your account to WordPress.com to get the most out of Jetpack.', 'jetpack' ) }
 					</div>
 					<div className="jp-connection-settings__actions">{ maybeShowLinkUnlinkBtn }</div>
 				</div>
 			);
 		} else if ( this.props.isFetchingUserData ) {
-			cardContent = __( 'Loading…' );
+			cardContent = __( 'Loading…', 'jetpack' );
 		} else {
 			cardContent = (
 				<div>
@@ -155,15 +160,16 @@ export class DashConnections extends Component {
 							src={ this.props.wpComConnectedUser.avatar }
 						/>
 						<div className="jp-connection-settings__text">
-							{ __( 'Connected as {{span}}%(username)s{{/span}}', {
-								args: {
-									username: this.props.wpComConnectedUser.login,
-								},
-								components: {
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: Placeholder is the WordPress user login name. */
+									__( 'Connected as <span>%s</span>', 'jetpack' ),
+									this.props.wpComConnectedUser.login
+								),
+								{
 									span: <span className="jp-connection-settings__username" />,
-								},
-								comment: '%(username) is the WordPress user login name.',
-							} ) }
+								}
+							) }
 							<div className="jp-connection-settings__email">
 								{ this.props.wpComConnectedUser.email }
 							</div>
@@ -187,7 +193,7 @@ export class DashConnections extends Component {
 						<div className="jp-dash-item__interior">
 							<DashItem
 								className="jp-connection-type"
-								label={ __( 'Site connection', { context: 'Dashboard widget header' } ) }
+								label={ _x( 'Site connection', 'Dashboard widget header', 'jetpack' ) }
 							>
 								{ this.siteConnection() }
 							</DashItem>
@@ -197,7 +203,7 @@ export class DashConnections extends Component {
 						<div className="jp-dash-item__interior">
 							<DashItem
 								className="jp-connection-type"
-								label={ __( 'Account connection', { context: 'Dashboard widget header' } ) }
+								label={ _x( 'Account connection', 'Dashboard widget header', 'jetpack' ) }
 							>
 								{ this.userConnection() }
 							</DashItem>

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -3,13 +3,13 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
+import { __ } from '@wordpress/i18n';
 import { chunk, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import DashSectionHeader from 'components/dash-section-header';
 import DashActivity from './activity';
@@ -62,12 +62,12 @@ class AtAGlance extends Component {
 		const securityHeader = (
 			<DashSectionHeader
 				key="securityHeader"
-				label={ __( 'Security' ) }
+				label={ __( 'Security', 'jetpack' ) }
 				settingsPath={ this.props.userCanManageModules ? '#security' : undefined }
 				externalLink={
 					this.props.isDevMode || ! this.props.userCanManageModules
 						? ''
-						: __( 'Manage security settings' )
+						: __( 'Manage security settings', 'jetpack' )
 				}
 				externalLinkPath={ this.props.isDevMode ? '' : '#/security' }
 				externalLinkClick={ this.trackSecurityClick }
@@ -76,7 +76,7 @@ class AtAGlance extends Component {
 		const connections = (
 			<div>
 				<DashSectionHeader
-					label={ __( 'Connections' ) }
+					label={ __( 'Connections', 'jetpack' ) }
 					className="jp-dash-section-header__connections"
 				/>
 				<DashConnections />
@@ -129,7 +129,9 @@ class AtAGlance extends Component {
 			}
 			if ( performanceCards.length ) {
 				pairs.push( {
-					header: <DashSectionHeader key="performanceHeader" label={ __( 'Performance' ) } />,
+					header: (
+						<DashSectionHeader key="performanceHeader" label={ __( 'Performance', 'jetpack' ) } />
+					),
 					cards: performanceCards,
 				} );
 			}

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -65,7 +65,7 @@ class DashMonitor extends Component {
 				<p className="jp-dash-item__description">
 					{ this.props.isDevMode
 						? __( 'Unavailable in Dev Mode.', 'jetpack' )
-						: createInterpolateElement(
+						: jetpackCreateInterpolateElement(
 								__(
 									'<a>Activate Monitor</a> to receive email notifications if your site goes down.',
 									'jetpack'

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -4,13 +4,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleAvailable } from 'state/modules';
 import { isDevMode } from 'state/connection';
 import DashItem from 'components/dash-item';
@@ -31,11 +32,12 @@ class DashMonitor extends Component {
 	};
 
 	getContent() {
-		const labelName = __( 'Downtime monitor' );
+		const labelName = __( 'Downtime monitor', 'jetpack' );
 
 		const support = {
 			text: __(
-				'Jetpack’s downtime monitor will continuously monitor your site, and alert you the moment that downtime is detected.'
+				'Jetpack’s downtime monitor will continuously monitor your site, and alert you the moment that downtime is detected.',
+				'jetpack'
 			),
 			link: getRedirectUrl( 'jetpack-support-monitor' ),
 		};
@@ -45,7 +47,8 @@ class DashMonitor extends Component {
 				<DashItem label={ labelName } module="monitor" support={ support } status="is-working">
 					<p className="jp-dash-item__description">
 						{ __(
-							'Jetpack is monitoring your site. If we think your site is down, you will receive an email.'
+							'Jetpack is monitoring your site. If we think your site is down, you will receive an email.',
+							'jetpack'
 						) }
 					</p>
 				</DashItem>
@@ -61,13 +64,14 @@ class DashMonitor extends Component {
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode.' )
-						: __(
-								'{{a}}Activate Monitor{{/a}} to receive email notifications if your site goes down.',
+						? __( 'Unavailable in Dev Mode.', 'jetpack' )
+						: createInterpolateElement(
+								__(
+									'<a>Activate Monitor</a> to receive email notifications if your site goes down.',
+									'jetpack'
+								),
 								{
-									components: {
-										a: <a href="javascript:void(0)" onClick={ this.activateAndTrack } />,
-									},
+									a: <a href="javascript:void(0)" onClick={ this.activateAndTrack } />,
 								}
 						  ) }
 				</p>

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -4,13 +4,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import DashItem from 'components/dash-item';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import DashItem from 'components/dash-item';
+import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleAvailable } from 'state/modules';
 import { isDevMode } from 'state/connection';
 
@@ -23,11 +24,12 @@ class DashPhoton extends Component {
 	activatePhoton = () => this.props.updateOptions( { photon: true } );
 
 	getContent() {
-		const labelName = __( 'Image Accelerator' );
+		const labelName = __( 'Image Accelerator', 'jetpack' );
 
 		const support = {
 			text: __(
-				'Jetpack will optimize your images and serve them from the server location nearest to your visitors. Using our global content delivery network will boost the loading speed of your site.'
+				'Jetpack will optimize your images and serve them from the server location nearest to your visitors. Using our global content delivery network will boost the loading speed of your site.',
+				'jetpack'
 			),
 			link: getRedirectUrl( 'jetpack-support-photon' ),
 		};
@@ -37,7 +39,8 @@ class DashPhoton extends Component {
 				<DashItem label={ labelName } module="photon" support={ support } status="is-working">
 					<p className="jp-dash-item__description">
 						{ __(
-							"Jetpack is optimizing your image sizes and download speed using our fast global network of servers. This improves your site's performance on desktop and mobile devices."
+							"Jetpack is optimizing your image sizes and download speed using our fast global network of servers. This improves your site's performance on desktop and mobile devices.",
+							'jetpack'
 						) }
 					</p>
 				</DashItem>
@@ -53,13 +56,14 @@ class DashPhoton extends Component {
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode' )
-						: __(
-								"{{a}}Activate{{/a}} to optimize image sizes and load images from Jetpack's fast global network of servers. This improves your site's performance on desktop and mobile devices.",
+						? __( 'Unavailable in Dev Mode', 'jetpack' )
+						: createInterpolateElement(
+								__(
+									"<a>Activate</a> to optimize image sizes and load images from Jetpack's fast global network of servers. This improves your site's performance on desktop and mobile devices.",
+									'jetpack'
+								),
 								{
-									components: {
-										a: <a href="javascript:void(0)" onClick={ this.activatePhoton } />,
-									},
+									a: <a href="javascript:void(0)" onClick={ this.activatePhoton } />,
 								}
 						  ) }
 				</p>

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -57,7 +57,7 @@ class DashPhoton extends Component {
 				<p className="jp-dash-item__description">
 					{ this.props.isDevMode
 						? __( 'Unavailable in Dev Mode', 'jetpack' )
-						: createInterpolateElement(
+						: jetpackCreateInterpolateElement(
 								__(
 									"<a>Activate</a> to optimize image sizes and load images from Jetpack's fast global network of servers. This improves your site's performance on desktop and mobile devices.",
 									'jetpack'

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { __, _n } from '@wordpress/i18n';
 
 /**
@@ -83,9 +83,12 @@ class DashPluginUpdates extends Component {
 									'jetpack'
 								) + ' ',
 								! this.props.isDevMode &&
-									createInterpolateElement( __( '<a>Turn on plugin autoupdates.</a>', 'jetpack' ), {
-										a: <a href={ managePluginsUrl } />,
-									} ),
+									jetpackCreateInterpolateElement(
+										__( '<a>Turn on plugin autoupdates.</a>', 'jetpack' ),
+										{
+											a: <a href={ managePluginsUrl } />,
+										}
+									),
 						  ]
 						: __( 'All plugins are up-to-date. Awesome work!', 'jetpack' ) }
 				</p>

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -7,8 +7,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import getRedirectUrl from 'lib/jp-redirect';
 import analytics from 'lib/analytics';
 import Card from 'components/card';
 import DashItem from 'components/dash-item';
+import getRedirectUrl from 'lib/jp-redirect';
 import QueryPluginUpdates from 'components/data/query-plugin-updates';
 import { getPluginUpdates } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
@@ -37,12 +38,13 @@ class DashPluginUpdates extends Component {
 	}
 
 	getContent() {
-		const labelName = __( 'Plugin Updates' );
+		const labelName = __( 'Plugin Updates', 'jetpack' );
 		const pluginUpdates = this.props.pluginUpdates;
 
 		const support = {
 			text: __(
-				'Jetpack’s Plugin Updates allows you to choose which plugins update automatically.'
+				'Jetpack’s Plugin Updates allows you to choose which plugins update automatically.',
+				'jetpack'
 			),
 			link: getRedirectUrl( 'jetpack-support-site-management' ),
 		};
@@ -51,7 +53,7 @@ class DashPluginUpdates extends Component {
 			return (
 				<DashItem label={ labelName } module="manage" support={ support } status="is-working">
 					<QueryPluginUpdates />
-					<p className="jp-dash-item__description">{ __( 'Loading…' ) }</p>
+					<p className="jp-dash-item__description">{ __( 'Loading…', 'jetpack' ) }</p>
 				</DashItem>
 			);
 		}
@@ -70,26 +72,22 @@ class DashPluginUpdates extends Component {
 				support={ support }
 				status={ updatesAvailable ? 'is-warning' : workingOrInactive }
 			>
-				{ updatesAvailable && (
-					<h2 className="jp-dash-item__count">
-						{ __( '%(number)s', '%(number)s', {
-							count: pluginUpdates.count,
-							args: { number: pluginUpdates.count },
-						} ) }
-					</h2>
-				) }
+				{ updatesAvailable && <h2 className="jp-dash-item__count">{ pluginUpdates.count }</h2> }
 				<p className="jp-dash-item__description">
 					{ updatesAvailable
 						? [
-								__( 'Plugin needs updating.', 'Plugins need updating.', {
-									count: pluginUpdates.count,
-								} ) + ' ',
+								_n(
+									'Plugin needs updating.',
+									'Plugins need updating.',
+									pluginUpdates.count,
+									'jetpack'
+								) + ' ',
 								! this.props.isDevMode &&
-									__( '{{a}}Turn on plugin autoupdates.{{/a}}', {
-										components: { a: <a href={ managePluginsUrl } /> },
+									createInterpolateElement( __( '<a>Turn on plugin autoupdates.</a>', 'jetpack' ), {
+										a: <a href={ managePluginsUrl } />,
 									} ),
 						  ]
-						: __( 'All plugins are up-to-date. Awesome work!' ) }
+						: __( 'All plugins are up-to-date. Awesome work!', 'jetpack' ) }
 				</p>
 			</DashItem>,
 			! this.props.isDevMode && (
@@ -101,7 +99,7 @@ class DashPluginUpdates extends Component {
 					onClick={ this.trackManagePlugins }
 					target="_blank"
 				>
-					{ __( 'Manage your plugins' ) }
+					{ __( 'Manage your plugins', 'jetpack' ) }
 				</Card>
 			),
 		];

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -4,17 +4,19 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import DashItem from 'components/dash-item';
-import { numberFormat, translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { numberFormat } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import QueryProtectCount from 'components/data/query-dash-protect';
-import { isModuleAvailable } from 'state/modules';
+import DashItem from 'components/dash-item';
 import { getProtectCount } from 'state/at-a-glance';
+import getRedirectUrl from 'lib/jp-redirect';
 import { isDevMode } from 'state/connection';
+import { isModuleAvailable } from 'state/modules';
+import QueryProtectCount from 'components/data/query-dash-protect';
 
 class DashProtect extends Component {
 	static propTypes = {
@@ -26,9 +28,12 @@ class DashProtect extends Component {
 	activateProtect = () => this.props.updateOptions( { protect: true } );
 
 	getContent() {
-		const labelName = __( 'Protect' );
+		const labelName = __( 'Protect', 'jetpack' );
 		const support = {
-			text: __( 'Protects your site from traditional and distributed brute force login attacks.' ),
+			text: __(
+				'Protects your site from traditional and distributed brute force login attacks.',
+				'jetpack'
+			),
 			link: getRedirectUrl( 'jetpack-support-protect' ),
 		};
 
@@ -48,7 +53,8 @@ class DashProtect extends Component {
 							<QueryProtectCount />
 							<p className="jp-dash-item__description">
 								{ __(
-									'Jetpack is actively blocking malicious login attempts. Data will display here soon!'
+									'Jetpack is actively blocking malicious login attempts. Data will display here soon!',
+									'jetpack'
 								) }
 							</p>
 						</div>
@@ -59,7 +65,7 @@ class DashProtect extends Component {
 				<DashItem label={ labelName } module="protect" support={ support } status="is-working">
 					<h2 className="jp-dash-item__count">{ numberFormat( protectCount ) }</h2>
 					<p className="jp-dash-item__description">
-						{ __( 'Total malicious attacks blocked on your site.' ) }
+						{ __( 'Total malicious attacks blocked on your site.', 'jetpack' ) }
 					</p>
 				</DashItem>
 			);
@@ -74,13 +80,14 @@ class DashProtect extends Component {
 			>
 				<p className="jp-dash-item__description">
 					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode' )
-						: __(
-								'{{a}}Activate Protect{{/a}} to keep your site protected from malicious sign in attempts.',
+						? __( 'Unavailable in Dev Mode', 'jetpack' )
+						: createInterpolateElement(
+								__(
+									'<a>Activate Protect</a> to keep your site protected from malicious sign in attempts.',
+									'jetpack'
+								),
 								{
-									components: {
-										a: <a href="javascript:void(0)" onClick={ this.activateProtect } />,
-									},
+									a: <a href="javascript:void(0)" onClick={ this.activateProtect } />,
 								}
 						  ) }
 				</p>

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { numberFormat } from 'i18n-calypso';
 import { __ } from '@wordpress/i18n';
 
@@ -81,7 +81,7 @@ class DashProtect extends Component {
 				<p className="jp-dash-item__description">
 					{ this.props.isDevMode
 						? __( 'Unavailable in Dev Mode', 'jetpack' )
-						: createInterpolateElement(
+						: jetpackCreateInterpolateElement(
 								__(
 									'<a>Activate Protect</a> to keep your site protected from malicious sign in attempts.',
 									'jetpack'

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -4,7 +4,9 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { numberFormat, translate as __ } from 'i18n-calypso';
+import { createInterpolateElement } from '@wordpress/element';
+import { numberFormat } from 'i18n-calypso';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -32,11 +34,12 @@ import getRedirectUrl from 'lib/jp-redirect';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Scan' ) }
+		label={ __( 'Scan', 'jetpack' ) }
 		module={ props.feature || 'scan' }
 		support={ {
 			text: __(
-				'Your site’s files are regularly scanned for unauthorized or suspicious modifications that could compromise your security and data.'
+				'Your site’s files are regularly scanned for unauthorized or suspicious modifications that could compromise your security and data.',
+				'jetpack'
 			),
 			link: getRedirectUrl( 'jetpack-support-security' ),
 		} }
@@ -108,7 +111,7 @@ class DashScan extends Component {
 			if ( 'N/A' === vpData ) {
 				return renderCard( {
 					status: '',
-					content: __( 'Loading…' ),
+					content: __( 'Loading…', 'jetpack' ),
 				} );
 			}
 
@@ -123,7 +126,7 @@ class DashScan extends Component {
 				if ( vpData.code === 'success' ) {
 					return renderCard( {
 						status: 'is-working',
-						content: __( "No threats found, you're good to go!" ),
+						content: __( "No threats found, you're good to go!", 'jetpack' ),
 					} );
 				}
 			}
@@ -132,7 +135,7 @@ class DashScan extends Component {
 		if ( fetchingSiteData ) {
 			return renderCard( {
 				status: '',
-				content: __( 'Loading…' ),
+				content: __( 'Loading…', 'jetpack' ),
 			} );
 		}
 
@@ -145,18 +148,19 @@ class DashScan extends Component {
 		const scanContent =
 			hasPremium || hasBusiness || scanEnabled ? (
 				<p className="jp-dash-item__description" key="inactive-scanning">
-					{ __(
-						'For automated, comprehensive scanning of security threats, please {{a}}install and activate{{/a}} VaultPress.',
+					{ createInterpolateElement(
+						__(
+							'For automated, comprehensive scanning of security threats, please <a>install and activate</a> VaultPress.',
+							'jetpack'
+						),
 						{
-							components: {
-								a: (
-									<a
-										href={ getRedirectUrl( 'calypso-plugins-vaultpress' ) }
-										target="_blank"
-										rel="noopener noreferrer"
-									/>
-								),
-							},
+							a: (
+								<a
+									href={ getRedirectUrl( 'calypso-plugins-vaultpress' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						}
 					) }
 				</p>
@@ -175,8 +179,8 @@ class DashScan extends Component {
 	getUpgradeBanner() {
 		return (
 			<JetpackBanner
-				callToAction={ __( 'Upgrade' ) }
-				title={ __( 'Find threats early so we can help fix them fast.' ) }
+				callToAction={ __( 'Upgrade', 'jetpack' ) }
+				title={ __( 'Find threats early so we can help fix them fast.', 'jetpack' ) }
 				disableHref="false"
 				href={ this.props.upgradeUrl }
 				eventFeature="scan"
@@ -188,25 +192,25 @@ class DashScan extends Component {
 	}
 
 	renderThreatsFound( numberOfThreats, dashboardUrl ) {
-		const { siteRawUrl } = this.props;
 		return (
 			<>
 				{ renderActiveCard( [
 					<h2 className="jp-dash-item__count is-alert">{ numberFormat( numberOfThreats ) }</h2>,
 					<p className="jp-dash-item__description">
-						{ __(
-							'Security threat found. Please {{a}}fix it{{/a}} as soon as possible.',
-							'Security threats found. Please {{a}}fix these{{/a}} as soon as possible.',
+						{ createInterpolateElement(
+							_n(
+								'Security threat found. Please <a>fix it</a> as soon as possible.',
+								'Security threats found. Please <a>fix these</a> as soon as possible.',
+								numberOfThreats,
+								'jetpack'
+							),
 							{
-								count: numberOfThreats,
-								components: {
-									a: <a href={ dashboardUrl } target="_blank" rel="noopener noreferrer" />,
-								},
+								a: <a href={ dashboardUrl } target="_blank" rel="noopener noreferrer" />,
 							}
 						) }
 					</p>,
 				] ) }
-				{ renderAction( dashboardUrl, __( 'View security scan details' ) ) }
+				{ renderAction( dashboardUrl, __( 'View security scan details', 'jetpack' ) ) }
 			</>
 		);
 	}
@@ -226,11 +230,11 @@ class DashScan extends Component {
 			return (
 				<>
 					{ renderActiveCard(
-						__( "You need to enter your server's credentials to finish the setup." )
+						__( "You need to enter your server's credentials to finish the setup.", 'jetpack' )
 					) }
 					{ renderAction(
 						getRedirectUrl( 'calypso-settings-security', { site: siteRawUrl } ),
-						__( 'Enter credentials' )
+						__( 'Enter credentials', 'jetpack' )
 					) }
 				</>
 			);
@@ -238,20 +242,22 @@ class DashScan extends Component {
 
 		switch ( scanStatus.state ) {
 			case 'provisioning':
-				return <>{ renderActiveCard( __( 'We are configuring your site protection.' ) ) }</>;
+				return (
+					<>{ renderActiveCard( __( 'We are configuring your site protection.', 'jetpack' ) ) }</>
+				);
 			case 'idle':
 			case 'scanning':
 				return (
 					<>
 						{ renderActiveCard(
 							__(
-								'We are making sure your site stays free of security threats. ' +
-									'You will be notified if we find one.'
+								'We are making sure your site stays free of security threats. You will be notified if we find one.',
+								'jetpack'
 							)
 						) }
 						{ renderAction(
 							getRedirectUrl( 'calypso-scanner', { site: siteRawUrl } ),
-							__( 'View security scan details' )
+							__( 'View security scan details', 'jetpack' )
 						) }
 					</>
 				);
@@ -275,14 +281,14 @@ class DashScan extends Component {
 		if ( this.props.isDevMode ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
-				content: __( 'Unavailable in Dev Mode.' ),
+				content: __( 'Unavailable in Dev Mode.', 'jetpack' ),
 			} );
 		}
 
 		// Show loading while we're getting props.
 		// Once we get them, test the Scan system and then VaultPress in order.
 		const { scanStatus, vaultPressData, fetchingScanStatus } = this.props;
-		let content = renderCard( { content: __( 'Loading…' ) } );
+		let content = renderCard( { content: __( 'Loading…', 'jetpack' ) } );
 		if ( ! fetchingScanStatus && scanStatus.state && 'unavailable' !== scanStatus.state ) {
 			content = <div className="jp-dash-item">{ this.getRewindContent() }</div>;
 		} else if ( get( vaultPressData, [ 'data', 'features', 'security' ], false ) ) {

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { numberFormat } from 'i18n-calypso';
 import { __, _n } from '@wordpress/i18n';
 
@@ -148,7 +148,7 @@ class DashScan extends Component {
 		const scanContent =
 			hasPremium || hasBusiness || scanEnabled ? (
 				<p className="jp-dash-item__description" key="inactive-scanning">
-					{ createInterpolateElement(
+					{ jetpackCreateInterpolateElement(
 						__(
 							'For automated, comprehensive scanning of security threats, please <a>install and activate</a> VaultPress.',
 							'jetpack'
@@ -197,7 +197,7 @@ class DashScan extends Component {
 				{ renderActiveCard( [
 					<h2 className="jp-dash-item__count is-alert">{ numberFormat( numberOfThreats ) }</h2>,
 					<p className="jp-dash-item__description">
-						{ createInterpolateElement(
+						{ jetpackCreateInterpolateElement(
 							_n(
 								'Security threat found. Please <a>fix it</a> as soon as possible.',
 								'Security threats found. Please <a>fix these</a> as soon as possible.',

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
 
@@ -153,7 +153,7 @@ class DashSearch extends Component {
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
 			pro_inactive: false,
-			content: createInterpolateElement(
+			content: jetpackCreateInterpolateElement(
 				__(
 					'<a>Activate</a> to help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
 					'jetpack'

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -4,22 +4,23 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { noop } from 'lodash';
-import { getPlanClass, PLAN_JETPACK_SEARCH } from 'lib/plans/constants';
-import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
-import getRedirectUrl from 'lib/jp-redirect';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import DashItem from 'components/dash-item';
 import Card from 'components/card';
-import JetpackBanner from 'components/jetpack-banner';
-import { isDevMode } from 'state/connection';
+import DashItem from 'components/dash-item';
+import { getPlanClass, PLAN_JETPACK_SEARCH } from 'lib/plans/constants';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getSitePlan, hasActiveSearchPurchase, isFetchingSitePurchases } from 'state/site';
 import { getUpgradeUrl } from 'state/initial-state';
+import { isDevMode } from 'state/connection';
+import JetpackBanner from 'components/jetpack-banner';
+import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
 
 /**
  * Displays a card for Search based on the props given.
@@ -29,7 +30,7 @@ import { getUpgradeUrl } from 'state/initial-state';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Search' ) }
+		label={ __( 'Search', 'jetpack' ) }
 		module="search"
 		support={ {
 			text: SEARCH_SUPPORT,
@@ -77,7 +78,7 @@ class DashSearch extends Component {
 		if ( this.props.isFetching ) {
 			return renderCard( {
 				status: '',
-				content: __( 'Loading…' ),
+				content: __( 'Loading…', 'jetpack' ),
 			} );
 		}
 
@@ -86,7 +87,7 @@ class DashSearch extends Component {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
 				pro_inactive: true,
-				content: __( 'Unavailable in Dev Mode' ),
+				content: __( 'Unavailable in Dev Mode', 'jetpack' ),
 			} );
 		}
 
@@ -97,7 +98,7 @@ class DashSearch extends Component {
 				pro_inactive: true,
 				overrideContent: (
 					<JetpackBanner
-						callToAction={ __( 'Upgrade' ) }
+						callToAction={ __( 'Upgrade', 'jetpack' ) }
 						title={ SEARCH_DESCRIPTION }
 						disableHref="false"
 						href={ this.props.upgradeUrl }
@@ -114,7 +115,7 @@ class DashSearch extends Component {
 			return (
 				<div className="jp-dash-item">
 					<DashItem
-						label={ __( 'Search' ) }
+						label={ __( 'Search', 'jetpack' ) }
 						module="search"
 						support={ {
 							text: SEARCH_SUPPORT,
@@ -125,7 +126,7 @@ class DashSearch extends Component {
 						pro={ true }
 					>
 						<p className="jp-dash-item__description">
-							{ __( 'Jetpack Search is powering search on your site.' ) }
+							{ __( 'Jetpack Search is powering search on your site.', 'jetpack' ) }
 						</p>
 					</DashItem>
 					{ this.props.hasSearchProduct ? (
@@ -142,7 +143,7 @@ class DashSearch extends Component {
 							className="jp-search-config-aag"
 							href="customize.php?autofocus[panel]=widgets"
 						>
-							{ __( 'Add Search (Jetpack) Widget' ) }
+							{ __( 'Add Search (Jetpack) Widget', 'jetpack' ) }
 						</Card>
 					) }
 				</div>
@@ -152,12 +153,13 @@ class DashSearch extends Component {
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
 			pro_inactive: false,
-			content: __(
-				'{{a}}Activate{{/a}} to help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
+			content: createInterpolateElement(
+				__(
+					'<a>Activate</a> to help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
+					'jetpack'
+				),
 				{
-					components: {
-						a: <a href="javascript:void(0)" onClick={ this.activateSearch } />,
-					},
+					a: <a href="javascript:void(0)" onClick={ this.activateSearch } />,
 				}
 			),
 		} );

--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { numberFormat, moment } from 'i18n-calypso';
 import { __, _x, _n, sprintf } from '@wordpress/i18n';
 
@@ -99,16 +99,19 @@ class DashStatsBottom extends Component {
 				<div className="jp-at-a-glance__stats-cta">
 					<div className="jp-at-a-glance__stats-cta-description" />
 					<div className="jp-at-a-glance__stats-cta-buttons">
-						{ createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
-							button: (
-								<Button
-									onClick={ this.trackViewDetailedStats }
-									href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
-								/>
-							),
-						} ) }
+						{ jetpackCreateInterpolateElement(
+							__( '<button>View detailed stats</button>', 'jetpack' ),
+							{
+								button: (
+									<Button
+										onClick={ this.trackViewDetailedStats }
+										href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
+									/>
+								),
+							}
+						) }
 						{ this.props.isLinked &&
-							createInterpolateElement(
+							jetpackCreateInterpolateElement(
 								__( '<button>View more stats on WordPress.com </button>', 'jetpack' ),
 								{
 									button: (
@@ -129,7 +132,10 @@ class DashStatsBottom extends Component {
 						<ConnectButton
 							connectUser={ true }
 							from="unlinked-user-connect"
-							connectLegend={ __( 'Connect your account to WordPress.com to view more stats', 'jetpack' ) }
+							connectLegend={ __(
+								'Connect your account to WordPress.com to view more stats',
+								'jetpack'
+							) }
 						/>
 					</Card>
 				) }

--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -3,16 +3,18 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Button from 'components/button';
-import analytics from 'lib/analytics';
-import Card from 'components/card';
-import getRedirectUrl from 'lib/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { numberFormat, moment } from 'i18n-calypso';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { numberFormat, moment, translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Card from 'components/card';
 import ConnectButton from 'components/connect-button';
+import getRedirectUrl from 'lib/jp-redirect';
 
 class DashStatsBottom extends Component {
 	statsBottom() {
@@ -55,23 +57,21 @@ class DashStatsBottom extends Component {
 				<div className="jp-at-a-glance__stats-summary">
 					<div className="jp-at-a-glance__stats-summary-today">
 						<p className="jp-at-a-glance__stat-details">
-							{ __( 'Views today', { comment: 'Referring to a number of page views' } ) }
+							{ _x( 'Views today', 'Referring to a number of page views', 'jetpack' ) }
 						</p>
 						<h3 className="jp-at-a-glance__stat-number">{ s.viewsToday }</h3>
 					</div>
 					<div className="jp-at-a-glance__stats-summary-bestday">
 						<p className="jp-at-a-glance__stat-details">
-							{ __( 'Best overall day', { comment: 'Referring to a number of page views' } ) }
+							{ _x( 'Best overall day', 'Referring to a number of page views', 'jetpack' ) }
 						</p>
 						<h3 className="jp-at-a-glance__stat-number">
 							{ '-' === s.bestDay.count
 								? '-'
-								: __( '%(number)s View', '%(number)s Views', {
-										count: s.bestDay.count,
-										args: {
-											number: numberFormat( s.bestDay.count ),
-										},
-								  } ) }
+								: sprintf(
+										_n( '%s View', '%s Views', s.bestDay.count, 'jetpack' ),
+										numberFormat( s.bestDay.count )
+								  ) }
 						</h3>
 						<p className="jp-at-a-glance__stat-details">
 							{ '-' === s.bestDay.day ? '-' : moment( s.bestDay.day ).format( 'MMMM Do, YYYY' ) }
@@ -80,7 +80,7 @@ class DashStatsBottom extends Component {
 					<div className="jp-at-a-glance__stats-summary-alltime">
 						<div className="jp-at-a-glance__stats-alltime-views">
 							<p className="jp-at-a-glance__stat-details">
-								{ __( 'All-time views', { comment: 'Referring to a number of page views' } ) }
+								{ _x( 'All-time views', 'Referring to a number of page views', 'jetpack' ) }
 							</p>
 							<h3 className="jp-at-a-glance__stat-number">
 								{ '-' === s.allTime.views ? '-' : numberFormat( s.allTime.views ) }
@@ -88,7 +88,7 @@ class DashStatsBottom extends Component {
 						</div>
 						<div className="jp-at-a-glance__stats-alltime-comments">
 							<p className="jp-at-a-glance__stat-details">
-								{ __( 'All-time comments', { comment: 'Referring to a number of comments' } ) }
+								{ _x( 'All-time comments', 'Referring to a number of comments', 'jetpack' ) }
 							</p>
 							<h3 className="jp-at-a-glance__stat-number">
 								{ '-' === s.allTime.comments ? '-' : numberFormat( s.allTime.comments ) }
@@ -99,19 +99,18 @@ class DashStatsBottom extends Component {
 				<div className="jp-at-a-glance__stats-cta">
 					<div className="jp-at-a-glance__stats-cta-description" />
 					<div className="jp-at-a-glance__stats-cta-buttons">
-						{ __( '{{button}}View detailed stats{{/button}}', {
-							components: {
-								button: (
-									<Button
-										onClick={ this.trackViewDetailedStats }
-										href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
-									/>
-								),
-							},
+						{ createInterpolateElement( __( '<button>View detailed stats</button>', 'jetpack' ), {
+							button: (
+								<Button
+									onClick={ this.trackViewDetailedStats }
+									href={ this.props.siteAdminUrl + 'admin.php?page=stats' }
+								/>
+							),
 						} ) }
 						{ this.props.isLinked &&
-							__( '{{button}}View more stats on WordPress.com {{/button}}', {
-								components: {
+							createInterpolateElement(
+								__( '<button>View more stats on WordPress.com </button>', 'jetpack' ),
+								{
 									button: (
 										<Button
 											onClick={ this.trackViewWpcomStats }
@@ -121,8 +120,8 @@ class DashStatsBottom extends Component {
 											} ) }
 										/>
 									),
-								},
-							} ) }
+								}
+							) }
 					</div>
 				</div>
 				{ ! this.props.isLinked && (
@@ -130,7 +129,7 @@ class DashStatsBottom extends Component {
 						<ConnectButton
 							connectUser={ true }
 							from="unlinked-user-connect"
-							connectLegend={ __( 'Connect your account to WordPress.com to view more stats' ) }
+							connectLegend={ __( 'Connect your account to WordPress.com to view more stats', 'jetpack' ) }
 						/>
 					</Card>
 				) }

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { forEach, get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { numberFormat, moment } from 'i18n-calypso';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -183,7 +183,7 @@ export class DashStats extends Component {
 				return (
 					<div className="jp-at-a-glance__stats-inactive">
 						<span>
-							{ createInterpolateElement(
+							{ jetpackCreateInterpolateElement(
 								__(
 									'Something happened while loading stats. Please try again later or <a>view your stats now on WordPress.com</a>',
 									'jetpack'
@@ -233,7 +233,7 @@ export class DashStats extends Component {
 				<div className="jp-at-a-glance__stats-inactive-text">
 					{ this.props.isDevMode
 						? __( 'Unavailable in Dev Mode', 'jetpack' )
-						: createInterpolateElement(
+						: jetpackCreateInterpolateElement(
 								__(
 									'<a>Activate Site Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
 									'jetpack'

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -4,28 +4,30 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { forEach, get, isEmpty } from 'lodash';
-import Card from 'components/card';
-import Chart from 'components/chart';
 import { connect } from 'react-redux';
-import DashSectionHeader from 'components/dash-section-header';
-import Button from 'components/button';
-import Spinner from 'components/spinner';
-import { numberFormat, moment, translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { createInterpolateElement } from '@wordpress/element';
+import { numberFormat, moment } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Card from 'components/card';
+import Chart from 'components/chart';
+import DashSectionHeader from 'components/dash-section-header';
+import DashStatsBottom from './dash-stats-bottom';
+import { emptyStatsCardDismissed } from 'state/settings';
+import { getInitialStateStatsData } from 'state/initial-state';
+import getRedirectUrl from 'lib/jp-redirect';
+import { getStatsData, statsSwitchTab, fetchStatsData, getActiveStatsTab } from 'state/at-a-glance';
 import { imagePath } from 'constants/urls';
 import { isDevMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
-import { getInitialStateStatsData } from 'state/initial-state';
-import QueryStatsData from 'components/data/query-stats-data';
-import DashStatsBottom from './dash-stats-bottom';
-import { getStatsData, statsSwitchTab, fetchStatsData, getActiveStatsTab } from 'state/at-a-glance';
 import { isModuleAvailable, getModuleOverride } from 'state/modules';
-import { emptyStatsCardDismissed } from 'state/settings';
 import ModuleOverriddenBanner from 'components/module-overridden-banner';
+import QueryStatsData from 'components/data/query-stats-data';
+import Spinner from 'components/spinner';
 
 export class DashStats extends Component {
 	static propTypes = {
@@ -75,9 +77,11 @@ export class DashStats extends Component {
 			} else if ( 'week' === unit ) {
 				date = date.replace( /W/g, '-' );
 				chartLabel = moment( date ).format( 'MMM D' );
-				tooltipLabel = __( 'Week of %(date)s', {
-					args: { date: moment( date ).format( 'MMMM Do' ) },
-				} );
+				tooltipLabel = sprintf(
+					/* translators: placeholder is a date. */
+					__( 'Week of %s', 'jetpack' ),
+					moment( date ).format( 'MMMM Do' )
+				);
 			} else if ( 'month' === unit ) {
 				chartLabel = moment( date ).format( 'MMM' );
 				tooltipLabel = moment( date ).format( 'MMMM, YYYY' );
@@ -97,12 +101,14 @@ export class DashStats extends Component {
 				tooltipData: [
 					{
 						label: tooltipLabel,
-						value: __( 'Views: %(numberOfViews)s', {
-							args: { numberOfViews: numberFormat( views ) },
-						} ),
+						value: sprintf(
+							/* translators: placeholder is a number */
+							__( 'Views: %s', 'jetpack' ),
+							numberFormat( views )
+						),
 						className: 'tooltip class',
 					},
-					{ label: __( 'Click to view detailed stats.' ) },
+					{ label: __( 'Click to view detailed stats.', 'jetpack' ) },
 				],
 			} );
 		} );
@@ -151,16 +157,19 @@ export class DashStats extends Component {
 					src={ imagePath + 'stats-people.svg' }
 					width="272"
 					height="144"
-					alt={ __( 'Jetpack Stats People' ) }
+					alt={ __( 'Jetpack Stats People', 'jetpack' ) }
 					className="jp-at-a-glance__stats-icon"
 				/>
 				<p>
-					{ __( 'Hello there! Your stats have been activated.' ) }
+					{ __( 'Hello there! Your stats have been activated.', 'jetpack' ) }
 					<br />
-					{ __( 'Just give us a little time to collect data so we can display it for you here.' ) }
+					{ __(
+						'Just give us a little time to collect data so we can display it for you here.',
+						'jetpack'
+					) }
 				</p>
 				<Button onClick={ this.dismissCard } primary>
-					{ __( 'Okay, got it!' ) }
+					{ __( 'Okay, got it!', 'jetpack' ) }
 				</Button>
 			</Card>
 		);
@@ -174,18 +183,19 @@ export class DashStats extends Component {
 				return (
 					<div className="jp-at-a-glance__stats-inactive">
 						<span>
-							{ __(
-								'Something happened while loading stats. Please try again later or {{a}}view your stats now on WordPress.com{{/a}}',
+							{ createInterpolateElement(
+								__(
+									'Something happened while loading stats. Please try again later or <a>view your stats now on WordPress.com</a>',
+									'jetpack'
+								),
 								{
-									components: {
-										a: (
-											<a
-												href={ getRedirectUrl( 'calypso-stats-insights', {
-													site: this.props.siteRawUrl,
-												} ) }
-											/>
-										),
-									},
+									a: (
+										<a
+											href={ getRedirectUrl( 'calypso-stats-insights', {
+												site: this.props.siteRawUrl,
+											} ) }
+										/>
+									),
 								}
 							) }
 						</span>
@@ -216,33 +226,34 @@ export class DashStats extends Component {
 						src={ imagePath + 'stats.svg' }
 						width="60"
 						height="60"
-						alt={ __( 'Jetpack Stats Icon' ) }
+						alt={ __( 'Jetpack Stats Icon', 'jetpack' ) }
 						className="jp-at-a-glance__stats-icon"
 					/>
 				</div>
 				<div className="jp-at-a-glance__stats-inactive-text">
 					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode' )
-						: __(
-								'{{a}}Activate Site Stats{{/a}} to see detailed stats, likes, followers, subscribers, and more! {{a1}}Learn More{{/a1}}',
+						? __( 'Unavailable in Dev Mode', 'jetpack' )
+						: createInterpolateElement(
+								__(
+									'<a>Activate Site Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
+									'jetpack'
+								),
 								{
-									components: {
-										a: <a href="javascript:void(0)" onClick={ this.activateStats } />,
-										a1: (
-											<a
-												href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
+									a: <a href="javascript:void(0)" onClick={ this.activateStats } />,
+									a1: (
+										<a
+											href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
 								}
 						  ) }
 				</div>
 				{ ! this.props.isDevMode && (
 					<div className="jp-at-a-glance__stats-inactive-button">
 						<Button onClick={ this.activateStats } primary>
-							{ __( 'Activate Site Stats' ) }
+							{ __( 'Activate Site Stats', 'jetpack' ) }
 						</Button>
 					</div>
 				) }
@@ -281,7 +292,7 @@ export class DashStats extends Component {
 							onClick={ this.switchToDay }
 							className={ this.getClass( 'day' ) }
 						>
-							{ __( 'Days' ) }
+							{ __( 'Days', 'jetpack' ) }
 						</a>
 					</li>
 					<li className="jp-at-a-glance__stats-view">
@@ -291,7 +302,7 @@ export class DashStats extends Component {
 							onClick={ this.switchToWeek }
 							className={ this.getClass( 'week' ) }
 						>
-							{ __( 'Weeks' ) }
+							{ __( 'Weeks', 'jetpack' ) }
 						</a>
 					</li>
 					<li className="jp-at-a-glance__stats-view">
@@ -301,7 +312,7 @@ export class DashStats extends Component {
 							onClick={ this.switchToMonth }
 							className={ this.getClass( 'month' ) }
 						>
-							{ __( 'Months' ) }
+							{ __( 'Months', 'jetpack' ) }
 						</a>
 					</li>
 				</ul>
@@ -319,7 +330,7 @@ export class DashStats extends Component {
 		if ( 'inactive' === this.props.getModuleOverride( 'stats' ) ) {
 			return (
 				<div>
-					<ModuleOverriddenBanner moduleName={ __( 'Site Stats' ) } />
+					<ModuleOverriddenBanner moduleName={ __( 'Site Stats', 'jetpack' ) } />
 				</div>
 			);
 		}
@@ -327,7 +338,7 @@ export class DashStats extends Component {
 			this.props.isModuleAvailable && (
 				<div>
 					<QueryStatsData range={ this.props.activeTab } />
-					<DashSectionHeader label={ __( 'Site Stats' ) }>
+					<DashSectionHeader label={ __( 'Site Stats', 'jetpack' ) }>
 						{ this.maybeShowStatsTabs() }
 					</DashSectionHeader>
 					<Card

--- a/_inc/client/components/create-interpolate-element/README.md
+++ b/_inc/client/components/create-interpolate-element/README.md
@@ -1,0 +1,23 @@
+Create Interpolate Element
+=========
+
+This function creates an interpolated element from a passed in string with specific tags matching how the string should be converted to an element via the conversion map value.
+
+`createInterpolateElement` is available in WordPress 5.5 and in latest versions of the Gutenberg plugin, but it is not available in WordPress 5.4, which we still support.
+
+## Example Usage:
+
+```js
+import Gridicon from 'components/gridicon';
+import { __ } from '@wordpress/i18n';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+const getDocumentationLink = () => {
+	return jetpackjetpackCreateInterpolateElement(lement(
+		__( '<FlagIcon /> Still confused? <a>Check out documentation for more!</a>', 'jetpack' ),
+		{
+			FlagIcon: <Gridicon icon="flag" size={ 64 } />
+			a: <a href="https://jetpack.com" />,
+		}
+	);
+};
+```

--- a/_inc/client/components/create-interpolate-element/index.jsx
+++ b/_inc/client/components/create-interpolate-element/index.jsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import {
+	createInterpolateElement,
+	__experimentalCreateInterpolateElement,
+} from '@wordpress/element';
+
+/**
+ * createInterpolateElement is available in WordPress 5.5
+ * and in latest versions of the Gutenberg plugin,
+ * but it is not available in WordPress 5.4, which we still support.
+ *
+ * @todo remove when Jetpack requires WordPress 5.5.
+ */
+export const jetpackCreateInterpolateElement =
+	createInterpolateElement || __experimentalCreateInterpolateElement;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -180,6 +180,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
+		wp_set_script_translations( 'react-plugin', 'jetpack', JETPACK__PLUGIN_DIR . '/languages/json/' );
+
 		// Add objects to be passed to the initial state of the app.
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
 		wp_add_inline_script( 'react-plugin', 'var Initial_State=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $this->get_initial_state() ) ) . '"));', 'before' );

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -180,7 +180,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 
-		wp_set_script_translations( 'react-plugin', 'jetpack', JETPACK__PLUGIN_DIR . '/languages/json/' );
+		wp_set_script_translations( 'react-plugin', 'jetpack' );
 
 		// Add objects to be passed to the initial state of the app.
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
 		"gulp-tap": "2.0.0",
 		"i18n-calypso": "4.0.0",
 		"i18n-calypso-cli": "1.0.0",
+		"interpolate-components": "1.1.1",
 		"jsdom": "16.3.0",
 		"jsdom-global": "3.0.2",
 		"json-loader": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
 		"gulp-tap": "2.0.0",
 		"i18n-calypso": "4.0.0",
 		"i18n-calypso-cli": "1.0.0",
-		"interpolate-components": "1.1.1",
 		"jsdom": "16.3.0",
 		"jsdom-global": "3.0.2",
 		"json-loader": "0.5.7",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

**This will need to happen in steps so reviews are easier. This is step 1.**

We're aiming to move away from the `i18n-calypso` tooling to handle translations. Instead we'll rely on 2 things:
- `@wordpress/i18n` for most translation work: `__`, `_n`, `_x`, and `sprintf`.
- `@wordpress/element` and its `createInterpolateElement` to handle React elements in strings.

`i18n-calypso` will remain in use for a few exceptions for now:
- `moment`
- `numberFormat`

This first PR introduces those changes for the At A Glance dashboard.

#### Jetpack product discussion

* p1HpG7-99c-p2
* Primary issue: #16481 

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Nothing should change at first sight:

- Under Jetpack > Dashboard, check how things look like everywhere on the page when you've connected your site to WordPress.com, or when Development mode is active.
- Try with different plugins and module active / inactive to get different card statues.
- Try with outdated plugins to see different messages.
- If you view source on the page, you should see a new section right before the React JS bundle is loaded: `react-plugin-js-translations`. There are no translations here for now, as no language pack is generated yet for this JS bundle. We'll need to push an Alpha first.

#### Proposed changelog entry for your changes:

* TBD


******************************

#### Original PR description below (before the discussion in the comments below happened)

This is a demo PR that shows how we'll be able to remove all of our uses of `translate()` (from i18n-calypso) within the Jetpack Dashboard so that we can move over to using language pack JSONs for this.

This could be merged as is and would have the Akismet "At a glance" use translations loaded the standard WordPress/Gutenberg way (i.e. using `wp_set_script_translations()`). The downside of this is that this duplicates the translations JSON in the HTML source.

To bring this over the finish line we'll also need to change our build process so that the translatable strings are picked up from the JavaScript source. We currently only ship the uglified `_inc/build/admin.js` and not the JavaScript clean source. If we committed the unmodified source to SVN, the strings would be extracted for translation and provided inside language packs.

To avoid duplication, the [convention in building the language packs](https://meta.trac.wordpress.org/browser/sites/trunk/wordpress.org/public_html/wp-content/plugins/wporg-gp-customizations/inc/cli/class-language-pack.php#L441) is to have the source be placed under a `src/` path, so that they won't be included in the language pack.