### PR TITLE
Contact Form: Add post-submission options.

### DIFF
--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -4,7 +4,16 @@
 import classnames from 'classnames';
 import emailValidator from 'email-validator';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, PanelBody, Path, Placeholder, TextControl } from '@wordpress/components';
+import {
+	Button,
+	PanelBody,
+	Path,
+	Placeholder,
+	SelectControl,
+	TextareaControl,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
 import { InnerBlocks, InspectorControls } from '@wordpress/editor';
@@ -190,6 +199,52 @@ class JetpackContactForm extends Component {
 		);
 	}
 
+	renderOnSubmissionFields() {
+		const {
+			customThankyou,
+			customThankyouType,
+			customThankyouMessage,
+			customThankyouRedirect,
+		} = this.props.attributes;
+		return (
+			<Fragment>
+				<ToggleControl
+					label={ __( 'Thank you message', 'jetpack' ) }
+					help={ __( 'Toggle to show a thank you message', 'jetpack' ) }
+					checked={ customThankyou }
+					onChange={ value => this.props.setAttributes( { customThankyou: value } ) }
+				/>
+				{ customThankyou && (
+					<SelectControl
+						label={ __( 'Message type', 'jetpack' ) }
+						value={ customThankyouType }
+						options={ [
+							{ label: __( 'Text message', 'jetpack' ), value: 'message' },
+							{ label: __( 'Redirect to another webpage', 'jetpack' ), value: 'redirect' },
+						] }
+						onChange={ value => this.props.setAttributes( { customThankyouType: value } ) }
+					/>
+				) }
+				{ customThankyou && ( ! customThankyouType || 'message' === customThankyouType ) && (
+					<TextareaControl
+						label={ __( 'Message text', 'jetpack' ) }
+						value={ customThankyouMessage }
+						placeholder={ __( 'Thank you for your submission!', 'jetpack' ) }
+						onChange={ value => this.props.setAttributes( { customThankyouMessage: value } ) }
+					/>
+				) }
+				{ customThankyou && 'redirect' === customThankyouType && (
+					<TextControl
+						label={ __( 'Redirect address', 'jetpack' ) }
+						value={ customThankyouRedirect }
+						placeholder={ 'https://' }
+						onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
+					/>
+				) }
+			</Fragment>
+		);
+	}
+
 	hasEmailError() {
 		const fieldEmailError = this.state.toError;
 		return fieldEmailError && fieldEmailError.length > 0;
@@ -207,6 +262,9 @@ class JetpackContactForm extends Component {
 				<InspectorControls>
 					<PanelBody title={ __( 'Email feedback settings', 'jetpack' ) }>
 						{ this.renderToAndSubjectFields() }
+					</PanelBody>
+					<PanelBody title={ __( 'On submission', 'jetpack' ) }>
+						{ this.renderOnSubmissionFields() }
 					</PanelBody>
 				</InspectorControls>
 				<div className={ formClassnames }>

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import emailValidator from 'email-validator';
 import { __, sprintf } from '@wordpress/i18n';
 import {
+	BaseControl,
 	Button,
 	PanelBody,
 	Path,
@@ -199,6 +200,7 @@ class JetpackContactForm extends Component {
 	}
 
 	renderConfirmationMessageFields() {
+		const { instanceId } = this.props;
 		const { customThankyou, customThankyouMessage, customThankyouRedirect } = this.props.attributes;
 		return (
 			<Fragment>
@@ -221,12 +223,17 @@ class JetpackContactForm extends Component {
 					/>
 				) }
 				{ 'redirect' === customThankyou && (
-					<URLInput
+					<BaseControl
 						label={ __( 'Redirect Address', 'jetpack' ) }
-						value={ customThankyouRedirect }
-						className="jetpack-contact-form__thankyou-redirect-url"
-						onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
-					/>
+						id={ `contact-form-${ instanceId }-thankyou-url` }
+					>
+						<URLInput
+							id={ `contact-form-${ instanceId }-thankyou-url` }
+							value={ customThankyouRedirect }
+							className="jetpack-contact-form__thankyou-redirect-url"
+							onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
+						/>
+					</BaseControl>
 				) }
 			</Fragment>
 		);

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -13,7 +13,6 @@ import {
 	SelectControl,
 	TextareaControl,
 	TextControl,
-	ToggleControl,
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
@@ -200,38 +199,22 @@ class JetpackContactForm extends Component {
 		);
 	}
 
-	renderOnSubmissionFields() {
+	renderConfirmationMessageFields() {
 		const { instanceId } = this.props;
-		const {
-			customThankyou,
-			customThankyouType,
-			customThankyouMessage,
-			customThankyouRedirect,
-		} = this.props.attributes;
+		const { customThankyou, customThankyouMessage, customThankyouRedirect } = this.props.attributes;
 		return (
 			<Fragment>
-				<ToggleControl
-					label={ __( 'Show a thank you message', 'jetpack' ) }
-					checked={ customThankyou }
-					onChange={ value => {
-						this.props.setAttributes( {
-							customThankyou: value,
-							customThankyouType: customThankyouType || 'message',
-						} );
-					} }
+				<SelectControl
+					label={ __( 'On Submission', 'jetpack' ) }
+					value={ customThankyou }
+					options={ [
+						{ label: __( 'Show a summary of submitted fields', 'jetpack' ), value: '' },
+						{ label: __( 'Show a custom text message', 'jetpack' ), value: 'message' },
+						{ label: __( 'Redirect to another webpage', 'jetpack' ), value: 'redirect' },
+					] }
+					onChange={ value => this.props.setAttributes( { customThankyou: value } ) }
 				/>
-				{ customThankyou && (
-					<SelectControl
-						label={ __( 'Message type', 'jetpack' ) }
-						value={ customThankyouType }
-						options={ [
-							{ label: __( 'Text message', 'jetpack' ), value: 'message' },
-							{ label: __( 'Redirect to another webpage', 'jetpack' ), value: 'redirect' },
-						] }
-						onChange={ value => this.props.setAttributes( { customThankyouType: value } ) }
-					/>
-				) }
-				{ customThankyou && 'message' === customThankyouType && (
+				{ 'message' === customThankyou && (
 					<TextareaControl
 						label={ __( 'Message text', 'jetpack' ) }
 						value={ customThankyouMessage }
@@ -239,7 +222,7 @@ class JetpackContactForm extends Component {
 						onChange={ value => this.props.setAttributes( { customThankyouMessage: value } ) }
 					/>
 				) }
-				{ customThankyou && 'redirect' === customThankyouType && (
+				{ 'redirect' === customThankyou && (
 					<BaseControl
 						label={ __( 'Redirect address', 'jetpack' ) }
 						id={ `contact-form-${ instanceId }-thankyou-url` }
@@ -271,11 +254,11 @@ class JetpackContactForm extends Component {
 		return (
 			<Fragment>
 				<InspectorControls>
-					<PanelBody title={ __( 'Email feedback settings', 'jetpack' ) }>
+					<PanelBody title={ __( 'Email Feedback Settings', 'jetpack' ) }>
 						{ this.renderToAndSubjectFields() }
 					</PanelBody>
-					<PanelBody title={ __( 'On submission', 'jetpack' ) }>
-						{ this.renderOnSubmissionFields() }
+					<PanelBody title={ __( 'Confirmation Message', 'jetpack' ) }>
+						{ this.renderConfirmationMessageFields() }
 					</PanelBody>
 				</InspectorControls>
 				<div className={ formClassnames }>

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import emailValidator from 'email-validator';
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	BaseControl,
 	Button,
 	PanelBody,
 	Path,
@@ -200,7 +199,6 @@ class JetpackContactForm extends Component {
 	}
 
 	renderConfirmationMessageFields() {
-		const { instanceId } = this.props;
 		const { customThankyou, customThankyouMessage, customThankyouRedirect } = this.props.attributes;
 		return (
 			<Fragment>
@@ -223,17 +221,12 @@ class JetpackContactForm extends Component {
 					/>
 				) }
 				{ 'redirect' === customThankyou && (
-					<BaseControl
+					<URLInput
 						label={ __( 'Redirect Address', 'jetpack' ) }
-						id={ `contact-form-${ instanceId }-thankyou-url` }
-					>
-						<URLInput
-							id={ `contact-form-${ instanceId }-thankyou-url` }
-							value={ customThankyouRedirect }
-							className="jetpack-contact-form__thankyou-redirect-url"
-							onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
-						/>
-					</BaseControl>
+						value={ customThankyouRedirect }
+						className="jetpack-contact-form__thankyou-redirect-url"
+						onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
+					/>
 				) }
 			</Fragment>
 		);

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -211,8 +211,7 @@ class JetpackContactForm extends Component {
 		return (
 			<Fragment>
 				<ToggleControl
-					label={ __( 'Thank you message', 'jetpack' ) }
-					help={ __( 'Toggle to show a thank you message', 'jetpack' ) }
+					label={ __( 'Show a thank you message', 'jetpack' ) }
 					checked={ customThankyou }
 					onChange={ value => this.props.setAttributes( { customThankyou: value } ) }
 				/>

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -223,6 +223,8 @@ class JetpackContactForm extends Component {
 					/>
 				) }
 				{ 'redirect' === customThankyou && (
+					// @todo This can likely be simplified when WP 5.4 is the minimum supported version.
+					// See https://github.com/Automattic/jetpack/pull/13745#discussion_r334712381
 					<BaseControl
 						label={ __( 'Redirect Address', 'jetpack' ) }
 						id={ `contact-form-${ instanceId }-thankyou-url` }

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -213,7 +213,12 @@ class JetpackContactForm extends Component {
 				<ToggleControl
 					label={ __( 'Show a thank you message', 'jetpack' ) }
 					checked={ customThankyou }
-					onChange={ value => this.props.setAttributes( { customThankyou: value } ) }
+					onChange={ value => {
+						this.props.setAttributes( {
+							customThankyou: value,
+							customThankyouType: customThankyouType || 'message',
+						} );
+					} }
 				/>
 				{ customThankyou && (
 					<SelectControl
@@ -226,7 +231,7 @@ class JetpackContactForm extends Component {
 						onChange={ value => this.props.setAttributes( { customThankyouType: value } ) }
 					/>
 				) }
-				{ customThankyou && ( ! customThankyouType || 'message' === customThankyouType ) && (
+				{ customThankyou && 'message' === customThankyouType && (
 					<TextareaControl
 						label={ __( 'Message text', 'jetpack' ) }
 						value={ customThankyouMessage }

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -216,7 +216,7 @@ class JetpackContactForm extends Component {
 				/>
 				{ 'message' === customThankyou && (
 					<TextareaControl
-						label={ __( 'Message text', 'jetpack' ) }
+						label={ __( 'Message Text', 'jetpack' ) }
 						value={ customThankyouMessage }
 						placeholder={ __( 'Thank you for your submission!', 'jetpack' ) }
 						onChange={ value => this.props.setAttributes( { customThankyouMessage: value } ) }
@@ -224,7 +224,7 @@ class JetpackContactForm extends Component {
 				) }
 				{ 'redirect' === customThankyou && (
 					<BaseControl
-						label={ __( 'Redirect address', 'jetpack' ) }
+						label={ __( 'Redirect Address', 'jetpack' ) }
 						id={ `contact-form-${ instanceId }-thankyou-url` }
 					>
 						<URLInput

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import emailValidator from 'email-validator';
 import { __, sprintf } from '@wordpress/i18n';
 import {
+	BaseControl,
 	Button,
 	PanelBody,
 	Path,
@@ -16,7 +17,7 @@ import {
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
-import { InnerBlocks, InspectorControls } from '@wordpress/editor';
+import { InnerBlocks, InspectorControls, URLInput } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -200,6 +201,7 @@ class JetpackContactForm extends Component {
 	}
 
 	renderOnSubmissionFields() {
+		const { instanceId } = this.props;
 		const {
 			customThankyou,
 			customThankyouType,
@@ -234,12 +236,17 @@ class JetpackContactForm extends Component {
 					/>
 				) }
 				{ customThankyou && 'redirect' === customThankyouType && (
-					<TextControl
+					<BaseControl
 						label={ __( 'Redirect address', 'jetpack' ) }
-						value={ customThankyouRedirect }
-						placeholder={ 'https://' }
-						onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
-					/>
+						id={ `contact-form-${ instanceId }-thankyou-url` }
+					>
+						<URLInput
+							id={ `contact-form-${ instanceId }-thankyou-url` }
+							value={ customThankyouRedirect }
+							className="jetpack-contact-form__thankyou-redirect-url"
+							onChange={ value => this.props.setAttributes( { customThankyouRedirect: value } ) }
+						/>
+					</BaseControl>
 				) }
 			</Fragment>
 		);

--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -39,6 +39,10 @@
 	width: 100%;
 }
 
+.jetpack-contact-form__thankyou-redirect-url input[type="text"] {
+	width: 100%;
+}
+
 .jetpack-field-label {
 	display: flex;
 	flex-direction: row;

--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -43,6 +43,10 @@
 	width: 100%;
 }
 
+.jetpack-contact-form__thankyou-redirect-url__suggestions {
+	width: 260px;
+}
+
 .jetpack-field-label {
 	display: flex;
 	flex-direction: row;

--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -43,10 +43,6 @@
 	width: 100%;
 }
 
-.jetpack-contact-form__thankyou-redirect-url__suggestions {
-	width: 260px;
-}
-
 .jetpack-field-label {
 	display: flex;
 	flex-direction: row;

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -56,6 +56,22 @@ export const settings = {
 			type: 'string',
 			default: null,
 		},
+		customThankyou: {
+			type: 'boolean',
+			default: false,
+		},
+		customThankyouType: {
+			type: 'string',
+			default: 'message',
+		},
+		customThankyouMessage: {
+			type: 'string',
+			default: '',
+		},
+		customThankyouRedirect: {
+			type: 'string',
+			default: '',
+		},
 
 		// Deprecated
 		has_form_settings_set: {

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -147,7 +147,10 @@ export const settings = {
 
 			isEligible: attr => {
 				// when the deprecated, snake_case values are default, no need to migrate
-				if ( ! attr.has_form_settings_set && attr.submit_button_text === 'Submit' ) {
+				if (
+					! attr.has_form_settings_set &&
+					( ! attr.submit_button_text || attr.submit_button_text === 'Submit' )
+				) {
 					return false;
 				}
 				return true;

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -62,7 +62,7 @@ export const settings = {
 		},
 		customThankyouType: {
 			type: 'string',
-			default: 'message',
+			default: '',
 		},
 		customThankyouMessage: {
 			type: 'string',

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -57,10 +57,6 @@ export const settings = {
 			default: null,
 		},
 		customThankyou: {
-			type: 'boolean',
-			default: false,
-		},
-		customThankyouType: {
 			type: 'string',
 			default: '',
 		},

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1995,10 +1995,6 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 				' (<a href="' . esc_url( $back_url ) . '">' . esc_html__( 'go back', 'jetpack' ) . '</a>)' .
 				"</h3>\n\n";
 
-			if ( $attributes['customThankyou'] && ( ! $attributes['customThankyouType'] || 'message' === $attributes['customThankyouType'] ) ) {
-				$r_success_message .= wpautop( $attributes['customThankyouMessage'] );
-			}
-
 			// Don't show the feedback details unless the nonce matches
 			if ( $feedback_id && wp_verify_nonce( stripslashes( $_GET['_wpnonce'] ), "contact-form-sent-{$feedback_id}" ) ) {
 				$r_success_message .= self::success_message( $feedback_id, $form );
@@ -2108,8 +2104,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * @return string $message
 	 */
 	static function success_message( $feedback_id, $form ) {
+		$thankyou = '';
+		if ( $form->get_attribute( 'customThankyou' ) && ( ! $form->get_attribute( 'customThankyouType' ) || 'message' === $form->get_attribute( 'customThankyouType' ) ) ) {
+			$thankyou = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+		}
+
 		return wp_kses(
-			'<blockquote class="contact-form-submission">'
+			$thankyou
+			. '<blockquote class="contact-form-submission">'
 			. '<p>' . join( '</p><p>', self::get_compiled_form( $feedback_id, $form ) ) . '</p>'
 			. '</blockquote>',
 			array(
@@ -2821,11 +2823,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		do_action( 'grunion_after_message_sent', $post_id, $to, $subject, $message, $headers, $all_values, $extra_values );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			$custom_thankyou = '';
-			if ( $this->get_attribute( 'customThankyou' ) && $this->get_attribute( 'customThankyouType' ) === 'message' ) {
-				$custom_thankyou = wpautop( $this->get_attribute( 'customThankyouMessage' ) );
-			}
-			return $custom_thankyou . self::success_message( $post_id, $this );
+			return self::success_message( $post_id, $this );
 		}
 
 		if ( $this->get_attribute( 'customThankyou' ) && $this->get_attribute( 'customThankyouType' ) === 'redirect' ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2825,6 +2825,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			return self::success_message( $post_id, $this );
 		}
 
+		$redirect = '';
 		if ( $this->get_attribute( 'customThankyou' ) === 'redirect' ) {
 			$redirect = $this->get_attribute( 'customThankyouRedirect' );
 		}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1844,6 +1844,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'widget'                 => 0,    // Not exposed to the user. Works with Grunion_Contact_Form_Plugin::widget_atts()
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack' ),
+			// These attributes come from the block editor, so use camel case instead of snake case.
 			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2105,7 +2105,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 */
 	static function success_message( $feedback_id, $form ) {
 		$thankyou = '';
-		if ( $form->get_attribute( 'customThankyou' ) && ( ! $form->get_attribute( 'customThankyouType' ) || 'message' === $form->get_attribute( 'customThankyouType' ) ) ) {
+		if ( $form->get_attribute( 'customThankyou' ) && 'message' === $form->get_attribute( 'customThankyouType' ) ) {
 			$thankyou = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
 		}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1844,8 +1844,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'widget'                 => 0,    // Not exposed to the user. Works with Grunion_Contact_Form_Plugin::widget_atts()
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack' ),
-			'customThankyou'         => 'false',
-			'customThankyouType'     => 'message',
+			'customThankyou'         => '',
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack' ),
 			'customThankyouRedirect' => '',
 		);
@@ -2104,16 +2103,16 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 	 * @return string $message
 	 */
 	static function success_message( $feedback_id, $form ) {
-		$thankyou = '';
-		if ( $form->get_attribute( 'customThankyou' ) && 'message' === $form->get_attribute( 'customThankyouType' ) ) {
-			$thankyou = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+		if ( 'message' === $form->get_attribute( 'customThankyou' ) ) {
+			$message = wpautop( $form->get_attribute( 'customThankyouMessage' ) );
+		} else {
+			$message = '<blockquote class="contact-form-submission">'
+			. '<p>' . join( '</p><p>', self::get_compiled_form( $feedback_id, $form ) ) . '</p>'
+			. '</blockquote>';
 		}
 
 		return wp_kses(
-			$thankyou
-			. '<blockquote class="contact-form-submission">'
-			. '<p>' . join( '</p><p>', self::get_compiled_form( $feedback_id, $form ) ) . '</p>'
-			. '</blockquote>',
+			$message,
 			array(
 				'br'         => array(),
 				'blockquote' => array( 'class' => array() ),
@@ -2826,7 +2825,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			return self::success_message( $post_id, $this );
 		}
 
-		if ( $this->get_attribute( 'customThankyou' ) && $this->get_attribute( 'customThankyouType' ) === 'redirect' ) {
+		if ( $this->get_attribute( 'customThankyou' ) === 'redirect' ) {
 			$redirect = $this->get_attribute( 'customThankyouRedirect' );
 		}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2826,7 +2826,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		$redirect = '';
-		if ( $this->get_attribute( 'customThankyou' ) === 'redirect' ) {
+		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
 			$redirect = $this->get_attribute( 'customThankyouRedirect' );
 		}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2827,7 +2827,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 		$redirect = '';
 		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
-			$redirect = $this->get_attribute( 'customThankyouRedirect' );
+			$redirect = esc_url( $this->get_attribute( 'customThankyouRedirect' ) );
 		}
 
 		if ( ! $redirect ) {

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1844,9 +1844,9 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'widget'                 => 0,    // Not exposed to the user. Works with Grunion_Contact_Form_Plugin::widget_atts()
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack' ),
-			'customThankyou'         => '',
-			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack' ),
-			'customThankyouRedirect' => '',
+			'customThankyou'         => '', // Whether to show a custom thank you response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
+			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack' ), // The message to show when customThankyou is set to 'message'.
+			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2827,28 +2827,35 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		$redirect = '';
+		$custom_redirect = false;
 		if ( 'redirect' === $this->get_attribute( 'customThankyou' ) ) {
-			$redirect = esc_url( $this->get_attribute( 'customThankyouRedirect' ) );
+			$custom_redirect = true;
+			$redirect        = esc_url( $this->get_attribute( 'customThankyouRedirect' ) );
 		}
 
 		if ( ! $redirect ) {
-			$redirect = wp_get_referer();
+			$custom_redirect = false;
+			$redirect        = wp_get_referer();
 		}
 
-		if ( ! $redirect ) { // wp_get_referer() returns false if the referer is the same as the current page
-			$redirect = $_SERVER['REQUEST_URI'];
+		if ( ! $redirect ) { // wp_get_referer() returns false if the referer is the same as the current page.
+			$custom_redirect = false;
+			$redirect        = $_SERVER['REQUEST_URI'];
 		}
 
-		$redirect = add_query_arg(
-			urlencode_deep(
-				array(
-					'contact-form-id'   => $id,
-					'contact-form-sent' => $post_id,
-					'contact-form-hash' => $this->hash,
-					'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :(
-				)
-			), $redirect
-		);
+		if ( ! $custom_redirect ) {
+			$redirect = add_query_arg(
+				urlencode_deep(
+					array(
+						'contact-form-id'   => $id,
+						'contact-form-sent' => $post_id,
+						'contact-form-hash' => $this->hash,
+						'_wpnonce'          => wp_create_nonce( "contact-form-sent-{$post_id}" ), // wp_nonce_url HTMLencodes :( .
+					)
+				),
+				$redirect
+			);
+		}
 
 		/**
 		 * Filter the URL where the reader is redirected after submitting a form.

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1844,7 +1844,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'widget'                 => 0,    // Not exposed to the user. Works with Grunion_Contact_Form_Plugin::widget_atts()
 			'id'                     => null, // Not exposed to the user. Set above.
 			'submit_button_text'     => __( 'Submit', 'jetpack' ),
-			'customThankyou'         => '', // Whether to show a custom thank you response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
+			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
 		);

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2862,6 +2862,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		 */
 		$redirect = apply_filters( 'grunion_contact_form_redirect_url', $redirect, $id, $post_id );
 
+		// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- We intentially allow external redirects here.
 		wp_redirect( $redirect );
 		exit;
 	}

--- a/to-test.md
+++ b/to-test.md
@@ -8,6 +8,10 @@ We've made some changes to simplify the Jetpack Dashboard interface when your us
 
 We've made some changes to ensure that blocks are properly translated in the block editor. If you switch to a language that offers language packs, like French or Spanish, you should see that Jetpack Blocks will now be translated in the editor.
 
+## Contact Form Block
+
+The Contact Form Block now includes options for showing a custom post-submission message, or to redirect to a different URL.
+
 ### Carousel
 
 In this release, we've made some changes to how the Carousel metadata was added to each gallery. To test this:


### PR DESCRIPTION
This PR adds post-submission options to the contact-form block.

Fixes #708, #12286.

#### Changes proposed in this Pull Request:

* Adds a new `InspectorControl` panel to to the contact form block, which allows setting an optional message or custom redirect URL to be used after the contact form is submitted.
* Adds support for these settings to the contact form submission handling.

*NOTE:* While this PR technically adds support for these options to the shortcode, this is just a side-effect of how the contact form works, rather than a deliberate decision, and should be considered unsupported. Support has not been added to the TinyMCE plugin.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Adds features to the Contact Form module. pb5gDS-7W-p2

#### Testing instructions:

- Create a new post in the block editor, and add a *Form* block.
- In the sidebar, go through the *Confirmation Message* options. Test that they behave as described.

#### Screenshots

<img width="1279" alt="" src="https://user-images.githubusercontent.com/352291/66796142-8a68ee00-ef52-11e9-90f0-fd145f0d56c8.png">
<img width="1279" alt="" src="https://user-images.githubusercontent.com/352291/66796144-8a68ee00-ef52-11e9-9a88-61e01be91e53.png">
<img width="1279" alt="" src="https://user-images.githubusercontent.com/352291/66796145-8a68ee00-ef52-11e9-9d94-32feeab1e7bc.png">
<img width="1279" alt="" src="https://user-images.githubusercontent.com/352291/66796146-8b018480-ef52-11e9-8765-d7a8b0600730.png">


#### Proposed changelog entry for your changes:
* Contact Form Block: Allow setting a custom post-submission message or redirect URL for the form.