### PR TITLE
Sync: Only allow white listed comment types to be inserted.

### DIFF
--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -178,6 +178,13 @@ class Comments extends Module {
 		);
 	}
 
+	/**
+	 * Prevents any comment types that are not in the white list from being enqued and send to WordPress.com.
+	 *
+	 * @param array $args Arguments passed to wp_insert_comment
+	 *
+	 * @return bool or array $args Arguments passed to wp_insert_comment
+	 */
 	public function only_allow_white_listed_comment_types( $args ) {
 		$comment = $args[1];
 

--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -88,6 +88,7 @@ class Comments extends Module {
 		add_action( 'untrashed_comment', $callable, 10, 2 );
 		add_action( 'unspammed_comment', $callable, 10, 2 );
 		add_filter( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
+		add_filter( 'jetpack_sync_before_enqueue_wp_insert_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
 
 		/**
 		 * Even though it's messy, we implement these hooks because
@@ -175,6 +176,16 @@ class Comments extends Module {
 			'jetpack_sync_whitelisted_comment_types',
 			array( '', 'trackback', 'pingback' )
 		);
+	}
+
+	public function only_allow_white_listed_comment_types( $args ) {
+			$comment = $args[1];
+
+		if ( ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
+			return false;
+		}
+
+			return $args;
 	}
 
 	/**

--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -179,7 +179,7 @@ class Comments extends Module {
 	}
 
 	/**
-	 * Prevents any comment types that are not in the white list from being enqued and send to WordPress.com.
+	 * Prevents any comment types that are not in the whitelist from being enqueued and sent to WordPress.com.
 	 *
 	 * @param array $args Arguments passed to wp_insert_comment
 	 *

--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -185,7 +185,7 @@ class Comments extends Module {
 			return false;
 		}
 
-			return $args;
+		return $args;
 	}
 
 	/**

--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -179,7 +179,7 @@ class Comments extends Module {
 	}
 
 	public function only_allow_white_listed_comment_types( $args ) {
-			$comment = $args[1];
+		$comment = $args[1];
 
 		if ( ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
 			return false;

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -76,7 +76,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$this->modify_comment_helper( $comment, $expected_variable );
 	}
 
-	public function test_do_not_sync_comment_with_unknow_comment_type() {
+	public function test_do_not_sync_comment_with_unknown_comment_type() {
 		$this->server_event_storage->reset();
 		$comment_data = array(
 			'comment_post_ID' => $this->post_id,

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -94,7 +94,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( $event );
 	}
 
-	public function test_do_sync_comments_with_knows_comment_types() {
+	public function test_do_sync_comments_with_known_comment_types() {
 		$this->server_event_storage->reset();
 		add_filter( 'jetpack_sync_whitelisted_comment_types', array( $this, 'add_custom_comment_type' ) );
 
@@ -105,7 +105,7 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 			'comment_author' => 'fun author',
 			'comment_content' => 'fun!',
 			'comment_agent' => 'fun things!',
-			'comment_type' => 'product_feedback', // This should be whiteliasted in the filter.
+			'comment_type' => 'product_feedback', // This should be whitelisted in the filter.
 		);
 		wp_insert_comment( $comment_data );
 		$this->sender->do_sync();

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -76,6 +76,25 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$this->modify_comment_helper( $comment, $expected_variable );
 	}
 
+	public function test_do_not_sync_comment_with_unknow_comment_type() {
+		$this->server_event_storage->reset();
+		$comment_data = array(
+			'comment_post_ID' => $this->post_id,
+			'comment_date' => date('Y-m-d H:i:s', time() ),
+			'comment_date_gmt' => date('Y-m-d H:i:s', time() ),
+			'comment_author' => 'ActionScheduler',
+			'comment_content' => 'fun!',
+			'comment_agent' => 'ActionScheduler',
+			'comment_type' => 'action_log',
+		);
+		wp_insert_comment( $comment_data );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'wp_insert_comment' );
+		$this->assertFalse( $event );
+
+	}
+
 	public function test_modify_comment_author() {
 		global $wp_version;
 		if ( version_compare( $wp_version, 4.7, '<' ) ) {


### PR DESCRIPTION
Currently we allow any comment type to be inserted. Which resulted in an increase of comments coming from the https://actionscheduler.org/ plugin.

This PR fixes it by making sure that any comments that are inserted that do not have the whitelisted comment type gets discarded. 

#### Changes proposed in this Pull Request:
* Check that the comment type is whitelisted before we enqueue it.

#### Testing instructions:
* Do the tests pass?
* Activate the action scheduler plugin. 
* Do you see the comments created by the plugin show up on your .com sandbox?

#### Proposed changelog entry for your changes:
* Prevent comments of non white listed comment type to be synced.
