### PR TITLE
Pinterest Block: Add a wrapping <div> to the save output.

### DIFF
--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -47,7 +47,7 @@ export const settings = {
 
 	edit,
 
-	save: ( { attributes } ) => {
+	save: ( { attributes, className } ) => {
 		const { url } = attributes;
 
 		const type = pinType( url );
@@ -56,7 +56,11 @@ export const settings = {
 			return null;
 		}
 
-		return <a data-pin-do={ pinType( url ) } href={ url } />;
+		return (
+			<div className={ className }>
+				<a data-pin-do={ pinType( url ) } href={ url } />
+			</div>
+		);
 	},
 
 	transforms: {


### PR DESCRIPTION
Pinterest's embed styling adds a `width: 100%` rule to the embed HTML, which will override any themes that add a different style to the children of their `.entry-content` output.

Add a wrapping `<div>` around the Pinterest embed ensures that the theme styling will apply to that `<div>`, then the Pinterest `width: 100%` rule only applies within that `<div>`.

Since this block is still in beta, I haven't included a `transforms` rule to automatically upgrade existing blocks.

Fixes #13989.

#### Changes proposed in this Pull Request:
* Modify the `save` function of the Pinterest block.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This is a bug fix.

#### Testing instructions:

* Follow the instructions in #13989 to install the Photos theme.
* Add some content and a Pinterest block, ensure that the block lines up correctly with the rest of the content.

#### Screenshots:

##### Before

<img width="1279" alt="Screen Shot 2019-11-08 at 9 50 28 am" src="https://user-images.githubusercontent.com/352291/68434533-4db8ab80-020d-11ea-9217-54483214c140.png">

##### After

<img width="1279" alt="Screen Shot 2019-11-08 at 9 50 37 am" src="https://user-images.githubusercontent.com/352291/68434534-4db8ab80-020d-11ea-838b-63da4e966176.png">

#### Proposed changelog entry for your changes:

No changelog entry needed.
