### PR TITLE
WooCommerce Services: Fix the redirect URL for Woo Services JITM CTAs

### DIFF
--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -60,7 +60,11 @@ class WC_Services_Installer {
 				break;
 		}
 
-		$redirect = isset( $_GET['redirect'] ) ? admin_url( $_GET['redirect'] ) : wp_get_referer();
+		if ( isset( $_GET['redirect'] ) ) {
+			$redirect = home_url( esc_url_raw( wp_unslash( $_GET['redirect'] ) ) );
+		} else {
+			$redirect = wp_get_referer();
+		}
 
 		if ( $result ) {
 			$this->jetpack->stat( 'jitm', 'wooservices-activated-' . JETPACK__VERSION );

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -1,28 +1,43 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Installs and activates the WooCommerce Services plugin.
+ */
 class WC_Services_Installer {
 
 	/**
+	 * The instance of the Jetpack class.
+	 *
 	 * @var Jetpack
-	 **/
+	 */
 	private $jetpack;
 
 	/**
+	 * The singleton instance of this class.
+	 *
 	 * @var WC_Services_Installer
-	 **/
+	 */
 	private static $instance = null;
 
-	static function init() {
+	/**
+	 * Returns the singleton instance of this class.
+	 *
+	 * @return object The WC_Services_Installer object.
+	 */
+	public static function init() {
 		if ( is_null( self::$instance ) ) {
 			self::$instance = new WC_Services_Installer();
 		}
 		return self::$instance;
 	}
 
+	/**
+	 * Constructor
+	 */
 	public function __construct() {
 		$this->jetpack = Jetpack::init();
 
@@ -92,7 +107,7 @@ class WC_Services_Installer {
 	public function error_notice() {
 		?>
 		<div class="notice notice-error is-dismissible">
-			<p><?php _e( 'There was an error installing WooCommerce Services.', 'jetpack' ); ?></p>
+			<p><?php esc_html_e( 'There was an error installing WooCommerce Services.', 'jetpack' ); ?></p>
 		</div>
 		<?php
 	}
@@ -103,11 +118,11 @@ class WC_Services_Installer {
 	 * @return bool result of installation
 	 */
 	private function install() {
-		include_once( ABSPATH . '/wp-admin/includes/admin.php' );
-		include_once( ABSPATH . '/wp-admin/includes/plugin-install.php' );
-		include_once( ABSPATH . '/wp-admin/includes/plugin.php' );
-		include_once( ABSPATH . '/wp-admin/includes/class-wp-upgrader.php' );
-		include_once( ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php' );
+		include_once ABSPATH . '/wp-admin/includes/admin.php';
+		include_once ABSPATH . '/wp-admin/includes/plugin-install.php';
+		include_once ABSPATH . '/wp-admin/includes/plugin.php';
+		include_once ABSPATH . '/wp-admin/includes/class-wp-upgrader.php';
+		include_once ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php';
 
 		$api = plugins_api( 'plugin_information', array( 'slug' => 'woocommerce-services' ) );
 
@@ -129,7 +144,7 @@ class WC_Services_Installer {
 	private function activate() {
 		$result = activate_plugin( 'woocommerce-services/woocommerce-services.php' );
 
-		// activate_plugin() returns null on success
+		// Activate_plugin() returns null on success.
 		return is_null( $result );
 	}
 }

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -96,7 +96,7 @@ class WC_Services_Installer {
 	 * Set up installation error admin notice.
 	 */
 	public function add_error_notice() {
-		if ( ! empty( $_GET['wc-services-install-error'] ) ) {
+		if ( ! empty( $_GET['wc-services-install-error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_action( 'admin_notices', array( $this, 'error_notice' ) );
 		}
 	}

--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -63,7 +63,7 @@ class WC_Services_Installer {
 		if ( isset( $_GET['redirect'] ) ) {
 			$redirect = home_url( esc_url_raw( wp_unslash( $_GET['redirect'] ) ) );
 		} else {
-			$redirect = wp_get_referer();
+			$redirect = admin_url();
 		}
 
 		if ( $result ) {

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -2,6 +2,7 @@
 module.exports = [
 	'3rd-party/3rd-party.php',
 	'3rd-party/class.jetpack-amp-support.php',
+	'3rd-party/woocommerce-services.php',
 	'class.jetpack-gutenberg.php',
 	'class.jetpack-plan.php',
 	'extensions/',


### PR DESCRIPTION
The redirect after clicking a Woo Services JITM CTA leads to a 404.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use `home_url()` instead of `admin_url()` to create the redirect URL. `$SERVER['REQUEST_URI']` is used to create the redirect URL, and it includes `wp-admin/`. So, the redirect URL created using `admin_url()` will include an extra `wp-admin/`. Fix this by using `home_url()`, which does not include `wp-admin/`.
* Some browsers strip the 'referer' header (see PR #9239). So let's just use admin_url() as the fallback redirect URL if `$_GET['redirect']` is empty.
* Fix most of the PHPCS errors and warnings in `3rd-party/woocommerce-services.php`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes a bug in an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

NOTE: The changes in PR #13720 are required to test this branch. Without those changes, the redirect fixed in this PR doesn't occur.

1. Install and activate Jetpack and WooCommerce. Do not install WooCommerce Services.
2. Connect Jetpack.
3. Navigate to the WooCommerce -> Orders page.
4. Click the Add New button to create a new order.
5. Click the Create button for the new order.
6. Navigate to wp-admin -> WooCommerce -> Settings.
7. Set the Country / State to United States (any state).
8. Refresh the WooCommerce -> Settings page.
9. Dismiss the JITMs (which are located above the tabs) until you see one with the button text "Install WooCommerce Services". Do not dismiss this JITM.
10. Click the “Install WooCommerce Services” button. Notice that you’re redirected to 404 with a URL containing:
    `wp-admin/wp-admin/admin.php?page=wc-settings`
11. Navigate to wp-admin -> Plugins. 
12. Uninstall the WooCommerce Services plugin.
13. Apply this branch.
14. Navigate to wp-admin -> WooCommerce ->Settings. The "Install WooCommerce Services" JITM should still be displayed at the top of the page.
15. Click the “Install WooCommerce Services” button. Notice that you’re redirected back to the WC Settings page as expected.
16. Navigate to Plugins and verify that the WooCommerce Services plugin is installed and activated.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* TBD
