### PR TITLE
Handles custom tab sizes for gist embeds and shortcodes

### DIFF
--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -242,7 +242,7 @@ function github_gist_shortcode( $atts, $content = '' ) {
  * @param int    $tab_size The tab size of the gist.
  * @return string          The script tag of the gist.
  */
-function github_gist_simple_embed( $id, $tab_size = 4 ) {
+function github_gist_simple_embed( $id, $tab_size = 8 ) {
 	$id = str_replace( 'json', 'js', $id );
 	return '<script src="' . esc_url( "https://gist.github.com/$id?ts=$tab_size" ) . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 }

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -87,7 +87,7 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 
 		// Keep the unique identifier without any leading or trailing slashes.
 		if ( ! empty( $parsed_url['path'] ) ) {
-			$gist_info['id'] = preg_replace( '/^\/([^\.]+)\./', '$1', $parsed_url['path'] );
+			$gist_info['id'] = trim( $parsed_url['path'], '/' );
 			// Overwrite $gist with our identifier to clean it up below.
 			$gist = $gist_info['id'];
 		}

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -58,6 +58,7 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 	$gist_info = array(
 		'id'   => '',
 		'file' => '',
+		'ts'   => 8,
 	);
 	// Simple shortcode, with just an ID.
 	if ( ctype_alnum( $gist ) ) {
@@ -89,6 +90,15 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 			$gist_info['id'] = preg_replace( '/^\/([^\.]+)\./', '$1', $parsed_url['path'] );
 			// Overwrite $gist with our identifier to clean it up below.
 			$gist = $gist_info['id'];
+		}
+
+		// Parse the query args to obtain the tab spacing.
+		if ( ! empty( $parsed_url['query'] ) ) {
+			$query_args = array();
+			wp_parse_str( $parsed_url['query'], $query_args );
+			if ( ! empty( $query_args['ts'] ) ) {
+				$gist_info['ts'] = absint( $query_args['ts'] );
+			}
 		}
 	}
 
@@ -156,6 +166,12 @@ function github_gist_shortcode( $atts, $content = '' ) {
 		$file = rawurlencode( $file );
 	}
 
+	// Set the tab size, allowing attributes to override the query string.
+	$tab_size = $gist_info['ts'];
+	if ( ! empty( $atts['ts'] ) ) {
+		$tab_size = absint( $atts['ts'] );
+	}
+
 	if (
 		class_exists( 'Jetpack_AMP_Support' )
 		&& Jetpack_AMP_Support::is_amp_request()
@@ -195,7 +211,11 @@ function github_gist_shortcode( $atts, $content = '' ) {
 	);
 
 	// inline style to prevent the bottom margin to the embed that themes like TwentyTen, et al., add to tables.
-	$return = '<style>.gist table { margin-bottom: 0; }</style><div class="gist-oembed" data-gist="' . esc_attr( $id ) . '"></div>';
+	$return = sprintf(
+		'<style>.gist table { margin-bottom: 0; }</style><div class="gist-oembed" data-gist="%1$s" data-ts="%2$d"></div>',
+		esc_attr( $id ),
+		absint( $tab_size )
+	);
 
 	if (
 		// No need to check for a nonce here, that's already handled by Core further up.
@@ -206,7 +226,7 @@ function github_gist_shortcode( $atts, $content = '' ) {
 		&& 'parse-embed' === $_POST['action']
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	) {
-		return github_gist_simple_embed( $id );
+		return github_gist_simple_embed( $id, $tab_size );
 	}
 
 	return $return;
@@ -218,9 +238,11 @@ function github_gist_shortcode( $atts, $content = '' ) {
  *
  * @since 3.9.0
  *
- * @param string $id The ID of the gist.
+ * @param string $id       The ID of the gist.
+ * @param int    $tab_size The tab size of the gist.
+ * @return string          The script tag of the gist.
  */
-function github_gist_simple_embed( $id ) {
+function github_gist_simple_embed( $id, $tab_size = 4 ) {
 	$id = str_replace( 'json', 'js', $id );
-	return '<script src="' . esc_url( "https://gist.github.com/$id" ) . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	return '<script src="' . esc_url( "https://gist.github.com/$id?ts=$tab_size" ) . '"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 }

--- a/modules/shortcodes/gist.php
+++ b/modules/shortcodes/gist.php
@@ -77,6 +77,7 @@ function jetpack_gist_get_shortcode_id( $gist = '' ) {
 			return array(
 				'id'   => '',
 				'file' => '',
+				'ts'   => 8,
 			);
 		}
 

--- a/modules/shortcodes/js/gist.js
+++ b/modules/shortcodes/js/gist.js
@@ -2,13 +2,18 @@
 	var gistStylesheetLoaded = false,
 		gistEmbed = function() {
 			$( '.gist-oembed' ).each( function( i, el ) {
-				var url = 'https://gist.github.com/' + $( el ).data( 'gist' );
+				var url = 'https://gist.github.com/' + $( el ).data( 'gist' ),
+					ts = Number.parseInt( $( el ).data( 'ts' ), 10 );
 
 				$.ajax( {
 					url: url,
 					dataType: 'jsonp',
 				} ).done( function( response ) {
-					$( el ).replaceWith( response.div );
+					if ( ts && 8 !== ts ) {
+						$( el ).replaceWith( $( response.div ).css( 'tab-size', ts.toString() ) );
+					} else {
+						$( el ).replaceWith( response.div );
+					}
 
 					if ( ! gistStylesheetLoaded ) {
 						var stylesheet =

--- a/tests/php/modules/shortcodes/test-class.gist.php
+++ b/tests/php/modules/shortcodes/test-class.gist.php
@@ -498,4 +498,134 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 			$actual
 		);
 	}
+
+	/**
+	 * Verify that gist URLs in shortcode preserves tab spacing.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.9.0
+	 */
+	public function test_shortcodes_gist_with_tab_size() {
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$content = '[gist https://gist.github.com/' . $gist_id . '/?ts=4]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="4"></div>', $shortcode_content );
+
+		// Test AMP version *lacks* tab size.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that gist URLs in shortcode content preserves tab spacing.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.9.0
+	 */
+	public function test_shortcodes_gist_full_url_with_tab_size_in_content() {
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$content = '[gist]https://gist.github.com/' . $gist_id . '/?ts=4[/gist]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="4"></div>', $shortcode_content );
+
+		// Test AMP version *lacks* tab size.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that gist URLs in shortcode allows tab size as an attribute.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.9.0
+	 */
+	public function test_shortcodes_gist_with_tab_size_in_attributes() {
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$content = '[gist https://gist.github.com/' . $gist_id . '/?ts=2 ts=4]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="4"></div>', $shortcode_content );
+
+		// Test AMP version *lacks* tab size.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that gist URLs in shortcode has their tab size overridden by attributes.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.9.0
+	 */
+	public function test_shortcodes_gist_with_tab_size_in_attributes_override() {
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$content = '[gist ' . $gist_id . ' ts=4]';
+
+		// Test HTML version.
+		$shortcode_content = do_shortcode( $content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="4"></div>', $shortcode_content );
+
+		// Test AMP version *lacks* tab size.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$shortcode_content = do_shortcode( $content );
+		$this->assertEquals(
+			sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ),
+			$shortcode_content
+		);
+	}
+
+	/**
+	 * Verify that content with a full Gist URL on its own line preserves tab spacing.
+	 *
+	 * @covers ::github_gist_shortcode
+	 *
+	 * @since 7.9.0
+	 */
+	public function test_shortcodes_gist_oembed_with_tab_size() {
+		global $post;
+
+		$gist_id = '57cc50246aab776e110060926a2face2';
+		$url     = 'https://gist.github.com/' . $gist_id . '/?ts=4';
+		$post    = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		do_action( 'init' );
+		setup_postdata( $post );
+
+		// Test HTML version.
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="4"></div>', $actual );
+
+		// Test AMP version *lacks* tab size.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertEquals(
+			wpautop( sprintf( '<amp-gist layout="fixed-height" data-gistid="%s" height="240"></amp-gist>', basename( $gist_id ) ) ),
+			$actual
+		);
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.gist.php
+++ b/tests/php/modules/shortcodes/test-class.gist.php
@@ -343,7 +343,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_gist_public_full_url() {
 		$gist_id = '57cc50246aab776e110060926a2face2';
-		$content = '[gist https://gist.github.com/' . $gist_id . ' /]';
+		$content = '[gist https://gist.github.com/' . $gist_id . '/ ]';
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
@@ -391,7 +391,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 	 */
 	public function test_shortcodes_gist_private_full_url() {
 		$gist_id = 'xknown/fc5891af153e2cf365c9';
-		$content = '[gist https://gist.github.com/' . $gist_id . ' /]';
+		$content = '[gist https://gist.github.com/' . $gist_id . '/ ]';
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );

--- a/tests/php/modules/shortcodes/test-class.gist.php
+++ b/tests/php/modules/shortcodes/test-class.gist.php
@@ -89,7 +89,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -113,7 +113,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -137,7 +137,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -161,7 +161,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -185,7 +185,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -209,7 +209,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -241,7 +241,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 		);
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $expected_gist_id . '"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $expected_gist_id . '" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -278,7 +278,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $expected_gist_id . '"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $expected_gist_id . '" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -347,7 +347,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -371,7 +371,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -395,7 +395,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -419,7 +419,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 
 		// Test HTML version.
 		$shortcode_content = do_shortcode( $content );
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json"></div>', $shortcode_content );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json" data-ts="8"></div>', $shortcode_content );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -451,7 +451,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 		ob_start();
 		the_content();
 		$actual = ob_get_clean();
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json"></div>', $actual );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . $gist_id . '.json" data-ts="8"></div>', $actual );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -486,7 +486,7 @@ class WP_Test_Jetpack_Shortcodes_Gist extends WP_UnitTestCase {
 		ob_start();
 		the_content();
 		$actual = ob_get_clean();
-		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json?file=wp-config.php"></div>', $actual );
+		$this->assertContains( '<div class="gist-oembed" data-gist="' . basename( $gist_id ) . '.json?file=wp-config.php" data-ts="8"></div>', $actual );
 
 		// Test AMP version.
 		add_filter( 'jetpack_is_amp_request', '__return_true' );


### PR DESCRIPTION
Fixes #10534

#### Changes proposed in this Pull Request:

* This adds functionality for tab sizing for gist embeds and shortcodes via `?ts=` query param.
* Adds `ts` attribute to shortcodes.

**Known limitation:** Currently, AMP [does not](https://amp.dev/documentation/examples/components/amp-gist/) have a way to change tab sizing. This is a limitation of the AMP `amp-gist` element.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds functionality to the embed/shortcode module.

#### Testing instructions:

* Enable Shortcode Embeds module.
* Create a post with a gist embed that appends `?ts=4` to the gist URL.
* Create a post with a gist shortcode that has `ts=4` in it.

Screenshot: 

![Screenshot on 2019-10-22 at 17_05_54](https://user-images.githubusercontent.com/426388/67367134-31621100-f575-11e9-80cc-5d23b785b1b7.png)

#### Proposed changelog entry for your changes:

* Adds support for tab sizing for gist embeds.
