### PR TITLE
Simple payments: update inline documentation

### DIFF
--- a/extensions/blocks/simple-payments/constants.js
+++ b/extensions/blocks/simple-payments/constants.js
@@ -2,11 +2,14 @@ export const SIMPLE_PAYMENTS_PRODUCT_POST_TYPE = 'jp_pay_product';
 
 export const DEFAULT_CURRENCY = 'USD';
 
-// https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
-// If this list changes, Simple Payments in Jetpack must be updated as well.
-// See https://github.com/Automattic/jetpack/blob/master/modules/simple-payments/simple-payments.php
-
 /**
+ * Currencies should be supported by PayPal:
+ * @link https://developer.paypal.com/docs/api/reference/currency-codes/
+ *
+ * List has to be in sync with list at the widget's backend side and API's backend side:
+ * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/modules/widgets/simple-payments.php#L19-L44
+ * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/modules/simple-payments/simple-payments.php#L386-L415
+ *
  * Indian Rupee not supported because at the time of the creation of this file
  * because it's limited to in-country PayPal India accounts only.
  * Discussion: https://github.com/Automattic/wp-calypso/pull/28236

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -377,11 +377,16 @@ class Jetpack_Simple_Payments {
 	/**
 	 * Sanitize three-character ISO-4217 Simple payments currency
 	 *
-	 * List has to be in sync with list at the client side:
-	 * @link https://github.com/Automattic/wp-calypso/blob/6d02ffe73cc073dea7270a22dc30881bff17d8fb/client/lib/simple-payments/constants.js
+	 * List has to be in sync with list at the block's client side and widget's backend side:
+	 * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/extensions/blocks/simple-payments/constants.js#L9-L39
+	 * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/modules/widgets/simple-payments.php#L19-L44
 	 *
 	 * Currencies should be supported by PayPal:
-	 * @link https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
+	 * @link https://developer.paypal.com/docs/api/reference/currency-codes/
+	 *
+	 * Indian Rupee (INR) not supported because at the time of the creation of this file
+	 * because it's limited to in-country PayPal India accounts only.
+	 * Discussion: https://github.com/Automattic/wp-calypso/pull/28236
 	 */
 	public static function sanitize_currency( $currency ) {
 		$valid_currencies = array(

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -15,7 +15,19 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 	 * Display a Simple Payments Button as a Widget.
 	 */
 	class Jetpack_Simple_Payments_Widget extends WP_Widget {
-		// https://developer.paypal.com/docs/integration/direct/rest/currency-codes/
+		/**
+		 * Currencies should be supported by PayPal:
+		 * @link https://developer.paypal.com/docs/api/reference/currency-codes/
+		 *
+		 * List has to be in sync with list at the block's client side and API's backend side:
+		 * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/extensions/blocks/simple-payments/constants.js#L9-L39
+		 * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/modules/simple-payments/simple-payments.php#L386-L415
+		 *
+		 * Indian Rupee (INR) is listed here for backwards compatibility with previously added widgets.
+		 * It's not supported by Simple Payments because at the time of the creation of this file
+		 * because it's limited to in-country PayPal India accounts only.
+		 * Discussion: https://github.com/Automattic/wp-calypso/pull/28236
+		 */
 		private static $supported_currency_list = array(
 			'USD' => '$',
 			'GBP' => '&#163;',


### PR DESCRIPTION
Update Simple payments inline documentation to clarify:
- Why INR currency isn't (or is in widget's case) on the list
- Crosslink all the 3 lists that should be kept in sync 
- Update links to fresh working versions

#### Changes proposed in this Pull Request:
* Update inline docs

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?


#### Testing instructions:
N/A

#### Proposed changelog entry for your changes:
*
