### PR TITLE
Admin Page: ensure user caps are available when picking active tab

### DIFF
--- a/_inc/client/components/non-admin-view/index.jsx
+++ b/_inc/client/components/non-admin-view/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import {
+	userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 	userIsSubscriber as _userIsSubscriber,
 } from 'state/initial-state';
@@ -47,6 +48,7 @@ class NonAdminView extends React.Component {
 							siteAdminUrl={ this.props.siteAdminUrl }
 							siteRawUrl={ this.props.siteRawUrl }
 							searchTerm={ this.props.searchTerm }
+							userCanManageModules={ this.props.userCanManageModules }
 						/>
 					);
 				}
@@ -80,5 +82,6 @@ export default connect( state => {
 		siteConnectionStatus: getSiteConnectionStatus( state ),
 		isSubscriber: _userIsSubscriber( state ),
 		isModuleActivated: module_name => _isModuleActivated( state, module_name ),
+		userCanManageModules: userCanManageModules( state ),
 	};
 } )( NonAdminView );

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -233,6 +233,7 @@ class Main extends React.Component {
 						siteRawUrl={ this.props.siteRawUrl }
 						searchTerm={ this.props.searchTerm }
 						rewindStatus={ this.props.rewindStatus }
+						userCanManageModules={ this.props.userCanManageModules }
 					/>
 				);
 				break;

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -27,6 +27,7 @@ export default class extends React.Component {
 			route: this.props.route,
 			searchTerm: this.props.searchTerm,
 			rewindStatus: this.props.rewindStatus,
+			userCanManageModules: this.props.userCanManageModules,
 		};
 
 		return (
@@ -45,7 +46,7 @@ export default class extends React.Component {
 					siteRawUrl={ this.props.siteRawUrl }
 					active={
 						'/security' === this.props.route.path ||
-						( '/settings' === this.props.route.path && this.props.userCanManageModules )
+						( '/settings' === this.props.route.path && commonProps.userCanManageModules )
 					}
 					{ ...commonProps }
 				/>
@@ -65,7 +66,7 @@ export default class extends React.Component {
 					siteAdminUrl={ this.props.siteAdminUrl }
 					active={
 						'/writing' === this.props.route.path ||
-						( '/settings' === this.props.route.path && ! this.props.userCanManageModules )
+						( '/settings' === this.props.route.path && ! commonProps.userCanManageModules )
 					}
 					{ ...commonProps }
 				/>


### PR DESCRIPTION
Follow-up from #13541

#### Changes proposed in this Pull Request:

We need to make sure this.props.userCanManageModules is available before we use it.

I introduced a bug in #13541: when an admin was loading Jetpack > Settings, the Writing tab was loading by default.

#### Testing instructions:

* Go to Jetpack > Settings as an admin on the site.
* The Security tab and its contents should load by default.
* Go to Users > Add New, and add a new editor to your site.
* Log to your site with that new user.
* Go to Jetpack > Settings.
* The Writing tab and its contents should load instead of the Security tab.

#### Proposed changelog entry for your changes:

* None
