### PR TITLE
Instant Search: Clean up some design bugs/issues

### DIFF
--- a/modules/search/instant-search/components/search-filter-dates.jsx
+++ b/modules/search/instant-search/components/search-filter-dates.jsx
@@ -50,7 +50,7 @@ export default class SearchFilterDates extends Component {
 				<h4 className="jetpack-search-filters-widget__sub-heading">
 					{ this.props.configuration.name }
 				</h4>
-				<ul className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
+				<div className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
 					{ this.props.aggregation &&
 						'buckets' in this.props.aggregation &&
 						[
@@ -62,7 +62,7 @@ export default class SearchFilterDates extends Component {
 							// TODO: Remove this reverse & slice when API adds filter count support
 							.reverse()
 							.slice( 0, this.props.configuration.count ) }
-				</ul>
+				</div>
 			</div>
 		);
 	}

--- a/modules/search/instant-search/components/search-filter-post-types.jsx
+++ b/modules/search/instant-search/components/search-filter-post-types.jsx
@@ -48,11 +48,11 @@ export default class SearchFilterPostTypes extends Component {
 				<h4 className="jetpack-search-filters-widget__sub-heading">
 					{ this.props.configuration.name }
 				</h4>
-				<ul className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
+				<div className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
 					{ this.props.aggregation &&
 						'buckets' in this.props.aggregation &&
 						this.props.aggregation.buckets.map( this.renderPostType ) }
-				</ul>
+				</div>
 			</div>
 		);
 	}

--- a/modules/search/instant-search/components/search-filter-taxonomies.jsx
+++ b/modules/search/instant-search/components/search-filter-taxonomies.jsx
@@ -48,11 +48,11 @@ export default class SearchFilterTaxonomies extends Component {
 				<h4 className="jetpack-search-filters-widget__sub-heading">
 					{ this.props.configuration.name }
 				</h4>
-				<ul className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
+				<div className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
 					{ this.props.aggregation &&
 						'buckets' in this.props.aggregation &&
 						this.props.aggregation.buckets.map( this.renderTaxonomy ) }
-				</ul>
+				</div>
 			</div>
 		);
 	}

--- a/modules/search/instant-search/components/search-filters-widget.scss
+++ b/modules/search/instant-search/components/search-filters-widget.scss
@@ -2,4 +2,5 @@
 	label {
 		display: inline-block;
 	}
+	margin-bottom: 10px;
 }

--- a/modules/search/instant-search/components/search-filters-widget.scss
+++ b/modules/search/instant-search/components/search-filters-widget.scss
@@ -2,7 +2,7 @@
 	div label {
 		display: inline-block;
 		width: auto;
-		margin-left: 7px;
+		margin-left: 5px;
 	}
 	margin-bottom: 10px;
 	text-align: left;

