### PR TITLE
Connection: Separate the remote_authorize method from Jetpack

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1477,10 +1477,93 @@ class Manager {
 
 	/**
 	 * Responds to a WordPress.com call to authorize the current user.
-	 * Should be changed to protected.
+	 *
+	 * @param array $request The user authorization request data.
+	 * @return array|\IXR_Error Returns an array containing 'result'=>'authorized' on success.
+	 *                          Returns an IXR_Error on failure.
 	 */
-	public function handle_authorization() {
+	public function handle_authorization( $request ) {
+		$user = isset( $request['state'] ) ? get_user_by( 'id', $request['state'] ) : null;
 
+		/**
+		 * Happens on various request handling events in the Jetpack XMLRPC server.
+		 * The action combines several types of events:
+		 *    - remote_authorize
+		 *    - remote_provision
+		 *    - get_user.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param String  $action the action name, i.e., 'remote_authorize'.
+		 * @param String  $stage  the execution stage, can be 'begin', 'success', 'error', etc.
+		 * @param Array   $parameters extra parameters from the event.
+		 * @param WP_User $user the acting user.
+		 */
+		do_action( 'jetpack_xmlrpc_server_event', 'remote_authorize', 'begin', array(), $user );
+
+		$return_error = function( \WP_Error $error ) use ( $user ) {
+			// This action is documented in class-manager.php.
+			do_action( 'jetpack_xmlrpc_server_event', 'remote_authorize', 'fail', $error, $user );
+
+			return $this->convert_to_ixr_error( $error );
+		};
+
+		foreach ( array( 'secret', 'state', 'redirect_uri', 'code' ) as $required ) {
+			if ( ! isset( $request[ $required ] ) || empty( $request[ $required ] ) ) {
+				return $return_error( new \WP_Error( 'missing_parameter', 'One or more parameters is missing from the request.', 400 ) );
+			}
+		}
+
+		if ( ! $user ) {
+			return $return_error( new \WP_Error( 'user_unknown', 'User not found.', 404 ) );
+		}
+
+		if ( $this->is_active() && $this->is_user_connected( $request['state'] ) ) {
+			return $return_error( new \WP_Error( 'already_connected', 'User already connected.', 400 ) );
+		}
+
+		$verified = $this->verify_secrets( 'authorize', $request['secret'], $request['state'] );
+
+		if ( is_wp_error( $verified ) ) {
+			return $return_error( $verified );
+		}
+
+		wp_set_current_user( $request['state'] );
+
+		$client_server = new \Jetpack_Client_Server();
+		$result        = $client_server->authorize( $request );
+
+		if ( is_wp_error( $result ) ) {
+			return $return_error( $result );
+		}
+
+		// This action is documented in class-manager.php.
+		do_action( 'jetpack_xmlrpc_server_event', 'remote_authorize', 'success' );
+
+		return array(
+			'result' => $result,
+		);
+	}
+
+	/**
+	 * Converts a WP_Error object to an \IXR_Error object.
+	 *
+	 * @param \WP_Error|\IXR_Error $error A WP_Error object.
+	 * @return \IXR_Error
+	 */
+	private function convert_to_ixr_error( $error ) {
+		if ( is_wp_error( $error ) ) {
+			$code = $error->get_error_data();
+			if ( ! $code ) {
+				$code = -10520;
+			}
+			$message = sprintf( 'Jetpack: [%s] %s', $error->get_error_code(), $error->get_error_message() );
+			return new \IXR_Error( $code, $message );
+		}
+
+		if ( is_a( $error, 'IXR_Error' ) ) {
+			return $error;
+		}
 	}
 
 	/**

--- a/packages/connection/src/class-xmlrpc-connector.php
+++ b/packages/connection/src/class-xmlrpc-connector.php
@@ -41,6 +41,7 @@ class XMLRPC_Connector {
 			$methods,
 			array(
 				'jetpack.verifyRegistration' => array( $this, 'verify_registration' ),
+				'jetpack.remoteAuthorize'    => array( $this, 'remote_authorize' ),
 			)
 		);
 	}
@@ -55,6 +56,18 @@ class XMLRPC_Connector {
 	 */
 	public function verify_registration( $registration_data ) {
 		return $this->output( $this->connection->handle_registration( $registration_data ) );
+	}
+
+	/**
+	 * Handles user authorization.
+	 *
+	 * @param array $request The request array.
+	 *
+	 * @return array|\IXR_Error Returns an array containing 'result'=>'authorized' on success.
+	 *                          Returns an IXR_Error on failure.
+	 */
+	public function remote_authorize( $request ) {
+		return $this->output( $this->connection->handle_authorization( $request ) );
 	}
 
 	/**

--- a/src/class-tracking.php
+++ b/src/class-tracking.php
@@ -104,7 +104,7 @@ class Tracking {
 	 *
 	 * @access public
 	 *
-	 * @param string $action Type of secret (one of 'register', 'authorize', 'publicize').
+	 * @param string   $action Type of secret (one of 'register', 'authorize', 'publicize').
 	 * @param \WP_User $user The user object.
 	 */
 	public function jetpack_verify_secrets_begin( $action, $user ) {
@@ -116,7 +116,7 @@ class Tracking {
 	 *
 	 * @access public
 	 *
-	 * @param string $action Type of secret (one of 'register', 'authorize', 'publicize').
+	 * @param string   $action Type of secret (one of 'register', 'authorize', 'publicize').
 	 * @param \WP_User $user The user object.
 	 */
 	public function jetpack_verify_secrets_success( $action, $user ) {
@@ -128,8 +128,8 @@ class Tracking {
 	 *
 	 * @access public
 	 *
-	 * @param string $action Type of secret (one of 'register', 'authorize', 'publicize').
-	 * @param \WP_User $user The user object.
+	 * @param string    $action Type of secret (one of 'register', 'authorize', 'publicize').
+	 * @param \WP_User  $user The user object.
 	 * @param \WP_Error $error Error object.
 	 */
 	public function jetpack_verify_secrets_fail( $action, $user, $error ) {


### PR DESCRIPTION
The `remote_authorize` method depends on Jetpack. We're currently working on separating the Connection package from Jetpack, and this PR is part of that work.

Refactor `remote_authorize` so that it's separated from Jetpack and fits into the structure of the Connection package.

#### Changes proposed in this Pull Request:
* Add the `jetpack.remoteAuthorize` XMLRPC method to the Connection package's
  XMLRPC_Connector class. Also add a `remote_authorize` method to this class.
* Add a `handle_authorization` method to the Manager class. This method does
  the work that was previously done by `remote_authorize` and will be called by
  the XMLRPC `remote_authorize` methods. Include `do_action` calls for tracking
  events.
* In `handle_authorization`, use `verify_secrets` directly rather than calling `verify_action`.
* Add a `convert_to_ixr_error` helper function that converts WP_Error objects to
  IXR_Error objects.
* Add the remote_authorize events to the Tracking class.

NOTE: These changes do not completely separate the new `handle_authorize` method from Jetpack. The `handle_authorize` method still uses the Jetpack_Client_Server class, and that will be addressed in another PR.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an update to an existing feature.

#### Testing instructions:
Verify that the Jetpack connection works:
1. Use a site that has Jetpack installed.
2. Deactivate Jetpack.
3. Reactivate Jetpack.
4. Connect Jetpack. The connection should be successful.

Verify that the Jetpack connection fails when an error occurs during user authorization:
1. TBD


#### Proposed changelog entry for your changes:
* N/A
