### PR TITLE
Keyring: register Sharing menu page if it has not been registered

### DIFF
--- a/_inc/lib/class.jetpack-keyring-service-helper.php
+++ b/_inc/lib/class.jetpack-keyring-service-helper.php
@@ -38,16 +38,35 @@ class Jetpack_Keyring_Service_Helper {
 		)
 	);
 
+	/**
+	 * Constructor
+	 */
 	private function __construct() {
+		add_action( 'admin_menu', array( __CLASS__, 'add_sharing_menu' ) );
+
 		add_action( 'load-settings_page_sharing', array( __CLASS__, 'admin_page_load' ), 9 );
 	}
 
-	function get_services( $filter = 'all' ) {
-		$services = array(
-
+	/**
+	 * We need a `sharing` submenu page to be able to connect and disconnect services.
+	 */
+	public static function add_sharing_menu() {
+		global $submenu;
+		$general_settings_names = array_map(
+			function ( $menu ) {
+				return array_values( $menu )[0];
+			},
+			$submenu['options-general.php']
 		);
+		if ( ! in_array( 'Sharing', $general_settings_names, true ) ) {
+			add_submenu_page( 'options-general.php', '', '', 'manage_options', 'sharing', '__return_empty_string' );
+		}
+	}
 
-		if ( 'all' == $filter ) {
+	function get_services( $filter = 'all' ) {
+		$services = array();
+
+		if ( 'all' === $filter ) {
 			return $services;
 		} else {
 			$connected_services = array();

--- a/_inc/lib/class.jetpack-keyring-service-helper.php
+++ b/_inc/lib/class.jetpack-keyring-service-helper.php
@@ -42,7 +42,7 @@ class Jetpack_Keyring_Service_Helper {
 	 * Constructor
 	 */
 	private function __construct() {
-		add_action( 'admin_menu', array( __CLASS__, 'add_sharing_menu' ) );
+		add_action( 'admin_menu', array( __CLASS__, 'add_sharing_menu' ), 21 );
 
 		add_action( 'load-settings_page_sharing', array( __CLASS__, 'admin_page_load' ), 9 );
 	}


### PR DESCRIPTION
Fixes #13732

#### Changes proposed in this Pull Request:

* When neither Publicize, Sharing, Likes, or Comment Likes are active, nothing in Jetpack registers the Sharing menu that the Keyring service relies on.
This checks if the menu exists and registers it (although without UI since we don't need one for Keyring services that are not Publicize)

#### Testing instructions:

* With this patch on, disable Publicize, Sharing, Likes, and Comment Likes on your site.
* Go to Jetpack > Settings > Traffic
* Try to automatically verify your site with Google.
* The pop up that opens should lead you to Google. 

#### Proposed changelog entry for your changes:

* Site Verification Tools: ensure that you can connect your site to Google Search Console even when Publicize is disabled.
