### PR TITLE
PHPCS: Error for an undefined variable

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -9,6 +9,17 @@
 	<rule ref="WordPress-Extra" />
 	<rule ref="VariableAnalysis" />
 
+	<!-- Elevate undefined variables to an Error instead of a Warning. -->
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">
+		<type>error</type>
+	</rule>
+
+	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis">
+		<properties>
+			<property name="allowWordPressPassByRefFunctions" value="true" />
+		</properties>
+	</rule>
+
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="jetpack" />


### PR DESCRIPTION
While testing out some unrelated linting issues, I realized we can error for an undefined variable and allow common WordPress assign by reference functions in our variable analysis ruleset.

For the undefined error, I can't imagine a situation where we would allow that to occur, so we should elevate the status. Warnings, in a pinch, is one thing to allow, but error. Nope.

I don't have a particular blocker that this would impact, but while in there, let's add it.

#### Changes proposed in this Pull Request:
* Update PHPCS ruleset.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add an undefined variable and run PHPCS against it before/after. See it goes from warning->error.
*

#### Proposed changelog entry for your changes:
* n/a
