### PR TITLE
Recurring Payments block - added example

### DIFF
--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -63,6 +63,11 @@ export const settings = {
 	},
 	edit,
 	save: () => null,
+	example: {
+		attributes: {
+			submitButtonText: __( '$100 Contribution', 'jetpack' ),
+		},
+	},
 	supports: {
 		html: false,
 		align: true,


### PR DESCRIPTION
Master issue: #13510

Adds example to Recurring Payments block

### In progress notes
I don't believe the current preview is very good. In fact, no preview is better than this, however, this will get the conversation started.

When hovering over the block, you see a loading state where it tries to talk to Stripe:
<img width="771" alt="image" src="https://user-images.githubusercontent.com/1123119/67437235-9c2f3e80-f5ad-11e9-99b6-d711dbb5f86b.png">

When that fails, you see this:
<img width="773" alt="image" src="https://user-images.githubusercontent.com/1123119/67437251-a5b8a680-f5ad-11e9-90f6-9cd30f35caf6.png">

**Ideally, this is what we want the user to see:**
![image](https://user-images.githubusercontent.com/1123119/67437277-b406c280-f5ad-11e9-8e28-1cab75d3fb77.png)

I need someone like @gravityrail or an experienced JS dev to remove the notice and loading state for the preview so the button shows up instantly. Sadly, this is beyond what I'm comfortable with.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Implements the ability to preview the block before inserting it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature of Gutenberg we are moving to support.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the post editor
* Click the + to open a block inserter from the top bar
* Hover over the recurring payments block

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* We should probably add one changelog entry for all the blocks we add examples to. Something like: "Added previews to Jetpack blocks within the Gutenberg editor."
