### PR TITLE
Allow TOS agreement before Jetpack is fully active so we track the connection flow

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -740,7 +740,7 @@ class Jetpack {
 			/**
 			 * Initialize tracking right after the user agrees to the terms of service.
 			 */
-			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
+			add_action( 'jetpack_reject_terms_of_service', array( $tracking, 'init' ) );
 		}
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -740,7 +740,7 @@ class Jetpack {
 			/**
 			 * Initialize tracking right after the user agrees to the terms of service.
 			 */
-			add_action( 'jetpack_reject_terms_of_service', array( $tracking, 'init' ) );
+			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
 		}
 	}
 

--- a/packages/terms-of-service/src/class-terms-of-service.php
+++ b/packages/terms-of-service/src/class-terms-of-service.php
@@ -44,7 +44,7 @@ class Terms_Of_Service {
 		/**
 		 * Acton fired when the master user has revoked their agreement to the terms of service.
 		 *
-		 * @since 7.9.0
+		 * @since 7.9.1
 		 */
 		do_action( 'jetpack_reject_terms_of_service' );
 	}

--- a/packages/terms-of-service/src/class-terms-of-service.php
+++ b/packages/terms-of-service/src/class-terms-of-service.php
@@ -46,7 +46,7 @@ class Terms_Of_Service {
 		 *
 		 * @since 7.9.0
 		 */
-		do_action( 'jetpack_reject_to_terms_of_service' );
+		do_action( 'jetpack_reject_terms_of_service' );
 	}
 
 	/**
@@ -60,15 +60,11 @@ class Terms_Of_Service {
 	 * @return bool
 	 */
 	public function has_agreed() {
-		if ( ! $this->get_raw_has_agreed() ) {
-			return false;
-		}
-
 		if ( $this->is_development_mode() ) {
 			return false;
 		}
 
-		return $this->is_active();
+		return $this->get_raw_has_agreed() || $this->is_active();
 	}
 
 	/**
@@ -88,8 +84,7 @@ class Terms_Of_Service {
 	 * @return bool
 	 */
 	protected function is_active() {
-		$manager = new Manager();
-		return $manager->is_active();
+		return ( new Manager() )->is_active();
 	}
 
 	/**
@@ -99,7 +94,7 @@ class Terms_Of_Service {
 	 * @return bool
 	 */
 	protected function get_raw_has_agreed() {
-		return \Jetpack_Options::get_option( self::OPTION_NAME );
+		return \Jetpack_Options::get_option( self::OPTION_NAME, false );
 	}
 
 	/**

--- a/packages/terms-of-service/tests/php/test_TermsOfService.php
+++ b/packages/terms-of-service/tests/php/test_TermsOfService.php
@@ -13,7 +13,7 @@ class Test_Terms_Of_Service extends TestCase {
 	 */
 	public function setUp() {
 		$this->terms_of_service = $this->createPartialMock( __NAMESPACE__ .'\\Terms_Of_Service',
-			[ 'get_raw_has_agreed', 'is_development_mode', 'is_active', 'set_agree', 'set_reject' ]
+			[ 'get_raw_has_agreed', 'is_development_mode', 'set_agree', 'is_active', 'set_reject' ]
 		);
 	}
 
@@ -29,7 +29,7 @@ class Test_Terms_Of_Service extends TestCase {
 	 */
 	public function test_agree() {
 		$this->mock_function( 'do_action', null,  'jetpack_agreed_to_terms_of_service' );
-		$this->terms_of_service->expects( $this->once() )->method( 'set_agree' )->willReturn( null );
+		$this->terms_of_service->expects( $this->once() )->method( 'set_agree' );
 
 		$this->terms_of_service->agree();
 	}
@@ -38,8 +38,8 @@ class Test_Terms_Of_Service extends TestCase {
 	 * @covers Automattic\Jetpack\Terms_Of_Service->revoke
 	 */
 	public function test_revoke() {
-		$this->mock_function( 'do_action', null, 'jetpack_reject_to_terms_of_service' );
-		$this->terms_of_service->expects( $this->once() )->method( 'set_reject' )->willReturn( null );
+		$this->mock_function( 'do_action', null, 'jetpack_reject_terms_of_service' );
+		$this->terms_of_service->expects( $this->once() )->method( 'set_reject' );
 
 		$this->terms_of_service->reject();
 	}
@@ -47,7 +47,7 @@ class Test_Terms_Of_Service extends TestCase {
 	/**
 	 * @covers Automattic\Jetpack\Terms_Of_Service->has_agreed
 	 */
-	public function test_has_agreed_before_the_site_agrees() {
+	public function test_returns_false_if_not_agreed() {
 		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( false );
 		$this->assertFalse( $this->terms_of_service->has_agreed() );
 	}
@@ -55,9 +55,9 @@ class Test_Terms_Of_Service extends TestCase {
 	/**
 	 * @covers Automattic\Jetpack\Terms_Of_Service->has_agreed
 	 */
-	public function test_has_agreed_is_development_mode() {
-		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( true );
+	public function test_returns_false_if_has_agreed_but_is_development_mode() {
 		// is_development_mode
+		$this->terms_of_service->method( 'get_raw_has_agreed' )->willReturn( true );
 		$this->terms_of_service->expects( $this->once() )->method( 'is_development_mode' )->willReturn( true );
 		$this->assertFalse( $this->terms_of_service->has_agreed() );
 	}
@@ -65,29 +65,14 @@ class Test_Terms_Of_Service extends TestCase {
 	/**
 	 * @covers Automattic\Jetpack\Terms_Of_Service->has_agreed
 	 */
-	public function test_has_agreed_is_active_mode() {
-		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( true );
-		// Not in dev mode...
+	public function test_returns_true_if_active_even_if_not_agreed() {
+		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( false );
 		$this->terms_of_service->expects( $this->once() )->method( 'is_development_mode' )->willReturn( false );
 
 		// Jetpack is active
 		$this->terms_of_service->expects( $this->once() )->method( 'is_active' )->willReturn( true );
 
 		$this->assertTrue( $this->terms_of_service->has_agreed() );
-	}
-
-	/**
-	 * @covers Automattic\Jetpack\Terms_Of_Service->has_agreed
-	 */
-	public function test_has_agreed_is_not_active_mode() {
-		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( true );
-		// not in dev mode...
-		$this->terms_of_service->expects( $this->once() )->method( 'is_development_mode' )->willReturn( false );
-
-		// Jetpack is not active
-		$this->terms_of_service->expects( $this->once() )->method( 'is_active' )->willReturn( false );
-
-		$this->assertFalse( $this->terms_of_service->has_agreed() );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14040

In #13763 we moved our ToS agreement code into a package, but we changed the logic at the same time. Now, instead of the user agreeing to the ToS when they click the connect button, it is not enabled until the site is fully active, which has essentially killed all the events we were getting during the connection flow.

#### Changes proposed in this Pull Request:
* Allow sending events when user has agreed to ToS
* As a fallback (on sites which may have been connected prior to the ToS flag being available) we also use is_active as a signal that the user has agreed to ToS
* This also fixes a typo in an action name

#### Testing instructions:
* It's helpful to add some debug code to the Tracks library so you can see if events are being sent
* Go through the connect flow
* Connection related events like `jetpack_jpc_register_begin` should now be sent. In 7.9 they were not sent.