### PR TITLE
Defensive Coding: Ensure value is an array

### DIFF
--- a/_inc/lib/class.jetpack-keyring-service-helper.php
+++ b/_inc/lib/class.jetpack-keyring-service-helper.php
@@ -52,6 +52,11 @@ class Jetpack_Keyring_Service_Helper {
 	 */
 	public static function add_sharing_menu() {
 		global $submenu;
+
+		if ( ! is_array( $submenu['options-general.php'] ) ) {
+			return;
+		}
+
 		$general_settings_names = array_map(
 			function ( $menu ) {
 				return array_values( $menu )[0];


### PR DESCRIPTION
When using `array_map()` ensure the second parameter is an array. Return out early if not.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13918

#### Changes proposed in this Pull Request:
* Defensive coding.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* n/a
