### PR TITLE
Jetpack Authors Widget - improve Author/Post text hierarchy and styling

### DIFF
--- a/modules/widgets/authors/style.css
+++ b/modules/widgets/authors/style.css
@@ -35,5 +35,5 @@
 }
 
 .widget_authors li:first-child {
-    margin-top: 2rem;
+	margin-top: 2rem;
 }

--- a/modules/widgets/authors/style.css
+++ b/modules/widgets/authors/style.css
@@ -3,6 +3,11 @@
 	margin-left: inherit;
 	padding-left: 0;
 }
+
+.widget_authors ul {
+	margin-left: 0;
+}
+
 .widget_authors ul li li {
 	padding-left: 0;
 }
@@ -22,4 +27,13 @@
 	vertical-align: middle;
 	-webkit-box-shadow: none;
 	box-shadow: none;
+}
+
+.widget_authors li {
+	margin-top: 1rem;
+	list-style: none;
+}
+
+.widget_authors li:first-child {
+    margin-top: 2rem;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates the styling of the Jetpack Authors block by removing the bullets, improving the hierarchy between the author and posts by adjusting the margins and padding between items, and removing the left margin from the widget.

Fixes #13718

**Before/After**
<img width="914" alt="Screen Shot 2019-10-10 at 4 38 34 PM" src="https://user-images.githubusercontent.com/204742/66611970-62a60e80-eb7d-11e9-98e2-fe74db8e9c77.png">

#### Testing instructions:
- Check out this PR on a site with Jetpack and Twenty Twenty theme installed
- Go to Jetpack Settings > Writing (at SITE_URL/wp-admin/admin.php?page=jetpack#/writing) and switch on both toggles under Widgets
- Go to Appearance > Widgets and add the "Authors (Jetpack)" widget to your site wherever you want
- See that the Authors widget looks like the above "After" mockup.

#### Proposed changelog entry for your changes:
* None needed
