### PR TITLE
Heartbeat: Ensure get_mu_plugins is present

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -102,6 +102,13 @@ class Jetpack_Heartbeat {
 		do_action( 'jetpack_heartbeat' );
 	}
 
+	/**
+	 * Generates heartbeat stats data.
+	 *
+	 * @param string $prefix Prefix to add before stats identifier.
+	 *
+	 * @return array The stats array.
+	 */
 	public static function generate_stats_array( $prefix = '' ) {
 		$return = array();
 
@@ -119,7 +126,9 @@ class Jetpack_Heartbeat {
 		$return[ "{$prefix}is-multisite" ]   = is_multisite() ? 'multisite' : 'singlesite';
 		$return[ "{$prefix}identitycrisis" ] = Jetpack::check_identity_crisis() ? 'yes' : 'no';
 		$return[ "{$prefix}plugins" ]        = implode( ',', Jetpack::get_active_plugins() );
-		$return[ "{$prefix}mu-plugins"]      = implode( ',', array_keys( get_mu_plugins() ) );
+		if ( function_exists( 'get_mu_plugins' ) ) {
+			$return[ "{$prefix}mu-plugins" ] = implode( ',', array_keys( get_mu_plugins() ) );
+		}
 		$return[ "{$prefix}manage-enabled" ] = true;
 
 		$xmlrpc_errors = Jetpack_Options::get_option( 'xmlrpc_errors', array() );
@@ -132,7 +141,7 @@ class Jetpack_Heartbeat {
 		$connection_manager                 = new Manager();
 		$return[ "{$prefix}missing-owner" ] = $connection_manager->is_missing_connection_owner();
 
-		// is-multi-network can have three values, `single-site`, `single-network`, and `multi-network`
+		// is-multi-network can have three values, `single-site`, `single-network`, and `multi-network`.
 		$return[ "{$prefix}is-multi-network" ] = 'single-site';
 		if ( is_multisite() ) {
 			$return[ "{$prefix}is-multi-network" ] = Jetpack::is_multi_network() ? 'multi-network' : 'single-network';
@@ -141,7 +150,7 @@ class Jetpack_Heartbeat {
 		if ( ! empty( $_SERVER['SERVER_ADDR'] ) || ! empty( $_SERVER['LOCAL_ADDR'] ) ) {
 			$ip     = ! empty( $_SERVER['SERVER_ADDR'] ) ? $_SERVER['SERVER_ADDR'] : $_SERVER['LOCAL_ADDR'];
 			$ip_arr = array_map( 'intval', explode( '.', $ip ) );
-			if ( 4 == count( $ip_arr ) ) {
+			if ( 4 === count( $ip_arr ) ) {
 				$return[ "{$prefix}ip-2-octets" ] = implode( '.', array_slice( $ip_arr, 0, 2 ) );
 			}
 		}


### PR DESCRIPTION
get_mu_plugins is within wp-admin/includes/plugin.php, so it is only available via the admin context. The primary purpose of adding this item to the array is to help happiness have that information instantly and is not processed for aggragate purposes. We can leave it out without impacting anything.

Resolves:
```
[07-Nov-2019 16:46:41 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function get_mu_plugins() in /home/travis/build/Automattic/jetpack/class.jetpack-heartbeat.php:122
Stack trace:
#0 /home/travis/build/Automattic/jetpack/class.jetpack-heartbeat.php(89): Jetpack_Heartbeat::generate_stats_array('v2-')
#1 /home/travis/wordpress/wp-includes/class-wp-hook.php(286): Jetpack_Heartbeat->cron_exec()
#2 /home/travis/wordpress/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filters('', Array)
#3 /home/travis/wordpress/wp-includes/plugin.php(531): WP_Hook->do_action(Array)
#4 /home/travis/wordpress/wp-cron.php(133): do_action_ref_array('jetpack_v2_hear...', Array)
#5 {main}
  thrown in /home/travis/build/Automattic/jetpack/class.jetpack-heartbeat.php on line 122
```

#### Changes proposed in this Pull Request:
* Only look at mu-plugins when the function is present.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Watch E2E testing... or
* Watch logs after letting a test site sit long enough to produce the heartbeat on its own.

#### Proposed changelog entry for your changes:
* n/a, feature added during this cycle.
