### PR TITLE
Update/Use the new Terms of Service package in Jetpack

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -12,7 +12,7 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Plugin\Tracking;
+use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
 
 /*
 Options:
@@ -731,7 +731,7 @@ class Jetpack {
 	function after_plugins_loaded() {
 
 		$terms_of_service = new Terms_Of_Service();
-		$tracking = new Tracking();
+		$tracking = new Plugin_Tracking();
 		if ( $terms_of_service->has_agreed() ) {
 			add_action( 'init', array( $tracking, 'init' ) );
 		} else {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\Plugin\Tracking;
 
 /*
 Options:
@@ -730,7 +731,7 @@ class Jetpack {
 	function after_plugins_loaded() {
 
 		$terms_of_service = new Terms_Of_Service();
-		$tracking = new \Automattic\Jetpack\Plugin\Tracking();
+		$tracking = new Tracking();
 		if ( $terms_of_service->has_agreed() ) {
 			add_action( 'init', array( $tracking, 'init' ) );
 		} else {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1,5 +1,5 @@
 <?php
-
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
@@ -10,8 +10,8 @@ use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
+use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Assets;
 
 /*
 Options:
@@ -567,10 +567,7 @@ class Jetpack {
 			add_action( 'init', array( 'Jetpack_Keyring_Service_Helper', 'init' ), 9, 0 );
 		}
 
-		if ( self::jetpack_tos_agreed() ) {
-			$tracking = new Automattic\Jetpack\Plugin\Tracking();
-			add_action( 'init', array( $tracking, 'init' ) );
-		}
+		add_action( 'plugins_loaded', array( $this, 'after_plugins_loaded' )  );
 
 		add_filter(
 			'jetpack_connection_secret_generator',
@@ -726,6 +723,22 @@ class Jetpack {
 		 * Load some scripts asynchronously.
 		 */
 		add_action( 'script_loader_tag', array( $this, 'script_add_async' ), 10, 3 );
