### PR TITLE
WP-CLI: Format the block list JSON when adding a new block

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1946,7 +1946,20 @@ class Jetpack_CLI extends WP_CLI_Command {
 			} elseif ( false === stripos( $block_list, $slug ) ) {
 				$new_block_list         = json_decode( $block_list );
 				$new_block_list->beta[] = $slug;
-				if ( ! $wp_filesystem->put_contents( $block_list_path, wp_json_encode( $new_block_list ) ) ) {
+
+				// Format the JSON to match our coding standards.
+				$new_block_list_formatted = wp_json_encode( $new_block_list, JSON_PRETTY_PRINT ) . "\n";
+				$new_block_list_formatted = preg_replace_callback(
+					// Find all occurrences of multiples of 4 spaces a the start of the line.
+					'/^((?:    )+)/m',
+					function ( $matches ) {
+						// Replace each occurrence of 4 spaces with a tab character.
+						return str_repeat( "\t", substr_count( $matches[0], '    ' ) );
+					},
+					$new_block_list_formatted
+				);
+
+				if ( ! $wp_filesystem->put_contents( $block_list_path, $new_block_list_formatted ) ) {
 					/* translators: %s is the path to the file with the block list */
 					WP_CLI::error( sprintf( esc_html__( 'Error writing new %s', 'jetpack' ), $block_list_path ) );
 				}


### PR DESCRIPTION
When adding a new block, `extensions/index.json` is updated to add that block to the `beta` list.

The current method doesn't format the JSON correctly, which results in changes to the `index.json` file needing to be reverted, then applied manually.

#### Changes proposed in this Pull Request:

Before writing the block list JSON to `extensions/index.json`, format it so that it applies cleanly.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Bug Fix.

#### Testing instructions:

* Run `wp jetpack scaffold block 'foo'`.
* Observer that the new block is added to `extensions/index.json`, and the JSON is appropriately formatted.


#### Proposed changelog entry for your changes:
* WP-CLI: Correct the formatting of the JSON that the `jetpack scaffold block` command adds to `extensions/index.json`.
