### PR TITLE
Move AMP rendering of [youtube] shortcode to Jetpack from AMP plugin

### DIFF
--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -353,7 +353,7 @@ function jetpack_amp_youtube_shortcode( $url ) {
 	$video_id = jetpack_get_youtube_id( $url );
 	if ( empty( $video_id ) ) {
 		return sprintf(
-			'<a href="%s" class="amp-wp-embed-fallback"></a>',
+			'<a href="%s" class="amp-wp-embed-fallback">%s</a>',
 			esc_url( $url )
 		);
 	}

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -181,30 +181,30 @@ function youtube_id( $url ) {
 	$url = youtube_sanitize_url( $url );
 	$url = wp_parse_url( $url );
 
-	$qargs = jetpack_shortcode_youtube_query_args( $url );
-	if ( empty( $qargs ) ) {
+	$args = jetpack_shortcode_youtube_args( $url );
+	if ( empty( $args ) ) {
 		return false;
 	}
 
-	list( $w, $h ) = jetpack_shortcode_youtube_dimensions( $qargs );
-	$rel           = ( isset( $qargs['rel'] ) && '0' === $qargs['rel'] ) ? 0 : 1;
-	$search        = ( isset( $qargs['showsearch'] ) && '1' === $qargs['showsearch'] ) ? 1 : 0;
-	$info          = ( isset( $qargs['showinfo'] ) && '0' === $qargs['showinfo'] ) ? 0 : 1;
-	$iv            = ( isset( $qargs['iv_load_policy'] ) && '3' === $qargs['iv_load_policy'] ) ? 3 : 1;
+	list( $w, $h ) = jetpack_shortcode_youtube_dimensions( $args );
+	$rel           = ( isset( $args['rel'] ) && '0' === $args['rel'] ) ? 0 : 1;
+	$search        = ( isset( $args['showsearch'] ) && '1' === $args['showsearch'] ) ? 1 : 0;
+	$info          = ( isset( $args['showinfo'] ) && '0' === $args['showinfo'] ) ? 0 : 1;
+	$iv            = ( isset( $args['iv_load_policy'] ) && '3' === $args['iv_load_policy'] ) ? 3 : 1;
 
-	$fmt = ( isset( $qargs['fmt'] ) && intval( $qargs['fmt'] ) ) ? '&fmt=' . (int) $qargs['fmt'] : '';
+	$fmt = ( isset( $args['fmt'] ) && intval( $args['fmt'] ) ) ? '&fmt=' . (int) $args['fmt'] : '';
 
-	if ( ! isset( $qargs['autohide'] ) || ( $qargs['autohide'] < 0 || 2 < $qargs['autohide'] ) ) {
+	if ( ! isset( $args['autohide'] ) || ( $args['autohide'] < 0 || 2 < $args['autohide'] ) ) {
 		$autohide = '&autohide=2';
 	} else {
-		$autohide = '&autohide=' . absint( $qargs['autohide'] );
+		$autohide = '&autohide=' . absint( $args['autohide'] );
 	}
 
 	$start = 0;
-	if ( isset( $qargs['start'] ) ) {
-		$start = intval( $qargs['start'] );
-	} elseif ( isset( $qargs['t'] ) ) {
-		$time_pieces = preg_split( '/(?<=\D)(?=\d+)/', $qargs['t'] );
+	if ( isset( $args['start'] ) ) {
+		$start = intval( $args['start'] );
+	} elseif ( isset( $args['t'] ) ) {
+		$time_pieces = preg_split( '/(?<=\D)(?=\d+)/', $args['t'] );
 
 		foreach ( $time_pieces as $time_piece ) {
 			$int = (int) $time_piece;
@@ -223,17 +223,17 @@ function youtube_id( $url ) {
 	}
 
 	$start = $start ? '&start=' . $start : '';
-	$end   = ( isset( $qargs['end'] ) && intval( $qargs['end'] ) ) ? '&end=' . (int) $qargs['end'] : '';
-	$hd    = ( isset( $qargs['hd'] ) && intval( $qargs['hd'] ) ) ? '&hd=' . (int) $qargs['hd'] : '';
+	$end   = ( isset( $args['end'] ) && intval( $args['end'] ) ) ? '&end=' . (int) $args['end'] : '';
+	$hd    = ( isset( $args['hd'] ) && intval( $args['hd'] ) ) ? '&hd=' . (int) $args['hd'] : '';
 
-	$vq = ( isset( $qargs['vq'] ) && in_array( $qargs['vq'], array( 'hd720', 'hd1080' ), true ) ) ? '&vq=' . $qargs['vq'] : '';
+	$vq = ( isset( $args['vq'] ) && in_array( $args['vq'], array( 'hd720', 'hd1080' ), true ) ) ? '&vq=' . $args['vq'] : '';
 
-	$cc      = ( isset( $qargs['cc_load_policy'] ) ) ? '&cc_load_policy=1' : '';
-	$cc_lang = ( isset( $qargs['cc_lang_pref'] ) ) ? '&cc_lang_pref=' . preg_replace( '/[^_a-z0-9-]/i', '', $qargs['cc_lang_pref'] ) : '';
+	$cc      = ( isset( $args['cc_load_policy'] ) ) ? '&cc_load_policy=1' : '';
+	$cc_lang = ( isset( $args['cc_lang_pref'] ) ) ? '&cc_lang_pref=' . preg_replace( '/[^_a-z0-9-]/i', '', $args['cc_lang_pref'] ) : '';
 
-	$wmode = ( isset( $qargs['wmode'] ) && in_array( strtolower( $qargs['wmode'] ), array( 'opaque', 'window', 'transparent' ), true ) ) ? $qargs['wmode'] : 'transparent';
+	$wmode = ( isset( $args['wmode'] ) && in_array( strtolower( $args['wmode'] ), array( 'opaque', 'window', 'transparent' ), true ) ) ? $args['wmode'] : 'transparent';
 
-	$theme = ( isset( $qargs['theme'] ) && in_array( strtolower( $qargs['theme'] ), array( 'dark', 'light' ), true ) ) ? '&theme=' . $qargs['theme'] : '';
+	$theme = ( isset( $args['theme'] ) && in_array( strtolower( $args['theme'] ), array( 'dark', 'light' ), true ) ) ? '&theme=' . $args['theme'] : '';
 
 	$autoplay = '';
 	/**
@@ -245,13 +245,13 @@ function youtube_id( $url ) {
 	 *
 	 * @param bool false Enable autoplay for YouTube videos.
 	 */
-	if ( apply_filters( 'jetpack_youtube_allow_autoplay', false ) && isset( $qargs['autoplay'] ) ) {
-		$autoplay = '&autoplay=' . (int) $qargs['autoplay'];
+	if ( apply_filters( 'jetpack_youtube_allow_autoplay', false ) && isset( $args['autoplay'] ) ) {
+		$autoplay = '&autoplay=' . (int) $args['autoplay'];
 	}
 
 	if (
 		( isset( $url['path'] ) && '/videoseries' === $url['path'] )
-		|| isset( $qargs['list'] )
+		|| isset( $args['list'] )
 	) {
 		$html = "<iframe class='youtube-player' type='text/html' width='$w' height='$h' src='" . esc_url( "https://www.youtube.com/embed/videoseries?list=$id&hl=en_US" ) . "' allowfullscreen='true' style='border:0;'></iframe>";
 	} else {
@@ -261,8 +261,8 @@ function youtube_id( $url ) {
 	// Let's do some alignment wonder in a span, unless we're producing a feed.
 	if ( ! is_feed() ) {
 		$alignmentcss = 'text-align:center;';
-		if ( isset( $qargs['align'] ) ) {
-			switch ( $qargs['align'] ) {
+		if ( isset( $args['align'] ) ) {
+			switch ( $args['align'] ) {
 				case 'left':
 					$alignmentcss = "float:left; width:{$w}px; height:{$h}px; margin-right:10px; margin-bottom: 10px;";
 					break;
@@ -295,7 +295,7 @@ function youtube_id( $url ) {
 }
 
 /**
- * Gets the query args present in the YouTube shortcode URL.
+ * Gets the args present in the YouTube shortcode URL.
  *
  * @since 8.0.0
  *
@@ -303,7 +303,7 @@ function youtube_id( $url ) {
  *
  * @return array|false The query args of the URL, or false.
  */
-function jetpack_shortcode_youtube_query_args( $url ) {
+function jetpack_shortcode_youtube_args( $url ) {
 	$qargs = array();
 	if ( ! empty( $url['query'] ) ) {
 		wp_parse_str( $url['query'], $qargs );
@@ -360,8 +360,8 @@ function jetpack_amp_youtube_shortcode( $url ) {
 
 	$sanitized_url          = youtube_sanitize_url( $url );
 	$parsed_url             = wp_parse_url( $sanitized_url );
-	$query_args             = jetpack_shortcode_youtube_query_args( $parsed_url );
-	list( $width, $height ) = jetpack_shortcode_youtube_dimensions( $query_args );
+	$args                   = jetpack_shortcode_youtube_args( $parsed_url );
+	list( $width, $height ) = jetpack_shortcode_youtube_dimensions( $args );
 	return sprintf(
 		'<amp-youtube data-videoid="%s" layout="responsive" width="%d" height="%d"></amp-youtube>',
 		esc_attr( $video_id ),

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -327,13 +327,15 @@ function jetpack_shortcode_youtube_query_args( $url ) {
  * @return string The rendered shortcode.
  */
 function youtube_shortcode( $atts ) {
+	$url = ( isset( $atts[0] ) ) ? ltrim( $atts[0], '=' ) : shortcode_new_to_old_params( $atts );
+
 	if (
 		class_exists( 'Jetpack_AMP_Support' )
 		&& Jetpack_AMP_Support::is_amp_request()
 	) {
-		return jetpack_amp_youtube_shortcode( $atts );
+		return jetpack_amp_youtube_shortcode( $url );
 	} else {
-		return youtube_id( ( isset( $atts[0] ) ) ? ltrim( $atts[0], '=' ) : shortcode_new_to_old_params( $atts ) );
+		return youtube_id( $url );
 	}
 }
 add_shortcode( 'youtube', 'youtube_shortcode' );
@@ -343,16 +345,11 @@ add_shortcode( 'youtube', 'youtube_shortcode' );
  *
  * @since 8.0.0
  *
- * @param array $atts The shortcode attributes.
+ * @param string $url The YouTube URL.
  *
  * @return string The AMP-compatible rendered shortcode.
  */
-function jetpack_amp_youtube_shortcode( $atts ) {
-	$url = ( isset( $atts[0] ) ) ? ltrim( $atts[0], '=' ) : shortcode_new_to_old_params( $atts );
-	if ( empty( $url ) ) {
-		return '';
-	}
-
+function jetpack_amp_youtube_shortcode( $url ) {
 	$video_id = jetpack_get_youtube_id( $url );
 	if ( empty( $video_id ) ) {
 		return sprintf(

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -354,6 +354,7 @@ function jetpack_amp_youtube_shortcode( $url ) {
 	if ( empty( $video_id ) ) {
 		return sprintf(
 			'<a href="%s" class="amp-wp-embed-fallback">%s</a>',
+			esc_url( $url ),
 			esc_url( $url )
 		);
 	}

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -175,7 +175,7 @@ function youtube_id( $url ) {
 	$id = jetpack_get_youtube_id( $url );
 
 	if ( ! $id ) {
-		return '<!--YouTube Error: bad URL entered-->';
+		return sprintf( '<!--%s-->', esc_html__( 'YouTube Error: bad URL entered', 'jetpack' ) );
 	}
 
 	$url = youtube_sanitize_url( $url );
@@ -183,7 +183,7 @@ function youtube_id( $url ) {
 
 	$args = jetpack_shortcode_youtube_args( $url );
 	if ( empty( $args ) ) {
-		return false;
+		return sprintf( '<!--%s-->', esc_html__( 'YouTube Error: empty URL args', 'jetpack' ) );
 	}
 
 	list( $w, $h ) = jetpack_shortcode_youtube_dimensions( $args );

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -356,7 +356,7 @@ function jetpack_amp_youtube_shortcode( $atts ) {
 	$video_id = jetpack_get_youtube_id( $url );
 	if ( empty( $video_id ) ) {
 		return sprintf(
-			'<a href="%s" class="amp-wp-embed-fallback">',
+			'<a href="%s" class="amp-wp-embed-fallback"></a>',
 			esc_url( $url )
 		);
 	}

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -353,7 +353,7 @@ function jetpack_amp_youtube_shortcode( $atts ) {
 		return '';
 	}
 
-	$video_id = get_amp_youtube_id_from_url( $url );
+	$video_id = jetpack_get_youtube_id( $url );
 	if ( empty( $video_id ) ) {
 		return sprintf(
 			'<a href="%s" class="amp-wp-embed-fallback">',
@@ -448,47 +448,6 @@ function jetpack_shortcode_youtube_dimensions( $query_args ) {
 	$h = (int) apply_filters( 'youtube_height', $h );
 
 	return array( $w, $h );
-}
-
-/**
- * Gets the video ID from the URL.
- *
- * @since 8.0.0
- *
- * @param string $url The YouTube URL.
- *
- * @return string|bool The video ID based on that URL, or false.
- */
-function get_amp_youtube_id_from_url( $url ) {
-	$video_id       = false;
-	$parsed_url     = wp_parse_url( $url );
-	$short_url_host = 'youtu.be'; // youtu.be/{id}.
-
-	if ( isset( $parsed_url['host'] ) && substr( $parsed_url['host'], -strlen( $short_url_host ) ) === $short_url_host ) {
-		$parts = explode( '/', $parsed_url['path'] );
-		if ( ! empty( $parts ) ) {
-			$video_id = $parts[1];
-		}
-	} elseif ( isset( $parsed_url['query'] ) ) {
-		// The query looks like ?v=<id> or ?list=<id>.
-		parse_str( $parsed_url['query'], $query_args );
-		if ( isset( $query_args['v'] ) ) {
-			$video_id = $query_args['v'];
-			if ( false !== strpos( $video_id, '?' ) ) {
-				$video_id = strtok( $video_id, '?' );
-			}
-		}
-	}
-
-	if ( empty( $video_id ) && isset( $parts[1], $parts[2] ) ) {
-		/* The path looks like /(v|e|embed)/{id} */
-		$parts = explode( '/', $parsed_url['path'] );
-		if ( in_array( $parts[1], [ 'v', 'e', 'embed' ], true ) ) {
-			$video_id = $parts[2];
-		}
-	}
-
-	return $video_id;
 }
 
 /**

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -236,47 +236,4 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
 		$this->assertEquals( $expected, jetpack_shortcode_youtube_dimensions( $query_args ) );
 	}
-
-	/**
-	 * Gets the test data for get_amp_youtube_id_from_url().
-	 *
-	 * @return array[] The test data.
-	 */
-	public function get_amp_video_id_shortcode_data() {
-		return array(
-			'v_query_arg'                 => array(
-				'https://www.youtube.com/watch?v=WVbQ-oro7FQ',
-				'WVbQ-oro7FQ',
-			),
-			'v_query_arg_with_other_args' => array(
-				'https://www.youtube.com/watch?v=_Oh12ROTQCE&w=640&h=385',
-				'_Oh12ROTQCE',
-			),
-			'wrong_query_arg_e'           => array(
-				'https://www.youtube.com/watch?e=WVbQ-oro7FQ',
-				false,
-			),
-			'short_youtube_url'           => array(
-				'https://youtu.be/gbS6_xOABTWo',
-				'gbS6_xOABTWo',
-			),
-			'non_youtube_url'             => array(
-				'https://www.vimeo.com/watch?e=WVbQ-oro7FQ',
-				false,
-			),
-		);
-	}
-
-	/**
-	 * Test get_amp_youtube_id_from_url.
-	 *
-	 * @dataProvider get_amp_video_id_shortcode_data
-	 * @covers ::get_amp_youtube_id_from_url
-	 *
-	 * @param string   $url The URL to pass as an argument.
-	 * @param int|bool $expected The expected return value.
-	 */
-	public function test_get_amp_youtube_id_from_url( $url, $expected ) {
-		$this->assertEquals( $expected, get_amp_youtube_id_from_url( $url ) );
-	}
 }

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -81,11 +81,11 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gets the test data for jetpack_shortcode_youtube_query_args().
+	 * Gets the test data for jetpack_shortcode_youtube_args().
 	 *
 	 * @return array[] The test data.
 	 */
-	public function get_youtube_query_args_data() {
+	public function get_youtube_args_data() {
 		return array(
 			'empty_url'                        => array(
 				array(),
@@ -126,16 +126,16 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test jetpack_shortcode_youtube_query_args.
+	 * Test jetpack_shortcode_youtube_args.
 	 *
-	 * @dataProvider get_youtube_query_args_data
-	 * @covers ::jetpack_shortcode_youtube_query_args
+	 * @dataProvider get_youtube_args_data
+	 * @covers ::jetpack_shortcode_youtube_args
 	 *
 	 * @param array      $url The parsed URL in which to look for query args.
 	 * @param array|bool $expected The expected return value of the tested function.
 	 */
-	public function test_jetpack_shortcode_youtube_query_args( $url, $expected ) {
-		$this->assertEquals( $expected, jetpack_shortcode_youtube_query_args( $url ) );
+	public function test_jetpack_shortcode_youtube_args( $url, $expected ) {
+		$this->assertEquals( $expected, jetpack_shortcode_youtube_args( $url ) );
 	}
 
 	/**

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -149,36 +149,36 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		$GLOBALS['content_width'] = $width;
 
 		return array(
-			'no_attributes'           => array(
-				array(),
+			'no_url'                  => array(
 				'',
+				'<a href="" class="amp-wp-embed-fallback"></a>',
 			),
-			'url_at_0_index'          => array(
-				array( 0 => 'https://www.youtube.com/watch?v=SVRiktFlWxI' ),
+			'valid_url'               => array(
+				'https://www.youtube.com/watch?v=SVRiktFlWxI',
 				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
 			),
 			'short_youtube_url'       => array(
-				array( 0 => 'https://youtu.be/gS6_xOABTWo' ),
+				'https://youtu.be/gS6_xOABTWo',
 				'<amp-youtube data-videoid="gS6_xOABTWo" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
 			),
 			'url_without_id'          => array(
-				array( 0 => 'https://youtube.com' ),
+				'https://youtube.com',
 				'<a href="https://youtube.com" class="amp-wp-embed-fallback"></a>',
 			),
 			'with_v_query_param'      => array(
-				array( 0 => 'https://www.youtube.com/watch?v=WVbQ-oro7FQ' ),
+				'https://www.youtube.com/watch?v=WVbQ-oro7FQ',
 				'<amp-youtube data-videoid="WVbQ-oro7FQ" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
 			),
 			'only_width_in_url'       => array(
-				array( 0 => 'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&w=850"' ),
+				'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&w=850"',
 				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="850" height="479"></amp-youtube>',
 			),
 			'only_height_in_url'      => array(
-				array( 0 => 'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&h=550"' ),
+				'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&h=550"',
 				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="' . $width . '" height="550"></amp-youtube>',
 			),
 			'width_and_height_in_url' => array(
-				array( 0 => 'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&w=600&h=400"' ),
+				'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&w=600&h=400"',
 				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="600" height="400"></amp-youtube>',
 			),
 		);

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -163,7 +163,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 			),
 			'url_without_id'          => array(
 				'https://youtube.com',
-				'<a href="https://youtube.com" class="amp-wp-embed-fallback"></a>',
+				'<a href="https://youtube.com" class="amp-wp-embed-fallback">https://youtube.com</a>',
 			),
 			'with_v_query_param'      => array(
 				'https://www.youtube.com/watch?v=WVbQ-oro7FQ',
@@ -190,12 +190,12 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 	 * @dataProvider get_amp_youtube_data
 	 * @covers ::jetpack_amp_youtube_shortcode
 	 *
-	 * @param array  $attr The shortcode attributes.
+	 * @param array  $url The shortcode URL.
 	 * @param string $expected The expected shortcode returned from the function.
 	 */
-	public function test_jetpack_amp_youtube_shortcode( $attr, $expected ) {
+	public function test_jetpack_amp_youtube_shortcode( $url, $expected ) {
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
-		$this->assertEquals( $expected, jetpack_amp_youtube_shortcode( $attr ) );
+		$this->assertEquals( $expected, jetpack_amp_youtube_shortcode( $url ) );
 	}
 
 	/**

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -194,6 +194,11 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 	 * @param string $expected The expected shortcode returned from the function.
 	 */
 	public function test_jetpack_amp_youtube_shortcode( $url, $expected ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
+			return;
+		}
+
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$this->assertEquals( $expected, jetpack_amp_youtube_shortcode( $url ) );
 	}

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -161,6 +161,10 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 				array( 0 => 'https://youtu.be/gS6_xOABTWo' ),
 				'<amp-youtube data-videoid="gS6_xOABTWo" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
 			),
+			'url_without_id'          => array(
+				array( 0 => 'https://youtube.com' ),
+				'<a href="https://youtube.com" class="amp-wp-embed-fallback"></a>',
+			),
 			'with_v_query_param'      => array(
 				array( 0 => 'https://www.youtube.com/watch?v=WVbQ-oro7FQ' ),
 				'<amp-youtube data-videoid="WVbQ-oro7FQ" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -3,6 +3,23 @@
 class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 
 	/**
+	 * Mock global $content_width value.
+	 *
+	 * @var int
+	 */
+	const CONTENT_WIDTH = 600;
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function tearDown() {
+		unset( $GLOBALS['content_width'] );
+		parent::tearDown();
+	}
+
+	/**
 	 * @author scotchfield
 	 * @covers ::youtube_shortcode
 	 * @since 3.2
@@ -63,4 +80,203 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Gets the test data for jetpack_shortcode_youtube_query_args().
+	 *
+	 * @return array[] The test data.
+	 */
+	public function get_youtube_query_args_data() {
+		return array(
+			'empty_url'                        => array(
+				array(),
+				false,
+			),
+			'only_in_query'                    => array(
+				array( 'query' => 'foo=baz&bar=example&even=more' ),
+				array(
+					'foo'  => 'baz',
+					'bar'  => 'example',
+					'even' => 'more',
+				)
+			),
+			'only_in_fragment'                 => array(
+				array( 'fragment' => 'example=shown&additional=here' ),
+				false,
+			),
+			'in_query_and_fragment'            => array(
+				array(
+					'query'    => 'foo=baz&example=more',
+					'fragment' => 'add=another&there=more',
+				),
+				array(
+					'foo'     => 'baz',
+					'example' => 'more',
+					'add'     => 'another',
+					'there'   => 'more',
+				)
+			),
+			'query_and_fragment_have_same_key' => array(
+				array(
+					'query'    => 'foo=inquery',
+					'fragment' => 'foo=infragment',
+				),
+				array( 'foo' => 'inquery' )
+			)
+		);
+	}
+
+	/**
+	 * Test jetpack_shortcode_youtube_query_args.
+	 *
+	 * @dataProvider get_youtube_query_args_data
+	 * @covers ::jetpack_shortcode_youtube_query_args
+	 *
+	 * @param array      $url The parsed URL in which to look for query args.
+	 * @param array|bool $expected The expected return value of the tested function.
+	 */
+	public function test_jetpack_shortcode_youtube_query_args( $url, $expected ) {
+		$this->assertEquals( $expected, jetpack_shortcode_youtube_query_args( $url ) );
+	}
+
+	/**
+	 * Gets the test data for jetpack_amp_youtube_shortcode().
+	 *
+	 * @return array[] The test data.
+	 */
+	public function get_amp_youtube_data() {
+		$height                   = 360;
+		$width                    = 640;
+		$GLOBALS['content_width'] = $width;
+
+		return array(
+			'no_attributes'           => array(
+				array(),
+				'<a href="" class="amp-wp-embed-fallback">',
+			),
+			'url_at_0_index'          => array(
+				array( 0 => 'https://www.youtube.com/watch?v=SVRiktFlWxI' ),
+				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
+			),
+			'short_youtube_url'       => array(
+				array( 0 => 'https://youtu.be/gS6_xOABTWo' ),
+				'<amp-youtube data-videoid="gS6_xOABTWo" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
+			),
+			'with_v_query_param'      => array(
+				array( 0 => 'https://www.youtube.com/watch?v=WVbQ-oro7FQ' ),
+				'<amp-youtube data-videoid="WVbQ-oro7FQ" layout="responsive" width="' . $width . '" height="' . $height . '"></amp-youtube>',
+			),
+			'only_width_in_url'       => array(
+				array( 0 => 'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&w=850"' ),
+				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="850" height="479"></amp-youtube>',
+			),
+			'only_height_in_url'      => array(
+				array( 0 => 'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&h=550"' ),
+				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="' . $width . '" height="550"></amp-youtube>',
+			),
+			'width_and_height_in_url' => array(
+				array( 0 => 'youtube="https://www.youtube.com/watch?v=SVRiktFlWxI&w=600&h=400"' ),
+				'<amp-youtube data-videoid="SVRiktFlWxI" layout="responsive" width="600" height="400"></amp-youtube>',
+			),
+		);
+	}
+
+	/**
+	 * Test jetpack_amp_youtube_shortcode.
+	 *
+	 * @dataProvider get_amp_youtube_data
+	 * @covers ::jetpack_amp_youtube_shortcode
+	 *
+	 * @param array  $attr The shortcode attributes.
+	 * @param string $expected The expected shortcode returned from the function.
+	 */
+	public function test_jetpack_amp_youtube_shortcode( $attr, $expected ) {
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$this->assertEquals( $expected, jetpack_amp_youtube_shortcode( $attr ) );
+	}
+
+	/**
+	 * Gets the test data for get_amp_youtube_shortcode_data().
+	 *
+	 * @return array[] The test data.
+	 */
+	public function get_amp_youtube_shortcode_data() {
+		return array(
+			'empty_argument'  => array(
+				array(),
+				array( self::CONTENT_WIDTH, 338 ),
+			),
+			'only_w_present'  => array(
+				array( 'w' => 500 ),
+				array( 500, 282 ),
+			),
+			'only_h_present'  => array(
+				array( 'h' => 600 ),
+				array( self::CONTENT_WIDTH, 600 ),
+			),
+			'w_and_h_present' => array(
+				array(
+					'w' => 500,
+					'h' => 400,
+				),
+				array( 500, 400 ),
+			),
+		);
+	}
+
+	/**
+	 * Test jetpack_amp_youtube_shortcode.
+	 *
+	 * @dataProvider get_amp_youtube_shortcode_data
+	 * @covers ::jetpack_shortcode_youtube_dimensions
+	 *
+	 * @param array  $query_args The query args to pass to the function.
+	 * @param string $expected The expected return value.
+	 */
+	public function test_jetpack_shortcode_youtube_dimensions( $query_args, $expected ) {
+		$GLOBALS['content_width'] = self::CONTENT_WIDTH;
+		$this->assertEquals( $expected, jetpack_shortcode_youtube_dimensions( $query_args ) );
+	}
+
+	/**
+	 * Gets the test data for get_amp_youtube_id_from_url().
+	 *
+	 * @return array[] The test data.
+	 */
+	public function get_amp_video_id_shortcode_data() {
+		return array(
+			'v_query_arg'                 => array(
+				'https://www.youtube.com/watch?v=WVbQ-oro7FQ',
+				'WVbQ-oro7FQ',
+			),
+			'v_query_arg_with_other_args' => array(
+				'https://www.youtube.com/watch?v=_Oh12ROTQCE&w=640&h=385',
+				'_Oh12ROTQCE',
+			),
+			'wrong_query_arg_e'           => array(
+				'https://www.youtube.com/watch?e=WVbQ-oro7FQ',
+				false,
+			),
+			'short_youtube_url'           => array(
+				'https://youtu.be/gbS6_xOABTWo',
+				'gbS6_xOABTWo',
+			),
+			'non_youtube_url'             => array(
+				'https://www.vimeo.com/watch?e=WVbQ-oro7FQ',
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Test get_amp_youtube_id_from_url.
+	 *
+	 * @dataProvider get_amp_video_id_shortcode_data
+	 * @covers ::get_amp_youtube_id_from_url
+	 *
+	 * @param string   $url The URL to pass as an argument.
+	 * @param int|bool $expected The expected return value.
+	 */
+	public function test_get_amp_youtube_id_from_url( $url, $expected ) {
+		$this->assertEquals( $expected, get_amp_youtube_id_from_url( $url ) );
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -151,7 +151,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 		return array(
 			'no_attributes'           => array(
 				array(),
-				'<a href="" class="amp-wp-embed-fallback">',
+				'',
 			),
 			'url_at_0_index'          => array(
 				array( 0 => 'https://www.youtube.com/watch?v=SVRiktFlWxI' ),

--- a/tests/php/modules/shortcodes/test-class.youtube.php
+++ b/tests/php/modules/shortcodes/test-class.youtube.php
@@ -121,7 +121,7 @@ class WP_Test_Jetpack_Shortcodes_Youtube extends WP_UnitTestCase {
 					'fragment' => 'foo=infragment',
 				),
 				array( 'foo' => 'inquery' )
-			)
+			),
 		);
 	}
 


### PR DESCRIPTION
#### Summary

This moves the AMP handling of the `[youtube]` shortcode from the [AMP plugin](https://github.com/ampproject/amp-wp/blob/b0bd40c18ce61741a366d54a9297dc440bf4330d/includes/embeds/class-amp-youtube-embed-handler.php#L138) to Jetpack. Very similar to #13921, but for `[youtube]` instead of `[vimeo]`.

Fixes https://github.com/ampproject/amp-wp/issues/3309

#### Changes proposed in this Pull Request:

* Apply the `[youtube]` shortcode handling [from the AMP plugin](https://github.com/ampproject/amp-wp/blob/b0bd40c18ce61741a366d54a9297dc440bf4330d/includes/embeds/class-amp-youtube-embed-handler.php#L138)
* Only refactor existing non-AMP `[youtube]` shortcode logic for reuse with the AMP shortcode, no intended change to it

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a new feature for Jetpack, but moved from the AMP plugin

#### Testing instructions:
1. Ensure that `wp-config.php` has `define( 'JETPACK_DEV_DEBUG', true);`
2. In `/wp-admin`, in the Jetpack 'Settings' page, and in the 'Writing' tab, ensure this is toggled on:

<img width="818" alt="jetpack-here" src="https://user-images.githubusercontent.com/4063887/67992321-dded6400-fc01-11e9-81ea-9a05716d1eca.png">

3. Fetch this PR's branch
4. Clone the AMP plugin 
```
$ git clone --recursive https://github.com/ampproject/amp-wp.git amp && cd amp
```
5. Fetch this PR of the AMP plugin, which deactivates the AMP plugin's `[youtube]` shortcode callback: https://github.com/ampproject/amp-wp/pull/3678
6. Do `$ npm install && composer install`
7. Activate the AMP plugin
8. Create a new post with a Shortcode block
9. Add a shortcode, like:
```
[youtube https://www.youtube.com/watch?v=_Oh12ROTQCE]
```
10. Preview the front-end of the AMP URL, like by adding `&amp` or `?amp`to the URL, and look at how the Vimeo shortcode looks
11. `checkout` the `master` branch of Jetpack, not this PR's branch
12. Preview the front-end of the AMP URL, and notice how the Vimeo shortcode looks
13. Expected: The shortcode should look the same, whether using this PR's branch, or the Jetpack plugin's `master` branch
14. Test more shortcodes under the [More Examples heading here](https://en.support.wordpress.com/videos/youtube/)

## Before

<img width="896" alt="amp-pr-before" src="https://user-images.githubusercontent.com/4063887/68559299-1a8b3d80-0402-11ea-90a8-ca536f97f668.png">

## After

<img width="859" alt="amp-pr-after" src="https://user-images.githubusercontent.com/4063887/68559306-20811e80-0402-11ea-8d62-270721105028.png">

#### Proposed changelog entry for your changes:
Migrate AMP-conversion of `[youtube]` shortcode to Jetpack from the AMP plugin

