### PR TITLE
Recurring Payments: better wording around "plan"

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -204,7 +204,7 @@ class MembershipsButtonEdit extends Component {
 					isLarge
 					onClick={ () => this.setState( { addingMembershipAmount: PRODUCT_FORM } ) }
 				>
-					{ __( 'Add a Recurring Payments Plan', 'jetpack' ) }
+					{ __( 'Add a plan', 'jetpack' ) }
 				</Button>
 			);
 		}
@@ -270,7 +270,7 @@ class MembershipsButtonEdit extends Component {
 						className="membership-button__field-button membership-button__add-amount"
 						onClick={ this.saveProduct }
 					>
-						{ __( 'Add Amount', 'jetpack' ) }
+						{ __( 'Add this plan', 'jetpack' ) }
 					</Button>
 					<Button
 						isLarge
@@ -440,7 +440,9 @@ class MembershipsButtonEdit extends Component {
 								notices={ notices }
 							>
 								<div className="components-placeholder__instructions">
-									<p>{ __( 'Add your first Recurring Payments plan:', 'jetpack' ) }</p>
+									<p>
+										{ __( 'To use this block, first add at least one payment plan.', 'jetpack' ) }
+									</p>
 									{ this.renderAddMembershipAmount() }
 									{ this.renderDisclaimer() }
 								</div>
@@ -459,9 +461,14 @@ class MembershipsButtonEdit extends Component {
 								notices={ notices }
 							>
 								<div className="components-placeholder__instructions">
-									<p>{ __( 'Select payment plan:', 'jetpack' ) }</p>
+									<p>
+										{ __(
+											'To use this block, select a previously created payment plan.',
+											'jetpack'
+										) }
+									</p>
 									{ this.renderMembershipAmounts() }
-									<p>{ __( 'Or add another Recurring Payments plan:', 'jetpack' ) }</p>
+									<p>{ __( 'Or a new one.', 'jetpack' ) }</p>
 									{ this.renderAddMembershipAmount() }
 									{ this.renderDisclaimer() }
 								</div>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -196,8 +196,8 @@ class MembershipsButtonEdit extends Component {
 		return sprintf( __( '%s / %s', 'jetpack' ), amount, product.interval );
 	};
 
-	renderAddMembershipAmount = () => {
-		if ( this.state.addingMembershipAmount === PRODUCT_NOT_ADDING ) {
+	renderAddMembershipAmount = ( forceShowForm = false ) => {
+		if ( this.state.addingMembershipAmount === PRODUCT_NOT_ADDING && ! forceShowForm ) {
 			return (
 				<Button
 					isDefault
@@ -443,7 +443,7 @@ class MembershipsButtonEdit extends Component {
 									<p>
 										{ __( 'To use this block, first add at least one payment plan.', 'jetpack' ) }
 									</p>
-									{ this.renderAddMembershipAmount() }
+									{ this.renderAddMembershipAmount( true ) }
 									{ this.renderDisclaimer() }
 								</div>
 							</Placeholder>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -196,7 +196,7 @@ class MembershipsButtonEdit extends Component {
 		return sprintf( __( '%s / %s', 'jetpack' ), amount, product.interval );
 	};
 
-	renderAddMembershipAmount = ( forceShowForm = false ) => {
+	renderAddMembershipAmount = forceShowForm => {
 		if ( this.state.addingMembershipAmount === PRODUCT_NOT_ADDING && ! forceShowForm ) {
 			return (
 				<Button
@@ -469,7 +469,7 @@ class MembershipsButtonEdit extends Component {
 									</p>
 									{ this.renderMembershipAmounts() }
 									<p>{ __( 'Or a new one.', 'jetpack' ) }</p>
-									{ this.renderAddMembershipAmount() }
+									{ this.renderAddMembershipAmount( false ) }
 									{ this.renderDisclaimer() }
 								</div>
 							</Placeholder>


### PR DESCRIPTION
This PR fixes language around the word plan, according to what @obi2020  suggested.
Almost no functional changes.

The reasoning behind it:
- p8hgLy-1Oq-p2#comment-3101
- p8hgLy-25q-p2

### Screenshots

![Zrzut ekranu 2019-10-9 o 16 45 16](https://user-images.githubusercontent.com/3775068/66493688-c3b6df00-eab6-11e9-9204-3f661ee5f4be.png)

![Zrzut ekranu 2019-10-9 o 16 45 48](https://user-images.githubusercontent.com/3775068/66493699-c7e2fc80-eab6-11e9-8935-ab1a1bb6e74c.png)



#### Changes proposed in this Pull Request:
* If no plans are created, automatically show the form to create a new plan
* Some language tweaks


#### Testing instructions:

Same as https://github.com/Automattic/jetpack/pull/9802
