### PR TITLE
Ad Block: add fill color to Ad block icon.

### DIFF
--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -17,7 +17,10 @@ export const title = __( 'Ad', 'jetpack' );
 export const icon = (
 	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
 		<Path fill="none" d="M0 0h24v24H0V0z" />
-		<Path d="M12,8H4A2,2 0 0,0 2,10V14A2,2 0 0,0 4,16H5V20A1,1 0 0,0 6,21H8A1,1 0 0,0 9,20V16H12L17,20V4L12,8M15,15.6L13,14H4V10H13L15,8.4V15.6M21.5,12C21.5,13.71 20.54,15.26 19,16V8C20.53,8.75 21.5,10.3 21.5,12Z" />
+		<Path
+			fill="currentColor"
+			d="M12,8H4A2,2 0 0,0 2,10V14A2,2 0 0,0 4,16H5V20A1,1 0 0,0 6,21H8A1,1 0 0,0 9,20V16H12L17,20V4L12,8M15,15.6L13,14H4V10H13L15,8.4V15.6M21.5,12C21.5,13.71 20.54,15.26 19,16V8C20.53,8.75 21.5,10.3 21.5,12Z"
+		/>
 	</SVG>
 );
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* See https://github.com/Automattic/jetpack/pull/13716#issuecomment-541080558

The block now looks like this:

<img width="543" alt="screenshot 2019-10-11 at 18 35 51" src="https://user-images.githubusercontent.com/426388/66668767-4033f400-ec56-11e9-8d6a-8d93766a1768.png">
<img width="634" alt="screenshot 2019-10-11 at 18 34 25" src="https://user-images.githubusercontent.com/426388/66668769-4033f400-ec56-11e9-9252-46c1dbe15fdf.png">
![image](https://user-images.githubusercontent.com/426388/66668872-85582600-ec56-11e9-9dc5-09d38dc4c119.png)

#### Testing instructions:

* Start with a site with a Jetpack Premium Plan
* Add an ad block to your site, the icon should look good.
* Switch to a dark theme like [this one](https://github.com/WordPress/gutenberg-starter-theme) (dark mode can be activated from "Theme Options").
* Open the editor again and check the look of the ad block.

#### Proposed changelog entry for your changes:

* None
