### PR TITLE
Fix/php notice status

### DIFF
--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -716,4 +716,4 @@ class Jetpack_IDC {
 	}
 }
 
-add_filter( 'plugins_loaded', array( 'Jetpack_IDC', 'init' ) );
+add_action( 'plugins_loaded', array( 'Jetpack_IDC', 'init' ) );

--- a/class.jetpack-idc.php
+++ b/class.jetpack-idc.php
@@ -53,7 +53,6 @@ class Jetpack_IDC {
 
 	private function __construct() {
 		add_action( 'jetpack_sync_processed_actions', array( $this, 'maybe_clear_migrate_option' ) );
-
 		if ( false === $urls_in_crisis = Jetpack::check_identity_crisis() ) {
 			return;
 		}
@@ -717,4 +716,4 @@ class Jetpack_IDC {
 	}
 }
 
-Jetpack_IDC::init();
+add_filter( 'plugins_loaded', array( 'Jetpack_IDC', 'init' ) );

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -68,7 +68,7 @@ if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-affiliate.php';
 	$jitm = new Automattic\Jetpack\JITM();
-	$jitm->register();
+	add_action( 'plugins_loaded', array( $jitm, 'register' ) );
 	jetpack_require_lib( 'debugger' );
 }
 

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -89,7 +89,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\Constants',
 						'Automattic\Jetpack\Tracking',
 						'Automattic\Jetpack\Plugin\Tracking',
-						'Automattic\Jetpack\Status',
 					),
 					true
 				);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the PHP Notices that I was getting in master. 

This was fix by making sure that the required code gets executed after all the plugins have loaded. This is important so that we can allow the autoloaded to always use the most up to date package. 

```
PHP Notice:  Automattic\Jetpack\Status was called <strong>incorrectly</strong>. Not all plugins have loaded yet but we requested the class Automattic\Jetpack\Status Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version dev-retry/phpcs-changed.) in /var/www/html/wp-includes/functions.php on line 4903
[14-Nov-2019 10:38:52 UTC] PHP Stack trace:
[14-Nov-2019 10:38:52 UTC] PHP   1. {main}() /var/www/html/wp-admin/admin-ajax.php:0
[14-Nov-2019 10:38:52 UTC] PHP   2. require_once() /var/www/html/wp-admin/admin-ajax.php:22
[14-Nov-2019 10:38:52 UTC] PHP   3. require_once() /var/www/html/wp-load.php:37
[14-Nov-2019 10:38:52 UTC] PHP   4. require_once() /var/www/html/wp-config.php:92
[14-Nov-2019 10:38:52 UTC] PHP   5. include_once() /var/www/html/wp-settings.php:360
[14-Nov-2019 10:38:52 UTC] PHP   6. require_once() /var/www/html/wp-content/plugins/jetpack/jetpack.php:146
[14-Nov-2019 10:38:52 UTC] PHP   7. Automattic\Jetpack\JITM->register() /var/www/html/wp-content/plugins/jetpack/load-jetpack.php:71
[14-Nov-2019 10:38:52 UTC] PHP   8. apply_filters() /var/www/html/wp-content/plugins/jetpack/packages/jitm/src/class-jitm.php:56
[14-Nov-2019 10:38:52 UTC] PHP   9. WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:206
[14-Nov-2019 10:38:52 UTC] PHP  10. Jetpack->is_active_and_not_development_mode() /var/www/html/wp-includes/class-wp-hook.php:288
[14-Nov-2019 10:38:52 UTC] PHP  11. spl_autoload_call() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:7049
[14-Nov-2019 10:38:52 UTC] PHP  12. Automattic\Jetpack\Autoloader\autoloader() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:7049
[14-Nov-2019 10:38:52 UTC] PHP  13. _doing_it_wrong() /var/www/html/wp-content/plugins/vaultpress/vendor/autoload_packages.php:102
[14-Nov-2019 10:38:52 UTC] PHP  14. trigger_error() /var/www/html/wp-includes/functions.php:4903
```

And then when I fixed the ^ error I started seeing the following.

```
PHP Notice:  Automattic\Jetpack\Status was called <strong>incorrectly</strong>. Not all plugins have loaded yet but we requested the class Automattic\Jetpack\Status Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version dev-retry/phpcs-changed.) in /var/www/html/wp-includes/functions.php on line 4903
[14-Nov-2019 10:38:52 UTC] PHP Stack trace:
[14-Nov-2019 10:38:52 UTC] PHP   1. {main}() /var/www/html/wp-admin/admin-ajax.php:0
[14-Nov-2019 10:38:52 UTC] PHP   2. require_once() /var/www/html/wp-admin/admin-ajax.php:22
[14-Nov-2019 10:38:52 UTC] PHP   3. require_once() /var/www/html/wp-load.php:37
[14-Nov-2019 10:38:52 UTC] PHP   4. require_once() /var/www/html/wp-config.php:92
[14-Nov-2019 10:38:52 UTC] PHP   5. include_once() /var/www/html/wp-settings.php:360
[14-Nov-2019 10:38:52 UTC] PHP   6. require_once() /var/www/html/wp-content/plugins/jetpack/jetpack.php:146
[14-Nov-2019 10:38:52 UTC] PHP   7. Automattic\Jetpack\JITM->register() /var/www/html/wp-content/plugins/jetpack/load-jetpack.php:71
[14-Nov-2019 10:38:52 UTC] PHP   8. apply_filters() /var/www/html/wp-content/plugins/jetpack/packages/jitm/src/class-jitm.php:56
[14-Nov-2019 10:38:52 UTC] PHP   9. WP_Hook->apply_filters() /var/www/html/wp-includes/plugin.php:206
[14-Nov-2019 10:38:52 UTC] PHP  10. Jetpack->is_active_and_not_development_mode() /var/www/html/wp-includes/class-wp-hook.php:288
[14-Nov-2019 10:38:52 UTC] PHP  11. spl_autoload_call() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:7049
[14-Nov-2019 10:38:52 UTC] PHP  12. Automattic\Jetpack\Autoloader\autoloader() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:7049
[14-Nov-2019 10:38:52 UTC] PHP  13. _doing_it_wrong() /var/www/html/wp-content/plugins/vaultpress/vendor/autoload_packages.php:102
[14-Nov-2019 10:38:52 UTC] PHP  14. trigger_error() /var/www/html/wp-includes/functions.php:4903
```

#### Changes proposed in this Pull Request:
Make sure that Jetpack_IDC class initialized gets called after all the plugins have loaded. 
And make sure that JITM registers gets called after all the plugins have loaded.

#### Testing instructions:
* Do you notice any PHP Notices? 
* I have confirmed that Jetpack_IDC can still add the appropriate actions. BY checking that the action that it wants to hasn't been called yet. 
* I have confirmed that JITM registes can still add the appropriate actions by checking that the action that it needs hasn't been called yet. 

#### Proposed changelog entry for your changes:
* Remove some PHP notices that are due to the Status package being called at the wrong time before all the plugins have loaded.
