### PR TITLE
Related Posts: Remove the call to remove_filter( 'the_content', ...)

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -163,7 +163,8 @@ class Jetpack_RelatedPosts {
 
 	/**
 	 * Adds a target to the post content to load related posts into if a shortcode for it did not already exist.
-	 * Will skip adding the target if the post content contains a Related Posts block.
+	 * Will skip adding the target if the post content contains a Related Posts block or if the 'get_the_excerpt'
+	 * hook is in the current filter list.
 	 *
 	 * @filter the_content
 	 *
@@ -172,7 +173,7 @@ class Jetpack_RelatedPosts {
 	 * @returns string
 	 */
 	public function filter_add_target_to_dom( $content ) {
-		if ( has_block( 'jetpack/related-posts', $content ) ) {
+		if ( has_block( 'jetpack/related-posts' ) ) {
 			return $content;
 		}
 
@@ -369,17 +370,7 @@ EOT;
 			'size'            => ! empty( $attributes['postsToShow'] ) ? absint( $attributes['postsToShow'] ) : 3,
 		);
 
-		$excludes      = $this->parse_numeric_get_arg( 'relatedposts_origin' );
-
-		$target_to_dom_priority = has_filter(
-			'the_content',
-			array( $this, 'filter_add_target_to_dom' )
-		);
-		remove_filter(
-			'the_content',
-			array( $this, 'filter_add_target_to_dom' ),
-			$target_to_dom_priority
-		);
+		$excludes = $this->parse_numeric_get_arg( 'relatedposts_origin' );
 
 		$related_posts = $this->get_for_post_id(
 			get_the_ID(),
@@ -452,7 +443,7 @@ EOT;
 	 *
 	 * @uses absint
 	 *
-	 * @param string $arg Name of the GET variable
+	 * @param string $arg Name of the GET variable.
 	 * @return array $result Parsed value(s)
 	 */
 	public function parse_numeric_get_arg( $arg ) {


### PR DESCRIPTION
Fixes #13775

The filter `filter_add_target_to_dom()` removes itself from the `the_content`
hook when the site is in AMP mode. When a filter removes itself from a hook, a bug in Core causes the filter with the next highest priority to be skipped.

For more information on the Core bug see: https://core.trac.wordpress.org/ticket/9968

To avoid this bug, remove the call to `remove_filter( 'the_content', array( $this,
'filter_add_target_to_dom'), ...)`. Instead, just rely on conditionals in the
`filter_add_target_to_dom()` method to control when related posts are added to the
content.

Related posts should not be added to the content when any of these three conditions are true:
1. The post contains a Related Posts block.
2. The post contains a `jetpack-related-posts` shortcode.
3. The `get_the_excerpt` hook is being executed. This hook is executed when the related
   posts are being generated, and related posts should not be added to the related post
   content.

These conditions are already handled by the `filter_add_target_to_dom()` method. However, when the call to `remove_filter( 'the_content', array( $this, 'filter_add_target_to_dom'), ...)`is removed, the legacy related posts are added to posts that contain a Related Posts block. Fix this by removing the `$content` parameter from `has_block('jetpack/related-posts', $content)`. Then, the `has_block()` method will determine whether the global `$post` contains a Related Posts block.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the call to `remove_filter( 'the_content', array( $this, 'filter_add_target_to_dom'), ...)`.
* Remove the $content parameter from `has_block('jetpack/related-posts', $content)`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Set up the test site:
   * The Jetpack and AMP plugins must be installed and activated. 
   * AMP should be set to Standard mode.
   * The Related Posts module must be activated.
   * The site must have enough posts with related content, tags, and categories that related post are generated.
   * At least one post must use legacy related posts.
   * At least one post must use a Related Posts block.

2. Add this code to a snipped plugin or your theme's functions.php:

```
add_filter( 'the_content', 'test_filter', 41 );

function test_filter( $content ) {
	return $content . ' TEST ';
}
```

3. Navigate to a post that uses legacy related posts. Note that the 'TEST' text (which should display after the related posts) is missing.

4. Apply this branch.

5. Refresh the post with legacy related posts. Verify that the 'TEST' text is now displayed under the related posts.

6. Navigate to a post that uses the Related Posts block. Verify that the legacy related posts are not displayed and that the 'TEST' text is displayed at the bottom of the post content.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix a bug in Related Posts that causes the filter with the next highest priority on the 'the_content' hook to be skipped while in AMP mode.
