### PR TITLE
Instant Search: Fix post type filter label format

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -217,9 +217,17 @@ class Jetpack_Search {
 					$widgets[$filter[ 'widget_id' ]][ 'filters' ][] = $new_filter;
 				}
 
+				$post_type_objs = get_post_types( array(), 'objects' );
+				$post_type_labels = array();
+				foreach( $post_type_objs as $key => $obj ) {
+					$post_type_labels[$key] = array(
+						'singular_name' => $obj->labels->singular_name,
+						'name' => $obj->labels->name,
+					);
+				}
 				// This is probably a temporary filter for testing the prototype.
 				$options = array(
-					'postTypes' => get_post_types(),
+					'postTypes' => $post_type_labels,
 					'siteId'		=> Jetpack::get_option( 'id' ),
 					'widgets' 	=> array_values( $widgets ),
 				);

--- a/modules/search/instant-search/components/search-filter-post-types.jsx
+++ b/modules/search/instant-search/components/search-filter-post-types.jsx
@@ -26,7 +26,7 @@ export default class SearchFilterPostTypes extends Component {
 	};
 
 	renderPostType = ( { key, doc_count: count } ) => {
-		const name = key in this.props.postTypes ? this.props.postTypes[ key ] : key;
+		const name = key in this.props.postTypes ? this.props.postTypes[ key ].singular_name : key;
 		return (
 			<div>
 				<input


### PR DESCRIPTION
Use the post type singular label names rather than the slug

#### Testing instructions:
* Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
* Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
( Add a Jetpack Search widget to the Search page sidebar and configure a post type filter.
* Try searching and filtering.
