### PR TITLE
Build: Throw error if gulp-sass errors.

### DIFF
--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -21,7 +21,7 @@ gulp.task( 'sass:dashboard', function( done ) {
 
 	return gulp
 		.src( './_inc/client/scss/style.scss' )
-		.pipe( sass( { outputStyle: 'compressed' } ).on( 'error', sass.logError ) )
+		.pipe( sass( { outputStyle: 'compressed' } ) )
 		.pipe(
 			prepend.prependText( '/* Do not modify this file directly.  It is compiled SASS code. */\n' )
 		)
@@ -39,7 +39,7 @@ gulp.task( 'sass:calypsoify', function( done ) {
 
 	return gulp
 		.src( './modules/calypsoify/*.scss' )
-		.pipe( sass( { outputStyle: 'compressed' } ).on( 'error', sass.logError ) )
+		.pipe( sass( { outputStyle: 'compressed' } ) )
 		.pipe(
 			prepend.prependText( '/* Do not modify this file directly.  It is compiled SASS code. */\n' )
 		)
@@ -57,7 +57,7 @@ gulp.task( 'sass:instant-search', function( done ) {
 
 	return gulp
 		.src( './modules/search/instant-search/*.scss' )
-		.pipe( sass( { outputStyle: 'compressed' } ).on( 'error', sass.logError ) )
+		.pipe( sass( { outputStyle: 'compressed' } ) )
 		.pipe(
 			prepend.prependText( '/* Do not modify this file directly.  It is compiled SASS code. */\n' )
 		)
@@ -112,7 +112,7 @@ gulp.task( 'sass:old:rtl', function() {
 	return (
 		gulp
 			.src( 'scss/*.scss' )
-			.pipe( sass( { outputStyle: 'expanded' } ).on( 'error', sass.logError ) )
+			.pipe( sass( { outputStyle: 'expanded' } ) )
 			.pipe(
 				prepend.prependText(
 					'/*!\n' + '* Do not modify this file directly.  It is compiled SASS code.\n' + '*/\n'
@@ -143,7 +143,7 @@ gulp.task(
 		return (
 			gulp
 				.src( 'scss/**/*.scss' )
-				.pipe( sass( { outputStyle: 'expanded' } ).on( 'error', sass.logError ) )
+				.pipe( sass( { outputStyle: 'expanded' } ) )
 				.pipe(
 					prepend.prependText(
 						'/*!\n' + '* Do not modify this file directly.  It is compiled SASS code.\n' + '*/\n'
@@ -171,7 +171,7 @@ gulp.task( 'sass:packages', function() {
 	return (
 		gulp
 			.src( 'packages/**/assets/*.scss', { base: '.' } )
-			.pipe( sass( { outputStyle: 'expanded' } ).on( 'error', sass.logError ) )
+			.pipe( sass( { outputStyle: 'expanded' } ) )
 			.pipe(
 				prepend.prependText(
 					'/*!\n' + '* Do not modify this file directly.  It is compiled SASS code.\n' + '*/\n'


### PR DESCRIPTION
```
[12:44:47] Error in plugin "gulp-sass"
Message:
    modules/calypsoify/style.scss
Error: Undefined variable: "$muriel-gray-50".
        on line 177 of modules/calypsoify/style.scss
>>      border-bottom: 1px solid $muriel-gray-50;
```

Added in #13628 and set to be resolved in #13861. Discovered in #13859. Our `gulp-sass` was logging the error, but not actually throwing one. Updating the script to throw the error. I'm digging through the layers of things (gulp sass is a wrapper to node sass which is a wrapper of...) to figure out if there is a better way, but this resolves it for now and will prevent regressions.

#### Changes proposed in this Pull Request:
* Throws an error (exit code 1) if gulp-sass errors for any reason.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Run `gulp sass:calypsoify` before and after.
*

#### Proposed changelog entry for your changes:
* n/a, already covered.

cc: @gravityrail @dereksmart 
