### PR TITLE
Instant Search: default to query string in `getResults()`

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -46,13 +46,7 @@ class SearchApp extends Component {
 	}
 
 	componentDidMount() {
-		this.getResults(
-			getSearchQuery(),
-			getFilterQuery(),
-			this.props.initialSort,
-			getResultFormatQuery(),
-			null
-		);
+		this.getResults( { sort: this.props.initialSort } );
 
 		this.getResults.flush();
 
@@ -116,27 +110,20 @@ class SearchApp extends Component {
 		} else {
 			this.hideResults();
 		}
-		this.getResults(
-			getSearchQuery(),
-			getFilterQuery(),
-			getSortQuery(),
-			getResultFormatQuery(),
-			null
-		);
+		this.getResults();
 	};
 
 	loadNextPage = () => {
-		this.hasNextPage() &&
-			this.getResults(
-				getSearchQuery(),
-				getFilterQuery(),
-				getSortQuery(),
-				getResultFormatQuery(),
-				this.state.response.page_handle
-			);
+		this.hasNextPage() && this.getResults( { pageHandle: this.state.response.page_handle } );
 	};
 
-	getResults = ( query, filter, sort, resultFormat, pageHandle ) => {
+	getResults = ( {
+		query = getSearchQuery(),
+		filter = getFilterQuery(),
+		sort = getSortQuery(),
+		resultFormat = getResultFormatQuery(),
+		pageHandle,
+	} ) => {
 		const requestId = this.state.requestId + 1;
 
 		this.setState( { requestId, isLoading: true }, () => {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -123,7 +123,7 @@ class SearchApp extends Component {
 		sort = getSortQuery(),
 		resultFormat = getResultFormatQuery(),
 		pageHandle,
-	} ) => {
+	} = {} ) => {
 		const requestId = this.state.requestId + 1;
 
 		this.setState( { requestId, isLoading: true }, () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
No functional changes. Refactors `getResults()` in `search-app.jsx` to default to using query string values.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

Ensure that Instant Search continues to function as expected. Example query: `?s=yes&blog_id=20115252`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required.