### PR TITLE
Match core button styles a little more closely

### DIFF
--- a/_inc/client/components/button/style.scss
+++ b/_inc/client/components/button/style.scss
@@ -99,9 +99,12 @@
 	}
 	&[disabled],
 	&:disabled {
-		background: tint( $blue-light, 50% );
-		border-color: tint( $blue-wordpress, 55% );
-		color: $white;
+		color: #66c6e4 !important;
+		background-color: #008ec2 !important;
+		border-color: #008ec2 !important;
+		box-shadow: none !important;
+		text-shadow: none !important;
+		cursor: default;
 	}
 	&.is-compact {
 		color: $white;

--- a/_inc/client/components/button/style.scss
+++ b/_inc/client/components/button/style.scss
@@ -21,8 +21,8 @@
 	text-decoration: none;
 	vertical-align: top;
 	box-sizing: border-box;
-	font-size: 14px;
-	border-radius: 4px;
+	font-size: 13px;
+	border-radius: 3px;
 	padding: 7px 14px 9px;
 	-webkit-appearance: none;
 	appearance: none;
@@ -45,10 +45,8 @@
 		box-shadow: 0 0 0 1px $blue-medium-dark;
 	}
 	&.is-compact {
-		padding: 7px;
-		font-size: 11px;
-		line-height: 1;
-		text-transform: uppercase;
+		padding: 0 10px;
+		line-height: 2;
 
 		&:disabled {
 			color: lighten( $gray, 30% );


### PR DESCRIPTION
Fixes #13926

The goal of this PR is to get us closer to core styles so that we can start using `@wordpress/components` interchangeably with Jetpack components.

* change border radius from 4px to 3px
* change font size from 14px to 13px
* remove uppercase from compact button 
* match margins and line-height to core button
* match disabled colors on primary button

We could probably turn some of these colors into new variables or functions on existing variables. I don't know exactly what the standards are around that.

### Screenshots

#### Example core button styles

Enabled primary (Chrome)
<img width="83" alt="save-draft-chrome" src="https://user-images.githubusercontent.com/51896/68073226-fb7a1500-fd4a-11e9-944a-3eaa4d9d997e.png">


Disabled primary (Chrome)
<img width="81" alt="save-draft-disabled-chrome" src="https://user-images.githubusercontent.com/51896/68073227-fddc6f00-fd4a-11e9-879e-17e8acdafcdf.png">

#### Compact Button

**Before**

Chrome
<img width="471" alt="setup-button-before" src="https://user-images.githubusercontent.com/51896/68073033-b1446400-fd49-11e9-933b-d1e046f32e3e.png">

Safari
<img width="520" alt="setup-button-before-safari" src="https://user-images.githubusercontent.com/51896/68073036-b5708180-fd49-11e9-96c1-bf65ddcac1e4.png">

Firefox
<img width="522" alt="setup-button-before-ff" src="https://user-images.githubusercontent.com/51896/68073037-b86b7200-fd49-11e9-86bc-49da4d9ae87c.png">

**After**

Chrome
<img width="469" alt="setup-button" src="https://user-images.githubusercontent.com/51896/68073045-c4573400-fd49-11e9-9521-b25e1e11dbd0.png">

Safari
<img width="523" alt="setup-button-safari" src="https://user-images.githubusercontent.com/51896/68073049-ca4d1500-fd49-11e9-8a92-f43bc43c9621.png">

Firefox
<img width="525" alt="setup-button-ff" src="https://user-images.githubusercontent.com/51896/68073052-d1742300-fd49-11e9-8655-209231f94b01.png">

#### Disabled Primary Button

**Before**

Chrome
<img width="672" alt="ads-save-settings-before-chrome" src="https://user-images.githubusercontent.com/51896/68073143-362f7d80-fd4a-11e9-8aa8-089958b38b14.png">

Safari
<img width="632" alt="ads-save-settings-before-safari" src="https://user-images.githubusercontent.com/51896/68073263-6c213180-fd4b-11e9-8c6f-29e256ca0064.png">


Firefox
<img width="762" alt="ads-save-settings-before-ff" src="https://user-images.githubusercontent.com/51896/68073149-3cbdf500-fd4a-11e9-9895-abe0ec16afa9.png">

**After**

Chrome
<img width="675" alt="ads-save-settings-chrome" src="https://user-images.githubusercontent.com/51896/68073153-4182a900-fd4a-11e9-83c2-df37a4f803da.png">

Safari
<img width="632" alt="ads-save-settings-safari" src="https://user-images.githubusercontent.com/51896/68073262-675c7d80-fd4b-11e9-862f-8850d3989210.png">


Firefox
<img width="665" alt="ads-save-settings-ff" src="https://user-images.githubusercontent.com/51896/68073155-45aec680-fd4a-11e9-82c4-3ed01c74ec61.png">

#### Changes proposed in this Pull Request:
* More closely match core button styles

#### Proposed changelog entry for your changes:
* N/A
