### PR TITLE
JITM: Correct the namespace and class in the add_filter() calls.

### DIFF
--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -419,26 +419,20 @@ class JITM {
 	/**
 	 * Asks the wpcom API for the current message to display keyed on query string and message path
 	 *
-	 * @param $message_path string The message path to ask for
-	 * @param $query string The query string originally from the front end
+	 * @param string $message_path The message path to ask for.
+	 * @param string $query The query string originally from the front end.
 	 *
 	 * @return array The JITM's to show, or an empty array if there is nothing to show
 	 */
-	function get_messages( $message_path, $query ) {
-		// custom filters go here
-		add_filter( 'jitm_woocommerce_services_msg', array( 'Jetpack_JITM', 'jitm_woocommerce_services_msg' ) );
-		add_filter( 'jitm_jetpack_woo_services_install', array( 'Jetpack_JITM', 'jitm_jetpack_woo_services_install' ) );
-		add_filter(
-			'jitm_jetpack_woo_services_activate',
-			array(
-				'Jetpack_JITM',
-				'jitm_jetpack_woo_services_activate',
-			)
-		);
+	public function get_messages( $message_path, $query ) {
+		// Custom filters go here.
+		add_filter( 'jitm_woocommerce_services_msg', array( $this, 'jitm_woocommerce_services_msg' ) );
+		add_filter( 'jitm_jetpack_woo_services_install', array( $this, 'jitm_jetpack_woo_services_install' ) );
+		add_filter( 'jitm_jetpack_woo_services_activate', array( $this, 'jitm_jetpack_woo_services_activate' ) );
 
 		$user = wp_get_current_user();
 
-		// unauthenticated or invalid requests just bail
+		// Unauthenticated or invalid requests just bail.
 		if ( ! $user ) {
 			return array();
 		}
@@ -446,7 +440,7 @@ class JITM {
 		$user_roles = implode( ',', $user->roles );
 		$site_id    = \Jetpack_Options::get_option( 'id' );
 
-		// build our jitm request
+		// Build our jitm request.
 		$path = add_query_arg(
 			array(
 				'external_user_id' => urlencode_deep( $user->ID ),
@@ -458,10 +452,10 @@ class JITM {
 			sprintf( '/sites/%d/jitm/%s', $site_id, $message_path )
 		);
 
-		// attempt to get from cache
+		// Attempt to get from cache.
 		$envelopes = get_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ) );
 
-		// if something is in the cache and it was put in the cache after the last sync we care about, use it
+		// If something is in the cache and it was put in the cache after the last sync we care about, use it.
 		$use_cache = false;
 
 		/** This filter is documented in class.jetpack.php */
@@ -476,7 +470,7 @@ class JITM {
 			$from_cache = false;
 		}
 
-		// otherwise, ask again
+		// Otherwise, ask again.
 		if ( ! $from_cache ) {
 			$wpcom_response = Client::wpcom_json_api_request_as_blog(
 				$path,
@@ -502,7 +496,7 @@ class JITM {
 
 			$expiration = isset( $envelopes[0] ) ? $envelopes[0]->ttl : 300;
 
-			// do not cache if expiration is 0 or we're not using the cache
+			// Do not cache if expiration is 0 or we're not using the cache.
 			if ( 0 != $expiration && $use_cache ) {
 				$envelopes['last_response_time'] = time();
 
@@ -526,7 +520,7 @@ class JITM {
 
 			$dismissed_feature = isset( $hidden_jitms[ $envelope->feature_class ] ) && is_array( $hidden_jitms[ $envelope->feature_class ] ) ? $hidden_jitms[ $envelope->feature_class ] : null;
 
-			// if the this feature class has been dismissed and the request has not passed the ttl, skip it as it's been dismissed
+			// If the this feature class has been dismissed and the request has not passed the ttl, skip it as it's been dismissed.
 			if ( is_array( $dismissed_feature ) && ( time() - $dismissed_feature['last_dismissal'] < $envelope->expires || $dismissed_feature['number'] >= $envelope->max_dismissal ) ) {
 				unset( $envelopes[ $idx ] );
 				continue;
@@ -550,7 +544,7 @@ class JITM {
 			if ( ! class_exists( 'Jetpack_Affiliate' ) ) {
 				require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 			}
-			// Get affiliate code and add it to the array of URL parameters
+			// Get affiliate code and add it to the array of URL parameters.
 			if ( '' !== ( $aff = \Jetpack_Affiliate::init()->get_affiliate_code() ) ) {
 				$url_params['aff'] = $aff;
 			}
@@ -569,7 +563,7 @@ class JITM {
 				unset( $envelope->content->hook );
 			}
 
-			// no point in showing an empty message
+			// No point in showing an empty message.
 			if ( empty( $envelope->content->message ) ) {
 				unset( $envelopes[ $idx ] );
 				continue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

The `add_filter()` calls in the `get_message()` method are using an old class name, `Jetpack_JITM`. When a JITM that uses one of these filters is displayed, the JITM's CTA does not work properly and the following PHP warning is generated:

`PHP Warning:  call_user_func_array() expects parameter 1 to be a valid callback, class 'Jetpack_JITM'`


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the `add_filter()` calls by adding the correct namespace and class name.
* Fix various PHPCS comment errors in the `get_messages()` method.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This fixes a bug in an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Install and activate Jetpack and WooCommerce. Do not install WooCommerce Services. Enable debug mode and debug logging.
2. Connect Jetpack.
3. On wp-admin, navigate to WooCommerce -> Settings and set the Country / State to United States (any state).
4. Refresh the WooCommerce -> Settings page.
5. Dismiss the JITMs (which are located above the tabs) until you see one with the button text "Install WooCommerce Services". Do not dismiss this JITM.
6. Check debug.log - you should see the PHP warning for `call_user_func_array()`.
7. Apply this patch.
8. Refresh WooCommerce ->Settings. The "Install WooCommerce Services" JITM should still be displayed at the top of the page.
9. Check debug.log. The PHP warning for `call_user_func_array()` should not be generated.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* TBD
