### PR TITLE
Instant Search: Use href to restore previous location state

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -251,7 +251,6 @@ class Jetpack_Search {
 					'postTypeFilters'    => $widget_options['post_types'],
 					'postTypes'          => $post_type_labels,
 					'siteId'             => Jetpack::get_option( 'id' ),
-					'siteUrl'            => site_url(),
 					'sort'               => $widget_options['sort'],
 					'widgets'            => array_values( $widgets ),
 				);

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -25,7 +25,7 @@ import {
 	setSortQuery,
 	getSortQuery,
 	hasFilter,
-	restorePreviousPath,
+	restorePreviousHref,
 	getSearchQuery,
 } from '../lib/query-string';
 import { removeChildren, hideElements, hideChildren, showChildren } from '../lib/dom';
@@ -97,7 +97,7 @@ class SearchApp extends Component {
 
 		this.setState( { showResults: false }, () => {
 			showChildren( this.props.themeOptions.resultsSelector );
-			restorePreviousPath( this.props.initialPath );
+			restorePreviousHref( this.props.initialHref );
 		} );
 	}
 

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -18,7 +18,7 @@ const injectSearchApp = grabFocus => {
 	render(
 		<SearchApp
 			grabFocus={ grabFocus }
-			initialPath={ window[ SERVER_OBJECT_NAME ].siteUrl }
+			initialHref={ window.location.href }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }
 			isSearchPage={ getSearchQuery() !== '' }
 			options={ window[ SERVER_OBJECT_NAME ] }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -28,9 +28,9 @@ function pushQueryString( queryString ) {
 	}
 }
 
-export function restorePreviousPath( newUrl ) {
+export function restorePreviousHref( initialHref ) {
 	if ( history.pushState ) {
-		window.history.pushState( { path: newUrl }, '', newUrl );
+		window.history.pushState( { href: initialHref }, '', initialHref );
 		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }


### PR DESCRIPTION
Fixes #13808.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes reliance on `site_url()` from PHP.
* Saves `window.location.href` on page load for future use.
* When hiding search results, the initial `href` on page load is restored onto window.location via the History API.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php. 
If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.

* Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. 
You can enable Jetpack Search in the Performance tab within the Jetpack menu (`/wp-admin/admin.php?page=jetpack#/performance`).

* Select a theme of your choosing and add a Jetpack Search widget to the site via the customizer, preferably with some filters enabled. If you're using a theme with a sidebar widget area, please add the Jetpack Search widget there.

* Navigate to a URL with a query parameter in the URL, like `?testQuery=true`.

* Perform a search by entering some text into the search input box. Ensure that a query string value for your search term has been appended onto the URL (e.g. `/?testQuery=true&`**`s=some-search-value`**).

* Hide the search interface by deleting the text in the search input box. Ensure that the URL has been restored to `/?testQuery=true`


#### Proposed changelog entry for your changes:
* None.
