### PR TITLE
Connection: Redirect plugins and dashboard connect buttons to the main flow

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -157,6 +157,7 @@ jQuery( document ).ready( function( $ ) {
 		},
 	};
 
+	// When we visit /wp-admin/admin.php?page=jetpack#/setup, immediately start the connection flow.
 	var hash = location.hash.replace( /#\//, '' );
 	if ( 'setup' === hash ) {
 		if ( connectionCards.length ) {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -4,13 +4,15 @@ jQuery( document ).ready( function( $ ) {
 	var connectButton = $( '.jp-connect-button, .jp-banner__alt-connect-button' ).eq( 0 );
 	var tosText = $( '.jp-connect-full__tos-blurb' );
 	var jetpackConnectIframe = $( '<iframe class="jp-jetpack-connect__iframe" />' );
-	var connectionCards = $( '#jetpack-connection-cards' );
+	var connectionHelpSections = $(
+		'#jetpack-connection-cards, .jp-connect-full__dismiss-paragraph'
+	);
 
 	connectButton.on( 'click', function( event ) {
 		event.preventDefault();
 
-		if ( connectionCards.length ) {
-			connectionCards.fadeOut( 600 );
+		if ( connectionHelpSections.length ) {
+			connectionHelpSections.fadeOut( 600 );
 		}
 
 		jetpackConnectButton.selectAndStartConnectionFlow();
@@ -20,9 +22,9 @@ jQuery( document ).ready( function( $ ) {
 		isRegistering: false,
 		isPaidPlan: false,
 		selectAndStartConnectionFlow: function() {
-			var connectionCards = $( '#jetpack-connection-cards' );
-			if ( connectionCards.length ) {
-				connectionCards.fadeOut( 600 );
+			var connectionHelpSections = $( '#jetpack-connection-cards' );
+			if ( connectionHelpSections.length ) {
+				connectionHelpSections.fadeOut( 600 );
 			}
 
 			if ( ! jetpackConnectButton.isRegistering ) {
@@ -160,8 +162,8 @@ jQuery( document ).ready( function( $ ) {
 	// When we visit /wp-admin/admin.php?page=jetpack#/setup, immediately start the connection flow.
 	var hash = location.hash.replace( /#\//, '' );
 	if ( 'setup' === hash ) {
-		if ( connectionCards.length ) {
-			connectionCards.hide();
+		if ( connectionHelpSections.length ) {
+			connectionHelpSections.hide();
 		}
 
 		jetpackConnectButton.selectAndStartConnectionFlow();

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -75,6 +75,16 @@ abstract class Jetpack_Admin_Page {
 			delete_transient( 'activated_jetpack' );
 		}
 
+		// If Jetpack not yet connected, but user is viewing one of the pages with a Jetpack connection banner.
+		if (
+			( 'index.php' === $pagenow || 'plugins.php' === $pagenow )
+			&& ! Jetpack::is_active()
+			&& current_user_can( 'jetpack_connect' )
+			&& ! Jetpack::is_development_mode()
+		) {
+			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
+		}
+
 		// Check if the site plan changed and deactivate modules accordingly.
 		add_action( 'current_screen', array( $this, 'check_plan_deactivate_modules' ) );
 

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -179,6 +179,7 @@ class Jetpack_Connection_Banner {
 				'buttonTextRegistering' => __( 'Loading...', 'jetpack' ),
 				'jetpackApiDomain'      => $jetpackApiUrl['scheme'] . '://' . $jetpackApiUrl['host'],
 				'forceVariation'        => $force_variation,
+				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
 				'plansPromptUrl'        => Jetpack::admin_url( 'page=jetpack#/plans-prompt' ),
 			)
@@ -284,7 +285,7 @@ class Jetpack_Connection_Banner {
 								<span class="jp-banner__tos-blurb"><?php jetpack_render_tos_blurb(); ?></span>
 								<a
 										href="<?php echo esc_url( $this->build_connect_url_for_slide( '72' ) ); ?>"
-										class="dops-button is-primary">
+										class="dops-button is-primary jp-banner__alt-connect-button">
 									<?php esc_html_e( 'Set up Jetpack', 'jetpack' ); ?>
 								</a>
 							</div>


### PR DESCRIPTION
Currently, the main connection flow starting from `/wp-admin/admin.php?page=jetpack#/` has the connect-in-place flow, but the buttons starting from the WP-admin dashboard (`/wp-admin/index.php`) and plugins screen (`/wp-admin/plugins.php`) still work the old way. 

This PR updates these buttons so they respect the constant and A/B test, and based on them, redirect to either the original connection flow or the connect-in-place flow.

#### Changes proposed in this Pull Request:
* Update dashboard and plugins screens connection buttons:
  * Respect the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant.
  * Respect the `jetpack_connect_in_place_v2` A/B test.
  * If connect-in-place flow is enabled through the constant or the A/B test, redirect to it and start the flow.
  * If connect-in-place flow is not enabled, the buttons would redirect to the WP.com connection flow, like they used to do before.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of p1HpG7-7nj-p2

#### Testing instructions:
* Checkout this branch.
* Build Jetpack `npm build`.
* Follow the instructions below in the following order. I've separated them in sections for clarity.
* **Test the connect in place flow from the Jetpack dashboard**
  * Disconnect Jetpack if it was connected.
  * Add this to your wp-config.php: `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
  * Go to `/wp-admin/admin.php?page=jetpack#/`
  * Click the "Set up Jetpack" button.
  * Verify it works the same way as it does on `master`.
  * Verify you're still able to connect like before.
  * Disconnect Jetpack.
* **Test the connect in place flow from the WP admin dashboard**
  * Go to `/wp-admin/index.php`.
  * Click the "Set up Jetpack" button.
  * Verify it redirects to `/wp-admin/admin.php?page=jetpack#/setup`
  * Verify you see the loading screen, and after a little, you see either the "Approve" button, or the "Connect with WordPress.com" button.
  * Verify you're still able to connect like before.
  * Disconnect Jetpack.
* **Test the connect in place flow from the plugins screen**
  * Go to `/wp-admin/plugins.php`.
  * Click the "Set up Jetpack" button.
  * Verify it redirects to `/wp-admin/admin.php?page=jetpack#/setup`
  * Verify you see the loading screen, and after a little, you see either the "Approve" button, or the "Connect with WordPress.com" button.
  * Verify you're still able to connect like before.
  * Disconnect Jetpack.
* **Test the original connection flow from the Jetpack dashboard**
  * Remove this from your wp-config.php: `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
  * Go to `/wp-admin/admin.php?page=jetpack#/`
  * Open your Network requests tab.
  * Click the "Set up Jetpack" button.
  * Verify that this performs a request to the A/B test endpoint.
  * Verify you're redirected to the WP.com Jetpack Connect authorization flow.
  * Verify you're still able to connect like before.
  * Disconnect Jetpack.
* **Test the original connection flow from the WP admin dashboard**
  * Go to `/wp-admin/index.php`.
  * Open your Network requests tab.
  * Click the "Set up Jetpack" button.
  * Verify that this performs a request to the A/B test endpoint.
  * Verify you're redirected to the WP.com Jetpack Connect authorization flow.
  * Verify you're still able to connect like before.
  * Disconnect Jetpack.
* **Test the original connection flow from the plugins screen**
  * Go to `/wp-admin/plugins.php`.
  * Open your Network requests tab.
  * Click the "Set up Jetpack" button.
  * Verify that this performs a request to the A/B test endpoint.
  * Verify you're redirected to the WP.com Jetpack Connect authorization flow.
  * Verify you're still able to connect like before.
* If you got to this point, I wish to thank you for the thorough testing ❤️💪

#### Proposed changelog entry for your changes:

* Connection: Redirect plugins and dashboard connect buttons to the main flow
