### PR TITLE
Fix timezone offset of modified date in autosave REST responses

### DIFF
--- a/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-autosave-post-v1-1-endpoint.php
@@ -105,7 +105,7 @@ class WPCOM_JSON_API_Autosave_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_
 			return array(
 				'ID'          => $auto_ID,
 				'post_ID'     => $post->ID,
-				'modified'    => $this->format_date( $updated_post->post_modified ),
+				'modified'    => $this->format_date( $updated_post->post_modified_gmt, $updated_post->post_modified ),
 				'preview_URL' => $preview_url
 			);
 		} else {

--- a/json-endpoints/class.wpcom-json-api-get-autosave-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-autosave-v1-1-endpoint.php
@@ -63,7 +63,7 @@ class WPCOM_JSON_API_Get_Autosave_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1
 				'content'     => $autosave->post_content,
 				'excerpt'     => $autosave->post_excerpt,
 				'preview_URL' => $preview_url,
-				'modified'    => $this->format_date( $autosave->post_modified )
+				'modified'    => $this->format_date( $autosave->post_modified_gmt, $autosave->post_modified )
 			);
 		} else {
 			return new WP_Error( 'not_found', 'No autosaves exist for this post', 404 );


### PR DESCRIPTION
If a site has non-GMT timezone, the autosave endpoints (both GET and POST) would format the `modified` field as local time with incorrect GMT offset (always `+00:00`).

This patch fixes the arguments of the `format_date` function, where the first argument is supposed to be a GMT timestamp (local one was used until now) and the optional second argument is the local timestamp, used to calculate the offset.

See also the original bug report in the Android mobile app: wordpress-mobile/WordPress-Android#10550

#### Testing instructions:
1. Set a site's timezone to a non-GMT zone
2. When using Calypso Classic Editor, watch the responses of the autosave endpoint and verify that the timestamps are right.
3. The GET response is also embedded as `meta.data.autosave` field in the response for `/rest/v1.1/sites/:site_id/posts/:post_id?context=edit&meta=autosave` -- a GET request used by Calypso to load the post when opening the Classic Editor UI.

#### Proposed changelog entry for your changes:
* Fixed timezone offset of `modified` timestamp returned by autosave REST endpoints

This commit syncs r197401-wpcom.
