### PR TITLE
Initialize tracking right after we assume that the user aggreed to the TOS

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3326,7 +3326,7 @@ p {
 		// The user has agreed to the TOS at some point by now.
 		Jetpack_Options::update_option( 'tos_agreed', true );
 		// Make sure that we initialize tracking if we haven't already
-		$tracking = new \Automattic\Jetpack\Plugin\Tracking();
+		$tracking = new Automattic\Jetpack\Plugin\Tracking();
 		$tracking->init();
 
 		// Let's get some testing in beta versions and such.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3325,6 +3325,9 @@ p {
 	public static function try_registration() {
 		// The user has agreed to the TOS at some point by now.
 		Jetpack_Options::update_option( 'tos_agreed', true );
+		// Make sure that we initialize tracking if we haven't already
+		$tracking = new \Automattic\Jetpack\Plugin\Tracking();
+		$tracking->init();
 
 		// Let's get some testing in beta versions and such.
 		if ( self::is_development_version() && defined( 'PHP_URL_HOST' ) ) {

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -13,9 +13,14 @@ class Tracking {
 	 * @access private
 	 */
 	private $tracking;
+	private $initialized = false;
 
 	function init() {
+		if ( $this->initialized ) {
+			return null; // Don't initalize this more then once.
+		}
 		$this->tracking = new Tracks( 'jetpack' );
+		$this->initialized = true;
 
 		// For tracking stuff via js/ajax
 		add_action( 'admin_enqueue_scripts', array( $this->tracking, 'enqueue_tracks_scripts' ) );


### PR DESCRIPTION
Currently we miss events because when the user hasn't agreed to the TOS yet and we only initialize the tracking on the WordPress `init` [See ](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L570-L573).

Missing these events means that the we don't have an accurate count of the number of user that have successfully connected their site. 

#### Changes proposed in this Pull Request:
* Initialize tracking right after the user agrees to the terms of service. 

#### Testing instructions:
* On a brand new jurassic ninja site. Notice that the tracking works as expected. 
When you are connecting a jetpack site for the first time. 

On a successful connection https://github.com/Automattic/jetpack/blob/master/packages/tracking/src/Tracking.php#L97 should fire the `jpc_register_success` event. 

#### Proposed changelog entry for your changes:
* Fix the jetpack connection event tracking
