### PR TITLE
Admin Page: define context properly in Stats graph.

### DIFF
--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, throttle } from 'lodash';
-import { translate as _x } from 'i18n-calypso';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -121,7 +121,9 @@ export default class ModuleChart extends React.Component {
 			emptyChart = (
 				<div className="dops-chart__empty">
 					<span className="dops-chart__empty_notice">
-						{ _x( 'No activity this period', 'Notice in the empty statistics chart' ) }
+						{ __( 'No activity this period', {
+							context: 'Notice in the empty statistics chart',
+						} ) }
 					</span>
 				</div>
 			);


### PR DESCRIPTION
Following up from #13558

#### Changes proposed in this Pull Request:

* Let's define context the `i18n-calypso` way to avoid this:

![image](https://user-images.githubusercontent.com/426388/66030001-b58a2100-e500-11e9-8604-5b6c8f070f1b.png)

#### Testing instructions:

* Start a new JN site with that patch.
* Check the Stats graph under Jetpack > Dashboard.

#### Proposed changelog entry for your changes:

* None
