### PR TITLE
Next step of Photon transition

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -178,11 +178,11 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	/*
 	 * Need to perform a slowroll out per pMz3w-arH-p2
 	 *
-	 * 7.9 - Use the old method if the value is not 0.
-	 * 8.0 - Use the old method if the value is not 0 or 1.
+	 * 7.9 - Use the old method if the value is not 0 (thus 1 or 2).
+	 * 8.0 - Use the old method if the value is 2 (thus not 0 or 1). [current step]
 	 * 8.1 - Remove this completely.
 	 */
-	if ( 0 !== $subdomain ) {
+	if ( 2 === $subdomain ) {
 		// Figure out which CDN subdomain to use.
 		srand( crc32( $image_host_path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_srand
 		$subdomain = rand( 0, 2 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand


### PR DESCRIPTION
Follow-up to #12159

#### Changes proposed in this Pull Request:
* Expand to 2/3rd of images the simpler Photon subdomain determination.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* pMz3w-arH-p2

#### Testing instructions:
* None really, but ensure Photon is still loading images.

#### Proposed changelog entry for your changes:
* Photon: Expand number of images using the new subdomain determination function.
