### PR TITLE
Instant Search: add sort widget

### DIFF
--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -28,7 +28,7 @@ export default class SearchSortWidget extends Component {
 		const sortOptions = getSortOptions();
 		return (
 			<label>
-				{ __( 'Sort by' ) }
+				{ __( 'Sort by', 'jetpack' ) }
 				<select
 					className="jetpack-instant-search__sort-widget-select"
 					onBlur={ this.handleChange }

--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -15,14 +15,17 @@ export default class SearchSortWidget extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = { selected: this.props.initialValue };
-		this.handleChange = this.handleChange.bind( this );
 	}
 
-	handleChange( event ) {
+	handleChange = event => {
+		if ( this.state.selected === event.target.value ) {
+			return;
+		}
+
 		this.setState( { selected: event.target.value }, () => {
 			this.props.onChange( event.target.value );
 		} );
-	}
+	};
 
 	render() {
 		const sortOptions = getSortOptions();
@@ -35,10 +38,7 @@ export default class SearchSortWidget extends Component {
 					onChange={ this.handleChange }
 				>
 					{ Object.keys( sortOptions ).map( sortKey => (
-						<option
-							value={ sortKey }
-							selected={ this.state.selected && this.state.selected === sortKey }
-						>
+						<option value={ sortKey } selected={ this.state.selected === sortKey }>
 							{ sortOptions[ sortKey ].label }
 						</option>
 					) ) }

--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -1,0 +1,18 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+
+export default class SearchSortWidget extends Component {
+	render() {
+		return (
+			<select className="jetpack-instant-search__sort-widget">
+				<option>one</option>
+				<option>two</option>
+				<option>three</option>
+			</select>
+		);
+	}
+}

--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -4,15 +4,25 @@
  * External dependencies
  */
 import { h, Component } from 'preact';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getSortOptions } from '../lib/sort';
 
 export default class SearchSortWidget extends Component {
 	render() {
+		const sortOptions = getSortOptions();
 		return (
-			<select className="jetpack-instant-search__sort-widget">
-				<option>one</option>
-				<option>two</option>
-				<option>three</option>
-			</select>
+			<label>
+				{ __( 'Sort by' ) }
+				<select className="jetpack-instant-search__sort-widget-select">
+					{ sortOptions.map( option => (
+						<option key={ option.name }>{ option.label }</option>
+					) ) }
+				</select>
+			</label>
 		);
 	}
 }

--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -26,22 +26,24 @@ export default class SearchSortWidget extends Component {
 
 	render() {
 		const sortOptions = getSortOptions();
-		/* eslint-disable jsx-a11y/no-onchange */
 		return (
 			<label>
 				{ __( 'Sort by' ) }
 				<select
 					className="jetpack-instant-search__sort-widget-select"
+					onBlur={ this.handleChange }
 					onChange={ this.handleChange }
 				>
-					{ Object.keys( sortOptions ).map( key => (
-						<option value={ key } selected={ this.state.selected && this.state.selected === key }>
-							{ sortOptions[ key ].label }
+					{ Object.keys( sortOptions ).map( sortKey => (
+						<option
+							value={ sortKey }
+							selected={ this.state.selected && this.state.selected === sortKey }
+						>
+							{ sortOptions[ sortKey ].label }
 						</option>
 					) ) }
 				</select>
 			</label>
 		);
-		/* eslint-enable jsx-a11y/no-onchange */
 	}
 }

--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -12,6 +12,11 @@ import { __ } from '@wordpress/i18n';
 import { getSortOptions } from '../lib/sort';
 
 export default class SearchSortWidget extends Component {
+	constructor( props ) {
+		super( props );
+		this.state = { selected: this.props.initialValue };
+	}
+
 	render() {
 		const sortOptions = getSortOptions();
 		return (
@@ -19,7 +24,12 @@ export default class SearchSortWidget extends Component {
 				{ __( 'Sort by' ) }
 				<select className="jetpack-instant-search__sort-widget-select">
 					{ sortOptions.map( option => (
-						<option key={ option.name }>{ option.label }</option>
+						<option
+							key={ option.name }
+							selected={ this.state.selected && this.state.selected === option.name }
+						>
+							{ option.label }
+						</option>
 					) ) }
 				</select>
 			</label>

--- a/modules/search/instant-search/components/search-sort-widget.jsx
+++ b/modules/search/instant-search/components/search-sort-widget.jsx
@@ -15,24 +15,33 @@ export default class SearchSortWidget extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = { selected: this.props.initialValue };
+		this.handleChange = this.handleChange.bind( this );
+	}
+
+	handleChange( event ) {
+		this.setState( { selected: event.target.value }, () => {
+			this.props.onChange( event.target.value );
+		} );
 	}
 
 	render() {
 		const sortOptions = getSortOptions();
+		/* eslint-disable jsx-a11y/no-onchange */
 		return (
 			<label>
 				{ __( 'Sort by' ) }
-				<select className="jetpack-instant-search__sort-widget-select">
-					{ sortOptions.map( option => (
-						<option
-							key={ option.name }
-							selected={ this.state.selected && this.state.selected === option.name }
-						>
-							{ option.label }
+				<select
+					className="jetpack-instant-search__sort-widget-select"
+					onChange={ this.handleChange }
+				>
+					{ Object.keys( sortOptions ).map( key => (
+						<option value={ key } selected={ this.state.selected && this.state.selected === key }>
+							{ sortOptions[ key ].label }
 						</option>
 					) ) }
 				</select>
 			</label>
 		);
+		/* eslint-enable jsx-a11y/no-onchange */
 	}
 }

--- a/modules/search/instant-search/components/search-sort-widget.scss
+++ b/modules/search/instant-search/components/search-sort-widget.scss
@@ -1,0 +1,3 @@
+.jetpack-instant-search__sort-widget-select {
+	margin-left: 4px;
+}

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -17,7 +17,13 @@ import SearchResults from './search-results';
 import SearchFiltersWidget from './search-filters-widget';
 import SearchSortWidget from './search-sort-widget';
 import { search, buildFilterAggregations } from '../lib/api';
-import { setSearchQuery, setFilterQuery, getFilterQuery, setSortQuery } from '../lib/query-string';
+import {
+	setSearchQuery,
+	setFilterQuery,
+	getFilterQuery,
+	setSortQuery,
+	getSortQuery,
+} from '../lib/query-string';
 import { removeChildren, hideSearchHeader } from '../lib/dom';
 
 class SearchApp extends Component {
@@ -53,17 +59,17 @@ class SearchApp extends Component {
 		const query = event.target.value;
 		this.setState( { query } );
 		setSearchQuery( query );
-		this.getResults( query, this.state.sort );
+		this.getResults( query, getFilterQuery(), getSortQuery() );
 	};
 
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
-		this.getResults( this.state.query, getFilterQuery() );
+		this.getResults( this.state.query, getFilterQuery(), getSortQuery() );
 	};
 
 	onChangeSort = sort => {
 		setSortQuery( sort );
-		this.getResults( this.state.query, sort );
+		this.getResults( this.state.query, getFilterQuery(), getSortQuery() );
 	};
 
 	getResults = ( query, filter, sort ) => {

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -107,7 +107,7 @@ class SearchApp extends Component {
 								</button>
 							</div>
 							<div className="jetpack-search-sort-wrapper">
-								<SearchSortWidget />
+								<SearchSortWidget widget={ widget } />
 							</div>
 							<SearchFiltersWidget
 								initialValues={ this.props.initialFilters }

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -17,7 +17,7 @@ import SearchResults from './search-results';
 import SearchFiltersWidget from './search-filters-widget';
 import SearchSortWidget from './search-sort-widget';
 import { search, buildFilterAggregations } from '../lib/api';
-import { setSearchQuery, setFilterQuery, getFilterQuery } from '../lib/query-string';
+import { setSearchQuery, setFilterQuery, getFilterQuery, setSortQuery } from '../lib/query-string';
 import { removeChildren, hideSearchHeader } from '../lib/dom';
 
 class SearchApp extends Component {
@@ -59,6 +59,11 @@ class SearchApp extends Component {
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
 		this.getResults( this.state.query, getFilterQuery() );
+	};
+
+	onChangeSort = sort => {
+		setSortQuery( sort );
+		this.getResults( this.state.query, sort );
 	};
 
 	getResults = ( query, filter, sort ) => {
@@ -107,7 +112,10 @@ class SearchApp extends Component {
 								</button>
 							</div>
 							<div className="jetpack-search-sort-wrapper">
-								<SearchSortWidget initialValue={ this.props.initialSort } />
+								<SearchSortWidget
+									initialValue={ this.props.initialSort }
+									onChange={ this.onChangeSort }
+								/>
 							</div>
 							<SearchFiltersWidget
 								initialValues={ this.props.initialFilters }

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -15,6 +15,7 @@ import debounce from 'lodash/debounce';
  */
 import SearchResults from './search-results';
 import SearchFiltersWidget from './search-filters-widget';
+import SearchSortWidget from './search-sort-widget';
 import { search, buildFilterAggregations } from '../lib/api';
 import { setSearchQuery, setFilterQuery, getFilterQuery } from '../lib/query-string';
 import { removeChildren, hideSearchHeader } from '../lib/dom';
@@ -105,7 +106,9 @@ class SearchApp extends Component {
 									<span className="screen-reader-text">Search</span>
 								</button>
 							</div>
-							<div className="jetpack-search-sort-wrapper" />
+							<div className="jetpack-search-sort-wrapper">
+								<SearchSortWidget />
+							</div>
 							<SearchFiltersWidget
 								initialValues={ this.props.initialFilters }
 								onChange={ this.onChangeFilter }

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -107,7 +107,7 @@ class SearchApp extends Component {
 								</button>
 							</div>
 							<div className="jetpack-search-sort-wrapper">
-								<SearchSortWidget widget={ widget } />
+								<SearchSortWidget initialValue={ this.props.initialSort } />
 							</div>
 							<SearchFiltersWidget
 								initialValues={ this.props.initialFilters }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -9,7 +9,7 @@ import { h, render } from 'preact';
  * Internal dependencies
  */
 import SearchWidget from './components/search-widget';
-import { getSearchQuery, getFilterQuery, getSearchSort } from './lib/query-string';
+import { getSearchQuery, getFilterQuery, getSortQuery } from './lib/query-string';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 
 const injectSearchWidget = grabFocus => {
@@ -17,7 +17,7 @@ const injectSearchWidget = grabFocus => {
 		<SearchWidget
 			grabFocus={ grabFocus }
 			initialFilters={ getFilterQuery() }
-			initialSort={ getSearchSort() }
+			initialSort={ getSortQuery() }
 			initialValue={ getSearchQuery() }
 			options={ window[ SERVER_OBJECT_NAME ] }
 		/>,

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -1,5 +1,6 @@
 @import './components/search-results.scss';
 @import './components/search-filters-widget.scss';
+@import './components/search-sort-widget.scss';
 @import './components/search-result-minimal.scss';
 //@import './components/search-result-engagement.scss';
 //@import './components/search-result-product.scss';

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -1,1 +1,3 @@
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
+export const SORT_DIRECTION_ASC = 'ASC';
+export const SORT_DIRECTION_DESC = 'DESC';

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -11,6 +11,7 @@ import get from 'lodash/get';
  * Internal dependencies
  */
 import { SERVER_OBJECT_NAME } from './constants';
+import { getSortOptions } from './sort';
 
 function getQuery() {
 	return decode( window.location.search.substring( 1 ) );
@@ -137,5 +138,21 @@ export function getFilterQuery( filterKey ) {
 export function setFilterQuery( filterKey, filterValue ) {
 	const query = getQuery();
 	query[ filterKey ] = filterValue;
+	pushQueryString( encode( query ) );
+}
+
+export function setSortQuery( sort ) {
+	//console.log( 'new sort: ' + sort );
+
+	const query = getQuery();
+	const sortOptions = getSortOptions();
+	const sortOption = sortOptions[ sort ];
+
+	if ( ! sortOption ) {
+		return false;
+	}
+
+	query.orderby = sortOption.field;
+	query.order = sortOption.direction;
 	pushQueryString( encode( query ) );
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -10,8 +10,8 @@ import get from 'lodash/get';
 /**
  * Internal dependencies
  */
-import { SERVER_OBJECT_NAME } from './constants';
-import { getSortOptions } from './sort';
+import { SERVER_OBJECT_NAME, SORT_DIRECTION_ASC } from './constants';
+import { getSortOption } from './sort';
 
 function getQuery() {
 	return decode( window.location.search.substring( 1 ) );
@@ -37,7 +37,6 @@ export function setSearchQuery( searchValue ) {
 	pushQueryString( encode( query ) );
 }
 
-// @todo separate sort field and sort direction?
 export function getSortQuery() {
 	const query = getQuery();
 	const order = 'order' in query ? query.order : 'DESC';
@@ -45,21 +44,21 @@ export function getSortQuery() {
 	let sort;
 	switch ( orderby ) {
 		case 'date':
-			if ( order === 'ASC' ) {
+			if ( order === SORT_DIRECTION_ASC ) {
 				sort = 'date_asc';
 			} else {
 				sort = 'date_desc';
 			}
 			break;
 		case 'price':
-			if ( order === 'ASC' ) {
+			if ( order === SORT_DIRECTION_ASC ) {
 				sort = 'price_asc';
 			} else {
 				sort = 'price_desc';
 			}
 			break;
 		case 'rating':
-			if ( order === 'ASC' ) {
+			if ( order === SORT_DIRECTION_ASC ) {
 				sort = 'rating_asc';
 			} else {
 				sort = 'rating_desc';
@@ -81,6 +80,19 @@ export function getSortQuery() {
 			break;
 	}
 	return sort;
+}
+
+export function setSortQuery( sortKey ) {
+	const query = getQuery();
+	const sortOption = getSortOption( sortKey );
+
+	if ( ! sortOption ) {
+		return false;
+	}
+
+	query.orderby = sortOption.field;
+	query.order = sortOption.direction;
+	pushQueryString( encode( query ) );
 }
 
 function getFilterQueryByKey( filterKey ) {
@@ -138,21 +150,5 @@ export function getFilterQuery( filterKey ) {
 export function setFilterQuery( filterKey, filterValue ) {
 	const query = getQuery();
 	query[ filterKey ] = filterValue;
-	pushQueryString( encode( query ) );
-}
-
-export function setSortQuery( sort ) {
-	//console.log( 'new sort: ' + sort );
-
-	const query = getQuery();
-	const sortOptions = getSortOptions();
-	const sortOption = sortOptions[ sort ];
-
-	if ( ! sortOption ) {
-		return false;
-	}
-
-	query.orderby = sortOption.field;
-	query.order = sortOption.direction;
 	pushQueryString( encode( query ) );
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -36,6 +36,7 @@ export function setSearchQuery( searchValue ) {
 	pushQueryString( encode( query ) );
 }
 
+// @todo separate sort field and sort direction?
 export function getSearchSort() {
 	const query = getQuery();
 	const order = 'order' in query ? query.order : 'DESC';

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -38,7 +38,7 @@ export function setSearchQuery( searchValue ) {
 }
 
 // @todo separate sort field and sort direction?
-export function getSearchSort() {
+export function getSortQuery() {
 	const query = getQuery();
 	const order = 'order' in query ? query.order : 'DESC';
 	const orderby = 'orderby' in query ? query.orderby : 'relevance';

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -9,9 +9,9 @@ export function getSortOptions() {
 		{ name: 'price', label: __( 'Price' ) },
 		{ name: 'rating', label: __( 'Rating' ) },
 		{ name: 'recency', label: __( 'Recency' ) },
-		{ name: 'keyword', label: __( 'Keyword' ) },
-		{ name: 'popularity', label: __( 'Popularity' ) },
-		{ name: 'relevance', label: __( 'Relevance' ) },
-		{ name: 'score', label: __( 'Score' ) },
+		{ name: 'score_keyword', label: __( 'Keyword' ) },
+		{ name: 'score_popularity', label: __( 'Popularity' ) },
+		{ name: 'score_relevance', label: __( 'Relevance' ) },
+		{ name: 'score_default', label: __( 'Score' ) },
 	];
 }

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -2,11 +2,20 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
 
 export function getSortOptions() {
-	return [
-		{ name: 'date_asc', label: __( 'Oldest' ) },
-		{ name: 'date_desc', label: __( 'Newest' ) },
-		{ name: 'score_default', label: __( 'Relevance' ) },
-	];
+	return {
+		date_asc: {
+			label: __( 'Oldest' ),
+			field: 'date',
+			direction: SORT_DIRECTION_ASC,
+		},
+		date_desc: {
+			label: __( 'Newest' ),
+			field: 'date',
+			direction: SORT_DIRECTION_DESC,
+		},
+		score_default: { label: __( 'Relevance' ), field: 'relevance', direction: SORT_DIRECTION_DESC },
+	};
 }

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export function getSortOptions() {
+	return [
+		{ name: 'date', label: __( 'Date' ) },
+		{ name: 'price', label: __( 'Price' ) },
+		{ name: 'rating', label: __( 'Rating' ) },
+		{ name: 'recency', label: __( 'Recency' ) },
+		{ name: 'keyword', label: __( 'Keyword' ) },
+		{ name: 'popularity', label: __( 'Popularity' ) },
+		{ name: 'relevance', label: __( 'Relevance' ) },
+		{ name: 'score', label: __( 'Score' ) },
+	];
+}

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
 
 export function getSortOptions() {
@@ -18,4 +22,9 @@ export function getSortOptions() {
 		},
 		score_default: { label: __( 'Relevance' ), field: 'relevance', direction: SORT_DIRECTION_DESC },
 	};
+}
+
+export function getSortOption( sortKey ) {
+	const sortOptions = getSortOptions();
+	return sortOptions[ sortKey ];
 }

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -5,13 +5,8 @@ import { __ } from '@wordpress/i18n';
 
 export function getSortOptions() {
 	return [
-		{ name: 'date', label: __( 'Date' ) },
-		{ name: 'price', label: __( 'Price' ) },
-		{ name: 'rating', label: __( 'Rating' ) },
-		{ name: 'recency', label: __( 'Recency' ) },
-		{ name: 'score_keyword', label: __( 'Keyword' ) },
-		{ name: 'score_popularity', label: __( 'Popularity' ) },
-		{ name: 'score_relevance', label: __( 'Relevance' ) },
-		{ name: 'score_default', label: __( 'Score' ) },
+		{ name: 'date_asc', label: __( 'Oldest' ) },
+		{ name: 'date_desc', label: __( 'Newest' ) },
+		{ name: 'score_default', label: __( 'Relevance' ) },
 	];
 }

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -11,16 +11,20 @@ import { SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
 export function getSortOptions() {
 	return {
 		date_asc: {
-			label: __( 'Oldest' ),
+			label: __( 'Oldest', 'jetpack' ),
 			field: 'date',
 			direction: SORT_DIRECTION_ASC,
 		},
 		date_desc: {
-			label: __( 'Newest' ),
+			label: __( 'Newest', 'jetpack' ),
 			field: 'date',
 			direction: SORT_DIRECTION_DESC,
 		},
-		score_default: { label: __( 'Relevance' ), field: 'relevance', direction: SORT_DIRECTION_DESC },
+		score_default: {
+			label: __( 'Relevance', 'jetpack' ),
+			field: 'relevance',
+			direction: SORT_DIRECTION_DESC,
+		},
 	};
 }
 

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -8,27 +8,28 @@ import { __ } from '@wordpress/i18n';
  */
 import { SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
 
+const sortOptions = {
+	date_asc: {
+		label: __( 'Oldest', 'jetpack' ),
+		field: 'date',
+		direction: SORT_DIRECTION_ASC,
+	},
+	date_desc: {
+		label: __( 'Newest', 'jetpack' ),
+		field: 'date',
+		direction: SORT_DIRECTION_DESC,
+	},
+	score_default: {
+		label: __( 'Relevance', 'jetpack' ),
+		field: 'relevance',
+		direction: SORT_DIRECTION_DESC,
+	},
+};
+
 export function getSortOptions() {
-	return {
-		date_asc: {
-			label: __( 'Oldest', 'jetpack' ),
-			field: 'date',
-			direction: SORT_DIRECTION_ASC,
-		},
-		date_desc: {
-			label: __( 'Newest', 'jetpack' ),
-			field: 'date',
-			direction: SORT_DIRECTION_DESC,
-		},
-		score_default: {
-			label: __( 'Relevance', 'jetpack' ),
-			field: 'relevance',
-			direction: SORT_DIRECTION_DESC,
-		},
-	};
+	return sortOptions;
 }
 
 export function getSortOption( sortKey ) {
-	const sortOptions = getSortOptions();
 	return sortOptions[ sortKey ];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This enables sorting of search results from Jetpack Instant Search.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes, this adds a sorting UI to Jetpack Instant Search.

#### Testing instructions:
Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
Ensure that your site has the Jetpack Pro plan and has Jetpack Search enabled.
Add a Jetpack Search widget to the Search page sidebar.
Enter a query into a search widget. Alternatively, navigate to a search page like /?s=privacy.
Ensure that you can use the sort dropdown to change sort order.

#### Proposed changelog entry for your changes:
Not required.