### PR TITLE
Admin Page: translate empty Stats chart's message

### DIFF
--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -120,7 +120,7 @@ export default class ModuleChart extends React.Component {
 		if ( values.length && this.isEmptyChart( values ) ) {
 			emptyChart = (
 				<div className="dops-chart__empty">
-					<span className="dops-chart__empty_notice">{ __( 'No activity this period' ) }</span>
+					<span className="dops-chart__empty_notice">{ _x( 'No activity this period', 'Notice in the empty statistics chart' ) }</span>
 				</div>
 			);
 		}

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, throttle } from 'lodash';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -119,10 +120,7 @@ export default class ModuleChart extends React.Component {
 		if ( values.length && this.isEmptyChart( values ) ) {
 			emptyChart = (
 				<div className="dops-chart__empty">
-					<span className="dops-chart__empty_notice">
-						{ /* Translate this. */ }
-						No activity this period
-					</span>
+					<span className="dops-chart__empty_notice">{ __( 'No activity this period' ) }</span>
 				</div>
 			);
 		}

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, throttle } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { translate as _x } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -120,7 +120,9 @@ export default class ModuleChart extends React.Component {
 		if ( values.length && this.isEmptyChart( values ) ) {
 			emptyChart = (
 				<div className="dops-chart__empty">
-					<span className="dops-chart__empty_notice">{ _x( 'No activity this period', 'Notice in the empty statistics chart' ) }</span>
+					<span className="dops-chart__empty_notice">
+						{ _x( 'No activity this period', 'Notice in the empty statistics chart' ) }
+					</span>
 				</div>
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This should allow us to translate the message appearing in the Jetpack Dashboard's Stats graph when there are no stats available:

![image](https://user-images.githubusercontent.com/426388/65754804-1f29ba00-e112-11e9-93b0-ee67b0d01942.png)

#### Testing instructions:

* Start from a new site in Spanish
* Apply this branch.
* Ensure that the message is still displayed (it won't be translated just yet, but it should still be displayed in English).

#### Proposed changelog entry for your changes:

* Admin Page: translate empty Stats chart's message
