### PR TITLE
Fix a bug causing some posts not to be cut down to the requested fields

### DIFF
--- a/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -291,7 +291,7 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 		foreach ( $response['posts'] as $post ) {
 
 			if ( ! isset( $post['meta'] ) || ! isset( $post['meta']->data ) || (! is_array( $post['meta']->data ) && ! is_object( $post['meta']->data ) ) ) {
-				break;
+				continue;
 			}
 			
 			$newmeta = [];


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* In #13538, we used `break`, which breaks out of the `foreach` loop, rather than `continue`, which skips to the next iteration of the loop.

This fixes that bug.

Differential Revision: D34836-code
This commit syncs r198826-wpcom.

#### Testing instructions:

* [Before] When requesting https://public-api.wordpress.com/rest/v1.1/sites/30121039/posts/, some posts won't be filtered correctly.
* [After] When doing the same request, all posts will be filtered correctly.

#### Proposed changelog entry for your changes:

* None
