### PR TITLE
Instant Search: Improve accessibility 

### DIFF
--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -30,19 +30,19 @@ class Gridicon extends Component {
 			default:
 				return null;
 			case 'gridicons-audio':
-				return <title>{ __( 'Has audio' ) }</title>;
+				return <title>{ __( 'Has audio.' ) }</title>;
 			case 'gridicons-calendar':
-				return <title>{ __( 'Is an event' ) }</title>;
+				return <title>{ __( 'Is an event.' ) }</title>;
 			case 'gridicons-cart':
-				return <title>{ __( 'Is a product' ) }</title>;
+				return <title>{ __( 'Is a product.' ) }</title>;
 			case 'gridicons-comment':
-				return <title>{ __( 'Matching comment' ) }</title>;
+				return <title>{ __( 'Matching comment.' ) }</title>;
 			case 'gridicons-folder':
 				return <title>{ __( 'Category' ) }</title>;
 			case 'gridicons-image-multiple':
-				return <title>{ __( 'Has multiple images' ) }</title>;
+				return <title>{ __( 'Has multiple images.' ) }</title>;
 			case 'gridicons-image':
-				return <title>{ __( 'Has an image' ) }</title>;
+				return <title>{ __( 'Has an image.' ) }</title>;
 			case 'gridicons-page':
 				return <title>{ __( 'Page' ) }</title>;
 			case 'gridicons-jetpack-search':
@@ -51,7 +51,7 @@ class Gridicon extends Component {
 			case 'gridicons-tag':
 				return <title>{ __( 'Tag' ) }</title>;
 			case 'gridicons-video':
-				return <title>{ __( 'Has a video' ) }</title>;
+				return <title>{ __( 'Has a video.' ) }</title>;
 		}
 	}
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -9,6 +9,13 @@ import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import uniqueId from 'lodash/uniqueId';
 
