### PR TITLE
Instant search: add post type icon component

### DIFF
--- a/modules/search/instant-search/components/post-type-icon.jsx
+++ b/modules/search/instant-search/components/post-type-icon.jsx
@@ -1,0 +1,69 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from './gridicon';
+import arrayOverlap from '../lib/array-overlap';
+
+const KNOWN_SHORTCODE_TYPES = {
+	video: [
+		'youtube',
+		'ooyala',
+		'anvplayer',
+		'wpvideo',
+		'bc_video',
+		'video',
+		'brightcove',
+		'tp_video',
+		'jwplayer',
+		'tempo-video',
+		'vimeo',
+	],
+	gallery: [ 'gallery', 'ione_media_gallery' ],
+	audio: [ 'audio', 'soundcloud' ],
+};
+
+const POST_TYPE_TO_ICON_MAP = {
+	product: 'cart',
+	video: 'video',
+	gallery: 'image-multiple',
+	event: 'calendar',
+	events: 'calendar',
+};
+
+const PostTypeIcon = ( { postType, shortcodeTypes, imageCount, iconSize = 18 } ) => {
+	// Do we have a special icon for this post type?
+	if ( Object.keys( POST_TYPE_TO_ICON_MAP ).includes( postType ) ) {
+		return <Gridicon icon={ POST_TYPE_TO_ICON_MAP[ postType ] } size={ iconSize } />;
+	}
+
+	// Otherwise, choose the icon based on whether the post has certain shortcodes
+	const hasVideo = arrayOverlap( shortcodeTypes, KNOWN_SHORTCODE_TYPES.video );
+	const hasAudio = arrayOverlap( shortcodeTypes, KNOWN_SHORTCODE_TYPES.audio );
+	const hasGallery = arrayOverlap( shortcodeTypes, KNOWN_SHORTCODE_TYPES.gallery );
+
+	if ( hasVideo ) {
+		return <Gridicon icon="video" size={ iconSize } />;
+	} else if ( hasAudio ) {
+		return <Gridicon icon="audio" size={ iconSize } />;
+	}
+
+	switch ( postType ) {
+		case 'page':
+			return <Gridicon icon="pages" size={ iconSize } />;
+		default:
+			if ( hasGallery || imageCount > 1 ) {
+				return <Gridicon icon="image-multiple" size={ iconSize } />;
+			}
+	}
+
+	return null;
+};
+
+export default PostTypeIcon;

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -9,34 +9,8 @@ import { h, Component } from 'preact';
  * Internal dependencies
  */
 import Gridicon from './gridicon';
-import arrayOverlap from '../lib/array-overlap';
+import PostTypeIcon from './post-type-icon';
 import { recordTrainTracksRender, recordTrainTracksInteract } from '../lib/tracks';
-
-const ShortcodeTypes = {
-	video: [
-		'youtube',
-		'ooyala',
-		'anvplayer',
-		'wpvideo',
-		'bc_video',
-		'video',
-		'brightcove',
-		'tp_video',
-		'jwplayer',
-		'tempo-video',
-		'vimeo',
-	],
-	gallery: [ 'gallery', 'ione_media_gallery' ],
-	audio: [ 'audio', 'soundcloud' ],
-};
-
-const POST_TYPE_TO_ICON_MAP = {
-	product: 'cart',
-	video: 'video',
-	gallery: 'image-multiple',
-	event: 'calendar',
-	events: 'calendar',
-};
 
 class SearchResultMinimal extends Component {
 	componentDidMount() {
@@ -85,37 +59,6 @@ class SearchResultMinimal extends Component {
 			cats = [ cats ];
 		}
 		return cats;
-	}
-
-	renderPostTypeIcon() {
-		const { fields } = this.props.result;
-		const iconSize = this.getIconSize();
-		const hasVideo = arrayOverlap( fields.shortcode_types, ShortcodeTypes.video );
-		const hasAudio = arrayOverlap( fields.shortcode_types, ShortcodeTypes.audio );
-		const hasGallery = arrayOverlap( fields.shortcode_types, ShortcodeTypes.gallery );
-
-		if ( Object.keys( POST_TYPE_TO_ICON_MAP ).includes( fields.post_type ) ) {
-			return POST_TYPE_TO_ICON_MAP[ fields.post_type ];
-		}
-
-		switch ( fields.post_type ) {
-			case 'page':
-				if ( hasVideo ) {
-					return <Gridicon icon="video" size={ iconSize } />;
-				} else if ( hasAudio ) {
-					return <Gridicon icon="audio" size={ iconSize } />;
-				}
-				return <Gridicon icon="pages" size={ iconSize } />;
-			default:
-				if ( hasVideo ) {
-					return <Gridicon icon="video" size={ iconSize } />;
-				} else if ( hasAudio ) {
-					return <Gridicon icon="audio" size={ iconSize } />;
-				} else if ( hasGallery ) {
-					return <Gridicon icon="image-multiple" size={ iconSize } />;
-				}
-		}
-		return null;
 	}
 
 	renderNoMatchingContent() {
@@ -185,7 +128,6 @@ class SearchResultMinimal extends Component {
 		if ( result_type !== 'post' ) {
 			return null;
 		}
-
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
 		return (
 			<div className="jetpack-instant-search__result-minimal">
@@ -195,7 +137,11 @@ class SearchResultMinimal extends Component {
 					} ) }
 				</span>
 				<h3>
-					{ this.renderPostTypeIcon() }
+					<PostTypeIcon
+						postType={ fields.post_type }
+						shortcodeTypes={ fields.shortcode_types }
+						imageCount={ fields[ 'has.image' ] }
+					/>
 					<a
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						className="jetpack-instant-search__result-minimal-title"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We currently show a post type icon alongside search results in the Jetpack Instant Search prototype. 

<img width="286" alt="Screen Shot 2019-10-21 at 15 39 18" src="https://user-images.githubusercontent.com/17325/67172729-fe0a6f80-f418-11e9-9ace-65caf2ea8043.png">

This is currently part of the 'minimal search result' component. As we expand to offer different search results styles (like products - see https://github.com/Automattic/jetpack/pull/13774), we need to reuse this icon in different spots. This PR moves the rendering of a post type icon into a separate Preact component so it can be shared.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is primarily a refactor of existing functionality. I've added one improvement - posts with multiple images now receive the same icon as posts containing a gallery.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php.
If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.

* Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).

* Perform a search and make sure the correct icon is applied for various results. For example: `/?s=card&blog_id=84860689` should give you a gallery icon for this result:

<img width="809" alt="Screen Shot 2019-10-21 at 15 35 10" src="https://user-images.githubusercontent.com/17325/67172587-6442c280-f418-11e9-8d3b-55aed472665e.png">

....and `/?s=socks&blog_id=84860689` should give you a product icon:

<img width="820" alt="Screen Shot 2019-10-21 at 15 35 53" src="https://user-images.githubusercontent.com/17325/67172616-7d4b7380-f418-11e9-8448-de8fdb662694.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed. This PR merges into the `instant-search-master` branch.
