### PR TITLE
Hide overflow on settings search transistion

### DIFF
--- a/_inc/client/components/search/style.scss
+++ b/_inc/client/components/search/style.scss
@@ -67,6 +67,7 @@
 	width: 50px;
 	top: 0;
 	right: 0;
+	overflow: hidden;
 
 	.dops-search__input-fade {
 		position: relative;


### PR DESCRIPTION
See the issue for a description of the problem. 
Fixes #13891

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This is a small CSS fix that hides any overflow to stop the bug.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack > Settings
* Click in the search bar.
* Notice the elements transition from outside of the card (look the right)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
