### PR TITLE
Connection: Re-deprecate function

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5209,8 +5209,7 @@ endif;
 	 * @deprecated since 7.7.0
 	 */
 	public static function load_xml_rpc_client() {
-		// Removed the php notice that shows up in order to give time to Akismet and VaultPress time to update.
-		// _deprecated_function( __METHOD__, 'jetpack-7.7' );
+		_deprecated_function( __METHOD__, 'jetpack-7.7' );
 	}
 
 	/**


### PR DESCRIPTION
Jetpack 7.7 deprecated a function, but we un-deprecated it to give Akismet and VaultPress time to update. This re-deprecates it.

Fixes #13401

#### Changes proposed in this Pull Request:
* Deprecates `load_xml_rpc_client`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* Deprecate `load_xml_rpc_client`. (probably not needed)
