### PR TITLE
Slideshow Shortcode: Add labels to navigation buttons for accessibility

### DIFF
--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -143,6 +143,23 @@ JetpackSlideshow.prototype.renderControls_ = function() {
 		var controlName = controls[ i ];
 		var a = document.createElement( 'a' );
 		a.href = '#';
+		switch ( i ) {
+			case 0:
+				a.className = 'classic-jetpack-slideshow_button-prev';
+				a.setAttribute( 'aria-label', 'Previous Slide' );
+				break;
+
+			case 1:
+				a.className = 'classic-jetpack-slideshow_button-pause';
+				a.setAttribute( 'aria-label', 'Pause Slideshow' );
+				break;
+
+			case 2:
+				a.className = 'classic-jetpack-slideshow_button-next';
+				a.setAttribute( 'aria-label', 'Next Slide' );
+				break;
+		}
+		a.setAttribute( 'role', 'button' );
 		controlsDiv.appendChild( a );
 		this.controls[ controlName ] = a;
 	}

--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -147,15 +147,11 @@ JetpackSlideshow.prototype.renderControls_ = function() {
 			case 0:
 				a.className = jetpackSlideshowSettings.class_prev;
 				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_prev );
-				// a.className = 'classic-jetpack-slideshow_button-prev';
-				// a.setAttribute( 'aria-label', 'Previous Slide' );
 				break;
 
 			case 1:
 				a.className = jetpackSlideshowSettings.class_pause;
 				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_pause );
-				// a.className = 'classic-jetpack-slideshow_button-pause';
-				// a.setAttribute( 'aria-label', 'Pause Slideshow' );
 				break;
 
 			case 2:

--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -141,25 +141,14 @@ JetpackSlideshow.prototype.renderControls_ = function() {
 	var controls = [ 'prev', 'stop', 'next' ];
 	for ( var i = 0; i < controls.length; i++ ) {
 		var controlName = controls[ i ];
+		var label_name = 'label_' + controlName;
 		var a = document.createElement( 'a' );
+
 		a.href = '#';
-		switch ( i ) {
-			case 0:
-				a.className = 'classic-jetpack-slideshow_button-previous';
-				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_prev );
-				break;
-
-			case 1:
-				a.className = 'classic-jetpack-slideshow_button-pause';
-				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_pause );
-				break;
-
-			case 2:
-				a.className = 'classic-jetpack-slideshow_button-next';
-				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_next );
-				break;
-		}
+		a.className = 'button-' + controlName;
+		a.setAttribute( 'aria-label', jetpackSlideshowSettings[ label_name ] );
 		a.setAttribute( 'role', 'button' );
+
 		controlsDiv.appendChild( a );
 		this.controls[ controlName ] = a;
 	}

--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -145,18 +145,22 @@ JetpackSlideshow.prototype.renderControls_ = function() {
 		a.href = '#';
 		switch ( i ) {
 			case 0:
-				a.className = 'classic-jetpack-slideshow_button-prev';
-				a.setAttribute( 'aria-label', 'Previous Slide' );
+				a.className = jetpackSlideshowSettings.class_prev;
+				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_prev );
+				// a.className = 'classic-jetpack-slideshow_button-prev';
+				// a.setAttribute( 'aria-label', 'Previous Slide' );
 				break;
 
 			case 1:
-				a.className = 'classic-jetpack-slideshow_button-pause';
-				a.setAttribute( 'aria-label', 'Pause Slideshow' );
+				a.className = jetpackSlideshowSettings.class_pause;
+				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_pause );
+				// a.className = 'classic-jetpack-slideshow_button-pause';
+				// a.setAttribute( 'aria-label', 'Pause Slideshow' );
 				break;
 
 			case 2:
-				a.className = 'classic-jetpack-slideshow_button-next';
-				a.setAttribute( 'aria-label', 'Next Slide' );
+				a.className = jetpackSlideshowSettings.class_next;
+				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_next );
 				break;
 		}
 		a.setAttribute( 'role', 'button' );

--- a/modules/shortcodes/js/slideshow-shortcode.js
+++ b/modules/shortcodes/js/slideshow-shortcode.js
@@ -145,17 +145,17 @@ JetpackSlideshow.prototype.renderControls_ = function() {
 		a.href = '#';
 		switch ( i ) {
 			case 0:
-				a.className = jetpackSlideshowSettings.class_prev;
+				a.className = 'classic-jetpack-slideshow_button-previous';
 				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_prev );
 				break;
 
 			case 1:
-				a.className = jetpackSlideshowSettings.class_pause;
+				a.className = 'classic-jetpack-slideshow_button-pause';
 				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_pause );
 				break;
 
 			case 2:
