### PR TITLE
[WIP] Add a 'Available in Development Mode' module header.

### DIFF
--- a/_inc/client/components/section-header/index.jsx
+++ b/_inc/client/components/section-header/index.jsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Gridicon from 'components/gridicon';
 
 import './style.scss';
 
@@ -17,19 +18,28 @@ export default class SectionHeader extends React.Component {
 
 	static propTypes = {
 		label: PropTypes.string,
+		devModeWarning: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		label: '',
+		devModeWarning: false,
 	};
 
 	render() {
 		const classes = classNames( this.props.className, 'dops-section-header' );
+		const { label, devModeWarning } = this.props;
 
 		return (
 			<Card compact className={ classes }>
 				<div className="dops-section-header__label">
-					<span className="dops-section-header__label-text">{ this.props.label }</span>
+					{ devModeWarning ? <Gridicon icon="notice" /> : null }
+					<span className="dops-section-header__label-text">
+						{ label +
+							( devModeWarning
+								? ' — This feature is available in Development Mode, but may not be as fully functional as on a live site'
+								: '' ) }
+					</span>
 				</div>
 				<div className="dops-section-header__actions">{ this.props.children }</div>
 			</Card>

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -311,7 +311,12 @@ export const SettingsCard = props => {
 	return (
 		getModuleOverridenBanner() || (
 			<form className="jp-form-settings-card" onSubmit={ ! isSaving ? props.onSubmit : undefined }>
-				<SectionHeader label={ header }>
+				<SectionHeader
+					label={ header }
+					devModeWarning={
+						props.isDevMode && module && module.requires_connection && module.available_in_dev_mode
+					}
+				>
 					{ ! props.hideButton && (
 						<Button primary compact type="submit" disabled={ isSaving || ! props.isDirty() }>
 							{ isSaving

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -24,7 +24,10 @@ import {
 	UNLINK_USER_SUCCESS,
 	MOCK_SWITCH_USER_PERMISSIONS,
 } from 'state/action-types';
-import { getModulesThatRequireConnection } from 'state/modules';
+import {
+	getModulesThatRequireConnection,
+	getModulesThatAreAvailableInDevMode,
+} from 'state/modules';
 
 export const status = (
 	state = { siteConnected: window.Initial_State.connectionStatus },
@@ -269,7 +272,7 @@ export function requiresConnection( state, slug ) {
  * @return {boolean} True if site is in dev mode and module requires connection. False otherwise.
  */
 export function isUnavailableInDevMode( state, module ) {
-	return isDevMode( state ) && requiresConnection( state, module );
+	return isDevMode( state ) && ! includes( getModulesThatAreAvailableInDevMode( state ), module );
 }
 
 /**

--- a/_inc/client/state/modules/reducer.js
+++ b/_inc/client/state/modules/reducer.js
@@ -235,6 +235,20 @@ export function getModulesThatRequireConnection( state ) {
 }
 
 /**
+ * Returns an array of modules that require connection.
+ *
+ * The module's header comments indicates if it requires connection or not.
+ *
+ * @param  {Object} state   Global state tree
+ * @return {Array}          Array of modules that require connection.
+ */
+export function getModulesThatAreAvailableInDevMode( state ) {
+	return Object.keys( state.jetpack.modules.items ).filter(
+		module_slug => state.jetpack.modules.items[ module_slug ].available_in_dev_mode
+	);
+}
+
+/**
  * Check that the module list includes at least one of these modules.
  *
  * @param  {Object} state   Global state tree

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -54,13 +54,12 @@ class RelatedPostsComponent extends React.Component {
 	};
 
 	render() {
-		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' ),
-			unavailableInDevMode = this.props.isUnavailableInDevMode( 'related-posts' );
+		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' );
+
 		return (
 			<SettingsCard { ...this.props } hideButton module="related-posts">
 				<SettingsGroup
 					hasChild
-					disableInDevMode
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
 						text: __(
@@ -89,7 +88,6 @@ class RelatedPostsComponent extends React.Component {
 					</p>
 					<ModuleToggle
 						slug="related-posts"
-						disabled={ unavailableInDevMode }
 						activated={ isRelatedPostsActive }
 						toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
 						toggleModule={ this.props.toggleModuleNow }
@@ -103,7 +101,6 @@ class RelatedPostsComponent extends React.Component {
 							checked={ this.state.show_headline }
 							disabled={
 								! isRelatedPostsActive ||
-								unavailableInDevMode ||
 								this.props.isSavingAnyOption( [ 'related-posts', 'show_headline' ] )
 							}
 							onChange={ this.handleShowHeadlineToggleChange }
@@ -116,7 +113,6 @@ class RelatedPostsComponent extends React.Component {
 							checked={ this.state.show_thumbnails }
 							disabled={
 								! isRelatedPostsActive ||
-								unavailableInDevMode ||
 								this.props.isSavingAnyOption( [ 'related-posts', 'show_thumbnails' ] )
 							}
 							onChange={ this.handleShowThumbnailsToggleChange }
@@ -180,7 +176,7 @@ class RelatedPostsComponent extends React.Component {
 						) }
 					</FormFieldset>
 				</SettingsGroup>
-				{ ! this.props.isUnavailableInDevMode( 'related-posts' ) && isRelatedPostsActive && (
+				{ isRelatedPostsActive && (
 					<Card
 						compact
 						className="jp-settings-card__configure-link"

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -194,12 +194,12 @@ class Jetpack_Core_API_Module_List_Endpoint {
 
 		$modules = Jetpack_Admin::init()->get_modules();
 		foreach ( $modules as $slug => $properties ) {
-			$modules[ $slug ]['options'] =
-				Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $slug );
+			$modules[ $slug ]['options'] = Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $slug );
+
 			if (
-				isset( $modules[ $slug ]['requires_connection'] )
-				&& $modules[ $slug ]['requires_connection']
-				&& ( new Status() )->is_development_mode()
+				( new Status() )->is_development_mode()
+			&&
+				! $modules[ $slug ]['available_in_dev_mode']
 			) {
 				$modules[ $slug ]['activated'] = false;
 			}
@@ -364,9 +364,9 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			$module['options'] = Jetpack_Core_Json_Api_Endpoints::prepare_options_for_response( $request['slug'] );
 
 			if (
-				isset( $module['requires_connection'] )
-				&& $module['requires_connection']
-				&& ( new Status() )->is_development_mode()
+				( new Status() )->is_development_mode()
+			&&
+				! $module['available_in_dev_mode']
 			) {
 				$module['activated'] = false;
 			}

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -199,7 +199,7 @@ class Jetpack_Admin {
 		}
 
 		if ( ( new Status() )->is_development_mode() ) {
-			return ! ( $module['requires_connection'] );
+			return $module['available_in_dev_mode'];
 		} else {
 			if ( ! Jetpack::is_active() ) {
 				return false;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1838,8 +1838,8 @@ class Jetpack {
 				if ( empty( $modules_data[ $module ] ) ) {
 					$modules_data[ $module ] = self::get_module( $module );
 				}
-				// If the module requires a connection, but we're in local mode, don't include it.
-				if ( $modules_data[ $module ]['requires_connection'] ) {
+				// If the module cannot be used in dev mode, don't include it.
+				if ( ! $modules_data[ $module ]['available_in_dev_mode'] ) {
 					continue;
 				}
 			}
@@ -2459,6 +2459,7 @@ class Jetpack {
 			'deactivate'                => 'Deactivate',
 			'free'                      => 'Free',
 			'requires_connection'       => 'Requires Connection',
+			'available_in_dev_mode'     => 'Available in Development Mode',
 			'auto_activate'             => 'Auto Activate',
 			'module_tags'               => 'Module Tags',
 			'feature'                   => 'Feature',
@@ -2478,6 +2479,11 @@ class Jetpack {
 		$mod['deactivate']           = empty( $mod['deactivate'] );
 		$mod['free']                 = empty( $mod['free'] );
 		$mod['requires_connection']  = ( ! empty( $mod['requires_connection'] ) && 'No' == $mod['requires_connection'] ) ? false : true;
+		if ( $mod['requires_connection'] ) {
+			$mod['available_in_dev_mode'] = ( empty( $mod['available_in_dev_mode'] ) || 'No' == $mod['available_in_dev_mode'] ) ? false : true;
+		} else {
+			$mod['available_in_dev_mode'] = true;
+		}
 
 		if ( empty( $mod['auto_activate'] ) || ! in_array( strtolower( $mod['auto_activate'] ), array( 'yes', 'no', 'public' ) ) ) {
 			$mod['auto_activate'] = 'No';
@@ -2970,8 +2976,8 @@ class Jetpack {
 				return false;
 			}
 
-			// If we're not connected but in development mode, make sure the module doesn't require a connection
-			if ( $is_development_mode && $module_data['requires_connection'] ) {
+			// If we're in development mode, make sure the module is compatible.
+			if ( $is_development_mode && ! $module_data['available_in_dev_mode'] ) {
 				return false;
 			}
 		}

--- a/modules/related-posts.php
+++ b/modules/related-posts.php
@@ -6,6 +6,7 @@
  * Sort Order: 29
  * Recommendation Order: 9
  * Requires Connection: Yes
+ * Available in Development Mode: Yes
  * Auto Activate: No
  * Module Tags: Recommended
  * Feature: Engagement


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When a module requires the connection but is able to partially function in development mode, this new header will allow the module to be activated.

As an example of how this will look, I've added the header to the Related Posts module. Note that the module doesn't actually do anything when activated in dev mode, since the modules own code needs updating to work without an active connection (see #13837).

The _inc/client UI in this PR isn't meant to be any good :) It's there to serve as an example of what all we'll need to think about: We need a way to show the user that it's possible to activate the feature, but that the site is still in dev mode and that the feature's output isn't necessarily what would be output on an active site.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: dev experience update.

#### Testing instructions:
1. On a local site (in dev mode):
1. Go to wp-admin/ -> Jetpack -> Settings -> Traffic
2. Look at the the Related Posts feature.

Prior to this PR, see that it is disabled.

With this PR, see that it is possible to enable (though it won't actually do anything blog-side without #13837).

#### Proposed changelog entry for your changes:

Allow some features that are normally only available on a site fully connected to WordPress.com to be activated on test sites.