### PR TITLE
Replace parse_url with wp_parse_url

### DIFF
--- a/_inc/jetpack-server-sandbox.php
+++ b/_inc/jetpack-server-sandbox.php
@@ -15,7 +15,7 @@
 function jetpack_server_sandbox_request_parameters( $sandbox, $url, $headers ) {
 	$host = '';
 
-	$url_host = parse_url( $url, PHP_URL_HOST );
+	$url_host = wp_parse_url( $url, PHP_URL_HOST );
 
 	switch ( $url_host ) {
 	case 'public-api.wordpress.com' :

--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -206,7 +206,7 @@ class Jetpack_Media_Meta_Extractor {
 			if ( preg_match_all( '#(?:^|\s|"|\')(https?://([^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/))))#', $content, $matches ) ) {
 
 				foreach ( $matches[1] as $link_raw ) {
-					$url = parse_url( $link_raw );
+					$url = wp_parse_url( $link_raw );
 
 					// Data URI links
 					if ( isset( $url['scheme'] ) && 'data' === $url['scheme'] )
@@ -286,7 +286,7 @@ class Jetpack_Media_Meta_Extractor {
 				$embeds = array();
 
 				foreach ( $matches[1] as $link_raw ) {
-					$url = parse_url( $link_raw );
+					$url = wp_parse_url( $link_raw );
 
 					list( $proto, $link_all_but_proto ) = explode( '://', $link_raw );
 
@@ -402,11 +402,11 @@ class Jetpack_Media_Meta_Extractor {
 		if ( !empty( $from_html ) ) {
 			$srcs = wp_list_pluck( $from_html, 'src' );
 			foreach( $srcs as $image_url ) {
-				if ( ( $src = parse_url( $image_url ) ) && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
+				if ( ( $src = wp_parse_url( $image_url ) ) && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
 					// Rebuild the URL without the query string
 					$queryless = $src['scheme'] . '://' . $src['host'] . $src['path'];
 				} elseif ( $length = strpos( $image_url, '?' ) ) {
-					// If parse_url() didn't work, strip off the query string the old fashioned way
+					// If wp_parse_url() didn't work, strip off the query string the old fashioned way
 					$queryless = substr( $image_url, 0, $length );
 				} else {
 					// Failing that, there was no spoon! Err ... query string!

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -131,7 +131,7 @@ class Jetpack_Media_Summary {
 							$poster_image = get_post_meta( $post_id, 'vimeo_poster_image', true );
 							if ( !empty( $poster_image ) ) {
 								$return['image'] = $poster_image;
-								$poster_url_parts = parse_url( $poster_image );
+								$poster_url_parts = wp_parse_url( $poster_image );
 								$return['secure']['image'] = 'https://secure-a.vimeocdn.com' . $poster_url_parts['path'];
 							}
 						}
@@ -162,12 +162,12 @@ class Jetpack_Media_Summary {
 							$poster_image = get_post_meta( $post_id, 'vimeo_poster_image', true );
 							if ( !empty( $poster_image ) ) {
 								$return['image'] = $poster_image;
-								$poster_url_parts = parse_url( $poster_image );
+								$poster_url_parts = wp_parse_url( $poster_image );
 								$return['secure']['image'] = 'https://secure-a.vimeocdn.com' . $poster_url_parts['path'];
 							}
 						} else if ( false !== strpos( $embed, 'dailymotion' ) ) {
 							$return['image'] = str_replace( 'dailymotion.com/video/','dailymotion.com/thumbnail/video/', $embed );
-							$return['image'] = parse_url( $return['image'], PHP_URL_SCHEME ) === null ? 'http://' . $return['image'] : $return['image'];
+							$return['image'] = wp_parse_url( $return['image'], PHP_URL_SCHEME ) === null ? 'http://' . $return['image'] : $return['image'];
 							$return['secure']['image'] = self::https( $return['image'] );
 						}
 
@@ -348,8 +348,8 @@ class Jetpack_Media_Summary {
 	static function split_content_in_words( $text ) {
 		$words = preg_split( '/[\s!?;,.]+/', $text, null, PREG_SPLIT_NO_EMPTY );
 
-		// Return an empty array if the split above fails. 
-		return $words ? $words : array();	
+		// Return an empty array if the split above fails.
+		return $words ? $words : array();
 	}
 
 	static function get_word_count( $post_content ) {
@@ -358,7 +358,7 @@ class Jetpack_Media_Summary {
 
 	static function get_word_remaining_count( $post_content, $excerpt_content ) {
 		$content_word_count = count( self::split_content_in_words( self::clean_text( $post_content ) ) );
-		$excerpt_word_count = count( self::split_content_in_words( self::clean_text( $excerpt_content ) ) ); 
+		$excerpt_word_count = count( self::split_content_in_words( self::clean_text( $excerpt_content ) ) );
 
 		return (int) $content_word_count - $excerpt_word_count;
 	}

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -145,7 +145,7 @@ class Jetpack_Client_Server {
 		Jetpack::invalidate_onboarding_token();
 
 		// If redirect_uri is SSO, ensure SSO module is enabled
-		parse_str( parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
+		parse_str( wp_parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
 
 		/** This filter is documented in class.jetpack-cli.php */
 		$jetpack_start_enable_sso = apply_filters( 'jetpack_start_enable_sso', true );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -154,7 +154,7 @@ class Jetpack_Connection_Banner {
 			)
 		);
 
-		$jetpackApiUrl = parse_url( Jetpack::connection()->api_url( '' ) );
+		$jetpackApiUrl = wp_parse_url( Jetpack::connection()->api_url( '' ) );
 
 		// Due to the limitation in how 3rd party cookies are handled in Safari,
 		// we're falling back to the original flow on Safari desktop and mobile.

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -208,7 +208,7 @@ class Jetpack_PostImages {
 		$inserted_images = array();
 
 		foreach ( $html_images as $html_image ) {
-			$src = parse_url( $html_image['src'] );
+			$src = wp_parse_url( $html_image['src'] );
 			// strip off any query strings from src
 			if ( ! empty( $src['scheme'] ) && ! empty( $src['host'] ) ) {
 				$inserted_images[] = $src['scheme'] . '://' . $src['host'] . $src['path'];
@@ -713,7 +713,7 @@ class Jetpack_PostImages {
 		}
 
 		// If WPCOM hosted image use native transformations
-		$img_host = parse_url( $src, PHP_URL_HOST );
+		$img_host = wp_parse_url( $src, PHP_URL_HOST );
 		if ( '.files.wordpress.com' == substr( $img_host, -20 ) ) {
 			return add_query_arg(
 				array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3141,7 +3141,7 @@ p {
 			return array( 'wp-cli', null );
 		}
 
-		$referer = parse_url( $referer_url );
+		$referer = wp_parse_url( $referer_url );
 
 		$source_type  = 'unknown';
 		$source_query = null;
@@ -3150,8 +3150,8 @@ p {
 			return array( $source_type, $source_query );
 		}
 
-		$plugins_path         = parse_url( admin_url( 'plugins.php' ), PHP_URL_PATH );
-		$plugins_install_path = parse_url( admin_url( 'plugin-install.php' ), PHP_URL_PATH );// /wp-admin/plugin-install.php
+		$plugins_path         = wp_parse_url( admin_url( 'plugins.php' ), PHP_URL_PATH );
+		$plugins_install_path = wp_parse_url( admin_url( 'plugin-install.php' ), PHP_URL_PATH );// /wp-admin/plugin-install.php
 
 		if ( isset( $referer['query'] ) ) {
 			parse_str( $referer['query'], $query_parts );
@@ -3331,8 +3331,8 @@ p {
 			// Before attempting to connect, let's make sure that the domains are viable.
 			$domains_to_check = array_unique(
 				array(
-					'siteurl' => parse_url( get_site_url(), PHP_URL_HOST ),
-					'homeurl' => parse_url( get_home_url(), PHP_URL_HOST ),
+					'siteurl' => wp_parse_url( get_site_url(), PHP_URL_HOST ),
+					'homeurl' => wp_parse_url( get_home_url(), PHP_URL_HOST ),
 				)
 			);
 			foreach ( $domains_to_check as $domain ) {
@@ -5583,7 +5583,7 @@ endif;
 	public static function staticize_subdomain( $url ) {
 
 		// Extract hostname from URL
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 
 		// Explode hostname on '.'
 		$exploded_host = explode( '.', $host );
@@ -5637,7 +5637,7 @@ endif;
 			return $url;
 		}
 
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 		$url        = strtok( $url, '?' );
 		$url        = "$url?{$_SERVER['QUERY_STRING']}";
 		if ( ! empty( $parsed_url['query'] ) ) {
@@ -6350,7 +6350,7 @@ endif;
 	public static function absolutize_css_urls( $css, $css_file_url ) {
 		$pattern = '#url\((?P<path>[^)]*)\)#i';
 		$css_dir = dirname( $css_file_url );
-		$p       = parse_url( $css_dir );
+		$p       = wp_parse_url( $css_dir );
 		$domain  = sprintf(
 			'%1$s//%2$s%3$s%4$s',
 			isset( $p['scheme'] ) ? "{$p['scheme']}:" : '',

--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -1923,7 +1923,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 		}
 
 		// if we didn't get a URL, let's bail
-		$parsed = @parse_url( $url );
+		$parsed = wp_parse_url( $url );
 		if ( empty( $parsed ) ) {
 			return false;
 		}
@@ -1942,7 +1942,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 
 		// emulate a $_FILES entry
 		$file_array = array(
-			'name'     => basename( parse_url( $url, PHP_URL_PATH ) ),
+			'name'     => basename( wp_parse_url( $url, PHP_URL_PATH ) ),
 			'tmp_name' => $tmp,
 		);
 

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -96,7 +96,7 @@ class WPCOM_JSON_API {
 			$this->url = $url;
 		}
 
-		$parsed = parse_url( $this->url );
+		$parsed = wp_parse_url( $this->url );
 		if ( ! empty( $parsed['path'] ) ) {
 			$this->path = $parsed['path'];
 		}

--- a/class.photon.php
+++ b/class.photon.php
@@ -1019,13 +1019,13 @@ class Jetpack_Photon {
 	 * @return bool
 	 */
 	protected static function validate_image_url( $url ) {
-		$parsed_url = @parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		if ( ! $parsed_url ) {
 			return false;
 		}
 
-		// Parse URL and ensure needed keys exist, since the array returned by `parse_url` only includes the URL components it finds.
+		// Parse URL and ensure needed keys exist, since the array returned by `wp_parse_url` only includes the URL components it finds.
 		$url_info = wp_parse_args(
 			$parsed_url,
 			array(

--- a/functions.compat.php
+++ b/functions.compat.php
@@ -24,7 +24,7 @@ function jetpack_get_youtube_id( $url ) {
 	}
 
 	$url = youtube_sanitize_url( $url );
-	$url = parse_url( $url );
+	$url = wp_parse_url( $url );
 	$id  = false;
 
 	if ( ! isset( $url['query'] ) )

--- a/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -287,7 +287,7 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 		}
 
 		// if we didn't get a URL, let's bail
-		$parsed = @parse_url( $url );
+		$parsed = wp_parse_url( $url );
 		if ( empty( $parsed ) ) {
 			return new WP_Error( 'invalid_url', 'No media provided in url.' );
 		}

--- a/json-endpoints/class.wpcom-json-api-render-embed-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-render-embed-endpoint.php
@@ -49,7 +49,7 @@ class WPCOM_JSON_API_Render_Embed_Endpoint extends WPCOM_JSON_API_Render_Endpoin
 		}
 
 		$embed_url = array_shift( $matches[1] );
-		$parts = parse_url( $embed_url );
+		$parts = wp_parse_url( $embed_url );
 		if ( ! $parts ) {
 			return new WP_Error( 'invalid_embed_url', __( 'The embed_url parameter must be a valid URL.', 'jetpack' ), 400 );
 		}

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -315,7 +315,7 @@ class Jetpack_Carousel {
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
 			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! Jetpack::is_development_mode() ) {
-				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
+				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.
 				if ( is_user_logged_in() && function_exists( 'stats_get_options' ) ) {

--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -38,7 +38,7 @@ class Jetpack_Comment_Likes {
 		$this->settings  = new Jetpack_Likes_Settings();
 		$this->blog_id   = Jetpack_Options::get_option( 'id' );
 		$this->url       = home_url();
-		$this->url_parts = parse_url( $this->url );
+		$this->url_parts = wp_parse_url( $this->url );
 		$this->domain    = $this->url_parts['host'];
 
 		add_action( 'template_redirect', array( $this, 'frontend_init' ) );

--- a/modules/comments/comments.php
+++ b/modules/comments/comments.php
@@ -156,7 +156,7 @@ class Jetpack_Comments extends Highlander_Comments_Base {
 
 		// Detect whether it's a Facebook or Twitter avatar
 		$foreign_avatar          = get_comment_meta( $comment->comment_ID, 'hc_avatar', true );
-		$foreign_avatar_hostname = parse_url( $foreign_avatar, PHP_URL_HOST );
+		$foreign_avatar_hostname = wp_parse_url( $foreign_avatar, PHP_URL_HOST );
 		if ( ! $foreign_avatar_hostname ||
 			! preg_match( '/\.?(graph\.facebook\.com|twimg\.com)$/', $foreign_avatar_hostname ) ) {
 			return $avatar;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2619,7 +2619,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$to[ $to_key ] = self::add_name_to_address( $to_value );
 		}
 
-		$blog_url        = parse_url( site_url() );
+		$blog_url        = wp_parse_url( site_url() );
 		$from_email_addr = 'wordpress@' . $blog_url['host'];
 
 		if ( ! empty( $comment_author_email ) ) {

--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -149,7 +149,7 @@ class Jetpack_Infinite_Scroll_Extras {
 			}
 
 			// We made it this far, so gather the data needed to track IS views
-			$settings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
+			$settings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 			// Pagetype parameter
 			$settings['stats'] .= '&x_pagetype=infinite';

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -136,7 +136,7 @@ function jetpack_mobile_available() {
 function jetpack_mobile_request_handler() {
 	global $wpdb;
 	if (isset($_GET['ak_action'])) {
-		$url = parse_url( get_bloginfo( 'url' ) );
+		$url = wp_parse_url( get_bloginfo( 'url' ) );
 		$domain = $url['host'];
 		if (!empty($url['path'])) {
 			$path = $url['path'];

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -881,14 +881,14 @@ class Jetpack_Protect_Module {
 			$uri = network_home_url();
 		}
 
-		$uridata = parse_url( $uri );
+		$uridata = wp_parse_url( $uri );
 
 		$domain = $uridata['host'];
 
 		// If we still don't have the site_url, get it
 		if ( ! $domain ) {
 			$uri     = get_site_url( 1 );
-			$uridata = parse_url( $uri );
+			$uridata = wp_parse_url( $uri );
 			$domain  = $uridata['host'];
 		}
 

--- a/modules/protect/shared-functions.php
+++ b/modules/protect/shared-functions.php
@@ -201,7 +201,7 @@ function jetpack_protect_get_ip() {
  */
 function jetpack_clean_ip( $ip ) {
 
-	// Some misconfigured servers give back extra info, which comes after "unless"
+	// Some misconfigured servers give back extra info, which comes after "unless".
 	$ips = explode( ' unless ', $ip );
 	$ip = $ips[0];
 
@@ -211,8 +211,8 @@ function jetpack_clean_ip( $ip ) {
 		$ip = $matches[1];
 	}
 
-	if ( function_exists( 'parse_url' ) ) {
-		$parsed_url = parse_url( $ip );
+	if ( function_exists( 'wp_parse_url' ) ) {
+		$parsed_url = wp_parse_url( $ip );
 
 		if ( isset( $parsed_url['host'] ) ) {
 			$ip = $parsed_url['host'];

--- a/modules/publicize/publicize-jetpack.php
+++ b/modules/publicize/publicize-jetpack.php
@@ -639,7 +639,7 @@ class Publicize extends Publicize_Base {
 	}
 
 	function get_basehostname( $url ) {
-		return parse_url( $url, PHP_URL_HOST );
+		return wp_parse_url( $url, PHP_URL_HOST );
 	}
 
 	function options_save_tumblr() {

--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -320,7 +320,7 @@ abstract class Publicize_Base {
 		$cmeta = $this->get_connection_meta( $connection );
 
 		if ( isset( $cmeta['connection_data']['meta']['link'] ) ) {
-			if ( 'facebook' == $service_name && 0 === strpos( parse_url( $cmeta['connection_data']['meta']['link'], PHP_URL_PATH ), '/app_scoped_user_id/' ) ) {
+			if ( 'facebook' == $service_name && 0 === strpos( wp_parse_url( $cmeta['connection_data']['meta']['link'], PHP_URL_PATH ), '/app_scoped_user_id/' ) ) {
 				// App-scoped Facebook user IDs are not usable profile links
 				return false;
 			}
@@ -337,7 +337,7 @@ abstract class Publicize_Base {
 				return false;
 			}
 
-			$profile_url_query = parse_url( $cmeta['connection_data']['meta']['profile_url'], PHP_URL_QUERY );
+			$profile_url_query = wp_parse_url( $cmeta['connection_data']['meta']['profile_url'], PHP_URL_QUERY );
 			wp_parse_str( $profile_url_query, $profile_url_query_args );
 			if ( isset( $profile_url_query_args['key'] ) ) {
 				$id = $profile_url_query_args['key'];

--- a/modules/sso/class.jetpack-sso-helpers.php
+++ b/modules/sso/class.jetpack-sso-helpers.php
@@ -192,7 +192,7 @@ class Jetpack_SSO_Helpers {
 		$hosts[] = 'public-api.wordpress.com';
 
 		if ( false === strpos( $api_base, 'jetpack.wordpress.com/jetpack' ) ) {
-			$base_url_parts = parse_url( esc_url_raw( $api_base ) );
+			$base_url_parts = wp_parse_url( esc_url_raw( $api_base ) );
 			if ( $base_url_parts && ! empty( $base_url_parts[ 'host' ] ) ) {
 				$hosts[] = $base_url_parts[ 'host' ];
 			}

--- a/modules/stats.php
+++ b/modules/stats.php
@@ -237,7 +237,7 @@ function stats_footer() {
 	} else {
 		stats_render_footer( $data );
 	}
-	
+
 }
 
 function stats_render_footer( $data ) {
@@ -903,7 +903,7 @@ function stats_update_blog() {
  * @return string
  */
 function stats_get_blog() {
-	$home = parse_url( trailingslashit( get_option( 'home' ) ) );
+	$home = wp_parse_url( trailingslashit( get_option( 'home' ) ) );
 	$blog = array(
 		'host'                => $home['host'],
 		'path'                => $home['path'],

--- a/modules/videopress/class.videopress-video.php
+++ b/modules/videopress/class.videopress-video.php
@@ -314,7 +314,7 @@ class VideoPress_Video {
 	 * @return bool|string host component of the URL, or false if none found
 	 */
 	public static function hostname( $url ) {
-		return parse_url( esc_url_raw( $url ), PHP_URL_HOST );
+		return wp_parse_url( esc_url_raw( $url ), PHP_URL_HOST );
 	}
 
 

--- a/modules/videopress/editor-media-view.php
+++ b/modules/videopress/editor-media-view.php
@@ -29,7 +29,7 @@ function videopress_handle_editor_view_js() {
 		'videopress-editor-view',
 		'vpEditorView',
 		array(
-			'home_url_host'     => parse_url( home_url(), PHP_URL_HOST ),
+			'home_url_host'     => wp_parse_url( home_url(), PHP_URL_HOST ),
 			'min_content_width' => VIDEOPRESS_MIN_WIDTH,
 			'content_width'     => $content_width,
 			'modal_labels'      => array(

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -226,7 +226,7 @@ class VideoPress_Shortcode {
 		if ( false === stripos( $oembed_provider, 'videopress.com' ) ) {
 			return $oembed_provider;
 		}
-		return add_query_arg( 'for', parse_url( home_url(), PHP_URL_HOST ), $oembed_provider );
+		return add_query_arg( 'for', wp_parse_url( home_url(), PHP_URL_HOST ), $oembed_provider );
 	}
 
 	/**

--- a/modules/widgets/flickr.php
+++ b/modules/widgets/flickr.php
@@ -74,7 +74,7 @@ if ( ! class_exists( 'Jetpack_Flickr_Widget' ) ) {
 				 * Parse the URL, and rebuild a URL that's sure to display images.
 				 * Some Flickr Feeds do not display images by default.
 				 */
-				$flickr_parameters = parse_url( htmlspecialchars_decode( $instance['flickr_rss_url'] ) );
+				$flickr_parameters = wp_parse_url( htmlspecialchars_decode( $instance['flickr_rss_url'] ) );
 
 				// Is it a Flickr Feed.
 				if (

--- a/modules/widgets/social-media-icons.php
+++ b/modules/widgets/social-media-icons.php
@@ -147,7 +147,7 @@ class WPCOM_social_media_icons_widget extends WP_Widget {
 			/** Check if full URL entered in configuration, use it instead of tinkering **/
 			if (
 				in_array(
-					parse_url( $username, PHP_URL_SCHEME ),
+					wp_parse_url( $username, PHP_URL_SCHEME ),
 					array( 'http', 'https' )
 				)
 			) {

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -52,7 +52,7 @@ class WordAds_Params {
 		$this->targeting_tags = array(
 			'WordAds' => 1,
 			'BlogId'  => Jetpack::is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
-			'Domain'  => esc_js( parse_url( home_url(), PHP_URL_HOST ) ),
+			'Domain'  => esc_js( wp_parse_url( home_url(), PHP_URL_HOST ) ),
 			'PageURL' => esc_js( $this->url ),
 			'LangId'  => false !== strpos( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?
 			'AdSafe'  => 1, // TODO

--- a/packages/connection/legacy/class.jetpack-signature.php
+++ b/packages/connection/legacy/class.jetpack-signature.php
@@ -156,7 +156,6 @@ class Jetpack_Signature {
 	 *
 	 * @todo Having body_hash v. body-hash is annoying. Refactor to accept an array?
 	 * @todo Use wp_json_encode() instead of json_encode()?
-	 * @todo Use wp_parse_url() instead of parse_url()?
 	 *
 	 * @param string $token            Request token.
 	 * @param int    $timestamp        Timestamp of the request.
@@ -225,8 +224,7 @@ class Jetpack_Signature {
 			}
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-		$parsed = parse_url( $url );
+		$parsed = wp_parse_url( $url );
 		if ( ! isset( $parsed['host'] ) ) {
 			return new WP_Error( 'invalid_signature', sprintf( 'The required "%s" parameter is malformed.', 'url' ), compact( 'signature_details' ) );
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -380,7 +380,7 @@ abstract class SAL_Site {
 	}
 
 	function get_xmlrpc_url() {
-		$xmlrpc_scheme = apply_filters( 'wpcom_json_api_xmlrpc_scheme', parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
+		$xmlrpc_scheme = apply_filters( 'wpcom_json_api_xmlrpc_scheme', wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME ) );
 		return site_url( 'xmlrpc.php', $xmlrpc_scheme );
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -571,7 +571,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		wp_set_current_user( $user->ID );
 
 		// Build URL to compare scheme and host with the one in response
-		$admin_url = parse_url( admin_url() );
+		$admin_url = wp_parse_url( admin_url() );
 
 		// Create REST request in JSON format and dispatch
 		$response = $this->create_and_get_request( 'connection/url' );
@@ -580,7 +580,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertResponseStatus( 200, $response );
 
 		// Format data to test it
-		$response->data = parse_url( $response->data );
+		$response->data = wp_parse_url( $response->data );
 		parse_str( $response->data['query'], $response->data['query'] );
 
 		// It has a nonce
@@ -638,7 +638,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Success, URL was built
 		$this->assertResponseStatus( 200, $response );
 
-		$response->data = parse_url( $response->data );
+		$response->data = wp_parse_url( $response->data );
 		parse_str( $response->data['query'], $response->data['query'] );
 
 		// Because dotcom will not respond to a fake token, the method

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -861,7 +861,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	function add_www_subdomain_to_siteurl( $url ) {
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		return "{$parsed_url['scheme']}://www.{$parsed_url['host']}";
 	}

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -27,7 +27,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photonizing_https_image_adds_ssl_query_arg() {
 		$url = jetpack_photon_url( 'https://example.com/images/photon.jpg' );
-		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
 		$this->assertEquals( '1', $args['ssl'], 'HTTPS image sources should have a ?ssl=1 query string.' );
 	}
 
@@ -38,7 +38,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photonizing_http_image_no_ssl_query_arg() {
 		$url = jetpack_photon_url( 'http://example.com/images/photon.jpg' );
-		parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+		parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
 		$this->assertArrayNotHasKey( 'ssl', $args, 'HTTP image source should not have an ssl query string.' );
 	}
 
@@ -50,7 +50,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photon_url_no_filter_http() {
 		$url = jetpack_photon_url( 'http://example.com/img.jpg' );
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		$this->assertEquals( 'https', $parsed_url['scheme'] );
 		$this->assertMatchesPhotonHost( $parsed_url['host'] );
@@ -65,7 +65,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 	 */
 	public function test_photon_url_no_filter_http_to_http() {
 		$url = jetpack_photon_url( 'http://example.com/img.jpg', array(), 'http' );
-		$parsed_url = parse_url( $url );
+		$parsed_url = wp_parse_url( $url );
 
 		$this->assertEquals( 'http', $parsed_url['scheme'] );
 		$this->assertMatchesPhotonHost( $parsed_url['host'] );

--- a/tools/export-translations.php
+++ b/tools/export-translations.php
@@ -33,7 +33,7 @@ function apize_url( $url ) {
 		return $url;
 	}
 
-	$host = preg_quote( parse_url( $url, PHP_URL_HOST ) );
+	$host = preg_quote( wp_parse_url( $url, PHP_URL_HOST ) );
 
 	return preg_replace( "#^https?://$host#", '\\0/api', $url );
 }

--- a/tools/import-translations.php
+++ b/tools/import-translations.php
@@ -30,7 +30,7 @@ function apize_url( $url ) {
 		return $url;
 	}
 
-	$host = preg_quote( parse_url( $url, PHP_URL_HOST ) );
+	$host = preg_quote( wp_parse_url( $url, PHP_URL_HOST ) );
 
 	return preg_replace( "#^https?://$host#", '\\0/api', $url );
 }


### PR DESCRIPTION
`wp_parse_url` is a wrapper for `parse_url` that normalizes differences across PHP versions. It is a drop-in replacement.

This updates all instances (with the exception of a couple of functions.photon.php already fixed in a pending PHPCS PR) and removes any error suppression (e.g. `@parse_url`) since `wp_parse_url` already does that.

Fixes #6801

#### Changes proposed in this Pull Request:
* Replaces `parse_url` with `wp_parse_url`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* Coding Standards: Replace parse_url with WordPress-provided functionality.
