### PR TITLE
XMLRPC: Fires clean_nonce action in all cases

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -79,6 +79,9 @@ class Manager {
 	) {
 		add_filter( 'xmlrpc_blog_options', array( $this, 'xmlrpc_options' ), 1000, 2 );
 		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
+		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
+			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
+		}
 
 		if (
 			! isset( $request_params['for'] )
@@ -138,10 +141,6 @@ class Manager {
 			} else {
 				new XMLRPC_Connector( $this );
 			}
-		}
-
-		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
-			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		}
 
 		// Now that no one can authenticate, and we're whitelisting all XML-RPC methods, force enable_xmlrpc on.

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -61,6 +61,11 @@ class Manager {
 		} else {
 			add_action( 'rest_api_init', array( $this, 'initialize_rest_api_registration_connector' ) );
 		}
+
+		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
+		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
+			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
+		}
 	}
 
 	/**
@@ -78,10 +83,6 @@ class Manager {
 		\Jetpack_XMLRPC_Server $xmlrpc_server = null
 	) {
 		add_filter( 'xmlrpc_blog_options', array( $this, 'xmlrpc_options' ), 1000, 2 );
-		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
-		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
-			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
-		}
 
 		if (
 			! isset( $request_params['for'] )

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -78,6 +78,7 @@ class Manager {
 		\Jetpack_XMLRPC_Server $xmlrpc_server = null
 	) {
 		add_filter( 'xmlrpc_blog_options', array( $this, 'xmlrpc_options' ), 1000, 2 );
+		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
 
 		if (
 			! isset( $request_params['for'] )
@@ -139,7 +140,6 @@ class Manager {
 			}
 		}
 
-		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
 		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		}
@@ -1643,7 +1643,7 @@ class Manager {
 	 */
 	public function public_xmlrpc_methods( $methods ) {
 		if ( array_key_exists( 'wp.getOptions', $methods ) ) {
-			$methods['wp.getOptions'] = array( $this, 'jetpack_getOptions' );
+			$methods['wp.getOptions'] = array( $this, 'jetpack_get_options' );
 		}
 		return $methods;
 	}
@@ -1654,7 +1654,7 @@ class Manager {
 	 * @param Array $args method call arguments.
 	 * @return an amended XMLRPC server options array.
 	 */
-	public function jetpack_getOptions( $args ) {
+	public function jetpack_get_options( $args ) {
 		global $wp_xmlrpc_server;
 
 		$wp_xmlrpc_server->escape( $args );


### PR DESCRIPTION
Moves the `add_action` to fire in more cases than only on Jetpack-only calls.

#### Changes proposed in this Pull Request:
* Moves add_actions higher in the stack.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add a cron job to fire the hook.
See p1569358812002100-slack-jetpack-plugin

#### Proposed changelog entry for your changes:
* XML-RPC: Restore ability to run jetpack_clean_nonce from a cron job.
