### PR TITLE
Full Sync updates to allow full enqueuing of chunks.

### DIFF
--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -226,7 +226,7 @@ class Full_Sync extends Module {
 			}
 
 			// Stop processing if we've reached our limit of items to enqueue.
-			if ( 0 >= $remaining_items_to_enqueue ) {
+			if ( 0 <= $remaining_items_to_enqueue ) {
 				$this->set_enqueue_status( $enqueue_status );
 				return;
 			}

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -201,6 +201,7 @@ class Full_Sync extends Module {
 			$enqueue_status = $this->get_enqueue_status();
 		}
 
+		$queue_finished = true;
 		foreach ( Modules::get_modules() as $module ) {
 			$module_name = $module->name();
 
@@ -225,14 +226,20 @@ class Full_Sync extends Module {
 				$remaining_items_to_enqueue        -= $items_enqueued;
 			}
 
+			if ( ! $next_enqueue_state ) {
+				$queue_finished = false;
+			}
 			// Stop processing if we've reached our limit of items to enqueue.
-			if ( 0 <= $remaining_items_to_enqueue ) {
-				$this->set_enqueue_status( $enqueue_status );
-				return;
+			if ( 0 >= $remaining_items_to_enqueue ) {
+				break;
 			}
 		}
 
 		$this->set_enqueue_status( $enqueue_status );
+
+		if ( ! $queue_finished ) {
+			return;
+		}
 
 		// Setting autoload to true means that it's faster to check whether we should continue enqueuing.
 		$this->update_status_option( 'queue_finished', time(), true );

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -239,7 +239,7 @@ class Full_Sync extends Module {
 
 		$this->set_enqueue_status( $enqueue_status );
 
-		if ( count( $modules ) === $modules_processed ) {
+		if ( count( $modules ) > $modules_processed ) {
 			return;
 		}
 

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -599,7 +599,7 @@ class Full_Sync extends Module {
 	 *
 	 * @return array Full sync enqueue status.
 	 */
-	private function get_enqueue_status() {
+	public function get_enqueue_status() {
 		return \Jetpack_Options::get_raw_option( 'jetpack_sync_full_enqueue_status' );
 	}
 

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -201,8 +201,9 @@ class Full_Sync extends Module {
 			$enqueue_status = $this->get_enqueue_status();
 		}
 
-		$queue_finished = true;
-		foreach ( Modules::get_modules() as $module ) {
+		$modules           = Modules::get_modules();
+		$modules_processed = 0;
+		foreach ( $modules as $module ) {
 			$module_name = $module->name();
 
 			// Skip module if not configured for this sync or module is done.
@@ -213,6 +214,7 @@ class Full_Sync extends Module {
 					! $enqueue_status[ $module_name ]
 				|| // Finished enqueuing this module.
 					true === $enqueue_status[ $module_name ][2] ) {
+				$modules_processed ++;
 				continue;
 			}
 
@@ -226,8 +228,8 @@ class Full_Sync extends Module {
 				$remaining_items_to_enqueue        -= $items_enqueued;
 			}
 
-			if ( ! $next_enqueue_state ) {
-				$queue_finished = false;
+			if ( true === $next_enqueue_state ) {
+				$modules_processed ++;
 			}
 			// Stop processing if we've reached our limit of items to enqueue.
 			if ( 0 >= $remaining_items_to_enqueue ) {
@@ -237,7 +239,7 @@ class Full_Sync extends Module {
 
 		$this->set_enqueue_status( $enqueue_status );
 
-		if ( ! $queue_finished ) {
+		if ( count( $modules ) === $modules_processed ) {
 			return;
 		}
 

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -126,7 +126,7 @@ class Term_Relationships extends Module {
 			$items                 = array_chunk( $objects, $term_relationships_full_sync_item_size );
 			$last_object_enqueued  = $this->bulk_enqueue_full_sync_term_relationships( $items, $last_object_enqueued );
 			$items_enqueued_count += count( $items );
-			$limit                 = min( $limit - $objects_count, self::QUERY_LIMIT );
+			$limit                 = min( $max_items_to_enqueue - $items_enqueued_count, self::QUERY_LIMIT );
 		}
 		return array( $items_enqueued_count, $last_object_enqueued );
 	}

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -128,6 +128,13 @@ class Term_Relationships extends Module {
 			$items_enqueued_count += count( $items );
 			$limit                 = min( $limit - $objects_count, self::QUERY_LIMIT );
 		}
+
+		// We need to do this extra check in case $max_items_to_enqueue * $term_relationships_full_sync_item_size == relationships objects left.
+		$count = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $wpdb->term_relationships WHERE ( object_id = %d AND term_taxonomy_id < %d ) OR ( object_id < %d ) ORDER BY object_id DESC, term_taxonomy_id DESC LIMIT %d", $last_object_enqueued['object_id'], $last_object_enqueued['term_taxonomy_id'], $last_object_enqueued['object_id'], 1 ) );
+		if ( intval( $count ) === 0 ) {
+			return array( $items_enqueued_count, true );
+		}
+
 		return array( $items_enqueued_count, $last_object_enqueued );
 	}
 

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -126,7 +126,7 @@ class Term_Relationships extends Module {
 			$items                 = array_chunk( $objects, $term_relationships_full_sync_item_size );
 			$last_object_enqueued  = $this->bulk_enqueue_full_sync_term_relationships( $items, $last_object_enqueued );
 			$items_enqueued_count += count( $items );
-			$limit                 = min( ($max_items_to_enqueue  - $items_enqueued_count) * $term_relationships_full_sync_item_size, self::QUERY_LIMIT );
+			$limit                 = min( $limit - $objects_count, self::QUERY_LIMIT );
 		}
 		return array( $items_enqueued_count, $last_object_enqueued );
 	}

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -126,7 +126,7 @@ class Term_Relationships extends Module {
 			$items                 = array_chunk( $objects, $term_relationships_full_sync_item_size );
 			$last_object_enqueued  = $this->bulk_enqueue_full_sync_term_relationships( $items, $last_object_enqueued );
 			$items_enqueued_count += count( $items );
-			$limit                 = min( $max_items_to_enqueue - $items_enqueued_count, self::QUERY_LIMIT );
+			$limit                 = min( ($max_items_to_enqueue  - $items_enqueued_count) * $term_relationships_full_sync_item_size, self::QUERY_LIMIT );
 		}
 		return array( $items_enqueued_count, $last_object_enqueued );
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -307,6 +307,64 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $original_number_of_term_relationships, $replica_number_of_term_relationships );
 	}
 
+	function test_full_sync_enqueue_term_relationships() {
+		global $wpdb;
+
+		// how many items are we allowed to enqueue on a single request/continue_enqueuing
+		$max_enqueue_full_sync = 2;
+		// how many items are we allowed to enqueue on any given time
+		$max_queue_size_full_sync = 3;
+		// how many term relationships we can put on a full_sync_term_relationships item
+		$sync_item_size = 4;
+
+		Settings::update_settings( [
+			'term_relationships_full_sync_item_size' => $sync_item_size,
+			'max_queue_size_full_sync'               => $max_queue_size_full_sync,
+			'max_enqueue_full_sync'                  => $max_enqueue_full_sync,
+		] );
+
+		$post_ids = $this->factory->post->create_many( 4 );
+
+		foreach ( $post_ids as $post_id ) {
+			wp_set_object_terms( $post_id, array( 'cat1', 'cat2', 'cat3' ), 'category', true );
+			wp_set_object_terms( $post_id, array( 'tag1', 'tag2', 'tag3' ), 'post_tag', true );
+		}
+
+		// 28
+		$original_number_of_term_relationships = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->term_relationships" );
+		// ceil(28/4) = 7
+		$total_items = intval( ceil( $original_number_of_term_relationships  / $sync_item_size ) );
+
+		$this->full_sync->start( array( 'term_relationships' => true ) );
+		$this->sender->do_full_sync(); // empty the queue since – "full_sync_start" takes one item in the queue
+
+		$status = $this->full_sync->get_enqueue_status();
+		list( $total, $initial_queued, $finished ) = $status['term_relationships'];
+
+		$this->assertEquals( $total_items, $total );
+		$this->assertEquals( $max_enqueue_full_sync, $initial_queued );
+		$this->assertNotTrue( $finished );
+
+		$this->full_sync->continue_enqueuing(); // try to enqueue $max_enqueue_full_sync items
+		$this->full_sync->continue_enqueuing(); // try to enqueue $max_enqueue_full_sync items
+
+		// hit $max_queue_size_full_sync limit
+		$status = $this->full_sync->get_enqueue_status();
+		list( $total, $queued, $finished ) = $status['term_relationships'];
+		$this->assertEquals( $initial_queued +  $max_queue_size_full_sync, $queued );
+
+		$this->sender->do_full_sync();
+
+		$this->full_sync->continue_enqueuing();
+
+		$status = $this->full_sync->get_enqueue_status();
+		list( $total, $queued, $finished ) = $status['term_relationships'];
+
+		$this->assertEquals( $total_items, $total );
+		$this->assertEquals( $total_items, $queued );
+		$this->assertTrue( $finished === true );
+	}
+
 	function test_full_sync_sends_all_term_relationships_with_previous_interval_end() {
 		$post_id = $this->factory->post->create();
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -363,7 +363,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( $total_items, $total );
 		$this->assertEquals( $total_items, $queued );
-		$this->assertTrue( $finished === true );
+		$this->assertSame( $finished, true );
 	}
 
 	function test_full_sync_sends_all_term_relationships_with_previous_interval_end() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -351,6 +351,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// hit $max_queue_size_full_sync limit
 		$status = $this->full_sync->get_enqueue_status();
 		list( $total, $queued, $finished ) = $status['term_relationships'];
+		$this->assertNotTrue( $finished );
 		$this->assertEquals( $initial_queued +  $max_queue_size_full_sync, $queued );
 
 		$this->sender->do_full_sync();

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -312,7 +312,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 		// how many items are we allowed to enqueue on a single request/continue_enqueuing
 		$max_enqueue_full_sync = 2;
-		// how many items are we allowed to enqueue on any given time
+		// how many sync items the full sync queue can contain
 		$max_queue_size_full_sync = 3;
 		// how many term relationships we can put on a full_sync_term_relationships item
 		$sync_item_size = 4;


### PR DESCRIPTION
Testing of the Term_Relationships module revealed that only 10 chunks were being enqueued and processed before a jetpack_full_sync_end action was being triggered. 

#### Changes proposed in this Pull Request:
This PR modifies the Term_Relationships module to allow for enqueuing of items to match the expected value of the arguments.

In addition it modifies the continue_enqueue function in Full_Sync module so that it returns when more items exist to be processed instead of sending an early `jetpack_full_sync_end` action.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bug Fix

#### Testing instructions:

* Initiate a Full Sync of the `term_relationships` module.
* `wp jetpack-sync start --blog-id=XXX --object-type=term_relationship`
* Check the Jetpack Debug page and you will see that only 10 chunks are enqueued.
* Wait for the Sync to complete
* Only 10 chunks in total will have been sent and processed.

* Apply the Patch
* Initiate a Full Sync of the `term_relationships` module.
* `wp jetpack-sync start --blog-id=XXX --object-type=term_relationship`
* Check the Jetpack Debug page and you will see that more than 10 chunks are enqueued.
* Wait for the Sync to complete
* All chunks will have been processed.

#### Proposed changelog entry for your changes:
Not sure any entry is required as this goes hand in hand with the refactoring in 13815

#### Additional Notes
Should there be additional unit test on both these functions to ensure that the max param is being adhered to and that continue_enqueue is existing correctly?
