### PR TITLE
Mailchimp: Update "Set up Form" Link

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
@@ -67,7 +67,7 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 				403
 			);
 		}
-		$connect_url = sprintf( 'https://wordpress.com/marketing/connections/%s', rawurlencode( $site_id ) );
+		$connect_url = sprintf( 'https://wordpress.com/marketing/connections/%s?mailchimp', rawurlencode( $site_id ) );
 		return array(
 			'code'        => $this->is_connected() ? 'connected' : 'not_connected',
 			'connect_url' => $connect_url,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Required for Automattic/wp-calypso#37216

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `?mailchimp` to the end of the Mailchimp connection link 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- On an account without Mailchimp set up, go to the Gutenberg editor and use the Mailchimp Block
- Click the "Set up Mailchimp" button
- Verify you're directed to the Marketing page, and that the box is expanded and highlighted if Automattic/wp-calypso#37216 is applied.

<img width="1199" alt="Screenshot 2019-10-31 at 12 31 26" src="https://user-images.githubusercontent.com/43215253/67947104-c3ec5b00-fbda-11e9-98b1-c6008867e59c.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not necessary, this is a very minor change
