### PR TITLE
Backups: improve wording for backed up message

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1643,7 +1643,8 @@ class Jetpack_Core_API_Module_Data_Endpoint {
 				'code'    => 'success',
 				'message' => esc_html(
 					sprintf(
-						__( 'Your site was successfully backed-up %s ago.', 'jetpack' ),
+						/* translators: placeholder is a unit of time (1 hour, 5 days, ...) */
+						esc_html__( 'Your site was successfully backed up %s ago.', 'jetpack' ),
 						human_time_diff(
 							$data->backups->last_backup,
 							current_time( 'timestamp' )


### PR DESCRIPTION
Fixes p8oabR-pm-p2#comment-3398

#### Changes proposed in this Pull Request:

* This effectively changes "backed-up" to "backed up" in the message displayed in the admin page.

#### Testing instructions:

* Not much needed here.

#### Proposed changelog entry for your changes:

* None needed.
