### PR TITLE
Jetpack Debug: Do not fail if WP.com SELF test times outs.

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -319,6 +319,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 *
 	 * Intentionally added last as it will be skipped if any local failed conditions exist.
 	 *
+	 * @since 7.1.0
+	 * @since 7.9.0 Timeout waiting for a WP.com response no longer fails the test. Test is marked skipped instead.
+	 *
 	 * @return array Test results.
 	 */
 	protected function last__wpcom_self_test() {
@@ -339,8 +342,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
 			return self::passing_test( $name );
+		} elseif ( is_wp_error( $response ) && false !== strpos( $response->get_error_message(), 'cURL error 28' ) ) { // Timeout.
+			return self::skipped_test( $name, __( 'The test timed out which may sometimes indicate a failure or may be a false failure.', 'jetpack' ) );
 		} else {
-			return self::failing_test( $name, __( 'Jetpack.com detected an error.', 'jetpack' ), __( 'Visit the Jetpack.com debugging page for more information or contact support.', 'jetpack' ) ); // @todo direct links.
+			return self::failing_test( $name, __( 'Jetpack.com detected an error on the WPcom Self Test.', 'jetpack' ), __( 'Visit the Jetpack.com debugging page for more information or contact support.', 'jetpack' ) ); // @todo direct links.
 		}
 	}
 }


### PR DESCRIPTION
Fixes #12881

The "WP.com SELF Test" pings WordPress.com and requests the Jetpack.com/support/debug/ test suite ran, then reports the result. To allow time for all of the work, the HTTP timeout is increased to 30 seconds. Sometimes this isn't long enough either because the site is slow or simply slower to reach over the network.

Previously, a timeout when requesting the SELF test resulted in a test failure, reporting as such in the Site Health section of a WordPress site.

Now, a timeout will not fail out the test and won't be reported on Site Health.

Next steps would be evaluate this test and the REST API-based connection test to only require one.

#### Changes proposed in this Pull Request:
* Debug: Self test no longer fails on a timeout.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add `add_filter( 'http_request_timeout', function () { return 1; } ), 999 );` to your site (to reduce the HTTP timeout to 1 second.
* Visit the Tools->Site Health page.
* Prior to this PR, a really generic error would be reported for Jetpack.
* With this PR, no error is returned.

#### Proposed changelog entry for your changes:
* Debug: Reduce instances when an inconclusive response would result in an error.
