### PR TITLE
Update/fix admin classes

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3978,7 +3978,7 @@ p {
 		$error = false;
 
 		// Make sure we have the right body class to hook stylings for subpages off of.
-		add_filter( 'admin_body_class', array( __CLASS__, 'add_jetpack_pagestyles' ) );
+		add_filter( 'admin_body_class', array( __CLASS__, 'add_jetpack_pagestyles' ), 20 );
 
 		if ( ! empty( $_GET['jetpack_restate'] ) ) {
 			// Should only be used in intermediate redirects to preserve state across redirects

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -640,7 +640,7 @@ class Jetpack {
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'admin_init', array( $this, 'dismiss_jetpack_notice' ) );
 
-		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
+		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ), 20 );
 
 		add_action( 'wp_dashboard_setup', array( $this, 'wp_dashboard_setup' ) );
 		// Filter the dashboard meta box order to swap the new one in in place of the old one.


### PR DESCRIPTION
Some themes or plugins don't correctly apply admin body classes. Such as the inVough theme. 
This PR fixes it by updating the priority of classes to be applied after the themes classes get applied. 

Before:
<img width="958" alt="Screen Shot 2019-09-30 at 1 07 35 PM" src="https://user-images.githubusercontent.com/115071/65873524-9b770400-e383-11e9-86b0-b9f809db3e67.png">

After:
<img width="957" alt="Screen Shot 2019-09-30 at 1 07 16 PM" src="https://user-images.githubusercontent.com/115071/65873533-9fa32180-e383-11e9-9e1f-1e8f614d9428.png">

#### Changes proposed in this Pull Request:
* increments the priority of when the admin classes get applied so that they still get displayed even though some other plugin could be ignoring them.

#### Testing instructions:
Install the inVough theme https://wordpress.org/themes/invogue/ 
* Go to Jetpack Dashboard notice that the page looks as expected. 

#### Proposed changelog entry for your changes:
* Minor fixes for improving the display of the jetpack admin pages.
