### PR TITLE
Sync: Add Settings to prevent a particular queue from being sent "the regular way"

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -556,6 +556,8 @@ $sync_settings_response = array(
 	'sync_via_cron'            => '(int|bool=false) Set to 1 or true to avoid using cron for sync.',
 	'cron_sync_time_limit'	   => '(int|bool=false) Limit cron jobs to number of seconds',
 	'enqueue_wait_time'        => '(int|bool=false) Wait time in seconds between attempting to continue a full sync, via requests',
+	'sync_sender_enabled'      => '(int|bool=false) Set to 1 or true to enable the default sender for the incremental queue.',
+	'full_sync_sender_enabled' => '(int|bool=false) Set to 1 or true to enable the default sender for the "full sync" queue.',
 );
 
 // GET /sites/%s/sync/settings

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -840,6 +840,6 @@ class Defaults {
 	static $default_sync_queue_lock_timeout                = 120; // 2 minutes
 	static $default_cron_sync_time_limit                   = 30; // 30 seconds
 	static $default_term_relationships_full_sync_item_size = 100;
-	static $default_send_enabled_full_sync                 = 1; // Should send full sync items
-	static $default_send_enabled_sync                      = 1; // Should send incremental sync items
+	static $default_sync_sender_enabled                    = 1; // Should send incremental sync items
+	static $default_full_sync_sender_enabled               = 1; // Should send full sync items
 }

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -840,4 +840,6 @@ class Defaults {
 	static $default_sync_queue_lock_timeout                = 120; // 2 minutes
 	static $default_cron_sync_time_limit                   = 30; // 30 seconds
 	static $default_term_relationships_full_sync_item_size = 100;
+	static $default_send_enabled_full_sync                 = 1; // Should send full sync items
+	static $default_send_enabled_sync                      = 1; // Should send incremental sync items
 }

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -310,7 +310,7 @@ class Sender {
 			return new \WP_Error( 'is_importing' );
 		}
 
