### PR TITLE
Contact form block: add `contact form` keyword

### DIFF
--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -29,7 +29,7 @@ export const settings = {
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'feedback', 'block search term', 'jetpack' ),
-		_x( 'contact', 'block search term', 'jetpack' ),
+		_x( 'contact form', 'block search term', 'jetpack' ),
 	],
 	category: 'jetpack',
 	supports: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Updates a keyword on the Contact Form block:

`contact` => `contact form`

Fixes https://github.com/Automattic/jetpack/issues/14000

#### Testing instructions:

* Spin up this PR.
* Go to `Posts > Add New`.
* In the block editor, try to add the Form block by searching for `contact form`.

#### Proposed changelog entry for your changes:
* None