### PR TITLE
WP-CLI: Set an appropriate version when scaffolding blocks

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1884,6 +1884,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 					'slug'            => $slug,
 					'title'           => $title,
 					'underscoredSlug' => str_replace( '-', '_', $slug ),
+					'jetpackVersion'  => substr( JETPACK__VERSION, 0, strpos( JETPACK__VERSION, '.' ) ) . '.x',
 				)
 			),
 			"$path/index.js"    => $this->render_block_file(

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -2,7 +2,7 @@
 /**
  * {{ title }} Block.
  *
- * @since 7.x
+ * @since {{ jetpackVersion }}
  *
  * @package Jetpack
  */


### PR DESCRIPTION
When scaffolding a block, the `{slug}.php` file contains an `@since` comment, with the version that the block was added. This is currently hardcoded to `7.x`, which is no longer correct, since the next version of Jetpack is 8.0. 🙂

This PR currently sets the version to `8.x`, rather than trying to be clever, as I suspect it would be unreliable if it tried to add more accuracy. For example, setting it to `8.0` would be fine early in the 8.0 cycle, as the block would potentially be finished in time. It gets hard to predict whether that is still true, the later it gets in the cycle, though.

#### Changes proposed in this Pull Request:

Modify the Moustache template for the `{slug}.php` file to use a variable for the version number.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Bug fix.

#### Testing instructions:

* Run `wp jetpack scaffold block 'foo'`.
* Observer that the new `foo.php` file has `@since 8.x` set.

#### Proposed changelog entry for your changes:

* WP-CLI: Fix the `jetpack scaffold block` command to set a more correct `@since` version in the new block.
