### PR TITLE
Instant Search: hide multiple image icon except gallery

### DIFF
--- a/modules/search/instant-search/components/post-type-icon.jsx
+++ b/modules/search/instant-search/components/post-type-icon.jsx
@@ -37,7 +37,7 @@ const POST_TYPE_TO_ICON_MAP = {
 	events: 'calendar',
 };
 
-const PostTypeIcon = ( { postType, shortcodeTypes, imageCount, iconSize = 18 } ) => {
+const PostTypeIcon = ( { postType, shortcodeTypes, iconSize = 18 } ) => {
 	// Do we have a special icon for this post type?
 	if ( Object.keys( POST_TYPE_TO_ICON_MAP ).includes( postType ) ) {
 		return <Gridicon icon={ POST_TYPE_TO_ICON_MAP[ postType ] } size={ iconSize } />;
@@ -58,7 +58,7 @@ const PostTypeIcon = ( { postType, shortcodeTypes, imageCount, iconSize = 18 } )
 		case 'page':
 			return <Gridicon icon="pages" size={ iconSize } />;
 		default:
-			if ( hasGallery || imageCount > 1 ) {
+			if ( hasGallery ) {
 				return <Gridicon icon="image-multiple" size={ iconSize } />;
 			}
 	}

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -121,11 +121,7 @@ class SearchResultMinimal extends Component {
 					} ) }
 				</span>
 				<h3 className="jetpack-instant-search__result-title">
-					<PostTypeIcon
-						postType={ fields.post_type }
-						shortcodeTypes={ fields.shortcode_types }
-						imageCount={ fields[ 'has.image' ] }
-					/>
+					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 					<a
 						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						className="jetpack-instant-search__result-minimal-title"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When testing accessibility changes, @gibrown commented that he found the multiple images icon being announced a bit too frequently because it is triggered by any post with more than 1 image in.

https://github.com/Automattic/jetpack/pull/13884#pullrequestreview-311763931

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR turns off the multiple image icon in search results unless the post has a gallery.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It adjusts an icon shown in Instant Search results. This PR merges into the instant-search-master development branch.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php.
If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.

Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled.
You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).

Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.

If using a theme with a sidebar widget, you can navigate to / to start the search experience. Otherwise, navigate to your search page (e.g. /?s=hello).

Try a search like `/?s=card&blog_id=84860689`. Ensure that the multiple image icon is only presented when the post has a gallery.

<img width="860" alt="Screen Shot 2019-11-06 at 15 25 09" src="https://user-images.githubusercontent.com/17325/68262970-aa9b5100-00a9-11ea-8d21-6e7a8502bfd1.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog required.
