### PR TITLE
Notifications: do not rely on admin-bar styles

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -209,7 +209,13 @@ class A8C_WPCOM_Masterbar {
 	 * Remove the default Admin Bar CSS.
 	 */
 	public function remove_core_styles() {
-		wp_dequeue_style( 'admin-bar' );
+		/*
+		 * Notifications need the admin bar styles,
+		 * so let's not remove them when the module is active.
+		 */
+		if ( ! Jetpack::is_module_active( 'notes' ) ) {
+			wp_dequeue_style( 'admin-bar' );
+		}
 	}
 
 	/**

--- a/modules/notes.php
+++ b/modules/notes.php
@@ -119,9 +119,9 @@ class Jetpack_Notifications {
 		}
 
 		if ( ! $is_rtl ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
 		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );

--- a/modules/notes.php
+++ b/modules/notes.php
@@ -119,9 +119,9 @@ class Jetpack_Notifications {
 		}
 
 		if ( ! $is_rtl ) {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/admin-bar-v2.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		} else {
-			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array( 'admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );
+			wp_enqueue_style( 'wpcom-notes-admin-bar', $this->wpcom_static_url( '/wp-content/mu-plugins/notes/rtl/admin-bar-v2-rtl.css' ), array(), JETPACK_NOTES__CACHE_BUSTER );
 		}
 
 		wp_enqueue_style( 'noticons', $this->wpcom_static_url( '/i/noticons/noticons.css' ), array( 'wpcom-notes-admin-bar' ), JETPACK_NOTES__CACHE_BUSTER );


### PR DESCRIPTION
Follow up from #13450

#### Changes proposed in this Pull Request:

* In some cases, admin-bar styles may be dequeued (like when the Masterbar module is active). Let's consequently not rely on them to be there.

cc @westonruter 

#### Testing instructions:

* Before to apply this patch, enable both Notifications and the Masterbar module.
* Notice the broken layout.
* Apply patch.
* Notice that both the Masterbar and the Notifications work well.

#### Proposed changelog entry for your changes:

* None
