### PR TITLE
Twitter timeline widget UX improvements

### DIFF
--- a/modules/widgets/twitter-timeline-admin.css
+++ b/modules/widgets/twitter-timeline-admin.css
@@ -1,0 +1,9 @@
+[id*="twitter_timeline"] input:disabled,
+[id*="twitter_timeline"] input:disabled + label,
+label.jp-twitter-disabled {
+	cursor: not-allowed;
+}
+[id*="twitter_timeline"] input:disabled + label,
+label.jp-twitter-disabled {
+	color: grey;
+}

--- a/modules/widgets/twitter-timeline-admin.js
+++ b/modules/widgets/twitter-timeline-admin.js
@@ -36,15 +36,33 @@ jQuery( function( $ ) {
 	// To use the No Scrollbar” option, you should not specify a number of
 	// tweets in the widget settings. Grey out the 'noscrollbar' option when
 	// user sets 'tweet-limit'
-	$container.on( 'input', '[id*="tweet-limit"]', function() {
-		var $scrollbarOptionCheckbox = $( this )
-			.closest( '.widget-content' )
-			.find( '[id*="chrome-noscrollbar"]' );
+	$container.on( 'input', '[id$="tweet-limit"]', function() {
+		var inputFieldNames = [ 'chrome-noscrollbar', 'height' ];
 
-		if ( ! $scrollbarOptionCheckbox.length ) {
-			return;
+		var tweet_limit_set = $( this ).val().length > 0;
+
+		for ( var i = 0; i < inputFieldNames.length; i++ ) {
+			var fieldName = inputFieldNames[ i ];
+			var $input = $( this )
+				.closest( '.widget-content' )
+				.find( '[id$="' + fieldName + '"]' );
+
+			var $label = $( this )
+				.closest( '.widget-content' )
+				.find( 'label[for$="' + fieldName + '"]' );
+
+			if ( ! $input.length ) {
+				return;
+			}
+
+			$input.prop( 'disabled', tweet_limit_set );
+
+			// Disable/Mute the label associated with the inputs
+			if ( tweet_limit_set ) {
+				$label.addClass( 'jp-twitter-disabled' );
+			} else {
+				$label.removeClass( 'jp-twitter-disabled' );
+			}
 		}
-
-		$scrollbarOptionCheckbox.prop( 'disabled', $( this ).val().length > 0 );
 	} );
 } );

--- a/modules/widgets/twitter-timeline-admin.js
+++ b/modules/widgets/twitter-timeline-admin.js
@@ -32,4 +32,19 @@ jQuery( function( $ ) {
 	$container.find( '.jetpack-twitter-timeline-widget-type' ).each( function() {
 		twitterWidgetTypeChanged( this );
 	} );
+
+	// To use the No Scrollbar” option, you should not specify a number of
+	// tweets in the widget settings. Grey out the 'noscrollbar' option when
+	// user sets 'tweet-limit'
+	$container.on( 'input', '[id*="tweet-limit"]', function() {
+		var $scrollbarOptionCheckbox = $( this )
+			.closest( '.widget-content' )
+			.find( '[id*="chrome-noscrollbar"]' );
+
+		if ( ! $scrollbarOptionCheckbox.length ) {
+			return;
+		}
+
+		$scrollbarOptionCheckbox.prop( 'disabled', $( this ).val().length > 0 );
+	} );
 } );

--- a/modules/widgets/twitter-timeline.css
+++ b/modules/widgets/twitter-timeline.css
@@ -1,0 +1,7 @@
+[id*="twitter_timeline"] input:disabled,
+[id*="twitter_timeline"] input:disabled + label {
+	cursor: not-allowed;
+}
+[id*="twitter_timeline"] input:disabled + label {
+	color: grey;
+}

--- a/modules/widgets/twitter-timeline.css
+++ b/modules/widgets/twitter-timeline.css
@@ -1,7 +1,0 @@
-[id*="twitter_timeline"] input:disabled,
-[id*="twitter_timeline"] input:disabled + label {
-	cursor: not-allowed;
-}
-[id*="twitter_timeline"] input:disabled + label {
-	color: grey;
-}

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -72,6 +72,13 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 					'modules/widgets/twitter-timeline-admin.js'
 				)
 			);
+
+			wp_enqueue_style(
+				'twitter-timeline-admin',
+				plugins_url( 'twitter-timeline.css', __FILE__ ),
+				array(),
+				'20191027'
+			);
 		}
 	}
 
@@ -335,6 +342,20 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		$instance['type'] = 'profile';
 		?>
 
+		<p class="jetpack-twitter-timeline-widget-id-container">
+			<label for="<?php echo $this->get_field_id( 'widget-id' ); ?>">
+				<?php esc_html_e( 'Twitter Username:', 'jetpack' ); ?>
+				<?php echo $this->get_docs_link( '#twitter-username' ); ?>
+			</label>
+			<input
+				class="widefat"
+				id="<?php echo $this->get_field_id( 'widget-id' ); ?>"
+				name="<?php echo $this->get_field_name( 'widget-id' ); ?>"
+				type="text"
+				value="<?php echo esc_attr( $instance['widget-id'] ); ?>"
+			/>
+		</p>
+
 		<p>
 			<label for="<?php echo $this->get_field_id( 'title' ); ?>">
 				<?php esc_html_e( 'Title:', 'jetpack' ); ?>
@@ -387,20 +408,6 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			/>
 		</p>
 
