### PR TITLE
JITM: Duplicate SCSS into the JITM package.

### DIFF
--- a/packages/jitm/.gitattributes
+++ b/packages/jitm/.gitattributes
@@ -1,4 +1,5 @@
 # Files not needed to be distributed in the package.
 .gitattributes  export-ignore
 phpunit.xml     export-ignore
+assets/scss     export-ignore
 tests/          export-ignore

--- a/packages/jitm/.gitattributes
+++ b/packages/jitm/.gitattributes
@@ -1,5 +1,5 @@
 # Files not needed to be distributed in the package.
 .gitattributes  export-ignore
 phpunit.xml     export-ignore
-assets/scss     export-ignore
+assets/scss/     export-ignore
 tests/          export-ignore

--- a/packages/jitm/assets/jetpack-admin-jitm.scss
+++ b/packages/jitm/assets/jetpack-admin-jitm.scss
@@ -1,9 +1,9 @@
 // Just in Time Messaging - message prompts
 
-@import '_inc/client/scss/functions/rem';
-@import '_inc/client/scss/variables/colors';
-@import '_inc/client/scss/mixins/breakpoints';
-@import '_inc/client/scss/calypso-colors';
+@import 'scss/functions/rem';
+@import 'scss/variables/colors';
+@import 'scss/mixins/breakpoints';
+@import 'scss/calypso-colors';
 
 @mixin clear-fix {
 	&:after {

--- a/packages/jitm/assets/scss/calypso-colors.scss
+++ b/packages/jitm/assets/scss/calypso-colors.scss
@@ -1,0 +1,60 @@
+// Blues
+$blue-wordpress:         #0087be;
+$blue-light:             #78dcfa;
+$blue-medium:            #007cba;
+$blue-dark:              #005082;
+$blue-medium-dark:       #0071a1;
+$blue-grey-light:        #f3f5f6;
+$blue-grey-dark:         #016087;
+$light-gray-700:         #ccd0d4;
+
+
+// Grays
+$gray-original:          #87a6bc;
+$gray:                   desaturate( $gray-original, 100% ); // Intermediary transform to match dotcom's colors
+
+// $gray color functions:
+//
+// lighten( $gray, 10% )
+// lighten( $gray, 20% )
+// lighten( $gray, 30% )
+// darken( $gray, 10% )
+// darken( $gray, 20% )
+// darken( $gray, 30% )
+//
+// See wordpress.com/design-handbook/colors/ for more info.
+
+$gray-light:             lighten( $gray, 33% ); //#f6f6f6
+$gray-dark:              darken( $gray, 38% ); //#404040
+
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text:              $gray-dark;
+$gray-text-min:          darken( $gray, 18% ); //#537994
+
+// Shades of gray
+$gray-lighten-10: lighten( $gray, 10% ); // #a8bece
+$gray-lighten-20: lighten( $gray, 20% ); // #c8d7e1
+$gray-lighten-30: lighten( $gray, 30% ); // #e9eff3
+$gray-darken-10:  darken( $gray, 10% );  // #668eaa
+$gray-darken-20:  darken( $gray, 20% );  // #4f748e
+$gray-darken-30:  darken( $gray, 30% );  // #3d596d
+
+// Oranges
+$orange-jazzy:           #f0821e;
+$orange-fire:            #d54e21;
+
+// Alerts
+$alert-yellow:           #f0b849;
+$alert-red:              #d94f4f;
+$alert-green:            #4ab866;
+$alert-purple:           #855DA6;
+
+// Link hovers
+$link-highlight:         tint($blue-medium, 20%);
+
+// Essentials
+$white:                  rgba(255,255,255,1);
+$transparent:            rgba(255,255,255,0);
+
+$border-ultra-light-gray: #e8f0f5;

--- a/packages/jitm/assets/scss/functions/colors.scss
+++ b/packages/jitm/assets/scss/functions/colors.scss
@@ -1,0 +1,32 @@
+/*
+The MIT License (MIT)
+
+Copyright © 2011–2015 thoughtbot, inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://github.com/thoughtbot/bourbon
+*/
+
+// Add percentage of white to a color
+// Copyright © 2011–2015 thoughtbot. See CREDITS.md#L3
+@function tint($color, $percent){
+	@return mix(white, $color, $percent);
+}
+
+// Add percentage of black to a color
+// Copyright © 2011–2015 thoughtbot. See CREDITS.md#L3
+@function shade($color, $percent){
+	@return mix(black, $color, $percent);
+}

--- a/packages/jitm/assets/scss/functions/rem.scss
+++ b/packages/jitm/assets/scss/functions/rem.scss
@@ -1,0 +1,14 @@
+
+// ======================================================================
+// Rem function
+//
+// Convert px to rem in a readable fashion.
+//
+// Example: font-size: rem( 21px );
+// ======================================================================
+
+$root-font-size: 16px;
+
+@function rem( $pixels, $context: $root-font-size ) {
+	@return $pixels / $context * 1rem;
+}

--- a/packages/jitm/assets/scss/jetpack-admin-jitm.scss
+++ b/packages/jitm/assets/scss/jetpack-admin-jitm.scss
@@ -1,9 +1,9 @@
 // Just in Time Messaging - message prompts
 
-@import 'scss/functions/rem';
-@import 'scss/variables/colors';
-@import 'scss/mixins/breakpoints';
-@import 'scss/calypso-colors';
+@import 'functions/rem';
+@import 'variables/colors';
+@import 'mixins/breakpoints';
+@import 'calypso-colors';
 
 @mixin clear-fix {
 	&:after {

--- a/packages/jitm/assets/scss/mixins/_breakpoints.scss
+++ b/packages/jitm/assets/scss/mixins/_breakpoints.scss
@@ -1,0 +1,58 @@
+// ==========================================================================
+// Breakpoint Mixin
+// See https://wpcalypso.wordpress.com/devdocs/docs/coding-guidelines/css.md#media-queries
+// ==========================================================================
+
+$breakpoints: 480px, 660px, 960px, 1040px; // Think very carefully before adding a new breakpoint
+
+@mixin breakpoint( $size ){
+	@if type-of($size) == string {
+	  $approved-value: 0;
+		@each $breakpoint in $breakpoints {
+			$and-larger: ">" + $breakpoint;
+			$and-smaller: "<" + $breakpoint;
+
+			@if $size == $and-smaller {
+				$approved-value: 1;
+				@media ( max-width: $breakpoint ) {
+					@content;
+				}
+			}
+			@else {
+				@if $size == $and-larger {
+					$approved-value: 2;
+					@media ( min-width: $breakpoint + 1 ) {
+						@content;
+					}
+				}
+				@else {
+					@each $breakpoint-end in $breakpoints {
+						$range: $breakpoint + "-" + $breakpoint-end;
+						@if $size == $range {
+							$approved-value: 3;
+							@media ( min-width: $breakpoint + 1 ) and ( max-width: $breakpoint-end ) {
+								@content;
+							}
+						}
+					}
+				}
+			}
+		}
+		@if $approved-value == 0 {
+			$sizes: "";
+			@each $breakpoint in $breakpoints {
+				$sizes: $sizes + " " + $breakpoint;
+			}
+			// TODO - change this to use @error, when it is supported by node-sass
+			@warn "ERROR in breakpoint( #{ $size } ): You can only use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+		}
+	}
+	@else {
+		$sizes: "";
+		@each $breakpoint in $breakpoints {
+			$sizes: $sizes + " " + $breakpoint;
+		}
+		// TODO - change this to use @error, when it is supported by node-sass
+		@warn "ERROR in breakpoint( #{ $size } ): Please wrap the breakpoint $size in parenthesis. You can use these sizes[ #{$sizes} ] using the following syntax [ <#{ nth( $breakpoints, 1 ) } >#{ nth( $breakpoints, 1 ) } #{ nth( $breakpoints, 1 ) }-#{ nth( $breakpoints, 2 ) } ]";
+	}
+}

--- a/packages/jitm/assets/scss/shared/_main.scss
+++ b/packages/jitm/assets/scss/shared/_main.scss
@@ -1,0 +1,81 @@
+// ==========================================================================
+// Global Shared Jetpack Styles
+// ==========================================================================
+
+// Utilities
+// TODO Extract into other files
+
+.jp-hidden-on-mobile {
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+// General Elements
+
+.jetpack-pagestyles #wpcontent {
+	padding-left: 0;
+}
+
+.wp-admin.toplevel_page_jetpack {
+	background-color: $gray-light;
+	line-height: 1.4; // fixes core bug that sets an em unit on body
+	height: auto;
+}
+
+.jetpack-pagestyles a {
+	text-decoration: none;
+}
+
+.dops-notice__text a {
+	text-decoration: underline;
+}
+
+// Hello Dolly positioning overwrite
+.jetpack-pagestyles #dolly {
+	float: none;
+	position: relative;
+	right: 0;
+	left: 0;
+	top: 0;
+	padding: rem( 10px );
+	text-align: right;
+	background: $white;
+	font-size: rem( 12px );
+	font-style: italic;
+	color: $gray;
+	border-bottom: 1px lighten( $gray, 30% ) solid;
+
+	@include breakpoint( "<660px" ) {
+		display: none;
+	}
+}
+
+// restyled the arrow to match our gray
+.toplevel_page_jetpack ul#adminmenu a.wp-has-current-submenu:after {
+	border-right-color: $gray-light;
+}
+
+.jp-lower {
+	margin: 0 auto;
+	text-align: left;
+	max-width: rem( 1040px );
+	padding: rem( 24px );
+
+	@media (max-width: 1250px) {
+		max-width: 95%;
+	}
+
+}
+
+#contextual-help-link-wrap {
+	display: none;
+}
+.is-placeholder {
+	animation: pulse-light 0.8s ease-in-out infinite;
+	background: lighten( $gray, 20% );
+}
+
+@keyframes pulse-light {
+	50% { background-color: lighten( $gray, 30% ); }
+}

--- a/packages/jitm/assets/scss/variables/_colors.scss
+++ b/packages/jitm/assets/scss/variables/_colors.scss
@@ -1,0 +1,105 @@
+@import "../functions/colors.scss";
+
+// ==========================================================================
+// WordPress.com Colors
+// ==========================================================================
+
+// Primary Accent (Blues)
+$blue-wordpress:         #0087be;
+$blue-light:             #78dcfa;
+$blue-medium:            #007cba;
+$blue-dark:              #005082;
+
+// Grays
+$gray-original:          #87a6bc;
+$gray:                   desaturate( $gray-original, 100% ); // Intermediary transform to match dotcom's colors
+
+$gray-light:             lighten( $gray, 33% ); //#f6f6f6
+$gray-dark:              darken( $gray, 38% ); //#404040
+
+// Text blues
+$blue-heading:           #668eaa;
+$blue-text:              #537994;
+$blue-dark-text:         #2e4453;
+
+// $gray-text: ideal for standard, non placeholder text
+// $gray-text-min: minimum contrast needed for WCAG 2.0 AA on white background
+$gray-text:              $gray-dark;
+$gray-text-min:          darken( $gray, 18% ); //#537994
+
+// $gray color functions:
+// lighten( $gray, 10% )
+// lighten( $gray, 20% )
+// lighten( $gray, 30% )
+// darken( $gray, 10% )
+// darken( $gray, 20% )
+// darken( $gray, 30% )
+//
+// See wordpress.com/design-handbook/colors/ for more info.
+
+// Secondary Accent (Oranges)
+$orange-jazzy:           #f0821e;
+$orange-fire:            #d54e21;
+
+// Alerts
+$alert-yellow:           #f0b849;
+$alert-red:              #d94f4f;
+$alert-green:            #4ab866;
+$alert-purple:           #855DA6;
+$alert-hot-red:          #eb0001; // 2019
+
+// Link hovers
+$link-highlight:         tint($blue-medium, 20%);
+
+// Essentials
+$black:                  #000000;
+$white:                  rgba(255,255,255,1);
+$transparent:            rgba(255,255,255,0);
+
+// Uncommon
+$border-ultra-light-gray: #e8f0f5;
+
+// Layout
+$masterbar-color:          $blue-wordpress;
+$sidebar-bg-color:         lighten( $gray, 30% );
+$sidebar-text-color:       $gray-dark;
+$sidebar-selected-color:   $gray;
+
+// Dashboard
+$dashboard-number-border: #CBD7E1;
+
+//Social media colors
+$color-facebook:    #1877F2;
+$color-twitter:     #55ACEE;
+$color-gplus:       #df4a32;
+$color-tumblr:      #35465c;
+$color-linkedin:    #0976b4;
+$color-path:        #df3b2f;
+$color-instagram:   #e12f67;
+$color-eventbrite:  #ff8000;
+$color-stumbleupon: #eb4924;
+$color-reddit:      #5f99cf;
+$color-pinterest:   #cc2127;
+$color-pocket:      #ee4256;
+$color-email:       #f8f8f8;
+$color-print:       #f8f8f8;
+$color-skype:       #00AFF0;
+$color-telegram:    #0088cc;
+$color-whatsapp:    #43d854;
+
+
+// ==========================================================================
+// Jetpack Specific Colors
+// ==========================================================================
+
+$green-primary:   #00BE28;
+$green-secondary: #00a523;
+$green-dark:      #008b1d;
+
+// ==========================================================================
+// WP-ADMIN Specific Colors
+// full color list here: http://codepen.io/hugobaeta/full/RNOzoV/
+// ==========================================================================
+
+$wpui-gray-light:       #f5f5f5;
+$wpui-dark-medium-gray: #555d66;


### PR DESCRIPTION
The JITM package SCSS, while not compiled through our build system, is incomplete, as it assumes it is within the Jetpack directory.

For the time-being, this PR duplicates the required files from `_inc/client` into the JITM package until a more robust system for sharing UI pieces is done.

#### Changes proposed in this Pull Request:
* Add dev files to JITM.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
*

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* n/a

Marking as DO NOT MERGE as I want to ensure this passes all preflight testing on wp.com before landing in the package itself.