### PR TITLE
Sync: Checkout Endpoint: Add `pop` argument 😱

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -189,7 +189,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			return new WP_Error( 'invalid_number_of_items', 'Number of items needs to be an integer that is larger than 0 and less then 100', 400 );
 		}
 
-		$number_of_items = intval( $args[ 'number_of_items' ] );
+		$number_of_items = absint( $args[ 'number_of_items' ] );
 
 		$queue = new Queue( $queue_name );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -200,7 +200,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		// try to give ourselves as much time as possible
 		set_time_limit( 0 );
 
-		if ( true ) {
+		if ( $args['pop'] ) {
 			$buffer = new Queue_Buffer( 'pop', $queue->pop( 5 ) );
 		} else {
 			// let's delete the checkin state
@@ -209,8 +209,6 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			}
 			$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
 		}
-
-
 		// Check that the $buffer is not checkout out already
 		if ( is_wp_error( $buffer ) ) {
 			return new WP_Error( 'buffer_open', "We couldn't get the buffer it is currently checked out", 400 );
@@ -218,12 +216,6 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 		if ( ! is_object( $buffer ) ) {
 			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
-		}
-
-		if ( false ) {
-			$queue->close( $buffer );
-			$full_sync_module = Modules::get_module( 'full-sync' );
-			$full_sync_module->update_sent_progress_action( $buffer->get_items() );
 		}
 
 		Settings::set_is_syncing( true );

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -207,10 +207,6 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 		$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
 
-		if ( $args['close'] ) {
-			$queue->close( $buffer );
-		}
-
 		// Check that the $buffer is not checkout out already
 		if ( is_wp_error( $buffer ) ) {
 			return new WP_Error( 'buffer_open', "We couldn't get the buffer it is currently checked out", 400 );
@@ -218,6 +214,12 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 		if ( ! is_object( $buffer ) ) {
 			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
+		}
+
+		if ( $args['close'] ) {
+			$queue->close( $buffer );
+			$full_sync_module = Modules::get_module( 'full-sync' );
+			$full_sync_module->update_sent_progress_action( $buffer->get_items() );
 		}
 
 		Settings::set_is_syncing( true );

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -189,6 +189,8 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			return new WP_Error( 'invalid_number_of_items', 'Number of items needs to be an integer that is larger than 0 and less then 100', 400 );
 		}
 
+		$number_of_items = intval( $args[ 'number_of_items' ] );
+
 		$queue = new Queue( $queue_name );
 
 		if ( 0 === $queue->size() ) {
@@ -201,13 +203,13 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		set_time_limit( 0 );
 
 		if ( $args['pop'] ) {
-			$buffer = new Queue_Buffer( 'pop', $queue->pop( 5 ) );
+			$buffer = new Queue_Buffer( 'pop', $queue->pop( $number_of_items ) );
 		} else {
 			// let's delete the checkin state
 			if ( $args['force'] ) {
 				$queue->unlock();
 			}
-			$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
+			$buffer = $this->get_buffer( $queue, $number_of_items );
 		}
 		// Check that the $buffer is not checkout out already
 		if ( is_wp_error( $buffer ) ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -200,12 +200,16 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		// try to give ourselves as much time as possible
 		set_time_limit( 0 );
 
-		// let's delete the checkin state
-		if ( $args['force'] ) {
-			$queue->unlock();
+		if ( true ) {
+			$buffer = new Queue_Buffer( 'pop', $queue->pop( 5 ) );
+		} else {
+			// let's delete the checkin state
+			if ( $args['force'] ) {
+				$queue->unlock();
+			}
+			$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
 		}
 
-		$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
 
 		// Check that the $buffer is not checkout out already
 		if ( is_wp_error( $buffer ) ) {
@@ -216,7 +220,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			return new WP_Error( 'buffer_non-object', 'Buffer is not an object', 400 );
 		}
 
-		if ( $args['close'] ) {
+		if ( false ) {
 			$queue->close( $buffer );
 			$full_sync_module = Modules::get_module( 'full-sync' );
 			$full_sync_module->update_sent_progress_action( $buffer->get_items() );

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -207,6 +207,10 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 		$buffer = $this->get_buffer( $queue, $args[ 'number_of_items' ] );
 
+		if ( $args['close'] ) {
+			$queue->close( $buffer );
+		}
+
 		// Check that the $buffer is not checkout out already
 		if ( is_wp_error( $buffer ) ) {
 			return new WP_Error( 'buffer_open', "We couldn't get the buffer it is currently checked out", 400 );

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -684,6 +684,7 @@ new Jetpack_JSON_API_Sync_Checkout_Endpoint( array(
 		'number_of_items'   => '(int=10) Maximum number of items from the queue to be returned',
 		'encode'            => '(bool=true) Use the default encode method',
 		'force'             => '(bool=false) Force unlock the queue',
+		'close'             => '(bool=false) Close the buffer and delete the processed items from the queue.',
 	),
 	'response_format' => array(
 		'buffer_id' => '(string) Buffer ID that we are using',

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -684,7 +684,7 @@ new Jetpack_JSON_API_Sync_Checkout_Endpoint( array(
 		'number_of_items'   => '(int=10) Maximum number of items from the queue to be returned',
 		'encode'            => '(bool=true) Use the default encode method',
 		'force'             => '(bool=false) Force unlock the queue',
-		'close'             => '(bool=false) Close the buffer and delete the processed items from the queue.',
+		'pop'               => '(bool=false) Pop from the queue without checkout, use carefully 😱',
 	),
 	'response_format' => array(
 		'buffer_id' => '(string) Buffer ID that we are using',

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -681,7 +681,7 @@ class Queue {
 	/**
 	 * Return true if the buffer is still valid or an Error other wise.
 	 *
-	 * @param Queue_Buffer $buffer The Queue_Buffer.
+	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer The Queue_Buffer.
 	 *
 	 * @return bool|\WP_Error
 	 */

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -696,7 +696,8 @@ class Queue {
 			return new \WP_Error( 'buffer_not_checked_out', 'There are no checked out buffers' );
 		}
 
-		if ( intval( $checkout_id ) !== intval( $buffer->id ) ) {
+		// TODO: change to strict comparison.
+		if ( $checkout_id != $buffer->id ) { // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 			return new \WP_Error( 'buffer_mismatch', 'The buffer you checked in was not checked out' );
 		}
 

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -66,7 +66,7 @@ class Queue {
 	 *
 	 * @param array $items Array of events to add to the queue.
 	 *
-	 * @return bool\WP_Error
+	 * @return bool|\WP_Error
 	 */
 	public function add_all( $items ) {
 		global $wpdb;

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * The class that describes the Queue for the sync package.
+ *
+ * @package jetpack/sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
@@ -11,26 +16,46 @@ use Automattic\Jetpack\Sync\Defaults;
  * tons of added_option callbacks.
  */
 class Queue {
+	/**
+	 * The queue id.
+	 *
+	 * @var string
+	 */
 	public $id;
+	/**
+	 * Keeps track of the rows.
+	 *
+	 * @var int
+	 */
 	private $row_iterator;
 
-	function __construct( $id ) {
-		$this->id           = str_replace( '-', '_', $id ); // necessary to ensure we don't have ID collisions in the SQL
+	/**
+	 * Queue constructor.
+	 *
+	 * @param string $id Name of the queue.
+	 */
+	public function __construct( $id ) {
+		$this->id           = str_replace( '-', '_', $id ); // Necessary to ensure we don't have ID collisions in the SQL.
 		$this->row_iterator = 0;
-		$this->random_int   = mt_rand( 1, 1000000 );
+		$this->random_int   = wp_rand( 1, 1000000 );
 	}
 
-	function add( $item ) {
+	/**
+	 * Add a single item to the queue.
+	 *
+	 * @param object $item Event object to add to queue.
+	 */
+	public function add( $item ) {
 		global $wpdb;
 		$added = false;
-		// this basically tries to add the option until enough time has elapsed that
-		// it has a unique (microtime-based) option key
+		// This basically tries to add the option until enough time has elapsed that
+		// it has a unique (microtime-based) option key.
 		while ( ! $added ) {
 			$rows_added = $wpdb->query(
 				$wpdb->prepare(
 					"INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES (%s, %s,%s)",
 					$this->get_next_data_row_option_name(),
-					serialize( $item ),
+					serialize( $item ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 					'no'
 				)
 			);
@@ -38,30 +63,43 @@ class Queue {
 		}
 	}
 
-	// Attempts to insert all the items in a single SQL query. May be subject to query size limits!
-	function add_all( $items ) {
+	/**
+	 * Insert all the items in a single SQL query. May be subject to query size limits!
+	 *
+	 * @param array $items Array of events to add to the queue.
+	 *
+	 * @return bool\WP_Error
+	 */
+	public function add_all( $items ) {
 		global $wpdb;
 		$base_option_name = $this->get_next_data_row_option_name();
 
 		$query = "INSERT INTO $wpdb->options (option_name, option_value, autoload) VALUES ";
 
-		$rows = array();
-
-		for ( $i = 0; $i < count( $items ); $i += 1 ) {
+		$rows        = array();
+		$count_items = count( $items );
+		for ( $i = 0; $i < $count_items; ++$i ) {
 			$option_name  = esc_sql( $base_option_name . '-' . $i );
-			$option_value = esc_sql( serialize( $items[ $i ] ) );
+			$option_value = esc_sql( serialize( $items[ $i ] ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			$rows[]       = "('$option_name', '$option_value', 'no')";
 		}
 
-		$rows_added = $wpdb->query( $query . join( ',', $rows ) );
+		$rows_added = $wpdb->query( $query . join( ',', $rows ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		if ( count( $items ) === $rows_added ) {
 			return new \WP_Error( 'row_count_mismatch', "The number of rows inserted didn't match the size of the input array" );
 		}
+		return true;
 	}
 
-	// Peek at the front-most item on the queue without checking it out
-	function peek( $count = 1 ) {
+	/**
+	 * Get the front-most item on the queue without checking it out.
+	 *
+	 * @param int $count Number of items to return when looking at the items.
+	 *
+	 * @return array
+	 */
+	public function peek( $count = 1 ) {
 		$items = $this->fetch_items( $count );
 		if ( $items ) {
 			return Utils::get_item_values( $items );
@@ -70,7 +108,14 @@ class Queue {
 		return array();
 	}
 
-	function peek_by_id( $item_ids ) {
+	/**
+	 * Gets items with particular IDs.
+	 *
+	 * @param array $item_ids Array of Ids names to retrieve.
+	 *
+	 * @return array
+	 */
+	public function peek_by_id( $item_ids ) {
 		$items = $this->fetch_items_by_id( $item_ids );
 		if ( $items ) {
 			return Utils::get_item_values( $items );
@@ -79,9 +124,16 @@ class Queue {
 		return array();
 	}
 
-	// lag is the difference in time between the age of the oldest item
-	// (aka first or frontmost item) and the current time
-	function lag( $now = null ) {
+	/**
+	 * Gets the queue lag.
+	 * Lag is the difference in time between the age of the oldest item
+	 * (aka first or frontmost item) and the current time.
+	 *
+	 * @param microtime $now The current time in microtime.
+	 *
+	 * @return float|int|mixed|null
+	 */
+	public function lag( $now = null ) {
 		global $wpdb;
 
 		$first_item_name = $wpdb->get_var(
@@ -99,7 +151,7 @@ class Queue {
 			$now = microtime( true );
 		}
 
-		// break apart the item name to get the timestamp
+		// Break apart the item name to get the timestamp.
 		$matches = null;
 		if ( preg_match( '/^jpsq_' . $this->id . '-(\d+\.\d+)-/', $first_item_name, $matches ) ) {
 			return $now - floatval( $matches[1] );
@@ -108,7 +160,10 @@ class Queue {
 		}
 	}
 
-	function reset() {
+	/**
+	 * Resets the queue.
+	 */
+	public function reset() {
 		global $wpdb;
 		$this->delete_checkout_id();
 		$wpdb->query(
@@ -119,7 +174,12 @@ class Queue {
 		);
 	}
 
-	function size() {
+	/**
+	 * Return the size of the queue.
+	 *
+	 * @return int
+	 */
+	public function size() {
 		global $wpdb;
 
 		return (int) $wpdb->get_var(
@@ -130,8 +190,14 @@ class Queue {
 		);
 	}
 
-	// we use this peculiar implementation because it's much faster than count(*)
-	function has_any_items() {
+	/**
+	 * Lets you know if there is any items in the queue.
+	 *
+	 * We use this peculiar implementation because it's much faster than count(*).
+	 *
+	 * @return bool
+	 */
+	public function has_any_items() {
 		global $wpdb;
 		$value = $wpdb->get_var(
 			$wpdb->prepare(
@@ -140,10 +206,17 @@ class Queue {
 			)
 		);
 
-		return ( $value === '1' );
+		return ( '1' === $value );
 	}
 
-	function checkout( $buffer_size ) {
+	/**
+	 * Used to checkout the queue.
+	 *
+	 * @param int $buffer_size Size of the buffer to checkout.
+	 *
+	 * @return Queue_Buffer|bool|int|\WP_Error
+	 */
+	public function checkout( $buffer_size ) {
 		if ( $this->get_checkout_id() ) {
 			return new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
@@ -168,13 +241,13 @@ class Queue {
 	}
 
 	/**
-	 * Given a list of items return the items ids
+	 * Given a list of items return the items ids.
 	 *
-	 * @param array $items list of item objects
+	 * @param array $items List of item objects.
 	 *
 	 * @return array Ids of the items.
 	 */
-	function get_ids( $items ) {
+	public function get_ids( $items ) {
 		return array_map(
 			function( $item ) {
 				return $item->id;
@@ -184,14 +257,13 @@ class Queue {
 	}
 
 	/**
-	 *
-	 * Pop elements from the queue
+	 * Pop elements from the queue.
 	 *
 	 * @param int $limit Number of items to pop from the queue.
 	 *
 	 * @return array|object|null
 	 */
-	function pop( $limit ) {
+	public function pop( $limit ) {
 		$items = $this->fetch_items( $limit );
 
 		$ids = $this->get_ids( $items );
@@ -201,12 +273,21 @@ class Queue {
 		return $items;
 	}
 
-	// this checks out rows until it either empties the queue or hits a certain memory limit
-	// it loads the sizes from the DB first so that it doesn't accidentally
-	// load more data into memory than it needs to.
-	// The only way it will load more items than $max_size is if a single queue item
-	// exceeds the memory limit, but in that case it will send that item by itself.
-	function checkout_with_memory_limit( $max_memory, $max_buffer_size = 500 ) {
+	/**
+	 * Get the items from the queue with a memory limit.
+	 *
+	 * This checks out rows until it either empties the queue or hits a certain memory limit
+	 * it loads the sizes from the DB first so that it doesn't accidentally
+	 * load more data into memory than it needs to.
+	 * The only way it will load more items than $max_size is if a single queue item
+	 * exceeds the memory limit, but in that case it will send that item by itself.
+	 *
+	 * @param int $max_memory Maximum memory threshold.
+	 * @param int $max_buffer_size Maximum buffer size.
+	 *
+	 * @return Queue_Buffer|bool|int|\WP_Error
+	 */
+	public function checkout_with_memory_limit( $max_memory, $max_buffer_size = 500 ) {
 		if ( $this->get_checkout_id() ) {
 			return new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
@@ -219,7 +300,7 @@ class Queue {
 			return $result;
 		}
 
-		// get the map of buffer_id -> memory_size
+		// Get the map of buffer_id -> memory_size.
 		global $wpdb;
 
 		$items_with_size = $wpdb->get_results(
@@ -236,14 +317,14 @@ class Queue {
 		}
 
 		$total_memory = 0;
-
-		$min_item_id = $max_item_id = $items_with_size[0]->id;
+		$max_item_id  = $items_with_size[0]->id;
+		$min_item_id  = $max_item_id;
 
 		foreach ( $items_with_size as $id => $item_with_size ) {
 			$total_memory += $item_with_size->value_size;
 
-			// if this is the first item and it exceeds memory, allow loop to continue
-			// we will exit on the next iteration instead
+			// If this is the first item and it exceeds memory, allow loop to continue
+			// we will exit on the next iteration instead.
 			if ( $total_memory > $max_memory && $id > 0 ) {
 				break;
 			}
@@ -257,7 +338,7 @@ class Queue {
 			$max_item_id
 		);
 
-		$items = $wpdb->get_results( $query, OBJECT );
+		$items = $wpdb->get_results( $query, OBJECT ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		foreach ( $items as $item ) {
 			$item->value = maybe_unserialize( $item->value );
 		}
@@ -273,7 +354,14 @@ class Queue {
 		return $buffer;
 	}
 
-	function checkin( $buffer ) {
+	/**
+	 * Checkin the queue.
+	 *
+	 * @param Queue_Buffer $buffer Queue_Buffer object.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function checkin( $buffer ) {
 		$is_valid = $this->validate_checkout( $buffer );
 
 		if ( is_wp_error( $is_valid ) ) {
@@ -285,7 +373,15 @@ class Queue {
 		return true;
 	}
 
-	function close( $buffer, $ids_to_remove = null ) {
+	/**
+	 * Close the buffer.
+	 *
+	 * @param Queue_Buffer $buffer Queue_Buffer object.
+	 * @param null|array   $ids_to_remove Ids to remove from the queue.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public function close( $buffer, $ids_to_remove = null ) {
 		$is_valid = $this->validate_checkout( $buffer );
 
 		if ( is_wp_error( $is_valid ) ) {
@@ -294,7 +390,7 @@ class Queue {
 
 		$this->delete_checkout_id();
 
-		// by default clear all items in the buffer
+		// By default clear all items in the buffer.
 		if ( is_null( $ids_to_remove ) ) {
 			$ids_to_remove = $buffer->get_item_ids();
 		}
@@ -312,43 +408,63 @@ class Queue {
 	 * @return bool|int
 	 */
 	private function delete( $ids ) {
-		if ( count( $ids ) > 0 ) {
+		if ( 0 === count( $ids ) ) {
 			return 0;
 		}
 		global $wpdb;
-		$sql   = "DELETE FROM $wpdb->options WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $ids_to_remove ), '%s' ) ) . ')';
-		$query = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $ids_to_remove ) );
-		return $wpdb->query( $query );
+		$sql   = "DELETE FROM $wpdb->options WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $ids ), '%s' ) ) . ')';
+		$query = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $ids ) );
+
+		return $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	}
 
-	function flush_all() {
+	/**
+	 * Flushes all items from the queue.
+	 *
+	 * @return array
+	 */
+	public function flush_all() {
 		$items = Utils::get_item_values( $this->fetch_items() );
 		$this->reset();
 
 		return $items;
 	}
 
-	function get_all() {
+	/**
+	 * Get all the items from the queue.
+	 *
+	 * @return array|object|null
+	 */
+	public function get_all() {
 		return $this->fetch_items();
 	}
 
-	// use with caution, this could allow multiple processes to delete
-	// and send from the queue at the same time
-	function force_checkin() {
+	/**
+	 * Forces Checkin of the queue.
+	 * Use with caution, this could allow multiple processes to delete
+	 * and send from the queue at the same time
+	 */
+	public function force_checkin() {
 		$this->delete_checkout_id();
 	}
 
-	// used to lock checkouts from the queue.
-	// tries to wait up to $timeout seconds for the queue to be empty
-	function lock( $timeout = 30 ) {
+	/**
+	 * Locks checkouts from the queue
+	 * tries to wait up to $timeout seconds for the queue to be empty.
+	 *
+	 * @param int $timeout The wait time in seconds for the queue to be empty.
+	 *
+	 * @return bool|int|\WP_Error
+	 */
+	public function lock( $timeout = 30 ) {
 		$tries = 0;
 
 		while ( $this->has_any_items() && $tries < $timeout ) {
 			sleep( 1 );
-			$tries += 1;
+			++$tries;
 		}
 
-		if ( $tries === 30 ) {
+		if ( 30 === $tries ) {
 			return new \WP_Error( 'lock_timeout', 'Timeout waiting for sync queue to empty' );
 		}
 
@@ -356,7 +472,7 @@ class Queue {
 			return new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' );
 		}
 
-		// hopefully this means we can acquire a checkout?
+		// Hopefully this means we can acquire a checkout?
 		$result = $this->set_checkout_id( 'lock' );
 
 		if ( ! $result || is_wp_error( $result ) ) {
@@ -366,7 +482,12 @@ class Queue {
 		return true;
 	}
 
-	function unlock() {
+	/**
+	 * Unlocks the queue.
+	 *
+	 * @return bool|int
+	 */
+	public function unlock() {
 		return $this->delete_checkout_id();
 	}
 
@@ -381,6 +502,11 @@ class Queue {
 		return sprintf( '%.6f', microtime( true ) );
 	}
 
+	/**
+	 * Gets the checkout ID.
+	 *
+	 * @return bool|string
+	 */
 	private function get_checkout_id() {
 		global $wpdb;
 		$checkout_value = $wpdb->get_var(
@@ -400,6 +526,13 @@ class Queue {
 		return false;
 	}
 
+	/**
+	 * Sets the checkout id.
+	 *
+	 * @param string $checkout_id The ID of the checkout.
+	 *
+	 * @return bool|int
+	 */
 	private function set_checkout_id( $checkout_id ) {
 		global $wpdb;
 
@@ -425,9 +558,14 @@ class Queue {
 		return $updated_num;
 	}
 
+	/**
+	 * Deletes the checkout ID.
+	 *
+	 * @return bool|int
+	 */
 	private function delete_checkout_id() {
 		global $wpdb;
-		// rather than delete, which causes fragmentation, we update in place
+		// Rather than delete, which causes fragmentation, we update in place.
 		return $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s",
@@ -438,15 +576,25 @@ class Queue {
 
 	}
 
+	/**
+	 * Return the lock option name.
+	 *
+	 * @return string
+	 */
 	private function get_lock_option_name() {
 		return "jpsq_{$this->id}_checkout";
 	}
 
+	/**
+	 * Return the next data row option name.
+	 *
+	 * @return string
+	 */
 	private function get_next_data_row_option_name() {
 		$timestamp = $this->generate_option_name_timestamp();
 
-		// row iterator is used to avoid collisions where we're writing data waaay fast in a single process
-		if ( $this->row_iterator === PHP_INT_MAX ) {
+		// Row iterator is used to avoid collisions where we're writing data waaay fast in a single process.
+		if ( PHP_INT_MAX === $this->row_iterator ) {
 			$this->row_iterator = 0;
 		} else {
 			$this->row_iterator += 1;
@@ -455,46 +603,85 @@ class Queue {
 		return 'jpsq_' . $this->id . '-' . $timestamp . '-' . $this->random_int . '-' . $this->row_iterator;
 	}
 
+	/**
+	 * Return the items in the queue.
+	 *
+	 * @param null|int $limit Limit to the number of items we fetch at once.
+	 *
+	 * @return array|object|null
+	 */
 	private function fetch_items( $limit = null ) {
 		global $wpdb;
 
 		if ( $limit ) {
-			$query_sql = $wpdb->prepare( "SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d", "jpsq_{$this->id}-%", $limit );
+			$items = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC LIMIT %d",
+					"jpsq_{$this->id}-%",
+					$limit
+				),
+				OBJECT
+			);
 		} else {
-			$query_sql = $wpdb->prepare( "SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC", "jpsq_{$this->id}-%" );
+			$items = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name LIKE %s ORDER BY option_name ASC",
+					"jpsq_{$this->id}-%"
+				),
+				OBJECT
+			);
 		}
 
-		return $this->query_for_items( $query_sql );
+		return $this->unserialze_values( $items );
+
 	}
 
+	/**
+	 * Return items with specific ids.
+	 *
+	 * @param array $items_ids Array of event ids.
+	 *
+	 * @return array|object|null
+	 */
 	private function fetch_items_by_id( $items_ids ) {
 		global $wpdb;
-		$ids_placeholders = implode( ', ', array_fill( 0, count( $items_ids ), '%s' ) );
 
-		$query_sql = $wpdb->prepare(
-			"
-			SELECT option_name AS id, option_value AS value
-			FROM $wpdb->options
-			WHERE option_name IN ( $ids_placeholders )",
-			$items_ids
+		$sql   = "SELECT option_name AS id, option_value AS value FROM $wpdb->options WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $items_ids ), '%s' ) ) . ')';
+		$query = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $items_ids ) );
+
+		$items = $wpdb->get_results(
+			$query, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			OBJECT
 		);
-
-		return $this->query_for_items( $query_sql );
+		return $this->unserialze_values( $items );
 	}
 
-	private function query_for_items( $query_sql ) {
-		global $wpdb;
-
-		$items = $wpdb->get_results( $query_sql, OBJECT );
+	/**
+	 * Unserialize item values.
+	 *
+	 * @param array $items Events from the Queue to be serialized.
+	 *
+	 * @return mixed
+	 */
+	private function unserialze_values( $items ) {
 		array_walk(
 			$items,
 			function( $item ) {
 				$item->value = maybe_unserialize( $item->value );
 			}
 		);
+
 		return $items;
+
 	}
 
+	/**
+	 * Return true if the buffer is still valid or an Error other wise.
+	 *
+	 * @param Queue_Buffer $buffer The Queue_Buffer.
+	 *
+	 * @return bool|\WP_Error
+	 */
 	private function validate_checkout( $buffer ) {
 		if ( ! $buffer instanceof Queue_Buffer ) {
 			return new \WP_Error( 'not_a_buffer', 'You must checkin an instance of Automattic\\Jetpack\\Sync\\Queue_Buffer' );
@@ -506,7 +693,7 @@ class Queue {
 			return new \WP_Error( 'buffer_not_checked_out', 'There are no checked out buffers' );
 		}
 
-		if ( $checkout_id != $buffer->id ) {
+		if ( $checkout_id !== $buffer->id ) {
 			return new \WP_Error( 'buffer_mismatch', 'The buffer you checked in was not checked out' );
 		}
 

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -212,7 +212,7 @@ class Queue {
 	 *
 	 * @param int $buffer_size Size of the buffer to checkout.
 	 *
-	 * @return Queue_Buffer|bool|int|\WP_Error
+	 * @return Automattic\Jetpack\Sync\Queue_Buffer|bool|int|\WP_Error
 	 */
 	public function checkout( $buffer_size ) {
 		if ( $this->get_checkout_id() ) {
@@ -280,7 +280,7 @@ class Queue {
 	 * The only way it will load more items than $max_size is if a single queue item
 	 * exceeds the memory limit, but in that case it will send that item by itself.
 	 *
-	 * @param int $max_memory Maximum memory threshold.
+	 * @param int $max_memory (bytes) Maximum memory threshold.
 	 * @param int $max_buffer_size Maximum buffer size (number of items).
 	 *
 	 * @return Queue_Buffer|bool|int|\WP_Error

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -265,15 +265,26 @@ class Queue {
 			$ids_to_remove = $buffer->get_item_ids();
 		}
 
-		global $wpdb;
-
-		if ( count( $ids_to_remove ) > 0 ) {
-			$sql   = "DELETE FROM $wpdb->options WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $ids_to_remove ), '%s' ) ) . ')';
-			$query = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $ids_to_remove ) );
-			$wpdb->query( $query );
-		}
+		$this->delete( $ids_to_remove );
 
 		return true;
+	}
+
+	/**
+	 * Delete elements from the queue.
+	 *
+	 * @param array $ids Ids to delete.
+	 *
+	 * @return bool|int
+	 */
+	private function delete( $ids ) {
+		if ( count( $ids ) > 0 ) {
+			return 0;
+		}
+		global $wpdb;
+		$sql   = "DELETE FROM $wpdb->options WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $ids_to_remove ), '%s' ) ) . ')';
+		$query = call_user_func_array( array( $wpdb, 'prepare' ), array_merge( array( $sql ), $ids_to_remove ) );
+		return $wpdb->query( $query );
 	}
 
 	function flush_all() {

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -283,7 +283,7 @@ class Queue {
 	 * @param int $max_memory (bytes) Maximum memory threshold.
 	 * @param int $max_buffer_size Maximum buffer size (number of items).
 	 *
-	 * @return Queue_Buffer|bool|int|\WP_Error
+	 * @return Automattic\Jetpack\Sync\Queue_Buffer|bool|int|\WP_Error
 	 */
 	public function checkout_with_memory_limit( $max_memory, $max_buffer_size = 500 ) {
 		if ( $this->get_checkout_id() ) {

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -109,7 +109,7 @@ class Queue {
 	/**
 	 * Gets items with particular IDs.
 	 *
-	 * @param array $item_ids Array of Ids names to retrieve.
+	 * @param array $item_ids Array of item IDs to retrieve.
 	 *
 	 * @return array
 	 */

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -353,7 +353,7 @@ class Queue {
 	}
 
 	/**
-	 * Checkin the queue.
+	 * Check in the queue.
 	 *
 	 * @param Queue_Buffer $buffer Queue_Buffer object.
 	 *

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -281,7 +281,7 @@ class Queue {
 	 * exceeds the memory limit, but in that case it will send that item by itself.
 	 *
 	 * @param int $max_memory Maximum memory threshold.
-	 * @param int $max_buffer_size Maximum buffer size.
+	 * @param int $max_buffer_size Maximum buffer size (number of items).
 	 *
 	 * @return Queue_Buffer|bool|int|\WP_Error
 	 */

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -167,6 +167,40 @@ class Queue {
 		return $buffer;
 	}
 
+	/**
+	 * Given a list of items return the items ids
+	 *
+	 * @param array $items list of item objects
+	 *
+	 * @return array Ids of the items.
+	 */
+	function get_ids( $items ) {
+		return array_map(
+			function( $item ) {
+				return $item->id;
+			},
+			$items
+		);
+	}
+
+	/**
+	 *
+	 * Pop elements from the queue
+	 *
+	 * @param int $limit Number of items to pop from the queue.
+	 *
+	 * @return array|object|null
+	 */
+	function pop( $limit ) {
+		$items = $this->fetch_items( $limit );
+
+		$ids = $this->get_ids( $items );
+
+		$this->delete( $ids );
+
+		return $items;
+	}
+
 	// this checks out rows until it either empties the queue or hits a certain memory limit
 	// it loads the sizes from the DB first so that it doesn't accidentally
 	// load more data into memory than it needs to.

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -355,7 +355,7 @@ class Queue {
 	/**
 	 * Check in the queue.
 	 *
-	 * @param Queue_Buffer $buffer Queue_Buffer object.
+	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
 	 *
 	 * @return bool|\WP_Error
 	 */

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -2,7 +2,7 @@
 /**
  * The class that describes the Queue for the sync package.
  *
- * @package jetpack/sync
+ * @package automattic/jetpack-sync
  */
 
 namespace Automattic\Jetpack\Sync;

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -374,7 +374,7 @@ class Queue {
 	/**
 	 * Close the buffer.
 	 *
-	 * @param Queue_Buffer $buffer Queue_Buffer object.
+	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
 	 * @param null|array   $ids_to_remove Ids to remove from the queue.
 	 *
 	 * @return bool|\WP_Error

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -375,7 +375,7 @@ class Queue {
 	 * Close the buffer.
 	 *
 	 * @param Automattic\Jetpack\Sync\Queue_Buffer $buffer Queue_Buffer object.
-	 * @param null|array   $ids_to_remove Ids to remove from the queue.
+	 * @param null|array                           $ids_to_remove Ids to remove from the queue.
 	 *
 	 * @return bool|\WP_Error
 	 */
@@ -630,7 +630,7 @@ class Queue {
 			);
 		}
 
-		return $this->unserialze_values( $items );
+		return $this->unserialize_values( $items );
 
 	}
 
@@ -656,7 +656,7 @@ class Queue {
 			OBJECT
 		);
 
-		return $this->unserialze_values( $items );
+		return $this->unserialize_values( $items );
 	}
 
 	/**
@@ -666,7 +666,7 @@ class Queue {
 	 *
 	 * @return mixed
 	 */
-	private function unserialze_values( $items ) {
+	private function unserialize_values( $items ) {
 		array_walk(
 			$items,
 			function( $item ) {

--- a/packages/sync/src/Queue.php
+++ b/packages/sync/src/Queue.php
@@ -693,7 +693,7 @@ class Queue {
 			return new \WP_Error( 'buffer_not_checked_out', 'There are no checked out buffers' );
 		}
 
-		if ( $checkout_id !== $buffer->id ) {
+		if ( intval( $checkout_id ) !== intval( $buffer->id ) ) {
 			return new \WP_Error( 'buffer_mismatch', 'The buffer you checked in was not checked out' );
 		}
 


### PR DESCRIPTION
Sorry for the poor description, and testing instructions, still testing some things and working on a wpcom patch so things get easier to test. I still appreciate early reviews, Thanks!

When passing `pop`, the endpoint will "consume" from the queue without doing any checkout checks.

It will allow us to write faster consumer clients(at their own risk).

#### Testing instructions:
* Waiting for D34507-code to be deployed, will make things easier to test.