### PR TITLE
Experimental support for Gutenberg JITMs

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -544,6 +544,36 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return array();
 		}
 
+		$fake_jitm_message = json_decode( <<<ENDJSON
+		{
+			"content": {
+			  "message": "Protect your site before making major changes.",
+			  "icon": "<div class=\"jp-emblem\"><svg id=\"jetpack-logo__icon\" xmlns=\"http://www.w3.org/2000/svg\" x=\"0px\" y=\"0px\" viewBox=\"0 0 32 32\"><path fill=\"#00BE28\" d=\"M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16c8.8,0,16-7.2,16-16S24.8,0,16,0z M15.2,18.7h-8l8-15.5V18.7z M16.8,28.8 V13.3h8L16.8,28.8z\"/></svg></div>",
+			  "list": [],
+			  "description": "Back up your theme, plugins, and content with Jetpack.",
+			  "classes": ""
+			},
+			"CTA": {
+			  "message": "Enable Backups",
+			  "hook": "",
+			  "newWindow": true,
+			  "primary": true
+			},
+			"template": "default",
+			"ttl": 300,
+			"id": "backup-updates",
+			"feature_class": "vaultpress",
+			"expires": 3628800,
+			"max_dismissal": 2,
+			"activate_module": null,
+			"url": "https://jetpack.com/redirect/?source=jitm-backup-updates&site=goldsounds2.ngrok.io&u=1",
+			"jitm_stats_url": "https://pixel.wp.com/g.gif?v=wpcom2&rand=a814e31aaefec80018811503ee5e6c30&x_jetpack-jitm=backup-updates"
+		  }
+ENDJSON
+		);
+
+		return [ $fake_jitm_message ];
+
 		return $jitm->get_messages( $request['message_path'], urldecode_deep( $request['query'] ) );
 	}
 


### PR DESCRIPTION
Fixes #8916

#### Changes proposed in this Pull Request:

* Display JITMs as core editor notices on Gutenberg pages

Note that this branch has a hack to always display a sample notice on every page, to assist with feedback and debugging. This change should be reverted before merging.

I need design help with this. Here's how it currently looks (I applied no CSS to it)

<img width="1193" alt="jitm-in-gutenberg" src="https://user-images.githubusercontent.com/51896/68514298-2f18db80-0232-11ea-8ba8-80469b3e79ac.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes JITMs. Internal reference: p1HpG7-7Yu-p2

#### Testing instructions:

* Go to the new post page
* You should see a (fake) JITM encouraging you to buy a backups plan

#### Proposed changelog entry for your changes:

* Show Just In Time messages in Gutenberg editor
