### PR TITLE
Widgets: update from deprecated function for tracking.

### DIFF
--- a/_inc/lib/widgets.php
+++ b/_inc/lib/widgets.php
@@ -558,10 +558,14 @@ class Jetpack_Widgets {
 		// Add a Tracks event for non-Headstart activity.
 		if ( ! defined( 'HEADSTART' ) ) {
 			$tracking = new Automattic\Jetpack\Tracking();
-			$tracking->jetpack_tracks_record_event( wp_get_current_user(), 'wpcom_widgets_activate_widget', array(
-				'widget' => $id_base,
-				'settings' => json_encode( $settings ),
-			) );
+			$tracking->tracks_record_event(
+				wp_get_current_user(),
+				'wpcom_widgets_activate_widget',
+				array(
+					'widget'   => $id_base,
+					'settings' => wp_json_encode( $settings ),
+				)
+			);
 		}
 
 		return self::get_widget_by_id( $widget_id );


### PR DESCRIPTION
Follow up from #12674

#### Changes proposed in this Pull Request:

* Now that we've moved away from jetpack_tracks_record_event, let's stop using it in Jetpack.

#### Testing instructions:

* Start from a fresh site you've connected to WordPress.com.
* Go to http://mysite.com/wp-admin/admin.php?page=jetpack&action=onboard
* You'll be redirected to Calypso where you can follow the flow; you'll want to pick the Business > Static Welcome Page flow so you are offered the option to add an address for your business. It will effectively add a new Contact Info widget to your site.
* In Tracks Live Events, you will not see the `wpcom_widgets_activate_widget` event, but it doesn't appear on `master` today either.

#### Proposed changelog entry for your changes:

* None
