### PR TITLE
Clicking "Make your site faster" will keep you in WP Dash

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -583,7 +583,7 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_performance' ) }
-									href={ 'https://wordpress.com/settings/performance/' + this.props.siteRawUrl }
+									href={ this.props.siteAdminUrl + 'admin.php?page=jetpack#/performance' }
 								>
 									{ __( 'Make your site faster' ) }
 								</Button>

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -217,7 +217,7 @@ class MyPlanBody extends React.Component {
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'paid_performance' ) }
-									href={ 'https://wordpress.com/settings/performance/' + this.props.siteRawUrl }
+									href={ this.props.siteAdminUrl + 'admin.php?page=jetpack#/performance' }
 								>
 									{ __( 'Make your site faster' ) }
 								</Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes #12899

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin/admin.php?page=jetpack#/my-plan
* Click on 'Make your site faster' under "Optimize Performance" box
* It keeps you in WP Dash at `/wp-admin/admin.php?page=jetpack#/performance` instead of taking you to Calypso

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
