### PR TITLE
Map block - fixes tiny Mapbox location marker popover close icon

### DIFF
--- a/extensions/blocks/map/editor.scss
+++ b/extensions/blocks/map/editor.scss
@@ -26,3 +26,10 @@
 		}
 	}
 }
+
+.wp-block-jetpack-map {
+	.mapboxgl-popup-close-button {
+		font-size: 21px;
+		padding: 0px 10px 5px 9px;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13650

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes size of tiny Mapbox location marker popover close icon

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fix for existing feature

#### Before
<img width="721" alt="image" src="https://user-images.githubusercontent.com/1123119/66480917-e916ff00-ea5c-11e9-93ba-32de542ea30f.png">

#### After
<img width="685" alt="image" src="https://user-images.githubusercontent.com/1123119/66480869-c553b900-ea5c-11e9-8a9b-962f30f4607b.png">


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post-new.php
* Add the map block
* Add a location
* Deselect and then select the pin
* Look at the size of the `x`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
