### PR TITLE
Sync: Full Sync: Remove `can_add_to_queue` check in favour of an enqueue "Lock"

### DIFF
--- a/packages/sync/src/Listener.php
+++ b/packages/sync/src/Listener.php
@@ -212,14 +212,6 @@ class Listener {
 		$queue = $this->get_full_sync_queue();
 
 		/*
-		 * Periodically check the size of the queue, and disable adding to it if
-		 * it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped).
-		 */
-		if ( ! $this->can_add_to_queue( $queue ) ) {
-			return;
-		}
-
-		/*
 		 * If we add any items to the queue, we should try to ensure that our script
 		 * can't be killed before they are sent.
 		 */

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -243,7 +243,7 @@ class Full_Sync extends Module {
 		$modules           = Modules::get_modules();
 		$modules_processed = 0;
 		foreach ( $modules as $module ) {
-			$modules_processed += $this->enqueue_module( $module, $configs[ $module->name() ], $this->enqueue_status[ $module->name() ], $this->remaining_items_to_enqueue );
+			$modules_processed += $this->enqueue_module( $module, $configs, $this->enqueue_status[ $module->name() ], $this->remaining_items_to_enqueue );
 			// Stop processing if we've reached our limit of items to enqueue.
 
 			if ( 0 >= $this->remaining_items_to_enqueue ) {
@@ -277,16 +277,16 @@ class Full_Sync extends Module {
 	 * Enqueue Full Sync Actions for the given module.
 	 *
 	 * @param Object $module The module to Enqueue.
-	 * @param array  $config The Full sync configuration for the module.
+	 * @param array  $configs The Full sync configuration for all modules.
 	 * @param array  $status The Full sync enqueue status for the module.
 	 *
 	 * @return int
 	 */
-	public function enqueue_module( $module, $config, $status ) {
+	public function enqueue_module( $module, $configs, $status ) {
 		// Skip module if not configured for this sync or module is done.
-		if ( ! isset( $config )
+		if ( ! isset( $configs[ $module->name() ] )
 			 || // No module config.
-			 ! $config
+			 ! $configs[ $module->name() ]
 			 || // No enqueue status.
 			 ! $status
 			 || // Finished enqueuing this module.
@@ -294,7 +294,7 @@ class Full_Sync extends Module {
 			return 1;
 		}
 
-		list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $config, $this->remaining_items_to_enqueue, $status[2] );
+		list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $configs[ $module->name() ], $this->remaining_items_to_enqueue, $status[2] );
 
 		$status[2] = $next_enqueue_state;
 

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -241,11 +241,10 @@ class Full_Sync extends Module {
 				if ( ! $configs[ $module->name() ] ) {
 					return false;
 				}
-				if ( ! isset( $this->enqueue_status[ $module->name() ] ) ) {
-					return false;
-				}
-				if ( true === $this->enqueue_status[ $module->name() ][2] ) {
-					return false;
+				if ( isset( $this->enqueue_status[ $module->name() ] ) ) {
+					if ( true === $this->enqueue_status[ $module->name() ][2] ) {
+						return false;
+					}
 				}
 
 				return true;

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -209,8 +209,6 @@ class Full_Sync extends Module {
 			$remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
 		}
 
-		$listener = Listener::get_instance();
-
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}
@@ -234,14 +232,6 @@ class Full_Sync extends Module {
 					true === $enqueue_status[ $module_name ][2] ) {
 				$modules_processed ++;
 				continue;
-			}
-
-			/*
-			* Periodically check the size of the queue, and disable adding to it if
-			* it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped).
-			*/
-			if ( ! $listener->can_add_to_queue( $full_sync_queue ) ) {
-				return;
 			}
 
 			list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $configs[ $module_name ], $remaining_items_to_enqueue, $enqueue_status[ $module_name ][2] );

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -199,7 +199,7 @@ class Full_Sync extends Module {
 		if ( ! $this->attempt_enqueue_lock() ) {
 			return;
 		}
-		if ( ! $this->get_status_option( 'queue_finished' ) ) {
+		if ( $this->get_status_option( 'queue_finished' ) ) {
 			return;
 		}
 		$this->enqueue_status = $enqueue_status ? $enqueue_status : $this->get_enqueue_status();

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -193,6 +193,8 @@ class Full_Sync extends Module {
 			$remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
 		}
 
+		$listener = Listener::get_instance();
+
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}
@@ -216,6 +218,14 @@ class Full_Sync extends Module {
 					true === $enqueue_status[ $module_name ][2] ) {
 				$modules_processed ++;
 				continue;
+			}
+
+			/*
+			* Periodically check the size of the queue, and disable adding to it if
+			* it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped).
+			*/
+			if ( ! $listener->can_add_to_queue( $full_sync_queue ) ) {
+				return;
 			}
 
 			list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $configs[ $module_name ], $remaining_items_to_enqueue, $enqueue_status[ $module_name ][2] );

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -270,8 +270,10 @@ class Full_Sync extends Module {
 			if ( 0 >= $this->remaining_items_to_enqueue ) {
 				return;
 			}
-			$this->enqueue_module( $module, $configs[ $module->name() ] );
-			// Stop processing if we've reached our limit of items to enqueue.
+			$finished = $this->enqueue_module( $module, $configs[ $module->name() ] );
+			if ( ! $finished ) {
+				return;
+			}
 		}
 
 		$this->queue_full_sync_end( $configs );

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -230,25 +230,20 @@ class Full_Sync extends Module {
 			return;
 		}
 
-		$this->remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $this->get_available_queue_slots() );
-
-		if ( $this->remaining_items_to_enqueue <= 0 ) {
-			return;
-		}
-
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}
 
+		$this->remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $this->get_available_queue_slots() );
+
 		$modules           = Modules::get_modules();
 		$modules_processed = 0;
 		foreach ( $modules as $module ) {
-			$modules_processed += $this->enqueue_module( $module, $configs, $this->enqueue_status[ $module->name() ], $this->remaining_items_to_enqueue );
-			// Stop processing if we've reached our limit of items to enqueue.
-
 			if ( 0 >= $this->remaining_items_to_enqueue ) {
 				break;
 			}
+			$modules_processed += $this->enqueue_module( $module, $configs, $this->enqueue_status[ $module->name() ], $this->remaining_items_to_enqueue );
+			// Stop processing if we've reached our limit of items to enqueue.
 		}
 
 		if ( count( $modules ) > $modules_processed ) {

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -268,7 +268,7 @@ class Full_Sync extends Module {
 
 		$finished = true;
 		foreach ( $this->get_remaining_modules_to_enqueue( $configs ) as $module ) {
-			if ( 0 >= $this->remaining_items_to_enqueue || ! $finished ) {
+			if ( 0 >= $this->remaining_items_to_enqueue || true !== $finished ) {
 				return;
 			}
 			$finished = $this->enqueue_module( $module, $configs[ $module->name() ] );

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -266,14 +266,12 @@ class Full_Sync extends Module {
 
 		$this->remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $this->get_available_queue_slots() );
 
+		$finished = true;
 		foreach ( $this->get_remaining_modules_to_enqueue( $configs ) as $module ) {
-			if ( 0 >= $this->remaining_items_to_enqueue ) {
+			if ( 0 >= $this->remaining_items_to_enqueue || ! $finished ) {
 				return;
 			}
 			$finished = $this->enqueue_module( $module, $configs[ $module->name() ] );
-			if ( ! $finished ) {
-				return;
-			}
 		}
 
 		$this->queue_full_sync_end( $configs );
@@ -308,7 +306,7 @@ class Full_Sync extends Module {
 	 * Enqueue Full Sync Actions for the given module.
 	 *
 	 * @param Automattic\Jetpack\Sync\Module $module The module to Enqueue.
-	 * @param array  $config The Full sync configuration for the modules.
+	 * @param array                          $config The Full sync configuration for the modules.
 	 *
 	 * @return int
 	 */

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -305,7 +305,7 @@ class Full_Sync extends Module {
 	/**
 	 * Enqueue Full Sync Actions for the given module.
 	 *
-	 * @param Object $module The module to Enqueue.
+	 * @param Automattic\Jetpack\Sync\Module $module The module to Enqueue.
 	 * @param array  $config The Full sync configuration for the modules.
 	 *
 	 * @return int

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -203,7 +203,7 @@ class Full_Sync extends Module {
 			return;
 		}
 		$this->enqueue_status = $enqueue_status ? $enqueue_status : $this->get_enqueue_status();
-		$this->continue_enqueuing_with_lock( $configs );
+		$this->_continue_enqueuing( $configs );
 		$this->set_enqueue_status( $this->enqueue_status );
 
 		$this->remove_enqueue_lock();
@@ -259,7 +259,7 @@ class Full_Sync extends Module {
 	 *
 	 * @param array $configs Full sync configuration for all sync modules.
 	 */
-	public function continue_enqueuing_with_lock( $configs = null ) {
+	private function _continue_enqueuing( $configs = null ) {
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -240,19 +240,25 @@ class Full_Sync extends Module {
 		$modules_processed = 0;
 		foreach ( $modules as $module ) {
 			if ( 0 >= $this->remaining_items_to_enqueue ) {
-				break;
+				return;
 			}
 			$modules_processed += $this->enqueue_module( $module, $configs, $this->enqueue_status[ $module->name() ], $this->remaining_items_to_enqueue );
 			// Stop processing if we've reached our limit of items to enqueue.
 		}
 
-		if ( count( $modules ) > $modules_processed ) {
-			return;
+		if ( count( $modules ) === $modules_processed ) {
+			$this->queue_full_sync_end( $configs );
 		}
+	}
 
-		// Setting autoload to true means that it's faster to check whether we should continue enqueuing.
-		$this->update_status_option( 'queue_finished', time(), true );
-
+	/**
+	 * Enqueue 'jetpack_full_sync_end' and update 'queue_finished' status.
+	 *
+	 * @access public
+	 *
+	 * @param array $configs Full sync configuration for all sync modules.
+	 */
+	public function queue_full_sync_end( $configs ) {
 		$range = $this->get_content_range( $configs );
 
 		/**
@@ -266,8 +272,10 @@ class Full_Sync extends Module {
 		 * @param array  $range    Range of the sync items, containing min and max IDs for some item types.
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
-	}
 
+		// Setting autoload to true means that it's faster to check whether we should continue enqueuing.
+		$this->update_status_option( 'queue_finished', time(), true );
+	}
 	/**
 	 * Enqueue Full Sync Actions for the given module.
 	 *

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -193,10 +193,15 @@ class Full_Sync extends Module {
 	 * @param array $enqueue_status Current status of the queue, indexed by sync modules.
 	 */
 	public function continue_enqueuing( $configs = null, $enqueue_status = null ) {
+		if ( ! $this->is_started() ) {
+			return;
+		}
 		if ( ! $this->attempt_enqueue_lock() ) {
 			return;
 		}
-
+		if ( ! $this->get_status_option( 'queue_finished' ) ) {
+			return;
+		}
 		$this->enqueue_status = $enqueue_status ? $enqueue_status : $this->get_enqueue_status();
 		$this->continue_enqueuing_with_lock( $configs );
 		$this->set_enqueue_status( $this->enqueue_status );
@@ -256,10 +261,6 @@ class Full_Sync extends Module {
 	 * @param array $configs Full sync configuration for all sync modules.
 	 */
 	public function continue_enqueuing_with_lock( $configs = null ) {
-		if ( ! $this->is_started() || $this->get_status_option( 'queue_finished' ) ) {
-			return;
-		}
-
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}

--- a/packages/sync/src/modules/Full_Sync.php
+++ b/packages/sync/src/modules/Full_Sync.php
@@ -181,20 +181,32 @@ class Full_Sync extends Module {
 			return;
 		}
 
-		// If full sync queue is full, don't enqueue more items.
-		$max_queue_size_full_sync = Settings::get_setting( 'max_queue_size_full_sync' );
-		$full_sync_queue          = new Queue( 'full_sync' );
+		$listener        = Listener::get_instance();
+		$full_sync_queue = new Queue( 'full_sync' );
 
-		$available_queue_slots = $max_queue_size_full_sync - $full_sync_queue->size();
-
-		if ( $available_queue_slots <= 0 ) {
+		/*
+		* Periodically check the size of the queue, and disable adding to it if
+		* it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped).
+		*/
+		if ( ! $listener->can_add_to_queue( $full_sync_queue ) ) {
 			return;
-		} else {
-			$remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
 		}
 
-		$listener = Listener::get_instance();
+		if ( ! $this->attempt_enqueue_lock() ) {
+			return;
+		}
+		$this->continue_enqueuing_with_lock( $configs, $enqueue_status, $full_sync_queue );
+		$this->remove_enqueue_lock();
+	}
 
+	/**
+	 * Enqueue the next items to sync. Once we have a lock.
+	 *
+	 * @param array  $configs Full sync configuration for all sync modules.
+	 * @param array  $enqueue_status Current status of the queue, indexed by sync modules.
+	 * @param Object $full_sync_queue The full sync queue.
+	 */
+	private function continue_enqueuing_with_lock( $configs, $enqueue_status, $full_sync_queue ) {
 		if ( ! $configs ) {
 			$configs = $this->get_config();
 		}
@@ -203,6 +215,11 @@ class Full_Sync extends Module {
 			$enqueue_status = $this->get_enqueue_status();
 		}
 
+		// If full sync queue is full, don't enqueue more items.
+		$max_queue_size_full_sync   = Settings::get_setting( 'max_queue_size_full_sync' );
+		$available_queue_slots      = $max_queue_size_full_sync - $full_sync_queue->size();
+		$remaining_items_to_enqueue = min( Settings::get_setting( 'max_enqueue_full_sync' ), $available_queue_slots );
+
 		$modules           = Modules::get_modules();
 		$modules_processed = 0;
 		foreach ( $modules as $module ) {
@@ -210,22 +227,14 @@ class Full_Sync extends Module {
 
 			// Skip module if not configured for this sync or module is done.
 			if ( ! isset( $configs[ $module_name ] )
-				|| // No module config.
-					! $configs[ $module_name ]
-				|| // No enqueue status.
-					! $enqueue_status[ $module_name ]
-				|| // Finished enqueuing this module.
-					true === $enqueue_status[ $module_name ][2] ) {
+				 || // No module config.
+				 ! $configs[ $module_name ]
+				 || // No enqueue status.
+				 ! $enqueue_status[ $module_name ]
+				 || // Finished enqueuing this module.
+				 true === $enqueue_status[ $module_name ][2] ) {
 				$modules_processed ++;
 				continue;
-			}
-
-			/*
-			* Periodically check the size of the queue, and disable adding to it if
-			* it exceeds some limit AND the oldest item exceeds the age limit (i.e. sending has stopped).
-			*/
-			if ( ! $listener->can_add_to_queue( $full_sync_queue ) ) {
-				return;
 			}
 
 			list( $items_enqueued, $next_enqueue_state ) = $module->enqueue_full_sync_actions( $configs[ $module_name ], $remaining_items_to_enqueue, $enqueue_status[ $module_name ][2] );
@@ -262,11 +271,11 @@ class Full_Sync extends Module {
 		 * Fires when a full sync ends. This action is serialized
 		 * and sent to the server.
 		 *
+		 * @param string $checksum Deprecated since 7.3.0 - @see https://github.com/Automattic/jetpack/pull/11945/
+		 * @param array $range Range of the sync items, containing min and max IDs for some item types.
+		 *
 		 * @since 4.2.0
 		 * @since 7.3.0 Added $range arg.
-		 *
-		 * @param string $checksum Deprecated since 7.3.0 - @see https://github.com/Automattic/jetpack/pull/11945/
-		 * @param array  $range    Range of the sync items, containing min and max IDs for some item types.
 		 */
 		do_action( 'jetpack_full_sync_end', '', $range );
 	}
@@ -646,68 +655,62 @@ class Full_Sync extends Module {
 		return \Jetpack_Options::get_raw_option( 'jetpack_sync_full_config' );
 	}
 
+
 	/**
-	 * Update an option manually to bypass filters and caching.
+	 * Prefix of the blog lock transient.
 	 *
-	 * @access private
+	 * @access public
 	 *
-	 * @param string $name  Option name.
-	 * @param mixed  $value Option value.
-	 * @return int The number of updated rows in the database.
+	 * @var string
 	 */
-	private function write_option( $name, $value ) {
-		// We write our own option updating code to bypass filters/caching/etc on set_option/get_option.
-		global $wpdb;
-		$serialized_value = maybe_serialize( $value );
+	const ENQUEUE_LOCK_TRANSIENT_PREFIX = 'jp_sync_enqueue_lock_';
 
-		/**
-		 * Try updating, if no update then insert
-		 * TODO: try to deal with the fact that unchanged values can return updated_num = 0
-		 * below we used "insert ignore" to at least suppress the resulting error.
-		 */
-		$updated_num = $wpdb->query(
-			$wpdb->prepare(
-				"UPDATE $wpdb->options SET option_value = %s WHERE option_name = %s",
-				$serialized_value,
-				$name
-			)
-		);
+	/**
+	 * Lifetime of the blog lock transient.
+	 *
+	 * @access public
+	 *
+	 * @var int
+	 */
+	const ENQUEUE_LOCK_TRANSIENT_EXPIRY = 15; // Seconds.
 
-		if ( ! $updated_num ) {
-			$updated_num = $wpdb->query(
-				$wpdb->prepare(
-					"INSERT IGNORE INTO $wpdb->options ( option_name, option_value, autoload ) VALUES ( %s, %s, 'no' )",
-					$name,
-					$serialized_value
-				)
-			);
+	/**
+	 * Attempt to lock enqueueing when the server receives concurrent requests from the same blog.
+	 *
+	 * @access public
+	 *
+	 * @param int $expiry  enqueue transient lifetime.
+	 * @return boolean True if succeeded, false otherwise.
+	 */
+	public function attempt_enqueue_lock( $expiry = self::ENQUEUE_LOCK_TRANSIENT_EXPIRY ) {
+		$transient_name = $this->get_concurrent_enqueue_transient_name();
+		$locked_time    = get_site_transient( $transient_name );
+		if ( $locked_time ) {
+			return false;
 		}
-		return $updated_num;
+		set_site_transient( $transient_name, microtime( true ), $expiry );
+
+		return true;
 	}
 
 	/**
-	 * Update an option manually to bypass filters and caching.
+	 * Retrieve the enqueue lock transient name for the current blog.
 	 *
-	 * @access private
+	 * @access public
 	 *
-	 * @param string $name    Option name.
-	 * @param mixed  $default Default option value.
-	 * @return mixed Option value.
+	 * @return string Name of the blog lock transient.
 	 */
-	private function read_option( $name, $default = null ) {
-		global $wpdb;
-		$value = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
-				$name
-			)
-		);
-		$value = maybe_unserialize( $value );
-
-		if ( null === $value && null !== $default ) {
-			return $default;
-		}
-
-		return $value;
+	private function get_concurrent_enqueue_transient_name() {
+		return self::ENQUEUE_LOCK_TRANSIENT_PREFIX . get_current_blog_id();
 	}
+
+	/**
+	 * Remove the enqueue lock.
+	 *
+	 * @access public
+	 */
+	public function remove_enqueue_lock() {
+		delete_site_transient( $this->get_concurrent_enqueue_transient_name() );
+	}
+
 }


### PR DESCRIPTION
Testing Full Sync on very large network sites revealed inconsistencies on the Full Sync enqueue status.
We think that multiple requests could be modifying the enqueue status in parallel resulting in not accurate enqueue status.

Alongside, we were doing a `can_add_to_queue` check late in the enqueue process aborting any enqueuing after having updated the enqueue status.


#### Changes proposed in this Pull Request:
This PR refactors the Full Sync module to add a Lock so two concurrent process can't enqueue at the same time.

In addition it removes multiple checks to `can_add_to_queue` when bulk enqueueing full sync actions.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bug Fix

#### Testing instructions:
** Test that Full Sync Still works** 
* Apply the Patch
* Initiate a Full Sync.
* `wp jetpack-sync start --blog-id=XXX`
* Check the Jetpack Debug page to see that everything is enqueued as expected.
* Wait for the Sync to complete
* All chunks will have been processed.

#### Proposed changelog entry for your changes:
Bug fixes to Full Sync.

#### Additional Notes
Should add tests to make sure that the "lock" works as expected.
