### PR TITLE
Add connection authentication URL.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4637,11 +4637,11 @@ endif;
 		add_filter( 'jetpack_connect_processing_url', array( __CLASS__, 'filter_connect_processing_url' ) );
 
 		if ( $iframe ) {
-			add_filter( 'jetpack_api_url', array( __CLASS__, 'filter_connect_api_iframe_url' ) );
+			add_filter( 'jetpack_api_url', array( __CLASS__, 'filter_connect_api_iframe_url' ), 10, 2 );
 		}
 
 		$c8n = self::connection();
-		$url = $c8n->build_connect_url( wp_get_current_user(), $redirect );
+		$url = $c8n->get_authorization_url( wp_get_current_user(), $redirect );
 
 		remove_filter( 'jetpack_connect_request_body', array( __CLASS__, 'filter_connect_request_body' ) );
 		remove_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4631,16 +4631,58 @@ endif;
 	}
 
 	public static function build_authorize_url( $redirect = false, $iframe = false ) {
-		if ( defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) && include_once JETPACK__GLOTPRESS_LOCALES_PATH ) {
-			$gp_locale = GP_Locales::by_field( 'wp_locale', get_locale() );
+
+		add_filter( 'jetpack_connect_request_body', array( __CLASS__, 'filter_connect_request_body' ) );
+		add_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
+
+		if ( $iframe ) {
+			add_filter( 'jetpack_api_url', array( __CLASS__, 'filter_connect_api_iframe_url' ) );
 		}
 
-		$roles       = new Roles();
-		$role        = $roles->translate_current_user_to_role();
-		$signed_role = self::connection()->sign_role( $role );
+		$c8n = self::connection();
+		$url = $c8n->build_connect_url( wp_get_current_user() );
 
-		$user = wp_get_current_user();
+		remove_filter( 'jetpack_connect_request_body', array( __CLASS__, 'filter_connect_request_body' ) );
+		remove_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
+		if ( $iframe ) {
+			remove_filter( 'jetpack_api_url', array( __CLASS__, 'filter_connect_api_iframe_url' ) );
+		}
 
+		return $url;
+	}
+
+	public static function filter_connect_request_body( $args ) {
+		if (
+			Constants::is_defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' )
+			&& include_once Constants::get_constant( 'JETPACK__GLOTPRESS_LOCALES_PATH' )
+		) {
+			$gp_locale = GP_Locales::by_field( 'wp_locale', get_locale() );
+			$args['locale'] = isset( $gp_locale ) && isset( $gp_locale->slug )
+				? $gp_locale->slug
+				: '';
+		}
+
+		$tracking        = new Tracking();
+		$tracks_identity = $tracking->tracks_get_identity( $args['state'] );
+
+		$args = array_merge(
+			$args,
+			array(
+				'_ui' => $tracks_identity['_ui'],
+				'_ut' => $tracks_identity['_ut'],
+			)
+		);
+
+		$calypso_env = self::get_calypso_env();
+
+		if ( ! empty( $calypso_env ) ) {
+			$args['calypso_env'] = $calypso_env;
+		}
+
+		return $args;
+	}
+
+	public static function filter_connect_redirect_url( $redirect ) {
 		$jetpack_admin_page = esc_url_raw( admin_url( 'admin.php?page=jetpack' ) );
 		$redirect           = $redirect
 			? wp_validate_redirect( esc_url_raw( $redirect ), $jetpack_admin_page )
@@ -4650,67 +4692,19 @@ endif;
 			$redirect = Jetpack_Network::init()->get_url( 'network_admin_page' );
 		}
 
-		$secrets = self::generate_secrets( 'authorize', false, 2 * HOUR_IN_SECONDS );
+		return $redirect;
+	}
 
