### PR TITLE
Connect in place: use original connection flow on Safari

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -8,7 +8,8 @@ jQuery( document ).ready( function( $ ) {
 		$( '#jetpack-connection-cards' ).fadeOut( 600 );
 		if ( ! jetpackConnectButton.isRegistering ) {
 			if ( 'original' === jpConnect.forceVariation ) {
-				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`.
+				// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`
+				// or we're dealing with Safari which has issues with handling 3rd party cookies.
 				jetpackConnectButton.handleOriginalFlow();
 			} else if ( 'in_place' === jpConnect.forceVariation ) {
 				// Forcing new connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = true`.

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -133,6 +133,8 @@ class Jetpack_Connection_Banner {
 	 * @since 7.7
 	 */
 	public static function enqueue_connect_button_scripts() {
+		global $is_safari;
+
 		wp_enqueue_script(
 			'jetpack-connect-button',
 			Assets::get_file_url_for_environment(
@@ -154,7 +156,11 @@ class Jetpack_Connection_Banner {
 
 		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
 
-		if ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		// Due to the limitation in how 3rd party cookies are handled in Safari,
+		// we're falling back to the original flow on Safari desktop and mobile.
+		if ( $is_safari ) {
+			$force_variation = 'original';
+		} elseif ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'in_place';
 		} elseif ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'original';


### PR DESCRIPTION
Due to the limitation in how 3rd party cookies are handled in Safari, we're falling back to the original flow on Safari desktop and mobile.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use original connection flow on Safari

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Jetpack dashboard in Safari (mobile or desktop).
* Make sure the site is disconnected from wordpress.com
* Start a connection to wordpress.com
* Confirm you're going through the original flow and not the connect-in-place
* Confirm the site gets successfully connected to wordpress.com

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Use original connection flow on Safari
