### PR TITLE
Gif block - move search button one pixel

### DIFF
--- a/extensions/blocks/gif/editor.scss
+++ b/extensions/blocks/gif/editor.scss
@@ -35,6 +35,9 @@
 			position: absolute;
 			top: -1000em;
 		}
+		.components-button {
+			margin-top: 1px;
+		}
 	}
 	.wp-block-jetpack-gif_input {
 		flex-grow: 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* moves search button one pixel

#### Before
<img width="661" alt="image" src="https://user-images.githubusercontent.com/1123119/67128693-ab7f4800-f1b9-11e9-8444-59593471eb0e.png">

#### After
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1123119/67128610-6e1aba80-f1b9-11e9-9675-19216942bc40.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes existing feature

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to post-new.php
* Add a Gif block
* Look closely at alignment of search field and submit button

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog needed
