### PR TITLE
Connect in Place: Update the ab test string

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -25,7 +25,7 @@ jQuery( document ).ready( function( $ ) {
 		isRegistering: false,
 		isPaidPlan: false,
 		startConnectionFlow: function() {
-			var abTestName = 'jetpack_connect_in_place';
+			var abTestName = 'jetpack_connect_in_place_v2';
 			$.ajax( {
 				url: 'https://public-api.wordpress.com/wpcom/v2/abtest/' + abTestName,
 				type: 'GET',


### PR DESCRIPTION
The current flow doesn't work for safari.
We are updating the ab test string so that the flow can be enabled for all users.
and work as expected. A new version of Jetpack will have the release that sends all safai users though the flow.

Related .com change set D33214-code

#### Changes proposed in this Pull Request:
* update the ab test string to the new test.

#### Testing instructions:
* Go to the jetapck dashboard. 
* Update the test to 100%. 
* Make sure that you don't have any constants set that make the the code not go through the AB test. 
* You should end up in the connect in place flow. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
