### PR TITLE
Use wordpress components for antispam settings

### DIFF
--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -135,7 +135,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 					<PanelBody
 						title={ __( 'Your site is protected from spam' ) }
 						icon="yes"
-						initialOpen={ true }
+						initialOpen={ false }
 					>
 						<PanelRow className="form-security__text-field-panel-row">
 							<div style={ { display: 'flex', flexDirection: 'column' } }>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -24,6 +24,8 @@ import { Monitor } from './monitor';
 import { Protect } from './protect';
 import { SSO } from './sso';
 
+import './style.scss';
+
 export class Security extends Component {
 	static displayName = 'SecuritySettings';
 

--- a/_inc/client/security/style.scss
+++ b/_inc/client/security/style.scss
@@ -1,0 +1,6 @@
+.components-base-control.is-valid .components-base-control__field .components-text-control__input {
+	border-color: var( --color-success );
+}
+.components-base-control.is-error .components-base-control__field .components-text-control__input {
+	border-color: var( --color-error );
+}

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -126,7 +126,7 @@ abstract class Jetpack_Admin_Page {
 	function admin_styles() {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
-		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons' ), JETPACK__VERSION . '-20121016' );
+		wp_enqueue_style( 'jetpack-admin', plugins_url( "css/jetpack-admin{$min}.css", JETPACK__PLUGIN_FILE ), array( 'genericons', 'wp-components' ), JETPACK__VERSION . '-20121016' );
 		wp_style_add_data( 'jetpack-admin', 'rtl', 'replace' );
 		wp_style_add_data( 'jetpack-admin', 'suffix', $min );
 	}

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"@babel/core": "7.4.0",
 		"@babel/register": "7.4.4",
 		"@wordpress/browserslist-config": "2.5.0",
+		"@wordpress/components": "8.0.0",
 		"@wordpress/compose": "3.5.0",
 		"@wordpress/data": "4.7.0",
 		"@wordpress/element": "2.5.0",
@@ -159,7 +160,6 @@
 	},
 	"devDependencies": {
 		"@slack/web-api": "5.1.0",
-		"@wordpress/components": "8.0.0",
 		"@wordpress/core-data": "2.4.0",
 		"@wordpress/e2e-test-utils": "2.2.0",
 		"@wordpress/editor": "9.4.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR explores using `@wordpress/components` in Jetpack by rebuilding the Jetpack Antispam settings component using `@wordpress/components`, similar to https://github.com/Automattic/wp-calypso/pull/36452.

Note that this is not currently production ready; this PR is just here to show the code and facilitate discussion.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use `@wordpress/components` to build the Jetpack Antispam setting control

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
