### PR TITLE
Social: update Facebook's color code

### DIFF
--- a/_inc/client/scss/variables/_colors.scss
+++ b/_inc/client/scss/variables/_colors.scss
@@ -69,7 +69,7 @@ $sidebar-selected-color:   $gray;
 $dashboard-number-border: #CBD7E1;
 
 //Social media colors
-$color-facebook:    #39579a;
+$color-facebook:    #1877F2;
 $color-twitter:     #55ACEE;
 $color-gplus:       #df4a32;
 $color-tumblr:      #35465c;

--- a/modules/calypsoify/_colors.scss
+++ b/modules/calypsoify/_colors.scss
@@ -71,7 +71,7 @@ $sidebar-selected-color:   $gray-text-min;
 
 
 //Social media colors
-$color-facebook: #39579a;
+$color-facebook: #1877F2;
 $color-twitter: #55ACEE;
 $color-gplus: #df4a32;
 $color-tumblr: #35465c;

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -599,7 +599,7 @@ body .sd-social-icon .sd-content li.share-custom a span {
 }
 
 .sd-social-icon .sd-content ul li[class*='share-'].share-facebook a.sd-button {
-	background: #3b5998;
+	background: #1877F2;
 	color: #fff !important;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Facebook's Logo now uses a different shade of blue, as per the brand guidelines:
https://en.facebookbrand.com/assets/f-logo/

**Before**

<img width="253" alt="screenshot 2019-10-07 at 11 21 37" src="https://user-images.githubusercontent.com/426388/66299982-cbc72100-e8f4-11e9-9e7a-4fcf566e5ec8.png">

**After**

<img width="251" alt="screenshot 2019-10-07 at 11 21 02" src="https://user-images.githubusercontent.com/426388/66299990-cf5aa800-e8f4-11e9-8878-4ac4622e44c0.png">

#### Testing instructions:

* Add a Facebook Sharing button to your posts, and pick the "Logo" button style.
* Enjoy the new blue!

#### Proposed changelog entry for your changes:

* Social Networks: update Facebook logo to match new color.
