### PR TITLE
Tests: trigger_error now throws E_USER_DEPRECATED

### DIFF
--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -147,18 +147,29 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 		$this->assertTrue( property_exists( 'Jetpack_Sync_Actions', 'sender' ) );
 	}
 
+	/**
+	 * Provides deprecated files and expected relacements.
+	 *
+	 * @todo Remove version check when WordPress 5.4 is the minimum.
+	 *
+	 * @return array
+	 */
 	function provider_deprecated_file_paths() {
+		global $wp_version;
+
+		$error = ( version_compare( $wp_version, '5.4-alpha', '>=' ) ) ? E_USER_DEPRECATED : E_USER_NOTICE;
+
 		return array(
 
 			array(
 				'class.jetpack-ixr-client.php',
 				null,
-				E_USER_DEPRECATED,
+				$error,
 			),
 			array(
 				'class.jetpack-xmlrpc-server.php',
 				null,
-				E_USER_DEPRECATED   ,
+				$error,
 			),
 		);
 	}

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -153,12 +153,12 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 			array(
 				'class.jetpack-ixr-client.php',
 				null,
-				E_USER_NOTICE,
+				E_USER_DEPRECATED,
 			),
 			array(
 				'class.jetpack-xmlrpc-server.php',
 				null,
-				E_USER_NOTICE,
+				E_USER_DEPRECATED   ,
 			),
 		);
 	}


### PR DESCRIPTION
In r46625-core ( https://github.com/WordPress/WordPress/commit/979a52690290f2134e2ab6129f5c443112c9df2b ), `E_USER_DEPRECATED` is now used when appropriate. 

Our file deprecation test was assuming the previous behavior of `E_USER_NOTICE` being thrown.

This PR add a WP version-based conditional to set the expected error notice level.