### PR TITLE
REST API: Site endpoint: Return last import engine used in options array

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -133,6 +133,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'design_type',
 		'site_goals',
 		'site_segment',
+		'import_engine',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -584,6 +585,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'site_segment':
 					$options[ $key ] = $site->get_site_segment();
+					break;
+				case 'import_engine':
+					$options[ $key ] = $site->get_import_engine();
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -93,6 +93,8 @@ abstract class SAL_Site {
 
 	abstract public function get_podcasting_archive();
 
+	abstract public function get_import_engine();
+
 	abstract public function get_jetpack_seo_front_page_description();
 
 	abstract public function get_jetpack_seo_title_formats();

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -205,6 +205,15 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Return the last engine used for an import on the site.
+	 *
+	 * This option is not used in Jetpack.
+	 */
+	function get_import_engine() {
+		return null;
+	}
+
+	/**
 	 * Post functions
 	 */
 


### PR DESCRIPTION
Summary: This PR adds `import_engine` to the response of the site endpoint, syncing D33115-code. 

Differential Revision: D33115-code

This commit syncs r197917-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The endpoint shouldn't return any `import_engine` for Jetpack sites. The PR just syncs the response format.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify the `import_engine` option appears empty for Jetpack sites.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed
