### PR TITLE
Pass through missing parameter on compatibility method

### DIFF
--- a/modules/likes.php
+++ b/modules/likes.php
@@ -158,7 +158,7 @@ class Jetpack_Likes {
 	static function is_post_likeable( $post_id = 0 ) {
 		_deprecated_function( __METHOD__, 'jetpack-5.4', 'Jetpack_Likes_Settings()->is_post_likeable' );
 		$settings = new Jetpack_Likes_Settings();
-		return $settings->is_post_likeable();
+		return $settings->is_post_likeable( $post_id );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes potential issue with third party code calling into `Jetpack_Likes::is_post_likeable( $post_id = 0 )`.

We were accepting the parameter but not passing it onto the delegated method, `Jetpack_Likes_Settings->is_post_likeable( $post_id = 0 )`

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix compatibility issue with deprecated method

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
* Invoke `Jetpack_Likes::is_post_likeable( $post_id )` with a post ID (e.g. disable Likes on the post by setting `switch_like_status` postmeta to '0' )
* Response should reflect whether the post is actually Likeable
* On master branch, this does not work - Likeable is always true if Likes are enabled