### PR TITLE
Fix GitHub action for building production version of master

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_master_job:
     runs-on: ubuntu-latest
-    name: Build production version of master to master-built branch!
+    name: Build production version of master to master-built branch
     steps:
       - name: Checkout Jetpack
         uses: actions/checkout@master

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -2,24 +2,16 @@ name: Build production to master-built
 on:
   push:
     branches:
-      - master
+      - try/test-action
 
 jobs:
   build_master_job:
     runs-on: ubuntu-latest
     name: Build production version of master to master-built branch
     steps:
-      - name: Checkout Jetpack
-        uses: actions/checkout@master
-      - name: Build production files
-        run: COMPOSER_MIRROR_PATH_REPOS=1 yarn run build-production
-      - name: Purge dev files
-        run: $GITHUB_WORKSPACE/bin/prepare-built-branch.sh
-      - name: Push to built branch
-        id: commit-and-push
-        uses: automattic/action-commit-to-branch@master
+      - name: Build production version
+        uses: automattic/action-jetpack-build-to-branch@master
         with:
-          branch: 'master-built'
+          branch_pull: 'try/test-action'
+          branch_push: 'try/test-action-built'
           commit_message: 'Automated production build from master'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Build production version of master to master-built branch
     steps:
+      - name: Checkout Jetpack
+        uses: actions/checkout@master
       - name: Build production version
         uses: automattic/action-jetpack-build-to-branch@master
         with:

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,8 +1,8 @@
-name: Build production to try/test-action
+name: Build production to master-built
 on:
   push:
     branches:
-      - try/test-action
+      - master
 
 jobs:
   build_master_job:
@@ -14,6 +14,6 @@ jobs:
       - name: Build production version
         uses: automattic/action-jetpack-build-to-branch@testing
         with:
-          branch_pull: 'try/test-action'
-          branch_push: 'try/test-action-built'
+          branch_pull: 'master'
+          branch_push: 'master-built'
           commit_message: 'Automated production build from master'

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Jetpack
         uses: actions/checkout@master
       - name: Build production version
-        uses: automattic/action-jetpack-build-to-branch@testing
+        uses: automattic/action-jetpack-build-to-branch@master
         with:
           branch_pull: 'master'
           branch_push: 'master-built'

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Jetpack
         uses: actions/checkout@master
       - name: Build production version
-        uses: automattic/action-jetpack-build-to-branch@master
+        uses: automattic/action-jetpack-build-to-branch@testing
         with:
           branch_pull: 'try/test-action'
           branch_push: 'try/test-action-built'

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build_master_job:
     runs-on: ubuntu-latest
-    name: Build production version of master to master-built branch
+    name: Build production version of master to master-built branch!
     steps:
       - name: Checkout Jetpack
         uses: actions/checkout@master

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,4 +1,4 @@
-name: Build production to master-built
+name: Build production to try/test-action
 on:
   push:
     branches:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes our broken master-built builds generated in the action. 

https://github.com/Automattic/jetpack/actions?query=workflow%3A%22Build+production+to+master-built%22

It has no chance of breaking things further :) 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The action now relies pretty much entirely on the isolated published action hosted in this repo https://github.com/Automattic/action-jetpack-build-to-branch

We can now makes changes to that external repo for modifying. 

I suggest we merge this and wait to see if master-built is being updated properly. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Check out the ones I tested in a separate branch, for example https://github.com/Automattic/jetpack/commit/933a9ccb92997da6ec6a443709db27238ea3ca7d/checks?check_suite_id=298902682

Does the `try/test-action-built` branch contain a complete production build? 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
n/a
