### PR TITLE
Site Logo: Updates site-logo-control-rtl.css using autortl

### DIFF
--- a/modules/theme-tools/site-logo/css/site-logo-control-rtl.css
+++ b/modules/theme-tools/site-logo/css/site-logo-control-rtl.css
@@ -1,6 +1,39 @@
+/* This file was automatically generated on Oct 03 2019 20:15:49 */
+
 /**
- * RTL styles for the Site Logo control. Just swaps the button sides.
+ * Styles for the Site Logo control.
  */
+#customize-control-site_logo .current {
+	margin-bottom: 6px;
+}
+
+#customize-control-site_logo .current span {
+	border: 1px solid #eee;
+	-webkit-border-radius: 2px;
+	border-radius: 2px;
+	color: #555;
+	display: block;
+	overflow: hidden;
+	line-height: 40px;
+	min-height: 40px;
+	padding: 0 6px;
+	text-align: center;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+#customize-control-site_logo .current img {
+	max-width: 100%;
+}
+
+#customize-control-site_logo button.new,
+#customize-control-site_logo button.change,
+#customize-control-site_logo button.remove {
+	height: auto;
+	width: 48%;
+	white-space: normal;
+}
+
 #customize-control-site_logo .remove {
 	float: right;
 	margin-left: 3px;
@@ -9,4 +42,10 @@
 #customize-control-site_logo .new,
 #customize-control-site_logo .change {
 	float: left;
+}
+
+#customize-control-site_logo .customize-control-description {
+	display: block;
+	clear: both;
+	margin-bottom: 10px;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The site logo module is shared between Jetpack and wpcom, but is not synced automatically.

I recently updated wpcom code to bring it into sync with Jetpack (D33102-code). One file that I could not update was `site-logo-control-rtl.css`, because it is automatically generated by `autortl`. This PR updates that file in Jetpack with the autortl generated version.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* See p9dueE-114-p2 for context about the site logo module

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate a theme that supports Jetpack's `site-logo`, such as Canape
* Go to Settings > General in wp-admin and change the site language to an rtl language, such as Arabic
* Load the customizer and select the "Site Identity" section (first one)
* See that the site logo Customizer control is correctly aligned on the right side of the screen.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Updated rtl css for site logo module using `autortl`
