### PR TITLE
Add block previews to Gutenberg blocks

### DIFF
--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -18,11 +18,11 @@ import renderMaterialIcon from '../../shared/render-material-icon';
 
 const defaultDays = [
 	{
-		name: 'Sun',
+		name: __( 'Sun', 'jetpack' ),
 		hours: [], // Closed by default
 	},
 	{
-		name: 'Mon',
+		name: __( 'Mon', 'jetpack' ),
 		hours: [
 			{
 				opening: '09:00',
@@ -31,7 +31,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: 'Tue',
+		name: __( 'Tue', 'jetpack' ),
 		hours: [
 			{
 				opening: '09:00',
@@ -40,7 +40,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: 'Wed',
+		name: __( 'Wed', 'jetpack' ),
 		hours: [
 			{
 				opening: '09:00',
@@ -49,7 +49,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: 'Thu',
+		name: __( 'Thu', 'jetpack' ),
 		hours: [
 			{
 				opening: '09:00',
@@ -58,7 +58,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: 'Fri',
+		name: __( 'Fri', 'jetpack' ),
 		hours: [
 			{
 				opening: '09:00',
@@ -67,7 +67,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: 'Sat',
+		name: __( 'Sat', 'jetpack' ),
 		hours: [], // Closed by default
 	},
 ];

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -16,6 +16,62 @@ import renderMaterialIcon from '../../shared/render-material-icon';
  * Block Registrations:
  */
 
+const defaultDays = [
+	{
+		name: 'Sun',
+		hours: [], // Closed by default
+	},
+	{
+		name: 'Mon',
+		hours: [
+			{
+				opening: '09:00',
+				closing: '17:00',
+			},
+		],
+	},
+	{
+		name: 'Tue',
+		hours: [
+			{
+				opening: '09:00',
+				closing: '17:00',
+			},
+		],
+	},
+	{
+		name: 'Wed',
+		hours: [
+			{
+				opening: '09:00',
+				closing: '17:00',
+			},
+		],
+	},
+	{
+		name: 'Thu',
+		hours: [
+			{
+				opening: '09:00',
+				closing: '17:00',
+			},
+		],
+	},
+	{
+		name: 'Fri',
+		hours: [
+			{
+				opening: '09:00',
+				closing: '17:00',
+			},
+		],
+	},
+	{
+		name: 'Sat',
+		hours: [], // Closed by default
+	},
+];
+
 export const name = 'business-hours';
 
 export const icon = renderMaterialIcon(
@@ -38,65 +94,17 @@ export const settings = {
 	attributes: {
 		days: {
 			type: 'array',
-			default: [
-				{
-					name: 'Sun',
-					hours: [], // Closed by default
-				},
-				{
-					name: 'Mon',
-					hours: [
-						{
-							opening: '09:00',
-							closing: '17:00',
-						},
-					],
-				},
-				{
-					name: 'Tue',
-					hours: [
-						{
-							opening: '09:00',
-							closing: '17:00',
-						},
-					],
-				},
-				{
-					name: 'Wed',
-					hours: [
-						{
-							opening: '09:00',
-							closing: '17:00',
-						},
-					],
-				},
-				{
-					name: 'Thu',
-					hours: [
-						{
-							opening: '09:00',
-							closing: '17:00',
-						},
-					],
-				},
-				{
-					name: 'Fri',
-					hours: [
-						{
-							opening: '09:00',
-							closing: '17:00',
-						},
-					],
-				},
-				{
-					name: 'Sat',
-					hours: [], // Closed by default
-				},
-			],
+			default: defaultDays,
 		},
 	},
 
 	edit: props => <BusinessHours { ...props } />,
 
 	save: () => null,
+
+	example: {
+		attributes: {
+			days: defaultDays,
+		},
+	},
 };

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -18,11 +18,11 @@ import renderMaterialIcon from '../../shared/render-material-icon';
 
 const defaultDays = [
 	{
-		name: __( 'Sun', 'jetpack' ),
+		name: 'Sun',
 		hours: [], // Closed by default
 	},
 	{
-		name: __( 'Mon', 'jetpack' ),
+		name: 'Mon',
 		hours: [
 			{
 				opening: '09:00',
@@ -31,7 +31,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: __( 'Tue', 'jetpack' ),
+		name: 'Tue',
 		hours: [
 			{
 				opening: '09:00',
@@ -40,7 +40,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: __( 'Wed', 'jetpack' ),
+		name: 'Wed',
 		hours: [
 			{
 				opening: '09:00',
@@ -49,7 +49,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: __( 'Thu', 'jetpack' ),
+		name: 'Thu',
 		hours: [
 			{
 				opening: '09:00',
@@ -58,7 +58,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: __( 'Fri', 'jetpack' ),
+		name: 'Fri',
 		hours: [
 			{
 				opening: '09:00',
@@ -67,7 +67,7 @@ const defaultDays = [
 		],
 	},
 	{
-		name: __( 'Sat', 'jetpack' ),
+		name: 'Sat',
 		hours: [], // Closed by default
 	},
 ];

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -70,6 +70,16 @@ export const settings = {
 
 	edit: JetpackContactForm,
 	save: () => <InnerBlocks.Content />,
+	example: {
+		attributes: {
+			hasFormSettingsSet: 'yes',
+			has_form_settings_set: null,
+			subject: 'My New Site',
+			submitButtonText: 'Submit',
+			submit_button_text: 'Submit',
+			to: 'email@example.com',
+		},
+	},
 	deprecated: [
 		{
 			attributes: {

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -74,10 +74,10 @@ export const settings = {
 		attributes: {
 			hasFormSettingsSet: 'yes',
 			has_form_settings_set: null,
-			subject: 'My New Site',
-			submitButtonText: 'Submit',
-			submit_button_text: 'Submit',
-			to: 'email@example.com',
+			subject: __( 'My New Site', 'jetpack' ),
+			submitButtonText: __( 'Submit', 'jetpack' ),
+			submit_button_text: __( 'Submit', 'jetpack' ),
+			to: __( 'email@example.com', 'jetpack' ),
 		},
 	},
 	deprecated: [

--- a/extensions/blocks/contact-info/edit.js
+++ b/extensions/blocks/contact-info/edit.js
@@ -35,7 +35,6 @@ const TEMPLATE = [ [ 'jetpack/email' ], [ 'jetpack/phone' ], [ 'jetpack/address'
 
 const ContactInfoEdit = props => {
 	const { isSelected } = props;
-
 	return (
 		<div
 			className={ classnames( {

--- a/extensions/blocks/contact-info/index.js
+++ b/extensions/blocks/contact-info/index.js
@@ -48,6 +48,9 @@ export const settings = {
 	attributes,
 	edit,
 	save,
+	example: {
+		attributes: {},
+	},
 };
 
 export const childBlocks = [

--- a/extensions/blocks/gif/index.js
+++ b/extensions/blocks/gif/index.js
@@ -63,7 +63,7 @@ export const settings = {
 			align: 'center',
 			giphyUrl: 'https://giphy.com/embed/fxKWgoOG9hzPPkE1oc',
 			paddingTop: '100%',
-			searchText: 'wordpress',
+			searchText: __( 'WordPress', 'jetpack' ),
 		},
 	},
 };

--- a/extensions/blocks/gif/index.js
+++ b/extensions/blocks/gif/index.js
@@ -58,4 +58,12 @@ export const settings = {
 	},
 	edit,
 	save: () => null,
+	example: {
+		attributes: {
+			align: 'center',
+			giphyUrl: 'https://giphy.com/embed/fxKWgoOG9hzPPkE1oc',
+			paddingTop: '100%',
+			searchText: 'wordpress',
+		},
+	},
 };

--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -67,4 +67,10 @@ export const settings = {
 	edit,
 
 	save,
+
+	example: {
+		attributes: {
+			source: '**This** is a [Markdown](https://daringfireball.net/projects/markdown/) _block_',
+		},
+	},
 };

--- a/extensions/blocks/related-posts/index.js
+++ b/extensions/blocks/related-posts/index.js
@@ -72,4 +72,14 @@ export const settings = {
 	edit,
 
 	save: () => null,
+
+	example: {
+		attributes: {
+			postLayout: 'grid',
+			displayDate: true,
+			displayThumbnails: false,
+			displayContext: false,
+			postsToShow: 3,
+		},
+	},
 };

--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -43,4 +43,10 @@ export const settings = {
 	title: __( 'Repeat Visitor', 'jetpack' ),
 	edit,
 	save,
+	example: {
+		attributes: {
+			criteria: CRITERIA_AFTER,
+			threshold: DEFAULT_THRESHOLD,
+		},
+	},
 };

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -70,6 +70,28 @@ const attributes = {
 	},
 };
 
+const exampleAttributes = {
+	align: 'center',
+	autoplay: false,
+	delay: 3,
+	ids: [ 22, 23 ],
+	images: [
+		{
+			alt: '',
+			caption: '',
+			id: 22,
+			url: 'http://goldsounds.local/wp-content/uploads/2019/09/preview-BH-frontend.png',
+		},
+		{
+			alt: '',
+			caption: '',
+			id: 23,
+			url: 'http://goldsounds.local/wp-content/uploads/2019/09/preview-BH-frontend-1.png',
+		},
+	],
+	effect: 'slide',
+};
+
 export const name = 'slideshow';
 
 export const settings = {
@@ -90,4 +112,7 @@ export const settings = {
 	edit,
 	save,
 	transforms,
+	example: {
+		attributes: exampleAttributes,
+	},
 };

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -119,6 +119,39 @@ const blockAttributes = {
 	},
 };
 
+const exampleAttributes = {
+	align: 'center',
+	className: 'is-style-rectangular',
+	ids: [ 25, 26, 27 ],
+	images: [
+		{
+			alt: '',
+			id: 25,
+			link: 'http://goldsounds.local/?attachment_id=25',
+			url: 'http://goldsounds.local/wp-content/uploads/2019/09/Screenshot_20190923-094645.png',
+			height: 2960,
+			width: 1440,
+		},
+		{
+			alt: '',
+			id: 26,
+			link: 'http://goldsounds.local/?attachment_id=26',
+			url: 'http://goldsounds.local/wp-content/uploads/2019/09/preview-BH-backend.png',
+			height: 2100,
+			width: 3360,
+		},
+		{
+			alt: '',
+			id: 27,
+			link: 'http://goldsounds.local/?attachment_id=27',
+			url: 'http://goldsounds.local/wp-content/uploads/2019/09/preview-BH-frontend-2.png',
+			height: 2278,
+			width: 3584,
+		},
+	],
+	linkTo: 'none',
+};
+
 export const name = 'tiled-gallery';
 
 export const icon = (
@@ -212,4 +245,7 @@ export const settings = {
 	edit,
 	save,
 	deprecated: [ deprecatedV1 ],
+	example: {
+		attributes: exampleAttributes,
+	},
 };

--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -63,4 +63,5 @@ export const settings = {
 	},
 	edit,
 	save: () => null,
+	example: { attributes: {} },
 };


### PR DESCRIPTION
Master issue: #13510

Done:
- Business Hours
- Contact Form
- Contact Info
- Gif

Done but Needs design:
- Slideshow needs hosted images for previews
- Tiled gallery needs hosted images for previews
- Markdown example content
- Related posts - I only show the "not enough content" preview. Maybe we should use an image?
- Repeat visitor - This wraps a nested block, mine doesn't have a nested block in the example. Not familiar with the official Gutenberg way to do this

Skipped:
- Mailchimp, because it has complicated state that depends on API calls (can be done, but complex) (render with image?)
- Map, because it requires an API key (render with image?)
- Publicize, requires connections (render with image?)
- Recurring payments (complex)
- Simple payments (complex)
- Publicize, doesn't appear to be registered
- SEO, couldn't get it to show up
- Likes, ditto
- Sharing, ditto
- Shortlinks, ditto
- Subscriptions, ditto
- VideoPress, ditto