### PR TITLE
Instant Search: add comments component

### DIFF
--- a/modules/search/instant-search/components/search-result-comments.jsx
+++ b/modules/search/instant-search/components/search-result-comments.jsx
@@ -1,0 +1,32 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from './gridicon';
+
+const SearchResultComments = ( { comments, iconSize = 18 } ) => {
+	if ( ! comments ) {
+		return null;
+	}
+
+	return (
+		<div className="jetpack-instant-search__result-comments">
+			<Gridicon icon="comment" size={ iconSize } />
+			<span
+				className="jetpack-instant-search__result-comments-text"
+				//eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={ {
+					__html: comments.join( ' ... ' ),
+				} }
+			/>
+		</div>
+	);
+};
+
+export default SearchResultComments;

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -10,6 +10,7 @@ import { h, Component } from 'preact';
  */
 import Gridicon from './gridicon';
 import PostTypeIcon from './post-type-icon';
+import SearchResultComments from './search-result-comments';
 import { recordTrainTracksRender, recordTrainTracksInteract } from '../lib/tracks';
 
 class SearchResultMinimal extends Component {
@@ -105,23 +106,6 @@ class SearchResultMinimal extends Component {
 		);
 	}
 
-	renderComments() {
-		return (
-			this.props.result.highlight.comments && (
-				<div className="jetpack-instant-search__result-minimal-comment">
-					<Gridicon icon="comment" size={ this.getIconSize() } />
-					<span
-						className="jetpack-instant-search__result-minimal-comment-span"
-						//eslint-disable-next-line react/no-danger
-						dangerouslySetInnerHTML={ {
-							__html: this.props.result.highlight.comments.join( ' ... ' ),
-						} }
-					/>
-				</div>
-			)
-		);
-	}
-
 	render() {
 		const { locale = 'en-US' } = this.props;
 		const { result_type, fields, highlight } = this.props.result;
@@ -151,7 +135,7 @@ class SearchResultMinimal extends Component {
 					/>
 				</h3>
 				{ noMatchingContent ? this.renderNoMatchingContent() : this.renderMatchingContent() }
-				{ this.renderComments() }
+				<SearchResultComments comments={ highlight && highlight.comments } />
 			</div>
 		);
 	}

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -34,13 +34,6 @@
 }
 
 .jetpack-instant-search__result-minimal-tags,
-.jetpack-instant-search__result-minimal-cats,
-.jetpack-instant-search__result-minimal-comment {
+.jetpack-instant-search__result-minimal-cats {
 	padding-left: 10px;
-}
-
-.jetpack-instant-search__result-minimal-title b,
-.jetpack-instant-search__result-minimal-content b,
-.jetpack-instant-search__result-minimal-comment-span b {
-	text-decoration: underline;
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -18,3 +18,7 @@
 	margin: 0;
 	padding: 0;
 }
+
+.jetpack-instant-search__result-comments {
+	padding-left: 10px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We currently show matching comments beneath search results in the Jetpack Instant Search prototype. 

<img width="822" alt="Screen Shot 2019-10-22 at 17 15 00" src="https://user-images.githubusercontent.com/17325/67258938-98d57d80-f4ef-11e9-9689-8b802c69a880.png">

This is currently part of the 'minimal search result' component. As we expand to offer different search results styles (like products - see https://github.com/Automattic/jetpack/pull/13774), we need to reuse this content in different spots. This PR moves the rendering into a separate Preact component so it can be shared.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a refactor of existing functionality.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php.
If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.

* Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).

* Perform a search and make sure comments are shown where available. For example: `/?s=yes&blog_id=20115252` should give you a comment for the first result.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed. This PR merges into the `instant-search-master` branch.
