### PR TITLE
Fix: Do not show jetpack link when jetpack is not connected to non admin.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -38,8 +38,8 @@ abstract class Jetpack_Admin_Page {
 	function add_actions() {
 		global $pagenow;
 
-		// If user is not an admin and site is in Dev Mode, don't do anything
-		if ( ! current_user_can( 'manage_options' ) && Jetpack::is_development_mode() ) {
+		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything
+		if ( ! current_user_can( 'manage_options' ) && ( Jetpack::is_development_mode() || ! Jetpack::is_active() ) ) {
 			return;
 		}
 

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -38,7 +38,7 @@ abstract class Jetpack_Admin_Page {
 	function add_actions() {
 		global $pagenow;
 
-		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything
+		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything.
 		if ( ! current_user_can( 'manage_options' ) && ( Jetpack::is_development_mode() || ! Jetpack::is_active() ) ) {
 			return;
 		}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -9,7 +9,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	protected $is_redirecting = false;
 
 	function get_page_hook() {
-
 		// Add the main admin Jetpack menu
 		return add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_admin_page', 'jetpack', array( $this, 'render' ), 'div' );
 	}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -9,6 +9,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	protected $is_redirecting = false;
 
 	function get_page_hook() {
+
 		// Add the main admin Jetpack menu
 		return add_menu_page( 'Jetpack', 'Jetpack', 'jetpack_admin_page', 'jetpack', array( $this, 'render' ), 'div' );
 	}


### PR DESCRIPTION
Currently as a non admin. I see the following the Jetpack is not connected and I am not in dev mode. (https://jetpack.com/support/development-mode/)

<img width="1110" alt="Screen Shot 2019-09-30 at 3 04 37 PM" src="https://user-images.githubusercontent.com/115071/65886809-4942dc80-e39d-11e9-93eb-dd217a5cb414.png">

This is not ideal. Since there is nothing for the user to do. 
This PR removed the link complete for user that do not have mange options privileged. (non admins) 

#### Changes proposed in this Pull Request:
* Remove the ability for non admins to visit the Jetpack dashboard page when jetpack is not connected. 

#### Testing instructions:

* Notice that as an **non admin** user you can't go to the Jetpack dashboard. 
*Notice that as an **admin** user you can go to the Jetpack dashboard in order to connect jetpack. 


Applied the `JETPACK_DEV_DEBUG` constant  in the wp-config.php ( `define( 'JETPACK_DEV_DEBUG', true );` )

* Notice that as an **non admin** user you can't go to the jetpack dashboard. 
* Notice as an **admin** that you can go to the jetpack dashboard. 


Notice if you connect jetpack. 

* Notice that as an **non admin** user you can go to the jetpack dashboard. 
* Notice as an **admin** that you can go to the jetpack dashboard. 

#### Proposed changelog entry for your changes:
* Removes the jetpack dashboard access for non admin user when Jetpack is not connected.
