### PR TITLE
Deprecate Jetpack::is_development_mode() in favor of the packaged Status()->is_development_mode()

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Status;
+
 // Shared logic between Jetpack admin pages
 abstract class Jetpack_Admin_Page {
 	// Add page specific actions given the page hook
@@ -38,13 +40,15 @@ abstract class Jetpack_Admin_Page {
 	function add_actions() {
 		global $pagenow;
 
+		$status = new Status();
+		$is_development_mode = $status->is_development_mode();
 		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything.
-		if ( ! current_user_can( 'manage_options' ) && ( Jetpack::is_development_mode() || ! Jetpack::is_active() ) ) {
+		if ( ! current_user_can( 'manage_options' ) && ( $is_development_mode || ! Jetpack::is_active() ) ) {
 			return;
 		}
 
 		// Don't add in the modules page unless modules are available!
-		if ( $this->dont_show_if_not_active && ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+		if ( $this->dont_show_if_not_active && ! Jetpack::is_active() && ! $is_development_mode ) {
 			return;
 		}
 
@@ -66,7 +70,7 @@ abstract class Jetpack_Admin_Page {
 			( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] )
 			&& ! Jetpack::is_active()
 			&& current_user_can( 'jetpack_connect' )
-			&& ! Jetpack::is_development_mode()
+			&& ! $is_development_mode
 		) {
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_banner_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
@@ -80,7 +84,7 @@ abstract class Jetpack_Admin_Page {
 			( 'index.php' === $pagenow || 'plugins.php' === $pagenow )
 			&& ! Jetpack::is_active()
 			&& current_user_can( 'jetpack_connect' )
-			&& ! Jetpack::is_development_mode()
+			&& ! $is_development_mode
 		) {
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
 		}
@@ -157,8 +161,9 @@ abstract class Jetpack_Admin_Page {
 	 * @return array
 	 */
 	function check_plan_deactivate_modules( $page ) {
+		$status = new Status();
 		if (
-			Jetpack::is_development_mode()
+			$status->is_development_mode()
 			|| ! in_array(
 				$page->base,
 				array(
@@ -354,9 +359,10 @@ abstract class Jetpack_Admin_Page {
 	 * Note that the Jetpack Dashboard may append additional links to that list.
 	 */
 	public static function render_footer() {
+		$status = new Status();
 		$admin_url = admin_url( 'admin.php?page=jetpack' );
 
-		$is_dev_mode_or_connected = Jetpack::is_active() || Jetpack::is_development_mode();
+		$is_dev_mode_or_connected = Jetpack::is_active() || $status->is_development_mode();
 
 		$privacy_url = ( $is_dev_mode_or_connected )
 			? $admin_url . '#/privacy'

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -161,9 +161,8 @@ abstract class Jetpack_Admin_Page {
 	 * @return array
 	 */
 	function check_plan_deactivate_modules( $page ) {
-		$status = new Status();
 		if (
-			$status->is_development_mode()
+			( new Status() )->is_development_mode()
 			|| ! in_array(
 				$page->base,
 				array(
@@ -359,10 +358,9 @@ abstract class Jetpack_Admin_Page {
 	 * Note that the Jetpack Dashboard may append additional links to that list.
 	 */
 	public static function render_footer() {
-		$status = new Status();
 		$admin_url = admin_url( 'admin.php?page=jetpack' );
 
-		$is_dev_mode_or_connected = Jetpack::is_active() || $status->is_development_mode();
+		$is_dev_mode_or_connected = Jetpack::is_active() || ( new Status() )->is_development_mode();
 
 		$privacy_url = ( $is_dev_mode_or_connected )
 			? $admin_url . '#/privacy'

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -40,8 +40,7 @@ abstract class Jetpack_Admin_Page {
 	function add_actions() {
 		global $pagenow;
 
-		$status = new Status();
-		$is_development_mode = $status->is_development_mode();
+		$is_development_mode = ( new Status() )->is_development_mode();
 		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything.
 		if ( ! current_user_can( 'manage_options' ) && ( $is_development_mode || ! Jetpack::is_active() ) ) {
 			return;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,4 +1,6 @@
 <?php
+use Automattic\Jetpack\Status;
+
 include_once( 'class.jetpack-admin-page.php' );
 
 // Builds the landing page and its menu
@@ -51,7 +53,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_dashboard_sub_nav_item() {
-		if ( Jetpack::is_development_mode() || Jetpack::is_active() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() || Jetpack::is_active() ) {
 			global $submenu;
 			if ( current_user_can( 'jetpack_admin_page' ) ) {
 				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/dashboard' );
@@ -65,7 +68,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		if ( ( Jetpack::is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
+		$status = new Status();
+		if ( ( $status->is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
 			global $submenu;
 			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/settings' );
 		}
@@ -146,12 +150,14 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need for scripts on a fallback page
 		}
 
+		$status = new Status();
+		$is_development_mode = $status->is_development_mode();
 		$script_deps_path    = JETPACK__PLUGIN_DIR . '_inc/build/admin.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ) )
 			: array();
 		$script_dependencies[] = 'wp-polyfill';
-		if ( Jetpack::is_active() || Jetpack::is_development_mode() ) {
+		if ( Jetpack::is_active() || $is_development_mode ) {
 			wp_enqueue_script(
 				'react-plugin',
 				plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ),
@@ -162,7 +168,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		}
 
 
-		if ( ! Jetpack::is_development_mode() && Jetpack::is_active() ) {
+		if ( ! $is_development_mode && Jetpack::is_active() ) {
 			// Required for Analytics.
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
@@ -177,6 +183,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 		$moduleListEndpoint = new Jetpack_Core_API_Module_List_Endpoint();
 		$modules = $moduleListEndpoint->get_modules();
+		$status = new Status();
 
 		// Preparing translated fields for JSON encoding by transforming all HTML entities to
 		// respective characters.
@@ -233,7 +240,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isActive'  => Jetpack::is_active(),
 				'isStaging' => Jetpack::is_staging_site(),
 				'devMode'   => array(
-					'isActive' => Jetpack::is_development_mode(),
+					'isActive' => $status->is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -53,8 +53,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_dashboard_sub_nav_item() {
-		$status = new Status();
-		if ( $status->is_development_mode() || Jetpack::is_active() ) {
+		if ( ( new Status() )->is_development_mode() || Jetpack::is_active() ) {
 			global $submenu;
 			if ( current_user_can( 'jetpack_admin_page' ) ) {
 				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/dashboard' );
@@ -68,8 +67,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		$status = new Status();
-		if ( ( $status->is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
+		if ( ( ( new Status() )->is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
 			global $submenu;
 			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/settings' );
 		}
@@ -150,8 +148,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need for scripts on a fallback page
 		}
 
-		$status = new Status();
-		$is_development_mode = $status->is_development_mode();
+		$is_development_mode = ( new Status() )->is_development_mode();
 		$script_deps_path    = JETPACK__PLUGIN_DIR . '_inc/build/admin.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ) )
@@ -183,7 +180,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 		$moduleListEndpoint = new Jetpack_Core_API_Module_List_Endpoint();
 		$modules = $moduleListEndpoint->get_modules();
-		$status = new Status();
 
 		// Preparing translated fields for JSON encoding by transforming all HTML entities to
 		// respective characters.
@@ -240,7 +236,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isActive'  => Jetpack::is_active(),
 				'isStaging' => Jetpack::is_staging_site(),
 				'devMode'   => array(
-					'isActive' => $status->is_development_mode(),
+					'isActive' => ( new Status() )->is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -4,6 +4,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\JITM;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\Status;
 
 /**
  * Register WP REST API endpoints for Jetpack.
@@ -926,12 +927,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool True if site is connected
 	 */
 	public static function jetpack_connection_status() {
+		$status = new Status();
 		return rest_ensure_response( array(
 				'isActive'     => Jetpack::is_active(),
 				'isStaging'    => Jetpack::is_staging_site(),
 				'isRegistered' => Jetpack::connection()->is_registered(),
 				'devMode'      => array(
-					'isActive' => Jetpack::is_development_mode(),
+					'isActive' => $status->is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -927,13 +927,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool True if site is connected
 	 */
 	public static function jetpack_connection_status() {
-		$status = new Status();
 		return rest_ensure_response( array(
 				'isActive'     => Jetpack::is_active(),
 				'isStaging'    => Jetpack::is_staging_site(),
 				'isRegistered' => Jetpack::connection()->is_registered(),
 				'devMode'      => array(
-					'isActive' => $status->is_development_mode(),
+					'isActive' => ( new Status() )->is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Status;
+
 /**
  * This is the base class for every Core API endpoint Jetpack uses.
  *
@@ -189,6 +192,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	public function get_modules() {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php' );
 
+		$status = new Status();
 		$modules = Jetpack_Admin::init()->get_modules();
 		foreach ( $modules as $slug => $properties ) {
 			$modules[ $slug ]['options'] =
@@ -196,7 +200,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 			if (
 				isset( $modules[ $slug ]['requires_connection'] )
 				&& $modules[ $slug ]['requires_connection']
-				&& Jetpack::is_development_mode()
+				&& $status->is_development_mode()
 			) {
 				$modules[ $slug ]['activated'] = false;
 			}
@@ -354,6 +358,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 * @return mixed|void|WP_Error
 	 */
 	public function get_module( $request ) {
+		$status = new Status();
 		if ( Jetpack::is_module( $request['slug'] ) ) {
 
 			$module = Jetpack::get_module( $request['slug'] );
@@ -363,7 +368,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			if (
 				isset( $module['requires_connection'] )
 				&& $module['requires_connection']
-				&& Jetpack::is_development_mode()
+				&& $status->is_development_mode()
 			) {
 				$module['activated'] = false;
 			}

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -192,7 +192,6 @@ class Jetpack_Core_API_Module_List_Endpoint {
 	public function get_modules() {
 		require_once( JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php' );
 
-		$status = new Status();
 		$modules = Jetpack_Admin::init()->get_modules();
 		foreach ( $modules as $slug => $properties ) {
 			$modules[ $slug ]['options'] =
@@ -200,7 +199,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 			if (
 				isset( $modules[ $slug ]['requires_connection'] )
 				&& $modules[ $slug ]['requires_connection']
-				&& $status->is_development_mode()
+				&& ( new Status() )->is_development_mode()
 			) {
 				$modules[ $slug ]['activated'] = false;
 			}
@@ -358,7 +357,6 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 	 * @return mixed|void|WP_Error
 	 */
 	public function get_module( $request ) {
-		$status = new Status();
 		if ( Jetpack::is_module( $request['slug'] ) ) {
 
 			$module = Jetpack::get_module( $request['slug'] );
@@ -368,7 +366,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			if (
 				isset( $module['requires_connection'] )
 				&& $module['requires_connection']
-				&& $status->is_development_mode()
+				&& ( new Status() )->is_development_mode()
 			) {
 				$module['activated'] = false;
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -1,4 +1,6 @@
 <?php
+use Automattic\Jetpack\Status;
+
 /**
  * Jetpack Connection Testing
  *
@@ -319,7 +321,8 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function output_results_for_cli( $type = 'all', $group = 'all' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			if ( Jetpack::is_development_mode() ) {
+			$status = new Status();
+			if ( $status->is_development_mode() ) {
 				WP_CLI::line( __( 'Jetpack is in Development Mode:', 'jetpack' ) );
 				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -321,8 +321,7 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function output_results_for_cli( $type = 'all', $group = 'all' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			$status = new Status();
-			if ( $status->is_development_mode() ) {
+			if ( ( new Status() )->is_development_mode() ) {
 				WP_CLI::line( __( 'Jetpack is in Development Mode:', 'jetpack' ) );
 				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Status;
 
 /**
  * Class Jetpack_Cxn_Tests contains all of the actual tests.
@@ -67,7 +68,8 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * Is Jetpack even connected and supposed to be talking to WP.com?
 	 */
 	protected function helper_is_jetpack_connected() {
-		return ( Jetpack::is_active() && ! Jetpack::is_development_mode() );
+		$status = new Status();
+		return ( Jetpack::is_active() && ! $status->is_development_mode() );
 	}
 
 	/**
@@ -75,9 +77,10 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function test__check_if_connected() {
 		$name = __FUNCTION__;
+		$status = new Status();
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test( $name );
-		} elseif ( Jetpack::is_development_mode() ) {
+		} elseif ( $status->is_development_mode() ) {
 			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {
 			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), 'cycle_connection' );
@@ -223,7 +226,8 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__wpcom_connection_test() {
 		$name = __FUNCTION__;
 
-		if ( ! Jetpack::is_active() || Jetpack::is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
+		$status = new Status();
+		if ( ! Jetpack::is_active() || $status->is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
 			return self::skipped_test( $name );
 		}
 
@@ -326,7 +330,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function last__wpcom_self_test() {
 		$name = 'test__wpcom_self_test';
-		if ( ! Jetpack::is_active() || Jetpack::is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
+
+		$status = new Status();
+		if ( ! Jetpack::is_active() || $status->is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
 			return self::skipped_test( $name );
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -68,8 +68,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * Is Jetpack even connected and supposed to be talking to WP.com?
 	 */
 	protected function helper_is_jetpack_connected() {
-		$status = new Status();
-		return ( Jetpack::is_active() && ! $status->is_development_mode() );
+		return ( Jetpack::is_active() && ! ( new Status() )->is_development_mode() );
 	}
 
 	/**
@@ -77,10 +76,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 */
 	protected function test__check_if_connected() {
 		$name = __FUNCTION__;
-		$status = new Status();
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test( $name );
-		} elseif ( $status->is_development_mode() ) {
+		} elseif ( ( new Status() )->is_development_mode() ) {
 			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {
 			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), 'cycle_connection' );
@@ -226,8 +224,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__wpcom_connection_test() {
 		$name = __FUNCTION__;
 
-		$status = new Status();
-		if ( ! Jetpack::is_active() || $status->is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
+		if ( ! Jetpack::is_active() || ( new Status() )->is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
 			return self::skipped_test( $name );
 		}
 
@@ -331,8 +328,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function last__wpcom_self_test() {
 		$name = 'test__wpcom_self_test';
 
-		$status = new Status();
-		if ( ! Jetpack::is_active() || $status->is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
+		if ( ! Jetpack::is_active() || ( new Status() )->is_development_mode() || Jetpack::is_staging_site() || ! $this->pass ) {
 			return self::skipped_test( $name );
 		}
 

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Status;
+
 /**
  * Jetpack Debugger functionality allowing for self-service diagnostic information via the legacy jetpack debugger.
  *
@@ -289,9 +292,10 @@ class Jetpack_Debugger {
 					</div>
 				<?php endif; ?>
 				<?php
+				$status = new Status();
 				if (
 					current_user_can( 'jetpack_manage_modules' )
-					&& ( Jetpack::is_development_mode() || Jetpack::is_active() )
+					&& ( $status->is_development_mode() || Jetpack::is_active() )
 				) {
 					printf(
 						wp_kses(

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -292,10 +292,9 @@ class Jetpack_Debugger {
 					</div>
 				<?php endif; ?>
 				<?php
-				$status = new Status();
 				if (
 					current_user_can( 'jetpack_manage_modules' )
-					&& ( $status->is_development_mode() || Jetpack::is_active() )
+					&& ( ( new Status() )->is_development_mode() || Jetpack::is_active() )
 				) {
 					printf(
 						wp_kses(

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Status;
 
 // Build the Jetpack admin menu as a whole
 class Jetpack_Admin {
@@ -73,10 +74,11 @@ class Jetpack_Admin {
 	// presentation like description, name, configuration url, etc.
 	function get_modules() {
 		include_once JETPACK__PLUGIN_DIR . 'modules/module-info.php';
+		$status = new Status();
 		$available_modules = Jetpack::get_available_modules();
 		$active_modules    = Jetpack::get_active_modules();
 		$modules           = array();
-		$jetpack_active    = Jetpack::is_active() || Jetpack::is_development_mode();
+		$jetpack_active    = Jetpack::is_active() || $status->is_development_mode();
 		$overrides         = Jetpack_Modules_Overrides::instance();
 		foreach ( $available_modules as $module ) {
 			if ( $module_array = Jetpack::get_module( $module ) ) {
@@ -197,7 +199,8 @@ class Jetpack_Admin {
 			return false;
 		}
 
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			return ! ( $module['requires_connection'] );
 		} else {
 			if ( ! Jetpack::is_active() ) {

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -74,11 +74,10 @@ class Jetpack_Admin {
 	// presentation like description, name, configuration url, etc.
 	function get_modules() {
 		include_once JETPACK__PLUGIN_DIR . 'modules/module-info.php';
-		$status = new Status();
 		$available_modules = Jetpack::get_available_modules();
 		$active_modules    = Jetpack::get_active_modules();
 		$modules           = array();
-		$jetpack_active    = Jetpack::is_active() || $status->is_development_mode();
+		$jetpack_active    = Jetpack::is_active() || ( new Status() )->is_development_mode();
 		$overrides         = Jetpack_Modules_Overrides::instance();
 		foreach ( $available_modules as $module ) {
 			if ( $module_array = Jetpack::get_module( $module ) ) {
@@ -199,8 +198,7 @@ class Jetpack_Admin {
 			return false;
 		}
 
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			return ! ( $module['requires_connection'] );
 		} else {
 			if ( ! Jetpack::is_active() ) {

--- a/class.jetpack-affiliate.php
+++ b/class.jetpack-affiliate.php
@@ -5,6 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\Jetpack\Status;
+
 /**
  * This class introduces routines to get an affiliate code, that might be obtained from:
  * - an `jetpack_affiliate_code` option in the WP database
@@ -21,7 +23,8 @@ class Jetpack_Affiliate {
 	private static $instance = null;
 
 	private function __construct() {
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			return;
 		}
 	}

--- a/class.jetpack-affiliate.php
+++ b/class.jetpack-affiliate.php
@@ -23,8 +23,7 @@ class Jetpack_Affiliate {
 	private static $instance = null;
 
 	private function __construct() {
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			return;
 		}
 	}

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -4,6 +4,7 @@ WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Queue;
@@ -824,6 +825,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$action = isset( $args[0] ) ? $args[0] : 'status';
 
+		$status = new Status();
+
 		switch ( $action ) {
 			case 'status':
 				$status     = Actions::get_sync_status();
@@ -902,7 +905,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. Jetpack is not connected.', 'jetpack' ) );
 						return;
 					}
-					if ( Jetpack::is_development_mode() ) {
+					if ( $status->is_development_mode() ) {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. The site is in development mode.', 'jetpack' ) );
 						return;
 					}
@@ -1608,7 +1611,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'The publicize module is not active.', 'jetpack' ) );
 		}
 
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			if (
 				! defined( 'JETPACK_DEV_DEBUG' ) &&
 				! has_filter( 'jetpack_development_mode' ) &&

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -825,8 +825,6 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 		$action = isset( $args[0] ) ? $args[0] : 'status';
 
-		$status = new Status();
-
 		switch ( $action ) {
 			case 'status':
 				$status     = Actions::get_sync_status();
@@ -905,7 +903,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. Jetpack is not connected.', 'jetpack' ) );
 						return;
 					}
-					if ( $status->is_development_mode() ) {
+					if ( ( new Status() )->is_development_mode() ) {
 						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. The site is in development mode.', 'jetpack' ) );
 						return;
 					}
@@ -1611,8 +1609,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'The publicize module is not active.', 'jetpack' ) );
 		}
 
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			if (
 				! defined( 'JETPACK_DEV_DEBUG' ) &&
 				! has_filter( 'jetpack_development_mode' ) &&

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status;
 
 /**
  * Wrapper function to safely register a gutenberg block type
@@ -445,7 +446,8 @@ class Jetpack_Gutenberg {
 	 * @return bool
 	 */
 	public static function should_load() {
-		if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( ! Jetpack::is_active() && ! $status->is_development_mode() ) {
 			return false;
 		}
 
@@ -580,8 +582,9 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
+		$status = new Status();
 		// Required for Analytics. See _inc/lib/admin-pages/class.jetpack-admin-page.php.
-		if ( ! Jetpack::is_development_mode() && Jetpack::is_active() ) {
+		if ( ! $status->is_development_mode() && Jetpack::is_active() ) {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -446,8 +446,7 @@ class Jetpack_Gutenberg {
 	 * @return bool
 	 */
 	public static function should_load() {
-		$status = new Status();
-		if ( ! Jetpack::is_active() && ! $status->is_development_mode() ) {
+		if ( ! Jetpack::is_active() && ! ( new Status() )->is_development_mode() ) {
 			return false;
 		}
 
@@ -582,9 +581,8 @@ class Jetpack_Gutenberg {
 			return;
 		}
 
-		$status = new Status();
 		// Required for Analytics. See _inc/lib/admin-pages/class.jetpack-admin-page.php.
-		if ( ! $status->is_development_mode() && Jetpack::is_active() ) {
+		if ( ! ( new Status() )->is_development_mode() && Jetpack::is_active() ) {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status;
 
 /**
  * Used to manage Jetpack installation on Multisite Network installs
@@ -432,7 +433,8 @@ class Jetpack_Network {
 			return;
 		}
 
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			return;
 		}
 
@@ -543,7 +545,8 @@ class Jetpack_Network {
 		restore_current_blog();
 
 		// If we are in dev mode, just show the notice and bail.
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			Jetpack::show_development_mode_notice();
 			return;
 		}

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -433,8 +433,7 @@ class Jetpack_Network {
 			return;
 		}
 
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			return;
 		}
 
@@ -545,8 +544,7 @@ class Jetpack_Network {
 		restore_current_blog();
 
 		// If we are in dev mode, just show the notice and bail.
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			Jetpack::show_development_mode_notice();
 			return;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1556,7 +1556,6 @@ class Jetpack {
 	 * @deprecated since 8.0
 	 */
 	public static function is_development_mode() {
-		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\\Jetpack\\Status->is_development_mode' );
 		$status = new Status();
 		return $status->is_development_mode();
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -929,11 +929,11 @@ class Jetpack {
 	}
 
 	function jetpack_custom_caps( $caps, $cap, $user_id, $args ) {
-		$status = new Status();
+		$is_development_mode = ( new Status() )->is_development_mode();
 		switch ( $cap ) {
 			case 'jetpack_connect':
 			case 'jetpack_reconnect':
-				if ( $status->is_development_mode() ) {
+				if ( $is_development_mode ) {
 					$caps = array( 'do_not_allow' );
 					break;
 				}
@@ -984,7 +984,7 @@ class Jetpack {
 				$caps = array( 'manage_sites' );
 				break;
 			case 'jetpack_admin_page':
-				if ( $status->is_development_mode() ) {
+				if ( $is_development_mode ) {
 					$caps = array( 'manage_options' );
 					break;
 				} else {
@@ -992,7 +992,7 @@ class Jetpack {
 				}
 				break;
 			case 'jetpack_connect_user':
-				if ( $status->is_development_mode() ) {
+				if ( $is_development_mode ) {
 					$caps = array( 'do_not_allow' );
 					break;
 				}
@@ -1556,8 +1556,7 @@ class Jetpack {
 	 * @deprecated since 8.0
 	 */
 	public static function is_development_mode() {
-		$status = new Status();
-		return $status->is_development_mode();
+		return ( new Status() )->is_development_mode();
 	}
 
 	/**
@@ -1579,8 +1578,7 @@ class Jetpack {
 	 * Determines reason for Jetpack development mode.
 	 */
 	public static function development_mode_trigger_text() {
-		$status = new Status();
-		if ( ! $status->is_development_mode() ) {
+		if ( ! ( new Status() )->is_development_mode() ) {
 			return __( 'Jetpack is not in Development Mode.', 'jetpack' );
 		}
 
@@ -1601,8 +1599,7 @@ class Jetpack {
 	 * Mirrors the checks made in Automattic\Jetpack\Status->is_development_mode
 	 */
 	public static function show_development_mode_notice() {
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			$notice = sprintf(
 				/* translators: %s is a URL */
 				__( 'In <a href="%s" target="_blank">Development Mode</a>:', 'jetpack' ),
@@ -1783,8 +1780,7 @@ class Jetpack {
 	 * Loads the currently active modules.
 	 */
 	public static function load_modules() {
-		$status = new Status();
-		$is_development_mode = $status->is_development_mode();
+		$is_development_mode = ( new Status() )->is_development_mode();
 		if (
 			! self::is_active()
 			&& ! $is_development_mode
@@ -2181,8 +2177,7 @@ class Jetpack {
 	}
 
 	public static function activate_new_modules( $redirect = false ) {
-		$status = new Status();
-		if ( ! self::is_active() && ! $status->is_development_mode() ) {
+		if ( ! self::is_active() && ! ( new Status() )->is_development_mode() ) {
 			return;
 		}
 
@@ -2963,8 +2958,7 @@ class Jetpack {
 
 		$module_data = self::get_module( $module );
 
-		$status = new Status();
-		$is_development_mode = $status->is_development_mode();
+		$is_development_mode = ( new Status() )->is_development_mode();
 		if ( ! self::is_active() ) {
 			if ( ! $is_development_mode && ! self::is_onboarding() ) {
 				return false;
@@ -3525,8 +3519,8 @@ p {
 			self::plugin_initialize();
 		}
 
-		$status = new Status();
-		if ( ! self::is_active() && ! $status->is_development_mode() ) {
+		$is_development_mode = ( new Status() )->is_development_mode();
+		if ( ! self::is_active() && ! $is_development_mode ) {
 			Jetpack_Connection_Banner::init();
 		} elseif ( false === Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) {
 			// Upgrade: 1.1 -> 1.1.1
@@ -3548,7 +3542,7 @@ p {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_menu_css' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( JETPACK__PLUGIN_DIR . 'jetpack.php' ), array( $this, 'plugin_action_links' ) );
 
-		if ( self::is_active() || $status->is_development_mode() ) {
+		if ( self::is_active() || $is_development_mode ) {
 			// Artificially throw errors in certain whitelisted cases during plugin activation
 			add_action( 'activate_plugin', array( $this, 'throw_error_on_activate_plugin' ) );
 		}
@@ -3935,8 +3929,7 @@ p {
 
 		$jetpack_home = array( 'jetpack-home' => sprintf( '<a href="%s">%s</a>', self::admin_url( 'page=jetpack' ), 'Jetpack' ) );
 
-		$status = new Status();
-		if ( current_user_can( 'jetpack_manage_modules' ) && ( self::is_active() || $status->is_development_mode() ) ) {
+		if ( current_user_can( 'jetpack_manage_modules' ) && ( self::is_active() || ( new Status() )->is_development_mode() ) ) {
 			return array_merge(
 				$jetpack_home,
 				array( 'settings' => sprintf( '<a href="%s">%s</a>', self::admin_url( 'page=jetpack#/settings' ), __( 'Settings', 'jetpack' ) ) ),
@@ -5883,8 +5876,7 @@ endif;
 	 * @return array|bool Array of options that are in a crisis, or false if everything is OK.
 	 */
 	public static function check_identity_crisis() {
-		$status = new Status();
-		if ( ! self::is_active() || $status->is_development_mode() || ! self::validate_sync_error_idc_option() ) {
+		if ( ! self::is_active() || ( new Status() )->is_development_mode() || ! self::validate_sync_error_idc_option() ) {
 			return false;
 		}
 
@@ -6454,8 +6446,7 @@ endif;
 		}
 
 		// We do not want to use the imploded file in dev mode, or if not connected
-		$status = new Status();
-		if ( $status->is_development_mode() || ! self::is_active() ) {
+		if ( ( new Status() )->is_development_mode() || ! self::is_active() ) {
 			if ( ! $travis_test ) {
 				return;
 			}
@@ -6660,8 +6651,7 @@ endif;
 			wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
 
 			// If we're inactive and not in development mode, sort our box to the top.
-			$status = new Status();
-			if ( ! self::is_active() && ! $status->is_development_mode() ) {
+			if ( ! self::is_active() && ! ( new Status() )->is_development_mode() ) {
 				global $wp_meta_boxes;
 
 				$dashboard = $wp_meta_boxes['dashboard']['normal']['core'];
@@ -6712,7 +6702,6 @@ endif;
 	}
 
 	public static function dashboard_widget_footer() {
-		$status = new Status();
 		?>
 		<footer>
 
@@ -6720,7 +6709,7 @@ endif;
 			<?php if ( self::is_module_active( 'protect' ) ) : ?>
 				<h3><?php echo number_format_i18n( get_site_option( 'jetpack_protect_blocked_attempts', 0 ) ); ?></h3>
 				<p><?php echo esc_html_x( 'Blocked malicious login attempts', '{#} Blocked malicious login attempts -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
-			<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! $status->is_development_mode() ) : ?>
+			<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! ( new Status() )->is_development_mode() ) : ?>
 				<a href="
 				<?php
 				echo esc_url(
@@ -7070,8 +7059,7 @@ endif;
 	 * @return bool True if Jetpack is active and not in development.
 	 */
 	public static function is_active_and_not_development_mode() {
-		$status = new Status();
-		if ( ! self::is_active() || $status->is_development_mode() ) {
+		if ( ! self::is_active() || ( new Status() )->is_development_mode() ) {
 			return false;
 		}
 		return true;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1551,9 +1551,14 @@ class Jetpack {
 	}
 
 	/**
-	 * Is Jetpack in development (offline) mode?
+	 * Deprecated: Is Jetpack in development (offline) mode?
 	 *
-	 * @deprecated since 8.0
+	 * This static method is being left here intentionally without the use of _deprecated_function(), as other plugins
+	 * and themes still use it, and we do not want to flood them with notices.
+	 *
+	 * Please use Automattic\Jetpack\Status()->is_development_mode() instead.
+	 *
+	 * @deprecated since 8.0.
 	 */
 	public static function is_development_mode() {
 		return ( new Status() )->is_development_mode();

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Status;
+
 /**
  * Generic functions using the Photon service.
  *
@@ -28,9 +31,10 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		 *
 		 * @since 4.1.0
 		 *
-		 * @param bool false Result of Jetpack::is_development_mode.
+		 * @param bool false Result of Automattic\Jetpack\Status->is_development_mode().
 		 */
-		if ( true === apply_filters( 'jetpack_photon_development_mode', Jetpack::is_development_mode() ) ) {
+		$status = new Status();
+		if ( true === apply_filters( 'jetpack_photon_development_mode', $status->is_development_mode() ) ) {
 			return $image_url;
 		}
 	}

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -33,8 +33,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		 *
 		 * @param bool false Result of Automattic\Jetpack\Status->is_development_mode().
 		 */
-		$status = new Status();
-		if ( true === apply_filters( 'jetpack_photon_development_mode', $status->is_development_mode() ) ) {
+		if ( true === apply_filters( 'jetpack_photon_development_mode', ( new Status() )->is_development_mode() ) ) {
 			return $image_url;
 		}
 	}

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -1,5 +1,6 @@
 <?php
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Status;
 /*
 Plugin Name: Jetpack Carousel
 Plugin URL: https://wordpress.com/
@@ -305,6 +306,8 @@ class Jetpack_Carousel {
 			 * Build string with tracking info.
 			 */
 
+			$status = new Status();
+
 			/**
 			 * Filter if Jetpack should enable stats collection on carousel views
 			 *
@@ -314,7 +317,7 @@ class Jetpack_Carousel {
 			 *
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
-			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! Jetpack::is_development_mode() ) {
+			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! $status->is_development_mode() ) {
 				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -306,8 +306,6 @@ class Jetpack_Carousel {
 			 * Build string with tracking info.
 			 */
 
-			$status = new Status();
-
 			/**
 			 * Filter if Jetpack should enable stats collection on carousel views
 			 *
@@ -317,7 +315,7 @@ class Jetpack_Carousel {
 			 *
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
-			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! $status->is_development_mode() ) {
+			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! ( new Status() )->is_development_mode() ) {
 				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -1,4 +1,6 @@
 <?php
+use Automattic\Jetpack\Status;
+
 /**
  * Module Name: Sharing
  * Module Description: Add Twitter, Facebook and Google+ buttons at the bottom of each post, making it easy for visitors to share your content.
@@ -35,7 +37,8 @@ function sharedaddy_loaded() {
  * @return string Sharing config URL
  */
 function jetpack_sharedaddy_configuration_url() {
-	if ( Jetpack::is_development_mode() || Jetpack::is_staging_site() || ! Jetpack::is_user_connected() ) {
+	$status = new Status();
+	if ( $status->is_development_mode() || Jetpack::is_staging_site() || ! Jetpack::is_user_connected() ) {
 		return admin_url( 'options-general.php?page=sharing' );
 	}
 

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -37,8 +37,7 @@ function sharedaddy_loaded() {
  * @return string Sharing config URL
  */
 function jetpack_sharedaddy_configuration_url() {
-	$status = new Status();
-	if ( $status->is_development_mode() || Jetpack::is_staging_site() || ! Jetpack::is_user_connected() ) {
+	if ( ( new Status() )->is_development_mode() || Jetpack::is_staging_site() || ! Jetpack::is_user_connected() ) {
 		return admin_url( 'options-general.php?page=sharing' );
 	}
 

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Status;
 
 // Include the class file containing methods for rounding constrained array elements.
 // Here the constrained array element is the dimension of a row, group or an image in the tiled gallery.
@@ -180,10 +181,12 @@ class Jetpack_Tiled_Gallery {
 			$gallery       = new $gallery_class( $attachments, $this->atts['link'], $this->atts['grayscale'], (int) $this->atts['columns'] );
 			$gallery_html  = $gallery->HTML();
 
+			$status = new Status();
+
 			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( 'Jetpack_Photon' ) ) {
 				// Tiled Galleries in Jetpack require that Photon be active.
 				// If it's not active, run it just on the gallery output.
-				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) && ! Jetpack::is_development_mode() ) {
+				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) && ! $status->is_development_mode() ) {
 					$gallery_html = Jetpack_Photon::filter_the_content( $gallery_html );
 				}
 			}

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -181,12 +181,10 @@ class Jetpack_Tiled_Gallery {
 			$gallery       = new $gallery_class( $attachments, $this->atts['link'], $this->atts['grayscale'], (int) $this->atts['columns'] );
 			$gallery_html  = $gallery->HTML();
 
-			$status = new Status();
-
 			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( 'Jetpack_Photon' ) ) {
 				// Tiled Galleries in Jetpack require that Photon be active.
 				// If it's not active, run it just on the gallery output.
-				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) && ! $status->is_development_mode() ) {
+				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) && ! ( new Status() )->is_development_mode() ) {
 					$gallery_html = Jetpack_Photon::filter_the_content( $gallery_html );
 				}
 			}

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -8,6 +8,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status;
 
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
 
@@ -268,7 +269,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 		$display_filters = false;
 
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			echo $args['before_widget'];
 			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
 				<div class="jetpack-search-sort-wrapper">

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -269,8 +269,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 		$display_filters = false;
 
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			echo $args['before_widget'];
 			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
 				<div class="jetpack-search-sort-wrapper">

--- a/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget.php
+++ b/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Status;
+
 /*
  * Display a list of recent posts from a WordPress.com or Jetpack-enabled blog.
  */
@@ -142,10 +144,11 @@ class Jetpack_Display_Posts_Widget extends Jetpack_Display_Posts_Widget__Base {
 		}
 
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			$status = new Status();
 			/**
 			 * If Jetpack is not active or in development mode, we don't want to update widget data.
 			 */
-			if ( ! Jetpack::is_active() && ! Jetpack::is_development_mode() ) {
+			if ( ! Jetpack::is_active() && ! $status->is_development_mode() ) {
 				return false;
 			}
 

--- a/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget.php
+++ b/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget.php
@@ -144,11 +144,10 @@ class Jetpack_Display_Posts_Widget extends Jetpack_Display_Posts_Widget__Base {
 		}
 
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			$status = new Status();
 			/**
 			 * If Jetpack is not active or in development mode, we don't want to update widget data.
 			 */
-			if ( ! Jetpack::is_active() && ! $status->is_development_mode() ) {
+			if ( ! Jetpack::is_active() && ! ( new Status() )->is_development_mode() ) {
 				return false;
 			}
 

--- a/modules/wordads/php/api.php
+++ b/modules/wordads/php/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Status;
 
 /**
  * Methods for accessing data through the WPCOM REST API
@@ -20,7 +21,8 @@ class WordAds_API {
 	 */
 	public static function get_wordads_status() {
 		global $wordads_status_response;
-		if ( Jetpack::is_development_mode() ) {
+		$status = new Status();
+		if ( $status->is_development_mode() ) {
 			self::$wordads_status = array(
 				'approved' => true,
 				'active'   => true,

--- a/modules/wordads/php/api.php
+++ b/modules/wordads/php/api.php
@@ -21,8 +21,7 @@ class WordAds_API {
 	 */
 	public static function get_wordads_status() {
 		global $wordads_status_response;
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			self::$wordads_status = array(
 				'approved' => true,
 				'active'   => true,

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Status;
+
 class WordAds_Params {
 
 	/**
@@ -49,9 +51,10 @@ class WordAds_Params {
 		$this->cloudflare     = self::is_cloudflare();
 		$this->blog_id        = Jetpack::get_option( 'id', 0 );
 		$this->mobile_device  = jetpack_is_mobile( 'any', true );
+		$status = new Status();
 		$this->targeting_tags = array(
 			'WordAds' => 1,
-			'BlogId'  => Jetpack::is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
+			'BlogId'  => $status->is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
 			'Domain'  => esc_js( wp_parse_url( home_url(), PHP_URL_HOST ) ),
 			'PageURL' => esc_js( $this->url ),
 			'LangId'  => false !== strpos( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?

--- a/modules/wordads/php/params.php
+++ b/modules/wordads/php/params.php
@@ -51,10 +51,9 @@ class WordAds_Params {
 		$this->cloudflare     = self::is_cloudflare();
 		$this->blog_id        = Jetpack::get_option( 'id', 0 );
 		$this->mobile_device  = jetpack_is_mobile( 'any', true );
-		$status = new Status();
 		$this->targeting_tags = array(
 			'WordAds' => 1,
-			'BlogId'  => $status->is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
+			'BlogId'  => ( new Status() )->is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
 			'Domain'  => esc_js( wp_parse_url( home_url(), PHP_URL_HOST ) ),
 			'PageURL' => esc_js( $this->url ),
 			'LangId'  => false !== strpos( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -89,6 +89,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\Constants',
 						'Automattic\Jetpack\Tracking',
 						'Automattic\Jetpack\Plugin\Tracking',
+						'Automattic\Jetpack\Status',
 					),
 					true
 				);

--- a/packages/sync/src/Actions.php
+++ b/packages/sync/src/Actions.php
@@ -185,8 +185,7 @@ class Actions {
 			return false;
 		}
 
-		$status = new Status();
-		if ( $status->is_development_mode() ) {
+		if ( ( new Status() )->is_development_mode() ) {
 			return false;
 		}
 

--- a/packages/terms-of-service/src/Terms_Of_Service.php
+++ b/packages/terms-of-service/src/Terms_Of_Service.php
@@ -78,8 +78,7 @@ class Terms_Of_Service {
 	 * @return bool
 	 */
 	protected function is_development_mode() {
-		$status = new Status();
-		return $status->is_development_mode();
+		return ( new Status() )->is_development_mode();
 	}
 
 	/**

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Status;
 
 // Extend with a public constructor so that can be mocked in tests
 class MockJetpack extends Jetpack {
@@ -585,14 +586,16 @@ EXPECTED;
 	}
 
 	function test_is_development_mode_filter() {
+		$status = new Status();
 		add_filter( 'jetpack_development_mode', '__return_true' );
-		$this->assertTrue( Jetpack::is_development_mode() );
+		$this->assertTrue( $status->is_development_mode() );
 		remove_filter( 'jetpack_development_mode', '__return_true' );
 	}
 
 	function test_is_development_mode_bool() {
+		$status = new Status();
 		add_filter( 'jetpack_development_mode', '__return_zero' );
-		$this->assertFalse( Jetpack::is_development_mode() );
+		$this->assertFalse( $status->is_development_mode() );
 		remove_filter( 'jetpack_development_mode', '__return_zero' );
 	}
 

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -586,16 +586,14 @@ EXPECTED;
 	}
 
 	function test_is_development_mode_filter() {
-		$status = new Status();
 		add_filter( 'jetpack_development_mode', '__return_true' );
-		$this->assertTrue( $status->is_development_mode() );
+		$this->assertTrue( ( new Status() )->is_development_mode() );
 		remove_filter( 'jetpack_development_mode', '__return_true' );
 	}
 
 	function test_is_development_mode_bool() {
-		$status = new Status();
 		add_filter( 'jetpack_development_mode', '__return_zero' );
-		$this->assertFalse( $status->is_development_mode() );
+		$this->assertFalse( ( new Status() )->is_development_mode() );
 		remove_filter( 'jetpack_development_mode', '__return_zero' );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes the case where we have two methods that do the same thing. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This refactors all calls to the legacy static Jetpack::is_development_mode() method to point to the newer and packaged version in Automattic\Jetpack\Status. 

It was a little annoying since it's going from a static to public method. 

Feedback appreciated: 
- Are there places I could initiate the class in a more global place? There's a lot of `new Status()` happening in this PR. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Read the code: Did I flip any logic? 
- Test all the things dev mode. 
- Test all the things non-dev mode. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A 
