### PR TITLE
[WIP] Search: Use Local Data in Dev Mode

### DIFF
--- a/modules/search.php
+++ b/modules/search.php
@@ -6,7 +6,7 @@
  * First Introduced: 5.0
  * Sort Order: 34
  * Free: false
- * Requires Connection: Yes
+ * Requires Connection: No
  * Auto Activate: No
  * Feature: Search
  * Additional Search Queries: search, elastic, elastic search, elasticsearch, fast search, search results, search performance, google search

--- a/modules/search/class.jetpack-search-local-endpoint.php
+++ b/modules/search/class.jetpack-search-local-endpoint.php
@@ -1,0 +1,269 @@
+<?php
+
+class Jetpack_Search_Local_Endpoint {
+	public function register_routes() {
+		register_rest_route(
+			'jetpack/v4',
+			'/search-local',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_request_args(),
+				),
+				'schema' => array( $this, 'get_schema' ),
+			)
+		);
+	}
+
+	public function get_request_args() {
+		return array(
+			'context' => 'view',
+			'size' => array(
+				'type' => 'integer',
+				'minimum' => 1,
+				'maximum' => 20,
+				'default' => 10,
+			),
+			'from' => array(
+				'type' => 'integer',
+				'minimum' => 0,
+				'maximum' => 200,
+				'default' => 0,
+			),
+			'fields' => array(
+				'type' => 'array',
+				'items' => array(
+					'type' => 'string',
+				),
+				'default' => array( 'blog_id', 'post_id' ),
+			),
+			'highlight_fields' => array(
+				'items' => array(
+					'type' => 'string',
+				),
+			),
+			'query' => array(
+				'type' => 'string',
+				'required' => true,
+			),
+			'sort' => array(
+				'type' => 'string',
+				'default' => 'score_default',
+				'enum' => array(
+					'score_default',
+					'date_desc',
+					'date_asc',
+				),
+			),
+			'page_handle' => array(
+				'type' => 'string',
+			),
+		);
+	}
+
+	public function get_schema() {
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'search-local-result',
+			'type'       => 'object',
+			'properties' => array(
+				'aggregations' => array(
+					'type'    => 'array',
+					'context' => array( 'view', 'edit' ),
+				),
+				'corrected_query' => array(
+					'type' => array( 'string', 'boolean' ),
+					'context' => array( 'view', 'edit' ),
+				),
+				'page_handle' => array(
+					'type' => array( 'string', 'boolean' ),
+					'context' => array( 'view', 'edit' ),
+				),
+				'results' => array(
+					'type' => 'array',
+					'items' => array(
+						'type' => 'object',
+						'properties' => array(
+							'fields' => array(
+								'type' => 'object',
+								'properties' => array(
+									'blog_id' => array(
+										'type' => 'integer',
+									),
+									'post_id' => array(
+										'type' => 'integer',
+									),
+									'date' => array(
+										'type' => 'string',
+										'format' => 'date-time',
+									),
+									'post_type' => array(
+										'type' => 'string',
+									),
+									'permalink.url.raw' => array(
+										'type' => 'string',
+									),
+									'has.image' => array(
+										'type' => 'integer',
+									),
+									'category.name.default' => array(
+										'type' => 'string',
+									),
+								),
+							),
+							'highlight' => array(
+								'type' => 'object',
+								'properties' => array(
+									'content' => array(
+										'type' => array(
+											'items' => array(
+												'type' => 'string',
+											),
+										),
+									),
+									'title' => array(
+										'type' => array(
+											'items' => array(
+												'type' => 'string',
+											),
+										),
+									),
+								),
+							),
+							'railcar' => array(
+								'type' => 'object',
+							),
+							'result_type' => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+				'suggestions' => array(
+					'type' => 'array',
+				),
+				'total' => array(
+					'type' => 'integer',
+				),
+			),
+		);
+	}
+
+	public function get_items_permissions_check() {
+		return Jetpack::is_development_mode()
+			? true
+			: new WP_Error(
+				'development_mode_only',
+				__( "This endpoint is meant only for local testing and is only available in Jetpack's Development Mode." ),
+				array(
+					'status' => 400,
+				)
+			);
+	}
+
+	// @todo - page_handle
+	// @todo - search comments
+	public function get_items( $request ) {
+		if ( 'score_default' === $request['sort'] ) {
+			$orderby = 'relevance';
+			$order   = 'DESC';
+		} else {
+			$orderby = 'date';
+			$order   = 'date_desc' === $request['sort'] ? 'DESC' : 'ASC';
+		}
+
+		$post_query = new WP_Query( array(
+			'posts_per_page' => $request['size'],
+			'offset'         => $request['from'],
+			'orderby'        => $orderby,
+			'order'          => $order,
+			's'              => $request['query'],
+
+			'fields' => 'ids',
+		) );
+
+		$terms = preg_split( '/\\s+/', wp_kses( $request['query'], 'strip' ) );
+
+		$term_regex = '/(' . join( '|', array_map( function( $term ) {
+			return preg_quote( $term, '/' );
+		}, $terms ) ) . ')/i';
+
+		$fields = $request['fields'];
+
+		$results = array();
+		foreach ( $post_query->posts as $post_id ) {
+			$result = $this->get_post_result( $post_id, $fields );
+			foreach ( $result['highlight'] as &$highlight ) {
+				foreach ( $highlight as &$text ) {
+					$text = preg_replace( $term_regex, '<mark>\\1</mark>', $text );
+				}
+			}
+
+			$results[] = $result;
+		}
+
+		return array(
+			'results'   => $results,
+			'total'     => (int) $post_query->found_posts,
+
+			// Unsupported
+			'aggregations'    => array(),
+			'corrected_query' => false,
+			'page_handle'     => false,
+			'suggestions'     => array(),
+		);
+	}
+
+	// @todo has.image
+	// @todo _score
+	private function get_post_result( $post_id, $fields ) {
+		$post = get_post( $post_id );
+		$blog_id = get_current_blog_id();
+
+		$return = array(
+			'fields'      => array(),
+			'highlight'   => array(
+				'title' => array(
+					// strip_tags() to remove HTML comments.
+					strip_tags( wp_kses( $post->post_title, 'strip' ) ),
+				),
+				'content' => array(
+					strip_tags( wp_kses( $post->post_content, 'strip' ) ),
+				),
+			),
+			'railcar'     => array(),
+			'result_type' => 'post',
+			'_score'      => 1,
+		);
+
+		foreach ( $fields as $field ) {
+			switch ( $field ) {
+				case 'blog_id' :
+					$return['fields'][ $field ] = (int) $blog_id;
+					break;
+				case 'post_id' :
+					$return['fields'][ $field ] = (int) $post_id;
+					break;
+				case 'date' :
+					$return['fields'][ $field ] = (string) $post->post_date;
+					break;
+				case 'post_type' :
+					$return['fields'][ $field ] = (string) $post->post_type;
+					break;
+				case 'permalink.url.raw' :
+					$return['fields'][ $field ] = (string) get_permalink( $post );
+					break;
+				case 'has.image' :
+					$return['fields'][ $field ] = (int) 0;
+					break;
+				case 'category.name.default' :
+					$return['fields'][ $field ] = (string) get_the_category( $post )[0]->name;
+					break;
+			}
+		}
+
+		return $return;
+	}
+}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -153,7 +153,12 @@ class Jetpack_Search {
 	 * @since 5.0.0
 	 */
 	public function setup() {
-		if ( ! Jetpack::is_active() || ! Jetpack_Plan::supports( 'search' ) ) {
+		if ( Jetpack::is_development_mode() ) {
+			require_once __DIR__ . '/class.jetpack-search-local-endpoint.php';
+
+			$jetpack_search_local_endpoint = new Jetpack_Search_Local_Endpoint();
+			add_action( 'rest_api_init', array( $jetpack_search_local_endpoint, 'register_routes' ) );
+		} elseif ( ! Jetpack::is_active() || ! Jetpack_Plan::supports( 'search' ) ) {
 			/**
 			 * Fires when the Jetpack Search fails and would fallback to MySQL.
 			 *

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -69,9 +69,9 @@ class SearchApp extends Component {
 	prepareDomForMounting() {
 		// Clean up the page prior to mounting component
 		hideElements( this.props.themeOptions.elementSelectors );
-		document
-			.querySelectorAll( '.jetpack-instant-search-wrapper' )
-			.forEach( widget => removeChildren( widget ) );
+		//		document
+		//			.querySelectorAll( '.jetpack-instant-search-wrapper' )
+		//			.forEach( widget => removeChildren( widget ) );
 		document
 			.querySelectorAll( this.props.themeOptions.searchFormSelector )
 			.forEach( searchForm => removeChildren( searchForm ) );

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -149,8 +149,12 @@ export function search( { aggregations, filter, pageHandle, query, resultFormat,
 		} )
 	);
 
+	const remoteURL = `https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?${ queryString }`;
+	const localURL = `/?rest_route=/jetpack/v4/search-local&${ queryString }`;
+
 	return fetch(
-		`https://public-api.wordpress.com/rest/v1.3/sites/${ siteId }/search?${ queryString }`
+		// @todo - send is_dev_mode to JS.
+		document.location.origin.includes( '.' ) ? remoteURL : localURL
 	).then( response => {
 		return response.json();
 	} );

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -268,19 +268,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 		$display_filters = false;
 
-		if ( Jetpack::is_development_mode() ) {
-			echo $args['before_widget'];
-			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
-				<div class="jetpack-search-sort-wrapper">
-					<label>
-						<?php esc_html_e( 'Jetpack Search not supported in Development Mode', 'jetpack' ); ?>
-					</label>
-				</div>
-			</div><?php
-			echo $args['after_widget'];
-			return;
-		}
-
 		if ( is_search() ) {
 			if ( Jetpack_Search_Helpers::should_rerun_search_in_customizer_preview() ) {
 				Jetpack_Search::instance()->update_search_results_aggregations();


### PR DESCRIPTION
See #385, #13837

#### Changes proposed in this Pull Request:

When in dev mode, uses direct `WP_Query` data for Search.

* [ ] Instant search
* [ ] "Normal" search results

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No: enhancement.

#### Testing instructions:

Work in progress :) This PR currently only changes the behavior of the instant search widget, which is shipped only behind the `JETPACK_SEARCH_PROTOTYPE` constant.

#### Proposed changelog entry for your changes:
* Allow the Jetpack Search feature to be activated in development mode.