### PR TITLE
Build: Let watching build Jetpack

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -69,10 +69,10 @@ The development build will create a build without minifying or deduping code. It
 $ yarn build
 ```
 
-## Watching changes
+## Development build with changes monitoring (watch)
 
 You can run a watch process, which will continuously watch the front-end JS and CSS/Sass for changes and rebuild accordingly.
-After an initial run of `yarn build` you'd use `yarn watch` for monitoring changes.
+Instead of `yarn build` you'd use `yarn watch`. `yarn watch` will fully build Jetpack and update the React-powered admin and CSS/Saas.
 
 ```
 $ yarn watch

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -31,6 +31,10 @@ gulp.task( 'old-styles:watch', function() {
 	return gulp.watch( 'scss/**/*.scss', gulp.parallel( 'old-styles' ) );
 } );
 
+gulp.task( 'blocks:watch', function() {
+	spawn( 'yarn', [ 'build-extensions', '--watch' ] );
+} );
+
 /*
 	I18n land
 */
@@ -222,7 +226,7 @@ gulp.task(
 );
 gulp.task(
 	'watch',
-	gulp.parallel( react_watch, sass_watch, sass_watch_packages, 'old-styles:watch' )
+	gulp.parallel( react_watch, sass_watch, sass_watch_packages, 'old-styles:watch', 'blocks:watch' )
 );
 
 // Keeping explicit task names to allow for individual runs

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -32,7 +32,11 @@ gulp.task( 'old-styles:watch', function() {
 } );
 
 gulp.task( 'blocks:watch', function() {
-	spawn( 'yarn', [ 'build-extensions', '--watch' ] );
+	const child = require( 'child_process' ).execFile( 'yarn', [ 'build-extensions', '--watch' ] );
+
+	child.stdout.on( 'data', function( data ) {
+		log( data.toString() );
+	} );
 } );
 
 /*

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"url": "https://github.com/Automattic/jetpack/issues"
 	},
 	"scripts": {
-		"watch": "yarn install-if-deps-outdated && yarn gulp watch",
+		"watch": "yarn build && yarn gulp watch",
 		"clean": "yarn clean-client && yarn clean-extensions && yarn clean-composer",
 		"clean-client": "rm -rf _inc/build/ css/",
 		"clean-composer": "rm -rf vendor/",


### PR DESCRIPTION
Fixes #10963
Fixes #11698

#### Changes proposed in this Pull Request:
* Adds `yarn build` to `yarn watch` so the latter can be a one-command way to build and watch Jetpack.
* Adds Blocks watching (`yarn build-extensions --watch` to `yarn watch` via gulp.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* `yarn clean && yarn dist-clean` to clean up everything before testing.
* Load Jetpack in the browser (e.g. `yarn docker:up -> http://localhost or your ngrok tunnel).
* Confirm the "Jetpack incomplete" error message in wp-admin.
* Run `yarn watch`
* Reload wp-admin after the build process has finished. Confirm it no longer says `Jetpack incomplete` (what occurred prior to this PR).

#### Proposed changelog entry for your changes:
* Developer Experience: `yarn watch` will build Jetpack from scratch too.
