### PR TITLE
Gif block - fix input positioning

### DIFF
--- a/extensions/blocks/gif/editor.scss
+++ b/extensions/blocks/gif/editor.scss
@@ -32,9 +32,8 @@
 		width: 100%;
 		z-index: 1;
 		.components-base-control__label {
-			height: 0;
-			margin: 0;
-			text-indent: -9999px;
+			position: absolute;
+			top: -1000em;
 		}
 	}
 	.wp-block-jetpack-gif_input {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13646

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Changed how label was positioned which made form look as intended

#### Before
<img width="689" alt="image" src="https://user-images.githubusercontent.com/1123119/66432111-8e3cc380-e9da-11e9-898c-e5321df0111a.png">
<img width="687" alt="image" src="https://user-images.githubusercontent.com/1123119/66432097-85e48880-e9da-11e9-8dad-1c1ee7fa425c.png">

#### After
<img width="676" alt="image" src="https://user-images.githubusercontent.com/1123119/66431880-1e2e3d80-e9da-11e9-8142-c5b58852df6b.png">
<img width="695" alt="image" src="https://user-images.githubusercontent.com/1123119/66431922-37cf8500-e9da-11e9-819f-de1d9c058bcb.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post-new.php
* Add a gif block

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed
