### PR TITLE
Recurring payments: adds `isPrimary` class to primary action buttons

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -200,7 +200,7 @@ class MembershipsButtonEdit extends Component {
 		if ( this.state.addingMembershipAmount === PRODUCT_NOT_ADDING && ! forceShowForm ) {
 			return (
 				<Button
-					isDefault
+					isPrimary
 					isLarge
 					onClick={ () => this.setState( { addingMembershipAmount: PRODUCT_FORM } ) }
 				>
@@ -265,7 +265,7 @@ class MembershipsButtonEdit extends Component {
 				/>
 				<div>
 					<Button
-						isDefault
+						isPrimary
 						isLarge
 						className="membership-button__field-button membership-button__add-amount"
 						onClick={ this.saveProduct }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds the correct class `isPrimary` to primary action buttons in the Recurring Payments block.

#### Testing instructions:

* Fire up this PR.
* Add a new post and include the Recurring Payments block.
* Set up Stripe if you haven't done so already.
* When setting up the recurring payment, ensure all primary actions are correctly styled with a primary button.

#### Before

![image](https://user-images.githubusercontent.com/390760/68858877-f9666d80-06dd-11ea-8a99-68a94ab02a40.png)

![image](https://user-images.githubusercontent.com/390760/68859043-4fd3ac00-06de-11ea-8bdc-43d677c48618.png)


#### After

![image](https://user-images.githubusercontent.com/390760/68858911-08e5b680-06de-11ea-8a4b-3cbe00476071.png)

![image](https://user-images.githubusercontent.com/390760/68859018-434f5380-06de-11ea-807e-0947543460dc.png)


#### Proposed changelog entry for your changes:
* None
