### PR TITLE
Make the contact form reusable

### DIFF
--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -33,7 +33,6 @@ export const settings = {
 	],
 	category: 'jetpack',
 	supports: {
-		reusable: false,
 		html: false,
 	},
 	attributes: {


### PR DESCRIPTION
When Contact Forms were originally created we disabled the ability to make them reusable because the preview was broken (https://github.com/Automattic/wp-calypso/issues/).

Now that the preview is working we should re-enable this.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* An improvement to an existing feature

#### Testing instructions:
* Create a new post and add a contact form block
* Make the contact form reusable
* Look at the reusable block in the block picker
* Check that the preview looks correct

![contact form](https://user-images.githubusercontent.com/275961/68019674-61f02c00-fc94-11e9-93db-457b21009d14.gif)

As you can see at the end of the video the editor throws an error. I can't reproduce this, so I assume its unrelated.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Make contact form blocks reusable.
