### PR TITLE
Make VaultPress notice dismissable

### DIFF
--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -17,7 +17,24 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 	?>
 	<div class="notice notice-success is-dismissible vp-deactivated">
 		<p style="margin-bottom: 0.25em;"><strong><?php esc_html_e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></strong></p>
-		<p><?php esc_html_e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?></p>
+		<p>
+			<?php esc_html_e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?>
+			<?php
+				echo sprintf(
+					wp_kses(
+						/* Translators: first variable is the URL of the web site without the protocol, e.g. mysite.com */
+						__( 'You can access your backups on your site\'s <a href="https://wordpress.com/activity-log/%s" target="_blank">Activity</a> page.', 'jetpack' ),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
+						)
+					),
+					esc_attr( Jetpack::build_raw_urls( get_home_url() ) )
+				);
+			?>
+		</p>
 	</div>
 	<style>#vp-notice{display:none;}</style>
 	<?php
@@ -29,6 +46,7 @@ function jetpack_vaultpress_rewind_enabled_notice() {
  * @since 5.8
  */
 function jetpack_vaultpress_rewind_check() {
+	add_action( 'admin_notices', 'jetpack_vaultpress_rewind_enabled_notice' );
 	if ( Jetpack::is_active() &&
 		 Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) &&
 		 Jetpack::is_rewind_enabled()

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -16,8 +16,8 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 	}
 	?>
 	<div class="notice notice-success is-dismissible vp-deactivated">
-		<h2 style="margin-bottom: 0.25em;"><?php _e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></h2>
-		<p><?php _e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?></p>
+		<p style="margin-bottom: 0.25em;"><strong><?php esc_html_e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></strong></p>
+		<p><?php esc_html_e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?></p>
 	</div>
 	<style>#vp-notice{display:none;}</style>
 	<?php

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -23,11 +23,12 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 				echo sprintf(
 					wp_kses(
 						/* Translators: first variable is the URL of the web site without the protocol, e.g. mysite.com */
-						__( 'You can access your backups on your site\'s <a href="https://wordpress.com/activity-log/%s" target="_blank">Activity</a> page.', 'jetpack' ),
+						__( 'You can access your backups on your site\'s <a href="https://wordpress.com/activity-log/%s" target="_blank" rel="noopener noreferrer">Activity</a> page.', 'jetpack' ),
 						array(
 							'a' => array(
 								'href'   => array(),
 								'target' => array(),
+								'rel'    => array(),
 							),
 						)
 					),

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -15,7 +15,7 @@ function jetpack_vaultpress_rewind_enabled_notice() {
 		unset( $_GET['activate'] );
 	}
 	?>
-	<div class="notice notice-success vp-deactivated">
+	<div class="notice notice-success is-dismissible vp-deactivated">
 		<h2 style="margin-bottom: 0.25em;"><?php _e( 'Jetpack is now handling your backups.', 'jetpack' ); ?></h2>
 		<p><?php _e( 'VaultPress is no longer needed and has been deactivated.', 'jetpack' ); ?></p>
 	</div>

--- a/3rd-party/vaultpress.php
+++ b/3rd-party/vaultpress.php
@@ -47,7 +47,6 @@ function jetpack_vaultpress_rewind_enabled_notice() {
  * @since 5.8
  */
 function jetpack_vaultpress_rewind_check() {
-	add_action( 'admin_notices', 'jetpack_vaultpress_rewind_enabled_notice' );
 	if ( Jetpack::is_active() &&
 		 Jetpack::is_plugin_active( 'vaultpress/vaultpress.php' ) &&
 		 Jetpack::is_rewind_enabled()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13866

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make VaultPress upgrade notice dismissable, and style more consistent with other notices
* Also updates usage of `_e` to `esc_html_e`

Before:

<img width="521" alt="jetpack-vp-before" src="https://user-images.githubusercontent.com/51896/67713718-98bbfe80-f983-11e9-8819-607144c544b7.png">

After:

<img width="737" alt="backups-activity" src="https://user-images.githubusercontent.com/51896/67718975-23a1f680-f98e-11e9-877e-12060aa654e6.png">

After, in Jetpack dash:

<img width="731" alt="backups-activity-dash" src="https://user-images.githubusercontent.com/51896/67718980-27357d80-f98e-11e9-8734-71029f2e8d1e.png">


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with VaultPress enabled and Rewind available, e.g. on Pressable
* Upgrade to a Premium plan that includes backups
* Visit wp-admin
* VP notice should be dismissable, and should not have a large h2 heading

Alternatively, you can create a micro-plugin which includes just this line of code:

```php
add_action( 'admin_notices', 'jetpack_vaultpress_rewind_enabled_notice' );
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
