### PR TITLE
Simple payments: update block description

### DIFF
--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -31,13 +31,13 @@ export const settings = {
 		<Fragment>
 			<p>
 				{ __(
-					'Lets you create and embed credit and debit card payment buttons with minimal setup.',
+					'Lets you add credit and debit card payment buttons with minimal setup.',
 					'jetpack'
 				) }
 			</p>
 			<p>
 				{ __(
-					'Good for collecting donations or paymens for products and services.',
+					'Good for collecting donations or payments for products and services.',
 					'jetpack'
 				) }
 			</p>

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -35,6 +35,12 @@ export const settings = {
 					'jetpack'
 				) }
 			</p>
+			<p>
+				{ __(
+					'Good for collecting donations or paymens for products and services.',
+					'jetpack'
+				) }
+			</p>
 			<ExternalLink href="https://support.wordpress.com/simple-payments/">
 				{ __( 'Support reference', 'jetpack' ) }
 			</ExternalLink>


### PR DESCRIPTION
Update Simple payment block's description.

The description could elaborate a bit more about the potential use cases for the block so that customers would be more encouraged to try it.

Also modified old sentence little bit "create and embed" sounded complicated and technical, changed to "add".

#### Before:

> Lets you create and embed credit and debit card payment buttons with minimal setup.
<img src="https://user-images.githubusercontent.com/87168/67900292-d5971980-fb6c-11e9-9174-2be188f8cef2.png" alt="" width="270"/>


#### After:

> Lets you add credit and debit card payment buttons with minimal setup.
>
> Good for collecting donations or payments for products and services.

Thoughts?

#### Changes proposed in this Pull Request:
* Update block description.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Modifying an old feature.

#### Testing instructions:
- In block editor, insert simple payments button
- Choose the block and check the sidebar's description

#### Proposed changelog entry for your changes:
*
