### PR TITLE
Subscriptions: create a new panel in the Jetpack Sidebar to control subscriptions

### DIFF
--- a/extensions/blocks/subscriptions-toggle/editor.js
+++ b/extensions/blocks/subscriptions-toggle/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { name, settings } from '.';
+import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
+
+registerJetpackPlugin( name, settings );

--- a/extensions/blocks/subscriptions-toggle/index.js
+++ b/extensions/blocks/subscriptions-toggle/index.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import SubscriptionsCheckbox from './subscriptions-checkbox';
+
+export const name = 'subscriptions-toggle';
+
+export const settings = { render: SubscriptionsCheckbox };

--- a/extensions/blocks/subscriptions-toggle/subscriptions-checkbox.js
+++ b/extensions/blocks/subscriptions-toggle/subscriptions-checkbox.js
@@ -16,7 +16,7 @@ const SubscriptionsCheckbox = ( { isPostExcludedFromSubs, editPost } ) => (
 	<PostTypeSupportCheck supportKeys="jetpack-post-subscriptions">
 		<JetpackSubscriptionsPanel>
 			<CheckboxControl
-				label={ __( 'Don’t send this to subscribers', 'jetpack' ) }
+				label={ __( 'Don’t send this post to subscribers.', 'jetpack' ) }
 				checked={ isPostExcludedFromSubs }
 				onChange={ value => {
 					editPost( { jetpack_dont_email_post_to_subs: value } );

--- a/extensions/blocks/subscriptions-toggle/subscriptions-checkbox.js
+++ b/extensions/blocks/subscriptions-toggle/subscriptions-checkbox.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { PostTypeSupportCheck } from '@wordpress/editor';
+import { withDispatch, withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import JetpackSubscriptionsPanel from '../../shared/jetpack-subscriptions-panel';
+
+const SubscriptionsCheckbox = ( { isPostExcludedFromSubs, editPost } ) => (
+	<PostTypeSupportCheck supportKeys="jetpack-post-subscriptions">
+		<JetpackSubscriptionsPanel>
+			<CheckboxControl
+				label={ __( 'Don’t send this to subscribers', 'jetpack' ) }
+				checked={ isPostExcludedFromSubs }
+				onChange={ value => {
+					editPost( { jetpack_dont_email_post_to_subs: value } );
+				} }
+			/>
+		</JetpackSubscriptionsPanel>
+	</PostTypeSupportCheck>
+);
+
+// Fetch the post meta.
+const applyWithSelect = withSelect( select => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const isPostExcludedFromSubs = getEditedPostAttribute( 'jetpack_dont_email_post_to_subs' );
+
+	return { isPostExcludedFromSubs };
+} );
+
+// Provide method to update post meta.
+const applyWithDispatch = withDispatch( dispatch => {
+	const { editPost } = dispatch( 'core/editor' );
+
+	return { editPost };
+} );
+
+// Combine the higher-order components.
+export default compose( [ applyWithSelect, applyWithDispatch ] )( SubscriptionsCheckbox );

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -17,6 +17,7 @@
 		"simple-payments",
 		"slideshow",
 		"subscriptions",
+		"subscriptions-toggle",
 		"tiled-gallery",
 		"videopress",
 		"wordads"

--- a/extensions/shared/jetpack-subscriptions-panel.js
+++ b/extensions/shared/jetpack-subscriptions-panel.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createSlotFill, PanelBody } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import JetpackPluginSidebar from './jetpack-plugin-sidebar';
+
+const { Fill, Slot } = createSlotFill( 'JetpackSubscriptionsPanel' );
+
+export { Fill as default };
+
+registerPlugin( 'jetpack-subscriptions-panel', {
+	render() {
+		return (
+			<Slot>
+				{ fills => {
+					if ( ! fills.length ) {
+						return null;
+					}
+
+					return (
+						<JetpackPluginSidebar>
+							<PanelBody title={ __( 'Subscriptions', 'jetpack' ) }>{ fills }</PanelBody>
+						</JetpackPluginSidebar>
+					);
+				} }
+			</Slot>
+		);
+	},
+} );

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -212,7 +212,7 @@ class Jetpack_Subscriptions {
 				},
 				'schema'          => array(
 					'description' => __( 'Don’t send this to subscribers', 'jetpack' ),
-					'type'        => 'integer',
+					'type'        => 'boolean',
 				),
 			)
 		);

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -230,17 +230,7 @@ class Jetpack_Subscriptions {
 	 * @since 8.0.0
 	 */
 	public function register_gutenberg_extension() {
-		if (
-			/** This filter is documented in modules/subscriptions.php */
-			! apply_filters( 'jetpack_allow_per_post_subscriptions', false )
-		) {
-			return;
-		}
-
-		if (
-			has_filter( 'jetpack_subscriptions_exclude_these_categories' )
-			|| has_filter( 'jetpack_subscriptions_include_only_these_categories' )
-		) {
+		if ( ! $this->should_show_subscription_toggle() ) {
 			return;
 		}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -196,7 +196,7 @@ class Jetpack_Subscriptions {
 				},
 				'update_callback' => function( $disable_subscribe_value, $post ) {
 					$updated = update_post_meta(
-						$post['id'],
+						$post->ID,
 						'_jetpack_dont_email_post_to_subs',
 						$disable_subscribe_value
 					);

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -94,6 +94,7 @@ class Jetpack_Subscriptions {
 		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 18, 1 );
 
 		add_action( 'rest_api_init', array( $this, 'register_sub_check_rest_field' ) );
+		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_extension' ) );
 	}
 
 	/**
@@ -218,6 +219,29 @@ class Jetpack_Subscriptions {
 		 * This feature support flag is used by the REST API and Gutenberg.
 		 */
 		add_post_type_support( $post_type, 'jetpack-post-subscriptions' );
+	}
+
+	/**
+	 * Register the block extension so it can be displayed in the editor.
+	 *
+	 * @since 8.0.0
+	 */
+	public function register_gutenberg_extension() {
+		if (
+			/** This filter is documented in modules/subscriptions.php */
+			! apply_filters( 'jetpack_allow_per_post_subscriptions', false )
+		) {
+			return;
+		}
+
+		if (
+			has_filter( 'jetpack_subscriptions_exclude_these_categories' )
+			|| has_filter( 'jetpack_subscriptions_include_only_these_categories' )
+		) {
+			return;
+		}
+
+		Jetpack_Gutenberg::set_extension_available( 'jetpack/subscriptions-toggle' );
 	}
 
 	/**

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -112,11 +112,14 @@ class Jetpack_Subscriptions {
 		);
 	}
 
-	/*
-	 * Disable Subscribe on Single Post
-	 * Register post meta
+	/**
+	 * Check whether a subscription toggle should be displayed in the editor.
+	 *
+	 * @since 8.0.0
+	 *
+	 * @return bool
 	 */
-	function subscription_post_page_metabox() {
+	private function should_show_subscription_toggle() {
 		if (
 			/**
 			 * Filter whether or not to show the per-post subscription option.
@@ -127,12 +130,22 @@ class Jetpack_Subscriptions {
 			 *
 			 * @param bool true = show checkbox option on all new posts | false = hide the option.
 			 */
-			 ! apply_filters( 'jetpack_allow_per_post_subscriptions', false ) )
-		{
-			return;
+			! apply_filters( 'jetpack_allow_per_post_subscriptions', false )
+			|| has_filter( 'jetpack_subscriptions_exclude_these_categories' )
+			|| has_filter( 'jetpack_subscriptions_include_only_these_categories' )
+		) {
+			return false;
 		}
 
-		if ( has_filter( 'jetpack_subscriptions_exclude_these_categories' ) || has_filter( 'jetpack_subscriptions_include_only_these_categories' ) ) {
+		return true;
+	}
+
+	/**
+	 * Disable Subscribe on Single Post
+	 * Register post meta
+	 */
+	public function subscription_post_page_metabox() {
+		if ( ! $this->should_show_subscription_toggle() ) {
 			return;
 		}
 
@@ -161,17 +174,7 @@ class Jetpack_Subscriptions {
 	 * @uses register_rest_field
 	 */
 	public function register_sub_check_rest_field() {
-		if (
-			/** This filter is documented in modules/subscriptions.php */
-			! apply_filters( 'jetpack_allow_per_post_subscriptions', false )
-		) {
-			return;
-		}
-
-		if (
-			has_filter( 'jetpack_subscriptions_exclude_these_categories' )
-			|| has_filter( 'jetpack_subscriptions_include_only_these_categories' )
-		) {
+		if ( ! $this->should_show_subscription_toggle() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #10876

#### Changes proposed in this Pull Request:

* This PR adds a new toggle to the block editor's Jetpack sidebar, but only when you use the existing `jetpack_allow_per_post_subscriptions` filter:
https://developer.jetpack.com/hooks/jetpack_allow_per_post_subscriptions/

![image](https://user-images.githubusercontent.com/426388/68786137-8dcdc300-063f-11ea-87c3-d2b4c69f4447.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature, that won't be available to most users for now since it requires the use of a filter.

#### To do / discuss / consider

- [ ] Test on WordPress.com. The filter is not in use there so everything should be okay (i.e. nothing new should appear).
- [ ] Should we consider making this available to all users, without the use of a filter?
- [ ] Should we do something once a post has already been published, to show that the toggle cannot be used anymore?
- [ ] We currently do not show the toggle if you use the `jetpack_subscriptions_exclude_these_categories` and `jetpack_subscriptions_include_only_these_categories` filters. That's not ideal as those are not used for all posts, but for only some categories. Will have to refactor.

#### Testing instructions:

To start testing, you will need to add the following to a functionality plugin on your site:
```php
add_filter( 'jetpack_allow_per_post_subscriptions', '__return_true' );
```

* Go to Jetpack > Settings and make sure that the Subscriptions feature is enabled.
* Go to Posts > Add New
* Add a new Subscription block to your post.
* Publish your post, and use the block to subscribe to your own site with a custom email address.
* Go to Posts > Add New again to start a new post.
* You should see the new toggle in the Jetpack sidebar.
* That sidebar and its toggle should be there even when Publicize, Likes, and Sharing are disabled.
* Check the toggle, publish your post, and make sure you do not receive any post by email.
* Go to Posts > Add New again to start a new post.
* Do not check the toggle, publish your post, and make sure you do receive the post via email.

#### Proposed changelog entry for your changes:

Subscriptions: create a new panel in the Jetpack Sidebar to control subscriptions
