### PR TITLE
Admin Page: change default settings tab depending on your role

### DIFF
--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -43,7 +43,10 @@ export default class extends React.Component {
 				<Security
 					siteAdminUrl={ this.props.siteAdminUrl }
 					siteRawUrl={ this.props.siteRawUrl }
-					active={ '/security' === this.props.route.path || '/settings' === this.props.route.path }
+					active={
+						'/security' === this.props.route.path ||
+						( '/settings' === this.props.route.path && this.props.userCanManageModules )
+					}
 					{ ...commonProps }
 				/>
 				<Discussion
@@ -60,7 +63,10 @@ export default class extends React.Component {
 				/>
 				<Writing
 					siteAdminUrl={ this.props.siteAdminUrl }
-					active={ '/writing' === this.props.route.path }
+					active={
+						'/writing' === this.props.route.path ||
+						( '/settings' === this.props.route.path && ! this.props.userCanManageModules )
+					}
 					{ ...commonProps }
 				/>
 				<Sharing


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Editors shouldn't see the Security tab when they load wp-admin/admin.php?page=jetpack#/settings, since they can't see anything on that tab. They should see the Writing tab instead, where they can use things like Post By Email.

**Before**

![image](https://user-images.githubusercontent.com/426388/65603016-2f705680-dfa5-11e9-9ad7-364de451537d.png)


**After**

![image](https://user-images.githubusercontent.com/426388/65603029-339c7400-dfa5-11e9-92af-592c0687ab39.png)


#### Testing instructions:

* Go to Users > Add New, and add a new editor to your site.
* Log to your site with that new user.
* Go to Jetpack > Settings.
* The Writing tab should load instead of the Security tab.

#### Proposed changelog entry for your changes:

* Admin Page: change default settings tab depending on your role
