### PR TITLE
Photon: Ignore data-width and data-height attributes

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -336,11 +336,11 @@ class Jetpack_Photon {
 					$width = $height = false;
 
 					// First, check the image tag
-					if ( preg_match( '#width=["|\']?([\d%]+)["|\']?#i', $images['img_tag'][ $index ], $width_string ) ) {
+					if ( preg_match( '#[\s|"|\']width=["|\']?([\d%]+)["|\']?#i', $images['img_tag'][ $index ], $width_string ) ) {
 						$width = $width_string[1];
 					}
 
-					if ( preg_match( '#height=["|\']?([\d%]+)["|\']?#i', $images['img_tag'][ $index ], $height_string ) ) {
+					if ( preg_match( '#[\s|"|\']height=["|\']?([\d%]+)["|\']?#i', $images['img_tag'][ $index ], $height_string ) ) {
 						$height = $height_string[1];
 					}
 

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -868,8 +868,8 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
 		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
 
-		$this->assertArrayHasKey( 'width', $attributes );
-		$this->assertArrayHasKey( 'height', $attributes );
+		$this->assertArrayNotHasKey( 'width', $attributes );
+		$this->assertArrayNotHasKey( 'height', $attributes );
 	}
 
 	/**

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -856,6 +856,38 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		}
 	}
 
+	/**
+	 * Checks that Photon ignores data-width and data-height attributes when parsing the attributes.
+	 *
+	 * @author mmtr
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @since 8.0.0
+	 */
+	public function test_photon_filter_the_content_ignores_data_width_and_data_height_attributes() {
+		$sample_html      = '<img src="http://example.com/test.png" data-width="100px" data-height="200px" />';
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+
+		$this->assertArrayHasKey( 'width', $attributes );
+		$this->assertArrayHasKey( 'height', $attributes );
+	}
+
+	/**
+	 * Checks that Photon parses correctly the width and height attributes when they are not preceded by a space.
+	 *
+	 * @author mmtr
+	 * @covers Jetpack_Photon::filter_the_content
+	 * @since 8.0.0
+	 */
+	public function test_photon_filter_the_content_parses_width_height_when_no_spaces_between_attributes() {
+		$sample_html      = '<img src="http://example.com/test.png"width="100px"height="200px" />';
+		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
+		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+
+		$this->assertEquals( 100, $attributes['width']['value'] );
+		$this->assertEquals( 200, $attributes['height']['value'] );
+	}
+
 	public function photon_attributes_when_filtered_data_provider() {
 		$assert_details = function ( $details ) {
 			$this->assertInternalType( 'array', $details );

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -864,12 +864,13 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	 * @since 8.0.0
 	 */
 	public function test_photon_filter_the_content_ignores_data_width_and_data_height_attributes() {
-		$sample_html      = '<img src="http://example.com/test.png" data-width="100px" data-height="200px" />';
+		$sample_html      = '<img src="http://example.com/test.png" class="test" data-width="100" data-height="200" />';
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
 		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+		$query_str        = wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
+		parse_str( $query_str, $query_params );
 
-		$this->assertArrayNotHasKey( 'width', $attributes );
-		$this->assertArrayNotHasKey( 'height', $attributes );
+		$this->assertArrayNotHasKey( 'resize', $query_params );
 	}
 
 	/**
@@ -880,12 +881,14 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	 * @since 8.0.0
 	 */
 	public function test_photon_filter_the_content_parses_width_height_when_no_spaces_between_attributes() {
-		$sample_html      = '<img src="http://example.com/test.png"width="100px"height="200px" />';
+		$sample_html      = '<img src="http://example.com/test.png" class="test"width="100"height="200" />';
 		$filtered_content = Jetpack_Photon::filter_the_content( $sample_html );
 		$attributes       = wp_kses_hair( $filtered_content, wp_allowed_protocols() );
+		$query_str        = wp_parse_url( $attributes['src']['value'], PHP_URL_QUERY );
+		parse_str( $query_str, $query_params );
 
-		$this->assertEquals( 100, $attributes['width']['value'] );
-		$this->assertEquals( 200, $attributes['height']['value'] );
+		$this->assertArrayHasKey( 'resize', $query_params );
+		$this->assertEquals( '100,200', $query_params['resize'] );
 	}
 
 	public function photon_attributes_when_filtered_data_provider() {


### PR DESCRIPTION
Fixes #https://github.com/Automattic/wp-calypso/issues/37193

#### Changes proposed in this Pull Request:

Ensures that only `width` and `height` attributes are taken into account by Photon when resizing an image.

Previously it was targeting any `*width`/`*height` attribute (such as `data-weight` and `data-height`) that are not intended for setting an image size (see https://github.com/Automattic/wp-calypso/issues/37193#issuecomment-548342798).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bugfix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Photon:
<img width="1474" alt="Jetpack ‹ WP Engine Test Site — WordPress" src="https://user-images.githubusercontent.com/7662449/67811952-4a3a5d00-fa74-11e9-979f-1a22c067e43e.png">

* Create a post and add an image using HTML like this:

```html
<img src="https://my-domain.com/wp-content/uploads/2019/11/image.png" data-width="100px" />
```

* Publish the post.
* View the post on the front end.
* Make sure the images has not been resize to 100px.
* Change the `data-width` attribute to `width` and update the post:
```html
<img src="https://my-domain.com/wp-content/uploads/2019/11/image.png" width="100px" />
```

* Make sure the image has been resized to 100px.
* Try to play around with the quotes and spaces and make sure the image is still resized:
```html
<!-- No whitespace -->
<img src="https://my-domain.com/wp-content/uploads/2019/11/image.png"width="100px" />
```

```html
<!-- Single quotes -->
<img src='https://my-domain.com/wp-content/uploads/2019/11/image.png' width="100px" />
```

```html
<!-- No whitespace and single quotes -->
<img src='https://my-domain.com/wp-content/uploads/2019/11/image.png'width="100px" />
```

#### Proposed changelog entry for your changes:

Photon: Ignore data-width and data-height attributes
