### PR TITLE
Instant Search: Standardize class and ID prefixes

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -10,16 +10,16 @@ import { __ } from '@wordpress/i18n';
 import uniqueId from 'lodash/uniqueId';
 
 const SearchBox = props => {
-	const [ inputId ] = useState( () => uniqueId( 'jp-instant-search__box-input-' ) );
+	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	return (
-		<div className={ 'jp-instant-search__box' }>
+		<div className={ 'jetpack-instant-search__box' }>
 			{ /* TODO: Add support for preserving label text */ }
 			<label htmlFor={ inputId } className="screen-reader-text">
 				{ __( 'Site Search', 'jetpack' ) }
 			</label>
 			<input
 				id={ inputId }
-				className="search-field jp-instant-search__box-input"
+				className="search-field jetpack-instant-search__box-input"
 				onInput={ props.onChangeQuery }
 				onFocus={ props.onFocus }
 				onBlur={ props.onBlur }

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -1,5 +1,5 @@
 /* apply to all the inputs to try and pick up any theme styling */
-.jp-instant-search__box input {
+.jetpack-instant-search__box input {
 	border-radius: 2px;
 	font-size: 14px;
 	height: 26px;

--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -5,6 +5,8 @@
  */
 import { h, createRef, Component } from 'preact';
 import strip from 'strip';
+// eslint-disable-next-line lodash/import-scope
+import uniqueId from 'lodash/uniqueId';
 
 /**
  * Internal dependencies
@@ -27,7 +29,7 @@ export default class SearchFilter extends Component {
 	constructor( props ) {
 		super( props );
 		this.filtersList = createRef();
-		this.idPrefix = `jetpack-instant-search-filter-${ Math.floor( Math.random() * 100 ) }`;
+		this.idPrefix = uniqueId( 'jetpack-instant-search__filter-' );
 
 		if ( this.props.type === 'date' ) {
 			// NOTE: This assumes that the configuration never changes. It will break if we

--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -27,7 +27,7 @@ export default class SearchFilter extends Component {
 	constructor( props ) {
 		super( props );
 		this.filtersList = createRef();
-		this.idPrefix = `jp-instant-search-filter-${ Math.floor( Math.random() * 100 ) }`;
+		this.idPrefix = `jetpack-instant-search-filter-${ Math.floor( Math.random() * 100 ) }`;
 
 		if ( this.props.type === 'date' ) {
 			// NOTE: This assumes that the configuration never changes. It will break if we


### PR DESCRIPTION
Fixes #13874.

#### Changes proposed in this Pull Request:
* Changes all instances of `jp-instant-search-*` class names and ID's with `jetpack-instant-search-*`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
1. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php. 
If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.

2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. 
You can enable Jetpack Search in the Performance tab within the Jetpack menu (`/wp-admin/admin.php?page=jetpack#/performance`).

3. Select a theme of your choosing and add a Jetpack Search widget to the site via the customizer, preferably with some filters enabled. If you're using a theme with a sidebar widget area, please add the Jetpack Search widget there.

4. If using a theme with a sidebar widget, you can navigate to `/` to start the search experience. Otherwise, navigate to your search page (e.g. `/?s=hello`).

5. Enter a search term into the input. Ensure that it renders search results in the main content area and that the search box is styled as expected.

#### Proposed changelog entry for your changes:
None.
