### PR TITLE
Blocks: link to Jetpack or wpcom support docs depending on site type

### DIFF
--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -9,6 +9,7 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import './editor.scss';
+import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import edit from './edit';
 import save from './save';
 
@@ -19,6 +20,11 @@ const exampleDescription = __(
 	'Markdown is a text formatting syntax that is converted into HTML. You can _emphasize_ text or **make it strong** with just a few characters.',
 	'jetpack'
 );
+
+const supportLink =
+	isSimpleSite() || isAtomicSite()
+		? 'https://en.support.wordpress.com/markdown-quick-reference/'
+		: 'https://jetpack.com/support/jetpack-blocks/markdown-block/';
 
 export const settings = {
 	title: __( 'Markdown', 'jetpack' ),
@@ -31,9 +37,7 @@ export const settings = {
 					'jetpack'
 				) }
 			</p>
-			<ExternalLink href="https://en.support.wordpress.com/markdown-quick-reference/">
-				{ __( 'Support reference', 'jetpack' ) }
-			</ExternalLink>
+			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
 		</Fragment>
 	),
 

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -8,9 +8,10 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { DEFAULT_CURRENCY } from './constants';
+import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import edit from './edit';
 import save from './save';
-import { DEFAULT_CURRENCY } from './constants';
 
 /**
  * Example image
@@ -24,6 +25,11 @@ import './editor.scss';
 
 export const name = 'simple-payments';
 
+const supportLink =
+	isSimpleSite() || isAtomicSite()
+		? 'https://support.wordpress.com/simple-payments/'
+		: 'https://jetpack.com/support/jetpack-blocks/simple-payments-block/';
+
 export const settings = {
 	title: __( 'Simple Payments button', 'jetpack' ),
 
@@ -35,9 +41,7 @@ export const settings = {
 					'jetpack'
 				) }
 			</p>
-			<ExternalLink href="https://support.wordpress.com/simple-payments/">
-				{ __( 'Support reference', 'jetpack' ) }
-			</ExternalLink>
+			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
 		</Fragment>
 	),
 


### PR DESCRIPTION
Link to Jetpack or WordPress.com support articles depending on site type.

#### Changes proposed in this Pull Request:
*

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- 

#### Testing instructions:
- Insert Markdown and Simple payments block and confirm that for a Jetpack site, you have links to Jetpack docks:

![image](https://user-images.githubusercontent.com/87168/67900283-cfa13880-fb6c-11e9-998d-935c9c30e746.png)

![image](https://user-images.githubusercontent.com/87168/67900292-d5971980-fb6c-11e9-9174-2be188f8cef2.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
