### PR TITLE
Fix logic for choosing between customizer and widgets.php

### DIFF
--- a/modules/widget-visibility/widget-conditions.php
+++ b/modules/widget-visibility/widget-conditions.php
@@ -31,7 +31,7 @@ class Jetpack_Widget_Conditions {
 				'modules/widget-visibility/widget-conditions/widget-conditions.js'
 			),
 			array( 'jquery', 'jquery-ui-core' ),
-			20171227,
+			20191128,
 			true
 		);
 

--- a/modules/widget-visibility/widget-conditions/widget-conditions.js
+++ b/modules/widget-visibility/widget-conditions/widget-conditions.js
@@ -3,7 +3,7 @@
 jQuery( function( $ ) {
 	var widgets_shell = $( 'div#widgets-right' );
 
-	if ( ! widgets_shell.length || ! $( widgets_shell ).find( '.widget-control-actions' ).length ) {
+	if ( ! widgets_shell && ! widgets_shell.length ) {
 		widgets_shell = $( 'form#customize-controls' );
 	}
 


### PR DESCRIPTION
This commit changes the logic for determining whether we are in the
customizer or widgets.php. Previously, when accessing widgets from
widgets.php, the logic failed to recognize this when the page
initialized with no widgets.

This ensures the correct element is selected, even when there are no
active plugins when the page loads.

Fixes #12302

#### Changes proposed in this Pull Request:

* removes an additional check for widget-control-actions class when initializing the widgets_shell variable
* instead check that widgets_shell is not undefined and empty before resorting to customize-controls ID

#### Testing instructions:
From https://github.com/Automattic/jetpack/issues/12302#issuecomment-538669241

* Go to the widgets page, remove all widgets from the widget area and refresh the page (imp step).
* Add a widget, hit visibility button, it doesn't work
* Refresh the page, hit visibility button, it works!

#### Proposed changelog entry for your changes:

* Fixes bug in widget visibility where visibility button did not work when widgets.php loaded with no active plugins
