### PR TITLE
Update: Add the tracks info to the abtest api endpoint

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -42,11 +42,17 @@ jQuery( document ).ready( function( $ ) {
 			}
 		},
 		startConnectionFlow: function() {
-			var abTestName = 'jetpack_connect_in_place_v2';
+			var abTestName = 'jetpack_connect_in_place_v3';
+			var type = jpConnect.identity && jpConnect.identity._ut;
+			var identity = jpConnect.identity && jpConnect.identity._ui;
 			$.ajax( {
 				url: 'https://public-api.wordpress.com/wpcom/v2/abtest/' + abTestName,
 				type: 'GET',
 				error: jetpackConnectButton.handleConnectionError,
+				data: {
+					_ut: type,
+					_ui: identity,
+				},
 				xhrFields: {
 					withCredentials: true,
 				},

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -43,16 +43,12 @@ jQuery( document ).ready( function( $ ) {
 		},
 		startConnectionFlow: function() {
 			var abTestName = 'jetpack_connect_in_place_v3';
-			var type = jpConnect.identity && jpConnect.identity._ut;
-			var identity = jpConnect.identity && jpConnect.identity._ui;
+
 			$.ajax( {
 				url: 'https://public-api.wordpress.com/wpcom/v2/abtest/' + abTestName,
 				type: 'GET',
 				error: jetpackConnectButton.handleConnectionError,
-				data: {
-					_ut: type,
-					_ui: identity,
-				},
+				data: jpConnect.identity,
 				xhrFields: {
 					withCredentials: true,
 				},

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -185,7 +185,7 @@ class Jetpack_Connection_Banner {
 				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
 				'plansPromptUrl'        => Jetpack::admin_url( 'page=jetpack#/plans-prompt' ),
-				'identity'             => $identity,
+				'identity'              => $identity,
 			)
 		);
 	}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -168,6 +168,9 @@ class Jetpack_Connection_Banner {
 			$force_variation = null;
 		}
 
+		$tracking = new Automattic\Jetpack\Tracking();
+		$identity = $tracking->tracks_get_identity( get_current_user_id() );
+
 		wp_localize_script(
 			'jetpack-connect-button',
 			'jpConnect',
@@ -182,6 +185,7 @@ class Jetpack_Connection_Banner {
 				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
 				'plansPromptUrl'        => Jetpack::admin_url( 'page=jetpack#/plans-prompt' ),
+				'identity'             => $identity,
 			)
 		);
 	}


### PR DESCRIPTION
Currently we don't pass in any info regarding the user to the tracks api endpoint which results in a leaky funnel. 

This PR fixes this by passing in the ut and ui to the api endpoint. 

#### Changes proposed in this Pull Request:
* Sends the user tracking info to the abtest endpoint. 

#### Testing instructions:
1. Apply the following code to your sandbox. D33826-code
2. Make sure that your site talks to your sandbox ( define( 'JETPACK__API_BASE', ...) ) as well as your browser talks to the .com api. (update /etc/hosts file) 
3. Go though the connection flow. 
4. Check the funnel make sure that we are not leaking info here. The events should be 100%. 

#### Proposed changelog entry for your changes:
Fixed: Connect in place abtest funnel. 
