### PR TITLE
Packages: Add gitattributes files to all packages that need th…

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -32,6 +32,7 @@ vendor/squizlabs
 vendor/wp-coding-standards
 vendor/automattic/jetpack-autoloader
 vendor/automattic/**/tests/
+vendor/automattic/**/.gitattributes
 vendor/automattic/**/README.md
 vendor/automattic/**/phpunit.xml
 vendor/automattic/**/phpunit.xml.dist

--- a/packages/abtest/.gitattributes
+++ b/packages/abtest/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/assets/.gitattributes
+++ b/packages/assets/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes export-ignore
+phpunit.xml    export-ignore
+tests/         export-ignore

--- a/packages/autoloader/.gitattributes
+++ b/packages/autoloader/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/connection/.gitattributes
+++ b/packages/connection/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes export-ignore
+phpunit.xml    export-ignore
+tests/         export-ignore

--- a/packages/constants/.gitattributes
+++ b/packages/constants/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/error/.gitattributes
+++ b/packages/error/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/logo/.gitattributes
+++ b/packages/logo/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/roles/.gitattributes
+++ b/packages/roles/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/status/.gitattributes
+++ b/packages/status/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore


### PR DESCRIPTION
Adds files not needed for distribution via .gitattributes.

This will allow stable versions of the packages or --prefer-dist install smaller packages.

#### Changes proposed in this Pull Request:
* Add export-ignore entries in gitattributes. For composer packages, in GitHub, GH will ignore these files when building the "distributed" version of these packages.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a, expanding upon earlier test.

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* n/a