-		if ( ! Settings::is_send_enabled( $queue->id ) ) {
+		if ( ! Settings::is_sender_enabled( $queue->id ) ) {
 			return new \WP_Error( 'send_not_enabled_for_queue_' . $queue->id );
 		}
 

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -311,7 +311,7 @@ class Sender {
 		}
 
 		if ( ! Settings::is_sender_enabled( $queue->id ) ) {
-			return new \WP_Error( 'send_not_enabled_for_queue_' . $queue->id );
+			return new \WP_Error( 'sender_disabled_for_queue_' . $queue->id );
 		}
 
 		// Don't sync if we are throttled.

--- a/packages/sync/src/Sender.php
+++ b/packages/sync/src/Sender.php
@@ -310,6 +310,10 @@ class Sender {
 			return new \WP_Error( 'is_importing' );
 		}
 
+		if ( ! Settings::is_send_enabled( $queue->id ) ) {
+			return new \WP_Error( 'send_not_enabled_for_queue_' . $queue->id );
+		}
+
 		// Don't sync if we are throttled.
 		if ( $this->get_next_sync_time( $queue->id ) > microtime( true ) ) {
 			return new \WP_Error( 'sync_throttled' );

--- a/packages/sync/src/Settings.php
+++ b/packages/sync/src/Settings.php
@@ -455,8 +455,6 @@ class Settings {
 	 * @return boolean Whether sync is enabled.
 	 */
 	public static function is_send_enabled( $queue_id ) {
-		l( 'send_enabled_' . $queue_id );
-		l( self::get_setting( 'send_enabled_' . $queue_id ) );
 		return (bool) self::get_setting( 'send_enabled_' . $queue_id );
 	}
 

--- a/packages/sync/src/Settings.php
+++ b/packages/sync/src/Settings.php
@@ -51,8 +51,8 @@ class Settings {
 		'cron_sync_time_limit'                   => true,
 		'known_importers'                        => true,
 		'term_relationships_full_sync_item_size' => true,
-		'send_enabled_full_sync'                 => true,
-		'send_enabled_sync'                      => true,
+		'sync_sender_enabled'                    => true,
+		'full_sync_sender_enabled'               => true,
 	);
 
 	/**
@@ -454,8 +454,8 @@ class Settings {
 	 *
 	 * @return boolean Whether sync is enabled.
 	 */
-	public static function is_send_enabled( $queue_id ) {
-		return (bool) self::get_setting( 'send_enabled_' . $queue_id );
+	public static function is_sender_enabled( $queue_id ) {
+		return (bool) self::get_setting( $queue_id . '_sender_enabled' );
 	}
 
 }

--- a/packages/sync/src/Settings.php
+++ b/packages/sync/src/Settings.php
@@ -51,6 +51,8 @@ class Settings {
 		'cron_sync_time_limit'                   => true,
 		'known_importers'                        => true,
 		'term_relationships_full_sync_item_size' => true,
+		'send_enabled_full_sync'                 => true,
+		'send_enabled_sync'                      => true,
 	);
 
 	/**
@@ -441,4 +443,21 @@ class Settings {
 	public static function set_is_sending( $is_sending ) {
 		self::$is_sending = $is_sending;
 	}
+
+	/**
+	 * Whether should send from the queue
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $queue_id The queue identifier.
+	 *
+	 * @return boolean Whether sync is enabled.
+	 */
+	public static function is_send_enabled( $queue_id ) {
+		l( 'send_enabled_' . $queue_id );
+		l( self::get_setting( 'send_enabled_' . $queue_id ) );
+		return (bool) self::get_setting( 'send_enabled_' . $queue_id );
+	}
+
 }

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1615,6 +1615,36 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->full_sync->reset_data();
 	}
 
+	function test_disable_sending_full_sync() {
+		$this->factory->post->create_many( 2 );
+
+		$this->sender->reset_data();
+		$this->server_event_storage->reset();
+
+		Settings::update_settings( array( 'send_enabled_full_sync' => 0 ) );
+
+		$this->full_sync->start();
+		$this->sender->do_full_sync();
+
+		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
+		$this->assertTrue( ! $start_event );
+	}
+
+	function test_enable_sending_full_sync() {
+		$this->factory->post->create_many( 2 );
+
+		$this->sender->reset_data();
+		$this->server_event_storage->reset();
+
+		Settings::update_settings( array( 'send_enabled_full_sync' => 1 ) );
+
+		$this->full_sync->start();
+		$this->sender->do_full_sync();
+
+		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
+		$this->assertTrue( $start_event );
+	}
+
 	function _do_cron() {
 		$_GET['check'] = wp_hash( '187425' );
 		require( ABSPATH . '/wp-cron.php' );

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1642,7 +1642,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_full_sync();
 
 		$start_event = $this->server_event_storage->get_most_recent_event( 'jetpack_full_sync_start' );
-		$this->assertTrue( $start_event );
+		$this->assertTrue( ! empty( $start_event ) );
 	}
 
 	function _do_cron() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -1621,7 +1621,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 		$this->server_event_storage->reset();
 
-		Settings::update_settings( array( 'send_enabled_full_sync' => 0 ) );
+		Settings::update_settings( array( 'full_sync_sender_enabled' => 0 ) );
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
@@ -1636,7 +1636,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 		$this->server_event_storage->reset();
 
-		Settings::update_settings( array( 'send_enabled_full_sync' => 1 ) );
+		Settings::update_settings( array( 'full_sync_sender_enabled' => 1 ) );
 
 		$this->full_sync->start();
 		$this->sender->do_full_sync();

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -167,7 +167,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 		$this->sender->do_sync();
 
-		Settings::update_settings( array( 'send_enabled_sync' => 0 ) );
+		Settings::update_settings( array( 'sync_sender_enabled' => 0 ) );
 
 		$this->server_event_storage->reset();
 
@@ -181,7 +181,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->reset_data();
 		$this->sender->do_sync();
 
-		Settings::update_settings( array( 'send_enabled_sync' => 1 ) );
+		Settings::update_settings( array( 'sync_sender_enabled' => 1 ) );
 
 		$this->server_event_storage->reset();
 

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -163,6 +163,34 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( 0, Settings::get_setting( 'render_filtered_content' ) );
 	}
 
+	function test_disable_sending_incremental_sync() {
+		$this->sender->reset_data();
+		$this->sender->do_sync();
+
+		Settings::update_settings( array( 'send_enabled_sync' => 0 ) );
+
+		$this->server_event_storage->reset();
+
+		$this->factory->post->create_many( 2 );
+		$this->sender->do_sync();
+
+		$this->assertTrue( empty(  $this->server_event_storage->get_all_events() ) );
+	}
+
+	function test_enable_sending_incremental_sync() {
+		$this->sender->reset_data();
+		$this->sender->do_sync();
+
+		Settings::update_settings( array( 'send_enabled_sync' => 1 ) );
+
+		$this->server_event_storage->reset();
+
+		$this->factory->post->create_many( 2 );
+		$this->sender->do_sync();
+
+		$this->assertFalse( empty(  $this->server_event_storage->get_all_events() ) );
+	}
+
 	/**
 	 * Utility functions
 	 */


### PR DESCRIPTION
This PR adds two new settings `send_enabled_full_sync`, `send_enabled_sync`(names open to discussion).

By default set to `true`, when switch to `false` it should prevent the site from sending data from the referring queue.

This could be useful for occasions where we want to stop the site from sending data but still use the queues and restart sending later without losing any events.

@mdbitz and I are interested in stopping a site from processing the `full_sync` queue so we are sure this is not causing race conditions on conflicts, in order to get more control over "manually" pulling data from the "full sync" queue.

**How to test**
(detailed commands coming soon) 
* Use your prefered way of listen to sync events, Unagi, wpcom, etc :)
* Set `send_enabled_full_sync`, `send_enabled_sync` Sync Settings to `0`
* Make sure no new events are being sent to the server

