### PR TITLE
Admin Page: do not display Composing header for editors.

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -53,11 +53,10 @@ export const SettingsCard = props => {
 		backupsEnabled = get( vpData, [ 'data', 'features', 'backups' ], false ),
 		scanEnabled = get( vpData, [ 'data', 'features', 'security' ], false );
 
-	// Non admin users only get Publicize, After the Deadline, and Post by Email settings.
-	// composing is not a module slug but it's used so the Composing card is rendered to show AtD.
+	// Non admin users only get Publicize and Post by Email settings.
 	if (
 		! props.userCanManageModules &&
-		! includes( [ 'composing', 'post-by-email', 'publicize' ], props.module )
+		! includes( [ 'post-by-email', 'publicize' ], props.module )
 	) {
 		return <span />;
 	}

--- a/_inc/client/components/settings-card/test/component.js
+++ b/_inc/client/components/settings-card/test/component.js
@@ -73,7 +73,6 @@ describe( 'SettingsCard', () => {
 			'photon'
 		],
 		allCardsForNonAdmin = [
-			'composing',
 			'post-by-email'
 		];
 
@@ -172,13 +171,13 @@ describe( 'SettingsCard', () => {
 			userCanManageModules: false
 		} );
 
-		it( 'does not render cards that are not Composing or Post by Email', () => {
+		it( 'does not render cards that are not Post by Email', () => {
 			allCardsNonAdminCantAccess.forEach( item => {
 				expect( shallow( <SettingsCard { ...testProps } module={ item } ><p>Child</p></SettingsCard> ).find( 'form' ) ).to.have.length( 0 );
 			} );
 		} );
 
-		it( 'renders Composing and Post by Email cards', () => {
+		it( 'renders Post by Email cards', () => {
 			allCardsForNonAdmin.forEach( item => {
 				expect( shallow( <SettingsCard { ...testProps } module={ item } ><p>Child</p></SettingsCard> ).find( 'form' ) ).to.have.length( 1 );
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Editors do not need that header anymore, since the After The Deadline module doesn't exist anymore.

**Before**

![image](https://user-images.githubusercontent.com/426388/65603713-76128080-dfa6-11e9-8756-335de7116ef0.png)

**After**

![image](https://user-images.githubusercontent.com/426388/65603723-7c086180-dfa6-11e9-98f9-5aaad8ba61b0.png)

#### Testing instructions:

* Go to Users > Add New, and create a new editor role for your site.
* Log in with that editor, and go to Jetpack > Settings
* You should not see any lonely "Composing" heading.

#### Proposed changelog entry for your changes:

* Admin Page: do not display Composing header for editors.
