### PR TITLE
Subscription Form block - block - added example

### DIFF
--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -50,6 +50,9 @@ export const settings = {
 	},
 	edit,
 	save,
+	example: {
+		attributes: {},
+	},
 	deprecated: [
 		{
 			attributes: {


### PR DESCRIPTION
Master issue: #13510

Adds example to Subscription Form block

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Implements the ability to preview the block before inserting it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature of Gutenberg we are moving to support.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the post editor
* Click the + to open a block inserter on the top bar
* Hover over the Subscription Form block

#### Before
<img width="815" alt="image" src="https://user-images.githubusercontent.com/1123119/67435378-38a31200-f5a9-11e9-85a7-e7364f7f8508.png">

#### After
<img width="773" alt="image" src="https://user-images.githubusercontent.com/1123119/67435323-190be980-f5a9-11e9-8b53-401d3e278540.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed for this.
