### PR TITLE
Jetpack Map block - fix close icon alignment in add location popover

### DIFF
--- a/extensions/blocks/map/add-point/style.scss
+++ b/extensions/blocks/map/add-point/style.scss
@@ -35,7 +35,7 @@
 	}
 }
 .component__add-point__close {
-	margin: 0;
+	margin: 0.4rem 0 0;
 	padding: 0;
 	border: none;
 	box-shadow: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The close icon in the top right of the Jetpack Map block "Add a location" marker popover has a close icon that isn't properly aligned. The text “Add a location” has a margin of 0.5rem, but that looked a bit too much for the close icon. Adding 0.4rem (only to the top) of the close icon felt optically right.

Fixes #13647 

Before/After:
<img width="1088" alt="Screen Shot 2019-10-03 at 4 19 20 PM" src="https://user-images.githubusercontent.com/204742/66169497-cf5d5e00-e5fd-11e9-875d-6034de7b84c0.png">


#### Testing instructions:
* Check out this PR
* Add Jetpack Map block to any post. A popover with text "Add a location" will appear.
* See that the close icon is better aligned with the text "Add a location" like in the above "After" mockup.

#### Proposed changelog entry for your changes:
* None needed
