### PR TITLE
Instant search: add product result component

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -26,7 +26,6 @@ import {
 	restorePreviousHref,
 } from '../lib/query-string';
 import { removeChildren, hideElements, hideChildren, showChildren } from '../lib/dom';
-import { RESULT_FORMAT_MINIMAL } from '../lib/constants';
 
 class SearchApp extends Component {
 	static defaultProps = {
@@ -41,7 +40,6 @@ class SearchApp extends Component {
 			response: {},
 			requestId: 0,
 			showResults: false,
-			resultFormat: RESULT_FORMAT_MINIMAL,
 		};
 		this.getResults = debounce( this.getResults, 200 );
 		this.prepareDomForMounting();
@@ -141,7 +139,7 @@ class SearchApp extends Component {
 	getResults = ( query, filter, sort, resultFormat, pageHandle ) => {
 		const requestId = this.state.requestId + 1;
 
-		this.setState( { requestId, isLoading: true, resultFormat }, () => {
+		this.setState( { requestId, isLoading: true }, () => {
 			search( {
 				// Skip aggregations when requesting for paged results
 				aggregations: !! pageHandle ? {} : this.props.aggregations,
@@ -186,6 +184,7 @@ class SearchApp extends Component {
 			/>
 		) );
 	}
+
 	renderSearchForms() {
 		const searchForms = Array.from(
 			document.querySelectorAll( this.props.themeOptions.searchFormSelector )
@@ -206,6 +205,7 @@ class SearchApp extends Component {
 	}
 
 	render() {
+		const resultFormat = getResultFormatQuery();
 		return (
 			<Fragment>
 				{ this.renderWidgets() }
@@ -219,7 +219,7 @@ class SearchApp extends Component {
 							locale={ this.props.options.locale }
 							query={ getSearchQuery() }
 							response={ this.state.response }
-							resultFormat={ this.state.resultFormat }
+							resultFormat={ resultFormat }
 							enableLoadOnScroll={ this.props.options.enableLoadOnScroll }
 						/>,
 						document.querySelector( this.props.themeOptions.resultsSelector )

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -205,7 +205,6 @@ class SearchApp extends Component {
 	}
 
 	render() {
-		const resultFormat = getResultFormatQuery();
 		return (
 			<Fragment>
 				{ this.renderWidgets() }
@@ -219,7 +218,7 @@ class SearchApp extends Component {
 							locale={ this.props.options.locale }
 							query={ getSearchQuery() }
 							response={ this.state.response }
-							resultFormat={ resultFormat }
+							resultFormat={ getResultFormatQuery() }
 							enableLoadOnScroll={ this.props.options.enableLoadOnScroll }
 						/>,
 						document.querySelector( this.props.themeOptions.resultsSelector )

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -11,31 +11,8 @@ import { h, Component } from 'preact';
 import Gridicon from './gridicon';
 import PostTypeIcon from './post-type-icon';
 import SearchResultComments from './search-result-comments';
-import { recordTrainTracksRender, recordTrainTracksInteract } from '../lib/tracks';
 
 class SearchResultMinimal extends Component {
-	componentDidMount() {
-		recordTrainTracksRender( this.getCommonTrainTracksProps() );
-	}
-
-	getCommonTrainTracksProps() {
-		return {
-			fetch_algo: this.props.result.railcar.fetch_algo,
-			fetch_position: this.props.result.railcar.fetch_position,
-			fetch_query: this.props.result.railcar.fetch_query,
-			railcar: this.props.result.railcar.railcar,
-			rec_blog_id: this.props.result.railcar.rec_blog_id,
-			rec_post_id: this.props.result.railcar.rec_post_id,
-			ui_algo: 'jetpack-instant-search-ui/v1',
-			ui_position: this.props.index,
-		};
-	}
-
-	onClick = () => {
-		// Send out analytics call
-		recordTrainTracksInteract( { ...this.getCommonTrainTracksProps(), action: 'click' } );
-	};
-
 	getIconSize() {
 		return 18;
 	}

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -45,12 +45,14 @@ class SearchResultMinimal extends Component {
 		const cats = this.getCategories();
 		const noTags = tags.length === 0 && cats.length === 0;
 		return (
-			<div className="jetpack-instant-search__result-minimal-content">
-				{ noTags && <div className="jetpack-instant-search__result-minimal-path">{ path }</div> }
+			<div className="jetpack-instant-search__search-result-minimal-content">
+				{ noTags && (
+					<div className="jetpack-instant-search__search-result-minimal-path">{ path }</div>
+				) }
 				{ tags.length !== 0 && (
-					<div className="jetpack-instant-search__result-minimal-tags">
+					<div className="jetpack-instant-search__search-result-minimal-tags">
 						{ tags.map( tag => (
-							<span className="jetpack-instant-search__result-minimal-tag">
+							<span className="jetpack-instant-search__search-result-minimal-tag">
 								<Gridicon icon="tag" size={ this.getIconSize() } />
 								{ tag }
 							</span>
@@ -58,9 +60,9 @@ class SearchResultMinimal extends Component {
 					</div>
 				) }
 				{ cats.length !== 0 && (
-					<div className="jetpack-instant-search__result-minimal-cats">
+					<div className="jetpack-instant-search__search-result-minimal-cats">
 						{ cats.map( cat => (
-							<span className="jetpack-instant-search__result-minimal-cat">
+							<span className="jetpack-instant-search__search-result-minimal-cat">
 								<Gridicon icon="folder" size={ this.getIconSize() } />
 								{ cat }
 							</span>
@@ -74,7 +76,7 @@ class SearchResultMinimal extends Component {
 	renderMatchingContent() {
 		return (
 			<div
-				className="jetpack-instant-search__result-minimal-content"
+				className="jetpack-instant-search__search-result-minimal-content"
 				//eslint-disable-next-line react/no-danger
 				dangerouslySetInnerHTML={ {
 					__html: this.props.result.highlight.content.join( ' ... ' ),
@@ -91,17 +93,17 @@ class SearchResultMinimal extends Component {
 		}
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
 		return (
-			<li className="jetpack-instant-search__result-minimal">
-				<span className="jetpack-instant-search__result-minimal-date">
+			<li className="jetpack-instant-search__search-result-minimal">
+				<span className="jetpack-instant-search__search-result-minimal-date">
 					{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
 						dateStyle: 'short',
 					} ) }
 				</span>
-				<h3 className="jetpack-instant-search__result-title">
+				<h3 className="jetpack-instant-search__search-result-title">
 					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 					<a
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
-						className="jetpack-instant-search__result-minimal-title"
+						className="jetpack-instant-search__search-result-minimal-title"
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 						onClick={ this.onClick }

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -1,39 +1,39 @@
-.jetpack-instant-search__result-minimal {
+.jetpack-instant-search__search-result-minimal {
 	padding: 0.125em 0;
 	margin: 1em 0;
 	position: relative;
 }
 
-.jetpack-instant-search__result-minimal h3 {
+.jetpack-instant-search__search-result-minimal h3 {
 	clear: none;
 }
 
-.jetpack-instant-search__result-minimal h3 .gridicon {
+.jetpack-instant-search__search-result-minimal h3 .gridicon {
 	margin-left: 5px;
 	margin-right: 5px;
 }
 
-.jetpack-instant-search__result-minimal .gridicon {
+.jetpack-instant-search__search-result-minimal .gridicon {
 	margin-right: 5px;
 }
 
-.jetpack-instant-search__result-minimal h3 {
+.jetpack-instant-search__search-result-minimal h3 {
 	overflow: hidden;
 }
 
-.jetpack-instant-search__result-minimal-date {
+.jetpack-instant-search__search-result-minimal-date {
 	margin: 0.5em 0;
 	float: right;
 	display: block;
 	font-size: 0.85em;
 }
 
-.jetpack-instant-search__result-minimal-tag,
-.jetpack-instant-search__result-minimal-cat {
+.jetpack-instant-search__search-result-minimal-tag,
+.jetpack-instant-search__search-result-minimal-cat {
 	margin-right: 0.5em;
 }
 
-.jetpack-instant-search__result-minimal-tags,
-.jetpack-instant-search__result-minimal-cats {
+.jetpack-instant-search__search-result-minimal-tags,
+.jetpack-instant-search__search-result-minimal-cats {
 	padding-left: 10px;
 }

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -31,11 +31,11 @@ class SearchResultProduct extends Component {
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
 				</h3>
-				{ fields[ 'img.url.raw' ] && (
+				{ fields[ 'image.url.raw' ] && (
 					<img
 						className="jetpack-instant-search__result-product-img"
-						src={ fields[ 'img.url.raw' ] }
-						alt={ strip( highlight.title ) }
+						src={ fields[ 'image.url.raw' ] }
+						alt=""
 					/>
 				) }
 				<div
@@ -45,17 +45,6 @@ class SearchResultProduct extends Component {
 						__html: highlight.content.join( ' ... ' ),
 					} }
 				/>
-				<div>
-					<span className="jetpack-instant-search__result-product-rating-ave">
-						{ fields[ 'meta._wc_average_rating.value.raw' ] &&
-							strip( fields[ 'meta._wc_average_rating.value.raw' ] ).split( ' ' )[ 0 ] }
-					</span>
-					<span className="jetpack-instant-search__result-product-rating-cnt">
-						{ fields[ 'meta._wc_rating_count' ] &&
-							strip( fields[ 'meta._wc_rating_count.value.raw' ] ).split( ' ' )[ 0 ] }
-					</span>
-				</div>
-
 				<div>
 					<span className="jetpack-instant-search__result-product-price">
 						{ strip( fields[ 'wc.price' ] ).split( ' ' )[ 0 ] }

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -19,6 +19,10 @@ class SearchResultProduct extends Component {
 			return null;
 		}
 
+		const firstImage = Array.isArray( fields[ 'image.url.raw' ] )
+			? fields[ 'image.url.raw' ][ 0 ]
+			: fields[ 'image.url.raw' ];
+
 		return (
 			<div className="jetpack-instant-search__result-product">
 				<h3>
@@ -31,10 +35,10 @@ class SearchResultProduct extends Component {
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
 				</h3>
-				{ fields[ 'image.url.raw' ] && (
+				{ firstImage && (
 					<img
 						className="jetpack-instant-search__result-product-img"
-						src={ fields[ 'image.url.raw' ] }
+						src={ `//${ firstImage }` }
 						alt=""
 					/>
 				) }

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -1,0 +1,18 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+
+class SearchResultProduct extends Component {
+	render() {
+		return (
+			<div className="jetpack-instant-search__result-product">
+				<h1>product!</h1>
+			</div>
+		);
+	}
+}
+
+export default SearchResultProduct;

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -52,7 +52,7 @@ class SearchResultProduct extends Component {
 					</span>
 					<span className="jetpack-instant-search__result-product-rating-cnt">
 						{ fields[ 'meta._wc_rating_count' ] &&
-							strip( fields[ 'meta._wc_average_rating.value.raw' ] ).split( ' ' )[ 0 ] }
+							strip( fields[ 'meta._wc_rating_count.value.raw' ] ).split( ' ' )[ 0 ] }
 					</span>
 				</div>
 

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -4,12 +4,65 @@
  * External dependencies
  */
 import { h, Component } from 'preact';
+import strip from 'strip';
+
+/**
+ * Internal dependencies
+ */
+import SearchResultComments from './search-result-comments';
 
 class SearchResultProduct extends Component {
 	render() {
+		//console.log( this.props.result );
+		const { result_type, fields, highlight } = this.props.result;
+		if ( result_type !== 'post' ) {
+			return null;
+		}
+
 		return (
 			<div className="jetpack-instant-search__result-product">
-				<h1>product!</h1>
+				<h3>
+					<a
+						href={ `//${ fields[ 'permalink.url.raw' ] }` }
+						target="_blank"
+						rel="noopener noreferrer"
+						className="jetpack-instant-search__result-product-title"
+						//eslint-disable-next-line react/no-danger
+						dangerouslySetInnerHTML={ { __html: highlight.title } }
+					/>
+				</h3>
+				{ fields[ 'img.url.raw' ] && (
+					<img
+						className="jetpack-instant-search__result-product-img"
+						src={ fields[ 'img.url.raw' ] }
+						alt={ strip( highlight.title ) }
+					/>
+				) }
+				<div
+					className="jetpack-instant-search__result-product-content"
+					//eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ {
+						__html: highlight.content.join( ' ... ' ),
+					} }
+				/>
+				<div>
+					<span className="jetpack-instant-search__result-product-rating-ave">
+						{ fields[ 'meta._wc_average_rating.value.raw' ] &&
+							strip( fields[ 'meta._wc_average_rating.value.raw' ] ).split( ' ' )[ 0 ] }
+					</span>
+					<span className="jetpack-instant-search__result-product-rating-cnt">
+						{ fields[ 'meta._wc_rating_count' ] &&
+							strip( fields[ 'meta._wc_average_rating.value.raw' ] ).split( ' ' )[ 0 ] }
+					</span>
+				</div>
+
+				<div>
+					<span className="jetpack-instant-search__result-product-price">
+						{ strip( fields[ 'wc.price' ] ).split( ' ' )[ 0 ] }
+					</span>
+				</div>
+
+				{ highlight.comments && <SearchResultComments comments={ highlight.comments } /> }
 			</div>
 		);
 	}

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { h, Component } from 'preact';
-import strip from 'strip';
 
 /**
  * Internal dependencies
@@ -49,11 +48,11 @@ class SearchResultProduct extends Component {
 						__html: highlight.content.join( ' ... ' ),
 					} }
 				/>
-				<div>
-					<span className="jetpack-instant-search__result-product-price">
-						{ strip( fields[ 'wc.price' ] ).split( ' ' )[ 0 ] }
-					</span>
-				</div>
+				{ fields[ 'wc.price' ] && (
+					<div className="jetpack-instant-search__result-product-price">
+						{ fields[ 'wc.price' ].toFixed( 2 ) }
+					</div>
+				) }
 
 				{ highlight.comments && <SearchResultComments comments={ highlight.comments } /> }
 			</div>

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -12,7 +12,6 @@ import SearchResultComments from './search-result-comments';
 
 class SearchResultProduct extends Component {
 	render() {
-		//console.log( this.props.result );
 		const { result_type, fields, highlight } = this.props.result;
 		if ( result_type !== 'post' ) {
 			return null;

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -22,7 +22,7 @@ class SearchResultProduct extends Component {
 			: fields[ 'image.url.raw' ];
 
 		return (
-			<li className="jetpack-instant-search__result-product">
+			<li className="jetpack-instant-search__search-result-product">
 				<h3>
 					<a
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
@@ -35,20 +35,20 @@ class SearchResultProduct extends Component {
 				</h3>
 				{ firstImage && (
 					<img
-						className="jetpack-instant-search__result-product-img"
+						className="jetpack-instant-search__search-result-product-img"
 						src={ `//${ firstImage }` }
 						alt=""
 					/>
 				) }
 				<div
-					className="jetpack-instant-search__result-product-content"
+					className="jetpack-instant-search__search-result-product-content"
 					//eslint-disable-next-line react/no-danger
 					dangerouslySetInnerHTML={ {
 						__html: highlight.content.join( ' ... ' ),
 					} }
 				/>
 				{ fields[ 'wc.price' ] && (
-					<div className="jetpack-instant-search__result-product-price">
+					<div className="jetpack-instant-search__search-result-product-price">
 						{ fields[ 'wc.price' ].toFixed( 2 ) }
 					</div>
 				) }

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -23,7 +23,7 @@ class SearchResultProduct extends Component {
 			: fields[ 'image.url.raw' ];
 
 		return (
-			<div className="jetpack-instant-search__result-product">
+			<li className="jetpack-instant-search__result-product">
 				<h3>
 					<a
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
@@ -55,7 +55,7 @@ class SearchResultProduct extends Component {
 				) }
 
 				{ highlight.comments && <SearchResultComments comments={ highlight.comments } /> }
-			</div>
+			</li>
 		);
 	}
 }

--- a/modules/search/instant-search/components/search-result-product.scss
+++ b/modules/search/instant-search/components/search-result-product.scss
@@ -1,0 +1,19 @@
+.jetpack-instant-search__is-format-product {
+	display: flex;
+	flex-wrap: wrap;
+	padding: 0;
+}
+
+.jetpack-instant-search__result-product {
+	flex: 0 1 calc( 25% - 1em );
+	margin-bottom: 1em;
+	border: 1px solid #eee;
+	margin-right: 1em;
+	min-width: 250px;
+	padding: 1em;
+}
+
+.jetpack-instant-search__result-product-img {
+	margin-top: 0.5em;
+	margin-bottom: 0.5em;
+}

--- a/modules/search/instant-search/components/search-result-product.scss
+++ b/modules/search/instant-search/components/search-result-product.scss
@@ -10,7 +10,7 @@
 	border: 1px solid #eee;
 	margin-right: 1em;
 	min-width: 250px;
-	padding: 1em;
+	padding: 0 1em 1em 1em;
 }
 
 .jetpack-instant-search__result-product-img {

--- a/modules/search/instant-search/components/search-result-product.scss
+++ b/modules/search/instant-search/components/search-result-product.scss
@@ -1,19 +1,19 @@
-.jetpack-instant-search__is-format-product {
+.jetpack-instant-search__search-results-list.is-format-product {
 	display: flex;
 	flex-wrap: wrap;
 	padding: 0;
 }
 
-.jetpack-instant-search__result-product {
+.jetpack-instant-search__search-result-product {
 	flex: 0 1 calc( 25% - 1em );
 	margin-bottom: 1em;
 	border: 1px solid #eee;
 	margin-right: 1em;
-	min-width: 250px;
+	min-width: 200px;
 	padding: 0 1em 1em 1em;
 }
 
-.jetpack-instant-search__result-product-img {
+.jetpack-instant-search__search-result-product-img {
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 }

--- a/modules/search/instant-search/components/search-result-product.scss
+++ b/modules/search/instant-search/components/search-result-product.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	padding: 0;
+	margin-top: 1em;
 }
 
 .jetpack-instant-search__search-result-product {

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -1,0 +1,24 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import SearchResultMinimal from './search-result-minimal';
+import SearchResultProduct from './search-result-product';
+
+class SearchResult extends Component {
+	render() {
+		if ( this.props.resultFormat === 'product' ) {
+			return <SearchResultProduct { ...this.props } />;
+		}
+
+		return <SearchResultMinimal { ...this.props } />;
+	}
+}
+
+export default SearchResult;

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { h, Component } from 'preact';
+import { h } from 'preact';
 
 /**
  * Internal dependencies
@@ -11,14 +11,12 @@ import { h, Component } from 'preact';
 import SearchResultMinimal from './search-result-minimal';
 import SearchResultProduct from './search-result-product';
 
-class SearchResult extends Component {
-	render() {
-		if ( this.props.resultFormat === 'product' ) {
-			return <SearchResultProduct { ...this.props } />;
-		}
-
-		return <SearchResultMinimal { ...this.props } />;
+const SearchResult = ( { resultFormat, ...props } ) => {
+	if ( resultFormat === 'product' ) {
+		return <SearchResultProduct { ...props } />;
 	}
-}
+
+	return <SearchResultMinimal { ...props } />;
+};
 
 export default SearchResult;

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -3,20 +3,45 @@
 /**
  * External dependencies
  */
-import { h } from 'preact';
+import { h, Component } from 'preact';
 
 /**
  * Internal dependencies
  */
 import SearchResultMinimal from './search-result-minimal';
 import SearchResultProduct from './search-result-product';
+import { recordTrainTracksRender, recordTrainTracksInteract } from '../lib/tracks';
 
-const SearchResult = ( { resultFormat, ...props } ) => {
-	if ( resultFormat === 'product' ) {
-		return <SearchResultProduct { ...props } />;
+class SearchResult extends Component {
+	componentDidMount() {
+		recordTrainTracksRender( this.getCommonTrainTracksProps() );
 	}
 
-	return <SearchResultMinimal { ...props } />;
-};
+	getCommonTrainTracksProps() {
+		return {
+			fetch_algo: this.props.result.railcar.fetch_algo,
+			fetch_position: this.props.result.railcar.fetch_position,
+			fetch_query: this.props.result.railcar.fetch_query,
+			railcar: this.props.result.railcar.railcar,
+			rec_blog_id: this.props.result.railcar.rec_blog_id,
+			rec_post_id: this.props.result.railcar.rec_post_id,
+			ui_algo: 'jetpack-instant-search-ui/v1',
+			ui_position: this.props.index,
+		};
+	}
+
+	onClick = () => {
+		// Send out analytics call
+		recordTrainTracksInteract( { ...this.getCommonTrainTracksProps(), action: 'click' } );
+	};
+
+	render() {
+		if ( this.props.resultFormat === 'product' ) {
+			return <SearchResultProduct { ...this.props } />;
+		}
+
+		return <SearchResultMinimal { ...this.props } />;
+	}
+}
 
 export default SearchResult;

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -11,6 +11,7 @@ import { h, Component } from 'preact';
 import SearchResultMinimal from './search-result-minimal';
 import SearchResultProduct from './search-result-product';
 import { recordTrainTracksRender, recordTrainTracksInteract } from '../lib/tracks';
+import { RESULT_FORMAT_PRODUCT } from '../lib/constants';
 
 class SearchResult extends Component {
 	componentDidMount() {
@@ -36,7 +37,7 @@ class SearchResult extends Component {
 	};
 
 	render() {
-		if ( this.props.resultFormat === 'product' ) {
+		if ( this.props.resultFormat === RESULT_FORMAT_PRODUCT ) {
 			return <SearchResultProduct { ...this.props } />;
 		}
 

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -10,6 +10,7 @@ import { h, Component } from 'preact';
  * Internal dependencies
  */
 import SearchResultMinimal from './search-result-minimal';
+import SearchResultProduct from './search-result-product';
 import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
 
@@ -18,6 +19,14 @@ class SearchResults extends Component {
 		switch ( this.props.resultFormat ) {
 			case 'engagement':
 			case 'product':
+				return (
+					<SearchResultProduct
+						index={ index }
+						locale={ this.props.locale }
+						query={ this.props.query }
+						result={ result }
+					/>
+				);
 			case 'minimal':
 			default:
 				return (

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -12,6 +12,7 @@ import { h, Component, Fragment } from 'preact';
 import SearchResult from './search-result';
 import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
+import { RESULT_FORMAT_MINIMAL } from '../lib/constants';
 
 class SearchResults extends Component {
 	getSearchTitle() {
@@ -38,12 +39,12 @@ class SearchResults extends Component {
 
 	renderEmptyResults( { showText = false } = {} ) {
 		return (
-			<div className="jetpack-instant-search__search-results" role="listitem">
-				{ showText ? (
+			<div className="jetpack-instant-search__search-results">
+				{ showText && (
 					<div>
 						<h3>{ sprintf( __( 'No Results.', 'jetpack' ), this.props.query ) }</h3>
 					</div>
-				) : null }
+				) }
 			</div>
 		);
 	}
@@ -72,26 +73,29 @@ class SearchResults extends Component {
 				<p className="jetpack-instant-search__search-results-real-query">
 					{ this.getSearchTitle() }
 				</p>
-				<div
-					className={ `jetpack-instant-search__search-results jetpack-instant-search__is-format-${
-						this.props.resultFormat
-					}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
-				>
-					{ hasCorrectedQuery && (
-						<p className="jetpack-instant-search__search-results-unused-query">
-							{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
-						</p>
-					) }
-					{ results.map( ( result, index ) => (
-						<SearchResult
-							index={ index }
-							locale={ this.props.locale }
-							query={ this.props.query }
-							result={ result }
-							resultFormat={ this.props.resultFormat }
-						/>
-					) ) }
-				</div>
+				{ hasCorrectedQuery && (
+					<p className="jetpack-instant-search__search-results-unused-query">
+						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
+					</p>
+				) }
+				{ results && (
+					<ol
+						className={ `jetpack-instant-search__search-results jetpack-instant-search__is-format-${ this
+							.props.resultFormat || RESULT_FORMAT_MINIMAL }${
+							this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
+						}` }
+					>
+						{ results.map( ( result, index ) => (
+							<SearchResult
+								index={ index }
+								locale={ this.props.locale }
+								query={ this.props.query }
+								result={ result }
+								resultFormat={ this.props.resultFormat }
+							/>
+						) ) }
+					</ol>
+				) }
 				<div className="jetpack-instant-search__search-pagination">
 					{ this.props.hasNextPage && (
 						<ScrollButton

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { h, Component } from 'preact';
+import { h, Component, Fragment } from 'preact';
 
 /**
  * Internal dependencies
@@ -72,27 +72,35 @@ class SearchResults extends Component {
 				<p className="jetpack-instant-search__search-results-real-query">
 					{ this.getSearchTitle() }
 				</p>
-				{ hasCorrectedQuery && (
-					<p className="jetpack-instant-search__search-results-unused-query">
-						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
-					</p>
-				) }
-				{ results.map( ( result, index ) => (
-					<SearchResult
-						index={ index }
-						locale={ this.props.locale }
-						query={ this.props.query }
-						result={ result }
-						resultFormat={ this.props.resultFormat }
-					/>
-				) ) }
-				{ this.props.hasNextPage && (
-					<ScrollButton
-						enableLoadOnScroll={ this.props.enableLoadOnScroll }
-						isLoading={ this.props.isLoading }
-						onLoadNextPage={ this.props.onLoadNextPage }
-					/>
-				) }
+				<div
+					className={ `jetpack-instant-search__search-results jetpack-instant-search__is-format-${
+						this.props.resultFormat
+					}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
+				>
+					{ hasCorrectedQuery && (
+						<p className="jetpack-instant-search__search-results-unused-query">
+							{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
+						</p>
+					) }
+					{ results.map( ( result, index ) => (
+						<SearchResult
+							index={ index }
+							locale={ this.props.locale }
+							query={ this.props.query }
+							result={ result }
+							resultFormat={ this.props.resultFormat }
+						/>
+					) ) }
+				</div>
+				<div className="jetpack-instant-search__search-pagination">
+					{ this.props.hasNextPage && (
+						<ScrollButton
+							enableLoadOnScroll={ this.props.enableLoadOnScroll }
+							isLoading={ this.props.isLoading }
+							onLoadNextPage={ this.props.onLoadNextPage }
+						/>
+					) }
+				</div>
 			</main>
 		);
 	}

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -9,37 +9,11 @@ import { h, Component } from 'preact';
 /**
  * Internal dependencies
  */
-import SearchResultMinimal from './search-result-minimal';
-import SearchResultProduct from './search-result-product';
+import SearchResult from './search-result';
 import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
 
 class SearchResults extends Component {
-	renderResult = ( result, index ) => {
-		switch ( this.props.resultFormat ) {
-			case 'engagement':
-			case 'product':
-				return (
-					<SearchResultProduct
-						index={ index }
-						locale={ this.props.locale }
-						query={ this.props.query }
-						result={ result }
-					/>
-				);
-			case 'minimal':
-			default:
-				return (
-					<SearchResultMinimal
-						index={ index }
-						locale={ this.props.locale }
-						query={ this.props.query }
-						result={ result }
-					/>
-				);
-		}
-	};
-
 	getSearchTitle() {
 		const { total = 0, corrected_query = false } = this.props.response;
 		const hasQuery = this.props.query !== '';
@@ -103,9 +77,15 @@ class SearchResults extends Component {
 						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
 					</p>
 				) }
-				<ol className="jetpack-instant-search__search-results-list">
-					{ results.map( this.renderResult ) }
-				</ol>
+				{ results.map( ( result, index ) => (
+					<SearchResult
+						index={ index }
+						locale={ this.props.locale }
+						query={ this.props.query }
+						result={ result }
+						resultFormat={ this.props.resultFormat }
+					/>
+				) ) }
 				{ this.props.hasNextPage && (
 					<ScrollButton
 						enableLoadOnScroll={ this.props.enableLoadOnScroll }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -12,7 +12,6 @@ import { h, Component } from 'preact';
 import SearchResult from './search-result';
 import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
-import { RESULT_FORMAT_MINIMAL } from '../lib/constants';
 
 class SearchResults extends Component {
 	getSearchTitle() {
@@ -79,10 +78,9 @@ class SearchResults extends Component {
 				) }
 				{ results && (
 					<ol
-						className={ `jetpack-instant-search__search-results-list jetpack-instant-search__is-format-${ this
-							.props.resultFormat || RESULT_FORMAT_MINIMAL }${
-							this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
-						}` }
+						className={ `jetpack-instant-search__search-results-list is-format-${
+							this.props.resultFormat
+						}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
 					>
 						{ results.map( ( result, index ) => (
 							<SearchResult

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { h, Component, Fragment } from 'preact';
+import { h, Component } from 'preact';
 
 /**
  * Internal dependencies
@@ -68,7 +68,6 @@ class SearchResults extends Component {
 				className={ `jetpack-instant-search__search-results ${
 					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
 				}` }
-				role="list"
 			>
 				<p className="jetpack-instant-search__search-results-real-query">
 					{ this.getSearchTitle() }
@@ -80,7 +79,7 @@ class SearchResults extends Component {
 				) }
 				{ results && (
 					<ol
-						className={ `jetpack-instant-search__search-results jetpack-instant-search__is-format-${ this
+						className={ `jetpack-instant-search__search-results-list jetpack-instant-search__is-format-${ this
 							.props.resultFormat || RESULT_FORMAT_MINIMAL }${
 							this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
 						}` }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -32,7 +32,7 @@
 
 .jetpack-instant-search__search-results-list {
 	list-style: none;
-	margin: 1em 0 0 0;
+	margin: 0;
 	padding: 0;
 
 	// Accessibility improvement for VoiceOVer

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -13,6 +13,12 @@
 		color: inherit;
 		padding: 0;
 	}
+
+	// Accessibility improvement for VoiceOVer
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
+	li:before {
+		content: '\200B';
+	}
 }
 
 .jetpack-instant-search__search-results-real-query {
@@ -29,16 +35,4 @@
 
 .jetpack-instant-search__result-comments {
 	padding-left: 10px;
-}
-
-.jetpack-instant-search__search-results-list {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-
-	// Accessibility improvement for VoiceOVer
-	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
-	li:before {
-		content: '\200B';
-	}
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -1,6 +1,6 @@
 .jetpack-instant-search__search-results {
 	padding: 0.125em 2em;
-	margin: 1em auto;
+	margin: 0 auto;
 	position: relative;
 	max-width: 1080px;
 	min-height: 400px;
@@ -32,7 +32,7 @@
 
 .jetpack-instant-search__search-results-list {
 	list-style: none;
-	margin: 0;
+	margin: 1em 0 0 0;
 	padding: 0;
 
 	// Accessibility improvement for VoiceOVer

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -1,23 +1,16 @@
 .jetpack-instant-search__search-results {
-	padding: 0.125em 0;
-	margin: 0;
+	padding: 0.125em 2em;
+	margin: 1em auto;
 	position: relative;
 	max-width: 1080px;
 	min-height: 400px;
 	text-align: left;
-	list-style-type: none;
 
 	mark {
 		background-color: #ffc;
 		font-weight: bold;
 		color: inherit;
 		padding: 0;
-	}
-
-	// Accessibility improvement for VoiceOVer
-	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
-	li:before {
-		content: '\200B';
 	}
 }
 
@@ -35,4 +28,16 @@
 
 .jetpack-instant-search__result-comments {
 	padding-left: 10px;
+}
+
+.jetpack-instant-search__search-results-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+
+	// Accessibility improvement for VoiceOVer
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
+	li:before {
+		content: '\200B';
+	}
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -1,10 +1,11 @@
 .jetpack-instant-search__search-results {
-	padding: 0.125em 2em;
-	margin: 1em auto;
+	padding: 0.125em 0;
+	margin: 0;
 	position: relative;
 	max-width: 1080px;
 	min-height: 400px;
 	text-align: left;
+	list-style-type: none;
 
 	mark {
 		background-color: #ffc;

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -5,7 +5,7 @@
 @import './components/search-result-minimal.scss';
 @import './components/search-box.scss';
 //@import './components/search-result-engagement.scss';
-//@import './components/search-result-product.scss';
+@import './components/search-result-product.scss';
 
 .jetpack-instant-search__is-loading {
 	opacity: 0.2;

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -2,9 +2,8 @@
 @import './components/search-results.scss';
 @import './components/search-filters.scss';
 @import './components/search-sort-widget.scss';
-@import './components/search-result-minimal.scss';
 @import './components/search-box.scss';
-//@import './components/search-result-engagement.scss';
+@import './components/search-result-minimal.scss';
 @import './components/search-result-product.scss';
 
 .jetpack-instant-search__is-loading {

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -118,30 +118,33 @@ function buildFilterObject( filterQuery ) {
 }
 
 export function search( { aggregations, filter, pageHandle, query, resultFormat, siteId, sort } ) {
-	let fields = [];
-	let highlight_fields = [];
+	let fields = [
+		'date',
+		'permalink.url.raw',
+		'tag.name.default',
+		'category.name.default',
+		'post_type',
+		'has.image',
+		'shortcode_types',
+	];
+	const highlightFields = [ 'title', 'content', 'comments' ];
+
 	switch ( resultFormat ) {
 		case 'engagement':
 		case 'product':
-		case 'minimal':
-		default:
-			highlight_fields = [ 'title', 'content', 'comments' ];
-			fields = [
-				'date',
-				'permalink.url.raw',
-				'tag.name.default',
-				'category.name.default',
-				'post_type',
-				'has.image',
-				'shortcode_types',
-			];
+			fields = fields.concat( [
+				//'meta._wc_average_rating.value.raw',
+				//'meta._wc_rating_count.value.raw',
+				'wc.price',
+				//'img.url.raw',
+			] );
 	}
 
 	const queryString = encode(
 		flatten( {
 			aggregations,
 			fields,
-			highlight_fields,
+			highlight_fields: highlightFields,
 			filter: buildFilterObject( filter ),
 			query: encodeURIComponent( query ),
 			sort,

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -132,12 +132,7 @@ export function search( { aggregations, filter, pageHandle, query, resultFormat,
 	switch ( resultFormat ) {
 		case 'engagement':
 		case 'product':
-			fields = fields.concat( [
-				//'meta._wc_average_rating.value.raw',
-				//'meta._wc_rating_count.value.raw',
-				'wc.price',
-				//'img.url.raw',
-			] );
+			fields = fields.concat( [ 'image.url.raw', 'wc.price' ] );
 	}
 
 	const queryString = encode(

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -1,3 +1,5 @@
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
 export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';
+export const RESULT_FORMAT_MINIMAL = 'minimal';
+export const RESULT_FORMAT_PRODUCT = 'product';

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -191,5 +191,5 @@ export function setFilterQuery( filterKey, filterValue ) {
 
 export function getResultFormatQuery() {
 	const query = getQuery();
-	return 'result_format' in query;
+	return query.result_format;
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -11,7 +11,12 @@ import get from 'lodash/get';
 /**
  * Internal dependencies
  */
-import { SERVER_OBJECT_NAME, SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
+import {
+	SERVER_OBJECT_NAME,
+	SORT_DIRECTION_ASC,
+	SORT_DIRECTION_DESC,
+	RESULT_FORMAT_MINIMAL,
+} from './constants';
 import { getSortOption } from './sort';
 
 function getQuery() {
@@ -191,5 +196,5 @@ export function setFilterQuery( filterKey, filterValue ) {
 
 export function getResultFormatQuery() {
 	const query = getQuery();
-	return query.result_format;
+	return query.result_format ? query.result_format : RESULT_FORMAT_MINIMAL;
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -20,6 +20,8 @@ import {
 } from './constants';
 import { getSortOption } from './sort';
 
+const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
+
 function getQuery() {
 	return decode( window.location.search.substring( 1 ) );
 }
@@ -196,7 +198,6 @@ export function setFilterQuery( filterKey, filterValue ) {
 }
 
 export function getResultFormatQuery() {
-	const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
 	const query = getQuery();
 
 	if ( knownResultFormats.includes( query.result_format ) ) {

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -188,3 +188,8 @@ export function setFilterQuery( filterKey, filterValue ) {
 	query[ filterKey ] = filterValue;
 	pushQueryString( encode( query ) );
 }
+
+export function getResultFormatQuery() {
+	const query = getQuery();
+	return 'result_format' in query;
+}

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -16,6 +16,7 @@ import {
 	SORT_DIRECTION_ASC,
 	SORT_DIRECTION_DESC,
 	RESULT_FORMAT_MINIMAL,
+	RESULT_FORMAT_PRODUCT,
 } from './constants';
 import { getSortOption } from './sort';
 
@@ -195,6 +196,12 @@ export function setFilterQuery( filterKey, filterValue ) {
 }
 
 export function getResultFormatQuery() {
+	const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
 	const query = getQuery();
-	return query.result_format ? query.result_format : RESULT_FORMAT_MINIMAL;
+
+	if ( knownResultFormats.includes( query.result_format ) ) {
+		return query.result_format;
+	}
+
+	return RESULT_FORMAT_MINIMAL;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In Instant Search, all search results currently use the 'minimal' component. This PR introduces a 'product' component to be used for e-commerce sites. It displays the first image from the post.

Presentation-wise, it is still pretty rough round the edges and needs work at different breakpoints. However, there's a fair bit of component refactoring and I'm keen that we land those changes into `instant-search-master`.

To activate product results, use `result_format=product`. For example:

`/?s=card&blog_id=84860689&result_format=product`

<img width="447" alt="Screen Shot 2019-10-18 at 16 17 46" src="https://user-images.githubusercontent.com/17325/67063322-dfab3680-f1c2-11e9-86bc-3e3a318be2c1.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It adds a new display type for Instant Search results. This PR merges into the instant-search-master development branch.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.

2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).

3. Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.

4. If using a theme with a sidebar widget, you can navigate to / to start the search experience. Otherwise, navigate to your search page (e.g. /?s=hello).

To activate product results, use `result_format=product`. For example:

`/?s=card&blog_id=84860689&result_format=product`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No changelog entry required.
