### PR TITLE
Facebook Page Plugin: update deprecated stream attribute

### DIFF
--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -77,7 +77,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		$page_url = set_url_scheme( $like_args['href'], 'https' );
 
 		$like_args['show_faces'] = (bool) $like_args['show_faces'] ? 'true' : 'false';
-		$like_args['stream']     = (bool) $like_args['stream'] ? 'true' : 'false';
+		$like_args['stream']     = (bool) $like_args['stream'] ? 'timeline' : 'false';
 		$like_args['cover']      = (bool) $like_args['cover'] ? 'false' : 'true';
 
 		echo $before_widget;
@@ -105,7 +105,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 
 		?>
 		<div id="fb-root"></div>
-		<div class="fb-page" data-href="<?php echo esc_url( $page_url ); ?>" data-width="<?php echo intval( $like_args['width'] ); ?>"  data-height="<?php echo intval( $like_args['height'] ); ?>" data-hide-cover="<?php echo esc_attr( $like_args['cover'] ); ?>" data-show-facepile="<?php echo esc_attr( $like_args['show_faces'] ); ?>" data-show-posts="<?php echo esc_attr( $like_args['stream'] ); ?>">
+		<div class="fb-page" data-href="<?php echo esc_url( $page_url ); ?>" data-width="<?php echo intval( $like_args['width'] ); ?>"  data-height="<?php echo intval( $like_args['height'] ); ?>" data-hide-cover="<?php echo esc_attr( $like_args['cover'] ); ?>" data-show-facepile="<?php echo esc_attr( $like_args['show_faces'] ); ?>" data-tabs="<?php echo esc_attr( $like_args['stream'] ); ?>">
 		<div class="fb-xfbml-parse-ignore"><blockquote cite="<?php echo esc_url( $page_url ); ?>"><a href="<?php echo esc_url( $page_url ); ?>"><?php echo esc_html( $title ); ?></a></blockquote></div>
 		</div>
 		<?php

--- a/modules/widgets/facebook-likebox.php
+++ b/modules/widgets/facebook-likebox.php
@@ -193,7 +193,7 @@ class WPCOM_Widget_Facebook_LikeBox extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'stream' ) ); ?>">
 				<input type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'stream' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'stream' ) ); ?>" <?php checked( $like_args['stream'] ); ?> />
-				<?php _e( 'Show Stream', 'jetpack' ); ?>
+				<?php _e( 'Show Timeline', 'jetpack' ); ?>
 				<br />
 				<small><?php _e( 'Show Page Posts.', 'jetpack' ); ?></small>
 			</label>


### PR DESCRIPTION
Fixes #13717

#### Changes proposed in this Pull Request:

* This attribute has now been deprecated by Facebook:
> The attribute data-show-posts is deprecated. Please use the attribute tabs/data-tabs and use the value timeline to show posts from the Page's timeline.
-- https://developers.facebook.com/docs/plugins/page-plugin/

This updates to the new recommended attribute.

**Note**

~~I did not update the label from "Show Stream" to "Show Timeline". Maybe we should? I'm not sure which term is more understandable for site owners.~~
I changed the UI to use the word "Timeline" as per Michelle's recommendation below:

![image](https://user-images.githubusercontent.com/426388/67475954-65156780-f657-11e9-9152-da9d6f8a3058.png)


#### Testing instructions:

* Go to Jetpack > Settings > Writing and enable the extra sidebar widgets
* Go to Appearance > Customize
* Add a new Facebook Widget to your site.
* In the widget options, choose to display a stream of posts.
* Check your site, the widget should show a list of recent posts from the Page.

#### Proposed changelog entry for your changes:

* Facebook Page Plugin: update deprecated option in the widget.
