### PR TITLE
Adds filter capability to the api_url method.

### DIFF
--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -689,7 +689,7 @@ class Manager {
 		/**
 		 * Filters the API URL that Jetpack uses for server communication.
 		 *
-		 * @since 7.9.0
+		 * @since 8.0.0
 		 *
 		 * @param String $url the generated URL.
 		 * @param String $relative_url the relative URL that was passed as an argument.

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -686,7 +686,23 @@ class Manager {
 		$api_base = $api_base ? $api_base : 'https://jetpack.wordpress.com/jetpack.';
 		$version  = $version ? '/' . $version . '/' : '/1/';
 
-		return rtrim( $api_base . $relative_url, '/\\' ) . $version;
+		/**
+		 * Filters the API URL that Jetpack uses for server communication.
+		 *
+		 * @since 7.9.0
+		 *
+		 * @param String $url the generated URL.
+		 * @param String $relative_url the relative URL that was passed as an argument.
+		 * @param String $api_base the API base string that is being used.
+		 * @param String $version the version string that is being used.
+		 */
+		return apply_filters(
+			'jetpack_api_url',
+			rtrim( $api_base . $relative_url, '/\\' ) . $version,
+			$relative_url,
+			$api_base,
+			$version
+		);
 	}
 
 	/**

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -20,10 +20,11 @@ class ManagerTest extends TestCase {
 		$builder = new MockBuilder();
 		$builder->setNamespace( __NAMESPACE__ )
 				->setName( 'apply_filters' )
-				->setFunction( function( $filter_name, $return_value ) {
-					$this->arguments_stack[ $filter_name ] []= $return_value;
-					return $return_value;
-				} );
+				->setFunction(
+					function( $filter_name, $return_value ) {
+						return $return_value;
+					}
+				);
 
 		$this->apply_filters = $builder->build();
 	}
@@ -95,10 +96,12 @@ class ManagerTest extends TestCase {
 		$builder = new MockBuilder();
 		$builder->setNamespace( __NAMESPACE__ )
 				->setName( 'apply_filters' )
-				->setFunction( function( $filter_name, $return_value ) {
-					$this->arguments_stack[ $filter_name ] []= func_get_args();
-					return 'completely overwrite';
-				} );
+				->setFunction(
+					function( $filter_name, $return_value ) {
+						$this->arguments_stack[ $filter_name ] []= func_get_args();
+						return 'completely overwrite';
+					}
+				);
 
 		$builder->build()->enable();
 

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -9,10 +9,23 @@ use PHPUnit\Framework\TestCase;
 use Automattic\Jetpack\Constants;
 
 class ManagerTest extends TestCase {
+
+	protected $arguments_stack = [];
+
 	public function setUp() {
 		$this->manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
 		                      ->setMethods( [ 'get_access_token' ] )
 		                      ->getMock();
+
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+				->setName( 'apply_filters' )
+				->setFunction( function( $filter_name, $return_value ) {
+					$this->arguments_stack[ $filter_name ] []= $return_value;
+					return $return_value;
+				} );
+
+		$this->apply_filters = $builder->build();
 	}
 
 	public function tearDown() {
@@ -48,6 +61,8 @@ class ManagerTest extends TestCase {
 	}
 
 	public function test_api_url_defaults() {
+		$this->apply_filters->enable();
+
 		$this->assertEquals(
 			'https://jetpack.wordpress.com/jetpack.something/1/',
 			$this->manager->api_url( 'something' )
@@ -58,7 +73,9 @@ class ManagerTest extends TestCase {
 		);
 	}
 
-	public function test_api_url_uses_constants() {
+	public function test_api_url_uses_constants_and_filters() {
+		$this->apply_filters->enable();
+
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://example.com/api/base.' );
 		$this->assertEquals(
 			'https://example.com/api/base.something/1/',
@@ -70,6 +87,37 @@ class ManagerTest extends TestCase {
 		$this->assertEquals(
 			'https://example.com/api/another.something/99/',
 			$this->manager->api_url( 'something' )
+		);
+
+		$this->apply_filters->disable();
+
+		// Getting a new special mock just for this occasion.
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+				->setName( 'apply_filters' )
+				->setFunction( function( $filter_name, $return_value ) {
+					$this->arguments_stack[ $filter_name ] []= func_get_args();
+					return 'completely overwrite';
+				} );
+
+		$builder->build()->enable();
+
+		$this->assertEquals(
+			'completely overwrite',
+			$this->manager->api_url( 'something' )
+		);
+
+		// The jetpack_api_url argument stack should not be empty, making sure the filter was
+		// called with a proper name and arguments.
+		$call_arguments = array_pop( $this->arguments_stack[ 'jetpack_api_url' ] );
+		$this->assertEquals( 'something', $call_arguments[2] );
+		$this->assertEquals(
+			Constants::get_constant( 'JETPACK__API_BASE' ),
+			$call_arguments[3]
+		);
+		$this->assertEquals(
+			'/' . Constants::get_constant( 'JETPACK__API_VERSION' ) . '/',
+			$call_arguments[4]
 		);
 	}
 

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -109,7 +109,7 @@ class ManagerTest extends TestCase {
 
 		// The jetpack_api_url argument stack should not be empty, making sure the filter was
 		// called with a proper name and arguments.
-		$call_arguments = array_pop( $this->arguments_stack[ 'jetpack_api_url' ] );
+		$call_arguments = array_pop( $this->arguments_stack['jetpack_api_url'] );
 		$this->assertEquals( 'something', $call_arguments[2] );
 		$this->assertEquals(
 			Constants::get_constant( 'JETPACK__API_BASE' ),

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -74,6 +74,11 @@ class ManagerTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Testing the ability of the api_url method to follow set constants and filters.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::api_url
+	 */
 	public function test_api_url_uses_constants_and_filters() {
 		$this->apply_filters->enable();
 
@@ -98,7 +103,7 @@ class ManagerTest extends TestCase {
 				->setName( 'apply_filters' )
 				->setFunction(
 					function( $filter_name, $return_value ) {
-						$this->arguments_stack[ $filter_name ] []= func_get_args();
+						$this->arguments_stack[ $filter_name ] [] = func_get_args();
 						return 'completely overwrite';
 					}
 				);
@@ -153,6 +158,7 @@ class ManagerTest extends TestCase {
 
 		$this->assertFalse( $this->manager->is_user_connected( 1 ) );
 	}
+
 
 	/**
 	 * @covers Automattic\Jetpack\Connection\Manager::is_user_connected


### PR DESCRIPTION
Before we were relying only on constants to generate the API URL used by the connection package. Future consumers of the package might need to override that URL, so that we introduce the filter here.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new filter to the `api_url` method of the connection manager.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an addition to the code to make the connection package closer to being consumable.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* The unit test basically covers it, but you can test by using the same filter to switch your Jetpack installation to your sandbox using something like this code:
```
add_filter( 'jetpack_api_url', 'jetpack_switch_api_url', 10, 4 );
function jetpack_switch_api_url( $url, $relative_url, $api_base, $version ) {
    return rtrim( 'YOUR_SANDBOX_URL_HERE' . $relative_url, '/\\' ) . $version;
}
```
Before adding this filter you would need to temporarily disable the other sandbox filters you may have enabled.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
