### PR TITLE
Tools: do not use wp_parse_url in non-WP environments.

### DIFF
--- a/tools/export-translations.php
+++ b/tools/export-translations.php
@@ -33,7 +33,7 @@ function apize_url( $url ) {
 		return $url;
 	}
 
-	$host = preg_quote( wp_parse_url( $url, PHP_URL_HOST ) );
+	$host = preg_quote( parse_url( $url, PHP_URL_HOST ) );
 
 	return preg_replace( "#^https?://$host#", '\\0/api', $url );
 }

--- a/tools/import-translations.php
+++ b/tools/import-translations.php
@@ -30,7 +30,7 @@ function apize_url( $url ) {
 		return $url;
 	}
 
-	$host = preg_quote( wp_parse_url( $url, PHP_URL_HOST ) );
+	$host = preg_quote( parse_url( $url, PHP_URL_HOST ) );
 
 	return preg_replace( "#^https?://$host#", '\\0/api', $url );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Reverts some of the changes from #13707, as `wp_parse_url` is not available in those scripts.

#### Testing instructions:

* Run `yarn build-languages`
* You should not into any issues.

#### Proposed changelog entry for your changes:

* None
