### PR TITLE
Add fallback for `space-evenly` for IE & Edge as they don't support it

### DIFF
--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -206,6 +206,7 @@
 
 .jp-connect-full__row {
 	display: flex;
+	justify-content: space-around; // Fallback for IE and Edge as they don't support the `space-evenly` value.
 	justify-content: space-evenly;
 	text-align: left;
 	align-items: baseline;


### PR DESCRIPTION
Add a fallback for the `space-evenly` value of the `justify-content` property for IE and Edge as they don't support it.

**Before on Edge:**

![edge-before](https://user-images.githubusercontent.com/478735/65696012-cf4ae480-e078-11e9-9a53-d80b8b96f943.png)

**After on Edge:**

![edge-after](https://user-images.githubusercontent.com/478735/65696026-d540c580-e078-11e9-9265-d45051061c26.png)

**After on Chrome** (to confirm that the `space-around` gets overridden by `space-evenly` if it's supported):

![chrome-after](https://user-images.githubusercontent.com/478735/65696059-e5f13b80-e078-11e9-8d60-ede4e6b287d7.png)


#### Testing instructions:
* Go to Jetpack dashboard using any Microsoft Edge version or IE 11
* Make sure you're disconnected from wordpress.com
* Confirm that the two banners below the 'Set up Jetpack' button are centered and have some space between them

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add a fallback for `space-evenly` value for IE & Edge in the connection banner
