### PR TITLE
Fix: Add tracking for Top Button on plans page

### DIFF
--- a/_inc/client/plans/top-button.jsx
+++ b/_inc/client/plans/top-button.jsx
@@ -12,11 +12,8 @@ import analytics from 'lib/analytics';
 
 export default class TopButton extends React.Component {
 	clickHandler = () => {
-		const { planType, isActivePlan, productSlug } = this.props;
+		const { planType, productSlug } = this.props;
 
-		if ( ! isActivePlan ) {
-			return;
-		}
 		analytics.tracks.recordJetpackClick( {
 			target: `upgrade-${ planType }`,
 			type: 'upgrade',


### PR DESCRIPTION
We found that the tracks events were not being recorded when the user didn't have a plan already. 

Which is the case for most cases.

This PR fixes the tracking by making sure that the tracks event always gets fired.

#### Changes proposed in this Pull Request:
* Remove the checks for isActivePlan before we track the clicks on the upgrade button. 

#### Testing instructions:
* Build this PR. 
* In you developer run the following code. 
`localStorage.setItem( 'debug', 'dops:analytics');`
* Presist the console log errors.
* On the plans page. Click the update button. 
* Notice the tracks event gets recorded as expected. 

* Go to the plans-prompt page.  Click the update button. 
* Notice the tracks event gets recorded as expected. 

#### Proposed changelog entry for your changes:
* Fix tracking of the plans upgrade button. 
