### PR TITLE
Search: Add hooks for failed attempts

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -169,7 +169,7 @@ class Jetpack_Search {
 		$this->jetpack_blog_id = Jetpack::get_option( 'id' );
 
 		if ( ! $this->jetpack_blog_id ) {
-			/** This action is documented in modules/search/class.jetpack-search.php
+			/** This action is documented in modules/search/class.jetpack-search.php */
 			do_action( 'jetpack_search_abort', 'no_blog_id', null );
 			return;
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -170,7 +170,6 @@ class Jetpack_Search {
 
 		if ( ! $this->jetpack_blog_id ) {
 			/** This action is documented in modules/search/class.jetpack-search.php
-			 */
 			do_action( 'jetpack_search_abort', 'no_blog_id', null );
 			return;
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -526,8 +526,7 @@ class Jetpack_Search {
 		$this->do_search( $query );
 
 		if ( ! is_array( $this->search_result ) ) {
-			/** This action is documented in modules/search/class.jetpack-search.php
-			 */
+			/** This action is documented in modules/search/class.jetpack-search.php */
 			do_action( 'jetpack_search_abort', 'no_search_results_array', $this->search_result );
 			return $posts;
 		}
@@ -572,6 +571,7 @@ class Jetpack_Search {
 	public function do_search( WP_Query $query ) {
 		if ( ! $this->should_handle_query( $query ) ) {
 			// If we make it here, either 'filter__posts_pre_query' somehow allowed it or a different entry to do_search.
+			/** This action is documented in modules/search/class.jetpack-search.php */
 			do_action( 'jetpack_search_abort', 'search_attempted_non_search_query', $query );
 			return;
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -156,6 +156,7 @@ class Jetpack_Search {
 			/**
 			 * Fires when the Jetpack Search fails and would fallback to MySQL.
 			 *
+			 * @module search
 			 * @since 7.9.0
 			 *
 			 * @param string $reason Reason for Search fallback.


### PR DESCRIPTION
When Search fails for some reason, it'll fall back to MySQL searching which can be very heavy for a database when ES results are assumed.

Adding some hooks to better be able to track where something comes off the rails and need to fall back to MySQL.

#### Changes proposed in this Pull Request:
* Adds hooks for error handling purposes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Would be used with something like 
```add_action( 'jetpack_search_abort, 'custon_function', 10, 4 );
function custom_function ( $reason, $data = null ) {
	$logging = new CustomLogger;
	$logging->set_reason( $reason );
	if ( $data ) {
		$logging->set_additional_data( $data );
	}
	$logging->save();
}
```

#### Proposed changelog entry for your changes:
* Search: Add hooks for when Search falls back to using the local database.

cc: @GaryJones 