+function ignoreEnterKey( event ) {
+	if ( event.key === 'Enter' ) {
+		// Prevent form submission
+		event.preventDefault();
+	}
+}
+
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	return (
@@ -20,6 +27,7 @@ const SearchBox = props => {
 			<input
 				id={ inputId }
 				className="search-field jetpack-instant-search__box-input"
+				onKeyPress={ ignoreEnterKey }
 				onInput={ props.onChangeQuery }
 				onFocus={ props.onFocus }
 				onBlur={ props.onBlur }

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -12,7 +12,7 @@ import uniqueId from 'lodash/uniqueId';
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	return (
-		<div className="jetpack-instant-search__box" role="search">
+		<div className="jetpack-instant-search__box">
 			{ /* TODO: Add support for preserving label text */ }
 			<label htmlFor={ inputId } className="screen-reader-text">
 				{ __( 'Site Search', 'jetpack' ) }

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -12,7 +12,7 @@ import uniqueId from 'lodash/uniqueId';
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	return (
-		<div className={ 'jetpack-instant-search__box' }>
+		<div className="jetpack-instant-search__box" role="search">
 			{ /* TODO: Add support for preserving label text */ }
 			<label htmlFor={ inputId } className="screen-reader-text">
 				{ __( 'Site Search', 'jetpack' ) }

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -114,7 +114,7 @@ class SearchResultMinimal extends Component {
 		}
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
 		return (
-			<div className="jetpack-instant-search__result-minimal">
+			<div className="jetpack-instant-search__result-minimal" role="listitem">
 				<span className="jetpack-instant-search__result-minimal-date">
 					{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
 						dateStyle: 'short',

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -114,7 +114,7 @@ class SearchResultMinimal extends Component {
 		}
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
 		return (
-			<div className="jetpack-instant-search__result-minimal" role="listitem">
+			<li className="jetpack-instant-search__result-minimal">
 				<span className="jetpack-instant-search__result-minimal-date">
 					{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
 						dateStyle: 'short',
@@ -136,7 +136,7 @@ class SearchResultMinimal extends Component {
 				</h3>
 				{ noMatchingContent ? this.renderNoMatchingContent() : this.renderMatchingContent() }
 				<SearchResultComments comments={ highlight && highlight.comments } />
-			</div>
+			</li>
 		);
 	}
 }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -94,7 +94,9 @@ class SearchResults extends Component {
 						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
 					</p>
 				) }
-				{ results.map( this.renderResult ) }
+				<ol className="jetpack-instant-search__search-results-list">
+					{ results.map( this.renderResult ) }
+				</ol>
 				{ this.props.hasNextPage && (
 					<ScrollButton
 						enableLoadOnScroll={ this.props.enableLoadOnScroll }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -55,7 +55,7 @@ class SearchResults extends Component {
 
 	renderEmptyResults( { showText = false } = {} ) {
 		return (
-			<div className="jetpack-instant-search__search-results">
+			<div className="jetpack-instant-search__search-results" role="listitem">
 				{ showText ? (
 					<div>
 						<h3>{ sprintf( __( 'No Results.', 'jetpack' ), this.props.query ) }</h3>
@@ -78,10 +78,12 @@ class SearchResults extends Component {
 		}
 
 		return (
-			<div
+			<main
+				aria-live="polite"
 				className={ `jetpack-instant-search__search-results ${
 					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
 				}` }
+				role="list"
 			>
 				<p className="jetpack-instant-search__search-results-real-query">
 					{ this.getSearchTitle() }
@@ -99,7 +101,7 @@ class SearchResults extends Component {
 						onLoadNextPage={ this.props.onLoadNextPage }
 					/>
 				) }
-			</div>
+			</main>
 		);
 	}
 }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -79,6 +79,7 @@ class SearchResults extends Component {
 
 		return (
 			<main
+				aria-hidden={ this.props.isLoading === true }
 				aria-live="polite"
 				className={ `jetpack-instant-search__search-results ${
 					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -29,3 +29,9 @@
 .jetpack-instant-search__result-comments {
 	padding-left: 10px;
 }
+
+.jetpack-instant-search__search-results-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -34,4 +34,10 @@
 	list-style: none;
 	margin: 0;
 	padding: 0;
+
+	// Accessibility improvement for VoiceOVer
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
+	li:before {
+		content: '\200B';
+	}
 }

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -29,7 +29,11 @@ export default class SearchWidget extends Component {
 
 	render() {
 		return createPortal(
-			<div id={ `${ this.props.widget.widget_id }-portaled-wrapper` }>
+			<form
+				id={ `${ this.props.widget.widget_id }-portaled-wrapper` }
+				className="jetpack-instant-search__portaled-wrapper"
+				role="search"
+			>
 				<div className="search-form">
 					<SearchBox
 						onChangeQuery={ this.onChangeQuery }
@@ -50,7 +54,7 @@ export default class SearchWidget extends Component {
 					results={ this.props.response }
 					widget={ this.props.widget }
 				/>
-			</div>,
+			</form>,
 			document.getElementById( `${ this.props.widget.widget_id }-wrapper` )
 		);
 	}

--- a/modules/search/instant-search/components/search-widget.jsx
+++ b/modules/search/instant-search/components/search-widget.jsx
@@ -22,6 +22,8 @@ import {
 	setSortQuery,
 } from '../lib/query-string';
 
+const noop = event => event.preventDefault();
+
 export default class SearchWidget extends Component {
 	onChangeFilter = ( filterName, filterValue ) => setFilterQuery( filterName, filterValue );
 	onChangeQuery = event => setSearchQuery( event.target.value );
@@ -32,6 +34,7 @@ export default class SearchWidget extends Component {
 			<form
 				id={ `${ this.props.widget.widget_id }-portaled-wrapper` }
 				className="jetpack-instant-search__portaled-wrapper"
+				onSubmit={ noop }
 				role="search"
 			>
 				<div className="search-form">


### PR DESCRIPTION
Fixes #13644 and parts of #13817.

#### Changes proposed in this Pull Request:
* Changes Gridicon titles into fragment sentences where appropriate.
* Adds `search`, `list`, `listitem`, and `main` roles where appropriate.
* Adds `aria-live` to the search results container.
* Adds `aria-hidden` to the search results container while results are loading.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
1. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php. 
If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.

2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. 
You can enable Jetpack Search in the Performance tab within the Jetpack menu (`/wp-admin/admin.php?page=jetpack#/performance`).

3. Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.

4. If using a theme with a sidebar widget, you can navigate to `/` to start the search experience. Otherwise, navigate to your search page (e.g. `/?s=hello`).

5. Enable a screen reader of your choice (e.g. VoiceOver on macOS).

6. Enter a search term into the input. Ensure that the search results are read aloud as soon as the search results have been loaded.

#### Proposed changelog entry for your changes:
None.