### PR TITLE
Don't show JITMs on Gutenberg editor pages (for now)

### DIFF
--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -631,7 +631,7 @@ class JITM {
 	 * @since 8.0.0
 	 */
 	private function is_gutenberg_page() {
-		$current_screen = get_current_screen();
+		$current_screen = \get_current_screen();
 		return ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() );
 	}
 }

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -323,6 +323,12 @@ class JITM {
 		if ( ! is_admin() ) {
 			return;
 		}
+
+		// do not display on Gutenberg pages.
+		if ( $this->is_gutenberg_page() ) {
+			return;
+		}
+
 		$message_path   = $this->get_message_path();
 		$query_string   = _http_build_query( $_GET, '', ',' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$current_screen = wp_unslash( $_SERVER['REQUEST_URI'] );
@@ -351,6 +357,9 @@ class JITM {
 	 * Function to enqueue jitm css and js
 	 */
 	public function jitm_enqueue_files() {
+		if ( $this->is_gutenberg_page() ) {
+			return;
+		}
 		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 		wp_register_style(
 			'jetpack-jitm-css',
@@ -614,5 +623,15 @@ class JITM {
 		}
 
 		return $envelopes;
+	}
+
+	/**
+	 * Is the current page a block editor page?
+	 *
+	 * @since 8.0.0
+	 */
+	private function is_gutenberg_page() {
+		$current_screen = get_current_screen();
+		return ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() );
 	}
 }

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -631,7 +631,7 @@ class JITM {
 	 * @since 8.0.0
 	 */
 	private function is_gutenberg_page() {
-		$current_screen = \get_current_screen();
+		$current_screen = get_current_screen();
 		return ( method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor() );
 	}
 }

--- a/packages/jitm/tests/php/test_JITM.php
+++ b/packages/jitm/tests/php/test_JITM.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class Test_Jetpack_JITM extends TestCase {
 	public function setUp() {
+		$this->mock_add_get_current_screen();
 		$this->mock_add_action();
 		$this->mock_do_action();
 		$this->mock_wp_enqueue_script();
@@ -112,6 +113,16 @@ class Test_Jetpack_JITM extends TestCase {
 	protected function clear_mock_filters() {
 		$this->apply_filters_mock->disable();
 		unset( $this->mocked_filters );
+	}
+
+	protected function mock_add_get_current_screen() {
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( 'get_current_screen' )
+			->setFunction( function() {
+				return new \stdClass;
+			} );
+		$builder->build()->enable();
 	}
 
 	protected function mock_add_action() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #8916

Alternative to #14007

See: p1HpG7-7Yu-p2

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Don't display JITMs or enqueue JITM assets on block editor pages

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Load a block editor page with the Chrome debugger open
* In a network tab, confirm that no `*jitm*` resources are loaded (JS, CSS, Ajax)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Don't show just in time messages in the block editor