--- a/modules/search/instant-search/components/search-filters-widget.scss
+++ b/modules/search/instant-search/components/search-filters-widget.scss
@@ -1,6 +1,9 @@
 .jetpack-search-filters-widget__filter-list {
-	label {
+	div label {
 		display: inline-block;
+		width: auto;
+		margin-left: 7px;
 	}
 	margin-bottom: 10px;
+	text-align: left;
 }

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -27,7 +27,6 @@ const ShortcodeTypes = {
 	],
 	gallery: [ 'gallery', 'ione_media_gallery' ],
 	audio: [ 'audio', 'soundcloud' ],
-	code: [ 'code', 'sourcecode' ],
 };
 
 class SearchResultMinimal extends Component {
@@ -66,49 +65,42 @@ class SearchResultMinimal extends Component {
 		}
 		const noTags = tags.length === 0 && cats.length === 0;
 
-		let hasVideo = this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.video );
-		let hasAudio = this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.audio );
-		const hasCode = this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.code );
-
-		let hasGallery =
-			this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.gallery ) ||
-			fields[ 'has.image' ] > 1;
-		let hasImage = fields[ 'has.image' ] === 1;
+		const hasVideo = this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.video );
+		const hasAudio = this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.audio );
+		const hasGallery = this.arrayOverlap( fields.shortcode_types, ShortcodeTypes.gallery );
 
 		let postTypeIcon = null;
 		switch ( fields.post_type ) {
 			case 'product':
 				postTypeIcon = <Gridicon icon="cart" size={ IconSize } />;
-				hasImage = false;
-				hasGallery = false;
 				break;
 			case 'page':
-				postTypeIcon = <Gridicon icon="pages" size={ IconSize } />;
+				if ( hasVideo ) {
+					postTypeIcon = <Gridicon icon="video" size={ IconSize } />;
+				} else if ( hasAudio ) {
+					postTypeIcon = <Gridicon icon="audio" size={ IconSize } />;
+				} else {
+					postTypeIcon = <Gridicon icon="pages" size={ IconSize } />;
+				}
 				break;
 			case 'video':
-				hasVideo = true;
+				postTypeIcon = <Gridicon icon="video" size={ IconSize } />;
 				break;
 			case 'gallery':
-				hasGallery = true;
+				postTypeIcon = <Gridicon icon="image-multiple" size={ IconSize } />;
 				break;
 			case 'event':
 			case 'events':
 				postTypeIcon = <Gridicon icon="calendar" size={ IconSize } />;
 				break;
-		}
-
-		//don't show too many icons
-		if ( hasVideo ) {
-			hasImage = false;
-			hasGallery = false;
-			hasAudio = false;
-		}
-		if ( hasAudio ) {
-			hasImage = false;
-			hasGallery = false;
-		}
-		if ( hasGallery ) {
-			hasImage = false;
+			default:
+				if ( hasVideo ) {
+					postTypeIcon = <Gridicon icon="video" size={ IconSize } />;
+				} else if ( hasAudio ) {
+					postTypeIcon = <Gridicon icon="audio" size={ IconSize } />;
+				} else if ( hasGallery ) {
+					postTypeIcon = <Gridicon icon="image-multiple" size={ IconSize } />;
+				}
 		}
 
 		return (
@@ -126,11 +118,6 @@ class SearchResultMinimal extends Component {
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
-					{ hasVideo && <Gridicon icon="video" size={ IconSize } /> }
-					{ hasImage && <Gridicon icon="image" size={ IconSize } /> }
-					{ hasGallery && <Gridicon icon="image-multiple" size={ IconSize } /> }
-					{ hasAudio && <Gridicon icon="audio" size={ IconSize } /> }
-					{ hasCode && <Gridicon icon="code" size={ IconSize } /> }
 				</h3>
 
 				{ no_content && (

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -4,6 +4,7 @@
 	position: relative;
 	max-width: 1080px;
 	min-height: 400px;
+	text-align: left;
 }
 
 .jetpack-instant-search__search-results-real-query {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -3,6 +3,7 @@
 	margin: 1em auto;
 	position: relative;
 	max-width: 1080px;
+	min-height: 400px;
 }
 
 .jetpack-instant-search__search-results-real-query {

--- a/modules/search/instant-search/components/search-sort-widget.scss
+++ b/modules/search/instant-search/components/search-sort-widget.scss
@@ -1,3 +1,7 @@
 .jetpack-instant-search__sort-widget-select {
 	margin-left: 4px;
+	text-align: left;
+}
+.jetpack-search-sort-wrapper {
+	text-align: left;
 }


### PR DESCRIPTION
Implements a number of design tweaks that were suggested from the demo:
- Gets rid of having multiple icons, but does potentially show a single one depending on the content or post type of the result. Hopefully this helps differentiate different types of results while not adding as much clutter.
- Fixes html for the filters so it is all divs
- adds left justify to fix issues with the zerif-lite theme
- a bit of spacing between filter checkbox and the label
- min-height for the results to try and prevent the page bouncing too much when you clear the search

Fixes some of the issues in #13391 

#### Testing instructions:
* Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and has Jetpack Search enabled.
* Add a Jetpack Search widget to the Search page sidebar. (though I guess it should now work without this added at all)
* Enter a query into a search widget. Alternatively, navigate to a search page like /?s=privacy.
* The following code lets you test against any other site by adding this filter and then adding `&blog_id=20115252` to your search page url (that is the jetpack.com blog_id). Also can dynamically set the theme with `&theme=twentyten`

```
function jp_instant_search_options( $options ) {
	if ( $_GET['blog_id'] ) {
		$options['siteId'] = (int) $_GET['blog_id'];
	}
	return $options;
}
add_filter( 'jetpack_instant_search_options', 'jp_instant_search_options' );

function filter_theme( $theme ) {
	if ( $_GET['theme'] ) {
		$theme = sanitize_key( $_GET['theme'] );
	}
	return $theme;
}
add_filter( 'stylesheet', 'filter_theme', 1 );
add_filter( 'template', 'filter_theme', 1 );
```

