### PR TITLE
Helper Script Endpoint: Use 'stat' param to fix PHP notice

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -1272,6 +1272,7 @@ new Jetpack_JSON_API_Install_Backup_Helper_Script_Endpoint( array(
 	'description'             => 'Setup a Helper Script, to allow Jetpack Backup to connect to this site',
 	'group'                   => '__do_not_document',
 	'method'                  => 'POST',
+	'stat'                    => 'install-backup-helper-script',
 	'path'                    => '/sites/%s/install-backup-helper-script',
 	'allow_jetpack_site_auth' => true,
 	'path_labels'             => array(
@@ -1299,6 +1300,7 @@ new Jetpack_JSON_API_Delete_Backup_Helper_Script_Endpoint( array(
 	'description'             => 'Delete a Helper Script',
 	'group'                   => '__do_not_document',
 	'method'                  => 'POST',
+	'stat'                    => 'delete-backup-helper-script',
 	'path'                    => '/sites/%s/delete-backup-helper-script',
 	'allow_jetpack_site_auth' => true,
 	'path_labels'             => array(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13890

I wasn't able to find how `stat` is used in Jetpack context, except `do_action` for `wpcom_json_api_output` which is not registered in Jetpack. Adding this only to prevent unexpected notices. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* adds `stat` to the endpoint initiation

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Have a connected Jetpack site with logging enabled
* Before applying this PR: load any admin page (maybe Jetpack Dashboard?)
* See the PHP Notice in logs
* Apply the PR. Load any admin page
* Make sure no notices in logs

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* fix PHP Notice in Helper script endpoints
