### PR TITLE
Tracks: use filter instead of relying on Jetpack class

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6938,7 +6938,13 @@ endif;
 	 * Will return true if a user has clicked to register, or is already connected.
 	 */
 	public static function jetpack_tos_agreed() {
-		return Jetpack_Options::get_option( 'tos_agreed' ) || self::is_active_and_not_development_mode();
+		$tos_agreed = Jetpack_Options::get_option( 'tos_agreed' ) || self::is_active_and_not_development_mode();
+
+		if ( $tos_agreed ) {
+			add_filter( 'jetpack_tos_agreed', '__return_true' );
+		}
+
+		return $tos_agreed;
 	}
 
 	/**

--- a/packages/tracking/src/Tracking.php
+++ b/packages/tracking/src/Tracking.php
@@ -102,7 +102,16 @@ class Tracking {
 		}
 
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
-		if ( ! \Jetpack::jetpack_tos_agreed() ) {
+		if (
+			/**
+			 * Filter whether ToS were accepted on this site.
+			 *
+			 * @since 7.9.0
+			 *
+			 * @param bool $tos_agreed Was ToS accepted for this site. Defaults to false.
+			 */
+			apply_filters( 'jetpack_tos_agreed', false )
+		) {
 			return false;
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

See https://github.com/Automattic/jetpack/pull/13698#discussion_r334453278

> Since Jetpack is not a package this means that his package is not usable outside of jetpack.
> Which kind of defeats the purpose of this a package.

#### Testing instructions:

* Upgrade your Jetpack site to Professional
* Add a Jetpack Search widget to the site
* Check that you see a `jetpack_search_widget_widget_added` event in Tracks
* Enable development mode (by adding this to wp-config.php): `define( 'JETPACK_DEV_DEBUG', true );`
* Add a Jetpack Search widget to the site
* Check that you don't see another `jetpack_search_widget_widget_added` event in Tracks

#### Proposed changelog entry for your changes:

* None
