### PR TITLE
7.4 Compatibility: Resolve unit testing errors

### DIFF
--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -250,8 +250,10 @@ class Jetpack_Network {
 
 		if ( is_string( $args ) ) {
 			$name = $args;
-		} else {
+		} else if ( is_array( $args ) ) {
 			$name = $args['name'];
+		} else {
+			return $url;
 		}
 
 		switch ( $name ) {

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -709,9 +709,13 @@ function sharing_display( $text = '', $echo = false ) {
 		}
 	}
 
-	// check whether we are viewing the front page and whether the front page option is checked
+	// check whether we are viewing the front page and whether the front page option is checked.
 	$options         = get_option( 'sharing-options' );
-	$display_options = $options['global']['show'];
+	$display_options = null;
+
+	if ( is_array( $options ) ) {
+		$display_options = $options['global']['show'];
+	}
 
 	if ( is_front_page() && ( is_array( $display_options ) && ! in_array( 'index', $display_options, true ) ) ) {
 		return $text;

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -669,6 +669,14 @@ function sharing_process_requests() {
 }
 add_action( 'template_redirect', 'sharing_process_requests', 9 );
 
+/**
+ * Append sharing links to text.
+ *
+ * @param string $text The original text to append sharing links onto.
+ * @param bool   $echo Where to echo the text or return.
+ *
+ * @return string The original $text with, if conditions are met, the sharing links.
+ */
 function sharing_display( $text = '', $echo = false ) {
 	global $post, $wp_current_filter;
 
@@ -684,15 +692,15 @@ function sharing_display( $text = '', $echo = false ) {
 		return $text;
 	}
 
-	// Don't output flair on excerpts
-	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter ) ) {
+	// Don't output flair on excerpts.
+	if ( in_array( 'get_the_excerpt', (array) $wp_current_filter, true ) ) {
 		return $text;
 	}
 
-	// Don't allow flair to be added to the_content more than once (prevent infinite loops)
+	// Don't allow flair to be added to the_content more than once (prevent infinite loops).
 	$done = false;
 	foreach ( $wp_current_filter as $filter ) {
-		if ( 'the_content' == $filter ) {
+		if ( 'the_content' === $filter ) {
 			if ( $done ) {
 				return $text;
 			} else {
@@ -705,11 +713,11 @@ function sharing_display( $text = '', $echo = false ) {
 	$options         = get_option( 'sharing-options' );
 	$display_options = $options['global']['show'];
 
-	if ( is_front_page() && ( is_array( $display_options ) && ! in_array( 'index', $display_options ) ) ) {
+	if ( is_front_page() && ( is_array( $display_options ) && ! in_array( 'index', $display_options, true ) ) ) {
 		return $text;
 	}
 
-	if ( is_attachment() && in_array( 'the_excerpt', (array) $wp_current_filter ) ) {
+	if ( is_attachment() && in_array( 'the_excerpt', (array) $wp_current_filter, true ) ) {
 		// Many themes run the_excerpt() conditionally on an attachment page, then run the_content().
 		// We only want to output the sharing buttons once.  Let's stick with the_content().
 		return $text;
@@ -720,9 +728,9 @@ function sharing_display( $text = '', $echo = false ) {
 
 	$show = false;
 	if ( ! is_feed() ) {
-		if ( is_singular() && in_array( get_post_type(), $global['show'] ) ) {
+		if ( is_singular() && in_array( get_post_type(), $global['show'], true ) ) {
 			$show = true;
-		} elseif ( in_array( 'index', $global['show'] ) && ( is_home() || is_front_page() || is_archive() || is_search() || in_array( get_post_type(), $global['show'] ) ) ) {
+		} elseif ( in_array( 'index', $global['show'], true ) && ( is_home() || is_front_page() || is_archive() || is_search() || in_array( get_post_type(), $global['show'], true ) ) ) {
 			$show = true;
 		}
 	}
@@ -746,7 +754,7 @@ function sharing_display( $text = '', $echo = false ) {
 		$show = false;
 	}
 
-	// Private post?
+	// Is the post private?
 	$post_status = get_post_status( $post->ID );
 
 	if ( 'private' === $post_status ) {
@@ -791,13 +799,11 @@ function sharing_display( $text = '', $echo = false ) {
 		$enabled = apply_filters( 'sharing_enabled', $sharer->get_blog_services() );
 
 		if ( count( $enabled['all'] ) > 0 ) {
-			global $post;
-
 			$dir = get_option( 'text_direction' );
 
-			// Wrapper
+			// Wrapper.
 			$sharing_content .= '<div class="sharedaddy sd-sharing-enabled"><div class="robots-nocontent sd-block sd-social sd-social-' . $global['button_style'] . ' sd-sharing">';
-			if ( $global['sharing_label'] != '' ) {
+			if ( '' !== $global['sharing_label'] ) {
 				$sharing_content .= sprintf(
 					/**
 					 * Filter the sharing buttons' headline structure.
@@ -816,7 +822,7 @@ function sharing_display( $text = '', $echo = false ) {
 			}
 			$sharing_content .= '<div class="sd-content"><ul>';
 
-			// Visible items
+			// Visible items.
 			$visible = '';
 			foreach ( $enabled['visible'] as $id => $service ) {
 				$klasses = array( 'share-' . $service->get_class() );
@@ -826,7 +832,7 @@ function sharing_display( $text = '', $echo = false ) {
 					}
 					$klasses[] = 'share-deprecated';
 				}
-				// Individual HTML for sharing service
+				// Individual HTML for sharing service.
 				$visible .= '<li class="' . implode( ' ', $klasses ) . '">' . $service->get_display( $post ) . '</li>';
 			}
 
@@ -841,7 +847,7 @@ function sharing_display( $text = '', $echo = false ) {
 				$parts[] = '<li><a href="#" class="sharing-anchor sd-button share-more"><span>' . $expand . '</span></a></li>';
 			}
 
-			if ( $dir == 'rtl' ) {
+			if ( 'rtl' === $dir ) {
 				$parts = array_reverse( $parts );
 			}
 
@@ -851,13 +857,13 @@ function sharing_display( $text = '', $echo = false ) {
 			if ( count( $enabled['hidden'] ) > 0 ) {
 				$sharing_content .= '<div class="sharing-hidden"><div class="inner" style="display: none;';
 
-				if ( count( $enabled['hidden'] ) == 1 ) {
+				if ( count( $enabled['hidden'] ) === 1 ) {
 					$sharing_content .= 'width:150px;';
 				}
 
 				$sharing_content .= '">';
 
-				if ( count( $enabled['hidden'] ) == 1 ) {
+				if ( count( $enabled['hidden'] ) === 1 ) {
 					$sharing_content .= '<ul style="background-image:none;">';
 				} else {
 					$sharing_content .= '<ul>';
@@ -865,7 +871,7 @@ function sharing_display( $text = '', $echo = false ) {
 
 				$count = 1;
 				foreach ( $enabled['hidden'] as $id => $service ) {
-					// Individual HTML for sharing service
+					// Individual HTML for sharing service.
 					$klasses = array( 'share-' . $service->get_class() );
 					if ( $service->is_deprecated() ) {
 						if ( ! current_user_can( 'manage_options' ) ) {
@@ -877,26 +883,27 @@ function sharing_display( $text = '', $echo = false ) {
 					$sharing_content .= $service->get_display( $post );
 					$sharing_content .= '</li>';
 
-					if ( ( $count % 2 ) == 0 ) {
+					if ( ( $count % 2 ) === 0 ) {
 						$sharing_content .= '<li class="share-end"></li>';
 					}
 
 					$count ++;
 				}
 
-				// End of wrapper
+				// End of wrapper.
 				$sharing_content .= '<li class="share-end"></li></ul></div></div>';
 			}
 
 			$sharing_content .= '</div></div></div>';
 
-			// Register our JS
+			// Register our JS.
 			if ( defined( 'JETPACK__VERSION' ) ) {
 				$ver = JETPACK__VERSION;
 			} else {
 				$ver = '20141212';
 			}
 
+			// @todo: Investigate if we can load this JS in the footer instead.
 			wp_register_script(
 				'sharing-js',
 				Assets::get_file_url_for_environment(
@@ -904,10 +911,11 @@ function sharing_display( $text = '', $echo = false ) {
 					'modules/sharedaddy/sharing.js'
 				),
 				array( 'jquery' ),
-				$ver
+				$ver,
+				false
 			);
 
-			// Enqueue scripts for the footer
+			// Enqueue scripts for the footer.
 			add_action( 'wp_footer', 'sharing_add_footer' );
 		}
 	}


### PR DESCRIPTION
In testing #13617, which adds PHP 7.4 to Travis, there are a couple of unit test failures. We'll likely need to fix this some thing in other aspects of Jetpack (accessing non-array variables like an array without verification), but at least we can fix these off the bat.

```
There were 2 errors:

1) WP_Test_Jetpack_Network::test_get_url_returns_null_for_invalid_input

Trying to access array offset on value of type int

/tmp/wordpress-master/src/wp-content/plugins/jetpack/class.jetpack-network.php:254

/tmp/wordpress-master/src/wp-content/plugins/jetpack/tests/php/general/test_class.jetpack-network.php:36

2) WP_Test_Jetpack_Sync_Post::test_remove_sharedaddy_from_filtered_content

Trying to access array offset on value of type bool

/tmp/wordpress-master/src/wp-content/plugins/jetpack/modules/sharedaddy/sharing-service.php:706

/tmp/wordpress-master/src/wp-includes/class-wp-hook.php:288

/tmp/wordpress-master/src/wp-includes/plugin.php:206

/tmp/wordpress-master/src/wp-content/plugins/jetpack/tests/php/sync/test_class.jetpack-sync-posts.php:770
```

#### Changes proposed in this Pull Request:
* Defensive coding to prevent 7.4 notices.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Run unit tests on PHP 7.4.

#### Proposed changelog entry for your changes:
* n/a, we can include a line by general 7.4 compat.
