### PR TITLE
Instant Search: add basic Photon support

### DIFF
--- a/modules/search/instant-search/components/photon-image.jsx
+++ b/modules/search/instant-search/components/photon-image.jsx
@@ -1,0 +1,15 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+import photon from 'photon';
+
+const PhotonImage = ( { src, maxWidth = 160, maxHeight = 160, alt, ...otherProps } ) => {
+	const photonSrc = photon( src, { resize: `${ maxWidth },${ maxHeight }` } );
+
+	return <img src={ photonSrc } alt={ alt } { ...otherProps } />;
+};
+
+export default PhotonImage;

--- a/modules/search/instant-search/components/photon-image.jsx
+++ b/modules/search/instant-search/components/photon-image.jsx
@@ -6,7 +6,7 @@
 import { h } from 'preact';
 import photon from 'photon';
 
-const PhotonImage = ( { src, maxWidth = 160, maxHeight = 160, alt, ...otherProps } ) => {
+const PhotonImage = ( { src, maxWidth = 300, maxHeight = 300, alt, ...otherProps } ) => {
 	const photonSrc = photon( src, { resize: `${ maxWidth },${ maxHeight }` } );
 
 	return <img src={ photonSrc } alt={ alt } { ...otherProps } />;

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -9,6 +9,7 @@ import { h, Component } from 'preact';
  * Internal dependencies
  */
 import SearchResultComments from './search-result-comments';
+import PhotonImage from './photon-image';
 
 class SearchResultProduct extends Component {
 	render() {
@@ -34,7 +35,7 @@ class SearchResultProduct extends Component {
 					/>
 				</h3>
 				{ firstImage && (
-					<img
+					<PhotonImage
 						className="jetpack-instant-search__search-result-product-img"
 						src={ `//${ firstImage }` }
 						alt=""

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,8 @@ const sharedWebpackConfig = {
 	devtool: isDevelopment ? 'source-map' : false,
 };
 
-// We export two configuration files: One for admin.js, and one for static.jsx. The latter produces pre-rendered HTML.
+// We export two main configuration files: One for admin.js, and one for static.jsx. The latter produces pre-rendered HTML.
+// The third configuration file is for Jetpack Search's Preact app.
 module.exports = [
 	{
 		...sharedWebpackConfig,
@@ -89,8 +90,8 @@ module.exports = [
 					hints: 'error',
 			  }
 			: {
-					maxAssetSize: 71680,
-					maxEntrypointSize: 71680,
+					maxAssetSize: 102400,
+					maxEntrypointSize: 102400,
 					hints: 'error',
 			  },
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds basic Photon support to Instant Search product results. This reduces the size of downloaded images and speeds up loading time.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No. Merges to the `instant-search-master` feature branch.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

Ensure that Instant Search resizes images with Photon. Example query: `/?s=card&blog_id=84860689&result_format=product`

<img width="262" alt="Screen Shot 2019-11-08 at 14 57 11" src="https://user-images.githubusercontent.com/17325/68443187-14e1fc00-0238-11ea-82cc-b2efa2d448d2.png">
<img width="906" alt="Screen Shot 2019-11-08 at 14 57 00" src="https://user-images.githubusercontent.com/17325/68443188-157a9280-0238-11ea-8bff-f9624717c41b.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not required.
