### PR TITLE
Connection: Set the value of user_id in Manager::generate_secrets

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5046,13 +5046,12 @@ endif;
 	 * Note these tokens are unique per call, NOT static per site for connecting.
 	 *
 	 * @since 2.6
+	 * @param String  $action  The action name.
+	 * @param Integer $user_id The user identifier.
+	 * @param Integer $exp     Expiration time in seconds.
 	 * @return array
 	 */
 	public static function generate_secrets( $action, $user_id = false, $exp = 600 ) {
-		if ( false === $user_id ) {
-			$user_id = get_current_user_id();
-		}
-
 		return self::connection()->generate_secrets( $action, $user_id, $exp );
 	}
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1136,6 +1136,10 @@ class Manager {
 	 * @param Integer $exp     Expiration time in seconds.
 	 */
 	public function generate_secrets( $action, $user_id = false, $exp = 600 ) {
+		if ( false === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
 		$callable = $this->get_secret_callable();
 
 		$secrets = \Jetpack_Options::get_raw_option(


### PR DESCRIPTION
`Jetpack::generate_secrets` sets the value of `$user_id` when the the `$user_id`
argument value is false. Move this logic to the `Manager::generate_secrets`
method. The user id is required for generating the secrets, and this change
ensures that the user id is correctly set when `Manager::get_secrets` is called.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves the logic that sets `$user_id` from `Jetpack::generate_secrets` to `Manager::generate_secrets`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The `generate_secrets` methods are used in the registration and authorization steps of the Jetpack connection process. Test this change by verifying that the connection is successful:

* Deactivate Jetpack.
* Reactivate Jetpack.
* Connect Jetpack. The connection should be successful.

Also verify that the Jetpack unit tests pass.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
