### PR TITLE
Composer: Streamline package contents (Experimental)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"build-client": "gulp",
 		"build-extensions": "webpack --config ./webpack.config.extensions.js",
 		"build-php": "composer install",
-		"build-production-php": "COMPOSER_MIRROR_PATH_REPOS=1 composer install -o --no-dev --classmap-authoritative",
+		"build-production-php": "COMPOSER_MIRROR_PATH_REPOS=1 composer install -o --no-dev --classmap-authoritative --prefer-dist",
 		"build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
 		"build-production": "yarn distclean && yarn install --production=false && yarn build-production-client && yarn build-production-php && NODE_ENV=production yarn build-extensions && gulp languages:extract",
 		"build-languages": "gulp languages",

--- a/packages/jitm/.gitattributes
+++ b/packages/jitm/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes  export-ignore
+phpunit.xml     export-ignore
+tests/          export-ignore


### PR DESCRIPTION
While `composer install --no-dev` will skip any devDependencies from installing, for production packages, all development files are still present.

Adding `--prefer-dist` will attempt to use the archived version provided by GitHub (this is standard for stable versions, but for dev versions of a package this will try to force the archive instead of the VCS source).

Within each package, we can add a `.gitattributes` file that `export-ignore` any test files. Adding an example in the JITM package. I'm testing here specifically because the unit tests violate coding standards on WP.com, so if we can simply exclude the tests from being distributed in a production use-case, it's a win for everyone.

Testing with JITM only right now. If it works as I think it should, I'll open a new PR to do this for the other existing packages.

#### Changes proposed in this Pull Request:
* package.json: Prefer the dist archive in production environments for composer.
* JITM Package: Exclude test files from dist archive.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Commit and https://github.com/automattic/jetpack-jitm reflects the new changes.
* Try `composer install --no-dev --prefer-dist` or `yarn build-production-php`
* Check the /vendor/automattic/jetpack-jitm directory for a tests folder.

#### Proposed changelog entry for your changes:
For Jetpack:
* Composer: Prefer distribution archives for deployment in production environments.

For JITM:
* Exclude test files from distributed stable versions.
