### PR TITLE
Sites API Endpoint: use created_at value from wpcom

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -155,6 +155,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'jetpack_frame_nonce',
 		'design_type',
 		'wordads',
+		// Use the site registered date from wpcom, since it is only available in a multisite context
+		// and defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site.
+		// See https://github.com/Automattic/jetpack/blob/58638f46094b36f5df9cbc4570006544f0ad300c/sal/class.json-api-site-base.php#L387.
+		'created_at',
 	);
 
 	private $site;


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/36578

#### Changes proposed in this Pull Request:

Updates the response from `/sites/{siteId}` to use the site registered date from wpcom for the `options.created_at` value. This value defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site, because the value isn't available outside a multisite environment.

#### Testing instructions:

* Apply D33813-code to a wpcom sandbox and sandbox public-api.wordpress.com
* Use the developer console (https://developer.wordpress.com/docs/api/console/) to query `/sites/{siteId}?options=created_at` with the site id of an Atomic or Jetpack site
* You should see a date value in the response (`options.created_at`), other than `0000-00-00T00:00:00+00:00`

#### Proposed changelog entry for your changes:

* This API endpoint code is only run on wpcom, so no changelog entry is needed.
