### PR TITLE
Related Posts: add Posts to all post types that support them

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1755,14 +1755,19 @@ EOT;
 	 * @return null
 	 */
 	public function rest_register_related_posts() {
-		register_rest_field( 'post',
-			'jetpack-related-posts',
-			array(
-				'get_callback' => array( $this, 'rest_get_related_posts' ),
-				'update_callback' => null,
-				'schema'          => null,
-			)
-		);
+		/** This filter is already documented in class.json-api-endpoints.php */
+		$post_types = apply_filters( 'rest_api_allowed_post_types', array( 'post', 'page', 'revision' ) );
+		foreach ( $post_types as $post_type ) {
+			register_rest_field(
+				$post_type,
+				'jetpack-related-posts',
+				array(
+					'get_callback'    => array( $this, 'rest_get_related_posts' ),
+					'update_callback' => null,
+					'schema'          => null,
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #10203

#### Changes proposed in this Pull Request:

* This can be used by folks using the core REST API post endpoint to fetch related posts, instead of the WordPress.com REST API.

#### Testing instructions:

* Test this on a site where you've enabled Jetpack's Portfolio custom post type, as well as Related Posts. 
* You should see the Related Posts field when you look at a portfolio item via the core REST API, e.g. `https://yoursite.com/wp-json/wp/v2/jetpack-portfolio/35762`

#### Proposed changelog entry for your changes:

* Related Posts: add Posts to the REST API response for all post types that support them
