### PR TITLE
Add support for filtering on dates

### DIFF
--- a/modules/search/instant-search/components/search-filter-dates.jsx
+++ b/modules/search/instant-search/components/search-filter-dates.jsx
@@ -3,38 +3,59 @@
 /**
  * External dependencies
  */
-import { h, Component } from 'preact';
+import { h, createRef, Component } from 'preact';
 import strip from 'strip';
+import { getCheckedInputNames } from '../lib/dom';
 
 export default class SearchFilterDates extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { selected: this.props.initialValue };
+		this.filtersList = createRef();
+	}
+
+	toggleFilter = () => {
+		const selected = getCheckedInputNames( this.filtersList.current );
+		this.setState( { selected }, () => {
+			this.props.onChange( this.props.configuration.interval, selected );
+		} );
+	};
+
+	renderDates = ( { key_as_string: key, doc_count: count } ) => {
+		return (
+			<div>
+				<input
+					checked={ this.state.selected && this.state.selected.includes( key ) }
+					id={ `jp-instant-search-filter-dates-${ key }` }
+					name={ key }
+					onChange={ this.toggleFilter }
+					type="checkbox"
+				/>
+				<label htmlFor={ `jp-instant-search-filter-dates-${ key }` }>
+					{ strip( key ) } ({ count })
+				</label>
+			</div>
+		);
+	};
+
 	render() {
 		return (
 			<div>
-				<h4 className="jetpack-search-filters-widget__sub-heading">{ this.props.filter.name }</h4>
-				<ul className="jetpack-search-filters-widget__filter-list">
+				<h4 className="jetpack-search-filters-widget__sub-heading">
+					{ this.props.configuration.name }
+				</h4>
+				<ul className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
 					{ this.props.aggregation &&
 						'buckets' in this.props.aggregation &&
 						[
 							...this.props.aggregation.buckets
 								// TODO: Remove this filter; API should only be sending buckets with document counts.
 								.filter( bucket => !! bucket && bucket.doc_count > 0 )
-								.map( bucket => (
-									<div>
-										<input
-											disabled
-											id={ `jp-instant-search-filter-dates-${ bucket.key_as_string }` }
-											name={ bucket.key_as_string }
-											type="checkbox"
-										/>
-										<label htmlFor={ `jp-instant-search-filter-dates-${ bucket.key_as_string }` }>
-											{ strip( bucket.key_as_string ) } ({ bucket.doc_count })
-										</label>
-									</div>
-								) ),
+								.map( this.renderDates ),
 						]
 							// TODO: Remove this reverse & slice when API adds filter count support
 							.reverse()
-							.slice( 0, 5 ) }
+							.slice( 0, this.props.configuration.count ) }
 				</ul>
 			</div>
 		);

--- a/modules/search/instant-search/components/search-filter-dates.jsx
+++ b/modules/search/instant-search/components/search-filter-dates.jsx
@@ -14,10 +14,16 @@ export default class SearchFilterDates extends Component {
 		this.filtersList = createRef();
 	}
 
+	getIdentifier() {
+		// (month || year)_(post_date || post_date_gmt || post_modified || post_modified_gmt )
+		// Ex: month_post_date_gmt
+		return `${ this.props.configuration.interval }_${ this.props.configuration.field }`;
+	}
+
 	toggleFilter = () => {
 		const selected = getCheckedInputNames( this.filtersList.current );
 		this.setState( { selected }, () => {
-			this.props.onChange( this.props.configuration.interval, selected );
+			this.props.onChange( this.getIdentifier(), selected );
 		} );
 	};
 