-				a.className = jetpackSlideshowSettings.class_next;
+				a.className = 'classic-jetpack-slideshow_button-next';
 				a.setAttribute( 'aria-label', jetpackSlideshowSettings.label_next );
 				break;
 		}

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -279,14 +279,26 @@ class Jetpack_Slideshow_Shortcode {
 			 * @since 4.7.0 Added the `speed` option to the array of options.
 			 *
 			 * @param array $args
-			 * - string - spinner - URL of the spinner image.
-			 * - string - speed   - Speed of the slideshow. Defaults to 4000.
+			 * - string - spinner        - URL of the spinner image.
+			 * - string - speed          - Speed of the slideshow. Defaults to 4000.
+			 * - string - class_prev     - CSS class for slideshow's previous button
+			 * - string - class_pause    - CSS class for slideshow's pause button
+			 * - string - class_next     - CSS class for slideshow's next button
+			 * - string - label_prev     - Aria label for slideshow's previous button
+			 * - string - label_pause    - Aria label for slideshow's pause button
+			 * - string - label_next     - Aria label for slideshow's next button
 			 */
 			apply_filters(
 				'jetpack_js_slideshow_settings',
 				array(
-					'spinner' => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
-					'speed'   => '4000',
+					'spinner'     => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
+					'speed'       => '4000',
+					'class_prev'  => 'classic-jetpack-slideshow_button-previous',
+					'class_pause' => 'classic-jetpack-slideshow_button-pause',
+					'class_next'  => 'classic-jetpack-slideshow_button-next',
+					'label_prev'  => 'Previous Slide',
+					'label_pause' => 'Pause Slideshow',
+					'label_next'  => 'Next Slide',
 				)
 			)
 		);

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -281,21 +281,18 @@ class Jetpack_Slideshow_Shortcode {
 			 * @param array $args
 			 * - string - spinner        - URL of the spinner image.
 			 * - string - speed          - Speed of the slideshow. Defaults to 4000.
-			 * - string - class_prev     - CSS class for slideshow's previous button
-			 * - string - class_pause    - CSS class for slideshow's pause button
-			 * - string - class_next     - CSS class for slideshow's next button
 			 * - string - label_prev     - Aria label for slideshow's previous button
-			 * - string - label_pause    - Aria label for slideshow's pause button
+			 * - string - label_stop    - Aria label for slideshow's pause button
 			 * - string - label_next     - Aria label for slideshow's next button
 			 */
 			apply_filters(
 				'jetpack_js_slideshow_settings',
 				array(
-					'spinner'     => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
-					'speed'       => '4000',
-					'label_prev'  => __( 'Previous Slide', 'jetpack' ),
-					'label_pause' => __( 'Pause Slideshow', 'jetpack' ),
-					'label_next'  => __( 'Next Slide', 'jetpack' ),
+					'spinner'    => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
+					'speed'      => '4000',
+					'label_prev' => __( 'Previous Slide', 'jetpack' ),
+					'label_stop' => __( 'Pause Slideshow', 'jetpack' ),
+					'label_next' => __( 'Next Slide', 'jetpack' ),
 				)
 			)
 		);

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -296,9 +296,9 @@ class Jetpack_Slideshow_Shortcode {
 					'class_prev'  => 'classic-jetpack-slideshow_button-previous',
 					'class_pause' => 'classic-jetpack-slideshow_button-pause',
 					'class_next'  => 'classic-jetpack-slideshow_button-next',
-					'label_prev'  => 'Previous Slide',
-					'label_pause' => 'Pause Slideshow',
-					'label_next'  => 'Next Slide',
+					'label_prev'  => __( 'Previous Slide', 'jetpack' ),
+					'label_pause' => __( 'Pause Slideshow', 'jetpack' ),
+					'label_next'  => __( 'Next Slide', 'jetpack' ),
 				)
 			)
 		);

--- a/modules/shortcodes/slideshow.php
+++ b/modules/shortcodes/slideshow.php
@@ -293,9 +293,6 @@ class Jetpack_Slideshow_Shortcode {
 				array(
 					'spinner'     => plugins_url( '/img/slideshow-loader.gif', __FILE__ ),
 					'speed'       => '4000',
-					'class_prev'  => 'classic-jetpack-slideshow_button-previous',
-					'class_pause' => 'classic-jetpack-slideshow_button-pause',
-					'class_next'  => 'classic-jetpack-slideshow_button-next',
 					'label_prev'  => __( 'Previous Slide', 'jetpack' ),
 					'label_pause' => __( 'Pause Slideshow', 'jetpack' ),
 					'label_next'  => __( 'Next Slide', 'jetpack' ),


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes this issue: https://github.com/Automattic/jetpack/issues/13603
* Added `aria-label` and `role` (similar to what we have in slideshow block).

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable these modules: 1. Tiled Galleries 2. Shortcodes Embeds
* Install Classic Editor plugin and activate it.
* Add a gallery slideshow in a new post
* Inspect the code and you'll find `aria-label` and `role` attributes for slideshow controls (check the screenshot below)

![Screen Shot on 2019-10-13 at 13:14:05](https://user-images.githubusercontent.com/20779676/66712511-5d360780-edbb-11e9-8132-a9131aaa1d39.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Accessibility labels for Slideshow shortcode

#### Other notes:

I have made changes to the JS file and not the [PHP file](https://github.com/Automattic/jetpack/blob/89a9af96b669e2e5a2ed47d3f3e07c804d6e0dd0/modules/shortcodes/slideshow.php) because the controls are rendered via JS. Thus it is much simpler to make the change this way. 