### PR TITLE
Plans Page: Remove react warnings due to the new buttons that were added.

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -35,7 +35,7 @@ class PlanGrid extends React.Component {
 
 	handlePeriodChange( newPeriod ) {
 		if ( newPeriod === this.state.period ) {
-			return false;
+			return null;
 		}
 
 		return () => {
@@ -114,6 +114,7 @@ class PlanGrid extends React.Component {
 				<ButtonGroup>
 					{ map( periods, ( periodLabel, periodName ) => (
 						<Button
+							key={ periodLabel }
 							primary={ periodName === period }
 							onClick={ this.handlePeriodChange( periodName ) }
 							compact

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -114,7 +114,7 @@ class PlanGrid extends React.Component {
 				<ButtonGroup>
 					{ map( periods, ( periodLabel, periodName ) => (
 						<Button
-							key={ periodLabel }
+							key={ 'plan-period-button-' + periodName }
 							primary={ periodName === period }
 							onClick={ this.handlePeriodChange( periodName ) }
 							compact


### PR DESCRIPTION
In Jetpack's plans page we now see react warning in the console. 

See 
![Screen Shot 2019-10-03 at 4 13 48 PM](https://user-images.githubusercontent.com/115071/66134639-ebaacc00-e5f8-11e9-9265-d23405ab55c8.png)

This PR fixes them.

#### Changes proposed in this Pull Request:
* Fixes the react warnings in the dev console on the plans page.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
1. Connect jetpack. 
2. Go to the plans page /wp-admin/admin.php?page=jetpack#/plans-prompt
3. Notice no react warning in the dev console. 

#### Proposed changelog entry for your changes:
* Fixed js warnings introduced in the as the plans monthly view change.