@@ -26,12 +32,12 @@ export default class SearchFilterDates extends Component {
 			<div>
 				<input
 					checked={ this.state.selected && this.state.selected.includes( key ) }
-					id={ `jp-instant-search-filter-dates-${ key }` }
+					id={ `jp-instant-search-filter-dates-${ this.getIdentifier() }-${ key }` }
 					name={ key }
 					onChange={ this.toggleFilter }
 					type="checkbox"
 				/>
-				<label htmlFor={ `jp-instant-search-filter-dates-${ key }` }>
+				<label htmlFor={ `jp-instant-search-filter-dates-${ this.getIdentifier() }-${ key }` }>
 					{ strip( key ) } ({ count })
 				</label>
 			</div>

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -20,7 +20,16 @@ export default class SearchFiltersWidget extends Component {
 	renderFilterComponent = ( { configuration, results } ) => {
 		switch ( configuration.type ) {
 			case 'date_histogram':
-				return results && <SearchFilterDates aggregation={ results } filter={ configuration } />;
+				return (
+					results && (
+						<SearchFilterDates
+							aggregation={ results }
+							configuration={ configuration }
+							initialValue={ this.props.initialValues[ configuration.interval ] }
+							onChange={ this.props.onChange }
+						/>
+					)
+				);
 			case 'taxonomy':
 				return (
 					results && (

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -25,7 +25,9 @@ export default class SearchFiltersWidget extends Component {
 						<SearchFilterDates
 							aggregation={ results }
 							configuration={ configuration }
-							initialValue={ this.props.initialValues[ configuration.interval ] }
+							initialValue={
+								this.props.initialValues[ `${ configuration.interval }_${ configuration.field }` ]
+							}
 							onChange={ this.props.onChange }
 						/>
 					)

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -72,13 +72,11 @@ class SearchApp extends Component {
 				resultFormat: this.props.options.resultFormat,
 				siteId: this.props.options.siteId,
 				sort,
-			} )
-				.then( response => response.json() )
-				.then( json => {
-					if ( this.requestId === requestId ) {
-						this.setState( { results: json } );
-					}
-				} );
+			} ).then( results => {
+				if ( this.requestId === requestId ) {
+					this.setState( { results } );
+				}
+			} );
 		} else {
 			this.setState( { results: [] } );
 		}

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -127,7 +127,6 @@ export function search( { aggregations, filter, query, resultFormat, siteId, sor
 			highlight_fields = [ 'title', 'content', 'comments' ];
 			fields = [
 				'date',
-				'modified',
 				'permalink.url.raw',
 				'tag.name.default',
 				'category.name.default',

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -78,11 +78,6 @@ function buildFilterObject( filterQuery ) {
 			filter.bool.must.push( { term: { 'tag.slug': tag } } );
 		} );
 	}
-	if ( isLengthyArray( filterQuery.post_tag ) ) {
-		filterQuery.post_tag.forEach( tag => {
-			filter.bool.must.push( { term: { 'tag.slug': tag } } );
-		} );
-	}
 	if ( isLengthyArray( filterQuery.month_post_date ) ) {
 		const { startDate, endDate } = generateDateRange( filterQuery.month_post_date, 'month' );
 		filter.bool.must.push( { range: { date: { gte: startDate, lt: endDate } } } );

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -89,9 +89,15 @@ export function getFilterQuery( filterKey ) {
 	}
 
 	return {
+		// Taxonomies
 		category: getFilterQueryByKey( 'category' ),
 		post_tag: getFilterQueryByKey( 'post_tag' ),
+		// Post types
 		post_types: getFilterQueryByKey( 'post_types' ),
+		// Date filters
+		day: getFilterQueryByKey( 'day' ),
+		monthnum: getFilterQueryByKey( 'monthnum' ),
+		year: getFilterQueryByKey( 'year' ),
 	};
 }
 

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -95,9 +95,14 @@ export function getFilterQuery( filterKey ) {
 		// Post types
 		post_types: getFilterQueryByKey( 'post_types' ),
 		// Date filters
-		day: getFilterQueryByKey( 'day' ),
-		monthnum: getFilterQueryByKey( 'monthnum' ),
-		year: getFilterQueryByKey( 'year' ),
+		month_post_date: getFilterQueryByKey( 'month_post_date' ),
+		month_post_date_gmt: getFilterQueryByKey( 'month_post_date_gmt' ),
+		month_post_modified: getFilterQueryByKey( 'month_post_modified' ),
+		month_post_modified_gmt: getFilterQueryByKey( 'month_post_modified_gmt' ),
+		year_post_date: getFilterQueryByKey( 'year_post_date' ),
+		year_post_date_gmt: getFilterQueryByKey( 'year_post_date_gmt' ),
+		year_post_modified: getFilterQueryByKey( 'year_post_modified' ),
+		year_post_modified_gmt: getFilterQueryByKey( 'year_post_modified_gmt' ),
 	};
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This enables filtering search results by year or month using search widget checkboxes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes, this adds date-based filtering to Jetpack Instant Search.

#### Testing instructions:
* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and has Jetpack Search enabled.
* Add a Jetpack Search widget to the Search page sidebar.
* Add a date filter to the Jetpack Search widget. Note that it's possible to filter by month or year for each of the following options:
  * Date posted
  * Date posted in GMT 
  * Date modified
  * Date modified in GMT
* Enter a query into a search widget. Alternatively, navigate to a search page like `/?s=privacy`.
* Ensure that you can select a date filter checkbox. 

#### Proposed changelog entry for your changes:
No.