### PR TITLE
Add tracking for the contact form with Tracks

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -26,6 +26,8 @@ function grunion_contact_form_require_endpoint() {
 	require_once GRUNION_PLUGIN_DIR . 'class-grunion-contact-form-endpoint.php';
 }
 
+require_once GRUNION_PLUGIN_DIR . 'tracks-events.php';
+
 /**
  * Sets up various actions, filters, post types, post statuses, shortcodes.
  */

--- a/modules/contact-form/tracks-events.php
+++ b/modules/contact-form/tracks-events.php
@@ -1,0 +1,13 @@
+<?php
+
+use Automattic\Jetpack\Tracking;
+
+function tracks_record_grunion_pre_message_sent( $post_id, $all_values, $extra_values ) {
+	$tracking = new Automattic\Jetpack\Tracking();
+	$tracking->tracks_record_event( wp_get_current_user(), 'grunion_pre_message_sent', array(
+		'entry_permalink' => $all_values['entry_permalink'],
+		'feedback_id' => $all_values['feedback_id'],
+	) );
+}
+
+add_action( 'grunion_pre_message_sent', 'tracks_record_grunion_pre_message_sent', 12, 3 );


### PR DESCRIPTION
This adds Tracks tracking to the contact form. This will be useful to see how much these forms are used.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This hooks onto the `grunion_pre_message_sent` event and pushes it to Tracks. We don't send personal information.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a contact form to a page on your site
* Submit the form as a user
* Check whether you see the `grunion_pre_message_sent` event in Tracks

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
