### PR TITLE
Sync: Fix total for term_relationship

### DIFF
--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -217,6 +217,8 @@ class Full_Sync extends Module {
 				$modules_processed ++;
 				continue;
 			}
+			// Recalculate the total for some modules.
+			$enqueue_status[ $module_name ][0] = $module->recalculate_total( $enqueue_status[ $module_name ] );
 
 			list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $configs[ $module_name ], $remaining_items_to_enqueue, $enqueue_status[ $module_name ][2] );
 

--- a/packages/sync/src/modules/Module.php
+++ b/packages/sync/src/modules/Module.php
@@ -321,7 +321,7 @@ abstract class Module {
 	 * In most cases the total of items that we enqueue will always stay the same.
 	 * Since the items are ordered using the primary key which auto increments.
 	 *
-	 * @param array $previous_enqueue_status Arr
+	 * @param array $previous_enqueue_status List containing total, enqueued item count, and last enqueued object.
 	 *
 	 * @return int Return the previous total
 	 */

--- a/packages/sync/src/modules/Module.php
+++ b/packages/sync/src/modules/Module.php
@@ -318,7 +318,7 @@ abstract class Module {
 	}
 
 	/**
-	 * In most cases the total of items that we enqueue will always stays the same.
+	 * In most cases the total of items that we enqueue will always stay the same.
 	 * Since the items are ordered using the primary key which auto increments.
 	 *
 	 * @param array $previous_enqueue_status Arr

--- a/packages/sync/src/modules/Module.php
+++ b/packages/sync/src/modules/Module.php
@@ -318,6 +318,18 @@ abstract class Module {
 	}
 
 	/**
+	 * In most cases the total of items that we enqueue will always stays the same.
+	 * Since the items are ordered using the primary key which auto increments.
+	 *
+	 * @param array $previous_enqueue_status Arr
+	 *
+	 * @return int Return the previous total
+	 */
+	public function recalculate_total( $previous_enqueue_status ) {
+		return $previous_enqueue_status[0]; // the previous total
+	}
+
+	/**
 	 * Initialize listeners for the particular meta type.
 	 *
 	 * @access public

--- a/packages/sync/src/modules/Module.php
+++ b/packages/sync/src/modules/Module.php
@@ -326,7 +326,7 @@ abstract class Module {
 	 * @return int Return the previous total
 	 */
 	public function recalculate_total( $previous_enqueue_status ) {
-		return $previous_enqueue_status[0]; // the previous total
+		return $previous_enqueue_status[0]; // The previous total.
 	}
 
 	/**

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -195,7 +195,7 @@ class Term_Relationships extends Module {
 	/**
 	 * Helper function that counts the remaining items given the last object enqueued.
 	 *
-	 * @param array $last_object_enqueued Array containing the place where we last left of.
+	 * @param array $last_object_enqueued Array containing the place where we last left off.
 	 *
 	 * @return int The number of term relationships that are left to enqueue.
 	 */

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -193,7 +193,7 @@ class Term_Relationships extends Module {
 	}
 
 	/**
-	 * Helper function that counts the remaining items give the last object enqueued.
+	 * Helper function that counts the remaining items given the last object enqueued.
 	 *
 	 * @param array $last_object_enqueued Array containing the place where we last left of.
 	 *

--- a/packages/sync/src/modules/Term_Relationships.php
+++ b/packages/sync/src/modules/Term_Relationships.php
@@ -177,17 +177,17 @@ class Term_Relationships extends Module {
 	/**
 	 * Use to calculate the new total.
 	 *
-	 * @param array $previous_enqueue_status
+	 * @param array $previous_enqueue_status List containing total, enqueued item count, and last enqueued object.
 	 *
 	 * @return int The number of items that we should be sending.
 	 */
 	public function recalculate_total( $previous_enqueue_status ) {
 
-		list( $previous_total, $previously_enqueued_item_count, $previous_enqueue_state ) = $previous_enqueue_status;
+		list( $previous_total, $previously_enqueued_item_count, $last_enqueue_object ) = $previous_enqueue_status;
 		if ( ! is_array( $previous_enqueue_status[2] ) ) {
 			return $previous_total;
 		}
-		$count = $this->count_remaining_items( $previous_enqueue_state );
+		$count = $this->count_remaining_items( $last_enqueue_object );
 
 		return (int) ceil( $count / Settings::get_setting( 'term_relationships_full_sync_item_size' ) ) + $previously_enqueued_item_count;
 	}

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -368,7 +368,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 
 	/**
 	 * This tests tries to test the accuracy of the total that gets stored in the enqueue status.
-	 * Since term relationships are not enqueued with an autoincromenting primary key.
+	 * Since term relationships are not enqueued with an autoincrementing primary key.
 	 *
 	 */
 	function test_full_sync_enqueue_older_post_add_term_relationships() {

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -367,7 +367,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/**
-	 * This tests tries to test the accuracy of the total that gets stored in the enqueu status.
+	 * This tests tries to test the accuracy of the total that gets stored in the enqueue status.
 	 * Since term relationships are not enqueued with an autoincromenting primary key.
 	 *
 	 */

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -400,7 +400,7 @@ class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 		// 28
 		$original_number_of_term_relationships = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->term_relationships" );
 		// ceil(28/4) = 7
-		$total_items = intval( ceil( $original_number_of_term_relationships  / $sync_item_size ) );
+		$total_items = intval( ceil( $original_number_of_term_relationships / $sync_item_size ) );
 
 		$this->full_sync->start( array( 'term_relationships' => true ) );
 		$this->sender->do_full_sync(); // empty the queue since – "full_sync_start" takes one item in the queue


### PR DESCRIPTION
Currently we don't do a good job recalculating the total number of items that we send over when we continue enqueue items in full sync. 

This is more prominent in with term_relationships but is true with other modules as well. (posts, comments, users, terms)

This PR is not super critical since we don't use the total for anything that is important. But more to keep track of how much we are sending. 

How this error in the number of items occurs. 

We start a full sync. Which calculates the total number of items that we are planning to send. 
When we reach the enqueuing limit we pause. 
If at this time someone removes older posts that were used in calculating the total we could end up with a total that isn't accurate any more. 

I have added a couple of tests to demonstrate this. 

#### Changes proposed in this Pull Request:
* Always recalculate the total for term_relationships. 

#### Testing instructions:
* Do the tests pass?
* Go to the debugger and initae a full sync. 
* Does it work as expected?

#### Proposed changelog entry for your changes:
* Improves the accuracy of the full sync status endpoint by keeping the total number of items up to date. 
