### PR TITLE
General: bring in changes introduced in WordPress 5.3

### DIFF
--- a/_inc/lib/class.jetpack-automatic-install-skin.php
+++ b/_inc/lib/class.jetpack-automatic-install-skin.php
@@ -65,8 +65,11 @@ class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
 
 	/**
 	 * Overwrites the feedback function
+	 *
+	 * @param string|array|WP_Error $data    Data.
+	 * @param mixed                 ...$args Optional text replacements.
 	 */
-	public function feedback( $data ) {
+	public function feedback( $data, ...$args ) {
 
 		$current_error = null;
 		if ( is_wp_error( $data ) ) {
@@ -86,9 +89,6 @@ class Jetpack_Automatic_Install_Skin extends Automatic_Upgrader_Skin {
 		}
 
 		if ( strpos( $string, '%' ) !== false ) {
-			// phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
-			$args = func_get_args();
-			$args = array_splice( $args, 1 );
 			if ( ! empty( $args ) ) {
 				$string = vsprintf( $string, $args );
 			}


### PR DESCRIPTION
Fixes #13694

#### Changes proposed in this Pull Request:

* See https://make.wordpress.org/core/2019/10/09/wp-5-3-introducing-the-spread-operator/

#### Testing instructions:

Run the following in both WordPress 5.2 and WordPress 5.3.

* Go to https://wordpress.com/plugins/woocommerce/yoursite.com
* Install a plugin
* Ensure there are no PHP warnings in your error log.

#### Proposed changelog entry for your changes:

* General: ensure the WordPress.com REST API is updated to take into account changes from WordPress 5.3.
