### PR TITLE
WP-CLI: Add block preview support to the block scaffolding template

### DIFF
--- a/wp-cli-templates/block-index-js.mustache
+++ b/wp-cli-templates/block-index-js.mustache
@@ -64,4 +64,10 @@ export const settings = {
 
 	/* @TODO Write the block editor output */
 	save: () => null,
+
+	example: {
+		attributes: {
+			// @TODO: Add default values for block attributes, for generating the block preview.
+		},
+	},
 };


### PR DESCRIPTION
Since we want all blocks to have previews, it'd be useful to include block preview support in the WP-CLI block scaffolding template, so new blocks don't accidentally forget it (like I did in #13905).

#### Changes proposed in this Pull Request:
* Add an `example` property to the `settings` object in the block `index.js` mustache template. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an enhancement to the existing `wp jetpack scaffold block` WP-CLI command.

#### Testing instructions:

* Run `wp jetpack scaffold block "My Block"`.
* Confirm that `settings.example` exists in the block's `index.js`.
* Confirm that a preview for the block shows in the block selector.

#### Proposed changelog entry for your changes:
* CLI: Add block preview support to the `wp jetpack scaffold block` command.
