### PR TITLE
Masterbar: Add My Home menu item for Atomic sites

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1375,7 +1375,7 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
-		if ( $this->my_home_enabled() ) {
+		if ( $this->is_my_home_enabled() ) {
 			$wp_admin_bar->add_menu(
 				array(
 					'parent' => 'blog',

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1,6 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Client;
 
 require_once dirname( __FILE__ ) . '/rtl-admin-bar.php';
 
@@ -866,6 +867,8 @@ class A8C_WPCOM_Masterbar {
 			);
 		}
 
+		$this->add_my_home_submenu_item( $wp_admin_bar );
+
 		// Stats.
 		if ( Jetpack::is_module_active( 'stats' ) && current_user_can( 'view_stats' ) ) {
 			$wp_admin_bar->add_menu(
@@ -1324,6 +1327,50 @@ class A8C_WPCOM_Masterbar {
 			 * @since 5.4.0
 			 */
 			do_action( 'jetpack_masterbar' );
+		}
+	}
+
+	/**
+	 * Adds "My Home" submenu item to sites that are eligible.
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
+	 * @return void
+	 */
+	private function add_my_home_submenu_item( &$wp_admin_bar ) {
+		if ( ! current_user_can( 'manage_options' ) || ! jetpack_is_atomic_site() ) {
+			return;
+		}
+
+		$site_id       = Jetpack_Options::get_option( 'id' );
+		$site_response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
+			'1.1'
+		);
+
+		if ( is_wp_error( $site_response ) ) {
+			return;
+		}
+
+		$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
+
+		l( $site_data->options );
+
+		if (
+			$site_data &&
+			isset( $site_data->options->created_at ) &&
+			( new Datetime( '2019-08-06 00:00:00.000' ) ) <= ( new Datetime( $site_data->options->created_at ) )
+		) {
+			$wp_admin_bar->add_menu(
+				array(
+					'parent' => 'blog',
+					'id'     => 'my-home',
+					'title'  => __( 'My Home', 'jetpack' ),
+					'href'   => 'https://wordpress.com/home/' . esc_attr( $this->primary_site_slug ),
+					'meta'   => array(
+						'class' => 'mb-icon',
+					),
+				)
+			);
 		}
 	}
 }

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1353,8 +1353,6 @@ class A8C_WPCOM_Masterbar {
 
 		$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
 
-		l( $site_data->options );
-
 		if (
 			$site_data &&
 			isset( $site_data->options->created_at ) &&

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -13,6 +13,7 @@
 		'wp-admin-bar-switch-site': 'my_sites_switch_site',
 		'wp-admin-bar-blog-info': 'my_sites_blog_info',
 		'wp-admin-bar-site-view': 'my_sites_view_site',
+		'wp-admin-bar-my-home': 'my_sites_my_home',
 		'wp-admin-bar-blog-stats': 'my_sites_blog_stats',
 		'wp-admin-bar-activity': 'my_sites_activity',
 		'wp-admin-bar-plan': 'my_sites_plan',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the Customer Home link to the Masterbar for Atomic sites to keep parity with Calypso sidebar

This PR depends on

- A bug fix for blog requests to the `/sites/{site}` API in https://github.com/Automattic/jetpack/pull/13844
- Adding the My Home icon to the masterbar css D34250-code

**Update: these dependencies have now been merged**

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

See pb5gDS-2L-p2 for context

#### Testing instructions:
* Create a new Jetpack site (must be created on or after 2019-08-06) and connect to WordPress.com
* Install wpcomsh as a mu-plugin to emulate an Atomic Site
* When clicking on "My Sites" in the master bar, you should see "My Home" added

Alternatively, you can edit the Registered date of the Jetpack cached site at `/wp-admin/network/site-info.php?id=SITE_ID` to be after 2019-08-06.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds "My Home" link to Masterbar for sites hosted on WordPress.com
