### PR TITLE
Heartbeat: Add mu-plugins

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -119,6 +119,7 @@ class Jetpack_Heartbeat {
 		$return[ "{$prefix}is-multisite" ]   = is_multisite() ? 'multisite' : 'singlesite';
 		$return[ "{$prefix}identitycrisis" ] = Jetpack::check_identity_crisis() ? 'yes' : 'no';
 		$return[ "{$prefix}plugins" ]        = implode( ',', Jetpack::get_active_plugins() );
+		$return[ "{$prefix}mu-plugins"]      = implode( ',', array_keys( get_mu_plugins() ) );
 		$return[ "{$prefix}manage-enabled" ] = true;
 
 		$xmlrpc_errors = Jetpack_Options::get_option( 'xmlrpc_errors', array() );


### PR DESCRIPTION
Fixes #10370

This will help Happiness by providing a quick way to confirm presence of mu-plugins. Regular plugins have been included for a long time.

#### Changes proposed in this Pull Request:
* Add the mu-plugins array to the heartbeat.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* A connected site with this branch and being an SA, visit the JP debugger.
* Under `test_get_heartbeat_data` confirm the `mu-plugins` is present.

#### Proposed changelog entry for your changes:
* n/a
