### PR TITLE
Use the correct link for NVM

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -27,7 +27,7 @@ You should expect to get no red `FAILED` check messages. If there happens to be 
 
 We try to frequently keep the Node version we use up to date. So, eventually you may need to refresh your package dependencies (i.e., the `node_modules` directories). This is because some dependencies are built specifically for the Node version you used when you installed them (either by running `yarn build` or `yarn`).
 
-We recommend usage of [nvm](https://www.npmjs.com/package/nvm) for managing different Node versions on the same environment.
+We recommend usage of [nvm](https://github.com/nvm-sh/nvm/) for managing different Node versions on the same environment.
 
 **Note:** If you have previously run the Jetpack build tasks (e.g. `yarn build`), and didn't come back to it for a long time, you can
 run this command before building again. Otherwise you may experience errors on the command line while trying to build.


### PR DESCRIPTION
The link for NVM in the dev environment docs is outdated. It currently links to 
[https://www.npmjs.com/package/nvm, which has a shiny red "DEPRECATED" notice.

The npmjs.com page links to `http://nvm.sh`, which redirects to the NVM GitHub repo's `README.md`. Unfortunately, `nvm.sh` doesn't supports `HTTPS`, so this PR links directly to the NVM GitHub repo, to avoid sending folks to HTTP URLs.

#### Testing instructions:

* Visit [`development-environment.md` in this PR](https://github.com/Automattic/jetpack/blob/900af7dbac3e082876d734bfd3f0d04ad59aa1f4/docs/development-environment.md#a-note-on-node-versions-used-for-the-build-tasks).
* Confirm that clicking the NVM link sends you to the NVM GitHub repo.

#### Proposed changelog entry for your changes:

No changelog entry needed. 