### PR TITLE
Plans Grid: Add tracking event for see all features button

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -50,7 +50,7 @@ class PlanGrid extends React.Component {
 		};
 	}
 
-	handleFeatureClick( planType ) {
+	handleSeeFeaturesClick( planType ) {
 		return () => {
 			analytics.tracks.recordJetpackClick( {
 				target: 'see-all-features-' + planType,
@@ -342,7 +342,7 @@ class PlanGrid extends React.Component {
 				>
 					<Button
 						href={ this.props.plansLearnMoreUpgradeUrl }
-						onClick={ this.handleFeatureClick( planType ) }
+						onClick={ this.handleSeeFeaturesClick( planType ) }
 					>
 						{ plan.strings.see_all }
 					</Button>

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -55,7 +55,7 @@ class PlanGrid extends React.Component {
 			analytics.tracks.recordJetpackClick( {
 				target: 'see-all-features-link',
 				feature: 'plans-grid',
-				extra: 'see-all-features-' + planType,
+				extra: planType,
 			} );
 		};
 	}

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -53,9 +53,9 @@ class PlanGrid extends React.Component {
 	handleSeeFeaturesClick( planType ) {
 		return () => {
 			analytics.tracks.recordJetpackClick( {
-				target: 'see-all-features-' + planType,
+				target: 'see-all-features-link',
 				feature: 'plans-grid',
-				extra: 'see-all-features-link',
+				extra: 'see-all-features-' + planType,
 			} );
 		};
 	}

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -50,6 +50,16 @@ class PlanGrid extends React.Component {
 		};
 	}
 
+	handleFeatureClick( planType ) {
+		return () => {
+			analytics.tracks.recordJetpackClick( {
+				target: 'see-all-features-' + planType,
+				feature: 'plans-grid',
+				extra: 'see-all-features-link',
+			} );
+		};
+	}
+
 	render() {
 		if ( ! this.props.plans ) {
 			return (
@@ -330,7 +340,12 @@ class PlanGrid extends React.Component {
 					key={ 'bottom-' + planType }
 					className="plan-features__table-item is-bottom-buttons has-border-bottom"
 				>
-					<Button href={ this.props.plansLearnMoreUpgradeUrl }>{ plan.strings.see_all }</Button>
+					<Button
+						href={ this.props.plansLearnMoreUpgradeUrl }
+						onClick={ this.handleFeatureClick( planType ) }
+					>
+						{ plan.strings.see_all }
+					</Button>
 				</td>
 			);
 		} );


### PR DESCRIPTION
Currently we don't have a tracking event for the see all features buttons on the plans grid. This PR adds it.

The tracking even it useful in terms to see how many users click on the see all features.

#### Changes proposed in this Pull Request:
* Adds the tracking event for the See All Features on the plans page. 

#### Testing instructions:
* Build this PR. 
* In the dev console  run `localStorage.setItem( 'debug', 'dops:analytics');` to enble debugging for tracks events.
* Presever your console out put in your browser.
* Go to the plans page. Click on the "See all freatures" button. 
* Notice that you see a tracks event for when clicking each of the "See all features buttons"

#### Proposed changelog entry for your changes:
* Adds the tracking event for the `See All Features` on the plans page. 
