### PR TITLE
Widgets: add aria-current attribute to links when on same page

### DIFF
--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -172,22 +172,20 @@ class Jetpack_Widget_Authors extends WP_Widget {
 				continue;
 			}
 
-			// Display a short list of recent posts for this author
-
+			// Display a short list of recent posts for this author.
 			if ( $r->have_posts() ) {
 				echo '<ul>';
 
 				while ( $r->have_posts() ) {
 					$r->the_post();
-					echo '<li><a href="' . get_permalink() . '">';
 
-					if ( get_the_title() ) {
-						echo get_the_title();
-					} else {
-						echo get_the_ID();
-					}
-
-					echo '</a></li>';
+					printf(
+						'<li><a href="%1$s" title="%2$s" %3$s>%4$s</a></li>',
+						esc_url( get_permalink() ),
+						esc_attr( wp_kses( get_the_title(), array() ) ),
+						( get_queried_object_id() === get_the_ID() ? ' aria-current="page"' : '' ),
+						esc_html( wp_kses( get_the_title(), array() ) )
+					);
 				}
 
 				echo '</ul>';

--- a/modules/widgets/authors.php
+++ b/modules/widgets/authors.php
@@ -180,7 +180,7 @@ class Jetpack_Widget_Authors extends WP_Widget {
 					$r->the_post();
 
 					printf(
-						'<li><a href="%1$s" title="%2$s" %3$s>%4$s</a></li>',
+						'<li><a href="%1$s" title="%2$s"%3$s>%4$s</a></li>',
 						esc_url( get_permalink() ),
 						esc_attr( wp_kses( get_the_title(), array() ) ),
 						( get_queried_object_id() === get_the_ID() ? ' aria-current="page"' : '' ),

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -406,11 +406,16 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 						 */
 						$filtered_permalink = apply_filters( 'jetpack_top_posts_widget_permalink', $post['permalink'], $post );
 
-						?>
-						<a href="<?php echo esc_url( $filtered_permalink ); ?>" title="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" class="bump-view" data-bump-view="tp">
-							<img width="<?php echo absint( $width ); ?>" height="<?php echo absint( $height ); ?>" src="<?php echo esc_url( $post['image'] ); ?>" alt="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" data-pin-nopin="true" />
-						</a>
-						<?php
+						printf(
+							'<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s><img width="%4$d" height="%5$d" src="%6$s" alt="%2$s" data-pin-nopin="true"/></a>',
+							esc_url( $filtered_permalink ),
+							esc_attr( wp_kses( $post['title'], array() ) ),
+							( get_queried_object_id() === $post['post_id'] ? ' aria-current="page"' : '' ),
+							absint( $width ),
+							absint( $height ),
+							esc_url( $post['image'] )
+						);
+
 						/**
 						 * Fires after each Top Post result, inside <li>.
 						 *
@@ -437,16 +442,24 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 						/** This filter is documented in modules/widgets/top-posts.php */
 						$filtered_permalink = apply_filters( 'jetpack_top_posts_widget_permalink', $post['permalink'], $post );
-						?>
-						<a href="<?php echo esc_url( $filtered_permalink ); ?>" title="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" class="bump-view" data-bump-view="tp">
-							<img width="<?php echo absint( $width ); ?>" height="<?php echo absint( $height ); ?>" src="<?php echo esc_url( $post['image'] ); ?>" class='widgets-list-layout-blavatar' alt="<?php echo esc_attr( wp_kses( $post['title'], array() ) ); ?>" data-pin-nopin="true" />
-						</a>
-						<div class="widgets-list-layout-links">
-							<a href="<?php echo esc_url( $filtered_permalink ); ?>" class="bump-view" data-bump-view="tp">
-								<?php echo esc_html( wp_kses( $post['title'], array() ) ); ?>
+
+						printf(
+							'<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s>
+								<img width="%4$d" height="%5$d" src="%6$s" alt="%2$s" data-pin-nopin="true" class="widgets-list-layout-blavatar"/>
 							</a>
-						</div>
-						<?php
+							<div class="widgets-list-layout-links">
+								<a href="%1$s" title="%2$s" class="bump-view" data-bump-view="tp"%3$s>%7$s</a>
+							</div>
+							',
+							esc_url( $filtered_permalink ),
+							esc_attr( wp_kses( $post['title'], array() ) ),
+							( get_queried_object_id() === $post['post_id'] ? ' aria-current="page"' : '' ),
+							absint( $width ),
+							absint( $height ),
+							esc_url( $post['image'] ),
+							esc_html( wp_kses( $post['title'], array() ) )
+						);
+
 						/** This action is documented in modules/widgets/top-posts.php */
 						do_action( 'jetpack_widget_top_posts_after_post', $post['post_id'] );
 						?>
@@ -467,11 +480,14 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 					/** This filter is documented in modules/widgets/top-posts.php */
 					$filtered_permalink = apply_filters( 'jetpack_top_posts_widget_permalink', $post['permalink'], $post );
-					?>
-					<a href="<?php echo esc_url( $filtered_permalink ); ?>" class="bump-view" data-bump-view="tp">
-						<?php echo esc_html( wp_kses( $post['title'], array() ) ); ?>
-					</a>
-					<?php
+
+					printf(
+						'<a href="%1$s" class="bump-view" data-bump-view="tp"%2$s>%3$s</a>',
+						esc_url( $filtered_permalink ),
+						( get_queried_object_id() === $post['post_id'] ? ' aria-current="page"' : '' ),
+						esc_html( wp_kses( $post['title'], array() ) )
+					);
+
 					/** This action is documented in modules/widgets/top-posts.php */
 					do_action( 'jetpack_widget_top_posts_after_post', $post['post_id'] );
 					?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This brings our 2 widgets currently outputting internal links (Authors and Top Posts) up to date with Core's accessibility improvements:
https://core.trac.wordpress.org/ticket/47094

#### Testing instructions:

* Both the Stats module and the Widgets module should be active on your site.
* Visit a few of your posts while logged out to make sure some of your posts will appear in your Top Posts widget later on.
* Go to Appearance > Widgets, and add both the Authors and the Top Posts widget to your site.
* Visit your site. When you are on a page listed in one of the widgets, the link in the widget should include a `aria-current="page"` attribute.

#### Proposed changelog entry for your changes:
* Widgets: add aria-current attribute to links when on same page