### PR TITLE
Moved tracking code to the Tracking file.

### DIFF
--- a/packages/connection/legacy/class.jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class.jetpack-xmlrpc-server.php
@@ -217,6 +217,8 @@ class Jetpack_XMLRPC_Server {
 		 *    - remote_provision
 		 *    - get_user.
 		 *
+		 * @since 8.0.0
+		 *
 		 * @param String  $action the action name, i.e., 'remote_authorize'.
 		 * @param String  $stage  the execution stage, can be 'begin', 'success', 'error', etc.
 		 * @param Array   $parameters extra parameters from the event.

--- a/src/Tracking.php
+++ b/src/Tracking.php
@@ -196,33 +196,21 @@ class Tracking {
 	 * @param Array|WP_Error|IXR_Error $parameters (optional) extra parameters to be passed to the tracked action.
 	 * @param WP_User                  $user (optional) the acting user.
 	 */
-	public function jetpack_xmlrpc_server_event( $action, $stage, $parameters = null, $user = null ) {
+	public function jetpack_xmlrpc_server_event( $action, $stage, $parameters = array(), $user = null ) {
 
 		if ( is_wp_error( $parameters ) ) {
-			$this->tracking->record_user_event(
-				'jpc_' . $action . '_' . $stage,
-				array(
-					'error_code'    => $parameters->get_error_code(),
-					'error_message' => $parameters->get_error_message(),
-				),
-				$user
+			$parameters = array(
+				'error_code'    => $parameters->get_error_code(),
+				'error_message' => $parameters->get_error_message(),
 			);
 		} elseif ( is_a( $parameters, '\\IXR_Error' ) ) {
-			$this->tracking->record_user_event(
-				'jpc_' . $action . '_' . $stage,
-				array(
-					'error_code'    => $parameters->code,
-					'error_message' => $parameters->message,
-				),
-				$user
+			$parameters = array(
+				'error_code'    => $parameters->code,
+				'error_message' => $parameters->message,
 			);
-		} elseif ( null === $user && null === $parameters ) {
-			$this->tracking->record_user_event( 'jpc_' . $action . '_' . $stage );
-		} elseif ( null === $user ) {
-			$this->tracking->record_user_event( 'jpc_' . $action . '_' . $stage, $parameters );
-		} else {
-			$this->tracking->record_user_event( 'jpc_' . $action . '_' . $stage, $parameters, $user );
 		}
+
+		$this->tracking->record_user_event( 'jpc_' . $action . '_' . $stage, $parameters, $user );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This change moves everything that depends on the Tracking class from the legacy XMLRPC Server class to the main Jetpack Tracking class.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Creates a new handler for XMLRPC server events in the Tracking class.
* Adds an action listener and attaches it to the handler.
* Changes the XMLRPC server class to fire actions instead of calling the tracking class directly.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
The testing is mostly manual and includes:
* registering the site (connecting Jetpack after clearing options);
* connecting the user (connecting the user after having a user already registered);
* running a getUser XMLRPC endpoint from WordPress.com (for example, using the Site Audit tool, as described in the testing instructions for D33491-code);
* bonus points for registering your site using the partner provisioning tools.

#### Proposed changelog entry for your changes:
* N/A
