### PR TITLE
Remove white background from Jetpack Ads block

### DIFF
--- a/extensions/blocks/wordads/editor.scss
+++ b/extensions/blocks/wordads/editor.scss
@@ -1,9 +1,5 @@
 @import '../../shared/styles/gutenberg-colors.scss';
 
-.wp-block-jetpack-wordads {
-	background: $white;
-}
-
 [data-type='jetpack/wordads'][data-align='center'] .jetpack-wordads__ad {
 	margin: 0 auto;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This removes the white background from the Jetpack Ads block.

Fixes #13715 

**Before:**
<img width="317" alt="Screen Shot 2019-10-10 at 2 43 12 PM" src="https://user-images.githubusercontent.com/204742/66606109-ac3b2d00-eb6e-11e9-8540-6554c30f7066.png">
**After:**
<img width="338" alt="Screen Shot 2019-10-10 at 2 43 36 PM" src="https://user-images.githubusercontent.com/204742/66606110-ac3b2d00-eb6e-11e9-94bb-d72624420971.png">


#### Testing instructions:
- Check out this PR
- Add a Jetpack Ads block to any post
- See that there is no white background color in the block like in the above "After" mockup.

#### Proposed changelog entry for your changes:
* None needed.