### PR TITLE
Migrate some of the AMP [soundcloud] shortcode conversion to Jetpack

### DIFF
--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -113,7 +113,7 @@ function soundcloud_shortcode( $atts, $content = null ) {
 	if (
 		class_exists( 'Jetpack_AMP_Support' )
 		&& Jetpack_AMP_Support::is_amp_request()
-		&& isset( $options['url'] )
+		&& ! empty( $options['url'] )
 		&& 'api.soundcloud.com' !== wp_parse_url( $options['url'], PHP_URL_HOST )
 	) {
 		// Defer to oEmbed if an oEmbeddable URL is provided.

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -30,6 +30,7 @@
  * @return string                  Widget embed code HTML
  */
 function soundcloud_shortcode( $atts, $content = null ) {
+	global $wp_embed;
 
 	// Custom shortcode options.
 	$shortcode_options = array_merge(
@@ -109,7 +110,16 @@ function soundcloud_shortcode( $atts, $content = null ) {
 		$options['visual'] = false;
 	}
 
-	// Build our list of Souncloud parameters.
+	if (
+		class_exists( 'Jetpack_AMP_Support' )
+		&& Jetpack_AMP_Support::is_amp_request()
+		&& isset( $options['url'] )
+		&& 'api.soundcloud.com' !== wp_parse_url( $options['url'], PHP_URL_HOST )
+	) {
+		return $wp_embed->shortcode( $options, $options['url'] );
+	}
+
+	// Build our list of Soundcloud parameters.
 	$query_args = array(
 		'url' => rawurlencode( $options['url'] ),
 	);

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -116,6 +116,7 @@ function soundcloud_shortcode( $atts, $content = null ) {
 		&& isset( $options['url'] )
 		&& 'api.soundcloud.com' !== wp_parse_url( $options['url'], PHP_URL_HOST )
 	) {
+		// Defer to oEmbed if an oEmbeddable URL is provided.
 		return $wp_embed->shortcode( $options, $options['url'] );
 	}
 

--- a/tests/php/modules/shortcodes/test-class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test-class.soundcloud.php
@@ -116,4 +116,35 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 
 		$this->assertEquals( $shortcode_content, '<a href="https://player.soundcloud.com/player.swf?url=http://api.soundcloud.com/tracks/70198773">https://player.soundcloud.com/player.swf?url=http://api.soundcloud.com/tracks/70198773</a>' );
 	}
+
+	/**
+	 * Tests the shortcode output on an AMP endpoint.
+	 *
+	 * @covers ::soundcloud_shortcode
+	 * @since 8.0.0
+	 */
+	public function tests_shortcodes_soundcloud_amp() {
+		// Simulate the oEmbed filter in the AMP plugin that should run on calling $wp_embed->shortcode().
+		$oembed_markup = '<amp-soundcloud></amp-soundcloud>';
+		add_filter(
+			'embed_oembed_html',
+			static function( $cache ) use ( $oembed_markup ) {
+				unset( $cache );
+				return $oembed_markup;
+			}
+		);
+
+		$content_with_url       = '[soundcloud url="https://soundcloud.com/necmusic/mozart-concerto-for-piano-no-2"]';
+		$content_with_empty_url = '[soundcloud url=""]';
+
+		// If the URL is empty, the AMP logic should not run.
+		$this->assertNotContains( $oembed_markup, do_shortcode( $content_with_empty_url ) );
+
+		// This is still not an AMP endpoint, so the AMP logic should not run.
+		$this->assertNotContains( $oembed_markup, do_shortcode( $content_with_url ) );
+
+		// Now that this is an AMP endpoint with a URL value, the AMP logic should run.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$this->assertEquals( $oembed_markup, do_shortcode( $content_with_url ) );
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test-class.soundcloud.php
@@ -124,6 +124,11 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 	 * @since 8.0.0
 	 */
 	public function tests_shortcodes_soundcloud_amp() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
+			return;
+		}
+
 		// Simulate the oEmbed filter in the AMP plugin that should run on calling $wp_embed->shortcode().
 		$oembed_markup = '<amp-soundcloud></amp-soundcloud>';
 		add_filter(


### PR DESCRIPTION
#### Summary

Migrates to Jetpack the [AMP plugin's](https://github.com/ampproject/amp-wp) handling of the Jetpack `[soundcloud]` shortcode


Fixes https://github.com/ampproject/amp-wp/issues/3309

#### Changes proposed in this Pull Request:
* Migrate `[soundcloud]` shortcode handling to Jetpack from the AMP plugin
* No intended change to the non-AMP behavior

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature for Jetpack, but migrated from the [AMP plugin](https://github.com/ampproject/amp-wp)

#### Testing instructions:
1. Ensure that `wp-config.php` has `define( 'JETPACK_DEV_DEBUG', true);`
2. In `/wp-admin`, in the Jetpack 'Settings' page, and in the 'Writing' tab, ensure this is toggled on:

<img width="818" alt="jetpack-here" src="https://user-images.githubusercontent.com/4063887/67992321-dded6400-fc01-11e9-81ea-9a05716d1eca.png">

3. Fetch this PR's branch
4. Clone the AMP plugin 
```
$ git clone --recursive https://github.com/ampproject/amp-wp.git amp && cd amp
```
5. Fetch this PR of the AMP plugin, which removes the AMP plugin's `[soundcloud]` shortcode callback: https://github.com/ampproject/amp-wp/pull/3678
6. Do `$ npm install && composer install`
7. Activate the AMP plugin
8. Create a new post with a Shortcode block
9. Add a shortcode, like:
```
[soundcloud url="https://soundcloud.com/closetorgan/sets/smells-like-lynx-africa-private"]
```
10. Preview the front-end of the AMP URL, like by adding `&amp` or `?amp`to the URL, and look at how the Soundcloud shortcode looks
11. `checkout` the `master` branch of Jetpack, not this PR's branch, and `checkout` the `develop` branch of the AMP plugin
12. Preview the front-end of the AMP URL, and notice how the Soundcloud shortcode looks
13. Expected: The shortcode should look similar, whether using this PR's branch, or the Jetpack plugin's `master` branch
14. Test more shortcodes [here](https://github.com/Automattic/jetpack/blob/d8b5223e1f1690ff683b7df8183b3d62913f51d7/modules/shortcodes/soundcloud.php#L12-L17)

#### Proposed changelog entry for your changes:
Migrate some AMP-conversion of `[soundcloud]` shortcode to Jetpack from the AMP plugin

