### PR TITLE
Settings: update Anti-spam settings card header

### DIFF
--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -130,7 +130,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Jetpack Anti-spam', { context: 'Settings header' } ) }
+					header={ __( 'Anti-spam', { context: 'Settings header' } ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'wordpress_api_key' ) }
 					feature={ FEATURE_SPAM_AKISMET_PLUS }
 				>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Remove word "Jetpack" from Anti-spam card title in Security settings. Fixes #13863 

ref: p1HpG7-7Ro (feature naming alignment)

<img width="1311" alt="Screen Shot 2019-10-28 at 1 37 09 PM" src="https://user-images.githubusercontent.com/204742/67718725-f6f1dd00-f995-11e9-88c9-1c2c59b1d12d.png">


#### Testing instructions:
* Check out this branch
* Run yarn build
* On a test site with a paid Jetpack plan, go to `SITE_URL/wp-admin/admin.php?page=jetpack#/settings` and see that the feature card title for "Jetpack Anti-spam" has changed to "Anti-spam" as in the above screenshot.

#### Proposed changelog entry for your changes:
* None needed
