### PR TITLE
Add isAtomicSite utility in Gutenberg extenions

### DIFF
--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -18,7 +18,7 @@ import {
 	LAYOUT_SQUARE,
 	LAYOUT_STYLES,
 } from './constants';
-import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
+import { isSimpleSite } from '../../shared/site-type-utils';
 
 /**
  * Style dependencies
@@ -196,7 +196,7 @@ export const settings = {
 	category: 'jetpack',
 	description:
 		__( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ) +
-		( ! isAtomicSite() && ! isSimpleSite()
+		( ! isSimpleSite()
 			? ' ' + __( "Serves images using Jetpack's fast global network of servers.", 'jetpack' )
 			: '' ),
 	icon,

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -18,6 +18,7 @@ import {
 	LAYOUT_SQUARE,
 	LAYOUT_STYLES,
 } from './constants';
+import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 
 /**
  * Style dependencies
@@ -193,10 +194,11 @@ export const icon = (
 export const settings = {
 	attributes: blockAttributes,
 	category: 'jetpack',
-	description: __(
-		"Display multiple images in an elegantly organized tiled layout. Serves images using Jetpack's fast global network of servers.",
-		'jetpack'
-	),
+	description:
+		__( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ) +
+		( ! isAtomicSite() && ! isSimpleSite()
+			? ' ' + __( "Serves images using Jetpack's fast global network of servers.", 'jetpack' )
+			: '' ),
 	icon,
 	keywords: [
 		_x( 'images', 'block search term', 'jetpack' ),

--- a/extensions/shared/plan-upgrade-notification.js
+++ b/extensions/shared/plan-upgrade-notification.js
@@ -11,7 +11,7 @@ import { parse as parseUrl } from 'url';
  * Internal dependencies
  */
 import getSiteFragment from './get-site-fragment';
-import { isSimpleSite } from './site-type-utils';
+import { isAtomicSite, isSimpleSite } from './site-type-utils';
 
 /**
  * Returns a URL where the current site's plan can be viewed from.
@@ -23,7 +23,7 @@ function getPlanUrl() {
 	const siteFragment = getSiteFragment();
 
 	if ( undefined !== typeof window && window.location && siteFragment ) {
-		if ( isSimpleSite() ) {
+		if ( isSimpleSite() || isAtomicSite() ) {
 			return `https://wordpress.com/plans/my-plan/${ siteFragment }`;
 		}
 

--- a/extensions/shared/site-type-utils.js
+++ b/extensions/shared/site-type-utils.js
@@ -17,3 +17,12 @@ function getSiteType() {
 export function isSimpleSite() {
 	return getSiteType() === 'simple';
 }
+
+/**
+ * Check if environment is Atomic site.
+ *
+ * @return {boolean} True for Atomic sites.
+ */
+export function isAtomicSite() {
+	return getSiteType() === 'atomic';
+}


### PR DESCRIPTION
Just a simple utility to check if a site is an Atomic site and using it in two places.

#### Changes proposed in this Pull Request:
- Add `isAtomicSite` utility
- Hides mention of Jetpack CDN in Tiled gallery description since it doesn't make much sense on that context. 
     <img width="298" alt="image" src="https://user-images.githubusercontent.com/87168/67549072-0f4ec700-f70c-11e9-8fa3-d077822f2e4e.png">

- Link to .com for plans link in the plan purchased success notification
    <img width="587" alt="image" src="https://user-images.githubusercontent.com/87168/67550112-60f85100-f70e-11e9-9026-8015cd962f96.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Modifying

#### Testing instructions:
- Confirm that you can see Jetpack CDN mentioned in Tiled gallery block's description for a Jetpack site.
- Confirm that when you append `&plan_upgraded=1` to post editor URLs, you'll see "see your plan" pointing to wp-admin instead of .com in Jetpack, and to .com in Simple sites

#### Proposed changelog entry for your changes:
*
