### PR TITLE
Instant Search: add label and button to search box

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -7,7 +7,7 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
-import uniqueId from 'lodash/uniqueid';
+import uniqueId from 'lodash/uniqueId';
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jp-instant-search__box-input-' ) );

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -3,28 +3,34 @@
 /**
  * External dependencies
  */
-import { h, Component } from 'preact';
+import { h } from 'preact';
+import { useState } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line lodash/import-scope
+import uniqueId from 'lodash/uniqueid';
 
-class SearchBox extends Component {
-	render() {
-		return (
-			<div className={ 'jp-instant-search__box' }>
-				{ /* TODO: Add support for preserving label text */ }
-				<span className="screen-reader-text">{ __( 'Search', 'jetpack' ) }</span>
-				<input
-					className="search-field jp-instant-search__box-input"
-					onInput={ this.props.onChangeQuery }
-					onFocus={ this.props.onFocus }
-					onBlur={ this.props.onBlur }
-					ref={ this.props.appRef }
-					placeholder={ __( 'Search…', 'jetpack' ) }
-					type="search"
-					value={ this.props.query }
-				/>
-			</div>
-		);
-	}
-}
+const SearchBox = props => {
+	const [ inputId ] = useState( () => uniqueId( 'jp-instant-search__box-input-' ) );
+	return (
+		<div className={ 'jp-instant-search__box' }>
+			{ /* TODO: Add support for preserving label text */ }
+			<label htmlFor={ inputId } className="screen-reader-text">
+				{ __( 'Site Search', 'jetpack' ) }
+			</label>
+			<input
+				id={ inputId }
+				className="search-field jp-instant-search__box-input"
+				onInput={ props.onChangeQuery }
+				onFocus={ props.onFocus }
+				onBlur={ props.onBlur }
+				ref={ props.appRef }
+				placeholder={ __( 'Search…', 'jetpack' ) }
+				type="search"
+				value={ props.query }
+			/>
+			<button className="screen-reader-text">{ __( 'Search', 'jetpack' ) }</button>
+		</div>
+	);
+};
 
 export default SearchBox;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This is part of our Instant Search a11y improvements outlined in https://github.com/Automattic/jetpack/issues/13817.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds a `label` and `button` to the markup for the search box.

I've also converted `SearchBox` to be a functional component. We're using a hook to generate a unique ID for the input box, as described here: https://stackoverflow.com/a/55505554

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It's an improvement to a prototype feature which has not yet been released as part of Jetpack.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow instructions in #13761 to get search running
* Try entering a search URL like /?s=yes&blog_id=20115252
* Inspect the markup of the search box and ensure that the label and button are present

<img width="935" alt="Screen Shot 2019-10-29 at 17 04 44" src="https://user-images.githubusercontent.com/17325/67736914-3d1a6f80-fa6e-11e9-890f-d8a94900d8ed.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog required.
