### PR TITLE
Disables height input when tweet limit is present

### DIFF
--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -362,7 +362,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'height' ); ?>">
+			<label
+				for="<?php echo $this->get_field_id( 'height' ); ?>"
+				<?php echo $instance['tweet-limit'] ? 'style="color:#ccc;"' : '' ?>
+			>
 				<?php esc_html_e( 'Height (px; at least 200):', 'jetpack' ); ?>
 			</label>
 			<input
@@ -371,6 +374,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				name="<?php echo $this->get_field_name( 'height' ); ?>"
 				type="number" min="200"
 				value="<?php echo esc_attr( $instance['height'] ); ?>"
+				<?php echo $instance['tweet-limit'] ? 'disabled' : '' ?>
 			/>
 		</p>
 
@@ -385,6 +389,11 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				type="number" min="1" max="20"
 				value="<?php echo esc_attr( $instance['tweet-limit'] ); ?>"
 			/>
+		</p>
+		<p>
+			<small>
+				<?php esc_html_e( 'Selecting a tweet limit will bypass the height option above. The timeline will expand to the default height for the selected number of tweets.', 'jetpack' ); ?>
+			</small>
 		</p>
 
 		<p class="jetpack-twitter-timeline-widget-id-container">

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -364,7 +364,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		<p>
 			<label
 				for="<?php echo $this->get_field_id( 'height' ); ?>"
-				<?php echo $instance['tweet-limit'] ? 'style="color:#ccc;"' : '' ?>
+				<?php echo $instance['tweet-limit'] ? 'style="color:#ccc;"' : ''; ?>
 			>
 				<?php esc_html_e( 'Height (px; at least 200):', 'jetpack' ); ?>
 			</label>
@@ -374,7 +374,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				name="<?php echo $this->get_field_name( 'height' ); ?>"
 				type="number" min="200"
 				value="<?php echo esc_attr( $instance['height'] ); ?>"
-				<?php echo $instance['tweet-limit'] ? 'disabled' : '' ?>
+				<?php echo $instance['tweet-limit'] ? 'disabled' : ''; ?>
 			/>
 		</p>
 


### PR DESCRIPTION
This commit disables the Height input and changes the color of the
Height label text if the '# of Tweets' option is present..

Fixes #13789

#### Changes proposed in this Pull Request:
* Checks for 'twitter-limit' in form instance array and adds
'style="color:#ccc;" and 'disabled' to Height label/input if
present.

#### Testing instructions:
* In wp-admin go to **Appearance > Widgets**
* Add the Twitter Timeline to a widget area
* Fill in the widget options being sure to add a tweet limit
* After saving, the Height input should be grayed out and empty

#### Proposed changelog entry for your changes:
* Disables Height input when a Tweet Limit is present.
