### PR TITLE
Photon: remove wp-dom-ready dependency

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -1221,8 +1221,8 @@ class Jetpack_Photon {
 				'_inc/build/photon/photon.min.js',
 				'modules/photon/photon.js'
 			),
-			array( 'wp-dom-ready' ),
-			20190901,
+			array(),
+			20191001,
 			true
 		);
 	}

--- a/modules/photon/photon.js
+++ b/modules/photon/photon.js
@@ -44,8 +44,13 @@
 	/**
 	 * Check both when page loads, and when IS is triggered.
 	 */
-	if ( typeof window !== 'undefined' ) {
-		window.wp.domReady( restore_dims );
+	if ( typeof window !== 'undefined' && typeof document !== 'undefined' ) {
+		// `DOMContentLoaded` may fire before the script has a chance to run
+		if ( document.readyState === 'loading' ) {
+			document.addEventListener( 'DOMContentLoaded', restore_dims );
+		} else {
+			restore_dims();
+		}
 	}
 
 	document.body.addEventListener( 'post-load', restore_dims );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Follow-up from #13383 

Remove wp-dom-ready dependency since it pulls in wp-polyfill which is a lot of kbs for nothing in Photon’s case since it’s ES5. 

#### Testing instructions:
- Open regular page without blocks or anything, with Photon active. Observe how `wp-polyfill` and `wp-dom-ready` scripts load before this PR and with the change they're gone.

#### Proposed changelog entry for your changes:

* Image CDN: remove wp-dom-ready dependency
