### PR TITLE
Rest API: Fix typo in the error name

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -747,7 +747,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return true;
 		}
 
-		return new WP_Error( 'invalid_user_permission_jetpack_disconnect', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
+		return new WP_Error( 'invalid_user_permission_jetpack_connect', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
 
 	}
 


### PR DESCRIPTION
This PR fixes a minor typo in the error name. The error was probably due to come coping and pasting. 

#### Testing instructions:
* Visit the url YOURSITE/wp-json/jetpack/v4/plans in a browser. 
* Notice that the error make sense now. 


#### Proposed changelog entry for your changes:
* Fixes a minor error type in the error name. 
