### PR TITLE
Disconnect Dialog: update wording for stats card

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -94,7 +94,7 @@ class Jetpack_Core_API_Site_Endpoint {
 			$benefits[] = array(
 				'name'        => 'jetpack-stats',
 				'title'       => esc_html__( 'Site Stats', 'jetpack' ),
-				'description' => esc_html__( 'Visitors tracked by Jetpack this year', 'jetpack' ),
+				'description' => esc_html__( 'Visitors tracked by Jetpack', 'jetpack' ),
 				'value'       => absint( $stats->stats->visitors ),
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* We currently retrieve all time stats to display in site benefits, and not yearly ones. Let's consequently update the wording so it's clearer.

This was brought up here:
p8oabR-qb-p2#comment-3489

#### Testing instructions:

* Start from a connected Jetpack site, where the Stats module is active and you've had visitors already.
* In Jetpack > Dashboard, click on the link to manage the site connection.
* In the modal that opens, the Stats card should not mention that the number of visitors is "this year", since it's not.

#### Proposed changelog entry for your changes:

* None
