### PR TITLE
Tiled Gallery: Ensure Photon strips only 'info', not 'all' when inserting SrcSet

### DIFF
--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -89,7 +89,7 @@ class Jetpack_Tiled_Gallery_Block {
 							$srcset_src = add_query_arg(
 								array(
 									'resize' => $w . ',' . $w,
-									'strip'  => 'all',
+									'strip'  => 'info',
 								),
 								$orig_src
 							);
@@ -108,7 +108,7 @@ class Jetpack_Tiled_Gallery_Block {
 						for ( $w = $min_width; $w <= $max_width; $w = min( $max_width, $w + self::IMG_SRCSET_WIDTH_STEP ) ) {
 							$srcset_src = add_query_arg(
 								array(
-									'strip' => 'all',
+									'strip' => 'info',
 									'w'     => $w,
 								),
 								$orig_src

--- a/extensions/blocks/tiled-gallery/utils/index.js
+++ b/extensions/blocks/tiled-gallery/utils/index.js
@@ -86,7 +86,7 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 			.map( srcsetWidth => {
 				const srcsetSrc = photonImplementation( url, {
 					resize: `${ srcsetWidth },${ srcsetWidth }`,
-					strip: 'all',
+					strip: 'info',
 				} );
 				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
 			} )
@@ -99,7 +99,7 @@ export function photonizedImgProps( img, galleryAtts = {} ) {
 		srcSet = range( minWidth, maxWidth, step )
 			.map( srcsetWidth => {
 				const srcsetSrc = photonImplementation( url, {
-					strip: 'all',
+					strip: 'info',
 					width: srcsetWidth,
 				} );
 				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This ensures that when SrcSets are generated by the Tiled Gallery they only direct Photon to strip 'Info' instead of 'all' (which removes color profile information).

This addresses issue #13561 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a bug fix

#### Testing instructions:
* Insert a Tiled Gallery block into a post or page.
* Upload an image which contains a Color Profile saved within the file. [You can use this image to test](https://lamontjordan.files.wordpress.com/2019/09/img_9901-test.jpg).
* Publish the post/page
* The image within the gallery should appear with the _same_ color brightness/values as you see when loading the original image directly in the browser.

Before (right image has color profile):
<img width="619" alt="Screen Shot 2019-10-12 at 8 51 07 pm" src="https://user-images.githubusercontent.com/1842363/66699699-a68f4400-ed34-11e9-8867-143abbaad4d8.png">

After (right image has color profile):
<img width="589" alt="Screen Shot 2019-10-12 at 8 51 21 pm" src="https://user-images.githubusercontent.com/1842363/66699707-b0b14280-ed34-11e9-9f2d-1e0686060a27.png">


#### Proposed changelog entry for your changes:
* Color Profile information is retained for images in Tiled Galleries