-		<p class="jetpack-twitter-timeline-widget-id-container">
-			<label for="<?php echo $this->get_field_id( 'widget-id' ); ?>">
-				<?php esc_html_e( 'Twitter Username:', 'jetpack' ); ?>
-				<?php echo $this->get_docs_link( '#twitter-username' ); ?>
-			</label>
-			<input
-				class="widefat"
-				id="<?php echo $this->get_field_id( 'widget-id' ); ?>"
-				name="<?php echo $this->get_field_name( 'widget-id' ); ?>"
-				type="text"
-				value="<?php echo esc_attr( $instance['widget-id'] ); ?>"
-			/>
-		</p>
-
 		<p>
 			<label for="<?php echo $this->get_field_id( 'chrome-noheader' ); ?>">
 				<?php esc_html_e( 'Layout Options:', 'jetpack' ); ?>
@@ -440,7 +447,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				type="checkbox"<?php checked( in_array( 'noscrollbar', $instance['chrome'] ) ); ?>
 				id="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>"
 				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
-				value="noscrollbar"
+				value="noscrollbar"<?php disabled( strlen( strval( $instance['tweet-limit'] ) ) > 0 ); ?>
 			/>
 			<label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>">
 				<?php esc_html_e( 'No Scrollbar', 'jetpack' ); ?>

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -74,10 +74,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 			);
 
 			wp_enqueue_style(
-				'twitter-timeline-admin',
-				plugins_url( 'twitter-timeline.css', __FILE__ ),
+				'twitter-timeline-admin-css',
+				plugins_url( 'twitter-timeline-admin.css', __FILE__ ),
 				array(),
-				'20191027'
+				JETPACK__VERSION
 			);
 		}
 	}
@@ -340,6 +340,8 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		}
 
 		$instance['type'] = 'profile';
+
+		$has_tweet_limit = strlen( strval( $instance['tweet-limit'] ) ) > 0;
 		?>
 
 		<p class="jetpack-twitter-timeline-widget-id-container">
@@ -383,11 +385,11 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'height' ); ?>">
+			<label for="<?php echo $this->get_field_id( 'height' ); ?>" <?= $has_tweet_limit ? 'class="jp-twitter-disabled"' : '' ?>>
 				<?php esc_html_e( 'Height (px; at least 200):', 'jetpack' ); ?>
 			</label>
 			<input
-				class="widefat"
+				class="widefat"<?php disabled( $has_tweet_limit ); ?>
 				id="<?php echo $this->get_field_id( 'height' ); ?>"
 				name="<?php echo $this->get_field_name( 'height' ); ?>"
 				type="number" min="200"
@@ -447,9 +449,9 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				type="checkbox"<?php checked( in_array( 'noscrollbar', $instance['chrome'] ) ); ?>
 				id="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>"
 				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
-				value="noscrollbar"<?php disabled( strlen( strval( $instance['tweet-limit'] ) ) > 0 ); ?>
+				value="noscrollbar"<?php disabled( $has_tweet_limit ); ?>
 			/>
-			<label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>">
+			<label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>" <?= $has_tweet_limit ? 'class="jp-twitter-disabled"' : '' ?>>
 				<?php esc_html_e( 'No Scrollbar', 'jetpack' ); ?>
 			</label>
 			<br />

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -385,15 +385,16 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 		</p>
 
 		<p>
-			<label for="<?php echo $this->get_field_id( 'height' ); ?>" <?= $has_tweet_limit ? 'class="jp-twitter-disabled"' : '' ?>>
+			<label for="<?php echo $this->get_field_id( 'height' ); ?>" <?php echo $has_tweet_limit ? 'class="jp-twitter-disabled"' : '' ?>>
 				<?php esc_html_e( 'Height (px; at least 200):', 'jetpack' ); ?>
 			</label>
 			<input
-				class="widefat"<?php disabled( $has_tweet_limit ); ?>
+				class="widefat"
 				id="<?php echo $this->get_field_id( 'height' ); ?>"
 				name="<?php echo $this->get_field_name( 'height' ); ?>"
 				type="number" min="200"
 				value="<?php echo esc_attr( $instance['height'] ); ?>"
+				<?php disabled( $has_tweet_limit ); ?>
 			/>
 		</p>
 
@@ -449,9 +450,10 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 				type="checkbox"<?php checked( in_array( 'noscrollbar', $instance['chrome'] ) ); ?>
 				id="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>"
 				name="<?php echo $this->get_field_name( 'chrome' ); ?>[]"
-				value="noscrollbar"<?php disabled( $has_tweet_limit ); ?>
+				value="noscrollbar"
+				<?php disabled( $has_tweet_limit ); ?>
 			/>
-			<label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>" <?= $has_tweet_limit ? 'class="jp-twitter-disabled"' : '' ?>>
+			<label for="<?php echo $this->get_field_id( 'chrome-noscrollbar' ); ?>" <?php echo $has_tweet_limit ? 'class="jp-twitter-disabled"' : '' ?>>
 				<?php esc_html_e( 'No Scrollbar', 'jetpack' ); ?>
 			</label>
 			<br />


### PR DESCRIPTION
Fixes #13789
Fixes #6290
Closes #13802 

Implements the suggestions in issue #6290. I was unable to find the widget type section though and wasn't sure if that was at some point removed all together.

Before:
<img width="439" alt="image" src="https://user-images.githubusercontent.com/3008677/67632297-e5f28000-f85e-11e9-8e5a-f1c8113bb705.png">

After:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/3008677/67632264-a4fa6b80-f85e-11e9-94e2-b3cb173b6aa6.png">


#### Changes proposed in this Pull Request:

* Moved "Username" field to top of widget settings as suggested in #6290
* Disabled the checkbox input for the tweet limit and change label to grey as suggested in #6290


#### Testing instructions:

* Go to the /wp-admin/admin.php?page=jetpack#/writing and enable the Jetpack widgets
* Go to /wp-admin/widgets.php and add the twitter widget
* If you edit the number of tweets input it should disable or enable the show scrollbars option

#### Proposed changelog entry for your changes:

* Improvements to Twitter widget settings UX