+	}
+	/**
+	 * Runs after all the plugins have loaded but before init.
+	 */
+	function after_plugins_loaded() {
+
+		$terms_of_service = new Terms_Of_Service();
+		$tracking = new \Automattic\Jetpack\Plugin\Tracking();
+		if ( $terms_of_service->has_agreed() ) {
+			add_action( 'init', array( $tracking, 'init' ) );
+		} else {
+			/**
+			 * Initialize tracking right after the user agrees to the terms of service.
+			 */
+			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
+		}
 	}
 
 	/**
@@ -3323,8 +3336,9 @@ p {
 	 * Attempts Jetpack registration.  If it fail, a state flag is set: @see ::admin_page_load()
 	 */
 	public static function try_registration() {
+		$terms_of_service = new Terms_Of_Service();
 		// The user has agreed to the TOS at some point by now.
-		Jetpack_Options::update_option( 'tos_agreed', true );
+		$terms_of_service->agree();
 
 		// Let's get some testing in beta versions and such.
 		if ( self::is_development_version() && defined( 'PHP_URL_HOST' ) ) {
@@ -6938,13 +6952,11 @@ endif;
 	 * Will return true if a user has clicked to register, or is already connected.
 	 */
 	public static function jetpack_tos_agreed() {
-		$tos_agreed = Jetpack_Options::get_option( 'tos_agreed' ) || self::is_active_and_not_development_mode();
+		_deprecated_function( 'Jetpack::jetpack_tos_agreed', 'Jetpack 7.9.0', '\Automattic\Jetpack\Terms_Of_Service->has_agreed' );
 
-		if ( $tos_agreed ) {
-			add_filter( 'jetpack_tos_agreed', '__return_true' );
-		}
+		$terms_of_service = new Terms_Of_Service();
+		return $terms_of_service->has_agreed();
 
-		return $tos_agreed;
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"automattic/jetpack-tracking": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-compat": "@dev",
-		"automattic/jetpack-terms-of-service": "1.0.0"
+		"automattic/jetpack-terms-of-service": "@dev"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-tracking": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
-		"automattic/jetpack-compat": "@dev"
+		"automattic/jetpack-compat": "@dev",
+		"automattic/jetpack-terms-of-service": "1.0.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -468,7 +468,8 @@
                 "shasum": null
             },
             "require": {
-                "automattic/jetpack-options": "@dev"
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-terms-of-service": "@dev"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,16 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8162c3890f643be1aa53bb24f61ad45",
+    "content-hash": "bacc30aa6929a0ba176b0a01ecc6bfa7",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-abtest.git",
-                "reference": "0ff467013f21976379aa7c5fb3470c5626e603b7"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-abtest/zipball/0ff467013f21976379aa7c5fb3470c5626e603b7",
-                "reference": "0ff467013f21976379aa7c5fb3470c5626e603b7",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/abtest",
+                "reference": "b873be98786907a49ac5cd21836167f662212aa0",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -34,26 +29,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Provides an interface to the WP.com A/B tests.",
-            "time": "2019-08-15T11:53:40+00:00"
+            "description": "Provides an interface to the WP.com A/B tests."
         },
         {
             "name": "automattic/jetpack-assets",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-assets.git",
-                "reference": "3e06acd358d6568867f15144828eac514af2d899"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/3e06acd358d6568867f15144828eac514af2d899",
-                "reference": "3e06acd358d6568867f15144828eac514af2d899",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/assets",
+                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -68,26 +62,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Asset management utilities for Jetpack ecosystem packages",
-            "time": "2019-06-21T20:53:20+00:00"
+            "description": "Asset management utilities for Jetpack ecosystem packages"
         },
         {
             "name": "automattic/jetpack-autoloader",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/301c2fbcf070d4f0147753447616b6e982bda09e",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/autoloader",
+                "reference": "43bb413915e6aad7e4a088490cb76d72df22a8fb",
+                "shasum": null
             },
             "require": {
                 "composer-plugin-api": "^1.1"
@@ -104,26 +97,25 @@
                     "Automattic\\Jetpack\\Autoloader\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-09-24T06:39:29+00:00"
+            "description": "Creates a custom autoloader for a plugin or theme."
         },
         {
             "name": "automattic/jetpack-compat",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-compat.git",
-                "reference": "a9af3164b4dfdcaa6b2209f14de129b199db19e4"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-compat/zipball/a9af3164b4dfdcaa6b2209f14de129b199db19e4",
-                "reference": "a9af3164b4dfdcaa6b2209f14de129b199db19e4",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/compat",
+                "reference": "2138cbc8b0b1aecb290608b5d82e873c7330aac5",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -138,26 +130,25 @@
                     "legacy"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Compatibility layer with previous versions of Jetpack",
-            "time": "2019-09-16T22:34:52+00:00"
+            "description": "Compatibility layer with previous versions of Jetpack"
         },
         {
             "name": "automattic/jetpack-connection",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "ed0647c0ba4a7c9aba0c82cf0abbfb58bff51e06"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/ed0647c0ba4a7c9aba0c82cf0abbfb58bff51e06",
-                "reference": "ed0647c0ba4a7c9aba0c82cf0abbfb58bff51e06",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/connection",
+                "reference": "59fa2bc973303b013ce63978ff8d875d1223f510",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -179,26 +170,25 @@
                     "legacy"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to connect to the Jetpack infrastructure",
-            "time": "2019-09-30T21:57:27+00:00"
+            "description": "Everything needed to connect to the Jetpack infrastructure"
         },
         {
             "name": "automattic/jetpack-constants",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "5a83f0a1f2b7fce5160d2ff148b0e7555f30a48f"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/5a83f0a1f2b7fce5160d2ff148b0e7555f30a48f",
-                "reference": "5a83f0a1f2b7fce5160d2ff148b0e7555f30a48f",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/constants",
+                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95",
+                "shasum": null
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -209,26 +199,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for defining constants in a more testable way.",
-            "time": "2019-09-16T22:34:52+00:00"
+            "description": "A wrapper for defining constants in a more testable way."
         },
         {
             "name": "automattic/jetpack-error",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-error.git",
-                "reference": "773eaca851158999d48c675032121a0db8377afa"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-error/zipball/773eaca851158999d48c675032121a0db8377afa",
-                "reference": "773eaca851158999d48c675032121a0db8377afa",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/error",
+                "reference": "1707cf33a92fc66f1635dfe1e4215819101e9bb4",
+                "shasum": null
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -239,26 +228,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Jetpack Error - a wrapper around WP_Error.",
-            "time": "2019-09-16T22:34:52+00:00"
+            "description": "Jetpack Error - a wrapper around WP_Error."
         },
         {
             "name": "automattic/jetpack-jitm",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-jitm.git",
-                "reference": "5d6a7d8e0c99db9c5636366e44174a61b789086e"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-jitm/zipball/5d6a7d8e0c99db9c5636366e44174a61b789086e",
-                "reference": "5d6a7d8e0c99db9c5636366e44174a61b789086e",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/jitm",
+                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -279,26 +267,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Just in time messages for Jetpack",
-            "time": "2019-10-16T20:45:59+00:00"
+            "description": "Just in time messages for Jetpack"
         },
         {
             "name": "automattic/jetpack-logo",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-logo.git",
-                "reference": "02c2d3644c4a6f9d37b1f0b491e4f768d97e1be3"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/02c2d3644c4a6f9d37b1f0b491e4f768d97e1be3",
-                "reference": "02c2d3644c4a6f9d37b1f0b491e4f768d97e1be3",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/logo",
+                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -310,26 +297,25 @@
                     "Automattic\\Jetpack\\Assets\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A logo for Jetpack",
-            "time": "2019-09-16T22:34:52+00:00"
+            "description": "A logo for Jetpack"
         },
         {
             "name": "automattic/jetpack-options",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "54f17b3b2f3bd5b5c96989b69115fa8ec1675fde"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/54f17b3b2f3bd5b5c96989b69115fa8ec1675fde",
-                "reference": "54f17b3b2f3bd5b5c96989b69115fa8ec1675fde",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/options",
+                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -344,26 +330,19 @@
                     "legacy"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for wp-options to manage specific Jetpack options.",
-            "time": "2019-08-27T08:13:29+00:00"
+            "description": "A wrapper for wp-options to manage specific Jetpack options."
         },
         {
             "name": "automattic/jetpack-roles",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "9c5706e3e3501e7e493509162deb68d80dba8e3c"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/9c5706e3e3501e7e493509162deb68d80dba8e3c",
-                "reference": "9c5706e3e3501e7e493509162deb68d80dba8e3c",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/roles",
+                "reference": "f38b3379c11a05e4711b4fb29b390c8107daccd7",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -375,26 +354,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Utilities, related with user roles and capabilities.",
-            "time": "2019-09-16T22:34:52+00:00"
+            "description": "Utilities, related with user roles and capabilities."
         },
         {
             "name": "automattic/jetpack-status",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "cb75e32fddf4be9a9f959a83355e43622691de81"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/cb75e32fddf4be9a9f959a83355e43622691de81",
-                "reference": "cb75e32fddf4be9a9f959a83355e43622691de81",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/status",
+                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
+                "shasum": null
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -406,26 +384,25 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
-            "time": "2019-09-16T22:34:52+00:00"
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
         },
         {
             "name": "automattic/jetpack-sync",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-sync.git",
-                "reference": "cc7db9d2e811908666d9de12ace28694b6a789a0"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/cc7db9d2e811908666d9de12ace28694b6a789a0",
-                "reference": "cc7db9d2e811908666d9de12ace28694b6a789a0",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/sync",
+                "reference": "1cad05fcfd38ad123af0bbf08b5a1224bd95312a",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -441,62 +418,19 @@
                     "Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
-            "time": "2019-10-07T07:19:24+00:00"
-        },
-        {
-            "name": "automattic/jetpack-terms-of-service",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
-                "reference": "174854d2d5406e1ba928cf7ee8613a7a7acca053"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/174854d2d5406e1ba928cf7ee8613a7a7acca053",
-                "reference": "174854d2d5406e1ba928cf7ee8613a7a7acca053",
-                "shasum": ""
-            },
-            "require": {
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-options": "@dev",
-                "automattic/jetpack-status": "@dev"
-            },
-            "require-dev": {
-                "php-mock/php-mock": "^2.1",
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Everything need to manage the terms of service state",
-            "time": "2019-10-22T06:37:51+00:00"
+            "description": "Everything needed to allow syncing to the WP.com infrastructure."
         },
         {
             "name": "automattic/jetpack-tracking",
             "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-tracking.git",
-                "reference": "c3ef8d03a1c6b64a008b2a33b10c504b069a4800"
-            },
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/c3ef8d03a1c6b64a008b2a33b10c504b069a4800",
-                "reference": "c3ef8d03a1c6b64a008b2a33b10c504b069a4800",
-                "shasum": ""
+                "type": "path",
+                "url": "./packages/tracking",
+                "reference": "b2c79c42a8ccd728db9450818aa95fd6d51afc85",
+                "shasum": null
             },
             "require": {
                 "automattic/jetpack-options": "@dev"
@@ -514,12 +448,16 @@
                     "legacy"
                 ]
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Tracking for Jetpack",
-            "time": "2019-10-15T20:06:39+00:00"
+            "description": "Tracking for Jetpack"
         }
     ],
     "packages-dev": [
@@ -591,16 +529,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.2",
+            "version": "9.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58"
+                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/bfca2be3992f40e92206e5a7ebe5eaee37280b58",
-                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9999344e47e7af6b00e1a898eacc4e4368fb7196",
+                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196",
                 "shasum": ""
             },
             "require": {
@@ -645,20 +583,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-16T21:24:24+00:00"
+            "time": "2019-09-05T18:36:49+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.2.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "94b2388c4fe99e9e2ef0772e280fa0eafa1d0603"
+                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/94b2388c4fe99e9e2ef0772e280fa0eafa1d0603",
-                "reference": "94b2388c4fe99e9e2ef0772e280fa0eafa1d0603",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
+                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
                 "shasum": ""
             },
             "require": {
@@ -697,7 +635,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-10-16T21:41:26+00:00"
+            "time": "2019-08-28T15:58:19+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -799,16 +737,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.1",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060"
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/82cd0f854ceca17731d6d019c7098e3755c45060",
-                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0afebf16a2e7f1e434920fa976253576151effe9",
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9",
                 "shasum": ""
             },
             "require": {
@@ -846,7 +784,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-16T21:14:26+00:00"
+            "time": "2019-09-26T23:12:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -425,7 +425,7 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-update/user-tos-package",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/terms-of-service",

--- a/composer.lock
+++ b/composer.lock
@@ -4,16 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bacc30aa6929a0ba176b0a01ecc6bfa7",
+    "content-hash": "c8162c3890f643be1aa53bb24f61ad45",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-abtest.git",
+                "reference": "0ff467013f21976379aa7c5fb3470c5626e603b7"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/abtest",
-                "reference": "b873be98786907a49ac5cd21836167f662212aa0",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-abtest/zipball/0ff467013f21976379aa7c5fb3470c5626e603b7",
+                "reference": "0ff467013f21976379aa7c5fb3470c5626e603b7",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -29,25 +34,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Provides an interface to the WP.com A/B tests."
+            "description": "Provides an interface to the WP.com A/B tests.",
+            "time": "2019-08-15T11:53:40+00:00"
         },
         {
             "name": "automattic/jetpack-assets",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-assets.git",
+                "reference": "3e06acd358d6568867f15144828eac514af2d899"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/assets",
-                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/3e06acd358d6568867f15144828eac514af2d899",
+                "reference": "3e06acd358d6568867f15144828eac514af2d899",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -62,25 +68,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Asset management utilities for Jetpack ecosystem packages"
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "time": "2019-06-21T20:53:20+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/autoloader",
-                "reference": "43bb413915e6aad7e4a088490cb76d72df22a8fb",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/301c2fbcf070d4f0147753447616b6e982bda09e",
+                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e",
+                "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1"
@@ -97,25 +104,26 @@
                     "Automattic\\Jetpack\\Autoloader\\": "src"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Creates a custom autoloader for a plugin or theme."
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "time": "2019-09-24T06:39:29+00:00"
         },
         {
             "name": "automattic/jetpack-compat",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-compat.git",
+                "reference": "a9af3164b4dfdcaa6b2209f14de129b199db19e4"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/compat",
-                "reference": "2138cbc8b0b1aecb290608b5d82e873c7330aac5",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-compat/zipball/a9af3164b4dfdcaa6b2209f14de129b199db19e4",
+                "reference": "a9af3164b4dfdcaa6b2209f14de129b199db19e4",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -130,25 +138,26 @@
                     "legacy"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Compatibility layer with previous versions of Jetpack"
+            "description": "Compatibility layer with previous versions of Jetpack",
+            "time": "2019-09-16T22:34:52+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-connection.git",
+                "reference": "ed0647c0ba4a7c9aba0c82cf0abbfb58bff51e06"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/connection",
-                "reference": "59fa2bc973303b013ce63978ff8d875d1223f510",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/ed0647c0ba4a7c9aba0c82cf0abbfb58bff51e06",
+                "reference": "ed0647c0ba4a7c9aba0c82cf0abbfb58bff51e06",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -170,25 +179,26 @@
                     "legacy"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to connect to the Jetpack infrastructure"
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "time": "2019-09-30T21:57:27+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-constants.git",
+                "reference": "5a83f0a1f2b7fce5160d2ff148b0e7555f30a48f"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/constants",
-                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/5a83f0a1f2b7fce5160d2ff148b0e7555f30a48f",
+                "reference": "5a83f0a1f2b7fce5160d2ff148b0e7555f30a48f",
+                "shasum": ""
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -199,25 +209,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for defining constants in a more testable way."
+            "description": "A wrapper for defining constants in a more testable way.",
+            "time": "2019-09-16T22:34:52+00:00"
         },
         {
             "name": "automattic/jetpack-error",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-error.git",
+                "reference": "773eaca851158999d48c675032121a0db8377afa"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/error",
-                "reference": "1707cf33a92fc66f1635dfe1e4215819101e9bb4",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-error/zipball/773eaca851158999d48c675032121a0db8377afa",
+                "reference": "773eaca851158999d48c675032121a0db8377afa",
+                "shasum": ""
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -228,25 +239,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Jetpack Error - a wrapper around WP_Error."
+            "description": "Jetpack Error - a wrapper around WP_Error.",
+            "time": "2019-09-16T22:34:52+00:00"
         },
         {
             "name": "automattic/jetpack-jitm",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-jitm.git",
+                "reference": "5d6a7d8e0c99db9c5636366e44174a61b789086e"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/jitm",
-                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-jitm/zipball/5d6a7d8e0c99db9c5636366e44174a61b789086e",
+                "reference": "5d6a7d8e0c99db9c5636366e44174a61b789086e",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -267,25 +279,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Just in time messages for Jetpack"
+            "description": "Just in time messages for Jetpack",
+            "time": "2019-10-16T20:45:59+00:00"
         },
         {
             "name": "automattic/jetpack-logo",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-logo.git",
+                "reference": "02c2d3644c4a6f9d37b1f0b491e4f768d97e1be3"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/logo",
-                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/02c2d3644c4a6f9d37b1f0b491e4f768d97e1be3",
+                "reference": "02c2d3644c4a6f9d37b1f0b491e4f768d97e1be3",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -297,25 +310,26 @@
                     "Automattic\\Jetpack\\Assets\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A logo for Jetpack"
+            "description": "A logo for Jetpack",
+            "time": "2019-09-16T22:34:52+00:00"
         },
         {
             "name": "automattic/jetpack-options",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-options.git",
+                "reference": "54f17b3b2f3bd5b5c96989b69115fa8ec1675fde"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/options",
-                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/54f17b3b2f3bd5b5c96989b69115fa8ec1675fde",
+                "reference": "54f17b3b2f3bd5b5c96989b69115fa8ec1675fde",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -330,19 +344,26 @@
                     "legacy"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for wp-options to manage specific Jetpack options."
+            "description": "A wrapper for wp-options to manage specific Jetpack options.",
+            "time": "2019-08-27T08:13:29+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-roles.git",
+                "reference": "9c5706e3e3501e7e493509162deb68d80dba8e3c"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/roles",
-                "reference": "f38b3379c11a05e4711b4fb29b390c8107daccd7",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/9c5706e3e3501e7e493509162deb68d80dba8e3c",
+                "reference": "9c5706e3e3501e7e493509162deb68d80dba8e3c",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -354,25 +375,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Utilities, related with user roles and capabilities."
+            "description": "Utilities, related with user roles and capabilities.",
+            "time": "2019-09-16T22:34:52+00:00"
         },
         {
             "name": "automattic/jetpack-status",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-status.git",
+                "reference": "cb75e32fddf4be9a9f959a83355e43622691de81"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/status",
-                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/cb75e32fddf4be9a9f959a83355e43622691de81",
+                "reference": "cb75e32fddf4be9a9f959a83355e43622691de81",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -384,25 +406,26 @@
                     "Automattic\\Jetpack\\": "src/"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Used to retrieve information about the current status of Jetpack and the site overall."
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "time": "2019-09-16T22:34:52+00:00"
         },
         {
             "name": "automattic/jetpack-sync",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-sync.git",
+                "reference": "cc7db9d2e811908666d9de12ace28694b6a789a0"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/sync",
-                "reference": "1cad05fcfd38ad123af0bbf08b5a1224bd95312a",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/cc7db9d2e811908666d9de12ace28694b6a789a0",
+                "reference": "cc7db9d2e811908666d9de12ace28694b6a789a0",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -418,19 +441,62 @@
                     "Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to allow syncing to the WP.com infrastructure."
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "time": "2019-10-07T07:19:24+00:00"
+        },
+        {
+            "name": "automattic/jetpack-terms-of-service",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
+                "reference": "174854d2d5406e1ba928cf7ee8613a7a7acca053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/174854d2d5406e1ba928cf7ee8613a7a7acca053",
+                "reference": "174854d2d5406e1ba928cf7ee8613a7a7acca053",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything need to manage the terms of service state",
+            "time": "2019-10-22T06:37:51+00:00"
         },
         {
             "name": "automattic/jetpack-tracking",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-tracking.git",
+                "reference": "c3ef8d03a1c6b64a008b2a33b10c504b069a4800"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/tracking",
-                "reference": "b2c79c42a8ccd728db9450818aa95fd6d51afc85",
-                "shasum": null
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/c3ef8d03a1c6b64a008b2a33b10c504b069a4800",
+                "reference": "c3ef8d03a1c6b64a008b2a33b10c504b069a4800",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-options": "@dev"
@@ -448,16 +514,12 @@
                     "legacy"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Tracking for Jetpack"
+            "description": "Tracking for Jetpack",
+            "time": "2019-10-15T20:06:39+00:00"
         }
     ],
     "packages-dev": [
@@ -529,16 +591,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.1",
+            "version": "9.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196"
+                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9999344e47e7af6b00e1a898eacc4e4368fb7196",
-                "reference": "9999344e47e7af6b00e1a898eacc4e4368fb7196",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/bfca2be3992f40e92206e5a7ebe5eaee37280b58",
+                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58",
                 "shasum": ""
             },
             "require": {
@@ -583,20 +645,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-09-05T18:36:49+00:00"
+            "time": "2019-10-16T21:24:24+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936"
+                "reference": "94b2388c4fe99e9e2ef0772e280fa0eafa1d0603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/94b2388c4fe99e9e2ef0772e280fa0eafa1d0603",
+                "reference": "94b2388c4fe99e9e2ef0772e280fa0eafa1d0603",
                 "shasum": ""
             },
             "require": {
@@ -635,7 +697,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-08-28T15:58:19+00:00"
+            "time": "2019-10-16T21:41:26+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -737,16 +799,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.0",
+            "version": "3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "0afebf16a2e7f1e434920fa976253576151effe9"
+                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0afebf16a2e7f1e434920fa976253576151effe9",
-                "reference": "0afebf16a2e7f1e434920fa976253576151effe9",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/82cd0f854ceca17731d6d019c7098e3755c45060",
+                "reference": "82cd0f854ceca17731d6d019c7098e3755c45060",
                 "shasum": ""
             },
             "require": {
@@ -784,7 +846,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-09-26T23:12:26+00:00"
+            "time": "2019-10-16T21:14:26+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -424,6 +424,41 @@
             "description": "Everything needed to allow syncing to the WP.com infrastructure."
         },
         {
+            "name": "automattic/jetpack-terms-of-service",
+            "version": "dev-update/user-tos-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/terms-of-service",
+                "reference": "6f53f2987be1c025edcd7820759df50c134065e6",
+                "shasum": null
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "require-dev": {
+                "php-mock/php-mock": "^2.1",
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything need to manage the terms of service state"
+        },
+        {
             "name": "automattic/jetpack-tracking",
             "version": "dev-master",
             "dist": {
@@ -846,6 +881,7 @@
         "automattic/jetpack-roles": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-tracking": 20,
+        "automattic/jetpack-terms-of-service": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-compat": 20
     },

--- a/packages/tracking/composer.json
+++ b/packages/tracking/composer.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-terms-of-service": "1.0.0"
+		"automattic/jetpack-terms-of-service": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/tracking/composer.json
+++ b/packages/tracking/composer.json
@@ -4,7 +4,8 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-options": "@dev"
+		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-terms-of-service": "1.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/tracking/legacy/class.tracks-client.php
+++ b/packages/tracking/legacy/class.tracks-client.php
@@ -50,6 +50,13 @@ class Jetpack_Tracks_Client {
 	const VERSION         = '0.3';
 
 	/**
+	 * Stores the Terms of Service Object Reference.
+	 *
+	 * @var null
+	 */
+	private static $terms_of_service = null;
+
+	/**
 	 * Record an event.
 	 *
 	 * @param  mixed $event Event object to send to Tracks. An array will be cast to object. Required.
@@ -57,7 +64,12 @@ class Jetpack_Tracks_Client {
 	 * @return mixed         True on success, WP_Error on failure
 	 */
 	public static function record_event( $event ) {
-		if ( ! Jetpack::jetpack_tos_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
+		if ( ! self::$terms_of_service ) {
+			self::$terms_of_service = new \Automattic\Jetpack\Terms_Of_Service();
+		}
+
+		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
+		if ( ! self::$terms_of_service->has_agreed() || ! empty( $_COOKIE['tk_opt-out'] ) ) {
 			return false;
 		}
 

--- a/packages/tracking/src/Tracking.php
+++ b/packages/tracking/src/Tracking.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Terms_Of_Service;
+
 /**
  * The Tracking class, used to record events in wpcom
  */
@@ -100,18 +102,9 @@ class Tracking {
 		if ( $user instanceof \WP_User && 'wptests_capabilities' === $user->cap_key ) {
 			return false;
 		}
-
+		$terms_of_service = Terms_Of_Service;
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
-		if (
-			/**
-			 * Filter whether ToS were accepted on this site.
-			 *
-			 * @since 7.9.0
-			 *
-			 * @param bool $tos_agreed Was ToS accepted for this site. Defaults to false.
-			 */
-			apply_filters( 'jetpack_tos_agreed', false )
-		) {
+		if ( ! $terms_of_service->has_agreed() ) {
 			return false;
 		}
 

--- a/packages/tracking/src/Tracking.php
+++ b/packages/tracking/src/Tracking.php
@@ -102,7 +102,7 @@ class Tracking {
 		if ( $user instanceof \WP_User && 'wptests_capabilities' === $user->cap_key ) {
 			return false;
 		}
-		$terms_of_service = Terms_Of_Service;
+		$terms_of_service = new Terms_Of_Service();
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
 		if ( ! $terms_of_service->has_agreed() ) {
 			return false;

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -13,8 +13,17 @@ class Tracking {
 	 * @access private
 	 */
 	private $tracking;
+	/**
+	 * Prevents the Tracking from being intialized more then once.
+	 * @var bool
+	 */
+	private $initalized = false;
 
 	function init() {
+		if ( $this->initalized ) {
+			return;
+		}
+		$this->initalized = true;
 		$this->tracking = new Tracks( 'jetpack' );
 
 		// For tracking stuff via js/ajax


### PR DESCRIPTION

This PR deprecated the Jetpack ::jetpack_tos_agreed().
Updates any calls that relied on that method the the new Terms_of_service->has_agreed();

Also instantiates any Jetpack tracking as soon as the sites agrees to the TOS.

Supersedes #13759

#### Changes proposed in this Pull Request:
* Fixes tracking of new connections, integrates the new Terms Of Service Package in Jetpack.


#### Testing instructions:
* Connect Jetpack, does it work as expected. 
* Does tracking for the connected user work as expected?
* Do you see the jetpack_connection_success again? After the site is connected.

#### Proposed changelog entry for your changes:
* Integrates the new Terms Of Service Package in Jetpack
