### PR TITLE
Instant Search: improve search phrase highlighting (#2)

### DIFF
--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -120,7 +120,7 @@ class SearchResultMinimal extends Component {
 						dateStyle: 'short',
 					} ) }
 				</span>
-				<h3>
+				<h3 className="jetpack-instant-search__result-title">
 					<PostTypeIcon
 						postType={ fields.post_type }
 						shortcodeTypes={ fields.shortcode_types }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -7,14 +7,11 @@
 	text-align: left;
 
 	mark {
-		background: none;
+		background-color: #ffc;
 		font-weight: bold;
 		color: inherit;
+		padding: 0;
 	}
-}
-
-.jetpack-instant-search__result-title mark {
-	padding: 0;
 }
 
 .jetpack-instant-search__search-results-real-query {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -5,6 +5,16 @@
 	max-width: 1080px;
 	min-height: 400px;
 	text-align: left;
+
+	mark {
+		background: none;
+		font-weight: bold;
+		color: inherit;
+	}
+}
+
+.jetpack-instant-search__result-title mark {
+	padding: 0;
 }
 
 .jetpack-instant-search__search-results-real-query {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/13792.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
We recently switched to use `<mark>` to show where search results contain the search phrase. It looks like this by default:

<img width="822" alt="Screen Shot 2019-10-22 at 16 30 41" src="https://user-images.githubusercontent.com/17325/67257658-88220900-f4e9-11e9-9fd8-103da5c74b97.png">

This PR changes the highlighting to have a more subtle appearance:

<img width="805" alt="67346520-8153ce80-f59b-11e9-9220-147aff242a87" src="https://user-images.githubusercontent.com/17325/67437805-3e9efe80-f64e-11e9-8d8a-54b737a04ae4.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No - it's a visual adjustment to an unreleased feature.

#### Testing instructions
Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.

Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).

Perform a search and make sure the correct highlighting is applied. For example: /?s=card&blog_id=84860689 should show the word "card" bolded in results.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog required.