### PR TITLE
Add experimental devcontainer for VS Code online

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"appPort": 80,
+
+	// Install ESLint and Peacock extensions
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"johnpapa.vscode-peacock",
+		"ikappas.phpcs",
+		"wordpresstoolbox.wordpress-toolbox"
+	],
+
+	// Set remote color for Peacock
+	"settings": {
+		"peacock.remoteColor": "#0078D7"
+	},
+
+	// Run Bash script in .devcontainer directory
+	// "postCreateCommand": "/bin/bash ./.devcontainer/post-create.sh > ~/post-create.log",
+	"postCreateCommand": "yarn docker:up > ~/post-create.log",
+
+	// Use the dockerfile in .devcontainer directory
+	"dockerfile": "./docker/Dockerfile",
+
+	"context": ".."
+}


### PR DESCRIPTION
Just messing about with this:

https://docs.microsoft.com/en-us/visualstudio/online/reference/configuring