### PR TITLE
Instant Search: Hook up default sort options

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -205,6 +205,11 @@ class Jetpack_Search {
 				$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 				wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 
+				$widget_options = Jetpack_Search_Helpers::get_widgets_from_option();
+				if ( is_array( $widget_options ) ) {
+					$widget_options = end( $widget_options );
+				}
+
 				$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
 				$widgets = array();
 				foreach( $filters as $key => $filter ) {
@@ -222,6 +227,9 @@ class Jetpack_Search {
 					'postTypes' => get_post_types(),
 					'siteId'		=> Jetpack::get_option( 'id' ),
 					'widgets' 	=> array_values( $widgets ),
+					'sort'      => $widget_options['sort'],
+					'postTypeFilters' => $widget_options['post_types'],
+					'enableLoadOnScroll' => false,
 				);
 				/**
 				 * Customize Instant Search Options.

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -24,6 +24,7 @@ import {
 	getFilterQuery,
 	setSortQuery,
 	getSortQuery,
+	determineDefaultSort,
 } from '../lib/query-string';
 import { removeChildren, hideElements } from '../lib/dom';
 
@@ -37,6 +38,7 @@ class SearchApp extends Component {
 		this.props.resultFormat = 'minimal';
 		this.props.aggregations = buildFilterAggregations( this.props.options.widgets );
 		this.props.widgets = this.props.options.widgets ? this.props.options.widgets : [];
+		this.props.initialSort = determineDefaultSort( this.props.options.sort );
 
 		this.state = {
 			isLoading: false,
@@ -188,6 +190,7 @@ class SearchApp extends Component {
 						query={ this.state.query }
 						response={ this.state.response }
 						resultFormat={ this.props.options.resultFormat }
+						enableLoadOnScroll={ this.props.options.enableLoadOnScroll }
 					/>
 				</Portal>
 			</Preact.Fragment>

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -24,7 +24,6 @@ import {
 	getFilterQuery,
 	setSortQuery,
 	getSortQuery,
-	determineDefaultSort,
 } from '../lib/query-string';
 import { removeChildren, hideElements } from '../lib/dom';
 
@@ -38,7 +37,6 @@ class SearchApp extends Component {
 		this.props.resultFormat = 'minimal';
 		this.props.aggregations = buildFilterAggregations( this.props.options.widgets );
 		this.props.widgets = this.props.options.widgets ? this.props.options.widgets : [];
-		this.props.initialSort = determineDefaultSort( this.props.options.sort );
 
 		this.state = {
 			isLoading: false,

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -64,7 +64,7 @@ class SearchResults extends Component {
 				{ results.map( result => this.render_result( result ) ) }
 				{ this.props.hasNextPage && (
 					<ScrollButton
-						enableLoadOnScroll
+						enableLoadOnScroll={ this.props.enableLoadOnScroll }
 						isLoading={ this.props.isLoading }
 						onLoadNextPage={ this.props.onLoadNextPage }
 					/>

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -9,7 +9,7 @@ import { h, render } from 'preact';
  * Internal dependencies
  */
 import SearchApp from './components/search-app';
-import { getSearchQuery, getFilterQuery, getSortQuery } from './lib/query-string';
+import { getSearchQuery, getFilterQuery } from './lib/query-string';
 import { getThemeOptions } from './lib/dom';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 
@@ -18,7 +18,6 @@ const injectSearchApp = grabFocus => {
 		<SearchApp
 			grabFocus={ grabFocus }
 			initialFilters={ getFilterQuery() }
-			initialSort={ getSortQuery() }
 			initialValue={ getSearchQuery() }
 			options={ window[ SERVER_OBJECT_NAME ] }
 			themeOptions={ getThemeOptions( window[ SERVER_OBJECT_NAME ] ) }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -9,7 +9,7 @@ import { h, render } from 'preact';
  * Internal dependencies
  */
 import SearchApp from './components/search-app';
-import { getSearchQuery, getFilterQuery } from './lib/query-string';
+import { getSearchQuery, getFilterQuery, determineDefaultSort } from './lib/query-string';
 import { getThemeOptions } from './lib/dom';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 
@@ -19,6 +19,7 @@ const injectSearchApp = grabFocus => {
 			grabFocus={ grabFocus }
 			initialFilters={ getFilterQuery() }
 			initialValue={ getSearchQuery() }
+			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort ) }
 			options={ window[ SERVER_OBJECT_NAME ] }
 			themeOptions={ getThemeOptions( window[ SERVER_OBJECT_NAME ] ) }
 		/>,

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -37,6 +37,23 @@ export function setSearchQuery( searchValue ) {
 	pushQueryString( encode( query ) );
 }
 
+export function determineDefaultSort( widgetOptions ) {
+	const query = getQuery();
+	if ( 'orderby' in query ) {
+		return getSortQuery();
+	}
+
+	switch ( widgetOptions ) {
+		case 'date|DESC':
+			return 'date_desc';
+		case 'date|ASC':
+			return 'date_asc';
+		case 'relevance|DESC':
+		default:
+			return 'score_default';
+	}
+}
+
 export function getSortQuery() {
 	const query = getQuery();
 	const order = 'order' in query ? query.order : 'DESC';


### PR DESCRIPTION
Connect options from the widget to the front end app:
- default sort when none is specified
- post type filters passed through, but not hooked up
- enabling load on scroll forced to be disabled. doesn't seem to be working yet

#### Testing instructions:
* Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
* Add a Jetpack Search widget to the Search page sidebar and configure some filters.
* Try different default sort settings in the widget and verify that they are reflected on the front end.