-		/**
-		 * Filter the type of authorization.
-		 * 'calypso' completes authorization on wordpress.com/jetpack/connect
-		 * while 'jetpack' ( or any other value ) completes the authorization at jetpack.wordpress.com.
-		 *
-		 * @since 4.3.3
-		 *
-		 * @param string $auth_type Defaults to 'calypso', can also be 'jetpack'.
-		 */
-		$auth_type = apply_filters( 'jetpack_auth_type', 'calypso' );
+	public static function filter_connect_api_iframe_url( $api_url, $relative_url ) {
 
-		$tracks          = new Tracking();
-		$tracks_identity = $tracks->tracks_get_identity( get_current_user_id() );
-
-		$args = urlencode_deep(
-			array(
-				'response_type' => 'code',
-				'client_id'     => Jetpack_Options::get_option( 'id' ),
-				'redirect_uri'  => add_query_arg(
-					array(
-						'action'   => 'authorize',
-						'_wpnonce' => wp_create_nonce( "jetpack-authorize_{$role}_{$redirect}" ),
-						'redirect' => urlencode( $redirect ),
-					),
-					esc_url( admin_url( 'admin.php?page=jetpack' ) )
-				),
-				'state'         => $user->ID,
-				'scope'         => $signed_role,
-				'user_email'    => $user->user_email,
-				'user_login'    => $user->user_login,
-				'is_active'     => self::is_active(),
-				'jp_version'    => JETPACK__VERSION,
-				'auth_type'     => $auth_type,
-				'secret'        => $secrets['secret_1'],
-				'locale'        => ( isset( $gp_locale ) && isset( $gp_locale->slug ) ) ? $gp_locale->slug : '',
-				'blogname'      => get_option( 'blogname' ),
-				'site_url'      => site_url(),
-				'home_url'      => home_url(),
-				'site_icon'     => get_site_icon_url(),
-				'site_lang'     => get_locale(),
-				'_ui'           => $tracks_identity['_ui'],
-				'_ut'           => $tracks_identity['_ut'],
-				'site_created'  => self::connection()->get_assumed_site_creation_date(),
-			)
-		);
-
-		self::apply_activation_source_to_args( $args );
-
-		$connection = self::connection();
-
-		$calypso_env = self::get_calypso_env();
-
-		if ( ! empty( $calypso_env ) ) {
-			$args['calypso_env'] = $calypso_env;
+		// Short-circuit on anything that is not related to connect requests.
+		if ( 'authorize' !== $relative_url ) {
+			return $api_url;
 		}
 
-		$api_url = $iframe ? $connection->api_url( 'authorize_iframe' ) : $connection->api_url( 'authorize' );
+		$c8n = self::connection();
 
-		return add_query_arg( $args, $api_url );
+		return $c8n->api_url( 'authorize_iframe');
 	}
 
 	/**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1449,7 +1449,7 @@ class Manager {
 		 */
 		$redirect = apply_filters( 'jetpack_connect_redirect_url', $redirect );
 
-		$secrets = $this->generate_secrets( 'authorize', false, 2 * HOUR_IN_SECONDS );
+		$secrets = $this->generate_secrets( 'authorize', $user->ID, 2 * HOUR_IN_SECONDS );
 
 		/**
 		 * Filter the type of authorization.

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -637,7 +637,7 @@ class Manager {
 	 * @param Integer $user_id (optional) the user identifier, defaults to current user.
 	 * @param String  $redirect_url the URL to redirect the user to for processing, defaults to
 	 *                              admin_url().
-	 * @return Bool|WP_Error
+	 * @return WP_Error only in case of a failed user lookup.
 	 */
 	public function connect_user( $user_id = null, $redirect_url = null ) {
 		$user = null;
@@ -656,7 +656,8 @@ class Manager {
 		}
 
 		// Using wp_redirect intentionally because we're redirecting outside.
-		return wp_redirect( $this->get_authorization_url( $user ) ); // phpcs:ignore WordPress.Security.SafeRedirect
+		wp_redirect( $this->get_authorization_url( $user ) ); // phpcs:ignore WordPress.Security.SafeRedirect
+		exit();
 	}
 
 	/**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1400,7 +1400,7 @@ class Manager {
 	 * @param String  $redirect (optional) a redirect URL to use instead of the default.
 	 * @return string Connect URL.
 	 */
-	public function build_connect_url( $user = null, $redirect = null ) {
+	public function get_authorization_url( $user = null, $redirect = null ) {
 
 		if ( empty( $user ) ) {
 			$user = wp_get_current_user();

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1397,9 +1397,10 @@ class Manager {
 	 * Builds a URL to the Jetpack connection auth page.
 	 *
 	 * @param WP_User $user (optional) defaults to the current logged in user.
-	 * @return string Connect URL
+	 * @param String  $redirect (optional) a redirect URL to use instead of the default.
+	 * @return string Connect URL.
 	 */
-	public function build_connect_url( $user = null ) {
+	public function build_connect_url( $user = null, $redirect = null ) {
 
 		if ( empty( $user ) ) {
 			$user = wp_get_current_user();
@@ -1410,6 +1411,16 @@ class Manager {
 		$signed_role = $this->sign_role( $role );
 
 		/**
+		 * Filter the URL of the first time the user gets redirected back to your site for connection
+		 * data processing.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param string $redirect_url Defaults to the site admin URL.
+		 */
+		$processing_url = apply_filters( 'jetpack_connect_processing_url', admin_url( 'admin.php' ) );
+
+		/**
 		 * Filter the URL to redirect the user back to when the authentication process
 		 * is complete.
 		 *
@@ -1417,7 +1428,7 @@ class Manager {
 		 *
 		 * @param string $redirect_url Defaults to the site URL.
 		 */
-		$redirect = apply_filters( 'jetpack_connect_redirect_url', esc_url_raw( site_url() ) );
+		$redirect = apply_filters( 'jetpack_connect_redirect_url', $redirect );
 
 		$secrets = $this->generate_secrets( 'authorize', false, 2 * HOUR_IN_SECONDS );
 
@@ -1435,7 +1446,7 @@ class Manager {
 		/**
 		 * Filters the user connection request data for additional property addition.
 		 *
-		 * @since 8.8.0
+		 * @since 8.0.0
 		 *
 		 * @param Array $request_data request data.
 		 */
@@ -1450,7 +1461,7 @@ class Manager {
 						'_wpnonce' => wp_create_nonce( "jetpack-authorize_{$role}_{$redirect}" ),
 						'redirect' => rawurlencode( $redirect ),
 					),
-					esc_url( admin_url( 'admin.php?page=jetpack' ) )
+					esc_url( $processing_url )
 				),
 				'state'         => $user->ID,
 				'scope'         => $signed_role,

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -27,6 +27,18 @@ class ManagerTest extends TestCase {
 				);
 
 		$this->apply_filters = $builder->build();
+
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+				->setName( 'wp_redirect' )
+				->setFunction(
+					function( $url ) {
+						$this->arguments_stack['wp_redirect'] [] = [ $url ];
+						return true;
+					}
+				);
+
+		$this->wp_redirect = $builder->build();
 	}
 
 	public function tearDown() {
@@ -72,6 +84,19 @@ class ManagerTest extends TestCase {
 			'https://jetpack.wordpress.com/jetpack.another_thing/1/',
 			$this->manager->api_url( 'another_thing/' )
 		);
+	}
+
+	/**
+	 * @covers Automattic\Jetpack\Connection\Manager::connect_user
+	 */
+	public function test_connect_user() {
+		$this->apply_filters->enable();
+		$this->wp_redirect->enable();
+
+		$this->manager->connect_user( 1 );
+
+		$this->assertNotEmpty( $this->arguments_stack['wp_redirect'] );
+		$this->assertEquals( $this->manager->api_url( 'authenticate' ),  $this->arguments_stack['wp_redirect'][0][0] );
 	}
 
 	/**

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -87,19 +87,6 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @covers Automattic\Jetpack\Connection\Manager::connect_user
-	 */
-	public function test_connect_user() {
-		$this->apply_filters->enable();
-		$this->wp_redirect->enable();
-
-		$this->manager->connect_user( 1 );
-
-		$this->assertNotEmpty( $this->arguments_stack['wp_redirect'] );
-		$this->assertEquals( $this->manager->api_url( 'authenticate' ), $this->arguments_stack['wp_redirect'][0][0] );
-	}
-
-	/**
 	 * Testing the ability of the api_url method to follow set constants and filters.
 	 *
 	 * @covers Automattic\Jetpack\Connection\Manager::api_url

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -96,7 +96,7 @@ class ManagerTest extends TestCase {
 		$this->manager->connect_user( 1 );
 
 		$this->assertNotEmpty( $this->arguments_stack['wp_redirect'] );
-		$this->assertEquals( $this->manager->api_url( 'authenticate' ),  $this->arguments_stack['wp_redirect'][0][0] );
+		$this->assertEquals( $this->manager->api_url( 'authenticate' ), $this->arguments_stack['wp_redirect'][0][0] );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds a new method that generates an authentication URL for a certain user. The Jetpack standard method is made to use that method.

#### Changes proposed in this Pull Request:
* The code that has been previously generating an authorization URL is now split into several chunks. The generic code that should run in any code consuming the package is moved into the Manager class.
* The code that's specific to Jetpack needs is moved to separate filters, tailoring the URL to Jetpack's specific needs.
* Unit tests are added for one method, but they were slowing me down very much so I decided to use the existing code without coverage. I'd appreciate any ideas on how to test it without taking too much time developing a solution.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the Jetpack DNA project for the Connection package.

#### Testing instructions:
This PR changes the way we generate a link to authorize the user, so the site needs to be registered first. You can get to that state by connecting a site and adding a user that hasn't been connected yet.

#### Proposed changelog entry for your changes:
* N/A
