### PR TITLE
Simple payments: hide upgrade nudge in feeds

### DIFF
--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -156,7 +156,10 @@ class Jetpack_Simple_Payments {
 		}
 
 		if ( ! $this->is_enabled_jetpack_simple_payments() ) {
-			return $this->output_admin_warning( $data );
+			if ( ! is_feed() ) {
+				$this->output_admin_warning( $data );
+			}
+			return;
 		}
 
 		if ( ! wp_script_is( 'paypal-express-checkout', 'enqueued' ) ) {


### PR DESCRIPTION
Simple payments frontend upgrade nudge nudge is normally visible only to admins on site's frontend:

<img width="1238" alt="Screenshot 2019-10-11 at 13 33 51" src="https://user-images.githubusercontent.com/87168/66645494-490fd000-ec2c-11e9-8824-6702f8a693e2.png">

The nudge does not appear in RSS when you're not authenticated:

<img width="820" alt="Screenshot 2019-10-11 at 13 32 17" src="https://user-images.githubusercontent.com/87168/66645383-fe8e5380-ec2b-11e9-8a43-2cfbd0628648.png">


...but does appear in RSS only when you are authenticated:

<img width="710" alt="Screenshot 2019-10-11 at 13 30 55" src="https://user-images.githubusercontent.com/87168/66645411-0d750600-ec2c-11e9-9771-89f77e4bb430.png">

That's not entirely harmless since it can get cached to RSS readers such as WordPress.com/read:

<img width="1094" alt="Screenshot 2019-10-11 at 13 34 13" src="https://user-images.githubusercontent.com/87168/66645526-6349ae00-ec2c-11e9-9667-b7f2a75d12b1.png">

There's not a whole lot benefit for having the nudge visible in the reader so this change hides it.

#### Changes proposed in this Pull Request:
* Hide Simple payments frontend upgrade nudge from (RSS) feeds.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Change

#### Testing instructions:
- On the free plan, add simple payments block or shortcode to a new post
- Open the post and confirm you see the nudge
- Open your site's `/feed` and confirm that the nudge is gone regardless if you're authenticated or not

#### Proposed changelog entry for your changes:
* Hide Simple payments upgrade nudge from RSS feeds
