### PR TITLE
Block editor: Replace `wp_startswith` with plain php strpos

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -107,7 +107,7 @@ class Jetpack_Gutenberg {
 	 * @return string The unprefixed extension name.
 	 */
 	private static function remove_extension_prefix( $extension_name ) {
-		if ( wp_startswith( $extension_name, 'jetpack/' ) || wp_startswith( $extension_name, 'jetpack-' ) ) {
+		if ( 0 === strpos( $extension_name, 'jetpack/' ) || 0 === strpos( $extension_name, 'jetpack-' ) ) {
 			return substr( $extension_name, strlen( 'jetpack/' ) );
 		}
 		return $extension_name;


### PR DESCRIPTION
An error was observed on a sandbox with `wp_startswith` not being
defined.

The plain PHP equivalent is trivial and prevents possibilities of the
function being unavailable. I'd suggest replacing other occurances in
Jetpack and dropping the helper function altogether.

Related: https://core.trac.wordpress.org/ticket/19347


#### Testing instructions:

* Activate the plugin and use the block editor and view Jetpack blocks on the frontend of your site. There should be no errors.
* No functional changes.