### PR TITLE
Sync: Ensure a post object is returned

### DIFF
--- a/packages/sync/src/modules/Posts.php
+++ b/packages/sync/src/modules/Posts.php
@@ -318,11 +318,7 @@ class Posts extends Module {
 	public function is_post_type_allowed( $post_id ) {
 		$post = get_post( intval( $post_id ) );
 
-		if ( ! $post || ! is_a( $post, '/WP_Post' ) ) {
-			return false;
-		}
-
-		if ( $post->post_type ) {
+		if ( isset( $post->post_type ) ) {
 			return ! in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ), true );
 		}
 		return false;
@@ -670,6 +666,6 @@ class Posts extends Module {
 	 * @return array|bool An array of min and max ids for each batch. FALSE if no table can be found.
 	 */
 	public function get_min_max_object_ids_for_batches( $batch_size, $where_sql = false ) {
-		return parent::get_min_max_object_ids_for_batches( $batch_size, $this->get_where_sql( false ) );
+		return parent::get_min_max_object_ids_for_batches( $batch_size, $this->get_where_sql( $where_sql ) );
 	}
 }

--- a/packages/sync/src/modules/Posts.php
+++ b/packages/sync/src/modules/Posts.php
@@ -317,6 +317,11 @@ class Posts extends Module {
 	 */
 	public function is_post_type_allowed( $post_id ) {
 		$post = get_post( intval( $post_id ) );
+
+		if ( ! $post || ! is_a( $post, '/WP_Post' ) ) {
+			return false;
+		}
+
 		if ( $post->post_type ) {
 			return ! in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ), true );
 		}


### PR DESCRIPTION
Fixes #13657

#### Changes proposed in this Pull Request:
* Defensive coding for when a post is not returned from `get_post`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Don't have a specific testing steps. I presume something like publish a post, but before it syncs, delete it totally.

#### Proposed changelog entry for your changes:
* Sync: Prevent a PHP Notice in some cases where a post isn't actually a post.
