### PR TITLE
Pre-Commit: Fail on PHPCS violation in changed lines throughou…

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -13,6 +13,7 @@ readme.md
 babel.config*
 phpunit.xml.dist
 dangerfile.js
+bin/phpcs-changed.sh
 bin/phpcs-whitelist.js
 bin/pre-commit-hook.js
 bin/prepare-built-branch.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ git:
 before_script:
   - export PLUGIN_SLUG=$(basename $(pwd))
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
-  - composer install
+  - composer install --ignore-platform-reqs
   - ./tests/setup-travis.sh
 
 script: ./tests/run-travis.sh

--- a/bin/phpcs-changed.sh
+++ b/bin/phpcs-changed.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This is meant to run only if PHP files have been staged. It'll fatal as of now if phpcs-changed can't find php files in the diff.
+function phpcschanged {
+  # We need three files for phpcs-changed.
+  # 1. A file of the combined diff.
+  # 2. A file of the phpcs results for the original files.
+  # 3. A file of the phpcs results for the revised files.
+
+  # Make a folder for the files.
+  mkdir tmp-phpcschanged
+  mkdir tmp-phpcschanged/original
+
+  # File 1
+  git diff --cached > tmp-phpcschanged/diff.diff
+
+  # File 2. This one is a bit fun to make.
+
+  for file in $( git diff --name-only --cached ); do
+	  mkdir -p tmp-phpcschanged/original/$(dirname ${file} ) > /dev/null 2>&1
+	  git cat-file -p master:${file} > tmp-phpcschanged/original/${file} > /dev/null 2>&1
+  done
+
+  vendor/bin/phpcs --report=json tmp-phpcschanged/original > tmp-phpcschanged/phpcs-orig.json
+
+  # File 3
+  vendor/bin/phpcs --report=json $(git diff --name-only --cached) > tmp-phpcschanged/phpcs-new.json
+
+  # Run the actual change tool!
+  vendor/bin/phpcs-changed --diff tmp-phpcschanged/diff.diff --phpcs-orig tmp-phpcschanged/phpcs-orig.json --phpcs-new tmp-phpcschanged/phpcs-new.json
+
+  # Clean up! Clean up! Everybody, eveywhere! Clean up! Clean up! Everybody does their share.
+ rm -rf tmp-phpcschanged
+}
+
+phpcschanged

