### PR TITLE
Repeat visitor block - add example

### DIFF
--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -7,7 +7,7 @@
 	}
 	.components-notice__content {
 		margin: 0.5em 0;
-		font-size: 0.8em;
+		font-size: 1em;
 
 		.components-base-control {
 			display: inline-block;

--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -53,3 +53,14 @@
 		text-align: center;
 	}
 }
+
+// Overrides to make the preview look good
+.block-editor-inserter__preview {
+	.wp-block-jetpack-repeat-visitor {
+		padding: 16px;
+
+		> .block-editor-inner-blocks > .block-editor-block-list__layout {
+			margin: 0;
+		}
+	}
+}

--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { Path } from '@wordpress/components';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -43,4 +44,19 @@ export const settings = {
 	title: __( 'Repeat Visitor', 'jetpack' ),
 	edit,
 	save,
+	example: {
+		attributes: {
+			criteria: CRITERIA_AFTER,
+			threshold: DEFAULT_THRESHOLD,
+		},
+		innerBlocks: [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content:
+						__( 'This block will only appear to a visitor who visited the page three or more times.', 'jetpack' ),
+				},
+			},
+		],
+	},
 };

--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -3,7 +3,6 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { Path } from '@wordpress/components';
-import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -53,8 +52,10 @@ export const settings = {
 			{
 				name: 'core/paragraph',
 				attributes: {
-					content:
-						__( 'This block will only appear to a visitor who visited the page three or more times.', 'jetpack' ),
+					content: __(
+						'This block will only appear to a visitor who visited the page three or more times.',
+						'jetpack'
+					),
 				},
 			},
 		],


### PR DESCRIPTION
* props @gravityrail
* Inlcudes CSS overrides for preview

Master issue: #13510

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added an example preview to the block in the Inspector.
* Increased text size of blue notice text, which Fixes #13645 

#### Before
<img width="768" alt="image" src="https://user-images.githubusercontent.com/1123119/66151093-d40d1c80-e5d3-11e9-9e49-90c73bc0ffbc.png">

#### After
<img width="722" alt="Screen Shot 2019-10-03 at 3 47 28 PM" src="https://user-images.githubusercontent.com/204742/66166672-2f9bd200-e5f5-11e9-9e98-142821056b9d.png">

Before/After for the increased blue notice text size:
<img width="1765" alt="Screen Shot 2019-10-03 at 3 51 18 PM" src="https://user-images.githubusercontent.com/204742/66166858-b3ee5500-e5f5-11e9-8a6c-dac1bdcdeacb.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have the latest Gutenberg plugin installed
* Create a new post
* Click the + to open the Inserter in the **top bar**
* Hover over Repeat Visitor
* Once you insert block, also notice the text size is larger and more legible in the blue notice bar.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
