### PR TITLE
Connect in place: add loading spinner and text animation

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -51,20 +51,7 @@ jQuery( document ).ready( function( $ ) {
 			jetpackConnectButton.isRegistering = true;
 			tosText.hide();
 			connectButton.hide();
-
-			var loadingText = $( '<span>' );
-			loadingText.addClass( 'jp-connect-full__button-container-loading' );
-			loadingText.text( jpConnect.buttonTextRegistering );
-			loadingText.appendTo( '.jp-connect-full__button-container' );
-
-			var spinner = $( '<div>' ).addClass( 'jp-spinner' );
-			var spinnerOuter = $( '<div>' )
-				.addClass( 'jp-spinner__outer' )
-				.appendTo( spinner );
-			$( '<div>' )
-				.addClass( 'jp-spinner__inner' )
-				.appendTo( spinnerOuter );
-			loadingText.after( spinner );
+			jetpackConnectButton.triggerLoadingState();
 
 			var registerUrl = jpConnect.apiBaseUrl + '/connection/register';
 
@@ -84,6 +71,21 @@ jQuery( document ).ready( function( $ ) {
 				error: jetpackConnectButton.handleConnectionError,
 				success: jetpackConnectButton.handleConnectionSuccess,
 			} );
+		},
+		triggerLoadingState: function() {
+			var loadingText = $( '<span>' )
+				.addClass( 'jp-connect-full__button-container-loading' )
+				.text( jpConnect.buttonTextRegistering )
+				.appendTo( '.jp-connect-full__button-container' );
+
+			var spinner = $( '<div>' ).addClass( 'jp-spinner' );
+			var spinnerOuter = $( '<div>' )
+				.addClass( 'jp-spinner__outer' )
+				.appendTo( spinner );
+			$( '<div>' )
+				.addClass( 'jp-spinner__inner' )
+				.appendTo( spinnerOuter );
+			loadingText.after( spinner );
 		},
 		handleConnectionSuccess: function( data ) {
 			jetpackConnectButton.fetchPlanType();

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -57,6 +57,15 @@ jQuery( document ).ready( function( $ ) {
 			loadingText.text( jpConnect.buttonTextRegistering );
 			loadingText.appendTo( '.jp-connect-full__button-container' );
 
+			var spinner = $( '<div>' ).addClass( 'jp-spinner' );
+			var spinnerOuter = $( '<div>' )
+				.addClass( 'jp-spinner__outer' )
+				.appendTo( spinner );
+			$( '<div>' )
+				.addClass( 'jp-spinner__inner' )
+				.appendTo( spinnerOuter );
+			loadingText.after( spinner );
+
 			var registerUrl = jpConnect.apiBaseUrl + '/connection/register';
 
 			// detect Calypso Env and add to API URL

--- a/scss/atoms/_animations.scss
+++ b/scss/atoms/_animations.scss
@@ -16,3 +16,17 @@
 		transform: scale(1);
 	}
 }
+
+@keyframes "loading-fade" {
+	0% {
+		opacity: .5;
+	}
+
+	50% {
+		opacity: 1;
+	}
+
+	100% {
+		opacity: .5;
+	}
+}

--- a/scss/atoms/_loading-spinner.scss
+++ b/scss/atoms/_loading-spinner.scss
@@ -1,0 +1,39 @@
+// ==========================================================================
+// Loading spinner
+// ==========================================================================
+
+.jp-spinner {
+	display: flex;
+	align-items: center;
+}
+
+.jp-spinner__inner,
+.jp-spinner__outer {
+	margin: auto;
+	box-sizing: border-box;
+	border: .1em solid transparent;
+	border-radius: 50%;
+	border-top-color: #00aadc;
+	animation: 3s linear infinite;
+	animation-name: jp-spinner-rotate;
+}
+
+.jp-spinner__outer {
+	width: 20px;
+	height: 20px;
+	font-size: 20px;
+}
+
+.jp-spinner__inner {
+	width: 100%;
+	height: 100%;
+	border-right-color: #00aadc;
+	opacity: .4;
+}
+
+@keyframes jp-spinner-rotate {
+	to {
+		transform: rotate(1turn);
+	}
+}
+

--- a/scss/jetpack-admin.scss
+++ b/scss/jetpack-admin.scss
@@ -5,6 +5,7 @@
 	"_utilities/grid",
 	"atoms/animations",
 	"atoms/buttons",
+	"atoms/loading-spinner",
 	"atoms/icons/automatticons",
 	"molecules/nav-horizontal",
 	"templates/main", // Main template

--- a/scss/organisms/_banners.scss
+++ b/scss/organisms/_banners.scss
@@ -255,14 +255,23 @@
 	}
 }
 
+.jp-connect-full__button-container-loading {
+	font-size: 14px;
+	animation: loading-fade 1.6s ease-in-out infinite;
+}
+
+.jp-connect-full__button-container .jp-spinner {
+	width: 100%;
+}
+
 @media screen and (max-width: 480px) {
-  .jp-connect-full__row {
-	display: block;
-  }
-  .jp-connect-full__slide {
-	margin: 2em 0;
-	max-width: 100%;
-  }
+	.jp-connect-full__row {
+		display: block;
+	}
+	.jp-connect-full__slide {
+		margin: 2em 0;
+		max-width: 100%;
+	}
 }
 
 


### PR DESCRIPTION
This PR adds a loading spinner and the "Loading" text pulsating animation:

![2019-09-26 17 14 06](https://user-images.githubusercontent.com/478735/65702480-6157ea80-e083-11e9-94b4-eb5097c97643.gif)

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack dashboard
* Make sure you're disconnected from wordpress.com
* Initiate Jetpack connection and confirm that the 'Loading' text is now pulsating and that there is an animated loading spinner below

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add loading spinner and text animation to connect in place screen.