### PR TITLE
At a Glance: add class to Connections section header

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -69,7 +69,10 @@ class AtAGlance extends Component {
 		);
 		const connections = (
 			<div>
-				<DashSectionHeader label={ __( 'Connections' ) } />
+				<DashSectionHeader
+					label={ __( 'Connections' ) }
+					className="jp-dash-section-header__connections"
+				/>
 				<DashConnections />
 			</div>
 		);


### PR DESCRIPTION
Fixes 94-gh-wpcomsh in conjunction with 336-gh-wpcomsh

#### Changes proposed in this Pull Request:

* Add extra class to Connections section header, so we can target it on `wpcomsh` and hide the entire section for Atomic sites.

#### Testing instructions:

* Go to your Jetpack Dashboard/At a Glance page.
* Ensure that the “Connections” section header has an extra class `jp-dash-section-header__connections`.

#### Proposed changelog entry for your changes:

* No changelog.
