### PR TITLE
SEO: do not display any tags in post titles display in meta tags

### DIFF
--- a/modules/seo-tools/jetpack-seo-titles.php
+++ b/modules/seo-tools/jetpack-seo-titles.php
@@ -131,7 +131,7 @@ class Jetpack_SEO_Titles {
 
 			case 'post_title':
 			case 'page_title':
-				return get_the_title();
+				return the_title_attribute( array( 'echo' => false ) );
 
 			case 'group_title':
 				return single_tag_title( '', false );


### PR DESCRIPTION
Fixes 4478-gh-jpop-issues


#### Changes proposed in this Pull Request:

Some plugins use the `the_title` filter to add HTML to post titles (to add schema.org metadata for example).
We consequently cannot assume anything returned by `get_the_title()` will be safe to display in a meta tag.
Let's use `the_title_attribute()` instead to avoid having any unwanted HTML.

#### Testing instructions:

* Start from a site running Jetpack Premium and where you've set posts to use a custom meta tag in SEO settings in Calypso:
![image](https://user-images.githubusercontent.com/426388/68402722-11893a80-017c-11ea-9b0b-8876f6ffc4a9.png)

* Install the Easy Digital Downloads plugin
* Create a Download
* View it, and check the meta tag.
    * Without this patch, you will see HTML like so: 
```html
<title>&lt;span itemprop="name"&gt;A test download&lt;/span&gt; and Testing Jetpack and Testing Jetpack</title>
```
   * With the patch, the HTML disappears.

#### Proposed changelog entry for your changes:

* SEO Tools: do not display any tags in post titles display in meta tags.
