### PR TITLE
Contact widget: Grayout API key if filter is applied

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -252,14 +252,18 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'address' ) ); ?>"><?php esc_html_e( 'Address:', 'jetpack' ); ?></label>
 				<textarea class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'address' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'address' ) ); ?>"><?php echo esc_textarea( $instance['address'] ); ?></textarea>
+			</p>
 
+			<p>
 				<input class="jp-contact-info-showmap" id="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'showmap' ) ); ?>" value="1" type="checkbox" <?php checked( $instance['showmap'], 1 ); ?> />
 				<label for="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>"><?php esc_html_e( 'Show map', 'jetpack' ); ?></label>
 			</p>
 
+			<?php if ( ! has_filter( 'jetpack_google_maps_api_key' ) ) { ?>
+
 			<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<label for="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>">
-					<?php esc_html_e( 'Google Maps API Key', 'jetpack' ); ?>
+					<?php esc_html_e( 'Google Maps API Key', 'jetpack' ); ?>					
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'apikey' ) ); ?>" type="text" value="<?php echo esc_attr( $apikey ); ?>" />
 					<br />
 					<small>
@@ -280,6 +284,8 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 					</small>
 				</label>
 			</p>
+
+			<?php } ?>
 
 			<p class="jp-contact-info-admin-map jp-contact-info-embed-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<?php

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -263,7 +263,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 
 			<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<label for="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>">
-					<?php esc_html_e( 'Google Maps API Key', 'jetpack' ); ?>					
+					<?php esc_html_e( 'Google Maps API Key', 'jetpack' ); ?>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'apikey' ) ); ?>" type="text" value="<?php echo esc_attr( $apikey ); ?>" />
 					<br />
 					<small>
@@ -285,7 +285,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				</label>
 			</p>
 
-			<?php } ?>
+			<?php } // end if jetpack_google_maps_api_key check. ?>
 
 			<p class="jp-contact-info-admin-map jp-contact-info-embed-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes https://github.com/Automattic/jetpack/issues/11470

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply `jetpack_google_maps_api_key` filter and set the API key as follows -

```
function omkar_api_key_test ($apikey) {
	$apikey = 'testapi';
	return $apikey;
}
add_filter(jetpack_google_maps_api_key, omkar_api_key_test);
```
* Go to Widgets > Add "Contact Info & Map" widget
* Click "show map"
* API key input field has our hardcoded key and is grayed out (or disabled)

![Screen Shot on 2019-10-06 at 13:26:18](https://user-images.githubusercontent.com/20779676/66266022-e76ef080-e83c-11e9-82cd-9162871a2e9a.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Minor improvements to "Contact Info & Map" widget and its filters
