### PR TITLE
Try: Travis Add PHP 7.4, nightly and add fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
 - "7.0"
 - "7.2"
 - "7.3"
+- "7.4"
 
 env:
   # Global variable is re-defined in matrix-include -list
@@ -27,6 +28,7 @@ env:
 # The versions listed above will automatically create our first configuration,
 # so it doesn't need to be re-defined below.
 matrix:
+  fast_finish: true
   include:
   - if: branch !~ /(^branch-.*-built)/
     name: "JavaScript & CSS lint"
@@ -40,6 +42,8 @@ matrix:
     name: "Build dashboard & extensions"
     language: node_js
     env: WP_TRAVISCI="yarn build"
+  - php: "nightly"
+    name: "PHP Nightly"
   - php: "7.0"
     name: "E2E tests"
     if: branch !~ /(^branch-.*-built)/ AND env(RUN_E2E) = true
@@ -60,8 +64,10 @@ matrix:
           # This is required to run new chrome on old trusty
           - libnss3
 
+
   allow_failures:
     - name: "E2E tests"
+    - name: "PHP Nightly"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ php:
 - "7.0"
 - "7.2"
 - "7.3"
-- "7.4"
+- "7.4snapshot"
+# Remove "snapshot" when PHP 7.4 hits GA.
 
 env:
   # Global variable is re-defined in matrix-include -list

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ php:
 - "7.0"
 - "7.2"
 - "7.3"
-- "7.4snapshot"
-# Remove "snapshot" when PHP 7.4 hits GA.
+# 7.4 can not be included here until 5.3 is the "previous" version of WP.
 
 env:
   # Global variable is re-defined in matrix-include -list
@@ -45,6 +44,9 @@ matrix:
     env: WP_TRAVISCI="yarn build"
   - php: "nightly"
     name: "PHP Nightly"
+  - php: "7.4snapshot"
+    env: WP_BRANCH=master SIMPLE_AND_MULTISITE=1
+    # add a new entry for "latest" WP once 5.3 has shipped. Remove snapshot once 7.4 is GA.
   - php: "7.0"
     name: "E2E tests"
     if: branch !~ /(^branch-.*-built)/ AND env(RUN_E2E) = true

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5981,9 +5981,13 @@ endif;
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
 		if ( $idc_allowed && $sync_error && self::sync_idc_optin() ) {
 			$local_options = self::get_sync_error_idc_option();
-			if ( $sync_error['home'] === $local_options['home'] && $sync_error['siteurl'] === $local_options['siteurl'] ) {
-				$is_valid = true;
+			// Ensure all values are set.
+			if ( isset( $sync_error['home'] ) && isset ( $local_options['home'] ) && isset( $sync_error['siteurl'] ) && isset( $local_options['siteurl'] ) ) {
+				if ( $sync_error['home'] === $local_options['home'] && $sync_error['siteurl'] === $local_options['siteurl'] ) {
+					$is_valid = true;
+				}
 			}
+
 		}
 
 		/**

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -384,7 +384,7 @@ class Sharing_Service {
 			if ( is_array( $options ) && isset( $options['global'] ) && is_array( $options['global'] ) ) {
 				$this->global = $options['global'];
 			} else {
-				$this->global = $this->set_global_options( $options['global'] );
+				$this->global = $this->set_global_options( $options );
 			}
 		}
 


### PR DESCRIPTION
Expanding our testing for the upcoming PHP 7.4 and allow_failure for php nightly (currently 8.0.0-dev)

Not wanting to merge this yet; testing out Travis config.

#### Changes proposed in this Pull Request:
* Expand test coverage.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Watch Travis.
*

#### Proposed changelog entry for your changes:
* n/a
