### PR TITLE
Masterbar: Add caching to the API call for the My Home link

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1,6 +1,7 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Connection\Client;
 
 require_once dirname( __FILE__ ) . '/rtl-admin-bar.php';
 
@@ -866,6 +867,8 @@ class A8C_WPCOM_Masterbar {
 			);
 		}
 
+		$this->add_my_home_submenu_item( $wp_admin_bar );
+
 		// Stats.
 		if ( Jetpack::is_module_active( 'stats' ) && current_user_can( 'view_stats' ) ) {
 			$wp_admin_bar->add_menu(
@@ -1324,6 +1327,50 @@ class A8C_WPCOM_Masterbar {
 			 * @since 5.4.0
 			 */
 			do_action( 'jetpack_masterbar' );
+		}
+	}
+
+	/**
+	 * Adds "My Home" submenu item to sites that are eligible.
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
+	 * @return void
+	 */
+	private function add_my_home_submenu_item( &$wp_admin_bar ) {
+		if ( ! current_user_can( 'manage_options' ) || ! jetpack_is_atomic_site() ) {
+			return;
+		}
+
+		$site_id       = Jetpack_Options::get_option( 'id' );
+		$site_response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
+			'1.1'
+		);
+
+		if ( is_wp_error( $site_response ) ) {
+			return;
+		}
+
+		$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
+
+		l( $site_data->options );
+
+		if (
+			$site_data &&
+			isset( $site_data->options->created_at ) &&
+			( new Datetime( '2019-08-06 00:00:00.000' ) ) <= ( new Datetime( $site_data->options->created_at ) )
+		) {
+			$wp_admin_bar->add_menu(
+				array(
+					'parent' => 'blog',
+					'id'     => 'my-home',
+					'title'  => __( 'My Home', 'jetpack' ),
+					'href'   => 'https://wordpress.com/home/' . esc_attr( $this->primary_site_slug ),
+					'meta'   => array(
+						'class' => 'mb-icon',
+					),
+				)
+			);
 		}
 	}
 }

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1353,8 +1353,6 @@ class A8C_WPCOM_Masterbar {
 
 		$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
 
-		l( $site_data->options );
-
 		if (
 			$site_data &&
 			isset( $site_data->options->created_at ) &&

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1331,6 +1331,44 @@ class A8C_WPCOM_Masterbar {
 	}
 
 	/**
+	 * Calls the wpcom API to get the creation date of the site
+	 * and determine if it's eligible for the 'My Home' page.
+	 *
+	 * @return bool Whether the site has 'My Home' enabled.
+	 */
+	private function is_my_home_enabled() {
+		$my_home_enabled = get_transient( 'jetpack_my_home_enabled' );
+
+		if ( false === $my_home_enabled ) {
+
+			$site_id       = Jetpack_Options::get_option( 'id' );
+			$site_response = Client::wpcom_json_api_request_as_blog(
+				sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
+				'1.1'
+			);
+
+			if ( is_wp_error( $site_response ) ) {
+				return false;
+			}
+
+			$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
+
+			if (
+				$site_data &&
+				isset( $site_data->options->created_at ) &&
+				( new Datetime( '2019-08-06 00:00:00.000' ) ) <= ( new Datetime( $site_data->options->created_at ) )
+			) {
+				$my_home_enabled = 1;
+			} else {
+				$my_home_enabled = 0;
+			}
+			set_transient( 'jetpack_my_home_enabled', $my_home_enabled );
+		}
+
+		return (bool) $my_home_enabled;
+	}
+
+	/**
 	 * Adds "My Home" submenu item to sites that are eligible.
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
@@ -1341,23 +1379,7 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
-		$site_id       = Jetpack_Options::get_option( 'id' );
-		$site_response = Client::wpcom_json_api_request_as_blog(
-			sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
-			'1.1'
-		);
-
-		if ( is_wp_error( $site_response ) ) {
-			return;
-		}
-
-		$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
-
-		if (
-			$site_data &&
-			isset( $site_data->options->created_at ) &&
-			( new Datetime( '2019-08-06 00:00:00.000' ) ) <= ( new Datetime( $site_data->options->created_at ) )
-		) {
+		if ( $this->is_my_home_enabled() ) {
 			$wp_admin_bar->add_menu(
 				array(
 					'parent' => 'blog',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We're adding a My Home link to the sidebar options, but that involves an
API call to wpcom. This stores the result in a transient, so we don't
need to keep checking if a site is eligible for My Home or not.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This builds on the My Home link feature

#### Testing instructions:

Load an admin page for a test site and check that the `jetpack_my_home_enabled` transient is set correctly.
