### PR TITLE
Sharing settings: bail early if General settings can't be foun…

### DIFF
--- a/_inc/lib/class.jetpack-keyring-service-helper.php
+++ b/_inc/lib/class.jetpack-keyring-service-helper.php
@@ -53,7 +53,10 @@ class Jetpack_Keyring_Service_Helper {
 	public static function add_sharing_menu() {
 		global $submenu;
 
-		if ( ! is_array( $submenu['options-general.php'] ) ) {
+		if (
+			! isset( $submenu['options-general.php'] )
+			|| ! is_array( $submenu['options-general.php'] )
+		) {
 			return;
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Still waiting on some more information, but it seems that in some cases `$submenu['options-general.php']` may not exist on some sites.

See https://wordpress.org/support/topic/warning-notice-undefined-index-options-general-php/

#### Testing instructions:

* With this patch on, disable Publicize, Sharing, Likes, and Comment Likes on your site.
* Go to Jetpack > Settings > Traffic
* Try to automatically verify your site with Google.
* The pop up that opens should lead you to Google. 

#### Proposed changelog entry for your changes:

* Site Verification Tools: avoid PHP warnings when using plugins to modify the WordPress admin menu.
