### PR TITLE
Instant Search: Add custom taxonomy filtering

### DIFF
--- a/modules/search/instant-search/components/search-filter-post-types.jsx
+++ b/modules/search/instant-search/components/search-filter-post-types.jsx
@@ -5,6 +5,10 @@
  */
 import { h, createRef, Component } from 'preact';
 import strip from 'strip';
+
+/**
+ * Internal dependencies
+ */
 import { getCheckedInputNames } from '../lib/dom';
 
 export default class SearchFilterPostTypes extends Component {

--- a/modules/search/instant-search/components/search-filter-taxonomies.jsx
+++ b/modules/search/instant-search/components/search-filter-taxonomies.jsx
@@ -5,6 +5,10 @@
  */
 import { h, createRef, Component } from 'preact';
 import strip from 'strip';
+
+/**
+ * Internal dependencies
+ */
 import { getCheckedInputNames } from '../lib/dom';
 
 export default class SearchFilterTaxonomies extends Component {

--- a/modules/search/instant-search/components/search-filters-widget.jsx
+++ b/modules/search/instant-search/components/search-filters-widget.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { h, Component } from 'preact';
-// NOTE: We only import the debounce package here for to reduced bundle size.
+// NOTE: We only import the get package here for to reduced bundle size.
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
 import get from 'lodash/get';

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -10,6 +10,7 @@ import { h, render } from 'preact';
  */
 import SearchWidget from './components/search-widget';
 import { getSearchQuery, getFilterQuery, getSearchSort } from './lib/query-string';
+import { SERVER_OBJECT_NAME } from './lib/constants';
 
 const injectSearchWidget = grabFocus => {
 	render(
@@ -18,7 +19,7 @@ const injectSearchWidget = grabFocus => {
 			initialFilters={ getFilterQuery() }
 			initialSort={ getSearchSort() }
 			initialValue={ getSearchQuery() }
-			options={ window.JetpackInstantSearchOptions }
+			options={ window[ SERVER_OBJECT_NAME ] }
 		/>,
 		document.body
 	);
@@ -26,8 +27,8 @@ const injectSearchWidget = grabFocus => {
 
 document.addEventListener( 'DOMContentLoaded', function() {
 	if (
-		!! window.JetpackInstantSearchOptions &&
-		'siteId' in window.JetpackInstantSearchOptions &&
+		!! window[ SERVER_OBJECT_NAME ] &&
+		'siteId' in window[ SERVER_OBJECT_NAME ] &&
 		document.body.classList.contains( 'search' )
 	) {
 		injectSearchWidget();

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -1,0 +1,1 @@
+export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { decode, encode } from 'qss';
-// NOTE: We only import the debounce package here for to reduced bundle size.
+// NOTE: We only import the get package here for to reduced bundle size.
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
 import get from 'lodash/get';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This enables filtering by custom taxonomies using search widget checkboxes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes, this adds support for custom taxonomy filtering to Jetpack Instant Search.

#### Testing instructions:
* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
* Ensure that your site has configured a custom taxonomy. An example code snippet follows how one might register a custom taxonomy for your site.
* Add a Jetpack Search widget to the Search page sidebar.
* Add a custom taxonomy filter to the Jetpack Search widget.
* Enter a query into a search widget. Alternatively, navigate to a search page like `/?s=privacy`.
* Ensure that you can select a custom taxonomy filter checkbox. 
* Ensure that other search filters, like dates and post types, still work as expected.

#### Configuring a custom taxonomy:
This following code snippet, when added to `wp-content/mu-plugins/functions.php`, will register a custom taxonomy named Speakers.
```
function register_speakers_taxonomy() {
    register_taxonomy( 'speakers', array( 'post' ), array(
        'label'    => __( 'Speakers' ),
        'template' => __( 'Speakers: %l.' ),
        'helps'    => __( 'Separate speakers with commas.' ),
        'sort'     => true,
        'args'     => array( 'orderby' => 'term_order' ),
        'rewrite'  => array( 'slug' => 'speakers' ),
    ) );
}
 
add_action( 'init', 'register_speakers_taxonomy' );
```

#### Proposed changelog entry for your changes:
None.