### PR TITLE
build-jetpack.sh: Use build-production

### DIFF
--- a/tools/build-jetpack.sh
+++ b/tools/build-jetpack.sh
@@ -70,7 +70,7 @@ hash yarn 2>/dev/null || {
     exit 1;
 }
 yarn --cwd $TARGET_DIR cache clean
-COMPOSER_MIRROR_PATH_REPOS=1 yarn --cwd $TARGET_DIR run build
+yarn --cwd $TARGET_DIR run build-production
 
 echo "Purging paths included in .svnignore, .gitignore and .git itself"
 # check .svnignore


### PR DESCRIPTION
Fixes p9dueE-15x-p2 which explains what happened to #13970 and #13973. tl;dr: Composer installed things and expected to autoload them, but we deleted them without telling Composer.

This fixes a mismatch where dev dependencies are installed when building Jetpack, but then removed by .svnignore. In this case, let's build an expected production version of Jetpack.

#### Changes proposed in this Pull Request:
* The build-jetpack.sh script to use build-production.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Run `tools/build-jetpack.sh -d -b retry/phpcs-changed Automattic/jetpack /tmp/jetpack` from master (before) and from this branch (after).
* NOTE: This script creates a version of Jetpack in your `/tmp/jetpack` directory. The following testing points explain what you will see there, not in the git repo working directory.
* BEFORE: See in `vendor/composer/autoload_files.php` references to PHPCS Changed. Look in `vendor` to see the directory of the above file missing.
* AFTER: In `autoload_files.php` there is no reference to PHPCS Changed and the directory is still not there.

#### Proposed changelog entry for your changes:
* n/a
