### PR TITLE
Docs: Clarify yarn watch

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -69,10 +69,10 @@ The development build will create a build without minifying or deduping code. It
 $ yarn build
 ```
 
-## Development build with changes monitoring (watch)
+## Watching changes
 
 You can run a watch process, which will continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
-Instead of `yarn build` you'd use `yarn watch`.
+After an initial run of `yarn build` you'd use `yarn watch` for monitoring changes.
 
 ```
 $ yarn watch


### PR DESCRIPTION
The docs aren't as clear as they should be that `yarn watch` alone is not enough to build Jetpack as it does not run everything needed (see https://github.com/Automattic/jetpack/issues/10963 ).

#### Changes proposed in this Pull Request:
* Clarify in docs that `yarn build` must run before `yarn watch`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* n/a
