### PR TITLE
Masterbar: send wpcom user ID to wpcom when attempting to log out

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -81,7 +81,7 @@ class A8C_WPCOM_Masterbar {
 		add_action( 'admin_bar_init', array( $this, 'init' ) );
 
 		// Post logout on the site, also log the user out of WordPress.com.
-		add_action( 'wp_logout', array( $this, 'maybe_logout_user_from_wpcom' ) );
+		add_filter( 'logout_redirect', array( $this, 'maybe_logout_user_from_wpcom' ), 10, 3 );
 	}
 
 	/**
@@ -167,8 +167,12 @@ class A8C_WPCOM_Masterbar {
 
 	/**
 	 * Log out from WordPress.com when logging out of the local site.
+	 *
+	 * @param string  $redirect_to           The redirect destination URL.
+	 * @param string  $requested_redirect_to The requested redirect destination URL passed as a parameter.
+	 * @param WP_User $user                  The WP_User object for the user that's logging out.
 	 */
-	public function maybe_logout_user_from_wpcom() {
+	public function maybe_logout_user_from_wpcom( $redirect_to, $requested_redirect_to, $user ) {
 		/**
 		 * Whether we should sign out from wpcom too when signing out from the masterbar.
 		 *
@@ -186,10 +190,9 @@ class A8C_WPCOM_Masterbar {
 			/*
 			 * Get the associated WordPress.com User ID, if the user is connected.
 			 */
-			$user_id            = get_current_user_id();
 			$connection_manager = new Connection_Manager();
-			if ( $connection_manager->is_user_connected( $user_id ) ) {
-				$wpcom_user_data = $connection_manager->get_connected_user_data( $user_id );
+			if ( $connection_manager->is_user_connected( $user->ID ) ) {
+				$wpcom_user_data = $connection_manager->get_connected_user_data( $user->ID );
 				if ( ! empty( $wpcom_user_data['ID'] ) ) {
 					/**
 					 * Hook into the log out event happening from the Masterbar.
@@ -205,6 +208,8 @@ class A8C_WPCOM_Masterbar {
 				}
 			}
 		}
+
+		return $redirect_to;
 	}
 
 	/**

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 require_once dirname( __FILE__ ) . '/rtl-admin-bar.php';
 
@@ -182,7 +183,27 @@ class A8C_WPCOM_Masterbar {
 			&& 'masterbar' === $_GET['context'] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&& $masterbar_should_logout_from_wpcom
 		) {
-			do_action( 'wp_masterbar_logout' );
+			/*
+			 * Get the associated WordPress.com User ID, if the user is connected.
+			 */
+			$user_id            = get_current_user_id();
+			$connection_manager = new Connection_Manager();
+			if ( $connection_manager->is_user_connected( $user_id ) ) {
+				$wpcom_user_data = $connection_manager->get_connected_user_data( $user_id );
+				if ( ! empty( $wpcom_user_data['ID'] ) ) {
+					/**
+					 * Hook into the log out event happening from the Masterbar.
+					 *
+					 * @since 5.1.0
+					 * @since 7.9.0 Added the $wpcom_user_id parameter to the action.
+					 *
+					 * @module masterbar
+					 *
+					 * @param int $wpcom_user_id WordPress.com User ID.
+					 */
+					do_action( 'wp_masterbar_logout', $wpcom_user_data['ID'] );
+				}
+			}
 		}
 	}
 

--- a/packages/sync/src/modules/class-users.php
+++ b/packages/sync/src/modules/class-users.php
@@ -127,7 +127,7 @@ class Users extends Module {
 		add_action( 'jetpack_wp_login', $callable, 10, 3 );
 
 		add_action( 'wp_logout', $callable, 10, 0 );
-		add_action( 'wp_masterbar_logout', $callable, 10, 0 );
+		add_action( 'wp_masterbar_logout', $callable, 10, 1 );
 
 		// Add on init.
 		add_filter( 'jetpack_sync_before_enqueue_jetpack_sync_add_user', array( $this, 'expand_action' ) );


### PR DESCRIPTION
Fixes #13680


#### Changes proposed in this Pull Request:

* Until now, we would send a sync event to WordPress.com anytime someone attempted to log out from a site using the "Sign Out" button in the masterbar.
From now on, we'll only do that when we have info about the connected WordPress.com user linked to that local user, and we'll send their wpcom user ID to WordPress.com so WordPress.com can disconnect them (and no one else) from WordPress.com.

Related discussion: p5TWut-lX-p2#comment-1098

#### Testing instructions:

* Start from a connected site without this patch.
* There should be 2 users on that site, both connected to 2 different WordPress.com accounts.
* ~Apply D34223-code and point your site to your WordPress.com sandbox with `JETPACK__SANDBOX_DOMAIN`.~ This has now been committed.
* Log in with one of the users, and log in to their associated WordPress.com account.
* In the admin bar, click on the Gravatar, and then on "Sign Out".
* You should be logged out of the site with no errors on your site, nor in your WordPress.com sandbox.
* You should not be logged out of WordPress.com.
* Apply this patch.
* Log back in to your site.
* Attempt to sign out again.
* You should now be logged out of both your local and wpcom accounts, with no errors.
* You can repeat the same test with the other user, and ensure that logging out with one does not log you out from the other user's accounts.

#### Proposed changelog entry for your changes:

* WordPress.com Toolbar: log user out of WordPress.com when attempting to log out from the site. 
