### PR TITLE
Fix/plans page loading

### DIFF
--- a/_inc/client/plans-prompt/index.jsx
+++ b/_inc/client/plans-prompt/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import Plans from '../plans';
 import { translate as __ } from 'i18n-calypso';
 import Gridicon from '../components/gridicon';
 import JetpackLogo from '../components/jetpack-logo';
+import { getAvailablePlans } from 'state/site/reducer';
 
 export class PlansPrompt extends React.Component {
 	trackStartWithFreeClick() {
@@ -34,6 +36,9 @@ export class PlansPrompt extends React.Component {
 	}
 
 	renderFooter() {
+		if ( typeof this.props.plans === 'undefined' ) {
+			return null;
+		}
 		return (
 			<div className="plans-prompt__footer">
 				<Button
@@ -58,4 +63,11 @@ export class PlansPrompt extends React.Component {
 	}
 }
 
-export default PlansPrompt;
+export default connect(
+	state => {
+		return {
+			plans: getAvailablePlans( state ),
+		};
+	},
+	null
+)( PlansPrompt );

--- a/_inc/client/plans-prompt/index.jsx
+++ b/_inc/client/plans-prompt/index.jsx
@@ -36,7 +36,7 @@ export class PlansPrompt extends React.Component {
 	}
 
 	renderFooter() {
-		if ( typeof this.props.plans === 'undefined' ) {
+		if ( ! this.props.plans ) {
 			return null;
 		}
 		return (

--- a/_inc/client/plans-prompt/index.jsx
+++ b/_inc/client/plans-prompt/index.jsx
@@ -64,10 +64,8 @@ export class PlansPrompt extends React.Component {
 }
 
 export default connect(
-	state => {
-		return {
-			plans: getAvailablePlans( state ),
-		};
-	},
+	state => ( {
+		plans: getAvailablePlans( state ),
+	} ),
 	null
 )( PlansPrompt );

--- a/_inc/client/plans-prompt/index.jsx
+++ b/_inc/client/plans-prompt/index.jsx
@@ -67,5 +67,4 @@ export default connect(
 	state => ( {
 		plans: getAvailablePlans( state ),
 	} )
-	null
 )( PlansPrompt );

--- a/_inc/client/plans-prompt/index.jsx
+++ b/_inc/client/plans-prompt/index.jsx
@@ -66,6 +66,6 @@ export class PlansPrompt extends React.Component {
 export default connect(
 	state => ( {
 		plans: getAvailablePlans( state ),
-	} ),
+	} )
 	null
 )( PlansPrompt );

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -28,8 +28,13 @@ class PlanGrid extends React.Component {
 	}
 
 	render() {
-		if ( typeof this.props.plans === 'undefined' ) {
-			return this.renderSkeletonGrid();
+		if ( ! this.props.plans ) {
+			return (
+				<div className="plan-features">
+					{ this.renderMobileCard() }
+					{ this.renderSkeletonGrid() }
+				</div>
+			);
 		}
 
 		const length = Object.values( this.getPlans() ).length;
@@ -74,10 +79,10 @@ class PlanGrid extends React.Component {
 
 	renderSkeletonGrid() {
 		return (
-			<div className="plan-grind-skeletons">
-				<div className="plan-grind-skeletons__plan is-placeholder"></div>
-				<div className="plan-grind-skeletons__plan is-placeholder"></div>
-				<div className="plan-grind-skeletons__plan is-placeholder"></div>
+			<div className="plan-grid-skeletons">
+				<div className="plan-grid-skeletons__plan is-placeholder"></div>
+				<div className="plan-grid-skeletons__plan is-placeholder"></div>
+				<div className="plan-grid-skeletons__plan is-placeholder"></div>
 			</div>
 		);
 	}

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -29,7 +29,7 @@ class PlanGrid extends React.Component {
 
 	render() {
 		if ( typeof this.props.plans === 'undefined' ) {
-			return null;
+			return this.renderSkeletonGrid();
 		}
 
 		const length = Object.values( this.getPlans() ).length;
@@ -68,6 +68,16 @@ class PlanGrid extends React.Component {
 				<Button href={ plansUrl } primary>
 					{ __( 'View all Jetpack plans' ) }
 				</Button>
+			</div>
+		);
+	}
+
+	renderSkeletonGrid() {
+		return (
+			<div className="plan-grind-skeletons">
+				<div className="plan-grind-skeletons__plan is-placeholder"></div>
+				<div className="plan-grind-skeletons__plan is-placeholder"></div>
+				<div className="plan-grind-skeletons__plan is-placeholder"></div>
 			</div>
 		);
 	}

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -236,7 +236,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-grid-skeletons__plan {
 	flex: 1;
-	height: 400px;
+	height: 545px;
 	margin: 0 10px;
 
 	@include breakpoint( "<1040px" ) {

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -221,3 +221,15 @@ $plan-features-sidebar-width: 272px;
 .plans-mobile-notice.dops-card h2 {
 	margin-top: 0;
 }
+.plan-grind-skeletons {
+	display:flex;
+}
+.plan-grind-skeletons__plan {
+	flex: 1;
+	height: 400px;
+	margin: 0 10px;
+
+	@include breakpoint( "<1040px" ) {
+		margin: 0 1px;
+	}
+}

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -223,6 +223,11 @@ $plan-features-sidebar-width: 272px;
 }
 .plan-grind-skeletons {
 	display:flex;
+	margin: 0 -10px;
+
+	@include breakpoint( "<1040px" ) {
+		margin: 0 -1px;
+	}
 }
 .plan-grind-skeletons__plan {
 	flex: 1;

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -222,7 +222,7 @@ $plan-features-sidebar-width: 272px;
 	margin-top: 0;
 }
 .plan-grid-skeletons {
-	display:flex;
+	display: flex;
 	margin: 0 -10px;
 
 	@include breakpoint( "<1040px" ) {

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -230,7 +230,7 @@ $plan-features-sidebar-width: 272px;
 	}
 
 	@include breakpoint( "<660px" ) {
-		 display:none;
+		 display: none;
 	}
 }
 

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -221,15 +221,20 @@ $plan-features-sidebar-width: 272px;
 .plans-mobile-notice.dops-card h2 {
 	margin-top: 0;
 }
-.plan-grind-skeletons {
+.plan-grid-skeletons {
 	display:flex;
 	margin: 0 -10px;
 
 	@include breakpoint( "<1040px" ) {
 		margin: 0 -1px;
 	}
+
+	@include breakpoint( "<660px" ) {
+		 display:none;
+	}
 }
-.plan-grind-skeletons__plan {
+
+.plan-grid-skeletons__plan {
 	flex: 1;
 	height: 400px;
 	margin: 0 10px;


### PR DESCRIPTION
Current the way the plans page loads after the user gets to it right after connecting is not ideal.
There is no sense of progress just choose a plan. but no plans. Then the free plan button appears. Then after a little bit of time the plans table shows up. 

This PR fixes it by:
1. Hiding the free plan until all the plans info is received. 
2. Shows a simple skeleton placeholder until all the plans info is received.

See https://cloudup.com/cX2JrZOSTrx

#### Testing instructions:
Connect your jetpack site. 
* Go to the plans prompt page. /wp-admin/admin.php?page=jetpack#/plans-prompt
* Go to the plans page /wp-admin/admin.php?page=jetpack#/plans

#### Proposed changelog entry for your changes:
* improve loading of the plans page.
