### PR TITLE
Add Open login popup at the same time as iframe

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -3,8 +3,53 @@
 jQuery( document ).ready( function( $ ) {
 	var connectButton = $( '.jp-connect-button' );
 	var tosText = $( '.jp-connect-full__tos-blurb' );
+	var loginPopUpRef = null;
+	var externalWindowCheck = null;
+
+	function pollExternalWindow() {
+		if ( ! loginPopUpRef || loginPopUpRef.closed ) {
+			// Login window is closed, don't keep trying
+			loginPopUpRef = null;
+			clearInterval( externalWindowCheck );
+			// reload the iframe...
+			var iframe = $( '.jp-jetpack-connect__iframe' );
+			iframe.attr( 'src', iframe.attr( 'src' ) );
+		}
+	}
+
+	function openLoginPopup() {
+		var popUpHeight = 800;
+		var popUpWidth = 500;
+		var left = screen.width / 2 - popUpWidth / 2;
+		var top = screen.height / 2 - popUpHeight / 2;
+		var url = 'https://wordpress.com/log-in/jetpack/?close_window_after_login=true';
+		var target = 'wpcom-login';
+		var features =
+			'status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=1,width=' +
+			popUpWidth +
+			',height=' +
+			popUpHeight +
+			',top=' +
+			top +
+			',left=' +
+			left;
+
+		if ( loginPopUpRef === null || loginPopUpRef.closed ) {
+			loginPopUpRef = window.open( url, target, features );
+		} else {
+			loginPopUpRef.focus();
+		}
+		return loginPopUpRef;
+	}
 	connectButton.click( function( event ) {
 		event.preventDefault();
+
+		loginPopUpRef = openLoginPopup();
+
+		if ( ! externalWindowCheck ) {
+			externalWindowCheck = setInterval( pollExternalWindow, 100 );
+		}
+
 		$( '#jetpack-connection-cards' ).fadeOut( 600 );
 		if ( ! jetpackConnectButton.isRegistering ) {
 			if ( 'original' === jpConnect.forceVariation ) {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -44,12 +44,6 @@ jQuery( document ).ready( function( $ ) {
 	connectButton.click( function( event ) {
 		event.preventDefault();
 
-		loginPopUpRef = openLoginPopup();
-
-		if ( ! externalWindowCheck ) {
-			externalWindowCheck = setInterval( pollExternalWindow, 100 );
-		}
-
 		$( '#jetpack-connection-cards' ).fadeOut( 600 );
 		if ( ! jetpackConnectButton.isRegistering ) {
 			if ( 'original' === jpConnect.forceVariation ) {
@@ -90,6 +84,8 @@ jQuery( document ).ready( function( $ ) {
 		},
 		handleOriginalFlow: function() {
 			window.location = connectButton.attr( 'href' );
+
+			loginPopUpRef && loginPopUpRef.close(); // Close the popup if we go though the original flow.
 		},
 		handleConnectInPlaceFlow: function() {
 			jetpackConnectButton.isRegistering = true;
@@ -107,6 +103,12 @@ jQuery( document ).ready( function( $ ) {
 			if ( window.Initial_State && window.Initial_State.calypsoEnv ) {
 				registerUrl =
 					registerUrl + '?' + $.param( { calypso_env: window.Initial_State.calypsoEnv } );
+			}
+
+			loginPopUpRef = openLoginPopup();
+
+			if ( ! externalWindowCheck ) {
+				externalWindowCheck = setInterval( pollExternalWindow, 100 );
 			}
 
 			$.ajax( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Instead of asking the user to login after they click a button this PR opens up a popup and an iframe that lets the user login. After the popup closed the iframe refreshed to allow the user to finish the authorization process. 

See https://cloudup.com/cI6AGT6sqcZ

#### Testing instructions:
* Go to the Jepack dashboard. Try to connect jetpack. Notice that the login popup shows up right away and notice that you can login or see the button to connect with wordpress.com (which opens up the popup again. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improved the connect in place flow by showing you a login window right away.
