### PR TITLE
Instant Search: Pay down technical debt

### DIFF
--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -1,0 +1,57 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { Component, h } from 'preact';
+import { createPortal } from 'preact/compat';
+
+/**
+ * Internal dependencies
+ */
+import SearchBox from './search-box';
+import SearchFilters from './search-filters';
+import SearchSortWidget from './search-sort-widget';
+
+import {
+	getFilterQuery,
+	getSearchQuery,
+	getSortQuery,
+	setFilterQuery,
+	setSearchQuery,
+	setSortQuery,
+} from '../lib/query-string';
+
+export default class SearchWidget extends Component {
+	onChangeFilter = ( filterName, filterValue ) => setFilterQuery( filterName, filterValue );
+	onChangeQuery = event => setSearchQuery( event.target.value );
+	onChangeSort = sort => setSortQuery( sort );
+
+	render() {
+		return createPortal(
+			<div id={ `${ this.props.widget.widget_id }-portaled-wrapper` }>
+				<div className="search-form">
+					<SearchBox
+						onChangeQuery={ this.onChangeQuery }
+						onFocus={ this.props.onSearchFocus }
+						onBlur={ this.props.onSearchBlur }
+						query={ getSearchQuery() }
+					/>
+				</div>
+				<div className="jetpack-search-sort-wrapper">
+					<SearchSortWidget onChange={ this.onChangeSort } value={ getSortQuery() } />
+				</div>
+				<SearchFilters
+					filters={ getFilterQuery() }
+					loading={ this.props.isLoading }
+					locale={ this.props.locale }
+					onChange={ this.onChangeFilter }
+					postTypes={ this.props.postTypes }
+					results={ this.props.response }
+					widget={ this.props.widget }
+				/>
+			</div>,
+			document.getElementById( `${ this.props.widget.widget_id }-wrapper` )
+		);
+	}
+}

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -13,10 +13,12 @@ import { getSearchQuery, determineDefaultSort } from './lib/query-string';
 import { getThemeOptions } from './lib/dom';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 import { initializeTracks, identifySite, resetTrackingCookies } from './lib/tracks';
+import { buildFilterAggregations } from './lib/api';
 
 const injectSearchApp = grabFocus => {
 	render(
 		<SearchApp
+			aggregations={ buildFilterAggregations( window[ SERVER_OBJECT_NAME ].widgets ) }
 			grabFocus={ grabFocus }
 			initialHref={ window.location.href }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Refactor widget rendering into a separate `SearchWidget` component.
* Simplify logic for showing/hiding search results.
* Move instance variable `requestId` into the Preact component state.
* Remove component property assignment in `SearchApp` constructor.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
1. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php. 
If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.

2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. 
You can enable Jetpack Search in the Performance tab within the Jetpack menu (`/wp-admin/admin.php?page=jetpack#/performance`).

3. Select a theme of your choosing and add a Jetpack Search widget to the site via the customizer, preferably with some filters enabled. If you're using a theme with a sidebar widget area, please add the Jetpack Search widget there.

4. If using a theme with a sidebar widget, you can navigate to `/` to start the search experience. Otherwise, navigate to your search page (e.g. `/?s=hello`).

5. Enter a search term into the input. Ensure that it renders search results in the main content area.

#### Proposed changelog entry for your changes:
None.