### PR TITLE
Ensure password field is enabled when switching to u/p from SSO form

### DIFF
--- a/modules/sso/jetpack-sso-login.js
+++ b/modules/sso/jetpack-sso-login.js
@@ -2,6 +2,7 @@ jQuery( document ).ready( function( $ ) {
 	var body = $( 'body' ),
 		toggleSSO = $( '.jetpack-sso-toggle' ),
 		userLogin = $( '#user_login' ),
+		userPassword = $( '#user_pass' ),
 		ssoWrap = $( '#jetpack-sso-wrap' ),
 		loginForm = $( '#loginform' ),
 		overflow = $( '<div class="jetpack-sso-clear"></div>' );
@@ -27,6 +28,7 @@ jQuery( document ).ready( function( $ ) {
 		body.toggleClass( 'jetpack-sso-form-display' );
 		if ( ! body.hasClass( 'jetpack-sso-form-display' ) ) {
 			userLogin.focus();
+			userPassword.prop( 'disabled', false );
 		}
 	} );
 } );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13551

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Enable password input field when switching from SSO login form.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site running the latest WordPress 5.3 nightly (5.3-beta2-46416) and 7.8...
* Try to log in using /wp-login.php - everything should work
* Enable "WordPress.com login" (aka SSO)
* Try log log in using /wp-login.php - everything should STILL work

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix issue with disabled password field and SSO module enabled on WordPress 5.3+
