### PR TITLE
VideoPress: Replace video uploads in Gutenberg

### DIFF
--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -31,6 +31,7 @@ class VideoPress_Gutenberg {
 	private function __construct() {
 		add_action( 'init', array( $this, 'register_video_block_with_videopress' ) );
 		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'set_extension_availability' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'override_video_upload' ) );
 	}
 
 	/**
@@ -163,6 +164,28 @@ class VideoPress_Gutenberg {
 			$content,
 			1
 		);
+	}
+
+	/**
+	 * Replaces the video uploaded in the block editor.
+	 *
+	 * Enqueues a script that registers an API fetch middleware replacing the video uploads in Gutenberg so they are
+	 * uploaded against the WP.com API media endpoint and thus transcoded by VideoPress.
+	 */
+	public function override_video_upload() {
+		if (
+			method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active()
+			&& method_exists( 'Jetpack', 'is_module_active' )
+			&& Jetpack::is_module_active( 'videopress' )
+		) {
+			wp_enqueue_script(
+				'jetpack-videopress-gutenberg-override-video-upload',
+				plugin_dir_url( __FILE__ ) . 'js/gutenberg-video-upload.js',
+				array( 'wp-api-fetch' ),
+				JETPACK__VERSION,
+				false
+			);
+		}
 	}
 }
 

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -175,11 +175,6 @@ class VideoPress_Gutenberg {
 	 * uploaded against the WP.com API media endpoint and thus transcoded by VideoPress.
 	 */
 	public function override_video_upload() {
-		// Bail if WP.com site.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			return;
-		}
-
 		// Bail if Jetpack or VideoPress is not active.
 		if ( ! Jetpack::is_active() || ! Jetpack::is_module_active( 'videopress' ) ) {
 			return;

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -173,19 +173,23 @@ class VideoPress_Gutenberg {
 	 * uploaded against the WP.com API media endpoint and thus transcoded by VideoPress.
 	 */
 	public function override_video_upload() {
-		if (
-			method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active()
-			&& method_exists( 'Jetpack', 'is_module_active' )
-			&& Jetpack::is_module_active( 'videopress' )
-		) {
-			wp_enqueue_script(
-				'jetpack-videopress-gutenberg-override-video-upload',
-				plugin_dir_url( __FILE__ ) . 'js/gutenberg-video-upload.js',
-				array( 'wp-api-fetch', 'wp-polyfill', 'lodash' ),
-				JETPACK__VERSION,
-				false
-			);
+		// Bail if WP.com site.
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			return;
 		}
+
+		// Bail if Jetpack or VideoPress is not active.
+		if ( ! Jetpack::is_active() || ! Jetpack::is_module_active( 'videopress' ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'jetpack-videopress-gutenberg-override-video-upload',
+			plugin_dir_url( __FILE__ ) . 'js/gutenberg-video-upload.js',
+			array( 'wp-api-fetch', 'wp-polyfill', 'lodash' ),
+			JETPACK__VERSION,
+			false
+		);
 	}
 }
 

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -5,6 +5,8 @@
  * @package Jetpack
  */
 
+use Automattic\Jetpack\Assets;
+
 /**
  * Register a VideoPress extension to replace the default Core Video block.
  */
@@ -185,7 +187,10 @@ class VideoPress_Gutenberg {
 
 		wp_enqueue_script(
 			'jetpack-videopress-gutenberg-override-video-upload',
-			plugin_dir_url( __FILE__ ) . 'js/gutenberg-video-upload.js',
+			Assets::get_file_url_for_environment(
+				'_inc/build/videopress/js/gutenberg-video-upload.min.js',
+				'modules/videopress/js/gutenberg-video-upload.js'
+			),
 			array( 'wp-api-fetch', 'wp-polyfill', 'lodash' ),
 			JETPACK__VERSION,
 			false

--- a/modules/videopress/class.videopress-gutenberg.php
+++ b/modules/videopress/class.videopress-gutenberg.php
@@ -181,7 +181,7 @@ class VideoPress_Gutenberg {
 			wp_enqueue_script(
 				'jetpack-videopress-gutenberg-override-video-upload',
 				plugin_dir_url( __FILE__ ) . 'js/gutenberg-video-upload.js',
-				array( 'wp-api-fetch' ),
+				array( 'wp-api-fetch', 'wp-polyfill', 'lodash' ),
 				JETPACK__VERSION,
 				false
 			);

--- a/modules/videopress/js/gutenberg-video-upload.js
+++ b/modules/videopress/js/gutenberg-video-upload.js
@@ -3,7 +3,8 @@
 wp.apiFetch.use( function( options, next ) {
 	var path = options.path;
 	var method = options.method;
-	var file = options.body ? options.body.get( 'file' ) : null;
+	var body = options.body;
+	var file = body ? body.get( 'file' ) : null;
 
 	// Override only requests to the WP REST API media endpoint uploading new videos.
 	if ( ! path || path.indexOf( '/wp/v2/media' ) === -1 ) {
@@ -36,6 +37,11 @@ wp.apiFetch.use( function( options, next ) {
 
 			// Handle CORS.
 			options.credentials = 'omit';
+
+			// Set data in expected param by WP.com media endpoint.
+			body.set( 'media[]', file );
+			body.delete( 'file' );
+			options.body = body;
 		} );
 
 	return next( options );

--- a/modules/videopress/js/gutenberg-video-upload.js
+++ b/modules/videopress/js/gutenberg-video-upload.js
@@ -33,6 +33,9 @@ wp.apiFetch.use( function( options, next ) {
 			// Replace upload URL.
 			delete options.path;
 			options.url = response.upload_action_url;
+
+			// Handle CORS.
+			options.credentials = 'omit';
 		} );
 
 	return next( options );

--- a/modules/videopress/js/gutenberg-video-upload.js
+++ b/modules/videopress/js/gutenberg-video-upload.js
@@ -1,4 +1,4 @@
-/* globals wp */
+/* globals wp, lodash */
 
 wp.apiFetch.use( function( options, next ) {
 	var path = options.path;
@@ -44,5 +44,20 @@ wp.apiFetch.use( function( options, next ) {
 			options.body = body;
 		} );
 
-	return next( options );
+	var result = next( options );
+
+	return new Promise( function( resolve, reject ) {
+		result
+			.then( function( data ) {
+				var wpcomMediaObject = lodash.get( data, 'media[0]' );
+				var id = lodash.get( wpcomMediaObject, 'ID' );
+				var gutenbergMediaObject = wp.apiFetch( {
+					path: '/wp/v2/media/' + id,
+				} );
+				resolve( gutenbergMediaObject );
+			} )
+			.catch( function() {
+				reject();
+			} );
+	} );
 } );

--- a/modules/videopress/js/gutenberg-video-upload.js
+++ b/modules/videopress/js/gutenberg-video-upload.js
@@ -1,0 +1,39 @@
+/* globals wp */
+
+wp.apiFetch.use( function( options, next ) {
+	var path = options.path;
+	var method = options.method;
+	var file = options.body ? options.body.get( 'file' ) : null;
+
+	// Override only requests to the WP REST API media endpoint uploading new videos.
+	if ( ! path || path.indexOf( '/wp/v2/media' ) === -1 ) {
+		return next( options );
+	}
+	if ( ! method || 'post' !== method.toLowerCase() ) {
+		return next( options );
+	}
+	if ( ! file || file.type.indexOf( 'video/' ) !== 0 ) {
+		return next( options );
+	}
+
+	// Get upload token.
+	wp.media
+		.ajax( 'videopress-get-upload-token', { async: false, data: { filename: file.name } } )
+		.done( function( response ) {
+			// Set auth header with upload token.
+			var headers = options.headers || {};
+			headers.Authorization =
+				'X_UPLOAD_TOKEN token="' +
+				response.upload_token +
+				'" blog_id="' +
+				response.upload_blog_id +
+				'"';
+			options.headers = headers;
+
+			// Replace upload URL.
+			delete options.path;
+			options.url = response.upload_action_url;
+		} );
+
+	return next( options );
+} );


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/11194

#### Changes proposed in this Pull Request:
Load an API fetch middleware in the block editor that overrides the video uploads in Gutenberg so they are uploaded against the WP.com API media endpoint and thus transcoded by VideoPress.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Improve VideoPress (paYKcK-f0-p2, p9dueE-xm-p2).

#### Testing instructions:
- Apply D33658-code and sandbox the API.
- Apply this branch to your JP dev environment.
- Start from a Jetpack site with an active Professional upgrade.
- Go to Jetpack > Settings in your dashboard, and enable the VideoPress feature.
- Load the block editor.
- Insert a video block.
- Upload a video using the "Upload" button (not the "Media Library" one).
- Check the VideoPress player is rendered on the editor.
- Publish the post.
- Check the VideoPress player is rendered on the published view.
- Deactivate VideoPress.
- Load the block editor again.
- Make sure the `gutenberg-video-upload.js` script is not enqueued.
- Sandbox a WP.com site and load the block editor.
- Make sure the `gutenberg-video-upload.js` script is not enqueued on the WP.com site.

#### Proposed changelog entry for your changes:
VideoPress: Replace video uploads in Gutenberg
