### PR TITLE
Check for last_error when enqueuing IDs

### DIFF
--- a/packages/sync/src/modules/Module.php
+++ b/packages/sync/src/modules/Module.php
@@ -253,6 +253,11 @@ abstract class Module {
 			$previous_interval_end = end( $ids );
 		}
 
+		if ( $wpdb->last_error ) {
+			// return the values that were passed in so all these chunks get retried.
+			return array( $max_items_to_enqueue, $state );
+		}
+
 		return array( $chunk_count, true );
 	}
 


### PR DESCRIPTION
This aims to improve the reliability of full sync by retrying batches if we detect a $wpdb->last_error value. 

Previously the `$module->enqueue_all_ids_as_action()` function was returning `array( $chunk_count, true )`, which up the stack was causing `Full_Sync->continue_enqueuing()` to bail thinking that this was the last batch and we're done enqueuing posts.

This problem is particularly acute with large databases under load running HyperDB, where reads may bail unexpectedly more often.