### PR TITLE
REST API: Add products endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -81,6 +81,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'callback'            => __CLASS__ . '::get_plans',
 			'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
 
+        ) );
+
+		register_rest_route( 'jetpack/v4', 'products', array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::get_products',
+			'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
+
 		) );
 
 		register_rest_route( 'jetpack/v4', 'marketing/survey', array(
@@ -502,7 +509,32 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return $data;
-	}
+    }
+
+    public static function get_products( $request ) {
+        $wpcom_request = Client::wpcom_json_api_request_as_user(
+            '/products?_locale=' . get_user_locale(),
+            'v1.1',
+			array(
+				'method'  => 'GET',
+				'headers' => array(
+					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
+				),
+			),
+	        null,
+	        'rest'
+        );
+
+	    $body = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
+	    if ( 200 === wp_remote_retrieve_response_code( $wpcom_request ) ) {
+		    $data = $body;
+	    } else {
+		    // something went wrong so we'll just return the response without caching
+		    return $body;
+	    }
+
+	    return $data;
+    }
 
 	public static function submit_survey( $request ) {
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -80,21 +80,18 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => __CLASS__ . '::get_plans',
 			'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
-
-        ) );
+		) );
 
 		register_rest_route( 'jetpack/v4', 'products', array(
 			'methods'             => WP_REST_Server::READABLE,
 			'callback'            => __CLASS__ . '::get_products',
 			'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
-
 		) );
 
 		register_rest_route( 'jetpack/v4', 'marketing/survey', array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => __CLASS__ . '::submit_survey',
 			'permission_callback' => __CLASS__ . '::disconnect_site_permission_callback',
-
 		) );
 
 		register_rest_route( 'jetpack/v4', '/jitm', array(
@@ -509,32 +506,41 @@ class Jetpack_Core_Json_Api_Endpoints {
 		}
 
 		return $data;
-    }
+	}
 
-    public static function get_products( $request ) {
-        $wpcom_request = Client::wpcom_json_api_request_as_user(
-            '/products?_locale=' . get_user_locale(),
-            'v1.1',
+	/**
+	 * Gets the products that are in use on wpcom.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return object A JSON object of wpcom products if the request was sucessful, or an error code otherwise.
+	 */
+	public static function get_products( $request ) {
+		$wpcom_request = Client::wpcom_json_api_request_as_user(
+			'/products?_locale=' . get_user_locale(),
+			'v1.1',
 			array(
 				'method'  => 'GET',
 				'headers' => array(
 					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
 				),
 			),
-	        null,
-	        'rest'
-        );
+			null,
+			'rest'
+		);
 
-	    $body = json_decode( wp_remote_retrieve_body( $wpcom_request ) );
-	    if ( 200 === wp_remote_retrieve_response_code( $wpcom_request ) ) {
-		    $data = $body;
-	    } else {
-		    // something went wrong so we'll just return the response without caching
-		    return $body;
-	    }
-
-	    return $data;
-    }
+		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
+		if ( 200 === $response_code ) {
+			return json_decode( wp_remote_retrieve_body( $wpcom_request ) );
+		} else {
+			// something went wrong so we'll just return the response without caching.
+			return new WP_Error(
+				'failed_to_fetch_data',
+				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+				array( 'status' => $response_code )
+			);
+		}
+	}
 
 	public static function submit_survey( $request ) {
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -509,7 +509,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Gets the products that are in use on wpcom.
+	 * Gets the WP.com products that are in use on wpcom.
+	 * Similar to the WP.com plans that we currently in user on WPCOM.
 	 *
 	 * @param WP_REST_Request $request The request.
 	 *

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -533,7 +533,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( 200 === $response_code ) {
 			return json_decode( wp_remote_retrieve_body( $wpcom_request ) );
 		} else {
-			// something went wrong so we'll just return the response without caching.
+			// Something went wrong so we'll just return the response without caching.
 			return new WP_Error(
 				'failed_to_fetch_data',
 				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -513,7 +513,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @param WP_REST_Request $request The request.
 	 *
-	 * @return object A JSON object of wpcom products if the request was sucessful, or an error code otherwise.
+	 * @return string|WP_Error A JSON object of wpcom products if the request was successful, or a WP_Error otherwise.
 	 */
 	public static function get_products( $request ) {
 		$wpcom_request = Client::wpcom_json_api_request_as_user(

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -517,7 +517,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 */
 	public static function get_products( $request ) {
 		$wpcom_request = Client::wpcom_json_api_request_as_user(
-			'/products?_locale=' . get_user_locale(),
+			'/products?_locale=' . get_user_locale() . '&type=jetpack',
 			'v1.1',
 			array(
 				'method'  => 'GET',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Adds a new REST endpoint to return the wordpress.com products to support the single product backup project.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
See the P2 here for the design of this PR: p1HpG7-7MK-p2 (specifically the part titled "WP Admin Desktop")
See the P2 here for the overall MT: p1HpG7-7ET-p2

#### Testing instructions:
* Using a tool like Postman, make a call to `https://:site/wp-json/jetpack/v4/products` and verify that the response object matches what you get from `https://public-api.wordpress.com/rest/v1.1/products`.

#### Proposed changelog entry for your changes:
* Added REST endpoint to retrieve WordPress.com product information.
