### PR TITLE
Plans: Add a plan billing period toggle

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -10,6 +10,7 @@ import { includes, map, reduce } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
 import { getSiteRawUrl, getUpgradeUrl, getUserId, showBackups } from 'state/initial-state';
 import { getSitePlan, getAvailablePlans } from 'state/site/reducer';
 import { getPlanClass } from 'lib/plans/constants';
@@ -18,6 +19,10 @@ import TopButton from './top-button';
 import FeatureItem from './feture-item';
 
 class PlanGrid extends React.Component {
+	state = {
+		period: 'yearly',
+	};
+
 	/**
 	 * Memoized storage for plans to display according to highlighted features
 	 */
@@ -25,6 +30,18 @@ class PlanGrid extends React.Component {
 
 	UNSAFE_componentWillUpdate() {
 		this.featuredPlans = false;
+	}
+
+	changePeriodSwitch( newPeriod ) {
+		if ( newPeriod === this.state.period ) {
+			return false;
+		}
+
+		return () => {
+			this.setState( {
+				period: newPeriod,
+			} );
+		};
 	}
 
 	render() {
@@ -43,6 +60,8 @@ class PlanGrid extends React.Component {
 		return (
 			<div className="plan-features">
 				{ this.renderMobileCard() }
+				{ this.renderPlanPeriodToggle() }
+
 				<div className="plan-features__content">
 					<table className={ tableClasses }>
 						<tbody>
@@ -73,6 +92,31 @@ class PlanGrid extends React.Component {
 				<Button href={ plansUrl } primary>
 					{ __( 'View all Jetpack plans' ) }
 				</Button>
+			</div>
+		);
+	}
+
+	renderPlanPeriodToggle() {
+		const { period } = this.state;
+
+		return (
+			<div className="plan-grid-period">
+				<ButtonGroup>
+					<Button
+						primary={ 'monthly' === period }
+						onClick={ this.changePeriodSwitch( 'monthly' ) }
+						compact
+					>
+						{ __( 'Monthly' ) }
+					</Button>
+					<Button
+						primary={ 'yearly' === period }
+						onClick={ this.changePeriodSwitch( 'yearly' ) }
+						compact
+					>
+						{ __( 'Yearly' ) }
+					</Button>
+				</ButtonGroup>
 			</div>
 		);
 	}
@@ -200,7 +244,7 @@ class PlanGrid extends React.Component {
 				<td key={ 'price-' + type } className={ className }>
 					<span
 						className="plan-price__yearly"
-						dangerouslySetInnerHTML={ { __html: plan.price.yearly.per } }
+						dangerouslySetInnerHTML={ { __html: plan.price[ this.state.period ].per } }
 					/>
 				</td>
 			);
@@ -229,6 +273,10 @@ class PlanGrid extends React.Component {
 			const { siteRawUrl, plansUpgradeUrl, sitePlan } = this.props;
 			const isActivePlan = this.isCurrentPlanType( planType );
 			const buttonText = isActivePlan ? plan.strings.manage : plan.strings.upgrade;
+			let planTypeWithPeriod = planType;
+			if ( 'monthly' === this.state.period ) {
+				planTypeWithPeriod += '-monthly';
+			}
 
 			return (
 				<TopButton
@@ -239,7 +287,7 @@ class PlanGrid extends React.Component {
 					isPrimary={ this.isPrimary( planType, plan ) }
 					shouldRenderButton={ this.shouldRenderButton( planType ) }
 					siteRawUrl={ siteRawUrl }
-					plansUpgradeUrl={ plansUpgradeUrl( planType ) }
+					plansUpgradeUrl={ plansUpgradeUrl( planTypeWithPeriod ) }
 					productSlug={ sitePlan.product_slug }
 				/>
 			);

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -9,6 +9,7 @@ import { includes, map, reduce } from 'lodash';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import { getSiteRawUrl, getUpgradeUrl, getUserId, showBackups } from 'state/initial-state';
@@ -38,6 +39,11 @@ class PlanGrid extends React.Component {
 		}
 
 		return () => {
+			analytics.tracks.recordJetpackClick( {
+				target: 'change-period-' + newPeriod,
+				feature: 'plans-grid',
+			} );
+
 			this.setState( {
 				period: newPeriod,
 			} );

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -104,24 +104,23 @@ class PlanGrid extends React.Component {
 
 	renderPlanPeriodToggle() {
 		const { period } = this.state;
+		const periods = {
+			monthly: __( 'Monthly' ),
+			yearly: __( 'Yearly' ),
+		};
 
 		return (
 			<div className="plan-grid-period">
 				<ButtonGroup>
-					<Button
-						primary={ 'monthly' === period }
-						onClick={ this.handlePeriodChange( 'monthly' ) }
-						compact
-					>
-						{ __( 'Monthly' ) }
-					</Button>
-					<Button
-						primary={ 'yearly' === period }
-						onClick={ this.handlePeriodChange( 'yearly' ) }
-						compact
-					>
-						{ __( 'Yearly' ) }
-					</Button>
+					{ map( periods, ( periodLabel, periodName ) => (
+						<Button
+							primary={ periodName === period }
+							onClick={ this.handlePeriodChange( periodName ) }
+							compact
+						>
+							{ periodLabel }
+						</Button>
+					) ) }
 				</ButtonGroup>
 			</div>
 		);

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -32,7 +32,7 @@ class PlanGrid extends React.Component {
 		this.featuredPlans = false;
 	}
 
-	changePeriodSwitch( newPeriod ) {
+	handlePeriodChange( newPeriod ) {
 		if ( newPeriod === this.state.period ) {
 			return false;
 		}
@@ -104,14 +104,14 @@ class PlanGrid extends React.Component {
 				<ButtonGroup>
 					<Button
 						primary={ 'monthly' === period }
-						onClick={ this.changePeriodSwitch( 'monthly' ) }
+						onClick={ this.handlePeriodChange( 'monthly' ) }
 						compact
 					>
 						{ __( 'Monthly' ) }
 					</Button>
 					<Button
 						primary={ 'yearly' === period }
-						onClick={ this.changePeriodSwitch( 'yearly' ) }
+						onClick={ this.handlePeriodChange( 'yearly' ) }
 						compact
 					>
 						{ __( 'Yearly' ) }

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -50,7 +50,8 @@ $plan-features-sidebar-width: 272px;
 
 	@include breakpoint( "<1040px" ) {
 		border-spacing: 0;
-		margin: 0 15px;
+		margin-left: 15px;
+		margin-right: 15px;
 		width: calc( 100% - 30px );
 	}
 }
@@ -218,15 +219,25 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-grid-period {
+	margin-bottom: 12px;
+	text-align: center;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
 .plans-mobile-notice.dops-card h2 {
 	margin-top: 0;
 }
 .plan-grid-skeletons {
 	display: flex;
-	margin: 0 -10px;
+	margin: 60px -10px 0;
 
 	@include breakpoint( "<1040px" ) {
-		margin: 0 -1px;
+		margin-left: -1px;
+		margin-right: -1px;
 	}
 
 	@include breakpoint( "<660px" ) {


### PR DESCRIPTION
This PR adds a plan billing period toggle to the plans screens. This will allow users to switch between monthly and yearly plans before upgrading to a plan from wp-admin.

#### Changes proposed in this Pull Request:
* Plans: Add a plan billing period toggle

#### Preview

Yearly plans (default):
![](https://cldup.com/NqmIECE9bX.png)

Monthly plans:
![](https://cldup.com/9FWqkD8Xdm.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the p1HpG7-7nj-p2 project.

#### Testing instructions:
* Apply this patch to your WP.com sandbox, and follow the instructions there (if you haven't yet): D33376-code
* Checkout this branch on your connected Jetpack site (ideally, on a free plan).
* Run `yarn build` or `yarn watch`.
* Go to `/wp-admin/admin.php?page=jetpack#/plans`
* Verify the loading placeholder plan boxes align with the plan boxes once they load.
* Verify you landed on the yearly plans view.
* Verify the toggle looks and works well, and it updates the price accordingly.
* Test on tablet and verify it works and looks good.
* Test on mobile and verify the toggle isn't visible there.
* Test also on `/wp-admin/admin.php?page=jetpack#/plans-prompt`
* Bonus: verify that we record a tracks event when we toggle the billing period:
  * Type `localStorage.setItem('debug', 'dops:analytics');` in your browser console.
  * Refresh the page.
  * Click a toggle that's not currently active.
  * Verify it records an adequate tracks event with the period of the toggle that was clicked.

#### Proposed changelog entry for your changes:
* Plans: Add a plan billing period toggle
