### PR TITLE
Instant search: add testing instructions to README

### DIFF
--- a/modules/search/instant-search/README.md
+++ b/modules/search/instant-search/README.md
@@ -7,3 +7,13 @@ Eventually, we expect this module to enhance all front-end views that enable the
 ## Why Preact?
 
 Given that we load this module's assets on every page load, we were concerned by the large bundle sizes for both React and `@wordpress/element` (35.6kB gzipped and 61kB gzipped, respectively). We ultimately decided on using Preact, which features a significantly smaller bundle footprint (4.7kB) and full API compatibility with React.
+
+## Testing Instructions
+
+Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php. If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.
+
+Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).
+
+Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.
+
+If using a theme with a sidebar widget, you can navigate to / to start the search experience. Otherwise, navigate to your search page (e.g. /?s=hello).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds instructions for testing Jetpack Instant Search to the module README file. With these included, we can point to the README file rather than repeating the full setup instructions in each PR.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It's a documentation update only.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow the setup instructions in the README and make sure the docs make sense.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry required.
