### PR TITLE
Connection: Move get_token() to Connection package

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -93,117 +93,13 @@ class Jetpack_Client_Server {
 	}
 
 	/**
+	 * @deprecated since 8.0.0 Use Automattic\Jetpack\Connection\Manager::get_token() instead.
+	 *
 	 * @return object|WP_Error
 	 */
 	function get_token( $data ) {
-		$roles = new Roles();
-		$role  = $roles->translate_current_user_to_role();
-
-		if ( ! $role ) {
-			return new Jetpack_Error( 'role', __( 'An administrator for this blog must set up the Jetpack connection.', 'jetpack' ) );
-		}
-
-		$client_secret = Jetpack_Data::get_access_token();
-		if ( ! $client_secret ) {
-			return new Jetpack_Error( 'client_secret', __( 'You need to register your Jetpack before connecting it.', 'jetpack' ) );
-		}
-
-		$redirect     = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
-		$redirect_uri = ( 'calypso' === $data['auth_type'] )
-			? $data['redirect_uri']
-			: add_query_arg(
-				array(
-					'action'   => 'authorize',
-					'_wpnonce' => wp_create_nonce( "jetpack-authorize_{$role}_{$redirect}" ),
-					'redirect' => $redirect ? urlencode( $redirect ) : false,
-				),
-				menu_page_url( 'jetpack', false )
-			);
-
-		// inject identity for analytics
-		$tracks          = new Automattic\Jetpack\Tracking();
-		$tracks_identity = $tracks->tracks_get_identity( get_current_user_id() );
-
-		$body = array(
-			'client_id'     => Jetpack_Options::get_option( 'id' ),
-			'client_secret' => $client_secret->secret,
-			'grant_type'    => 'authorization_code',
-			'code'          => $data['code'],
-			'redirect_uri'  => $redirect_uri,
-			'_ui'           => $tracks_identity['_ui'],
-			'_ut'           => $tracks_identity['_ut'],
-		);
-
-		$args     = array(
-			'method'  => 'POST',
-			'body'    => $body,
-			'headers' => array(
-				'Accept' => 'application/json',
-			),
-		);
-		$response = Client::_wp_remote_request( Connection_Utils::fix_url_for_bad_hosts( Jetpack::connection()->api_url( 'token' ) ), $args );
-
-		if ( is_wp_error( $response ) ) {
-			return new Jetpack_Error( 'token_http_request_failed', $response->get_error_message() );
-		}
-
-		$code   = wp_remote_retrieve_response_code( $response );
-		$entity = wp_remote_retrieve_body( $response );
-
-		if ( $entity ) {
-			$json = json_decode( $entity );
-		} else {
-			$json = false;
-		}
-
-		if ( 200 != $code || ! empty( $json->error ) ) {
-			if ( empty( $json->error ) ) {
-				return new Jetpack_Error( 'unknown', '', $code );
-			}
-
-			$error_description = isset( $json->error_description ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->error_description ) : '';
-
-			return new Jetpack_Error( (string) $json->error, $error_description, $code );
-		}
-
-		if ( empty( $json->access_token ) || ! is_scalar( $json->access_token ) ) {
-			return new Jetpack_Error( 'access_token', '', $code );
-		}
-
-		if ( empty( $json->token_type ) || 'X_JETPACK' != strtoupper( $json->token_type ) ) {
-			return new Jetpack_Error( 'token_type', '', $code );
-		}
-
-		if ( empty( $json->scope ) ) {
-			return new Jetpack_Error( 'scope', 'No Scope', $code );
-		}
-
-		@list( $role, $hmac ) = explode( ':', $json->scope );
-		if ( empty( $role ) || empty( $hmac ) ) {
-			return new Jetpack_Error( 'scope', 'Malformed Scope', $code );
-		}
-
-		if ( Jetpack::connection()->sign_role( $role ) !== $json->scope ) {
-			return new Jetpack_Error( 'scope', 'Invalid Scope', $code );
-		}
-
-		$cap = $roles->translate_role_to_cap( $role );
-		if ( ! $cap ) {
-			return new Jetpack_Error( 'scope', 'No Cap', $code );
-		}
-
-		if ( ! current_user_can( $cap ) ) {
-			return new Jetpack_Error( 'scope', 'current_user_cannot', $code );
-		}
-
-		/**
-		 * Fires after user has successfully received an auth token.
-		 *
-		 * @since 3.9.0
-		 */
-		do_action( 'jetpack_user_authorized' );
-
-		return (string) $json->access_token;
+		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\\Jetpack\\Connection\\Manager\\get_token' );
+		return Jetpack::connection()->get_token( $data );
 	}
 
 	public function get_jetpack() {

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1414,6 +1414,150 @@ class Manager {
 	}
 
 	/**
+	 * Obtains the auth token.
+	 *
+	 * @param array $data The request data.
+	 * @return object|\WP_Error Returns the auth token on success.
+	 *                          Returns a \WP_Error on failure.
+	 */
+	public function get_token( $data ) {
+		$roles = new Roles();
+		$role  = $roles->translate_current_user_to_role();
+
+		if ( ! $role ) {
+			return new \WP_Error( 'role', __( 'An administrator for this blog must set up the Jetpack connection.', 'jetpack' ) );
+		}
+
+		$client_secret = $this->get_access_token();
+		if ( ! $client_secret ) {
+			return new \WP_Error( 'client_secret', __( 'You need to register your Jetpack before connecting it.', 'jetpack' ) );
+		}
+
+		/**
+		 * Filter the URL of the first time the user gets redirected back to your site for connection
+		 * data processing.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param string $redirect_url Defaults to the site admin URL.
+		 */
+		$processing_url = apply_filters( 'jetpack_token_processing_url', admin_url( 'admin.php' ) );
+
+		$redirect = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
+
+		/**
+		* Filter the URL to redirect the user back to when the authentication process
+		* is complete.
+		*
+		* @since 8.0.0
+		*
+		* @param string $redirect_url Defaults to the site URL.
+		*/
+		$redirect = apply_filters( 'jetpack_token_redirect_url', $redirect );
+
+		$redirect_uri = ( 'calypso' === $data['auth_type'] )
+			? $data['redirect_uri']
+			: add_query_arg(
+				array(
+					'action'   => 'authorize',
+					'_wpnonce' => wp_create_nonce( "jetpack-authorize_{$role}_{$redirect}" ),
+					'redirect' => $redirect ? rawurlencode( $redirect ) : false,
+				),
+				esc_url( $processing_url )
+			);
+
+		/**
+		 * Filters the token request data.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param Array $request_data request data.
+		 */
+		$body = apply_filters(
+			'jetpack_token_request_body',
+			array(
+				'client_id'     => \Jetpack_Options::get_option( 'id' ),
+				'client_secret' => $client_secret->secret,
+				'grant_type'    => 'authorization_code',
+				'code'          => $data['code'],
+				'redirect_uri'  => $redirect_uri,
+			)
+		);
+
+		$args = array(
+			'method'  => 'POST',
+			'body'    => $body,
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		);
+
+		$response = Client::_wp_remote_request( Utils::fix_url_for_bad_hosts( $this->api_url( 'token' ) ), $args );
+
+		if ( is_wp_error( $response ) ) {
+			return new \WP_Error( 'token_http_request_failed', $response->get_error_message() );
+		}
+
+		$code   = wp_remote_retrieve_response_code( $response );
+		$entity = wp_remote_retrieve_body( $response );
+
+		if ( $entity ) {
+			$json = json_decode( $entity );
+		} else {
+			$json = false;
+		}
+
+		if ( 200 !== $code || ! empty( $json->error ) ) {
+			if ( empty( $json->error ) ) {
+				return new \WP_Error( 'unknown', '', $code );
+			}
+
+			$error_description = isset( $json->error_description ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->error_description ) : '';
+
+			return new \WP_Error( (string) $json->error, $error_description, $code );
+		}
+
+		if ( empty( $json->access_token ) || ! is_scalar( $json->access_token ) ) {
+			return new \WP_Error( 'access_token', '', $code );
+		}
+
+		if ( empty( $json->token_type ) || 'X_JETPACK' !== strtoupper( $json->token_type ) ) {
+			return new \WP_Error( 'token_type', '', $code );
+		}
+
+		if ( empty( $json->scope ) ) {
+			return new \WP_Error( 'scope', 'No Scope', $code );
+		}
+
+		@list( $role, $hmac ) = explode( ':', $json->scope );
+		if ( empty( $role ) || empty( $hmac ) ) {
+			return new \WP_Error( 'scope', 'Malformed Scope', $code );
+		}
+
+		if ( $this->sign_role( $role ) !== $json->scope ) {
+			return new \WP_Error( 'scope', 'Invalid Scope', $code );
+		}
+
+		$cap = $roles->translate_role_to_cap( $role );
+		if ( ! $cap ) {
+			return new \WP_Error( 'scope', 'No Cap', $code );
+		}
+
+		if ( ! current_user_can( $cap ) ) {
+			return new \WP_Error( 'scope', 'current_user_cannot', $code );
+		}
+
+		/**
+		 * Fires after user has successfully received an auth token.
+		 *
+		 * @since 3.9.0
+		 */
+		do_action( 'jetpack_user_authorized' );
+
+		return (string) $json->access_token;
+	}
+
+	/**
 	 * Builds a URL to the Jetpack connection auth page.
 	 *
 	 * @param WP_User $user (optional) defaults to the current logged in user.

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1699,8 +1699,7 @@ class Manager {
 			return new \WP_Error( 'no_code', 'Request must include an authorization code.', 400 );
 		}
 
-		$client_server = new \Jetpack_Client_Server();
-		$token         = $client_server->get_token( $data );
+		$token = $this->get_token( $data );
 
 		if ( is_wp_error( $token ) ) {
 			$code = $token->get_error_code();

--- a/tests/php/general/test_class.jetpack-client-server.php
+++ b/tests/php/general/test_class.jetpack-client-server.php
@@ -101,16 +101,16 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 	 * @since 3.2
 	 */
 	public function test_jetpack_client_server_get_token() {
-		$author_id = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$author_id = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 		wp_set_current_user( $author_id );
 
-		$client_server = new Jetpack_Client_Server;
+		$return_value = Jetpack::connection()->get_token( 'test' );
 
-		$return_value = $client_server->get_token( 'test' );
-
-		$this->assertInstanceOf( 'Jetpack_Error', $return_value );
+		$this->assertInstanceOf( 'WP_Error', $return_value );
 	}
 
 }


### PR DESCRIPTION
Move the `get_token()` method from the Jetpack_Client_Server class to the
Connection package's Manager class. This change helps to separate the package
from the plugin.

#### Changes proposed in this Pull Request:
* Deprecate the existing `Jetpack_Client_Server::get_token()` method.
* Add the new `Manager::get_token()` method.
* Add filters that contain the Jetpack plugin specific code in the new `get_token()` method.
* Update the `get_token` unit test.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the Jetpack DNA project for the Connection package.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Verify that the connection process is successful for primary and secondary users:

* Deactivate and reactivate Jetpack.
* Connect the primary user.
* Create another user and log in as that user.
* Connect the second user.

Also run the Jetpack unit tests.

#### Proposed changelog entry for your changes:
* N/A