### PR TITLE
Instant Search: formatting improvements for mobile

### DIFF
--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -92,14 +92,18 @@ class SearchResultMinimal extends Component {
 			return null;
 		}
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
+		const resultDate = new Date( fields.date.split( ' ' )[ 0 ] );
 		return (
 			<li className="jetpack-instant-search__search-result-minimal">
 				<div className="jetpack-instant-search__search-result-minimal-header">
-					<span className="jetpack-instant-search__search-result-minimal-date">
-						{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
+					<time
+						className="jetpack-instant-search__search-result-minimal-date"
+						datetime={ resultDate.toISOString() }
+					>
+						{ resultDate.toLocaleDateString( locale, {
 							dateStyle: 'short',
 						} ) }
-					</span>
+					</time>
 					<h3 className="jetpack-instant-search__search-result-title">
 						<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 						<a

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -94,21 +94,23 @@ class SearchResultMinimal extends Component {
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
 		return (
 			<li className="jetpack-instant-search__search-result-minimal">
-				<span className="jetpack-instant-search__search-result-minimal-date">
-					{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
-						dateStyle: 'short',
-					} ) }
-				</span>
-				<h3 className="jetpack-instant-search__search-result-title">
-					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
-					<a
-						href={ `//${ fields[ 'permalink.url.raw' ] }` }
-						className="jetpack-instant-search__search-result-minimal-title"
-						//eslint-disable-next-line react/no-danger
-						dangerouslySetInnerHTML={ { __html: highlight.title } }
-						onClick={ this.onClick }
-					/>
-				</h3>
+				<div className="jetpack-instant-search__search-result-minimal-header">
+					<span className="jetpack-instant-search__search-result-minimal-date">
+						{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
+							dateStyle: 'short',
+						} ) }
+					</span>
+					<h3 className="jetpack-instant-search__search-result-title">
+						<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
+						<a
+							href={ `//${ fields[ 'permalink.url.raw' ] }` }
+							className="jetpack-instant-search__search-result-minimal-title"
+							//eslint-disable-next-line react/no-danger
+							dangerouslySetInnerHTML={ { __html: highlight.title } }
+							onClick={ this.onClick }
+						/>
+					</h3>
+				</div>
 				{ noMatchingContent ? this.renderNoMatchingContent() : this.renderMatchingContent() }
 				<SearchResultComments comments={ highlight && highlight.comments } />
 			</li>

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -31,7 +31,15 @@
 	font-size: 0.85em;
 
 	@include break-small {
-		float: right;
+		margin: 0.25em 0;
+	}
+}
+
+.jetpack-instant-search__search-result-minimal-header {
+	@include break-small {
+		display: flex;
+		flex-direction: row-reverse;
+		justify-content: space-between;
 	}
 }
 

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -1,7 +1,11 @@
 .jetpack-instant-search__search-result-minimal {
 	padding: 0.125em 0;
-	margin: 1em 0;
+	margin: 0;
 	position: relative;
+
+	@include break-small {
+		margin: 1em 0;
+	}
 }
 
 .jetpack-instant-search__search-result-minimal h3 {
@@ -23,9 +27,12 @@
 
 .jetpack-instant-search__search-result-minimal-date {
 	margin: 0.5em 0;
-	float: right;
 	display: block;
 	font-size: 0.85em;
+
+	@include break-small {
+		float: right;
+	}
 }
 
 .jetpack-instant-search__search-result-minimal-tag,

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -2,10 +2,6 @@
 	padding: 0.125em 0;
 	margin: 0;
 	position: relative;
-
-	@include break-small {
-		margin: 1em 0;
-	}
 }
 
 .jetpack-instant-search__search-result-minimal h3 {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -28,6 +28,10 @@
 
 .jetpack-instant-search__result-comments {
 	padding-left: 10px;
+	margin-left: 1px;
+	margin-top: 10px;
+	border-left: 2px solid #eee;
+	font-size: 0.9em;
 }
 
 .jetpack-instant-search__search-results-list {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -6,6 +6,10 @@
 	min-height: 400px;
 	text-align: left;
 
+	@include break-small {
+		padding: 0;
+	}
+
 	mark {
 		background-color: #ffc;
 		font-weight: bold;
@@ -15,8 +19,7 @@
 }
 
 .jetpack-instant-search__search-results-real-query {
-	font-size: 1.5em;
-	text-decoration: bold;
+	font-size: 1.25em;
 }
 
 .jetpack-instant-search__search-results-unused-query,

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -17,5 +17,3 @@ $grid-size-large: 16px;
 .jetpack-instant-search__is-loading {
 	opacity: 0.2;
 }
-
-

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -6,6 +6,7 @@ $grid-size-large: 16px;
 		@content;
 	}
 }
+
 @import './components/gridicon/style.scss';
 @import './components/search-results.scss';
 @import './components/search-filters.scss';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Address feedback from @joanrho on the mobile experience when using the standard 'minimal' result format.

https://cloudup.com/cK8mBUIKy95/f

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
On the smallest breakpoint:
* Move date above search results
* Improve appearance of comment matches

<img width="491" alt="Screen Shot 2019-11-14 at 15 21 37" src="https://user-images.githubusercontent.com/17325/68821187-7c91be80-06f2-11ea-95fa-14662aa1a02a.png">

On larger breakpoints:
* line up the result title and date
* remove padding around search result container (retained for mobile)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No - it's part of the Instant Search prototype and merges into `instant-search-master`.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

Check the results at different breakpoints. Example query: `/?s=card&blog_id=84860689`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not required.
