### PR TITLE
Add support for filtering meta data on post lookup

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -278,6 +278,40 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 		return $response;
 	}
 
+	function filter_response( $response ) {
+
+		// Do minimal processing if the caller didn't request it
+		if ( ! isset( $_REQUEST['meta_fields'] ) ) {
+			return $response;
+		}
+
+		// Retrieve an array of field paths, such as: [`autosave.modified`, `autosave.post_ID`]
+		$fields = explode( ',', $_REQUEST['meta_fields'] );
+
+		foreach ( $response['posts'] as $post ) {
+
+			if ( ! isset( $post['meta'] ) || ! isset( $post['meta']->data ) || (! is_array( $post['meta']->data ) && ! is_object( $post['meta']->data ) ) ) {
+				break;
+			}
+			
+			$newmeta = [];
+			foreach ( $post['meta']->data as $field_key => $field_value ) {
+
+				foreach ( $field_value as $subfield_key => $subfield_value ) {
+					$key_path = $field_key . '.' . $subfield_key;
+
+					if ( in_array( $key_path, $fields ) ) {
+						$newmeta[ $field_key ][ $subfield_key ] = $subfield_value;
+					}
+				}
+			}
+
+			$post['meta']->data = $newmeta;
+		}
+
+		return $response;
+	}
+	
 	// TODO: factor this out
 	function get_blog_post( $blog_id, $post_id, $context = 'display' ) {
 		$blog_id = $this->api->get_blog_id( $blog_id );


### PR DESCRIPTION
Differential Revision: D29715-code

This commit syncs r196943-wpcom.

#### Changes proposed in this Pull Request:

* Details at the link above.

#### Testing instructions:

1) Download this patch to your sandbox
2) Using your favourite API client, request `https://public-api.wordpress.com/rest/v1.1/sites/133112643/posts?number=1&fields=title,modified,status,meta&context=edit&meta=autosave&meta_fields=autosave.modified,autosave.post_ID,autosave.ID`. This is a testing site belonging to @malinajirka - alternatively, you could follow his directions to create an autosave post on your own blog:

```
You can create your own “autosave” if you
1. open a published blog post
2. change something
3. wait for about 30s before it’s autosaved
4. leave the blog post without manually saving/publishing the changes.
```

3) Note that the response includes the fields `ID`, `post_ID`, and `modified`.
4) Remove the `meta_fields` param, and note that the response now includes the entire `meta.data.autosafe` object.

#### Proposed changelog entry for your changes:

* None
