### PR TITLE
Sync: Bail initial sync if there is an ongoing full sync

### DIFF
--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Sync;
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * The role of this class is to hook the Sync subsystem into WordPress - when to listen for actions,
@@ -352,6 +353,12 @@ class Actions {
 	public static function do_initial_sync() {
 		// Lets not sync if we are not suppose to.
 		if ( ! self::sync_allowed() ) {
+			return false;
+		}
+
+		// Don't start new sync if a full sync is in process.
+		$full_sync_module = Modules::get_module( 'full-sync' );
+		if ( $full_sync_module && ( $full_sync_module->is_started() && ! $full_sync_module->is_finished() ) ) {
 			return false;
 		}
 

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -358,7 +358,7 @@ class Actions {
 
 		// Don't start new sync if a full sync is in process.
 		$full_sync_module = Modules::get_module( 'full-sync' );
-		if ( $full_sync_module && ( $full_sync_module->is_started() && ! $full_sync_module->is_finished() ) ) {
+		if ( $full_sync_module && $full_sync_module->is_started() && ! $full_sync_module->is_finished() ) {
 			return false;
 		}
 

--- a/tests/php/sync/test_class.jetpack-sync-actions.php
+++ b/tests/php/sync/test_class.jetpack-sync-actions.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Actions;
+use Automattic\Jetpack\Sync\Modules;
 
 class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 	function test_get_sync_status() {
@@ -47,5 +48,22 @@ class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'comments_checksum', $comment_meta );
 		$this->assertArrayNotHasKey( 'post_meta_checksum', $comment_meta );
 		$this->assertArrayHasKey( 'comment_meta_checksum', $comment_meta );
+	}
+
+	function test_do_initial_sync_during_full_sync() {
+		$full_sync = Modules::get_module( 'full-sync' );
+		$full_sync->start();
+
+		$initial_sync = Actions::do_initial_sync();
+
+		$this->assertFalse( $initial_sync );
+
+		$full_sync->reset_data();
+	}
+
+	function test_do_initial_sync_during_no_sync() {
+		$initial_sync = Actions::do_initial_sync();
+
+		$this->assertNull( $initial_sync );
 	}
 }


### PR DESCRIPTION
Fixes #12548.

**Changes proposed in this Pull Request:**
do_initial_sync() will check if there is a current ongoing full sync before initializing the incremental sync.

**Testing instructions:**
1. Kick off a full sync in progress
2. Assuming your user isn't connected to JP yet, go to Jetpack > Dashboard
3. Scroll down to "Account Connection" and hit "Link to WordPress.com"
4. Current full sync will continue to sync without being overwritten
5. Alternatively, in lieu of steps 2. and 3., you could just call `Automattic\Jetpack\Sync\Actions::do_initial_sync();` in`wp shell`.

**Proposed changelog entry for your changes:**
Add check for ongoing full sync in before `do_initial_sync()` initializes.