### PR TITLE
Admin page: update Anti-spam feature card title in My Plan page

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -278,7 +278,7 @@ class MyPlanBody extends React.Component {
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Spam Filtering' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">{ __( 'Anti-spam' ) }</h3>
 								<p>{ __( 'Spam is automatically blocked from your comments.' ) }</p>
 								{ this.props.isPluginInstalled( 'akismet/akismet.php' ) &&
 								this.props.isPluginActive( 'akismet/akismet.php' ) ? (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Replaces "Spam Filtering" with "Anti-spam" in feature card title in wp-admin Jetpack Dashboard > My Plan page. Fixes #13864  

ref: p1HpG7-7Ro (feature naming alignment)

<img width="1311" alt="Screen Shot 2019-10-28 at 1 37 30 PM" src="https://user-images.githubusercontent.com/204742/67718047-94e4a800-f994-11e9-9120-72f8bf949cbe.png">

#### Testing instructions:
* Check out this branch
* Run yarn build
* On a test site with a paid Jetpack plan, go to `SITE_URL/wp-admin/admin.php?page=jetpack#/my-plan` and see that the feature card title for "Spam Filtering" has changed to "Anti-spam" as in the above screenshot.

#### Proposed changelog entry for your changes:
* None needed