### PR TITLE
[WIP] Related Posts: Use Local Data in Dev Mode

### DIFF
--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -5,7 +5,7 @@
  * First Introduced: 2.9
  * Sort Order: 29
  * Recommendation Order: 9
- * Requires Connection: Yes
+ * Requires Connection: No
  * Auto Activate: No
  * Module Tags: Recommended
  * Feature: Engagement

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1149,13 +1149,22 @@ EOT;
 		}
 
 		if ( $args['post_formats'] ) {
-			$post_formats_query = array(
-				'relation' => 'OR',
-				'taxonomy' => 'post_format',
-				'terms' => array_intersect( $args['post_formats'], get_post_format_strings() ),
-			);
+			$post_formats = array_intersect( $args['post_formats'], get_post_format_slugs() );
 
-			$tax_query = $post_formats_query;
+			if ( $post_formats ) {
+				foreach ( $post_formats as &$post_format ) {
+					$post_format = "post-format-{$post_format}";
+				}
+
+				$post_formats_query = array(
+					'relation' => 'OR',
+					'taxonomy' => 'post_format',
+					'field'    => 'slug',
+					'terms'    => $post_formats,
+				);
+
+				$tax_query[] = $post_formats_query;
+			}
 		}
 
 		if ( $args['date_range'] ) {
@@ -1204,6 +1213,7 @@ EOT;
 			$related_posts[ $index ]['url']     = esc_url( get_permalink( $real_post ) );
 			$related_posts[ $index ]['title']   = $this->_to_utf8( $this->_get_title( $real_post->post_title, $real_post->post_content ) );
 			$related_posts[ $index ]['date']    = get_the_date( '', $real_post );
+			$related_posts[ $index ]['format']  = get_post_format( $real_post );
 			$related_posts[ $index ]['excerpt'] = html_entity_decode( $this->_to_utf8( $this->_get_excerpt( $real_post->post_excerpt, $real_post->post_content ) ), ENT_QUOTES, 'UTF-8' );
 			$related_posts[ $index ]['img']     = $this->_generate_related_post_image_params( $real_post->ID );
 			$related_posts[ $index ]['context'] = $this->_generate_related_post_context( $real_post->ID );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1141,7 +1141,7 @@ EOT;
 			foreach ( $args['has_terms'] as $term ) {
 				$term_query[] = array(
 					'taxonomy' => $term->taxonomy,
-					'terms'    => $term->id,
+					'terms'    => $term->term_id,
 				);
 			}
 

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1052,8 +1052,10 @@ EOT;
 			return $related_posts;
 		}
 
-		$options = $this->get_options();
+		return $this->get_mock_results( $post_id, $args );
+	}
 
+	public function get_mock_results( $post_id, $args ) {
 		$date_now = current_time( get_option( 'date_format' ) );
 
 		// Dummy content
@@ -1121,9 +1123,10 @@ EOT;
 		);
 
 		// Pad to required length
-		for ( $total = 0; $total < $options['size'] - 3; $total++ ) {
-			$related_posts[] = $related_posts[ $total ];
+		if ( 3 < $args['size'] ) {
+			$related_posts = call_user_func_array( 'array_merge', array_fill( 0, (int) ceil( $args['size'] / 3 ), $related_posts ) );
 		}
+		$related_posts = array_slice( $related_posts, 0, $args['size'] );
 
 		// Exclude current post after filtering to make sure it's excluded and not lost during filtering.
 		$excluded_posts = array_merge(
@@ -1167,7 +1170,7 @@ EOT;
 
 		// Fetch posts with featured image.
 		$with_post_thumbnails = get_posts( array(
-			'posts_per_page'   => $options['size'],
+			'posts_per_page'   => $args['size'],
 			'post__not_in'     => $excluded_posts,
 			'post_type'        => $args['post_type'],
 			'meta_key'         => '_thumbnail_id',
@@ -1177,7 +1180,7 @@ EOT;
 		) );
 
 		// If we don't have enough, fetch posts without featured image.
-		if ( 0 < ( $more = $options['size'] - count( $with_post_thumbnails ) ) ) {
+		if ( 0 < ( $more = $args['size'] - count( $with_post_thumbnails ) ) ) {
 			$no_post_thumbnails = get_posts( array(
 				'posts_per_page'  => $more,
 				'post__not_in'    => $excluded_posts,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When in dev mode, uses direct `WP_Query` data and/or fake data for Related Posts.

The fake data already existed for wp-admin/ and Customizer previews. All this PR does is refactor some things and switch from `Requires Connection: Yes` to `Requires Connection: No`. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: enhancement.

#### Testing instructions:
1. On a test site, make sure you're in dev mode. (You can turn it on with the `JETPACK_DEV_DEBUG` constant or the `jetpack_development_mode` filter.)
2. Go to wp-admin/ -> Jetpack Settings -> Traffic
3. Prior to this PR, Related Posts is grayed out.
4. With this PR, Related Posts is able to be activated.
5. Turn on Related Posts.
6. Click "Configure related posts in the Customizer".
7. Play around with the various Customizer settings. If you have real posts, they'll show up as "related" posts. If you don't have enough local posts, the remainder will be filled in with fake data.

#### Todo:

We may need UI/copy changes in wp-admin/, the Customizer, and in blog-side views to make it clear the feature is "on" but not actually working: that the output is there for theme/plugin/site development, but that it's not actually doing it's "related" job.

#### Proposed changelog entry for your changes:
* Allow the Related Posts feature to be activated in development mode.