### PR TITLE
Sites API: Return options for Jetpack blog requests

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -227,44 +227,44 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			array_intersect( $default_fields, $this->fields_to_include ) :
 			$default_fields;
 
-		if ( ! $this->has_blog_access( $this->api->token_details, $blog_id ) ) {
+		$has_blog_access = $this->has_blog_access( $this->api->token_details );
+		$has_user_access = $this->has_user_access();
+
+		if ( ! $has_user_access && ! $has_blog_access ) {
+			// Users without user or blog access, only return `$no_member_fields`.
 			$response_keys = array_intersect( $response_keys, self::$no_member_fields );
+		} elseif ( $has_user_access && ! current_user_can( 'edit_posts' ) ) {
+			// Subscriber level user, don't return site options.
+			$response_keys = array_diff( $response_keys, [ 'options' ] );
 		}
 
 		return $this->render_response_keys( $response_keys );
 	}
 
 	/**
-	 * Checks that the current user has access to the current blog,
-	 * and failing that checks that we have a valid blog token.
+	 * Checks that the current user has access to the current blog.
 	 *
-	 * @param $token_details array Details obtained from the authorization token
-	 * @param $blog_id int The server-side blog id on wordpress.com
+	 * @return bool Whether or not the current user can access the current blog.
+	 */
+	private function has_user_access() {
+		return is_user_member_of_blog( get_current_user_id(), get_current_blog_id() );
+	}
+
+	/**
+	 * Checks if the request has a valid blog token for the current blog.
 	 *
+	 * @param array $token_details Access token for the api request.
 	 * @return bool
 	 */
-	private function has_blog_access( $token_details, $blog_id ) {
-		$current_blog_id = (  defined( 'IS_WPCOM' ) && IS_WPCOM ) ?
-			$blog_id :
-			get_current_blog_id();
-
-		if ( is_user_member_of_blog( get_current_user_id(), $current_blog_id ) ) {
-			return true;
-		}
-
+	private function has_blog_access( $token_details ) {
 		$token_details = (array) $token_details;
 		if ( ! isset( $token_details['access'], $token_details['auth'], $token_details['blog_id'] ) ) {
 			return false;
 		}
 
-		if (
-			'jetpack' === $token_details['auth'] &&
+		return 'jetpack' === $token_details['auth'] &&
 			'blog' === $token_details['access'] &&
-			$current_blog_id === $token_details['blog_id']
-		) {
-			return true;
-		}
-		return false;
+			get_current_blog_id() === $token_details['blog_id'];
 	}
 
 	private function render_response_keys( &$response_keys ) {
@@ -389,10 +389,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	}
 
 	protected function render_option_keys( &$options_response_keys ) {
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return array();
-		}
-
 		$options = array();
 		$site = $this->site;
 
@@ -628,7 +624,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			$response->{ $key } = $value;
 		}
 
-		if ( $this->has_blog_access( $this->api->token_details, $response->ID ) ) {
+		if ( $this->has_user_access() || $this->has_blog_access( $this->api->token_details ) ) {
 			$wpcom_member_response = $this->render_response_keys( self::$jetpack_response_field_member_additions );
 
 			foreach( $wpcom_member_response as $key => $value ) {

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -231,11 +231,11 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$has_user_access = $this->has_user_access();
 
 		if ( ! $has_user_access && ! $has_blog_access ) {
-			// Users without user or blog access, only return `$no_member_fields`.
+			// Public access without user or blog auth, only return `$no_member_fields`.
 			$response_keys = array_intersect( $response_keys, self::$no_member_fields );
 		} elseif ( $has_user_access && ! current_user_can( 'edit_posts' ) ) {
 			// Subscriber level user, don't return site options.
-			$response_keys = array_diff( $response_keys, [ 'options' ] );
+			$response_keys = array_diff( $response_keys, array( 'options' ) );
 		}
 
 		return $this->render_response_keys( $response_keys );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Returns site options for blog requests
- Removes all site options for user requests when the user doesn't have at least the `edit_posts` capability (subscriber users)

Because this endpoint is currently using a `current_user_can( 'edit_posts' )` capability check to determine whether to return site options, blog requests do not see most site options.

Some site options that were added when [decorating the request](https://github.com/Automattic/jetpack/blob/update/sites-endpoint--return-options-for-blog-requests/json-endpoints/class.wpcom-json-api-get-site-endpoint.php#L614) on wpcom still leaked through to subscriber level users, so this change also removes all site level options for those users.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

See p1571157924035600-slack-jetpack-developers for context.

#### Testing instructions:

Testing this can be complex, because there are a lot of different ways the code is run on wpcom + Jetpack sites. I'd recommend the following testing methodology to verify the output.

- Copy the JSON responses of each api request and paste into a text file
- Prettify the JSON and save the file
- Make the API requests first against the production API and place all of those responses within a folder
- Make the API requests against against the sandboxed API + Jetpack development site and put those responses in a separate folder, with the same file names corresponding to each request
- Diff the folder to see any differences, and ensure that all response output is as expected

Setup

- Set up your local Jetpack development site so that it has an admin and a subscriber level user
- Make each request 4 times: as an admin user, as a subscriber user, as a logged out user, and as the blog
- For user requests, use `developer.wordpress.com/console`
- For blog requests, `wp shell` for your Jetpack development site and run `echo wp_remote_retrieve_body( Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog( 'sites/{site_id}?force=wpcom') );` (replacing the site_id with the id of your local Jetpack development site)

Requests

- `/sites/{site}?force=wpcom`
- `/sites/{site}`
- Additionally, call these endpoint for a different Jetpack site, to ensure user and blog requests get the same response as a logged out users

#### Proposed changelog entry for your changes:

- Return site options when making an `as_blog` request to `/site/{site}`
