### PR TITLE
Carousel: improve gallery parsing

### DIFF
--- a/projects/plugins/jetpack/changelog/update-carousel-add-metadata
+++ b/projects/plugins/jetpack/changelog/update-carousel-add-metadata
@@ -1,0 +1,4 @@
+Significance: minor
+Type: bugfix
+
+Carousel: improve how post content is parsed before Carousel metadata is attached to the post, to avoid issues with some types of images.

--- a/projects/plugins/jetpack/tests/php/modules/carousel/test-class.jetpack-carousel.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/test-class.jetpack-carousel.php
@@ -30,6 +30,13 @@ class WP_Test_Jetpack_Carousel extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Clean up tests.
+	 */
+	public function tearDown() {
+		update_option( 'blog_charset', 'utf-8' );
+	}
+
+	/**
 	 * Gets the test data for test_add_data_img_tags_and_enqueue_assets().
 	 *
 	 * @return array The test data.
@@ -116,5 +123,82 @@ class WP_Test_Jetpack_Carousel extends WP_UnitTestCase {
 		if ( $is_amp ) {
 			$this->assertFalse( wp_script_is( 'jetpack-carousel' ) );
 		}
+	}
+
+	/**
+	 * Test add_data_to_container.
+	 *
+	 * @covers Jetpack_Carousel::add_data_to_container()
+	 */
+	public function test_add_data_to_container() {
+		$post_id = $this->factory->post->create();
+		$extra   = 'data-carousel-extra=\'{"blog_id":1,"permalink":"http:\\/\\/example.org\\/?p=' . $post_id . '"}\'';
+
+		$this->assertEquals( '<div class="gallery" ' . $extra . '></div>', $this->instance->add_data_to_container( '<div class="gallery"></div>' ) );
+	}
+
+	/**
+	 * Set of example post data to be used with UTF-8 charset.
+	 */
+	public function utf_8_provider() {
+		$extra = 'data-carousel-extra=\'{"blog_id":1,"permalink":"http:\\/\\/example.org\\/?p=%%%POST_ID%%%"}\'';
+
+		return array(
+			'ascii'                 => array( '<div class="gallery">hello</div>', '<div class="gallery" ' . $extra . '>hello</div>' ),
+			'latin with diacritics' => array( '<div class="gallery">Ĵëṫṕãḉǩ</div>', '<div class="gallery" ' . $extra . '>Ĵëṫṕãḉǩ</div>' ),
+			'encoded'               => array( '<div class="gallery">&#308;&euml;&#7787;&#7765;&atilde;&#7689;&#489;</div>', '<div class="gallery" ' . $extra . '>&#308;&euml;&#7787;&#7765;&atilde;&#7689;&#489;</div>' ),
+			'japanese'              => array( '<div class="gallery">最高のパック</div>', '<div class="gallery" ' . $extra . '>最高のパック</div>' ),
+			'linear b (4-byte)'     => array( '<div class="gallery">𐁂𐀐𐀷</div>', '<div class="gallery" ' . $extra . '>𐁂𐀐𐀷</div>' ),
+			'emoji (4-byte)'        => array( '<div class="gallery">✈️🎒</div>', '<div class="gallery" ' . $extra . '>✈️🎒</div>' ),
+		);
+	}
+
+	/**
+	 * Test add_data_to_container with different characters with UTF-8.
+	 *
+	 * @covers Jetpack_Carousel::add_data_to_container()
+	 * @dataProvider utf_8_provider
+	 *
+	 * @param string $input    Post content saved in WP.
+	 * @param string $expected Post content with Carousel data added.
+	 */
+	public function test_add_data_to_container_with_utf_8_input( $input, $expected ) {
+		$post_id  = $this->factory->post->create();
+		$expected = str_replace( '%%%POST_ID%%%', $post_id, $expected );
+
+		update_option( 'blog_charset', 'utf-8' );
+
+		$this->assertEquals( $expected, $this->instance->add_data_to_container( $input ) );
+	}
+
+	/**
+	 * Set of example post data to be used with big-5 charset.
+	 */
+	public function big_5_provider() {
+		$extra = 'data-carousel-extra=\'{"blog_id":1,"permalink":"http:\\/\\/example.org\\/?p=%%%POST_ID%%%"}\'';
+
+		return array(
+			'ascii'                => array( '<div class="gallery">hello</div>', '<div class="gallery" ' . $extra . '>hello</div>' ),
+			'common characters'    => array( "<div class=\"gallery\">\xB1\x60\xA5\xCE\xA6\x72</div>", "<div class=\"gallery\" $extra>\xB1\x60\xA5\xCE\xA6\x72</div>" ),
+			'graphical characters' => array( "<div class=\"gallery\">\xA1\x4B\xA1\x4B</div>", "<div class=\"gallery\" $extra>\xA1\x4B\xA1\x4B</div>" ),
+		);
+	}
+
+	/**
+	 * Test add_data_to_container with Big5 (chinese char encoding) characters.
+	 *
+	 * @covers Jetpack_Carousel::add_data_to_container()
+	 * @dataProvider big_5_provider
+	 *
+	 * @param string $input    Post content saved in WP.
+	 * @param string $expected Post content with Carousel data added.
+	 */
+	public function test_add_data_to_container_with_big_5_input( $input, $expected ) {
+		$post_id  = $this->factory->post->create();
+		$expected = str_replace( '%%%POST_ID%%%', $post_id, $expected );
+
+		update_option( 'blog_charset', 'big-5' );
+
+		$this->assertEquals( $expected, $this->instance->add_data_to_container( $input ) );
 	}
 }

--- a/tools/phpcs-excludelist.json
+++ b/tools/phpcs-excludelist.json
@@ -192,7 +192,6 @@
 	"projects/plugins/jetpack/json-endpoints/jetpack/json-api-jetpack-endpoints.php",
 	"projects/plugins/jetpack/locales.php",
 	"projects/plugins/jetpack/modules/carousel.php",
-	"projects/plugins/jetpack/modules/carousel/jetpack-carousel.php",
 	"projects/plugins/jetpack/modules/comments/admin.php",
 	"projects/plugins/jetpack/modules/comments/base.php",
 	"projects/plugins/jetpack/modules/comments/comments.php",


### PR DESCRIPTION
Fixes #13531
Fixes #13428 
Fixes #11191 
Fixes #17090 

#### Changes proposed in this Pull Request:

**This is still a work in progress. I'd like to add Unit Tests to cover each possible use of Carousel, as detailed in the testing instructions below.**

Parsing post content to insert carousel metadata is a bit fragile at the moment. Depending on the format of your images, how they are inserted, and what metadata is available for each image, you may run into several issues, highlighted in the issues above.

This PR introduces a different approach to add the Carousel metadata to the classic galleries (it hooks into the `do_shortcode_tag` filter instead of `gallery_style`).
It also takes on @mdawaffe's approach from #13547 to improve our use of `DOMDocument`.
It also fixes PHPCS errors to get things to be more readable as I was going through that file.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* In new posts, insert a variety of blocks:
	- A classic block with a gallery
	- A classic block with a tiled gallery
	- A classic block with a single image
	- An image block
	- A gallery block
	- A Tiled Gallery block
	- A column block with some text
	- A column block with a gallery block in it.
* Publish all those posts
* When moving your mouse over each image, make sure the cursor only becomes a pointer when the element can be expanded to a Carousel modal.
* Carousel should work well for all those blocks.
* You should not see any JavaScript error.
