### PR TITLE
Disconnect Dialog: revert to spinner default size

### DIFF
--- a/_inc/client/components/jetpack-termination-dialog/dialog.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/dialog.jsx
@@ -103,7 +103,7 @@ class JetpackTerminationDialog extends Component {
 			/>
 		) : (
 			<Card className="jetpack-termination-dialog__spinner">
-				<Spinner size={ 50 } />
+				<Spinner />
 			</Card>
 		);
 	}


### PR DESCRIPTION
Fixes #13893

#### Changes proposed in this Pull Request:

* Disconnect Dialog: revert to spinner default size

#### Testing instructions:

1. Start with a site connected to WordPress.com.
2. Click on the link to manage your connection in Jetpack > Dashboard
3. As the modal loads, you'll notice the spinner.
4. It should be smaller and the default size now.

#### Proposed changelog entry for your changes:

* None