--- a/bin/phpcs-changed.sh
+++ b/bin/phpcs-changed.sh
@@ -18,7 +18,7 @@ function phpcschanged {
 
   for file in $( git diff --name-only --cached ); do
 	  mkdir -p tmp-phpcschanged/original/$(dirname ${file} ) > /dev/null 2>&1
-	  git cat-file -p master:${file} > tmp-phpcschanged/original/${file} > /dev/null 2>&1
+	  git cat-file -p HEAD:${file} > tmp-phpcschanged/original/${file}
   done
 
   vendor/bin/phpcs --report=json tmp-phpcschanged/original > tmp-phpcschanged/phpcs-orig.json

--- a/bin/phpcs-changed.sh
+++ b/bin/phpcs-changed.sh
@@ -12,22 +12,22 @@ function phpcschanged {
   mkdir /tmp/jetpack-phpcschanged/original
 
   # File 1
-  git diff --cached > tmp-phpcschanged/diff.diff
+  git diff --cached > /tmp/jetpack-phpcschanged/diff.diff
 
   # File 2. This one is a bit fun to make.
 
   for file in $( git diff --name-only --cached ); do
-	  mkdir -p tmp-phpcschanged/original/$(dirname ${file} ) > /dev/null 2>&1
-	  git cat-file -p HEAD:${file} > tmp-phpcschanged/original/${file}
+	  mkdir -p /tmp/jetpack-phpcschanged/original/$(dirname ${file} ) > /dev/null 2>&1
+	  git cat-file -p HEAD:${file} > /tmp/jetpack-phpcschanged/original/${file}
   done
 
-  vendor/bin/phpcs --report=json tmp-phpcschanged/original > tmp-phpcschanged/phpcs-orig.json
+  vendor/bin/phpcs --report=json /tmp/jetpack-phpcschanged/original > /tmp/jetpack-phpcschanged/phpcs-orig.json
 
   # File 3
-  vendor/bin/phpcs --report=json $(git diff --name-only --cached) > tmp-phpcschanged/phpcs-new.json
+  vendor/bin/phpcs --report=json $(git diff --name-only --cached) > /tmp/jetpack-phpcschanged/phpcs-new.json
 
   # Run the actual change tool!
-  vendor/bin/phpcs-changed --diff tmp-phpcschanged/diff.diff --phpcs-orig tmp-phpcschanged/phpcs-orig.json --phpcs-new tmp-phpcschanged/phpcs-new.json
+  vendor/bin/phpcs-changed --diff /tmp/jetpack-phpcschanged/diff.diff --phpcs-orig /tmp/jetpack-phpcschanged/phpcs-orig.json --phpcs-new /tmp/jetpack-phpcschanged/phpcs-new.json
 
   # Clean up! Clean up! Everybody, eveywhere! Clean up! Clean up! Everybody does their share.
  rm -rf /tmp/jetpack-phpcschanged

--- a/bin/phpcs-changed.sh
+++ b/bin/phpcs-changed.sh
@@ -8,8 +8,8 @@ function phpcschanged {
   # 3. A file of the phpcs results for the revised files.
 
   # Make a folder for the files.
-  mkdir tmp-phpcschanged
-  mkdir tmp-phpcschanged/original
+  mkdir /tmp/jetpack-phpcschanged
+  mkdir /tmp/jetpack-phpcschanged/original
 
   # File 1
   git diff --cached > tmp-phpcschanged/diff.diff
@@ -30,7 +30,7 @@ function phpcschanged {
   vendor/bin/phpcs-changed --diff tmp-phpcschanged/diff.diff --phpcs-orig tmp-phpcschanged/phpcs-orig.json --phpcs-new tmp-phpcschanged/phpcs-new.json
 
   # Clean up! Clean up! Everybody, eveywhere! Clean up! Clean up! Everybody does their share.
- rm -rf tmp-phpcschanged
+ rm -rf /tmp/jetpack-phpcschanged
 }
 
 phpcschanged

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -58,7 +58,8 @@ function checkFailed() {
 		chalk.red( 'COMMIT ABORTED:' ),
 		'The linter reported some problems. ' +
 			'If you are aware of them and it is OK, ' +
-			'repeat the commit command with --no-verify to avoid this check.'
+			'repeat the commit command with --no-verify to avoid this check. ' +
+			"But please don't. Code is poetry."
 	);
 	exitCode = 1;
 }
@@ -188,11 +189,18 @@ let phpChangedResult;
 if ( phpFiles.length > 0 ) {
 	phpChangedResult = spawnSync( 'composer', [ 'php:changed' ], {
 		shell: true,
-		stdio: 'inherit',
+		stdio: 'pipe',
+		encoding: 'utf-8',
 	} );
 }
 
 if ( phpChangedResult && phpChangedResult.stdout ) {
+	let phpChangedResultText;
+	phpChangedResultText = phpChangedResult.stdout.toString().split( '\n' );
+	phpChangedResultText.shift();
+	console.log(
+		JSON.stringify( JSON.parse( phpChangedResultText.toString().slice( 0, -1 ) ), null, 2 )
+	);
 	checkFailed();
 }
 

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -184,6 +184,18 @@ if ( phpcsResult && phpcsResult.status ) {
 	exitCode = 1;
 }
 
+let phpChangedResult;
+if ( phpFiles.length > 0 ) {
+	phpChangedResult = spawnSync( 'composer', [ 'php:changed' ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+}
+
+if ( phpChangedResult && phpChangedResult.status ) {
+	checkFailed();
+}
+
 capturePreCommitDate();
 
 process.exit( exitCode );

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -192,7 +192,7 @@ if ( phpFiles.length > 0 ) {
 	} );
 }
 
-if ( phpChangedResult && phpChangedResult.status ) {
+if ( phpChangedResult && phpChangedResult.stdout ) {
 	checkFailed();
 }
 

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -115,10 +115,12 @@ function runJSLinter( toLintFiles ) {
 
 /**
  * Run phpcs-changed.
+ *
+ * @param {Array} phpFilesToCheck Array of PHP files changed.
  */
-function runPHPCSChanged( phpFiles ) {
+function runPHPCSChanged( phpFilesToCheck ) {
 	let phpChangedResult;
-	if ( phpFiles.length > 0 ) {
+	if ( phpFilesToCheck.length > 0 ) {
 		phpChangedResult = spawnSync( 'composer', [ 'php:changed' ], {
 			shell: true,
 			stdio: 'pipe',
@@ -140,10 +142,12 @@ function runPHPCSChanged( phpFiles ) {
 
 /**
  * Exit
+ *
+ * @param {Number} exitCodePassed Shell exit code.
  */
-function exit( exitCode ) {
+function exit( exitCodePassed ) {
 	capturePreCommitDate();
-	process.exit( exitCode );
+	process.exit( exitCodePassed );
 }
 
 dirtyFiles.forEach( file =>

--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -198,10 +198,11 @@ if ( phpChangedResult && phpChangedResult.stdout ) {
 	let phpChangedResultText;
 	phpChangedResultText = phpChangedResult.stdout.toString().split( '\n' );
 	phpChangedResultText.shift();
-	console.log(
-		JSON.stringify( JSON.parse( phpChangedResultText.toString().slice( 0, -1 ) ), null, 2 )
-	);
-	checkFailed();
+	phpChangedResultText = phpChangedResultText.toString().slice( 0, -1 );
+	if ( phpChangedResultText ) {
+		console.log( JSON.stringify( JSON.parse( phpChangedResultText ), null, 2 ) );
+		checkFailed();
+	}
 }
 
 capturePreCommitDate();

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "automattic/jetpack",
 	"description": "Jetpack supercharges your self‑hosted WordPress site with the awesome cloud power of WordPress.com",
-	"homepage": "https://jetpack.com/",
+	"homepage": "https://jetpack.com/....",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"support": {
@@ -29,13 +29,15 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0",
 		"wp-coding-standards/wpcs": "2.1.1",
 		"sirbrillig/phpcs-variable-analysis": "2.7.0",
-		"phpcompatibility/phpcompatibility-wp": "2.1.0"
+		"phpcompatibility/phpcompatibility-wp": "2.1.0",
+		"sirbrillig/phpcs-changed": "^1.0"
 	},
 	"scripts": {
 		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.6-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
 		"php:lint": "composer install && vendor/bin/phpcs -p -s",
 		"php:autofix": "composer install && vendor/bin/phpcbf",
-		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
+		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
+		"php:changed": "composer install && bin/phpcs-changed.sh"
 	},
 	"repositories": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
 		"sirbrillig/phpcs-changed": "^1.0"
 	},
 	"scripts": {
-		"php:compatibility": "composer install && vendor/bin/phpcs -p -s --runtime-set testVersion '5.6-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
-		"php:lint": "composer install && vendor/bin/phpcs -p -s",
-		"php:autofix": "composer install && vendor/bin/phpcbf",
-		"php:lint:errors": "composer install && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
+		"php:compatibility": "composer install --ignore-platform-reqs && vendor/bin/phpcs -p -s --runtime-set testVersion '5.6-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
+		"php:lint": "composer install --ignore-platform-reqs && vendor/bin/phpcs -p -s",
+		"php:autofix": "composer install --ignore-platform-reqs && vendor/bin/phpcbf",
+		"php:lint:errors": "composer install --ignore-platform-reqs && vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
 		"php:changed": "composer install && bin/phpcs-changed.sh"
 	},
 	"repositories": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "automattic/jetpack",
 	"description": "Jetpack supercharges your self‑hosted WordPress site with the awesome cloud power of WordPress.com",
-	"homepage": "https://jetpack.com/....",
+	"homepage": "https://jetpack.com/",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"support": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bacc30aa6929a0ba176b0a01ecc6bfa7",
+    "content-hash": "93e0b67a67cc488d8765306b24ccd75c",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/abtest",
@@ -41,7 +41,7 @@
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
@@ -73,7 +73,7 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
@@ -107,7 +107,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -139,7 +139,7 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
@@ -178,7 +178,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -206,7 +206,7 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/error",
@@ -234,7 +234,7 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
@@ -272,7 +272,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -301,7 +301,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -327,7 +327,7 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
@@ -356,7 +356,7 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
@@ -385,7 +385,7 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
@@ -412,7 +412,7 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-update/composer-lock",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
@@ -672,6 +672,53 @@
                 "wordpress"
             ],
             "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-changed",
+            "version": "v1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-changed.git",
+                "reference": "bb7e513c7fcad503623064f240c8c76ce4891f3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-changed/zipball/bb7e513c7fcad503623064f240c8c76ce4891f3a",
+                "reference": "bb7e513c7fcad503623064f240c8c76ce4891f3a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "limedeck/phpunit-detailed-printer": "^3.1",
+                "phpunit/phpunit": "^6.4",
+                "sirbrillig/phpcs-import-detection": "^1.1.1",
+                "sirbrillig/phpcs-variable-analysis": "^2.1.3",
+                "squizlabs/php_codesniffer": "^3.2.1"
+            },
+            "bin": [
+                "bin/phpcs-changed"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpcsChanged\\": "PhpcsChanged/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "Run phpcs on files, but only report warnings/errors from lines which were changed.",
+            "time": "2018-11-19T21:11:44+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"build": "yarn install-if-deps-outdated && yarn clean && yarn build-client && yarn build-php && yarn build-extensions",
 		"build-client": "gulp",
 		"build-extensions": "webpack --config ./webpack.config.extensions.js",
-		"build-php": "composer install",
+		"build-php": "composer install --ignore-platform-reqs",
 		"build-production-php": "COMPOSER_MIRROR_PATH_REPOS=1 composer install -o --no-dev --classmap-authoritative --prefer-dist",
 		"build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",
 		"build-production": "yarn distclean && yarn install --production=false && yarn build-production-client && yarn build-production-php && NODE_ENV=production yarn build-extensions && gulp languages:extract",


### PR DESCRIPTION
Supersedes #11545

We can use the https://github.com/sirbrillig/phpcs-changed package (based on our own https://github.com/Automattic/phpcs-diff ) to report PHPCS issues only on changed lines. This is similar to the existing blocking check on WP.com.

Previously, we had (and still do) a whitelist of files that are in full compliance that errors would block. Other files had no automated PHPCS checks.

This would scan changed lines only and block, allowing us to clean up our code without requiring an all-or-nothing approach.

The whitelist is still helpful as it also runs `phpcbf` so authors to those files can still commit and keep moving even if they have minor, fixable issues. (This PR would be blocking in those cases for non-whitelist files).

The implementation is, I admit, a bit hacky. The *current* version of https://github.com/sirbrillig/phpcs-changed has a built-in git workflow to make this magically just work, but that version requires PHP 7.2 on the machines committing.

Our normal dev environment at a8c is OS X. Catalina includes PHP 7.3, but it is only a week old and with the hesitancy to update due to 32-bit concerns, I do not want to make Catalina-or-roll-your-own-PHP a requirement of Jetpack development. Previous modern version of OS X include PHP 7.1 which means we need to use version 1.0 of the phpcs-changed package.

This is fine, except that version requires three files to be passed -- a diff of the changes, the phpcs results of the original files, and the phpcs results of the current files.

To do this, I wrote a bash script that does this work in a temporary folder, then deletes the folder. This older version of the package also only reports in JSON, so the pre-commit.js needs a bit of extra massaging of the data to pretty print it out.

#### Changes proposed in this Pull Request:
* PHPCS all changed files.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Check out this branch and have run `yarn install` at some point historically.
* Make a change in a non-whitelisted file (e.g. `uninstall.php`) that would break PHPCS.
Example: Add a line that says `// I am not ending this single-line comment with a period`
* Commit.
* It should fail the commit with an error and a pretty print explanation, e.g. 
```
{
  "totals": {
    "errors": 1,
    "warnings": 0,
    "fixable": 0
  },
  "files": {
    "/code/jetpack/uninstall.php": {
      "errors": 1,
      "warnings": 0,
      "messages": [
        {
          "line": 20,
          "message": "Inline comments must end in full-stops, exclamation marks, or question marks",
          "source": "Squiz.Commenting.InlineComment.InvalidEndChar",
          "severity": 5,
          "fixable": false,
          "type": "ERROR",
          "column": 1
        }
      ]
    }
  }
}
COMMIT ABORTED: The linter reported some problems. If you are aware of them and it is OK, repeat the commit command with --no-verify to avoid this check. But please don't. Code is poetry.
husky > pre-commit hook failed (add --no-verify to bypass)

```

#### Proposed changelog entry for your changes:
* n/a
