### PR TITLE
Carousel: Fix markup changes from Gutenberg 6.5.

### DIFF
--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1665,7 +1665,7 @@ jQuery( document ).ready( function( $ ) {
 	// register the event listener for starting the gallery
 	$( document.body ).on(
 		'click.jp-carousel',
-		'div.gallery, div.tiled-gallery, ul.wp-block-gallery, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
+		'div.gallery, div.tiled-gallery, ul.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
 		function( e ) {
 			if ( ! $( this ).jp_carousel( 'testForData', e.currentTarget ) ) {
 				return;

--- a/modules/carousel/jetpack-carousel.js
+++ b/modules/carousel/jetpack-carousel.js
@@ -1665,7 +1665,7 @@ jQuery( document ).ready( function( $ ) {
 	// register the event listener for starting the gallery
 	$( document.body ).on(
 		'click.jp-carousel',
-		'div.gallery, div.tiled-gallery, ul.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
+		'div.gallery, div.tiled-gallery, ul.wp-block-gallery, ul.blocks-gallery-grid, div.wp-block-jetpack-tiled-gallery, a.single-image-gallery',
 		function( e ) {
 			if ( ! $( this ).jp_carousel( 'testForData', e.currentTarget ) ) {
 				return;

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -542,7 +542,7 @@ class Jetpack_Carousel {
 			$extra_data = apply_filters( 'jp_carousel_add_data_to_container', $extra_data );
 			foreach ( (array) $extra_data as $data_key => $data_values ) {
 				$html = str_replace( '<div ', '<div ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' ", $html );
-				$html = str_replace( '<ul class="wp-block-gallery', '<ul ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' class=\"wp-block-gallery", $html );
+				$html = str_replace( '<ul class="blocks-gallery-grid', '<ul ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' class=\"blocks-gallery-grid", $html );
 			}
 		}
 

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -542,6 +542,7 @@ class Jetpack_Carousel {
 			$extra_data = apply_filters( 'jp_carousel_add_data_to_container', $extra_data );
 			foreach ( (array) $extra_data as $data_key => $data_values ) {
 				$html = str_replace( '<div ', '<div ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' ", $html );
+				$html = str_replace( '<ul class="wp-block-gallery', '<ul ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' class=\"wp-block-gallery", $html );
 				$html = str_replace( '<ul class="blocks-gallery-grid', '<ul ' . esc_attr( $data_key ) . "='" . json_encode( $data_values ) . "' class=\"blocks-gallery-grid", $html );
 			}
 		}


### PR DESCRIPTION
Gutenberg 6.5 introduced [gallery captions](https://github.com/WordPress/gutenberg/pull/17101), which also took the liberty of making some markup changes; these changes [removed markup](https://github.com/WordPress/gutenberg/pull/17101/files#diff-f46dc4d2a6eae38926f9e715a23b08b5L9) that Carousel depends on for its [click handlers](https://github.com/Automattic/jetpack/blob/master/modules/carousel/jetpack-carousel.js#L1668). This PR updates the class Carousel looks for to identify the new Gallery blocks.

See: https://github.com/Automattic/wp-calypso/issues/36406

#### Testing instructions:
* Load your Jetpack dev environment with the Gutenberg 6.5 plugin active, `SCRIPT_DEBUG` defined, and the Carousel module active.
* Create a new post with the block editor, add a Gallery block, and select "Media file" under the "Link To" dropdown in the block's sidebar.
* Publish the post, and verify on the front-end that the Carousel does not display when a gallery image is clicked.
* Switch to this PR.
* Refresh the published post, and verify the Carousel now works as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Bug: Fix carousels when the Gutenberg v6.5.0 plugin is active.
