### PR TITLE
Fixes tabs for geo-location RSS feeds

### DIFF
--- a/modules/geo-location/class.jetpack-geo-location.php
+++ b/modules/geo-location/class.jetpack-geo-location.php
@@ -251,6 +251,7 @@ class Jetpack_Geo_Location {
 	public function rss_namespace() {
 		echo PHP_EOL . "\t" . 'xmlns:georss="http://www.georss.org/georss\"';
 		echo PHP_EOL . "\t" . 'xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"';
+		echo PHP_EOL . "\t";
 	}
 
 	/**

--- a/modules/geo-location/class.jetpack-geo-location.php
+++ b/modules/geo-location/class.jetpack-geo-location.php
@@ -249,7 +249,7 @@ class Jetpack_Geo_Location {
 	 * Add the georss namespace during RSS generation.
 	 */
 	public function rss_namespace() {
-		echo PHP_EOL . "\t" . 'xmlns:georss="http://www.georss.org/georss\"';
+		echo PHP_EOL . "\t" . 'xmlns:georss="http://www.georss.org/georss"';
 		echo PHP_EOL . "\t" . 'xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"';
 		echo PHP_EOL . "\t";
 	}

--- a/modules/geo-location/class.jetpack-geo-location.php
+++ b/modules/geo-location/class.jetpack-geo-location.php
@@ -249,7 +249,8 @@ class Jetpack_Geo_Location {
 	 * Add the georss namespace during RSS generation.
 	 */
 	public function rss_namespace() {
-		echo PHP_EOL . 'xmlns:georss="http://www.georss.org/georss" xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"' . PHP_EOL;
+		echo PHP_EOL . "\t" . 'xmlns:georss="http://www.georss.org/georss\"';
+		echo PHP_EOL . "\t" . 'xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"';
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12051

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This resolves an issue where the RSS feeds with geo-location had invalid whitespacing, causing parser issues.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a bug fix.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit RSS feed, and view namespaces.

Before:
![Screenshot from 2019-10-22 11-51-52](https://user-images.githubusercontent.com/1760168/67304791-606b7a80-f4c2-11e9-9f99-b26221d6ead0.png)

After:
![Screenshot from 2019-10-22 11-50-44](https://user-images.githubusercontent.com/1760168/67304796-63666b00-f4c2-11e9-9f9b-f9490977ced3.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed spacing for RSS geo-location namespaces.
