### PR TITLE
Instant Search: Account for site URL when appending query string

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -251,6 +251,7 @@ class Jetpack_Search {
 					'postTypeFilters'    => $widget_options['post_types'],
 					'postTypes'          => $post_type_labels,
 					'siteId'             => Jetpack::get_option( 'id' ),
+					'siteUrl'            => site_url(),
 					'sort'               => $widget_options['sort'],
 					'widgets'            => array_values( $widgets ),
 				);

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -247,11 +247,11 @@ class Jetpack_Search {
 				// This is probably a temporary filter for testing the prototype.
 				$options = array(
 					'enableLoadOnScroll' => false,
+					'homeUrl'            => home_url(),
 					'locale'             => str_replace( '_', '-', get_locale() ),
 					'postTypeFilters'    => $widget_options['post_types'],
 					'postTypes'          => $post_type_labels,
 					'siteId'             => Jetpack::get_option( 'id' ),
-					'siteUrl'            => site_url(),
 					'sort'               => $widget_options['sort'],
 					'widgets'            => array_values( $widgets ),
 				);

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -58,9 +58,11 @@ class SearchApp extends Component {
 			this.input.current.focus();
 		}
 
+		window.addEventListener( 'popstate', this.onChangeQueryString );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 	}
 	componentWillUnmount() {
+		window.removeEventListener( 'popstate', this.onChangeQueryString );
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
 	}
 

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import 'url-polyfill';
 import { h, render } from 'preact';
 
 /**

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import 'url-polyfill';
 import { h, render } from 'preact';
 
 /**

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -21,8 +21,8 @@ function getQuery() {
 function pushQueryString( queryString ) {
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );
-		if ( window[ SERVER_OBJECT_NAME ] && 'siteUrl' in window[ SERVER_OBJECT_NAME ] ) {
-			url.href = window[ SERVER_OBJECT_NAME ].siteUrl;
+		if ( window[ SERVER_OBJECT_NAME ] && 'homeUrl' in window[ SERVER_OBJECT_NAME ] ) {
+			url.href = window[ SERVER_OBJECT_NAME ].homeUrl;
 		}
 		url.search = queryString;
 		window.history.pushState( null, null, url.toString() );

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -20,17 +20,16 @@ function getQuery() {
 function pushQueryString( queryString ) {
 	// NOTE: This erases location.pathname
 	if ( history.pushState ) {
-		const newUrl = queryString
-			? `${ window.location.protocol }//${ window.location.host }?${ queryString }`
-			: `${ window.location.protocol }//${ window.location.host }${ window.location.pathname }`;
-		window.history.pushState( { path: newUrl }, '', newUrl );
+		const url = new window.URL( window.location.href );
+		url.search = queryString;
+		window.history.pushState( null, null, url.toString() );
 		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }
 
 export function restorePreviousHref( initialHref ) {
 	if ( history.pushState ) {
-		window.history.pushState( { href: initialHref }, '', initialHref );
+		window.history.pushState( null, null, initialHref );
 		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import 'url-polyfill';
 import { decode, encode } from 'qss';
 // NOTE: We only import the get package here for to reduced bundle size.
 //       Do not import the entire lodash library!

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -18,9 +18,11 @@ function getQuery() {
 }
 
 function pushQueryString( queryString ) {
-	// NOTE: This erases location.pathname
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );
+		if ( window[ SERVER_OBJECT_NAME ] && 'siteUrl' in window[ SERVER_OBJECT_NAME ] ) {
+			url.href = window[ SERVER_OBJECT_NAME ].siteUrl;
+		}
 		url.search = queryString;
 		window.history.pushState( null, null, url.toString() );
 		window.dispatchEvent( new Event( 'queryStringChange' ) );

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
 		"swiper": "4.5.1",
 		"uglify-save-license": "0.4.1",
 		"unfetch": "4.1.0",
+		"url-polyfill": "1.1.7",
 		"webpack": "4.41.0",
 		"webpack-cli": "3.3.9"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -13079,6 +13079,11 @@ url-loader@1.1.2:
     mime "^2.0.3"
     schema-utils "^1.0.0"
 
+url-polyfill@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.7.tgz#402ee84360eb549bbeb585f4c7971e79a31de9e3"
+  integrity sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA==
+
 url-template@^2.0.8:
   version "2.0.8"
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"


### PR DESCRIPTION
Fixes #13845.

#### Changes proposed in this Pull Request:
* Propagates output of `site_url()` to Instant Search's front-end application.
* Uses the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) for appending query strings.
* Imports [url-polyfill](https://github.com/lifaon74/url-polyfill) package to ensure IE 11 support.

#### Testing instructions:
* Testing on a WordPress installation at a root URL (e.g. `/`):
  1. Ensure that you've set up Jetpack Search on your WordPress installation.  
  2. Enter text into your Jetpack Search input.
  3. Ensure that your URL is correctly formatted (e.g. `/?s=hello`)

* Testing on a WordPress installation at a non-root URL (e.g. `/wp-blog`):
  1. Ensure that you've set up Jetpack Search on your WordPress installation.  
  2. Enter text into your Jetpack Search input.
  3. Ensure that your URL is correctly formatted (e.g. `/wp-blog/?s=hello`)

#### Setting up Jetpack Search:
1. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php. 
If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.

2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. 
You can enable Jetpack Search in the Performance tab within the Jetpack menu (`/wp-admin/admin.php?page=jetpack#/performance`).

3. Select a theme of your choosing and add a Jetpack Search widget to the site via the customizer, preferably with some filters enabled. If you're using a theme with a sidebar widget area, please add the Jetpack Search widget there.

#### Proposed changelog entry for your changes:
* No changelog necessary. Changelog in #13761 should be sufficient.
