### PR TITLE
Carousel: Improve DOM Parsing

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -566,7 +566,7 @@ class Jetpack_Carousel {
 				$old_libxml_disable_entity_loader = libxml_disable_entity_loader( true );
 				$old_libxml_use_internal_errors   = libxml_use_internal_errors( true );
 				@$dom_doc->loadHTML( // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-					$a = sprintf(
+					sprintf(
 						'<head><meta http-equiv="Content-Type" content="text/html; charset=%1$s"/></head><%2$s>%3$s</%2$s>',
 						esc_attr( $charset ),
 						tag_escape( $fake_root_tag ),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -93,6 +93,9 @@
 		<testsuite name="geo-location">
 			<directory prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
 		</testsuite>
+		<testsuite name="carousel">
+			<directory prefix="test_" suffix=".php">tests/php/modules/carousel</directory>
+		</testsuite>
 		<testsuite name="deprecation">
 			<file>tests/php/test_deprecation.php</file>
 		</testsuite>

--- a/tests/php/modules/carousel/test_jetpack-carousel.php
+++ b/tests/php/modules/carousel/test_jetpack-carousel.php
@@ -1,0 +1,81 @@
+<?php
+
+require_once dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/modules/carousel.php';
+
+class Test_Jetpack_Carousel extends WP_UnitTestCase {
+	static $post_id = 0;
+	static $charset = '';
+
+	var $carousel;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$post_id = self::factory()->post->create();
+		self::$charset = get_option( 'blog_charset', 'utf-8' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		update_option( 'blog_charset', self::$charset );
+	}
+
+	public function setUp() {
+		$GLOBALS['post'] = get_post( self::$post_id );
+
+		$this->carousel = $this->getMockBuilder( 'Jetpack_Carousel' )
+			->setMethods( null )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	public function test_add_data_to_container() {
+		$extra = 'data-carousel-extra=\'{"blog_id":1,"permalink":"http:\\/\\/example.org\\/?p=' . self::$post_id . '"}\'';
+
+		$this->assertEquals( '<div class="gallery" ' . $extra . '>', $this->carousel->add_data_to_container(  '<div class="gallery">' ) );
+	}
+
+	public function utf_8_provider() {
+		// Data Providers are called prior to `::setUpBeforeClass()`, so we can't know `self::$post_id` here.
+		$extra = 'data-carousel-extra=\'{"blog_id":1,"permalink":"http:\\/\\/example.org\\/?p=%%%POST_ID%%%"}\'';
+
+		return [
+			'ascii'                 => [ '<div class="gallery">hello</div>', '<div class="gallery" ' . $extra . '>hello</div>' ],
+			'latin with diacritics' => [ '<div class="gallery">Ĵëṫṕãḉǩ</div>', '<div class="gallery" ' . $extra . '>Ĵëṫṕãḉǩ</div>' ],
+			'encoded'               => [ '<div class="gallery">&#308;&euml;&#7787;&#7765;&atilde;&#7689;&#489;</div>', '<div class="gallery" ' . $extra . '>&#308;&euml;&#7787;&#7765;&atilde;&#7689;&#489;</div>' ],
+			'japanese'              => [ '<div class="gallery">最高のパック</div>', '<div class="gallery" ' . $extra . '>最高のパック</div>' ],
+			'linear b (4-byte)'     => [ '<div class="gallery">𐁂𐀐𐀷</div>', '<div class="gallery" ' . $extra . '>𐁂𐀐𐀷</div>' ],
+			'emoji (4-byte)'        => [ '<div class="gallery">✈️🎒</div>', '<div class="gallery" ' . $extra . '>✈️🎒</div>' ],
+		];
+	}
+
+	/**
+	 * @dataProvider utf_8_provider
+	 */
+	public function test_add_data_to_html_with_utf_8_input( $input, $expected ) {
+		$expected = str_replace( '%%%POST_ID%%%', self::$post_id, $expected );
+
+		update_option( 'blog_charset', 'utf-8' );
+
+		$this->assertEquals( $expected, $this->carousel->add_data_to_html( $input ) );
+	}
+
+	public function big_5_provider() {
+		// Data Providers are called prior to `::setUpBeforeClass()`, so we can't know `self::$post_id` here.
+		$extra = 'data-carousel-extra=\'{"blog_id":1,"permalink":"http:\\/\\/example.org\\/?p=%%%POST_ID%%%"}\'';
+
+		return [
+			'ascii'                 => [ '<div class="gallery">hello</div>', '<div class="gallery" ' . $extra . '>hello</div>' ],
+			'common characters'     => [ "<div class=\"gallery\">\xB1\x60\xA5\xCE\xA6\x72</div>", "<div class=\"gallery\" $extra>\xB1\x60\xA5\xCE\xA6\x72</div>" ],
+			'graphical characters'  => [ "<div class=\"gallery\">\xA1\x4B\xA1\x4B</div>", "<div class=\"gallery\" $extra>\xA1\x4B\xA1\x4B</div>" ],
+		];
+	}
+
+	/**
+	 * @dataProvider big_5_provider
+	 */
+	public function test_add_data_to_html_with_big_5_input( $input, $expected ) {
+		$expected = str_replace( '%%%POST_ID%%%', self::$post_id, $expected );
+
+		update_option( 'blog_charset', 'big-5' );
+
+		$this->assertEquals( $expected, $this->carousel->add_data_to_html( $input ) );
+	}
+}


### PR DESCRIPTION
Fixes #13531, but not really.

#### Changes proposed in this Pull Request:
* Separate `->add_data_to_container()` into `->add_data_to_container()` for the `gallery_style` filter (which filters only an opening `<div>` tag), and `->add_data_to_html()` for general HTML.
* Wrap input to `DOMDocument->loadHTML()` in fake root tag.
* Specify blog's charset in input to `DOMDocument->loadHTML()`.
* Add tests for different charsets.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: bug fix.

#### Testing instructions:
* `phpunit --testsuite=carousel`
* See that some tests fail :(

#### Proposed changelog entry for your changes:
Carousel: Improve HTML parsing.