### PR TITLE
PHPCS: JITM and Assets packages

### DIFF
--- a/packages/assets/src/Assets.php
+++ b/packages/assets/src/Assets.php
@@ -17,6 +17,7 @@ class Assets {
 	 * Constructor.
 	 *
 	 * Static-only class, so nothing here.
+	 */
 	private function __construct() {}
 
 	/**

--- a/packages/assets/src/Assets.php
+++ b/packages/assets/src/Assets.php
@@ -1,10 +1,22 @@
 <?php
+/**
+ * Jetpack Assets package.
+ *
+ * @package  automattic/jetpack-assets
+ */
+
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Constants as Jetpack_Constants;
 
+/**
+ * Class Assets
+ */
 class Assets {
-	// static-only class
+	/**
+	 * Constructor.
+	 *
+	 * Static-only class, so nothing here.
 	private function __construct() {}
 
 	/**
@@ -16,8 +28,8 @@ class Assets {
 	 *
 	 * @since 5.6.0
 	 *
-	 * @param string $min_path
-	 * @param string $non_min_path
+	 * @param string $min_path minified path.
+	 * @param string $non_min_path non-minified path.
 	 * @return string The URL to the file
 	 */
 	public static function get_file_url_for_environment( $min_path, $non_min_path ) {

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Jetpack's JITM class.
+ *
+ * @package Jetpack
+ */
 
 namespace Automattic\Jetpack;
 
@@ -16,7 +21,7 @@ use Automattic\Jetpack\Connection\Manager;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '1.0';
+	const PACKAGE_VERSION = '1.0'; // TODO: Keep in sync with version specified in composer.json.
 
 	/**
 	 * Tracking object.
@@ -34,6 +39,11 @@ class JITM {
 		$this->tracking = new Tracking();
 	}
 
+	/**
+	 * Determines if JITMs are enabled.
+	 *
+	 * @return bool Enable JITMs.
+	 */
 	public function register() {
 		/**
 		 * Filter to turn off all just in time messages
@@ -55,7 +65,7 @@ class JITM {
 	 *
 	 * @return string The Jetpack emblem
 	 */
-	function get_emblem() {
+	public function get_emblem() {
 		$jetpack_logo = new Jetpack_Logo();
 		return '<div class="jp-emblem">' . $jetpack_logo->get_jp_emblem() . '</div>';
 	}
@@ -67,22 +77,23 @@ class JITM {
 	 *
 	 * @uses Jetpack_Autoupdate::get_possible_failures()
 	 *
-	 * @param object $screen
+	 * @param \WP_Screen $screen WP Core's screen object.
 	 */
-	function prepare_jitms( $screen ) {
+	public function prepare_jitms( $screen ) {
 		if ( ! in_array(
 			$screen->id,
 			array(
 				'jetpack_page_stats',
 				'jetpack_page_akismet-key-config',
 				'admin_page_jetpack_modules',
-			)
+			),
+			true
 		) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'jitm_enqueue_files' ) );
 			add_action( 'admin_notices', array( $this, 'ajax_message' ) );
 			add_action( 'edit_form_top', array( $this, 'ajax_message' ) );
 
-			// Not really a JITM. Don't know where else to put this :)
+			// Not really a JITM. Don't know where else to put this :) .
 			add_action( 'admin_notices', array( $this, 'delete_user_update_connection_owner_notice' ) );
 		}
 	}
@@ -90,11 +101,11 @@ class JITM {
 	/**
 	 * A special filter for WooCommerce, to set a message based on local state.
 	 *
-	 * @param $message string The current message
+	 * @param string $content The current message.
 	 *
-	 * @return array The new message
+	 * @return array The new message.
 	 */
-	static function jitm_woocommerce_services_msg( $content ) {
+	public static function jitm_woocommerce_services_msg( $content ) {
 		if ( ! function_exists( 'wc_get_base_location' ) ) {
 			return $content;
 		}
@@ -118,11 +129,9 @@ class JITM {
 	/**
 	 * A special filter for WooCommerce Call To Action button
 	 *
-	 * @param $CTA string The existing CTA
-	 *
 	 * @return string The new CTA
 	 */
-	static function jitm_jetpack_woo_services_install( $CTA ) {
+	public static function jitm_jetpack_woo_services_install() {
 		return wp_nonce_url(
 			add_query_arg(
 				array(
@@ -135,13 +144,11 @@ class JITM {
 	}
 
 	/**
-	 * A special filter for WooCommerce Call To Action button
-	 *
-	 * @param $CTA string The existing CTA
+	 * A special filter for WooCommerce Call To Action button.
 	 *
 	 * @return string The new CTA
 	 */
-	static function jitm_jetpack_woo_services_activate( $CTA ) {
+	public static function jitm_jetpack_woo_services_activate() {
 		return wp_nonce_url(
 			add_query_arg(
 				array(
@@ -157,8 +164,15 @@ class JITM {
 	 * This is an entire admin notice dedicated to messaging and handling of the case where a user is trying to delete
 	 * the connection owner.
 	 */
-	function delete_user_update_connection_owner_notice() {
+	public function delete_user_update_connection_owner_notice() {
 		global $current_screen;
+
+		/*
+		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
+		 *
+		 * This function is firing within wp-admin and checks (below) if it is in the midst of a deletion on the users
+		 * page. Nonce will be already checked by WordPress, so we do not need to check ourselves.
+		 */
 
 		if ( ! isset( $current_screen->base ) || 'users' !== $current_screen->base ) {
 			return;
@@ -168,7 +182,7 @@ class JITM {
 			return;
 		}
 
-		// Get connection owner or bail
+		// Get connection owner or bail.
 		$connection_manager  = new Manager();
 		$connection_owner_id = $connection_manager->get_connection_owner_id();
 		if ( ! $connection_owner_id ) {
@@ -183,13 +197,16 @@ class JITM {
 		} elseif ( isset( $_REQUEST['user'] ) ) {
 			$user_ids_to_delete[] = $_REQUEST['user'];
 		}
-		$deleting_connection_owner = in_array( $connection_owner_id, (array) $user_ids_to_delete );
+
+		// phpcs:enable
+
+		$deleting_connection_owner = in_array( $connection_owner_id, (array) $user_ids_to_delete, true );
 		if ( ! $deleting_connection_owner ) {
 			return;
 		}
 
 		// Bail if they're trying to delete themselves to avoid confusion.
-		if ( $connection_owner_id == get_current_user_id() ) {
+		if ( get_current_user_id() === $connection_owner_id ) {
 			return;
 		}
 
@@ -200,12 +217,14 @@ class JITM {
 
 		$connection_manager = new Manager();
 		$connected_admins   = $connection_manager->get_connected_users( 'jetpack_disconnect' );
+		$user               = is_a( $connection_owner_userdata, 'WP_User' ) ? esc_html( $connection_owner_userdata->data->user_login ) : '';
 
 		echo "<div class='notice notice-warning' id='jetpack-notice-switch-connection-owner'>";
 		echo '<h2>' . esc_html__( 'Important notice about your Jetpack connection:', 'jetpack' ) . '</h2>';
 		echo '<p>' . sprintf(
+			/* translators: WordPress User, if available. */
 			esc_html__( 'Warning! You are about to delete the Jetpack connection owner (%s) for this site, which may cause some of your Jetpack features to stop working.', 'jetpack' ),
-			is_a( $connection_owner_userdata, 'WP_User' ) ? esc_html( $connection_owner_userdata->data->user_login ) : ''
+			esc_html( $user )
 		) . '</p>';
 
 		if ( ! empty( $connected_admins ) && count( $connected_admins ) > 1 ) {
@@ -245,10 +264,10 @@ class JITM {
 
 						$.ajax( {
 							type        : "POST",
-							url         : "<?php echo get_rest_url() . 'jetpack/v4/connection/owner'; ?>",
+							url         : "<?php echo esc_url( get_rest_url() . 'jetpack/v4/connection/owner' ); ?>",
 							data        : formData,
 							headers     : {
-								'X-WP-Nonce': "<?php echo wp_create_nonce( 'wp_rest' ); ?>",
+								'X-WP-Nonce': "<?php echo esc_js( wp_create_nonce( 'wp_rest' ) ); ?>",
 							},
 							success: function() {
 								results.innerHTML = "<?php esc_html_e( 'Success!', 'jetpack' ); ?>";
@@ -275,6 +294,7 @@ class JITM {
 		echo '<p>';
 		printf(
 			wp_kses(
+				/* translators: URL to Jetpack support doc regarding the primary user. */
 				__( "<a href='%s' target='_blank' rel='noopener noreferrer'>Learn more</a> about the connection owner and what will break if you do not have one.", 'jetpack' ),
 				array(
 					'a' => array(
@@ -290,6 +310,7 @@ class JITM {
 		echo '<p>';
 		printf(
 			wp_kses(
+				/* translators: URL to contact Jetpack support. */
 				__( 'As always, feel free to <a href="%s" target="_blank" rel="noopener noreferrer">contact our support team</a> if you have any questions.', 'jetpack' ),
 				array(
 					'a' => array(
@@ -306,18 +327,21 @@ class JITM {
 	}
 
 	/**
-	 * Injects the dom to show a JITM inside of
+	 * Injects the dom to show a JITM inside of wp-admin.
 	 */
-	function ajax_message() {
+	public function ajax_message() {
+		if ( ! is_admin() ) {
+			return;
+		}
 		$message_path   = $this->get_message_path();
-		$query_string   = _http_build_query( $_GET, '', ',' );
+		$query_string   = _http_build_query( $_GET, '', ',' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$current_screen = wp_unslash( $_SERVER['REQUEST_URI'] );
 		?>
 		<div class="jetpack-jitm-message"
-			 data-nonce="<?php echo wp_create_nonce( 'wp_rest' ); ?>"
-			 data-message-path="<?php echo esc_attr( $message_path ); ?>"
-			 data-query="<?php echo urlencode_deep( $query_string ); ?>"
-			 data-redirect="<?php echo urlencode_deep( $current_screen ); ?>"
+			data-nonce="<?php echo esc_attr( wp_create_nonce( 'wp_rest' ) ); ?>"
+			data-message-path="<?php echo esc_attr( $message_path ); ?>"
+			data-query="<?php echo urlencode_deep( $query_string ); ?>"
+			data-redirect="<?php echo urlencode_deep( $current_screen ); ?>"
 		></div>
 		<?php
 	}
@@ -327,7 +351,7 @@ class JITM {
 	 *
 	 * @return string The message path
 	 */
-	function get_message_path() {
+	public function get_message_path() {
 		$screen = get_current_screen();
 
 		return 'wp:' . $screen->id . ':' . current_filter();
@@ -336,7 +360,7 @@ class JITM {
 	/**
 	 * Function to enqueue jitm css and js
 	 */
-	function jitm_enqueue_files() {
+	public function jitm_enqueue_files() {
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_register_style(
 			'jetpack-jitm-css',
@@ -353,7 +377,7 @@ class JITM {
 			'jetpack-jitm-new',
 			Assets::get_file_url_for_environment( '_inc/build/jetpack-jitm.min.js', '_inc/jetpack-jitm.js' ),
 			array( 'jquery' ),
-			self::PACKAGE_VERSION, // TODO: Keep in sync with version specified in composer.json
+			self::PACKAGE_VERSION,
 			true
 		);
 		wp_localize_script(
@@ -369,14 +393,14 @@ class JITM {
 	}
 
 	/**
-	 * Dismisses a JITM feature class so that it will no longer be shown
+	 * Dismisses a JITM feature class so that it will no longer be shown.
 	 *
-	 * @param $id string The id of the JITM that was dismissed
-	 * @param $feature_class string The feature class of the JITM that was dismissed
+	 * @param string $id The id of the JITM that was dismissed.
+	 * @param string $feature_class The feature class of the JITM that was dismissed.
 	 *
-	 * @return bool Always true
+	 * @return bool Always true.
 	 */
-	function dismiss( $id, $feature_class ) {
+	public function dismiss( $id, $feature_class ) {
 		$this->tracking->record_user_event(
 			'jitm_dismiss_client',
 			array(
@@ -497,7 +521,7 @@ class JITM {
 			$expiration = isset( $envelopes[0] ) ? $envelopes[0]->ttl : 300;
 
 			// Do not cache if expiration is 0 or we're not using the cache.
-			if ( 0 != $expiration && $use_cache ) {
+			if ( 0 !== $expiration && $use_cache ) {
 				$envelopes['last_response_time'] = time();
 
 				set_transient( 'jetpack_jitm_' . substr( md5( $path ), 0, 31 ), $envelopes, $expiration );
@@ -545,7 +569,8 @@ class JITM {
 				require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 			}
 			// Get affiliate code and add it to the array of URL parameters.
-			if ( '' !== ( $aff = \Jetpack_Affiliate::init()->get_affiliate_code() ) ) {
+			$aff = \Jetpack_Affiliate::init()->get_affiliate_code();
+			if ( '' !== $aff ) {
 				$url_params['aff'] = $aff;
 			}
 
@@ -553,10 +578,13 @@ class JITM {
 
 			$envelope->jitm_stats_url = \Jetpack::build_stats_url( array( 'x_jetpack-jitm' => $envelope->id ) );
 
+			// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			// $CTA is not valid per PHPCS, but it is part of the return from WordPress.com, so allowing.
 			if ( $envelope->CTA->hook ) {
 				$envelope->url = apply_filters( 'jitm_' . $envelope->CTA->hook, $envelope->url );
 				unset( $envelope->CTA->hook );
 			}
+			// phpcs:enable
 
 			if ( isset( $envelope->content->hook ) ) {
 				$envelope->content = apply_filters( 'jitm_' . $envelope->content->hook, $envelope->content );

--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -2,7 +2,7 @@
 /**
  * Jetpack's JITM class.
  *
- * @package Jetpack
+ * @package automattic/jetpack-jitm
  */
 
 namespace Automattic\Jetpack;


### PR DESCRIPTION
Needed as part of efforts to use packages on WordPress.com. Manual PHPCS fixes in the JITM and Assets packages.

Sync still needs work and the analyzer package has a ton of outstanding issues, but bite-size pieces for now.

#### Changes proposed in this Pull Request:
* PHPCS

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p9dueE-11H-p2

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* n/a
