### PR TITLE
Core REST API: Plans endpoint - Move the json encoding to the backend.

### DIFF
--- a/_inc/client/state/site/actions.js
+++ b/_inc/client/state/site/actions.js
@@ -68,10 +68,9 @@ export const fetchAvailablePlans = () => {
 		return restApi
 			.getPlans()
 			.then( sitePlans => {
-				const plans = JSON.parse( sitePlans );
 				dispatch( {
 					type: JETPACK_SITE_PLANS_FETCH_RECEIVE,
-					plans,
+					plans: sitePlans,
 				} );
 				return sitePlans;
 			} )

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -492,7 +492,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			)
 		);
 
-		$body = wp_remote_retrieve_body( $request );
+		$body = json_decode( wp_remote_retrieve_body( $request ) );
 		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
 			$data = $body;
 		} else {


### PR DESCRIPTION
The current plans api endpoint return a string and not json. This PR fixes that by making sure that we encode the data that we get back from .com on the backend and return json as expected. 

cc: @gravityrail 
#### Changes proposed in this Pull Request:
* Move the json_encoding to the backend so that so that it is constant and works as expected. 

#### Testing instructions:
* Update to this PR. run `yarn build` to build the js.
* Connect Jetpack
* Go to the plans page.
* Notice it still works as expected.

#### Proposed changelog entry for your changes:
* Update the plans core api endpoint to return json instead of a string.
