### PR TITLE
Tracks: Don't track users in dev mode or when opted out

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7045,7 +7045,14 @@ endif;
 		}
 	}
 
-	public static function is_active_and_not_development_mode( $maybe = null ) {
+	/**
+	 * Checks if a Jetpack site is both active and not in development.
+	 *
+	 * This is a DRY function to avoid repeating `Jetpack::is_active && ! Jetpack::is_development_mode`.
+	 *
+	 * @return bool True if Jetpack is active and not in development.
+	 */
+	public static function is_active_and_not_development_mode() {
 		if ( ! self::is_active() || self::is_development_mode() ) {
 			return false;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6938,7 +6938,7 @@ endif;
 	 * Will return true if a user has clicked to register, or is already connected.
 	 */
 	public static function jetpack_tos_agreed() {
-		return Jetpack_Options::get_option( 'tos_agreed' ) || self::is_active();
+		return Jetpack_Options::get_option( 'tos_agreed' ) || self::is_active_and_not_development_mode();
 	}
 
 	/**
@@ -7045,7 +7045,7 @@ endif;
 		}
 	}
 
-	function is_active_and_not_development_mode( $maybe ) {
+	public static function is_active_and_not_development_mode( $maybe = null ) {
 		if ( ! self::is_active() || self::is_development_mode() ) {
 			return false;
 		}

--- a/packages/tracking/legacy/class.tracks-client.php
+++ b/packages/tracking/legacy/class.tracks-client.php
@@ -57,7 +57,7 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	public static function record_event( $event ) {
-		if ( ! Jetpack::jetpack_tos_agreed() ) {
+		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;
 		}
 

--- a/packages/tracking/legacy/class.tracks-client.php
+++ b/packages/tracking/legacy/class.tracks-client.php
@@ -57,7 +57,7 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	public static function record_event( $event ) {
-		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] || Jetpack::is_development_mode() ) ) {
+		if ( ! Jetpack::jetpack_tos_agreed() ) {
 			return false;
 		}
 

--- a/packages/tracking/legacy/class.tracks-client.php
+++ b/packages/tracking/legacy/class.tracks-client.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Legacy Jetpack Tracks Client
+ *
+ * @package Jetpack
+ */
 
 /**
  * Jetpack_Tracks_Client
@@ -38,7 +43,6 @@
 	}
 ```
  */
-
 class Jetpack_Tracks_Client {
 	const PIXEL           = 'https://pixel.wp.com/t.gif';
 	const BROWSER_TYPE    = 'php-agent';
@@ -46,13 +50,13 @@ class Jetpack_Tracks_Client {
 	const VERSION         = '0.3';
 
 	/**
-	 * record_event
+	 * Record an event.
 	 *
 	 * @param  mixed $event Event object to send to Tracks. An array will be cast to object. Required.
 	 *                      Properties are included directly in the pixel query string after light validation.
 	 * @return mixed         True on success, WP_Error on failure
 	 */
-	static function record_event( $event ) {
+	public static function record_event( $event ) {
 		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] || Jetpack::is_development_mode() ) ) {
 			return false;
 		}
@@ -74,16 +78,19 @@ class Jetpack_Tracks_Client {
 	}
 
 	/**
-	 * Synchronously request the pixel
+	 * Synchronously request the pixel.
+	 *
+	 * @param string $pixel The wp.com tracking pixel.
+	 * @return array|bool|WP_Error True if successful. wp_remote_get response or WP_Error if not.
 	 */
-	static function record_pixel( $pixel ) {
+	public static function record_pixel( $pixel ) {
 		// Add the Request Timestamp and URL terminator just before the HTTP request.
 		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
 
 		$response = wp_remote_get(
 			$pixel,
 			array(
-				'blocking'    => true, // The default, but being explicit here :)
+				'blocking'    => true, // The default, but being explicit here :).
 				'timeout'     => 1,
 				'redirection' => 2,
 				'httpversion' => '1.1',
@@ -97,14 +104,19 @@ class Jetpack_Tracks_Client {
 
 		$code = isset( $response['response']['code'] ) ? $response['response']['code'] : 0;
 
-		if ( $code !== 200 ) {
+		if ( 200 !== $code ) {
 			return new WP_Error( 'request_failed', 'Tracks pixel request failed', $code );
 		}
 
 		return true;
 	}
 
-	static function get_user_agent() {
+	/**
+	 * Get the user agent.
+	 *
+	 * @return string The user agent.
+	 */
+	public static function get_user_agent() {
 		return self::USER_AGENT_SLUG . '-v' . self::VERSION;
 	}
 
@@ -112,10 +124,10 @@ class Jetpack_Tracks_Client {
 	 * Build an event and return its tracking URL
 	 *
 	 * @deprecated          Call the `build_pixel_url` method on a Jetpack_Tracks_Event object instead.
-	 * @param  array $event Event keys and values
-	 * @return string       URL of a tracking pixel
+	 * @param  array $event Event keys and values.
+	 * @return string       URL of a tracking pixel.
 	 */
-	static function build_pixel_url( $event ) {
+	public static function build_pixel_url( $event ) {
 		$_event = new Jetpack_Tracks_Event( $event );
 		return $_event->build_pixel_url();
 	}
@@ -124,7 +136,7 @@ class Jetpack_Tracks_Client {
 	 * Validate input for a tracks event.
 	 *
 	 * @deprecated          Instantiate a Jetpack_Tracks_Event object instead
-	 * @param  array $event Event keys and values
+	 * @param  array $event Event keys and values.
 	 * @return mixed        Validated keys and values or WP_Error on failure
 	 */
 	private static function validate_and_sanitize( $event ) {
@@ -135,8 +147,14 @@ class Jetpack_Tracks_Client {
 		return get_object_vars( $_event );
 	}
 
-	// Milliseconds since 1970-01-01
-	static function build_timestamp() {
+	/**
+	 * Builds a timestamp.
+	 *
+	 * Milliseconds since 1970-01-01.
+	 *
+	 * @return string
+	 */
+	public static function build_timestamp() {
 		$ts = round( microtime( true ) * 1000 );
 		return number_format( $ts, 0, '', '' );
 	}
@@ -146,7 +164,7 @@ class Jetpack_Tracks_Client {
 	 *
 	 * @return string An anon id for the user
 	 */
-	static function get_anon_id() {
+	public static function get_anon_id() {
 		static $anon_id = null;
 
 		if ( ! isset( $anon_id ) ) {
@@ -158,13 +176,13 @@ class Jetpack_Tracks_Client {
 
 				$binary = '';
 
-				// Generate a new anonId and try to save it in the browser's cookies
-				// Note that base64-encoding an 18 character string generates a 24-character anon id
+				// Generate a new anonId and try to save it in the browser's cookies.
+				// Note that base64-encoding an 18 character string generates a 24-character anon id.
 				for ( $i = 0; $i < 18; ++$i ) {
-					$binary .= chr( mt_rand( 0, 255 ) );
+					$binary .= chr( wp_rand( 0, 255 ) );
 				}
 
-				$anon_id = 'jetpack:' . base64_encode( $binary );
+				$anon_id = 'jetpack:' . base64_encode( $binary ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 
 				if ( ! headers_sent()
 					&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
@@ -183,8 +201,9 @@ class Jetpack_Tracks_Client {
 	 *
 	 * @return array|bool
 	 */
-	static function get_connected_user_tracks_identity() {
-		if ( ! $user_data = Jetpack::get_connected_user_data() ) {
+	public static function get_connected_user_tracks_identity() {
+		$user_data = Jetpack::get_connected_user_data();
+		if ( ! $user_data ) {
 			return false;
 		}
 

--- a/packages/tracking/legacy/class.tracks-client.php
+++ b/packages/tracking/legacy/class.tracks-client.php
@@ -53,7 +53,7 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	static function record_event( $event ) {
-		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
+		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] || Jetpack::is_development_mode() ) ) {
 			return false;
 		}
 

--- a/packages/tracking/src/Tracking.php
+++ b/packages/tracking/src/Tracking.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Status;
+
 /**
  * The Tracking class, used to record events in wpcom
  */
@@ -77,6 +79,12 @@ class Tracking {
 
 		// We don't want to track user events during unit tests/CI runs.
 		if ( $user instanceof \WP_User && 'wptests_capabilities' === $user->cap_key ) {
+			return false;
+		}
+
+		// Don't track users who have opted our, or not agreed to the TOS, or sites in development mode
+		$status = new Status();
+		if ( ! \Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) || $status->is_development_mode() ) {
 			return false;
 		}
 

--- a/packages/tracking/src/Tracking.php
+++ b/packages/tracking/src/Tracking.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack;
 
-use Automattic\Jetpack\Status;
-
 /**
  * The Tracking class, used to record events in wpcom
  */
@@ -103,9 +101,8 @@ class Tracking {
 			return false;
 		}
 
-		// Don't track users who have opted our, or not agreed to the TOS, or sites in development mode.
-		$status = new Status();
-		if ( ! \Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) || $status->is_development_mode() ) {
+		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
+		if ( ! \Jetpack::jetpack_tos_agreed() ) {
 			return false;
 		}
 


### PR DESCRIPTION
We shouldn't fire Tracks events when we are in dev mode, or if users haven't accepted our TOS, or if they have opted out of Tracks.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR adds a check for these three cases to ensure that we don't fire Tracks events in these cases

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This came up here: https://github.com/Automattic/jetpack/pull/13688#issuecomment-540026634, but is a more generic solution

#### Testing instructions:
* Upgrade your Jetpack site to Professional
* Add a Jetpack Search widget to the site
* Check that you see a `jetpack_search_widget_widget_added` event in Tracks
* Enable development mode (by adding this to `wp-config.php`):
`define( 'JETPACK_DEV_DEBUG', true );`
* Add a Jetpack Search widget to the site
* Check that you don't see another `jetpack_search_widget_widget_added` event in Tracks

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog required?
