### PR TITLE
PHPCS: Rest of the packages

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,4 +47,5 @@
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/packages/analyzer*</exclude-pattern>
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -47,5 +47,4 @@
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
-	<exclude-pattern>/packages/analyzer*</exclude-pattern>
 </ruleset>

--- a/packages/analyzer/data/example-external.php
+++ b/packages/analyzer/data/example-external.php
@@ -1,20 +1,21 @@
 <?php
-
 /**
- * This file is not meant to be run. It is used as example input to the compatibility checker script
+ * This file is not meant to be run. It is used as example input to the compatibility checker script.
+ *
+ * @package automattic/jetpack-analyzer
  */
 
-// valid signature initialization with missing class
+// valid signature initialization with missing class.
 $sig = new Jetpack_Signature( 'abcd1234', 12345 );
 
-// static method
+// static method.
 Jetpack_Tracks_Client::record_event( array( '_en' => 'jetpack_sample_event' ) );
 
-// assignment from static prop
+// assignment from static prop.
 $product_name = \JetpackTracking::$product_name;
 
-// assignment to static prop
+// assignment to static prop.
 \Jetpack_Sync_Defaults::$default_options_whitelist = array( 'a', 'b', 'c' );
 
-// use removed function
-$id = jetpack_shortcode_get_videopress_id( array( 'foo' => 'bar' ) );
+// use removed function.
+$id = jetpack_shortcode_get_videopress_id( array( 'foo' => 'bar' ) ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/packages/analyzer/scripts/example.php
+++ b/packages/analyzer/scripts/example.php
@@ -1,34 +1,53 @@
 <?php
+/**
+ * Example usage script.
+ *
+ * @package automattic/jetpack-anaylizer
+ */
+
+/**
+ * This script is meant to run outside of typical WordPress environments and only by knowledgeable folks.
+ * Disabling some phpcs scripts:
+ *
+ * phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ * phpcs:disable Squiz.PHP.CommentedOutCode.Found
+ */
 
 require dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
 
 $base_path          = dirname( dirname( dirname( __DIR__ ) ) );
 $external_base_path = dirname( __DIR__ ) . '/data';
 
-// a place for exported data
-$data_path = '/Users/dan/Downloads/';
+// a place for exported data.
+$data_path = '/Users/dan/Downloads/'; // Obviously, update this!
 
-// analyze a single file
-// echo "*** File declarations\n";
-// $file_declarations = new Automattic\Jetpack\Analyzer\Declarations();
-// $file_declarations->scan( $base_path . '/class.jetpack.php' );
-// $file_declarations->output();
+/**
+ * Analyze a single file.
+ *
+ * Run the following: *
+ * echo "*** File declarations\n";
+ * $file_declarations = new Automattic\Jetpack\Analyzer\Declarations();
+ * $file_declarations->scan( $base_path . '/class.jetpack.php' );
+ * $file_declarations->output();
+ */
 
-// scan a whole directory
+// scan a whole directory.
 echo "*** Find Jetpack master declarations\n";
 $dir_declarations = new Automattic\Jetpack\Analyzer\Declarations();
 $jetpack_exclude  = array( '.git', 'vendor', 'tests', 'docker', 'bin', 'scss', 'images', 'docs', 'languages', 'node_modules' );
 $dir_declarations->scan( $base_path, $jetpack_exclude );
 $dir_declarations->save( $data_path . 'master.csv' );
-// $dir_declarations->output();
+// $dir_declarations->output(); // .
 
-// test loading the output into another analyzer
+// test loading the output into another analyzer.
 echo "*** Load Jetpack master declarations\n";
 $master_declarations = new Automattic\Jetpack\Analyzer\Declarations();
 $master_declarations->load( $data_path . 'master.csv' );
-// $master_declarations->output();
+// $master_declarations->output(); // .
 
-// analyze a separate code base
+// analyze a separate code base.
 $jp74_base_path = '/Users/dan/Downloads/jetpack';
 echo "*** Find Jetpack 7.4 declarations\n";
 $jp74_declarations = new Automattic\Jetpack\Analyzer\Declarations();
@@ -36,24 +55,24 @@ $jp74_declarations->scan( $jp74_base_path, $jetpack_exclude );
 $jp74_declarations->save( $data_path . 'jp74.csv' );
 $jp74_declarations = new Automattic\Jetpack\Analyzer\Declarations();
 $jp74_declarations->load( $data_path . 'jp74.csv' );
-// $jp74_declarations->output();
+// $jp74_declarations->output(); // .
 
 echo "*** Finding differences between the two versions\n";
 $differences = new Automattic\Jetpack\Analyzer\Differences();
 $differences->find( $master_declarations, $jp74_declarations, $base_path );
 
-// $differences->output();
-// $differences->save( $data_path . 'differences.csv' );
+// $differences->output(); // .
+// $differences->save( $data_path . 'differences.csv' ); // .
 
 echo "*** Checking compatibility of single external file\n";
 $invocations = new Automattic\Jetpack\Analyzer\Invocations();
 $invocations->scan( $external_base_path . '/example-external.php' );
-// $invocations->scan( '/Users/dan/workspace/a8c/some-repo', array( '.git', '.gitmodules', 'assets' ) );
-// $invocations->output();
+// $invocations->scan( '/Users/dan/workspace/a8c/some-repo', array( '.git', '.gitmodules', 'assets' ) ); // .
+// $invocations->output(); // .
 
 echo "\n*** List of dependencies\n";
 $dependencies = new Automattic\Jetpack\Analyzer\Dependencies();
-$dependencies->generate( $invocations, $jp74_declarations, $repo_path );
+$dependencies->generate( $invocations, $jp74_declarations, $data_path );
 $dependencies->output();
 
 echo "\n*** Summary of dependencies by declaration\n";
@@ -72,3 +91,5 @@ echo "*** Summary of issues and counts\n";
 echo $warnings->summary() . "\n";
 
 echo "*** Done\n";
+
+// phpcs:enable

--- a/packages/analyzer/scripts/example.php
+++ b/packages/analyzer/scripts/example.php
@@ -2,7 +2,7 @@
 /**
  * Example usage script.
  *
- * @package automattic/jetpack-anaylizer
+ * @package automattic/jetpack-analyzer
  */
 
 /**
@@ -72,7 +72,7 @@ $invocations->scan( $external_base_path . '/example-external.php' );
 
 echo "\n*** List of dependencies\n";
 $dependencies = new Automattic\Jetpack\Analyzer\Dependencies();
-$dependencies->generate( $invocations, $jp74_declarations, $data_path );
+$dependencies->generate( $invocations, $jp74_declarations, $base_path );
 $dependencies->output();
 
 echo "\n*** Summary of dependencies by declaration\n";

--- a/packages/analyzer/scripts/jetpack-example.php
+++ b/packages/analyzer/scripts/jetpack-example.php
@@ -2,7 +2,7 @@
 /**
  * Example usage script.
  *
- * @package automattic/jetpack-anaylzer
+ * @package automattic/jetpack-analyzer
  */
 
 /**

--- a/packages/analyzer/scripts/jetpack-example.php
+++ b/packages/analyzer/scripts/jetpack-example.php
@@ -1,4 +1,18 @@
 <?php
+/**
+ * Example usage script.
+ *
+ * @package automattic/jetpack-anaylzer
+ */
+
+/**
+ * This script is meant to run outside of typical WordPress environments and only by knowledgeable folks.
+ * Disabling some phpcs scripts:
+ *
+ * phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ */
 
 require dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
 
@@ -29,3 +43,5 @@ echo "Generate warnings\n";
 $warnings = new Automattic\Jetpack\Analyzer\Warnings();
 $warnings->generate( $invocations, $differences );
 $warnings->output();
+
+// phpcs:enable

--- a/packages/analyzer/scripts/jetpack-svn.php
+++ b/packages/analyzer/scripts/jetpack-svn.php
@@ -10,7 +10,7 @@
  *
  * `php jetpack-svn.php path/to/your/plugin/code`
  *
- * @package automattic/jetpack-anaylzer
+ * @package automattic/jetpack-analyzer
  */
 
 /**

--- a/packages/analyzer/scripts/jetpack-svn.php
+++ b/packages/analyzer/scripts/jetpack-svn.php
@@ -9,13 +9,23 @@
  * two are optional, and probably a bit gratuitous :)
  *
  * `php jetpack-svn.php path/to/your/plugin/code`
+ *
+ * @package automattic/jetpack-anaylzer
  */
 
+/**
+ * This script is meant to run outside of typical WordPress environments and only by knowledgeable folks.
+ * Disabling some phpcs scripts:
+ *
+ * phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ */
 require dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
 
-// Args
+// Args.
 $external_repo_path = isset( $argv[1] ) ? $argv[1] : '/path/to/workspace/a8c/some-repo';
-$from_version       = isset( $argv[2] ) ? $argv[2] : ''; // Defaults to latest stable version in wp.org svn
+$from_version       = isset( $argv[2] ) ? $argv[2] : ''; // Defaults to latest stable version in wp.org svn.
 $to_version         = isset( $argv[3] ) ? $argv[3] : 'trunk';
 
 if ( ! file_exists( $external_repo_path ) ) {
@@ -23,18 +33,18 @@ if ( ! file_exists( $external_repo_path ) ) {
 	exit;
 }
 
-// tmp paths
+// tmp paths.
 $tmp_path             = dirname( __DIR__ ) . '/data/tmp';
 $to_path              = $tmp_path . '/jetpack-to';
 $from_path            = $tmp_path . '/jetpack-from';
 $jetpack_version_to   = "$to_path/jetpack";
 $jetpack_version_from = "$from_path/jetpack";
 
-// Make tmp directories
+// Make tmp directories.
 exec( "mkdir -p $tmp_path $to_path $from_path" );
 
 if ( empty( $from_version ) ) {
-	// Get latest stable version in svn
+	// Get latest stable version in svn.
 	$jetpack_info = json_decode( file_get_contents( 'https://api.wordpress.org/plugins/info/1.0/jetpack.json' ) );
 	$org_versions = array_reverse( (array) $jetpack_info->versions );
 	foreach ( $org_versions as $version => $zip_path ) {
@@ -45,13 +55,13 @@ if ( empty( $from_version ) ) {
 	}
 }
 
-// Download and unzip "from" version
+// Download and unzip "from" version.
 if ( ! file_exists( $jetpack_version_from ) ) {
 	echo "Downloading {$org_versions[ $from_version ]} to $jetpack_version_from...\n";
 	exec( "wget -O $from_path/$from_version.zip {$org_versions[ $from_version ]}; unzip $from_path/$from_version.zip -d $from_path; rm $from_path/$from_version.zip" );
 }
 
-// Download and unzip "to" version
+// Download and unzip "to" version.
 if ( ! file_exists( $jetpack_version_to ) ) {
 	echo "Downloading {$org_versions[ $to_version ]} to $jetpack_version_to...\n";
 	exec( "wget -O $to_path/$to_version.zip {$org_versions[ $to_version ]}; unzip $to_path/$to_version.zip -d $to_path; rm $to_path/$to_version.zip" );
@@ -84,3 +94,5 @@ echo "Done!\n";
 
 echo "Cleaning up...\n";
 exec( "rm -rf $tmp_path" );
+
+// phpcs:enable

--- a/packages/analyzer/src/Dependencies.php
+++ b/packages/analyzer/src/Dependencies.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * This collects dependencies of invocations in Codebase A to declarations in codebase B.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer;
 
@@ -6,13 +11,21 @@ namespace Automattic\Jetpack\Analyzer;
  * This collects dependencies of invocations in Codebase A to declarations in codebase B
  */
 class Dependencies extends PersistentList {
-	function generate( $invocations, $declarations, $invocation_root = null ) {
+	/**
+	 * Generates items for PersistentList
+	 *
+	 * @param object $invocations The invocation.
+	 * @param object $declarations Declaration.
+	 * @param null   $invocation_root Invocation root name.
+	 * @throws \Exception If unable to add declaration.
+	 */
+	public function generate( $invocations, $declarations, $invocation_root = null ) {
 		if ( $invocation_root ) {
 			$invocation_root = $this->slashit( $invocation_root );
 		}
 
 		/**
-		 * Scan every invocation to see if it depends on a declaration
+		 * Scan every invocation to see if it depends on a declaration.
 		 */
 		foreach ( $invocations->get() as $invocation ) {
 			foreach ( $declarations->get() as $declaration ) {
@@ -23,17 +36,28 @@ class Dependencies extends PersistentList {
 		}
 	}
 
+	/**
+	 * Adds a slash to the end of the $path
+	 *
+	 * @param string $path Path to slash.
+	 * @return string Slashed path.
+	 */
 	private function slashit( $path ) {
-		$path .= ( substr( $path, -1 ) == '/' ? '' : '/' );
+		$path .= ( substr( $path, -1 ) === '/' ? '' : '/' );
 		return $path;
 	}
 
+	/**
+	 * Returns summary of declarations.
+	 *
+	 * @return string
+	 */
 	public function declaration_summary() {
 		if ( $this->count() === 0 ) {
 			return '';
 		}
 
-		// assoc array of declarations and counts
+		// assoc array of declarations and counts.
 		$summary = array();
 		foreach ( $this->get() as $dependency ) {
 			$unique_issue_key = $dependency->declaration->display_name();
@@ -55,12 +79,17 @@ class Dependencies extends PersistentList {
 		return $summary_string;
 	}
 
+	/**
+	 * Returns summary of external files involved.
+	 *
+	 * @return string
+	 */
 	public function external_file_summary() {
 		if ( $this->count() === 0 ) {
 			return '';
 		}
 
-		// assoc array of files and counts
+		// assoc array of files and counts.
 		$summary = array();
 		foreach ( $this->get() as $dependency ) {
 			$unique_issue_key = $dependency->full_path();

--- a/packages/analyzer/src/Differences/Class_Const_Missing.php
+++ b/packages/analyzer/src/Differences/Class_Const_Missing.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class Constant Missing
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,14 +11,32 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Const;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Const_Missing
+ */
 class Class_Const_Missing extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Declaration.
+	 *
+	 * @var object
+	 */
 	public $declaration;
 
-	function __construct( $declaration ) {
+	/**
+	 * Class_Const_Missing constructor.
+	 *
+	 * @param object $declaration The declaration.
+	 */
+	public function __construct( $declaration ) {
 		$this->declaration = $declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->declaration->path,
@@ -22,10 +45,21 @@ class Class_Const_Missing extends PersistentListItem implements Invocation_Warne
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'class_cont_missing'
+	 */
 	public function type() {
 		return 'class_const_missing';
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation instanceof Static_Const ) {
 			if ( $invocation->class_name === $this->declaration->class_name

--- a/packages/analyzer/src/Differences/Class_Const_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Const_Moved.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class_Const_Moved.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,16 +11,42 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Const;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Const_Moved
+ */
 class Class_Const_Moved extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
 	public $old_declaration;
+
+	/**
+	 * New declaration.
+	 *
+	 * @var object
+	 */
 	public $new_declaration;
 
-	function __construct( $old_declaration, $new_declaration ) {
+	/**
+	 * Class_Const_Moved constructor.
+	 *
+	 * @param object $old_declaration Old declaration.
+	 * @param object $new_declaration New declaration.
+	 */
+	public function __construct( $old_declaration, $new_declaration ) {
 		$this->old_declaration = $old_declaration;
 		$this->new_declaration = $new_declaration;
 	}
 
-	function to_csv_array() {
+
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->old_declaration->path,
@@ -24,13 +55,24 @@ class Class_Const_Moved extends PersistentListItem implements Invocation_Warner 
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'property_moved'
+	 */
 	public function type() {
 		return 'property_moved';
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation instanceof Static_Const ) {
-			// check if it's using this missing property
+			// check if it's using this missing property.
 			if ( $invocation->class_name === $this->old_declaration->class_name
 				&& $invocation->const_name === $this->old_declaration->const_name ) {
 				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class const ' . $this->old_declaration->display_name() . ' was moved from ' . $this->old_declaration->path . ' to ' . $this->new_declaration->path, $this->old_declaration ) );

--- a/packages/analyzer/src/Differences/Class_Method_Missing.php
+++ b/packages/analyzer/src/Differences/Class_Method_Missing.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class Method Missing Warner.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,14 +11,32 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Method_Missing
+ */
 class Class_Method_Missing extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Declaration.
+	 *
+	 * @var object
+	 */
 	public $declaration;
 
-	function __construct( $declaration ) {
+	/**
+	 * Class_Method_Missing constructor.
+	 *
+	 * @param object $declaration Declaration.
+	 */
+	public function __construct( $declaration ) {
 		$this->declaration = $declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->declaration->path,
@@ -22,17 +45,33 @@ class Class_Method_Missing extends PersistentListItem implements Invocation_Warn
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'method_missing'
+	 */
 	public function type() {
 		return 'method_missing';
 	}
 
+	/**
+	 * Returns display name.
+	 *
+	 * @return mixed
+	 */
 	public function display_name() {
 		return $this->declaration->display_name();
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation instanceof Static_Call ) {
-			// check if it's instantiating this missing class
+			// check if it's instantiating this missing class.
 			if ( $invocation->class_name === $this->declaration->class_name
 				&& $invocation->method_name === $this->declaration->method_name
 				&& $this->declaration->static ) {

--- a/packages/analyzer/src/Differences/Class_Method_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Method_Moved.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class Method Moved checker.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,16 +11,40 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Method_Moved
+ */
 class Class_Method_Moved extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
 	public $old_declaration;
+	/**
+	 * New declaration.
+	 *
+	 * @var object
+	 */
 	public $new_declaration;
 
-	function __construct( $old_declaration, $new_declaration ) {
+	/**
+	 * Class_Method_Moved constructor.
+	 *
+	 * @param object $old_declaration Old declaration.
+	 * @param object $new_declaration New declaration.
+	 */
+	public function __construct( $old_declaration, $new_declaration ) {
 		$this->old_declaration = $old_declaration;
 		$this->new_declaration = $new_declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->old_declaration->path,
@@ -24,14 +53,30 @@ class Class_Method_Moved extends PersistentListItem implements Invocation_Warner
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'method_moved'
+	 */
 	public function type() {
 		return 'method_moved';
 	}
 
+	/**
+	 * Display name of issue.
+	 *
+	 * @return string
+	 */
 	public function display_name() {
 		return $this->old_declaration->display_name();
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(

--- a/packages/analyzer/src/Differences/Class_Missing.php
+++ b/packages/analyzer/src/Differences/Class_Missing.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class missing checker.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,14 +11,32 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\New_;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Missing
+ */
 class Class_Missing extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Declaration.
+	 *
+	 * @var object
+	 */
 	public $declaration;
 
-	function __construct( $declaration ) {
+	/**
+	 * Class_Missing constructor.
+	 *
+	 * @param object $declaration Declaration.
+	 */
+	public function __construct( $declaration ) {
 		$this->declaration = $declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->declaration->path,
@@ -22,14 +45,24 @@ class Class_Missing extends PersistentListItem implements Invocation_Warner {
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'class_missing'
+	 */
 	public function type() {
 		return 'class_missing';
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation instanceof New_ ) {
-			// check if it's instantiating this missing class
-			// echo "Checking " . $invocation->class_name . " matches " . $this->declaration->class_name . "\n";
+			// check if it's instantiating this missing class.
 			if ( $invocation->class_name === $this->declaration->class_name ) {
 				$warnings->add( new Warning( $this->type(), $invocation->path, $invocation->line, 'Class ' . $this->declaration->display_name() . ' is missing', $this->declaration ) );
 			}

--- a/packages/analyzer/src/Differences/Class_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Moved.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class_Moved.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,16 +11,40 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\New_;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Moved.
+ */
 class Class_Moved extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
 	public $old_declaration;
+	/**
+	 * New declaration.
+	 *
+	 * @var object
+	 */
 	public $new_declaration;
 
-	function __construct( $old_declaration, $new_declaration ) {
+	/**
+	 * Class_Moved constructor.
+	 *
+	 * @param object $old_declaration Old declaration.
+	 * @param object $new_declaration New declaration.
+	 */
+	public function __construct( $old_declaration, $new_declaration ) {
 		$this->old_declaration = $old_declaration;
 		$this->new_declaration = $new_declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->old_declaration->path,
@@ -24,10 +53,21 @@ class Class_Moved extends PersistentListItem implements Invocation_Warner {
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'class_moved'
+	 */
 	public function type() {
 		return 'class_moved';
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(

--- a/packages/analyzer/src/Differences/Class_Property_Missing.php
+++ b/packages/analyzer/src/Differences/Class_Property_Missing.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class Property Missing check.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,14 +11,32 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Property;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Property_Missing
+ */
 class Class_Property_Missing extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Declaration.
+	 *
+	 * @var object
+	 */
 	public $declaration;
 
-	function __construct( $declaration ) {
+	/**
+	 * Class_Property_Missing constructor.
+	 *
+	 * @param object $declaration Declaration.
+	 */
+	public function __construct( $declaration ) {
 		$this->declaration = $declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->declaration->path,
@@ -22,10 +45,21 @@ class Class_Property_Missing extends PersistentListItem implements Invocation_Wa
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'property_missing'
+	 */
 	public function type() {
 		return 'property_missing';
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->declaration ) ) {
 			$warnings->add(

--- a/packages/analyzer/src/Differences/Class_Property_Moved.php
+++ b/packages/analyzer/src/Differences/Class_Property_Moved.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Class propery moved checker.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,16 +11,40 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Static_Property;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Class_Property_Moved
+ */
 class Class_Property_Moved extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
 	public $old_declaration;
+	/**
+	 * New declaration.
+	 *
+	 * @var object
+	 */
 	public $new_declaration;
 
-	function __construct( $old_declaration, $new_declaration ) {
+	/**
+	 * Class_Property_Moved constructor.
+	 *
+	 * @param object $old_declaration Old declaration.
+	 * @param object $new_declaration New declaration.
+	 */
+	public function __construct( $old_declaration, $new_declaration ) {
 		$this->old_declaration = $old_declaration;
 		$this->new_declaration = $new_declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->old_declaration->path,
@@ -24,10 +53,21 @@ class Class_Property_Moved extends PersistentListItem implements Invocation_Warn
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'property_missing'
+	 */
 	public function type() {
 		return 'property_moved';
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(

--- a/packages/analyzer/src/Differences/Function_Missing.php
+++ b/packages/analyzer/src/Differences/Function_Missing.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Function Missing checker
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,14 +11,32 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Function_Call;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Function_Missing
+ */
 class Function_Missing extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Declaration.
+	 *
+	 * @var object
+	 */
 	public $declaration;
 
-	function __construct( $declaration ) {
+	/**
+	 * Function_Missing constructor.
+	 *
+	 * @param object $declaration Declaration.
+	 */
+	public function __construct( $declaration ) {
 		$this->declaration = $declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->declaration->path,
@@ -22,14 +45,28 @@ class Function_Missing extends PersistentListItem implements Invocation_Warner {
 		);
 	}
 
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'function_missing'
+	 */
 	public function type() {
 		return 'function_missing';
 	}
 
+	/**
+	 * Returns the display name for the issue.
+	 */
 	public function display_name() {
 		return $this->declaration->display_name();
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->declaration ) ) {
 			$warnings->add(

--- a/packages/analyzer/src/Differences/Function_Moved.php
+++ b/packages/analyzer/src/Differences/Function_Moved.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Function Moved Checker.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
@@ -6,16 +11,41 @@ use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 use Automattic\Jetpack\Analyzer\Invocations\Function_Call;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
+/**
+ * Class Function_Moved
+ */
 class Function_Moved extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
 	public $old_declaration;
+
+	/**
+	 * New declaration.
+	 *
+	 * @var object
+	 */
 	public $new_declaration;
 
-	function __construct( $old_declaration, $new_declaration ) {
+	/**
+	 * Function_Moved constructor.
+	 *
+	 * @param object $old_declaration Old declaration.
+	 * @param object $new_declaration New declaration.
+	 */
+	public function __construct( $old_declaration, $new_declaration ) {
 		$this->old_declaration = $old_declaration;
 		$this->new_declaration = $new_declaration;
 	}
 
-	function to_csv_array() {
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type(),
 			$this->old_declaration->path,
@@ -24,14 +54,30 @@ class Function_Moved extends PersistentListItem implements Invocation_Warner {
 		);
 	}
 
+	/**
+	 * Returns type of issue discovered.
+	 *
+	 * @return string 'function_moved'
+	 */
 	public function type() {
 		return 'function_moved';
 	}
 
+	/**
+	 * Returns the display name of the issue.
+	 *
+	 * @return mixed
+	 */
 	public function display_name() {
 		return $this->old_declaration->display_name();
 	}
 
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(

--- a/packages/analyzer/src/Differences/Invocation_Warner.php
+++ b/packages/analyzer/src/Differences/Invocation_Warner.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * Invocation Warning interface
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Differences;
 
 interface Invocation_Warner {
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
 	public function find_invocation_warnings( $invocation, $warnings );
 }

--- a/packages/analyzer/src/PersistentList/Item.php
+++ b/packages/analyzer/src/PersistentList/Item.php
@@ -1,7 +1,20 @@
 <?php
+/**
+ * PersistentList Item abstract.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\PersistentList;
 
+/**
+ * Class Item
+ */
 abstract class Item {
-	abstract function to_csv_array();
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	abstract public function to_csv_array();
 }

--- a/packages/analyzer/src/Warnings.php
+++ b/packages/analyzer/src/Warnings.php
@@ -1,26 +1,44 @@
 <?php
+/**
+ * Warnings class.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer;
 
+/**
+ * Class Warnings
+ */
 class Warnings extends PersistentList {
+	/**
+	 * Generates if a invocation is due to a difference.
+	 *
+	 * @param object $invocations The invocations.
+	 * @param object $differences The differences.
+	 */
 	public function generate( $invocations, $differences ) {
 		/**
-		 * Scan every invocation to see if it depends on a Difference
+		 * Scan every invocation to see if it depends on a Difference.
 		 */
 		foreach ( $invocations->get() as $invocation ) {
 			foreach ( $differences->get() as $difference ) {
-				// $warning = $
 				$difference->find_invocation_warnings( $invocation, $this );
 			}
 		}
 	}
 
+	/**
+	 * Summary of Warnings by count.
+	 *
+	 * @return string
+	 */
 	public function summary() {
 		if ( $this->count() === 0 ) {
 			return '';
 		}
 
-		// assoc array of issues and counts
+		// assoc array of issues and counts.
 		$summary = array();
 		foreach ( $this->get() as $warning ) {
 			$unique_issue_key = $warning->unique_issue_key();

--- a/packages/analyzer/src/Warnings/Warning.php
+++ b/packages/analyzer/src/Warnings/Warning.php
@@ -1,17 +1,63 @@
 <?php
+/**
+ * Warnings processing of Persistent List items.
+ *
+ * @package automattic/jetpack-analyzer
+ */
 
 namespace Automattic\Jetpack\Analyzer\Warnings;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
 
+/**
+ * Class Warning
+ */
 class Warning extends PersistentListItem {
+	/**
+	 * Type.
+	 *
+	 * @var string
+	 */
 	public $type;
+
+	/**
+	 * Path.
+	 *
+	 * @var string
+	 */
 	public $path;
+
+	/**
+	 * Line.
+	 *
+	 * @var string
+	 */
 	public $line;
+
+	/**
+	 * Message.
+	 *
+	 * @var string
+	 */
 	public $message;
+
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
 	public $old_declaration;
 
-	function __construct( $type, $path, $line, $message, $old_declaration ) {
+	/**
+	 * Warning constructor.
+	 *
+	 * @param string $type Type.
+	 * @param string $path Path.
+	 * @param string $line Line.
+	 * @param string $message Message.
+	 * @param object $old_declaration Previous declaration.
+	 */
+	public function __construct( $type, $path, $line, $message, $old_declaration ) {
 		$this->type            = $type;
 		$this->path            = $path;
 		$this->line            = $line;
@@ -22,11 +68,16 @@ class Warning extends PersistentListItem {
 	/**
 	 * This key is used to identify unique issues (e.g. Jetpack_Options has moved) across multiple invocations
 	 */
-	function unique_issue_key() {
+	public function unique_issue_key() {
 		return $this->type . ',' . $this->old_declaration->path . ',' . $this->old_declaration->line . ',' . $this->old_declaration->display_name();
 	}
 
-	function to_csv_array() {
+	/**
+	 * Returns an array of the Warnings item.
+	 *
+	 * @return array Array of CSV items.
+	 */
+	public function to_csv_array() {
 		return array(
 			$this->type,
 			$this->path,

--- a/packages/compat/legacy/class.jetpack-client.php
+++ b/packages/compat/legacy/class.jetpack-client.php
@@ -65,7 +65,7 @@ class Jetpack_Client {
 
 	/**
 	 * Wrapper for wp_remote_request().  Turns off SSL verification for certain SSL errors.
-	 * This is lame, but many, many, many hosts have misconfigured SSL.
+	 * This is suboptimal, but many, many, many hosts have misconfigured SSL.
 	 *
 	 * @deprecated use Automattic\Jetpack\Connection\Client::_wp_remote_request
 	 *
@@ -83,7 +83,7 @@ class Jetpack_Client {
 	 * @param Boolean $set_fallback whether to allow flagging this request to use a fallback certficate override.
 	 * @return array|WP_Error WP HTTP response on success
 	 */
-	public static function _wp_remote_request( $url, $args, $set_fallback = false ) {
+	public static function _wp_remote_request( $url, $args, $set_fallback = false ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Connection\Client' );
 		return Client::_wp_remote_request( $url, $args, $set_fallback );
 	}

--- a/packages/compat/legacy/class.jetpack-sync-settings.php
+++ b/packages/compat/legacy/class.jetpack-sync-settings.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Legacy/deprecated Sync Setting getter and setter.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 use Automattic\Jetpack\Sync\Settings;
 
@@ -9,92 +14,215 @@ use Automattic\Jetpack\Sync\Settings;
  */
 class Jetpack_Sync_Settings {
 
-	static function get_settings() {
+	/**
+	 * Return all settings
+	 *
+	 * @deprecated See Automattic/Jetpack/Sync/Settings
+	 *
+	 * @return array All Sync Settings.
+	 */
+	public static function get_settings() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::get_settings();
 	}
 
-	static function get_setting( $setting ) {
+	/**
+	 * Return a single setting.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param string $setting Setting to return.
+	 *
+	 * @return mixed Value of setting.
+	 */
+	public static function get_setting( $setting ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::get_setting( $setting );
 	}
 
-	static function update_settings( $new_settings ) {
+	/**
+	 * Update a sync setting
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param mixed $new_settings New setting to set.
+	 */
+	public static function update_settings( $new_settings ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		Settings::update_settings( $new_settings );
 	}
 
-	static function is_network_setting( $setting ) {
+	/**
+	 * Return is_network_setting result.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param string $setting Setting to check.
+	 *
+	 * @return bool
+	 */
+	public static function is_network_setting( $setting ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::is_network_setting( $setting );
 	}
 
-	static function get_blacklisted_post_types_sql() {
+
+	/**
+	 * Return blacklisted post types SQL.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 */
+	public static function get_blacklisted_post_types_sql() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::get_blacklisted_post_types_sql();
 	}
 
-	static function get_whitelisted_post_meta_sql() {
+	/**
+	 * Return whitelisted post meta SQL.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @return string
+	 */
+	public static function get_whitelisted_post_meta_sql() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::get_whitelisted_post_meta_sql();
 	}
 
-	static function get_whitelisted_comment_meta_sql() {
+	/**
+	 * Return whitelsited comment meta SQL
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 */
+	public static function get_whitelisted_comment_meta_sql() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::get_whitelisted_comment_meta_sql();
 	}
 
-	static function get_comments_filter_sql() {
+	/**
+	 * Return get_comments_filter_sql
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 */
+	public static function get_comments_filter_sql() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::get_comments_filter_sql();
 	}
 
-	static function reset_data() {
+	/**
+	 * Result data.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 */
+	public static function reset_data() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		Settings::reset_data();
 	}
 
-	static function set_importing( $is_importing ) {
+	/**
+	 * Set importing status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param mixed $is_importing Value to set.
+	 */
+	public static function set_importing( $is_importing ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		Settings::set_importing( $is_importing );
 	}
 
-	static function is_importing() {
+	/**
+	 * Return is_importing status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @return bool
+	 */
+	public static function is_importing() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::is_importing();
 	}
 
-	static function is_sync_enabled() {
+	/**
+	 * Return is_sync_enabled status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @return bool
+	 */
+	public static function is_sync_enabled() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::is_sync_enabled();
 	}
 
-	static function set_doing_cron( $is_doing_cron ) {
+	/**
+	 * Set cron status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param mixed $is_doing_cron Value to set.
+	 */
+	public static function set_doing_cron( $is_doing_cron ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		Settings::set_doing_cron( $is_doing_cron );
 	}
 
-	static function is_doing_cron() {
+	/**
+	 * Return is_doing_cron status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @return bool
+	 */
+	public static function is_doing_cron() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::is_doing_cron();
 	}
 
-	static function is_syncing() {
+	/**
+	 * Return is_syncing status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @return bool
+	 */
+	public static function is_syncing() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::is_syncing();
 	}
 
-	static function set_is_syncing( $is_syncing ) {
+	/**
+	 * Set "is syncing" status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param mixed $is_syncing Is syncing value.
+	 */
+	public static function set_is_syncing( $is_syncing ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		Settings::set_is_syncing( $is_syncing );
 	}
 
-	static function is_sending() {
+	/**
+	 * Return is_sending status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @return bool
+	 */
+	public static function is_sending() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		return Settings::is_sending();
 	}
 
-	static function set_is_sending( $is_sending ) {
+	/**
+	 * Set "is sending" status.
+	 *
+	 * @deprecated See Automattic\Jetpack\Sync\Settings
+	 *
+	 * @param mixed $is_sending Is sending value.
+	 */
+	public static function set_is_sending( $is_sending ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Settings' );
 		Settings::set_is_sending( $is_sending );
 	}

--- a/packages/compat/legacy/class.jetpack-tracks.php
+++ b/packages/compat/legacy/class.jetpack-tracks.php
@@ -1,17 +1,43 @@
 <?php
+/**
+ * Legacy and deprecated Jetpack Tracking class.
+ *
+ * @package automattic/jetpack-compat
+ */
 
 use Automattic\Jetpack\Tracking;
 
+/**
+ * Legacy class JetpackTracking
+ *
+ * @deprecated See Automattic\Jetpack\Tracking
+ */
 class JetpackTracking {
 
-	static function enqueue_tracks_scripts() {
+	/**
+	 * Enqueue tracks scripts.
+	 *
+	 * @deprecated See Automattic\Jetpack\Tracking
+	 */
+	public static function enqueue_tracks_scripts() {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Tracking' );
 
 		$tracking = new Tracking();
 		return $tracking->enqueue_tracks_scripts();
 	}
 
-	static function record_user_event( $event_type, $data = array(), $user = null ) {
+	/**
+	 * Record user event.
+	 *
+	 * @deprecated See Automattic\Jetpack\Tracking
+	 *
+	 * @param mixed $event_type Event type.
+	 * @param array $data Event data.
+	 * @param mixed $user User who did the event.
+	 *
+	 * @return bool
+	 */
+	public static function record_user_event( $event_type, $data = array(), $user = null ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Tracking' );
 
 		$tracking = new Tracking();

--- a/packages/compat/lib/tracks/client.php
+++ b/packages/compat/lib/tracks/client.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * Deprecated Tracks client.
+ *
+ * @package automattic/jetpack-compat
+ */
 
 /**
+ * Get tracks identity for an user.
+ *
  * @deprecated 7.5.0 use Automattic\Jetpack\Tracking->tracks_get_identity instead
+ *
+ * @param int $user_id User id.
+ *
+ * @return mixed tracks identity.
  */
 function jetpack_tracks_get_identity( $user_id ) {
 	_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Tracking->tracks_get_identity' );
@@ -11,7 +22,16 @@ function jetpack_tracks_get_identity( $user_id ) {
 }
 
 /**
+ * Record Jetpack Tracks Event
+ *
  * @deprecated 7.5.0 use Automattic\Jetpack\Tracking->tracks_record_event instead
+ *
+ * @param object      $user User acting.
+ * @param string      $event_name Event name.
+ * @param array       $properties Properties.
+ * @param string|bool $event_timestamp_millis Timestamp.
+ *
+ * @return bool
  */
 function jetpack_tracks_record_event( $user, $event_name, $properties = array(), $event_timestamp_millis = false ) {
 	_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Tracking->tracks_record_event' );

--- a/packages/options/legacy/class.jetpack-options.php
+++ b/packages/options/legacy/class.jetpack-options.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Legacy Jetpack_Options class.
+ *
+ * @package automattic/jetpack-options
+ */
 
 use Automattic\Jetpack\Constants;
 
+/**
+ * Class Jetpack_Options
+ */
 class Jetpack_Options {
 
 	/**
@@ -80,10 +88,10 @@ class Jetpack_Options {
 
 		return array(
 			'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
-			'publicize_connections',        // (array)  An array of Publicize connections from WordPress.com
+			'publicize_connections',        // (array)  An array of Publicize connections from WordPress.com.
 			'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
-			'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
-			'old_version',                  // (string) Used to determine which modules are the most recently added. previous_version:time
+			'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time.
+			'old_version',                  // (string) Used to determine which modules are the most recently added. previous_version:time.
 			'fallback_no_verify_ssl_certs', // (int)    Flag for determining if this host must skip SSL Certificate verification due to misconfigured SSL.
 			'time_diff',                    // (int)    Offset between Jetpack server's clocks and this server's clocks. Jetpack Server Time = time() + (int) Jetpack_Options::get_option( 'time_diff' )
 			'public',                       // (int|bool) If we think this site is public or not (1, 0), false if we haven't yet tried to figure it out.
@@ -93,10 +101,10 @@ class Jetpack_Options {
 			'identity_crisis_whitelist',    // (array)  An array of options, each having an array of the values whitelisted for it.
 			'gplus_authors',                // (array)  The Google+ authorship information for connected users.
 			'last_heartbeat',               // (int)    The timestamp of the last heartbeat that fired.
-			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user
+			'hide_jitm',                    // (array)  A list of just in time messages that we should not show because they have been dismissed by the user.
 			'custom_css_4.7_migration',     // (bool)   Whether Custom CSS has scanned for and migrated any legacy CSS CPT entries to the new Core format.
-			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget
-			'gallery_widget_migration',     // (bool)   Whether any legacy Gallery Widgets have been converted to the new Core widget
+			'image_widget_migration',       // (bool)   Whether any legacy Image Widgets have been converted to the new Core widget.
+			'gallery_widget_migration',     // (bool)   Whether any legacy Gallery Widgets have been converted to the new Core widget.
 			'sso_first_login',              // (bool)   Is this the first time the user logins via SSO.
 			'dismissed_hints',              // (array)  Part of Plugin Search Hints. List of cards that have been dismissed.
 			'first_admin_view',             // (bool)   Set to true the first time the user views the admin. Usually after the initial connection.
@@ -106,7 +114,7 @@ class Jetpack_Options {
 	/**
 	 * Is the option name valid?
 	 *
-	 * @param string      $name  The name of the option
+	 * @param string      $name  The name of the option.
 	 * @param string|null $group The name of the group that the option is in. Default to null, which will search non_compact.
 	 *
 	 * @return bool Is the option name valid?
@@ -124,14 +132,14 @@ class Jetpack_Options {
 		}
 
 		if ( is_null( $group ) || 'non_compact' === $group ) {
-			if ( in_array( $name, self::get_option_names( $group ) ) ) {
+			if ( in_array( $name, self::get_option_names( $group ), true ) ) {
 				return true;
 			}
 		}
 
 		foreach ( array_keys( self::$grouped_options ) as $_group ) {
 			if ( is_null( $group ) || $group === $_group ) {
-				if ( in_array( $name, self::get_option_names( $_group ) ) ) {
+				if ( in_array( $name, self::get_option_names( $_group ), true ) ) {
 					return true;
 				}
 			}
@@ -151,14 +159,14 @@ class Jetpack_Options {
 		if ( ! is_multisite() ) {
 			return false;
 		}
-		return in_array( $option_name, self::get_option_names( 'network' ) );
+		return in_array( $option_name, self::get_option_names( 'network' ), true );
 	}
 
 	/**
 	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
-	 * @param mixed  $default (optional)
+	 * @param mixed  $default (optional).
 	 *
 	 * @return mixed
 	 */
@@ -177,7 +185,7 @@ class Jetpack_Options {
 			}
 		}
 
-		trigger_error( sprintf( 'Invalid Jetpack option name: %s', $name ), E_USER_WARNING );
+		trigger_error( sprintf( 'Invalid Jetpack option name: %s', esc_html( $name ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Don't wish to change legacy behavior.
 
 		return $default;
 	}
@@ -186,15 +194,15 @@ class Jetpack_Options {
 	 * Returns the requested option, and ensures it's autoloaded in the future.
 	 * This does _not_ adjust the prefix in any way (does not prefix jetpack_%)
 	 *
-	 * @param string $name Option name
-	 * @param mixed  $default (optional)
+	 * @param string $name Option name.
+	 * @param mixed  $default (optional).
 	 *
 	 * @return mixed
 	 */
 	public static function get_option_and_ensure_autoload( $name, $default ) {
 		// In this function the name is not adjusted by prefixing jetpack_
 		// so if it has already prefixed, we'll replace it and then
-		// check if the option name is a network option or not
+		// check if the option name is a network option or not.
 		$jetpack_name      = preg_replace( '/^jetpack_/', '', $name, 1 );
 		$is_network_option = self::is_network_option( $jetpack_name );
 		$value             = $is_network_option ? get_site_option( $name ) : get_option( $name );
@@ -211,6 +219,15 @@ class Jetpack_Options {
 		return $value;
 	}
 
+	/**
+	 * Update grouped option
+	 *
+	 * @param string $group Options group.
+	 * @param string $name Options name.
+	 * @param mixed  $value Options value.
+	 *
+	 * @return bool Success or failure.
+	 */
 	private static function update_grouped_option( $group, $name, $value ) {
 		$options = get_option( self::$grouped_options[ $group ] );
 		if ( ! is_array( $options ) ) {
@@ -225,7 +242,7 @@ class Jetpack_Options {
 	 * Updates the single given option.  Updates jetpack_options or jetpack_$name as appropriate.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
-	 * @param mixed  $value Option value
+	 * @param mixed  $value Option value.
 	 * @param string $autoload If not compact option, allows specifying whether to autoload or not.
 	 *
 	 * @return bool Was the option successfully updated?
@@ -255,7 +272,7 @@ class Jetpack_Options {
 			}
 		}
 
-		trigger_error( sprintf( 'Invalid Jetpack option name: %s', $name ), E_USER_WARNING );
+		trigger_error( sprintf( 'Invalid Jetpack option name: %s', esc_html( $name ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Don't want to change legacy behavior.
 
 		return false;
 	}
@@ -263,13 +280,13 @@ class Jetpack_Options {
 	/**
 	 * Updates the multiple given options.  Updates jetpack_options and/or jetpack_$name as appropriate.
 	 *
-	 * @param array $array array( option name => option value, ... )
+	 * @param array $array array( option name => option value, ... ).
 	 */
 	public static function update_options( $array ) {
 		$names = array_keys( $array );
 
 		foreach ( array_diff( $names, self::get_option_names(), self::get_option_names( 'non_compact' ), self::get_option_names( 'private' ) ) as $unknown_name ) {
-			trigger_error( sprintf( 'Invalid Jetpack option name: %s', $unknown_name ), E_USER_WARNING );
+			trigger_error( sprintf( 'Invalid Jetpack option name: %s', esc_html( $unknown_name ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Don't change legacy behavior.
 			unset( $array[ $unknown_name ] );
 		}
 
@@ -291,7 +308,9 @@ class Jetpack_Options {
 		$names  = (array) $names;
 
 		if ( ! self::is_valid( $names ) ) {
+			// phpcs:disable -- This line triggers a handful of errors; ignoring to avoid changing legacy behavior.
 			trigger_error( sprintf( 'Invalid Jetpack option names: %s', print_r( $names, 1 ) ), E_USER_WARNING );
+			// phpcs:enable
 			return false;
 		}
 
@@ -312,6 +331,15 @@ class Jetpack_Options {
 		return $result;
 	}
 
+	/**
+	 * Get group option.
+	 *
+	 * @param string $group Option group name.
+	 * @param string $name Option name.
+	 * @param mixed  $default Default option value.
+	 *
+	 * @return mixed Option.
+	 */
 	private static function get_grouped_option( $group, $name, $default ) {
 		$options = get_option( self::$grouped_options[ $group ] );
 		if ( is_array( $options ) && isset( $options[ $name ] ) ) {
@@ -321,6 +349,14 @@ class Jetpack_Options {
 		return $default;
 	}
 
+	/**
+	 * Delete grouped option.
+	 *
+	 * @param string $group Option group name.
+	 * @param array  $names Option names.
+	 *
+	 * @return bool Success or failure.
+	 */
 	private static function delete_grouped_option( $group, $names ) {
 		$options = get_option( self::$grouped_options[ $group ], array() );
 
@@ -336,9 +372,11 @@ class Jetpack_Options {
 		return true;
 	}
 
-	// Raw option methods allow Jetpack to get / update / delete options via direct DB queries, including options
-	// that are not created by the Jetpack plugin. This is helpful only in rare cases when we need to bypass
-	// cache and filters.
+	/*
+	 * Raw option methods allow Jetpack to get / update / delete options via direct DB queries, including options
+	 * that are not created by the Jetpack plugin. This is helpful only in rare cases when we need to bypass
+	 * cache and filters.
+	 */
 
 	/**
 	 * Deletes an option via $wpdb query.
@@ -347,7 +385,7 @@ class Jetpack_Options {
 	 *
 	 * @return bool Is the option deleted?
 	 */
-	static function delete_raw_option( $name ) {
+	public static function delete_raw_option( $name ) {
 		if ( self::bypass_raw_option( $name ) ) {
 			return delete_option( $name );
 		}
@@ -365,7 +403,7 @@ class Jetpack_Options {
 	 *
 	 * @return bool Is the option updated?
 	 */
-	static function update_raw_option( $name, $value, $autoload = false ) {
+	public static function update_raw_option( $name, $value, $autoload = false ) {
 		if ( self::bypass_raw_option( $name ) ) {
 			return update_option( $name, $value, $autoload );
 		}
@@ -383,7 +421,7 @@ class Jetpack_Options {
 		}
 
 		$serialized_value = maybe_serialize( $value );
-		// below we used "insert ignore" to at least suppress the resulting error
+		// below we used "insert ignore" to at least suppress the resulting error.
 		$updated_num = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s",
@@ -396,9 +434,10 @@ class Jetpack_Options {
 		if ( ! $updated_num ) {
 			$updated_num = $wpdb->query(
 				$wpdb->prepare(
-					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, '$autoload_value' )",
+					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, %s )",
 					$name,
-					$serialized_value
+					$serialized_value,
+					$autoload_value
 				)
 			);
 		}
@@ -415,7 +454,7 @@ class Jetpack_Options {
 	 *
 	 * @return mixed Option value, or null if option is not found and default is not specified.
 	 */
-	static function get_raw_option( $name, $default = null ) {
+	public static function get_raw_option( $name, $default = null ) {
 		if ( self::bypass_raw_option( $name ) ) {
 			return get_option( $name, $default );
 		}
@@ -429,7 +468,7 @@ class Jetpack_Options {
 		);
 		$value = maybe_unserialize( $value );
 
-		if ( $value === null && $default !== null ) {
+		if ( null === $value && null !== $default ) {
 			return $default;
 		}
 
@@ -440,11 +479,11 @@ class Jetpack_Options {
 	 * This function checks for a constant that, if present, will disable direct DB queries Jetpack uses to manage certain options and force Jetpack to always use Options API instead.
 	 * Options can be selectively managed via a blacklist by filtering option names via the jetpack_disabled_raw_option filter.
 	 *
-	 * @param $name Option name
+	 * @param string $name Option name.
 	 *
 	 * @return bool
 	 */
-	static function bypass_raw_option( $name ) {
+	public static function bypass_raw_option( $name ) {
 
 		if ( Constants::get_constant( 'JETPACK_DISABLE_RAW_OPTIONS' ) ) {
 			return true;
@@ -468,7 +507,7 @@ class Jetpack_Options {
 	 * @param boolean $strip_unsafe_options If true, and by default, will strip out options necessary for the connection to WordPress.com.
 	 * @return array An array of all options managed via the Jetpack_Options class.
 	 */
-	static function get_all_jetpack_options( $strip_unsafe_options = true ) {
+	public static function get_all_jetpack_options( $strip_unsafe_options = true ) {
 		$jetpack_options            = self::get_option_names();
 		$jetpack_options_non_compat = self::get_option_names( 'non_compact' );
 		$jetpack_options_private    = self::get_option_names( 'private' );
@@ -476,25 +515,26 @@ class Jetpack_Options {
 		$all_jp_options = array_merge( $jetpack_options, $jetpack_options_non_compat, $jetpack_options_private );
 
 		if ( $strip_unsafe_options ) {
-			// Flag some Jetpack options as unsafe
+			// Flag some Jetpack options as unsafe.
 			$unsafe_options = array(
 				'id',                           // (int)    The Client ID/WP.com Blog ID of this site.
 				'master_user',                  // (int)    The local User ID of the user who connected this site to jetpack.wordpress.com.
 				'version',                      // (string) Used during upgrade procedure to auto-activate new modules. version:time
 
-				// non_compact
+				// non_compact.
 				'activated',
 
-				// private
+				// private.
 				'register',
 				'blog_token',                  // (string) The Client Secret/Blog Token of this site.
 				'user_token',                  // (string) The User Token of this site. (deprecated)
 				'user_tokens',
 			);
 
-			// Remove the unsafe Jetpack options
+			// Remove the unsafe Jetpack options.
 			foreach ( $unsafe_options as $unsafe_option ) {
-				if ( false !== ( $key = array_search( $unsafe_option, $all_jp_options ) ) ) {
+				$key = array_search( $unsafe_option, $all_jp_options, true );
+				if ( false !== $key ) {
 					unset( $all_jp_options[ $key ] );
 				}
 			}
@@ -510,8 +550,8 @@ class Jetpack_Options {
 	 *
 	 * @return array
 	 */
-	static function get_all_wp_options() {
-		// A manual build of the wp options
+	public static function get_all_wp_options() {
+		// A manual build of the wp options.
 		return array(
 			'sharing-options',
 			'disabled_likes',
@@ -567,7 +607,7 @@ class Jetpack_Options {
 	 *
 	 * @return array array Associative array containing jp_options which are managed by the Jetpack_Options class and wp_options which are not.
 	 */
-	static function get_options_for_reset() {
+	public static function get_options_for_reset() {
 		$all_jp_options = self::get_all_jetpack_options();
 
 		$wp_options = self::get_all_wp_options();
@@ -587,18 +627,18 @@ class Jetpack_Options {
 	 *
 	 * @return void
 	 */
-	static function delete_all_known_options() {
-		// Delete all compact options
+	public static function delete_all_known_options() {
+		// Delete all compact options.
 		foreach ( (array) self::$grouped_options as $option_name ) {
 			delete_option( $option_name );
 		}
 
-		// Delete all non-compact Jetpack options
+		// Delete all non-compact Jetpack options.
 		foreach ( (array) self::get_option_names( 'non-compact' ) as $option_name ) {
 			self::delete_option( $option_name );
 		}
 
-		// Delete all options that can be reset via CLI, that aren't Jetpack options
+		// Delete all options that can be reset via CLI, that aren't Jetpack options.
 		foreach ( (array) self::get_all_wp_options() as $option_name ) {
 			delete_option( $option_name );
 		}

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -658,7 +658,7 @@ class Actions {
 	 * @static
 	 */
 	public static function init_sync_cron_jobs() {
-		add_filter( 'cron_schedules', array( __CLASS__, 'jetpack_cron_schedule' ) );
+		add_filter( 'cron_schedules', array( __CLASS__, 'jetpack_cron_schedule' ) ); // phpcs:ignore WordPress.WP.CronInterval.ChangeDetected
 
 		add_action( 'jetpack_sync_cron', array( __CLASS__, 'do_cron_sync' ) );
 		add_action( 'jetpack_sync_full_cron', array( __CLASS__, 'do_cron_full_sync' ) );

--- a/packages/sync/src/Defaults.php
+++ b/packages/sync/src/Defaults.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Jetpack Sync Defaults
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
@@ -8,11 +13,16 @@ use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Functions;
 
 /**
- * Just some defaults that we share with the server
+ * Just some defaults that we share with the server.
  */
 class Defaults {
 
-	static $default_options_whitelist = array(
+	/**
+	 * Default Options.
+	 *
+	 * @var array
+	 */
+	public static $default_options_whitelist = array(
 		'stylesheet',
 		'blogname',
 		'blogdescription',
@@ -118,8 +128,8 @@ class Defaults {
 		'users_can_register',
 		'active_plugins',
 		'uninstall_plugins',
-		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION
-		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION
+		'advanced_seo_front_page_description', // Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION.
+		'advanced_seo_title_formats', // Jetpack_SEO_Titles::TITLE_FORMATS_OPTION.
 		'jetpack_api_cache_enabled',
 		'start_of_week',
 		'blacklist_keys',
@@ -136,8 +146,8 @@ class Defaults {
 		'default_role',
 		'page_for_posts',
 		'mailserver_url',
-		'mailserver_login', // Not syncing contents, only the option name
-		'mailserver_pass', // Not syncing contents, only the option name
+		'mailserver_login', // Not syncing contents, only the option name.
+		'mailserver_pass', // Not syncing contents, only the option name.
 		'mailserver_port',
 		'wp_page_for_privacy_policy',
 		'enable_header_ad',
@@ -153,6 +163,11 @@ class Defaults {
 		'jetpack_excluded_extensions',
 	);
 
+	/**
+	 * Return options whitelist filtered.
+	 *
+	 * @return array Options whitelist.
+	 */
 	public static function get_options_whitelist() {
 		/** This filter is already documented in json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php */
 		$options_whitelist = apply_filters( 'jetpack_options_whitelist', self::$default_options_whitelist );
@@ -168,12 +183,25 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_options_whitelist', $options_whitelist );
 	}
 
-	// Do not sync contents for these events, only the option name
-	static $default_options_contentless = array(
+	/**
+	 * "Contentless" Options.
+	 *
+	 * Do not sync contents for these events, only the option name. Good for sensitive information that Sync does not need.
+	 *
+	 * @var array Options to sync name only.
+	 */
+	public static $default_options_contentless = array(
 		'mailserver_login',
 		'mailserver_pass',
 	);
 
+	/**
+	 * Return contentless options.
+	 *
+	 * These are options that Sync only uses the option names, not the content of the option.
+	 *
+	 * @return array
+	 */
 	public static function get_options_contentless() {
 		/**
 		 * Filter the list of WordPress options that should be synced without content
@@ -187,7 +215,12 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_options_contentless', self::$default_options_contentless );
 	}
 
-	static $default_constants_whitelist = array(
+	/**
+	 * Array of defaulted constants whitelisted.
+	 *
+	 * @var array Default constants whitelist
+	 */
+	public static $default_constants_whitelist = array(
 		'EMPTY_TRASH_DAYS',
 		'WP_POST_REVISIONS',
 		'AUTOMATIC_UPDATER_DISABLED',
@@ -210,6 +243,11 @@ class Defaults {
 		'WP_DEBUG',
 	);
 
+	/**
+	 * Get constants whitelisted by Sync.
+	 *
+	 * @return array Constants accessible via sync.
+	 */
 	public static function get_constants_whitelist() {
 		/**
 		 * Filter the list of PHP constants that are manageable via the JSON API.
@@ -223,7 +261,12 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_constants_whitelist', self::$default_constants_whitelist );
 	}
 
-	static $default_callable_whitelist = array(
+	/**
+	 * Callables able to be managed via JSON API.
+	 *
+	 * @var array Default whitelist of callables.
+	 */
+	public static $default_callable_whitelist = array(
 		'wp_max_upload_size'               => 'wp_max_upload_size',
 		'is_main_network'                  => array( __CLASS__, 'is_multi_network' ),
 		'is_multi_site'                    => 'is_multisite',
@@ -254,13 +297,18 @@ class Defaults {
 		'site_icon_url'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'site_icon_url' ),
 		'roles'                            => array( 'Automattic\\Jetpack\\Sync\\Functions', 'roles' ),
 		'timezone'                         => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_timezone' ),
-		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins
+		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins.
 		'paused_themes'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_paused_themes' ),
 		'paused_plugins'                   => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_paused_plugins' ),
 	);
 
 
-	static $default_post_type_attributes = array(
+	/**
+	 * Array of post type attributes synced.
+	 *
+	 * @var array Default post type attributes.
+	 */
+	public static $default_post_type_attributes = array(
 		'name'                => '',
 		'label'               => '',
 		'labels'              => array(),
@@ -292,6 +340,11 @@ class Defaults {
 		'_edit_link'          => 'post.php?post=%d',
 	);
 
+	/**
+	 * Get the whitelist of callables allowed to be managed via the JSON API.
+	 *
+	 * @return array Whitelist of callables allowed to be managed via the JSON API.
+	 */
 	public static function get_callable_whitelist() {
 		/**
 		 * Filter the list of callables that are manageable via the JSON API.
@@ -305,11 +358,18 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_callable_whitelist', self::$default_callable_whitelist );
 	}
 
-	static $blacklisted_post_types = array(
+	/**
+	 * Post types that will not be synced.
+	 *
+	 * These are usually automated post types (sitemaps, logs, etc).
+	 *
+	 * @var array Blacklisted post types.
+	 */
+	public static $blacklisted_post_types = array(
 		'ai1ec_event',
 		'bwg_album',
 		'bwg_gallery',
-		'customize_changeset', // WP built-in post type for Customizer changesets
+		'customize_changeset', // WP built-in post type for Customizer changesets.
 		'dn_wp_yt_log',
 		'http',
 		'idx_page',
@@ -495,38 +555,73 @@ class Defaults {
 		'wp_title_rss',
 	);
 
-	static $default_post_checksum_columns = array(
+	/**
+	 * Default array of post table columns.
+	 *
+	 * @var array Post table columns.
+	 */
+	public static $default_post_checksum_columns = array(
 		'ID',
 		'post_modified',
 	);
 
-	static $default_post_meta_checksum_columns = array(
+	/**
+	 * Default array of post meta table columns.
+	 *
+	 * @var array Post meta table columns.
+	 */
+	public static $default_post_meta_checksum_columns = array(
 		'meta_id',
 		'meta_value',
 	);
 
-	static $default_comment_checksum_columns = array(
+	/**
+	 * Default array of comment table columns.
+	 *
+	 * @var array Default comment table columns.
+	 */
+	public static $default_comment_checksum_columns = array(
 		'comment_ID',
 		'comment_content',
 	);
 
-	static $default_comment_meta_checksum_columns = array(
+	/**
+	 * Default array of comment meta columns.
+	 *
+	 * @var array Comment meta table columns.
+	 */
+	public static $default_comment_meta_checksum_columns = array(
 		'meta_id',
 		'meta_value',
 	);
 
-	static $default_option_checksum_columns = array(
+	/**
+	 * Default array of option table columns.
+	 *
+	 * @var array Default array of option columns.
+	 */
+	public static $default_option_checksum_columns = array(
 		'option_name',
 		'option_value',
 	);
 
-	static $default_term_checksum_columns = array(
+	/**
+	 * Default array of term columns.
+	 *
+	 * @var array array of term columns.
+	 */
+	public static $default_term_checksum_columns = array(
 		'term_id',
 		'name',
 		'slug',
 	);
 
-	static $default_term_taxonomy_checksum_columns = array(
+	/**
+	 * Default array of term taxonomy columns.
+	 *
+	 * @var array Array of term taxonomy columns.
+	 */
+	public static $default_term_taxonomy_checksum_columns = array(
 		'term_taxonomy_id',
 		'term_id',
 		'taxonomy',
@@ -534,13 +629,23 @@ class Defaults {
 		'count',
 	);
 
-	static $default_term_relationships_checksum_columns = array(
+	/**
+	 * Default term relationship columns.
+	 *
+	 * @var array Array of term relationship columns.
+	 */
+	public static $default_term_relationships_checksum_columns = array(
 		'object_id',
 		'term_taxonomy_id',
 		'term_order',
 	);
 
-	static $default_multisite_callable_whitelist = array(
+	/**
+	 * Default multisite callables able to be managed via JSON API.
+	 *
+	 * @var array multsite callables whitelisted
+	 */
+	public static $default_multisite_callable_whitelist = array(
 		'network_name'                        => array( 'Jetpack', 'network_name' ),
 		'network_allow_new_registrations'     => array( 'Jetpack', 'network_allow_new_registrations' ),
 		'network_add_new_users'               => array( 'Jetpack', 'network_add_new_users' ),
@@ -549,6 +654,11 @@ class Defaults {
 		'network_enable_administration_menus' => array( 'Jetpack', 'network_enable_administration_menus' ),
 	);
 
+	/**
+	 * Get array of multisite callables whitelisted.
+	 *
+	 * @return array Multisite callables managable via JSON API.
+	 */
 	public static function get_multisite_callable_whitelist() {
 		/**
 		 * Filter the list of multisite callables that are manageable via the JSON API.
@@ -562,7 +672,12 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_multisite_callable_whitelist', self::$default_multisite_callable_whitelist );
 	}
 
-	static $post_meta_whitelist = array(
+	/**
+	 * Array of post meta keys whitelisted.
+	 *
+	 * @var array Post meta whitelist.
+	 */
+	public static $post_meta_whitelist = array(
 		'_feedback_akismet_values',
 		'_feedback_email',
 		'_feedback_extra_fields',
@@ -599,9 +714,14 @@ class Defaults {
 		'switch_like_status',
 		'videopress_guid',
 		'vimeo_poster_image',
-		'advanced_seo_description', // Jetpack_SEO_Posts::DESCRIPTION_META_KEY
+		'advanced_seo_description', // Jetpack_SEO_Posts::DESCRIPTION_META_KEY.
 	);
 
+	/**
+	 * Get the post meta key whitelist.
+	 *
+	 * @return array Post meta whitelist.
+	 */
 	public static function get_post_meta_whitelist() {
 		/**
 		 * Filter the list of post meta data that are manageable via the JSON API.
@@ -615,13 +735,23 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_post_meta_whitelist', self::$post_meta_whitelist );
 	}
 
-	static $comment_meta_whitelist = array(
+	/**
+	 * Comment meta whitelist.
+	 *
+	 * @var array Comment meta whitelist.
+	 */
+	public static $comment_meta_whitelist = array(
 		'hc_avatar',
 		'hc_post_as',
 		'hc_wpcom_id_sig',
 		'hc_foreign_user_id',
 	);
 
+	/**
+	 * Get the comment meta whitelist.
+	 *
+	 * @return array
+	 */
 	public static function get_comment_meta_whitelist() {
 		/**
 		 * Filter the list of comment meta data that are manageable via the JSON API.
@@ -635,9 +765,15 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_comment_meta_whitelist', self::$comment_meta_whitelist );
 	}
 
-	// TODO: move this to server? - these are theme support values
-	// that should be synced as jetpack_current_theme_supports_foo option values
-	static $default_theme_support_whitelist = array(
+	/**
+	 * Default theme support whitelist.
+	 *
+	 * @todo move this to server? - these are theme support values
+	 * that should be synced as jetpack_current_theme_supports_foo option values
+	 *
+	 * @var array Default theme support whitelist.
+	 */
+	public static $default_theme_support_whitelist = array(
 		'post-thumbnails',
 		'post-formats',
 		'custom-header',
@@ -655,10 +791,16 @@ class Defaults {
 		'site-logo',
 	);
 
-	static function is_whitelisted_option( $option ) {
+	/**
+	 * Is an option whitelisted?
+	 *
+	 * @param string $option Option name.
+	 * @return bool If option is on the whitelist.
+	 */
+	public static function is_whitelisted_option( $option ) {
 		$whitelisted_options = self::get_options_whitelist();
 		foreach ( $whitelisted_options as $whitelisted_option ) {
-			if ( $whitelisted_option[0] === '/' && preg_match( $whitelisted_option, $option ) ) {
+			if ( '/' === $whitelisted_option[0] && preg_match( $whitelisted_option, $option ) ) {
 				return true;
 			} elseif ( $whitelisted_option === $option ) {
 				return true;
@@ -668,7 +810,12 @@ class Defaults {
 		return false;
 	}
 
-	static $default_capabilities_whitelist = array(
+	/**
+	 * Default whitelist of capabilities to sync.
+	 *
+	 * @var array Array of WordPress capabilities.
+	 */
+	public static $default_capabilities_whitelist = array(
 		'switch_themes',
 		'edit_themes',
 		'edit_theme_options',
@@ -727,6 +874,11 @@ class Defaults {
 		'upload_themes',
 	);
 
+	/**
+	 * Get default capabilities whitelist.
+	 *
+	 * @return array
+	 */
 	public static function get_capabilities_whitelist() {
 		/**
 		 * Filter the list of capabilities that we care about
@@ -740,21 +892,37 @@ class Defaults {
 		return apply_filters( 'jetpack_sync_capabilities_whitelist', self::$default_capabilities_whitelist );
 	}
 
-	static function get_max_sync_execution_time() {
+	/**
+	 * Get max execution sync time.
+	 *
+	 * @return float Number of seconds.
+	 */
+	public static function get_max_sync_execution_time() {
 		$max_exec_time = intval( ini_get( 'max_execution_time' ) );
 		if ( 0 === $max_exec_time ) {
-			// 0 actually means "unlimited", but let's not treat it that way
+			// 0 actually means "unlimited", but let's not treat it that way.
 			$max_exec_time = 60;
 		}
 		return floor( $max_exec_time / 3 );
 	}
 
-	static function get_default_setting( $setting ) {
-		$default_name = "default_$setting"; // e.g. default_dequeue_max_bytes
+	/**
+	 * Get default for a given setting.
+	 *
+	 * @param string $setting Setting to get.
+	 * @return mixed Value will be a string, int, array, based on the particular setting requested.
+	 */
+	public static function get_default_setting( $setting ) {
+		$default_name = "default_$setting"; // e.g. default_dequeue_max_bytes.
 		return self::$$default_name;
 	}
 
-	static $default_network_options_whitelist = array(
+	/**
+	 * Default list of network options.
+	 *
+	 * @var array network options
+	 */
+	public static $default_network_options_whitelist = array(
 		'site_name',
 		'jetpack_protect_key',
 		'jetpack_protect_global_whitelist',
@@ -815,31 +983,197 @@ class Defaults {
 		return $status->is_multi_network();
 	}
 
-	static $default_taxonomy_whitelist                     = array();
-	static $default_dequeue_max_bytes                      = 500000; // very conservative value, 1/2 MB
-	static $default_upload_max_bytes                       = 600000; // a little bigger than the upload limit to account for serialization
-	static $default_upload_max_rows                        = 500;
-	static $default_sync_wait_time                         = 10; // seconds, between syncs
-	static $default_sync_wait_threshold                    = 5; // only wait before next send if the current send took more than X seconds
-	static $default_enqueue_wait_time                      = 10; // wait between attempting to continue a full sync, via requests
-	static $default_max_queue_size                         = 1000;
-	static $default_max_queue_lag                          = 900; // 15 minutes
-	static $default_queue_max_writes_sec                   = 100; // 100 rows a second
-	static $default_post_types_blacklist                   = array();
-	static $default_taxonomies_blacklist                   = array();
-	static $default_post_meta_whitelist                    = array();
-	static $default_comment_meta_whitelist                 = array();
-	static $default_disable                                = 0; // completely disable sending data to wpcom
-	static $default_network_disable                        = 0; // completely disable sending data to wpcom network wide
-	static $default_sync_via_cron                          = 1; // use cron to sync
-	static $default_render_filtered_content                = 0; // render post_filtered_content
-	static $default_max_enqueue_full_sync                  = 100; // max number of items to enqueue at a time when running full sync
-	static $default_max_queue_size_full_sync               = 1000; // max number of total items in the full sync queue
-	static $default_sync_callables_wait_time               = MINUTE_IN_SECONDS; // seconds before sending callables again
-	static $default_sync_constants_wait_time               = HOUR_IN_SECONDS; // seconds before sending constants again
-	static $default_sync_queue_lock_timeout                = 120; // 2 minutes
-	static $default_cron_sync_time_limit                   = 30; // 30 seconds
-	static $default_term_relationships_full_sync_item_size = 100;
-	static $default_sync_sender_enabled                    = 1; // Should send incremental sync items
-	static $default_full_sync_sender_enabled               = 1; // Should send full sync items
+	/**
+	 * Default bytes to dequeue.
+	 *
+	 * @var int Bytes.
+	 */
+	public static $default_dequeue_max_bytes = 500000; // very conservative value, 1/2 MB.
+
+	/**
+	 * Default upload bytes.
+	 *
+	 * This value is a little bigger than the upload limit to account for serialization.
+	 *
+	 * @var int Bytes.
+	 */
+	public static $default_upload_max_bytes = 600000;
+
+	/**
+	 * Default number of rows uploaded.
+	 *
+	 * @var int Number of rows.
+	 */
+	public static $default_upload_max_rows = 500;
+
+	/**
+	 * Default sync wait time.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_sync_wait_time = 10; // seconds, between syncs.
+
+	/**
+	 * Only wait before next send if the current send took more than this number of seconds.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_sync_wait_threshold = 5;
+
+	/**
+	 * Default wait between attempting to continue a full sync via requests.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_enqueue_wait_time = 10;
+
+	/**
+	 * Maximum queue size.
+	 *
+	 * Each item is represented with a new row in the wp_options table.
+	 *
+	 * @var int Number of queue items.
+	 */
+	public static $default_max_queue_size = 1000;
+
+	/**
+	 * Default maximum lag allowed in the queue.
+	 *
+	 * @var int Number of seconds
+	 */
+	public static $default_max_queue_lag = 900; // 15 minutes.
+
+	/**
+	 * Default for default writes per sec.
+	 *
+	 * @var int Rows per second.
+	 */
+	public static $default_queue_max_writes_sec = 100; // 100 rows a second.
+
+	/**
+	 * Default for post types blacklist.
+	 *
+	 * @var array Empty array.
+	 */
+	public static $default_post_types_blacklist = array();
+
+	/**
+	 * Default for taxonomies blacklist.
+	 *
+	 * @var array Empty array.
+	 */
+	public static $default_taxonomies_blacklist = array();
+
+	/**
+	 * Default for taxonomies whitelist.
+	 *
+	 * @var array Empty array.
+	 */
+	public static $default_taxonomy_whitelist = array();
+
+	/**
+	 * Default for post meta whitelist.
+	 *
+	 * @var array Empty array.
+	 */
+	public static $default_post_meta_whitelist = array();
+
+	/**
+	 * Default for comment meta whitelist.
+	 *
+	 * @var array Empty array.
+	 */
+	public static $default_comment_meta_whitelist = array();
+
+	/**
+	 * Default for disabling sync across the site.
+	 *
+	 * @var int Bool-ish. Default to 0.
+	 */
+	public static $default_disable = 0; // completely disable sending data to wpcom.
+
+	/**
+	 * Default for disabling sync across the entire network on multisite.
+	 *
+	 * @var int Bool-ish. Default 0.
+	 */
+	public static $default_network_disable = 0;
+
+	/**
+	 * Should Sync use cron?
+	 *
+	 * @var int Bool-ish value. Default 1.
+	 */
+	public static $default_sync_via_cron = 1;
+
+	/**
+	 * Default if Sync should render content.
+	 *
+	 * @var int Bool-ish value. Default is 0.
+	 */
+	public static $default_render_filtered_content = 0;
+
+	/**
+	 * Default number of items to enqueue at a time when running full sync.
+	 *
+	 * @var int Number of items.
+	 */
+	public static $default_max_enqueue_full_sync = 100;
+
+	/**
+	 * Default for maximum queue size during a full sync.
+	 *
+	 * Each item will represent a value in the wp_options table.
+	 *
+	 * @var int Number of items.
+	 */
+	public static $default_max_queue_size_full_sync = 1000; // max number of total items in the full sync queue.
+
+	/**
+	 * Defaul for time between syncing callables.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_sync_callables_wait_time = MINUTE_IN_SECONDS; // seconds before sending callables again.
+
+	/**
+	 * Default for time between syncing constants.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_sync_constants_wait_time = HOUR_IN_SECONDS; // seconds before sending constants again.
+	/**
+	 * Default for sync queue lock timeout time.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_sync_queue_lock_timeout = 120; // 2 minutes.
+
+	/**
+	 * Default for cron sync time limit.
+	 *
+	 * @var int Number of seconds.
+	 */
+	public static $default_cron_sync_time_limit = 30; // 30 seconds.
+
+	/**
+	 * Default for number of term relationship items sent in an full sync item.
+	 *
+	 * @var int Number of items.
+	 */
+	public static $default_term_relationships_full_sync_item_size = 100;
+
+	/**
+	 * Default for enabling incremental sync.
+	 *
+	 * @var int 1 for true.
+	 */
+	public static $default_sync_sender_enabled = 1; // Should send incremental sync items.
+
+	/**
+	 * Default for enabling Full Sync.
+	 *
+	 * @var int 1 for true.
+	 */
+	public static $default_full_sync_sender_enabled = 1; // Should send full sync items.
 }

--- a/packages/sync/src/Json_Deflate_Array_Codec.php
+++ b/packages/sync/src/Json_Deflate_Array_Codec.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * An implementation of Automattic\Jetpack\Sync\Codec_Interface that uses gzip's DEFLATE
+ * algorithm to compress objects serialized using json_encode.
+ *
+ * @package automattic/jetpack-sync
+ */
 
 namespace Automattic\Jetpack\Sync;
 
@@ -11,31 +17,69 @@ use Automattic\Jetpack\Sync\Codec_Interface;
 class JSON_Deflate_Array_Codec implements Codec_Interface {
 	const CODEC_NAME = 'deflate-json-array';
 
+	/**
+	 * Return the name of the codec.
+	 *
+	 * @return string
+	 */
 	public function name() {
 		return self::CODEC_NAME;
 	}
 
+	/**
+	 * Encodes an object.
+	 *
+	 * @param object $object Item to encode.
+	 * @return string
+	 */
 	public function encode( $object ) {
-		return base64_encode( gzdeflate( $this->json_serialize( $object ) ) );
+		return base64_encode( gzdeflate( $this->json_serialize( $object ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
+	/**
+	 * Decode compressed serialized value.
+	 *
+	 * @param string $input Item to decode.
+	 * @return array|mixed|object
+	 */
 	public function decode( $input ) {
-		return $this->json_unserialize( gzinflate( base64_decode( $input ) ) );
+		return $this->json_unserialize( gzinflate( base64_decode( $input ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 	}
 
-	// @see https://gist.github.com/muhqu/820694
+	/**
+	 * Serialize JSON
+	 *
+	 * @see https://gist.github.com/muhqu/820694
+	 *
+	 * @param string $any Value to serialize and wrap.
+	 *
+	 * @return false|string
+	 */
 	protected function json_serialize( $any ) {
 		if ( function_exists( 'jetpack_json_wrap' ) ) {
 			return wp_json_encode( jetpack_json_wrap( $any ) );
 		}
-		// This prevents fatal error when updating pre 6.0 via the cli command
+		// This prevents fatal error when updating pre 6.0 via the cli command.
 		return wp_json_encode( $this->json_wrap( $any ) );
 	}
 
+	/**
+	 * Unserialize JSON
+	 *
+	 * @param string $str JSON string.
+	 * @return array|object Unwrapped JSON.
+	 */
 	protected function json_unserialize( $str ) {
 		return $this->json_unwrap( json_decode( $str, true ) );
 	}
 
+	/**
+	 * Wraps JSON
+	 *
+	 * @param object|array $any Wrapping value.
+	 * @param array        $seen_nodes Seen nodes.
+	 * @return array
+	 */
 	private function json_wrap( &$any, $seen_nodes = array() ) {
 		if ( is_object( $any ) ) {
 			$input        = get_object_vars( $any );
@@ -66,6 +110,12 @@ class JSON_Deflate_Array_Codec implements Codec_Interface {
 		return $any;
 	}
 
+	/**
+	 * Unwraps a json_decode return.
+	 *
+	 * @param array|object $any json_decode object.
+	 * @return array|object
+	 */
 	private function json_unwrap( $any ) {
 		if ( is_array( $any ) ) {
 			foreach ( $any as $k => $v ) {

--- a/packages/sync/src/modules/Comments.php
+++ b/packages/sync/src/modules/Comments.php
@@ -181,7 +181,7 @@ class Comments extends Module {
 	/**
 	 * Prevents any comment types that are not in the whitelist from being enqueued and sent to WordPress.com.
 	 *
-	 * @param array $args Arguments passed to wp_insert_comment
+	 * @param array $args Arguments passed to wp_insert_comment.
 	 *
 	 * @return bool or array $args Arguments passed to wp_insert_comment
 	 */

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -103,9 +103,9 @@ class Term_Relationships extends Module {
 	public function enqueue_full_sync_actions( $config, $max_items_to_enqueue, $last_object_enqueued ) {
 		global $wpdb;
 		$term_relationships_full_sync_item_size = Settings::get_setting( 'term_relationships_full_sync_item_size' );
-		$limit                         = min( $max_items_to_enqueue * $term_relationships_full_sync_item_size, self::QUERY_LIMIT );
-		$items_enqueued_count          = 0;
-		$last_object_enqueued          = $last_object_enqueued ? $last_object_enqueued : array(
+		$limit                                  = min( $max_items_to_enqueue * $term_relationships_full_sync_item_size, self::QUERY_LIMIT );
+		$items_enqueued_count                   = 0;
+		$last_object_enqueued                   = $last_object_enqueued ? $last_object_enqueued : array(
 			'object_id'        => self::MAX_INT,
 			'term_taxonomy_id' => self::MAX_INT,
 		);

--- a/packages/tracking/legacy/class.tracks-event.php
+++ b/packages/tracking/legacy/class.tracks-event.php
@@ -1,6 +1,11 @@
 <?php
-
 /**
+ * Class Jetpack_Tracks_Event. Legacy.
+ *
+ * @package automattic/jetpack-sync
+ */
+
+/*
  * @autounit nosara tracks-client
  *
  * Example Usage:
@@ -36,12 +41,26 @@
 ```
  */
 
+/**
+ * Class Jetpack_Tracks_Event
+ */
 class Jetpack_Tracks_Event {
 	const EVENT_NAME_REGEX = '/^(([a-z0-9]+)_){2}([a-z0-9_]+)$/';
 	const PROP_NAME_REGEX  = '/^[a-z_][a-z0-9_]*$/';
+
+	/**
+	 * Tracks Event Error.
+	 *
+	 * @var mixed Error.
+	 */
 	public $error;
 
-	function __construct( $event ) {
+	/**
+	 * Jetpack_Tracks_Event constructor.
+	 *
+	 * @param object $event Tracks event.
+	 */
+	public function __construct( $event ) {
 		$_event = self::validate_and_sanitize( $event );
 		if ( is_wp_error( $_event ) ) {
 			$this->error = $_event;
@@ -53,25 +72,28 @@ class Jetpack_Tracks_Event {
 		}
 	}
 
-	function record() {
+	/**
+	 * Record a track event.
+	 */
+	public function record() {
 		return Jetpack_Tracks_Client::record_event( $this );
 	}
 
 	/**
 	 * Annotate the event with all relevant info.
 	 *
-	 * @param  mixed $event Object or (flat) array
+	 * @param  mixed $event Object or (flat) array.
 	 * @return mixed        The transformed event array or WP_Error on failure.
 	 */
-	static function validate_and_sanitize( $event ) {
+	public static function validate_and_sanitize( $event ) {
 		$event = (object) $event;
 
-		// Required
+		// Required.
 		if ( ! $event->_en ) {
 			return new WP_Error( 'invalid_event', 'A valid event must be specified via `_en`', 400 );
 		}
 
-		// delete non-routable addresses otherwise geoip will discard the record entirely
+		// delete non-routable addresses otherwise geoip will discard the record entirely.
 		if ( property_exists( $event, '_via_ip' ) && preg_match( '/^192\.168|^10\./', $event->_via_ip ) ) {
 			unset( $event->_via_ip );
 		}
@@ -99,7 +121,7 @@ class Jetpack_Tracks_Event {
 	 *
 	 * @return string A pixel URL or empty string ('') if there were invalid args.
 	 */
-	function build_pixel_url() {
+	public function build_pixel_url() {
 		if ( $this->error ) {
 			return '';
 		}
@@ -119,15 +141,33 @@ class Jetpack_Tracks_Event {
 		return Jetpack_Tracks_Client::PIXEL . '?' . http_build_query( $validated );
 	}
 
-	static function event_name_is_valid( $name ) {
+	/**
+	 * Validate the event name.
+	 *
+	 * @param string $name Event name.
+	 * @return false|int
+	 */
+	public static function event_name_is_valid( $name ) {
 		return preg_match( self::EVENT_NAME_REGEX, $name );
 	}
 
-	static function prop_name_is_valid( $name ) {
+	/**
+	 * Validates prop name
+	 *
+	 * @param string $name Property name.
+	 *
+	 * @return false|int Truthy value.
+	 */
+	public static function prop_name_is_valid( $name ) {
 		return preg_match( self::PROP_NAME_REGEX, $name );
 	}
 
-	static function scrutinize_event_names( $event ) {
+	/**
+	 * Scrutinize event name.
+	 *
+	 * @param object $event Tracks event.
+	 */
+	public static function scrutinize_event_names( $event ) {
 		if ( ! self::event_name_is_valid( $event->_en ) ) {
 			return;
 		}
@@ -138,7 +178,7 @@ class Jetpack_Tracks_Event {
 		);
 
 		foreach ( array_keys( (array) $event ) as $key ) {
-			if ( in_array( $key, $whitelisted_key_names ) ) {
+			if ( in_array( $key, $whitelisted_key_names, true ) ) {
 				continue;
 			}
 			if ( ! self::prop_name_is_valid( $key ) ) {


### PR DESCRIPTION
Makes the rest of the packages directory PHPCS compliant except for:

* Queue.php in the sync package. Will be made so as part of #13806 so deferring to that PR.
* analyzer/ -- A few more files are compliant, but there's still a lot left. This package is not actually used by Jetpack or any other project that I'm aware of. Initially, I marked to ignore the whole thing, but on second thought, I'd rather that we eventually get it compliant or remove it from the repo. Since it isn't used anywhere, it would not be potentially blocking for a future WP.com commit.

#### Changes proposed in this Pull Request:
* Various PHPCS related updates.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Supports the composer on wp.com work.

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* n/a

**One request: If there needs to be any changes to this beyond what someone can suggest, may I ask that it be added in a new PR targeting this branch? Due to the high LOC count, I'd like to land this quickly so tweaks in a separate PR would help support that.**
