### PR TITLE
CLI: On disconnect, if the site is already disconnected, exit with a success

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -184,6 +184,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	public function disconnect( $args, $assoc_args ) {
 		if ( ! Jetpack::is_active() ) {
 			WP_CLI::success( __( 'The site is not currently connected, so nothing to do!', 'jetpack' ) );
+			return;
 		}
 
 		$action = isset( $args[0] ) ? $args[0] : 'prompt';

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -183,7 +183,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 */
 	public function disconnect( $args, $assoc_args ) {
 		if ( ! Jetpack::is_active() ) {
-			WP_CLI::error( __( 'You cannot disconnect, without having first connected.', 'jetpack' ) );
+			WP_CLI::success( __( 'The site is not currently connected, so nothing to do!', 'jetpack' ) );
 		}
 
 		$action = isset( $args[0] ) ? $args[0] : 'prompt';


### PR DESCRIPTION
Fixes #13778. 

#### Changes proposed in this Pull Request:
* When using `wp jetpack disconnect`, exit with a success code if the site is not connected.

When using `wp jetpack disconnect` as part of a chain of actions, exiting as failed can end the chain early. The intent is to have a disconnected site and so the command was "successful" in that sense.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p6jPRI-2t4-p2

#### Testing instructions:
* Connect and disconnect Jetpack (or never connect Jetpack)
* `wp jetpack disconnect blog`

#### Proposed changelog entry for your changes:
* CLI: No longer return exit code 1 if trying to disconnect a disconnected site.
