### PR TITLE
Fix/goodreads-timeout

### DIFF
--- a/modules/widgets/goodreads.php
+++ b/modules/widgets/goodreads.php
@@ -95,7 +95,7 @@ class WPCOM_Widget_Goodreads extends WP_Widget {
 		$response = wp_remote_head(
 			$url, array(
 				'httpversion' => '1.1',
-				'timeout'     => 3,
+				'timeout'     => 10,
 				'redirection' => 2,
 			)
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes this issue: https://github.com/Automattic/jetpack/issues/13240

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to 'widgets' page, add goodreads widget
* Test with this test ID: `101233110`. It works fine with the previous code containing `timeout => 3`
* Testing with this user ID: `3846340` previously failed **but it works now** with `timeout => 10` change in the code.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes timeout issues with Goodreads widget
