### PR TITLE
fix text align and console errors

### DIFF
--- a/_inc/client/components/jetpack-termination-dialog/dialog.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/dialog.jsx
@@ -49,6 +49,7 @@ function mapBenefitNameToGridicon( benefitName ) {
 
 function mapBenefitDataToViewData( benefit ) {
 	return {
+		name: benefit.name,
 		title: benefit.title,
 		description: benefit.description,
 		amount: benefit.value,

--- a/_inc/client/components/jetpack-termination-dialog/features.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/features.jsx
@@ -112,8 +112,9 @@ class JetpackTerminationDialogFeatures extends Component {
 								: 'jetpack-termination-dialog__features-list'
 						}
 					>
-						{ siteBenefits.map( ( { title, description, amount, gridIcon } ) => (
+						{ siteBenefits.map( ( { amount, description, name, gridIcon, title } ) => (
 							<SingleFeature
+								key={ name }
 								amount={ amount }
 								description={ description }
 								gridIcon={ gridIcon }

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -113,7 +113,6 @@
 	font-weight: normal;
 	line-height: 24px;
 	margin-top: 29px;
-	text-align: center;
 
 	// replicates behavior from .dops-card and keeps this centered
 	@include breakpoint( '>480px' ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13889

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Left aligns "Have a question... " text to match alignment of "Are you sure..." text below it
* Adds keys to `<SingleFeature />` components to suppress console warning.

##### Before
<img width="665" alt="Screen Shot 2019-10-30 at 11 30 23 AM" src="https://user-images.githubusercontent.com/2810519/67888243-02661500-fb0a-11e9-9e66-ffb48429f321.png">

##### After
<img width="686" alt="Screen Shot 2019-10-30 at 11 36 03 AM" src="https://user-images.githubusercontent.com/2810519/67888233-ff6b2480-fb09-11e9-8f97-f0b7c9d58984.png">


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Navigate to `/wp-admin/admin.php?page=jetpack#/dashboard` on a connected site
2. Press "Manage Site Connection Link"
3. Confirm it matches "After" screenshot above
4. Open browser console
5. Confirm there are no errors, specifically  none matching:
<img width="1321" alt="Screen Shot 2019-10-30 at 11 35 44 AM" src="https://user-images.githubusercontent.com/2810519/67888380-3c371b80-fb0a-11e9-92d2-5d5562644619.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix, no entry needed
