### PR TITLE
Connection: Move update_user_token to the Connection package

### DIFF
--- a/_inc/class.jetpack-provision.php
+++ b/_inc/class.jetpack-provision.php
@@ -1,6 +1,7 @@
 <?php //phpcs:ignore
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Sync\Actions;
 
@@ -220,7 +221,7 @@ class Jetpack_Provision { //phpcs:ignore
 
 	private static function authorize_user( $user_id, $access_token ) {
 		// authorize user and enable SSO
-		Jetpack::update_user_token( $user_id, sprintf( '%s.%d', $access_token, $user_id ), true );
+		Connection_Utils::update_user_token( $user_id, sprintf( '%s.%d', $access_token, $user_id ), true );
 
 		/**
 		 * Auto-enable SSO module for new Jetpack Start connections

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -4,6 +4,7 @@ WP_CLI::add_command( 'jetpack', 'Jetpack_CLI' );
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
@@ -1266,7 +1267,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		$is_master_user  = ! Jetpack::is_active();
 		$current_user_id = get_current_user_id();
 
-		Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $named_args['token'], $current_user_id ), $is_master_user );
+		Connection_Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $named_args['token'], $current_user_id ), $is_master_user );
 
 		WP_CLI::log( wp_json_encode( $named_args ) );
 

--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -134,7 +134,7 @@ class Jetpack_Client_Server {
 
 		$is_master_user = ! Jetpack::is_active();
 
-		Jetpack::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+		Connection_Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
 
 		if ( ! $is_master_user ) {
 			Jetpack::state( 'message', 'linked' );

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 
@@ -471,7 +472,7 @@ class Jetpack_Network {
 	 */
 	public function filter_register_user_token( $token ) {
 		$is_master_user = ! Jetpack::is_active();
-		Jetpack::update_user_token(
+		Connection_Utils::update_user_token(
 			get_current_user_id(),
 			sprintf( '%s.%d', $token->secret, get_current_user_id() ),
 			$is_master_user

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -2123,26 +2123,18 @@ class Jetpack {
 	}
 
 	/**
+	 * @deprecated 8.0 Use Automattic\Jetpack\Connection\Utils::update_user_token() instead.
+	 *
 	 * Enters a user token into the user_tokens option
 	 *
-	 * @param int    $user_id
-	 * @param string $token
-	 * return bool
+	 * @param int    $user_id The user id.
+	 * @param string $token The user token.
+	 * @param bool   $is_master_user Whether the user is the master user.
+	 * @return bool
 	 */
 	public static function update_user_token( $user_id, $token, $is_master_user ) {
-		// not designed for concurrent updates
-		$user_tokens = Jetpack_Options::get_option( 'user_tokens' );
-		if ( ! is_array( $user_tokens ) ) {
-			$user_tokens = array();
-		}
-		$user_tokens[ $user_id ] = $token;
-		if ( $is_master_user ) {
-			$master_user = $user_id;
-			$options     = compact( 'user_tokens', 'master_user' );
-		} else {
-			$options = compact( 'user_tokens' );
-		}
-		return Jetpack_Options::update_options( $options );
+		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\\Jetpack\\Connection\\Utils::update_user_token' );
+		return Connection_Utils::update_user_token( $user_id, $token, $is_master_user );
 	}
 
 	/**
@@ -4818,7 +4810,7 @@ endif;
 
 	/**
 	 * @deprecated 8.0 Use Automattic\Jetpack\Connection\Utils::fix_url_for_bad_hosts() instead.
-     *
+	 *
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requsets
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-user-connect-endpoint.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+
 class Jetpack_JSON_API_User_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
 
 	protected $needed_capabilities = 'create_users';
@@ -8,7 +10,7 @@ class Jetpack_JSON_API_User_Connect_Endpoint extends Jetpack_JSON_API_Endpoint {
 	private $user_token;
 
 	function result() {
-		Jetpack::update_user_token( $this->user_id, sprintf( '%s.%d', $this->user_token, $this->user_id ), false );
+		Connection_Utils::update_user_token( $this->user_id, sprintf( '%s.%d', $this->user_token, $this->user_id ), false );
 		return array( 'success' => Jetpack::is_user_connected( $this->user_id ) );
 	}
 

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -492,7 +492,7 @@ class Jetpack_XMLRPC_Server {
 		}
 		$token = sanitize_text_field( $token );
 
-		Jetpack::update_user_token( $user->ID, sprintf( '%s.%d', $token, $user->ID ), true );
+		Connection_Utils::update_user_token( $user->ID, sprintf( '%s.%d', $token, $user->ID ), true );
 
 		$this->do_post_authorization();
 

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -18,8 +18,8 @@ class Utils {
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requests.
 	 * This method sets the URL scheme to HTTP when HTTPS requests can't be made.
 	 *
-	 * @param String $url The url.
-	 * @return String The url with the required URL scheme.
+	 * @param string $url The url.
+	 * @return string The url with the required URL scheme.
 	 */
 	public static function fix_url_for_bad_hosts( $url ) {
 		// If we receive an http url, return it.
@@ -34,5 +34,29 @@ class Utils {
 
 		// Otherwise, return the https url.
 		return $url;
+	}
+
+	/**
+	 * Enters a user token into the user_tokens option
+	 *
+	 * @param int    $user_id The user id.
+	 * @param string $token The user token.
+	 * @param bool   $is_master_user Whether the user is the master user.
+	 * @return bool
+	 */
+	public static function update_user_token( $user_id, $token, $is_master_user ) {
+		// Not designed for concurrent updates.
+		$user_tokens = \Jetpack_Options::get_option( 'user_tokens' );
+		if ( ! is_array( $user_tokens ) ) {
+			$user_tokens = array();
+		}
+		$user_tokens[ $user_id ] = $token;
+		if ( $is_master_user ) {
+			$master_user = $user_id;
+			$options     = compact( 'user_tokens', 'master_user' );
+		} else {
+			$options = compact( 'user_tokens' );
+		}
+		return \Jetpack_Options::update_options( $options );
 	}
 }

--- a/tests/php/general/test_class.jetpack-xmlrpc-server.php
+++ b/tests/php/general/test_class.jetpack-xmlrpc-server.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Sync\Sender;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 
 class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 	static $xmlrpc_admin = 0;
@@ -9,7 +10,7 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 		$user_id = $factory->user->create();
 		$user = get_user_by( 'ID', $user_id );
 		$user->set_role( 'administrator' );
-		Jetpack::update_user_token( $user_id, sprintf( '%s.%s.%d', 'key', 'private', $user_id ), false );
+		Connection_Utils::update_user_token( $user_id, sprintf( '%s.%s.%d', 'key', 'private', $user_id ), false );
 
 		self::$xmlrpc_admin = $user_id;
 	}
@@ -179,7 +180,7 @@ class WP_Test_Jetpack_XMLRPC_Server extends WP_UnitTestCase {
 			'blog_token'  => 1,
 			'id'          => 1001,
 		) );
-		Jetpack::update_user_token( 1, sprintf( '%s.%d', 'token', 1 ), true );
+		Connection_Utils::update_user_token( 1, sprintf( '%s.%d', 'token', 1 ), true );
 
 		$server = new Jetpack_XMLRPC_Server();
 

--- a/tests/php/modules/wpcom-block-editor/test_class-jetpack-wpcom-block-editor.php
+++ b/tests/php/modules/wpcom-block-editor/test_class-jetpack-wpcom-block-editor.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+
 require_once dirname( __FILE__ ) . '/../../../../modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php';
 
 /**
@@ -41,7 +43,7 @@ class WP_Test_Jetpack_WPCOM_Block_Editor extends WP_UnitTestCase {
 		$this->assertFalse( $wpcom_block_editor->verify_frame_nonce( $this->create_nonce(), 'action' ) );
 
 		// Set user token.
-		Jetpack::update_user_token( $this->user_id, sprintf( '%s.%d.%d', 'token', JETPACK__API_VERSION, $this->user_id ), true );
+		Connection_Utils::update_user_token( $this->user_id, sprintf( '%s.%d.%d', 'token', JETPACK__API_VERSION, $this->user_id ), true );
 		$nonce = $this->create_nonce();
 
 		// User ID mismatch.


### PR DESCRIPTION
This change helps separate the Connection package from the plugin.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move the `update_user_token` method from the Jetpack class to the Utils class in the Connection package.
* Deprecate the existing `update_user_token` method.
* Change all invocations of the `update_user_token` method to the Utils class of the Connection package.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an update to an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Deactivate and activate Jetpack.
* Connect Jetpack. The connection process should be successful.
* Verify that the user token for your user id was stored with this command:
`wp jetpack options get user_tokens`
* Run Jetpack's unit tests.

#### Proposed changelog entry for your changes:
* Not needed.
