### PR TITLE
Disconnect Dialog: update close button to cancel instead

### DIFF
--- a/_inc/client/components/jetpack-termination-dialog/dialog.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/dialog.jsx
@@ -138,7 +138,7 @@ class JetpackTerminationDialog extends Component {
 								: __( 'Are you sure you want to disconnect and deactivate?' ) }
 						</p>
 						<div className="jetpack-termination-dialog__button-row-buttons">
-							<Button onClick={ this.handleDialogCloseClick }>{ __( 'Close' ) }</Button>
+							<Button onClick={ this.handleDialogCloseClick }>{ __( 'Cancel' ) }</Button>
 							<Button scary primary onClick={ this.handleTerminationClick }>
 								{ purpose === 'disconnect' ? __( 'Disconnect' ) : __( 'Disable' ) }
 							</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As suggested here:
p8oabR-qb-p2#comment-3478

* Update close button to cancel instead. It reads better with the “Are you sure you want to disconnect?” sentence.

![image](https://user-images.githubusercontent.com/426388/67936810-be881400-fbcc-11e9-9664-667cd060ef4e.png)

#### Testing instructions:

* Start from a site that's connected to WordPress.com.
* Click on the Manage connection link in Jetpack > Dashboard to disconnect that site from WordPress.com. 
* Notice the button at the bottom of the modal to cancel that action.

#### Proposed changelog entry for your changes:

* None
