### PR TITLE
Instant Search: Ignore empty query values for filters

### DIFF
--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -123,7 +123,7 @@ export function setSortQuery( sortKey ) {
 
 function getFilterQueryByKey( filterKey ) {
 	const query = getQuery();
-	if ( ! ( filterKey in query ) ) {
+	if ( ! ( filterKey in query ) || query[ filterKey ] === '' ) {
 		return [];
 	}
 	if ( typeof query[ filterKey ] === 'string' ) {


### PR DESCRIPTION
Fixes #13872.

#### Changes proposed in this Pull Request:
* Updates query string processing to treat `''` as an ignorable value.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
1. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your wp-config.php. 
If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.

2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. 
You can enable Jetpack Search in the Performance tab within the Jetpack menu (`/wp-admin/admin.php?page=jetpack#/performance`).

3. Select a theme of your choosing and add a Jetpack Search widget to the site via the customizer, preferably with some filters enabled. If you're using a theme with a sidebar widget area, please add the Jetpack Search widget there.

4. Navigate to a search URL with a blank filter value such as `/?s=privacy&post_types=`

5. Ensure search results render as expected.

#### Proposed changelog entry for your changes:
None.