### PR TITLE
Admin Page: Update security settings external link gridicons

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -256,6 +256,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 							compact
 							className="jp-settings-card__configure-link"
 							onClick={ this.trackConfigureClick }
+							target="_blank"
 							href="https://dashboard.vaultpress.com/"
 						>
 							{ __( 'Configure your Security Scans' ) }

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -60,6 +60,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 							compact
 							className="jp-settings-card__configure-link"
 							onClick={ this.trackConfigureClick }
+							target="_blank"
 							href={ 'https://wordpress.com/settings/security/' + this.props.siteRawUrl }
 						>
 							{ __( 'Configure your notification settings' ) }


### PR DESCRIPTION
Updates external link gridicons for the security scan and downtime monitoring notification settings from "chevron-right" to "external" (they all link to destinations outside of wp-admin).

Fixes #13569

**Before/After screenshots:**

<img width="1376" alt="Screen Shot 2019-09-27 at 3 46 27 PM" src="https://user-images.githubusercontent.com/204742/65804204-5615c500-e13e-11e9-95ca-dd3748336929.png">

**Testing instructions:**
- Check out this branch
- Run yarn build
- Visit the Jetpack Settings in wp-admin on your Jetpack Sandbox site or whatever site you're testing on
- Ensure the changes reflect the above "After" mockup as shown above

**Proposed changelog entry:**
- Update security settings external link gridicons
