### PR TITLE
Connection: call verify_secrets() in verify_action()

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -568,18 +568,19 @@ class Jetpack_XMLRPC_Server {
 	 *
 	 * The 'authorize' and 'register' actions have additional error codes
 	 *
-	 * Possible values for action are `authorize`, `publicize` and `register`.
-	 *
 	 * state_missing: a state ( user id ) was not supplied
 	 * state_malformed: state is not the correct data type
 	 * invalid_state: supplied state does not match the stored state
 	 *
-	 * @param array $params action parameters.
+	 * @param array $params action An array of 3 parameters:
+	 *     [0]: string action. Possible values are `authorize`, `publicize` and `register`.
+	 *     [1]: string secret_1.
+	 *     [2]: int state.
 	 * @return \IXR_Error|string IXR_Error on failure, secret_2 on success.
 	 */
 	public function verify_action( $params ) {
-		$action        = $params[0];
-		$verify_secret = $params[1];
+		$action        = isset( $params[0] ) ? $params[0] : '';
+		$verify_secret = isset( $params[1] ) ? $params[1] : '';
 		$state         = isset( $params[2] ) ? $params[2] : '';
 
 		$result = $this->connection->verify_secrets( $action, $verify_secret, $state );

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -578,71 +578,11 @@ class Jetpack_XMLRPC_Server {
 	 * @return \WP_Error|string secret_2 on success, WP_Error( error_code => error_code, error_message => error description, error_data => status code ) on failure
 	 */
 	public function verify_action( $params ) {
-		$action                    = $params[0];
-		$verify_secret             = $params[1];
-		$state                     = isset( $params[2] ) ? $params[2] : '';
-		$user                      = get_user_by( 'id', $state );
-		$tracks_failure_event_name = '';
+		$action        = $params[0];
+		$verify_secret = $params[1];
+		$state         = isset( $params[2] ) ? $params[2] : '';
 
-		if ( 'authorize' === $action ) {
-			$tracks_failure_event_name = 'jpc_verify_authorize_fail';
-			$this->tracking->record_user_event( 'jpc_verify_authorize_begin', array(), $user );
-		}
-		if ( 'publicize' === $action ) {
-			// This action is used on a response from a direct XML-RPC done from WordPress.com.
-			$tracks_failure_event_name = 'jpc_verify_publicize_fail';
-			$this->tracking->record_user_event( 'jpc_verify_publicize_begin', array(), $user );
-		}
-		if ( 'register' === $action ) {
-			$tracks_failure_event_name = 'jpc_verify_register_fail';
-			$this->tracking->record_user_event( 'jpc_verify_register_begin', array(), $user );
-		}
-
-		if ( empty( $verify_secret ) ) {
-			return $this->error( new Jetpack_Error( 'verify_secret_1_missing', sprintf( 'The required "%s" parameter is missing.', 'secret_1' ), 400 ), $tracks_failure_event_name, $user );
-		} elseif ( ! is_string( $verify_secret ) ) {
-			return $this->error( new Jetpack_Error( 'verify_secret_1_malformed', sprintf( 'The required "%s" parameter is malformed.', 'secret_1' ), 400 ), $tracks_failure_event_name, $user );
-		} elseif ( empty( $state ) ) {
-			return $this->error( new Jetpack_Error( 'state_missing', sprintf( 'The required "%s" parameter is missing.', 'state' ), 400 ), $tracks_failure_event_name, $user );
-		} elseif ( ! ctype_digit( $state ) ) {
-			return $this->error( new Jetpack_Error( 'state_malformed', sprintf( 'The required "%s" parameter is malformed.', 'state' ), 400 ), $tracks_failure_event_name, $user );
-		}
-
-		$secrets = Jetpack::get_secrets( $action, $state );
-
-		if ( ! $secrets ) {
-			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( 'verify_secrets_missing', 'Verification secrets not found', 400 ), $tracks_failure_event_name, $user );
-		}
-
-		if ( is_wp_error( $secrets ) ) {
-			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( $secrets->get_error_code(), $secrets->get_error_message(), 400 ), $tracks_failure_event_name, $user );
-		}
-
-		if ( empty( $secrets['secret_1'] ) || empty( $secrets['secret_2'] ) || empty( $secrets['exp'] ) ) {
-			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( 'verify_secrets_incomplete', 'Verification secrets are incomplete', 400 ), $tracks_failure_event_name, $user );
-		}
-
-		if ( ! hash_equals( $verify_secret, $secrets['secret_1'] ) ) {
-			Jetpack::delete_secrets( $action, $state );
-			return $this->error( new Jetpack_Error( 'verify_secrets_mismatch', 'Secret mismatch', 400 ), $tracks_failure_event_name, $user );
-		}
-
-		Jetpack::delete_secrets( $action, $state );
-
-		if ( 'authorize' === $action ) {
-			$this->tracking->record_user_event( 'jpc_verify_authorize_success', array(), $user );
-		}
-		if ( 'publicize' === $action ) {
-			$this->tracking->record_user_event( 'jpc_verify_publicize_success', array(), $user );
-		}
-		if ( 'register' === $action ) {
-			$this->tracking->record_user_event( 'jpc_verify_register_success', array(), $user );
-		}
-
-		return $secrets['secret_2'];
+		return $this->connection->verify_secrets( $action, $verify_secret, $state );
 	}
 
 	/**

--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -575,14 +575,20 @@ class Jetpack_XMLRPC_Server {
 	 * invalid_state: supplied state does not match the stored state
 	 *
 	 * @param array $params action parameters.
-	 * @return \WP_Error|string secret_2 on success, WP_Error( error_code => error_code, error_message => error description, error_data => status code ) on failure
+	 * @return \IXR_Error|string IXR_Error on failure, secret_2 on success.
 	 */
 	public function verify_action( $params ) {
 		$action        = $params[0];
 		$verify_secret = $params[1];
 		$state         = isset( $params[2] ) ? $params[2] : '';
 
-		return $this->connection->verify_secrets( $action, $verify_secret, $state );
+		$result = $this->connection->verify_secrets( $action, $verify_secret, $state );
+
+		if ( is_wp_error( $result ) ) {
+			return $this->error( $result );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1289,9 +1289,7 @@ class Manager {
 					400
 				)
 			);
-		}
-
-		if ( self::SECRETS_MISSING === $stored_secrets ) {
+		} elseif ( self::SECRETS_MISSING === $stored_secrets ) {
 			$error = $return_error(
 				new \WP_Error(
 					'verify_secrets_missing',
@@ -1337,7 +1335,7 @@ class Manager {
 		}
 
 		// Something went wrong during the checks, returning the error.
-		if ( null !== $error ) {
+		if ( ! empty( $error ) ) {
 			return $error;
 		}
 

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1214,7 +1214,7 @@ class Manager {
 	 * @param string $secret_1 The secret string to compare to what is stored.
 	 * @param int    $user_id  The user ID of the owner of the secret.
 	 */
-	protected function verify_secrets( $action, $secret_1, $user_id ) {
+	public function verify_secrets( $action, $secret_1, $user_id ) {
 		$allowed_actions = array( 'register', 'authorize', 'publicize' );
 		if ( ! in_array( $action, $allowed_actions, true ) ) {
 			return new \WP_Error( 'unknown_verification_action', 'Unknown Verification Action', 400 );
@@ -1281,7 +1281,7 @@ class Manager {
 		} elseif ( ! ctype_digit( (string) $user_id ) ) {
 			return $return_error(
 				new \WP_Error(
-					'verify_secret_1_malformed',
+					'state_malformed',
 					/* translators: "%s" is the name of a paramter. It can be either "secret_1" or "state". */
 					sprintf( __( 'The required "%s" parameter is malformed.', 'jetpack' ), 'state' ),
 					400

--- a/packages/connection/src/Manager.php
+++ b/packages/connection/src/Manager.php
@@ -1213,6 +1213,7 @@ class Manager {
 	 * @param string $action   The type of secret to verify.
 	 * @param string $secret_1 The secret string to compare to what is stored.
 	 * @param int    $user_id  The user ID of the owner of the secret.
+	 * @return \WP_Error|string WP_Error on failure, secret_2 on success.
 	 */
 	public function verify_secrets( $action, $secret_1, $user_id ) {
 		$allowed_actions = array( 'register', 'authorize', 'publicize' );


### PR DESCRIPTION
The method `Manager::verify_secrets()` is the basically the same as the method `Jetpack_XMLRPC_Server::verify_action()`. Remove the duplication of code by calling
`Manager::verify_secrets()` from `Jetpack_XMLRPC_Server::verify_action()`.

#### Changes proposed in this Pull Request:
* Call `Manager::verify_secrets()` from `Jetpack_XMLRPC_Server::verify_action()`.
* Make `Manager::verify_secrets()` public.
* Fix the error code in the `elseif ( ! ctype_digit( (string) $user_id )` branch of `Manager::verify_secrets()`. It should be "state_malformed".

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This improves an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* see [this comment](https://github.com/Automattic/jetpack/pull/13886#pullrequestreview-310180626) and [this comment](https://github.com/Automattic/jetpack/pull/13886#issuecomment-548839119)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
