### PR TITLE
Remove unused get_emblem method

### DIFF
--- a/packages/jitm/src/JITM.php
+++ b/packages/jitm/src/JITM.php
@@ -61,16 +61,6 @@ class JITM {
 	}
 
 	/**
-	 * Get's the Jetpack emblem
-	 *
-	 * @return string The Jetpack emblem
-	 */
-	public function get_emblem() {
-		$jetpack_logo = new Jetpack_Logo();
-		return '<div class="jp-emblem">' . $jetpack_logo->get_jp_emblem() . '</div>';
-	}
-
-	/**
 	 * Prepare actions according to screen and post type.
 	 *
 	 * @since 3.8.2


### PR DESCRIPTION
I just happened to notice this isn't called anywhere.