### PR TITLE
Contact Info Widget: Add '%s' to the confit-hours div

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -157,7 +157,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 
 			if ( '' !== $instance['hours'] ) {
 				printf(
-					'<div class="confit-hours" itemprop="openingHours"></div>',
+					'<div class="confit-hours" itemprop="openingHours">%s</div>',
 					str_replace( "\n", '<br/>', esc_html( $instance['hours'] ) ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				);
 			}


### PR DESCRIPTION
This fixes a bug that prevents the hours from being displayed.

Fixes #13982

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add '%s' to the confit-hours div.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes a bug in an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate Jetpack.
* Enable the Extra SIdebar Widgets module.
* Add a Contact Info Widget using the Customizer or from Appearance -> Widgets.
* Ensure that there is some text in the Hours text box.
* Save the widget.
* If using the Customizer, make sure that the Contact Info widget in the preview correctly displays the hours text.
* Navigate to a post on your site and make sure that the Contact Info widget correctly displays the hours text.

#### Proposed changelog entry for your changes:
* Fixed a bug that prevented the hours from being displayed in the Contact Info widget. 
