### PR TITLE
Connection: Move the authorize() method to the connection package

### DIFF
--- a/class.jetpack-client-server.php
+++ b/class.jetpack-client-server.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
@@ -24,7 +25,10 @@ class Jetpack_Client_Server {
 		check_admin_referer( "jetpack-authorize_{$role}_{$redirect}" );
 
 		$tracking = new Tracking();
-		$result   = $this->authorize( $data );
+
+		$manager = new Connection_Manager();
+		$result  = $manager->authorize( $data );
+
 		if ( is_wp_error( $result ) ) {
 			Jetpack::state( 'error', $result->get_error_code() );
 
@@ -59,109 +63,13 @@ class Jetpack_Client_Server {
 		$this->do_exit();
 	}
 
+	/*
+	 * @deprecated 8.0 Use Automattic\Jetpack\Connection\Manager::authorize() instead.
+	 */
 	function authorize( $data = array() ) {
-		$redirect = isset( $data['redirect'] ) ? esc_url_raw( (string) $data['redirect'] ) : '';
-
-		$jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' );
-		// Checking if site has been active/connected previously before recording unique connection
-		if ( ! $jetpack_unique_connection ) {
-			// jetpack_unique_connection option has never been set
-			$jetpack_unique_connection = array(
-				'connected'    => 0,
-				'disconnected' => 0,
-				'version'      => '3.6.1',
-			);
-
-			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
-
-			// track unique connection
-			$jetpack = $this->get_jetpack();
-
-			$jetpack->stat( 'connections', 'unique-connection' );
-			$jetpack->do_stats( 'server_side' );
-		}
-
-		// increment number of times connected
-		$jetpack_unique_connection['connected'] += 1;
-		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
-
-		$roles = new Roles();
-		$role  = $roles->translate_current_user_to_role();
-
-		if ( ! $role ) {
-			return new Jetpack_Error( 'no_role', 'Invalid request.', 400 );
-		}
-
-		$cap = $roles->translate_role_to_cap( $role );
-		if ( ! $cap ) {
-			return new Jetpack_Error( 'no_cap', 'Invalid request.', 400 );
-		}
-
-		if ( ! empty( $data['error'] ) ) {
-			return new Jetpack_Error( $data['error'], 'Error included in the request.', 400 );
-		}
-
-		if ( ! isset( $data['state'] ) ) {
-			return new Jetpack_Error( 'no_state', 'Request must include state.', 400 );
-		}
-
-		if ( ! ctype_digit( $data['state'] ) ) {
-			return new Jetpack_Error( $data['error'], 'State must be an integer.', 400 );
-		}
-
-		$current_user_id = get_current_user_id();
-		if ( $current_user_id != $data['state'] ) {
-			return new Jetpack_Error( 'wrong_state', 'State does not match current user.', 400 );
-		}
-
-		if ( empty( $data['code'] ) ) {
-			return new Jetpack_Error( 'no_code', 'Request must include an authorization code.', 400 );
-		}
-
-		$token = $this->get_token( $data );
-
-		if ( is_wp_error( $token ) ) {
-			$code = $token->get_error_code();
-			if ( empty( $code ) ) {
-				$code = 'invalid_token';
-			}
-			return new Jetpack_Error( $code, $token->get_error_message(), 400 );
-		}
-
-		if ( ! $token ) {
-			return new Jetpack_Error( 'no_token', 'Error generating token.', 400 );
-		}
-
-		$is_master_user = ! Jetpack::is_active();
-
-		Connection_Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
-
-		if ( ! $is_master_user ) {
-			Jetpack::state( 'message', 'linked' );
-			// Don't activate anything since we are just connecting a user.
-			return 'linked';
-		}
-
-		// If this site has been through the Jetpack Onboarding flow, delete the onboarding token
-		Jetpack::invalidate_onboarding_token();
-
-		// If redirect_uri is SSO, ensure SSO module is enabled
-		parse_str( wp_parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
-
-		/** This filter is documented in class.jetpack-cli.php */
-		$jetpack_start_enable_sso = apply_filters( 'jetpack_start_enable_sso', true );
-
-		$activate_sso = (
-			isset( $redirect_options['action'] ) &&
-			'jetpack-sso' === $redirect_options['action'] &&
-			$jetpack_start_enable_sso
-		);
-
-		$do_redirect_on_error = ( 'client' === $data['auth_type'] );
-
-		Jetpack::handle_post_authorization_actions( $activate_sso, $do_redirect_on_error );
-
-		return 'authorized';
+		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\\Jetpack\\Connection\\Manager::authorize' );
+		$manager = new Connection_Manager();
+		return $manager->authorize( $data );
 	}
 
 	public static function deactivate_plugin( $probable_file, $probable_title ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3961,12 +3961,12 @@ p {
 	 * 4 - redirect to https://wordpress.com/start/jetpack-connect
 	 * 5 - user logs in with WP.com account
 	 * 6 - remote request to this site's xmlrpc.php with action remoteAuthorize, Jetpack_XMLRPC_Server->remote_authorize
-	 *		- Jetpack_Client_Server::authorize()
+	 *		- Manager::authorize()
 	 *		- Jetpack_Client_Server::get_token()
 	 *		- GET https://jetpack.wordpress.com/jetpack.token/1/ with
 	 *        client_id, client_secret, grant_type, code, redirect_uri:action=authorize, state, scope, user_email, user_login
 	 *			- which responds with access_token, token_type, scope
-	 *		- Jetpack_Client_Server::authorize() stores jetpack_options: user_token => access_token.$user_id
+	 *		- Manager::authorize() stores jetpack_options: user_token => access_token.$user_id
 	 *		- Jetpack::activate_default_modules()
 	 *     		- Deactivates deprecated plugins
 	 *     		- Activates all default modules

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -726,6 +726,11 @@ class Jetpack {
 		 * Load some scripts asynchronously.
 		 */
 		add_action( 'script_loader_tag', array( $this, 'script_add_async' ), 10, 3 );
+
+		// Actions for Manager::authorize().
+		add_action( 'jetpack_authorize_starting', array( $this, 'authorize_starting' ) );
+		add_action( 'jetpack_authorize_ending_linked', array( $this, 'authorize_ending_linked' ) );
+		add_action( 'jetpack_authorize_ending_authorized', array( $this, 'authorize_ending_authorized' ) );
 	}
 	/**
 	 * Runs after all the plugins have loaded but before init.
@@ -4711,6 +4716,70 @@ endif;
 		$api_url = $iframe ? $connection->api_url( 'authorize_iframe' ) : $connection->api_url( 'authorize' );
 
 		return add_query_arg( $args, $api_url );
+	}
+
+	/**
+	 * This action fires at the beginning of the Manager::authorize method.
+	 */
+	public static function authorize_starting() {
+		$jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' );
+		// Checking if site has been active/connected previously before recording unique connection.
+		if ( ! $jetpack_unique_connection ) {
+			// jetpack_unique_connection option has never been set.
+			$jetpack_unique_connection = array(
+				'connected'    => 0,
+				'disconnected' => 0,
+				'version'      => '3.6.1',
+			);
+
+			update_option( 'jetpack_unique_connection', $jetpack_unique_connection );
+
+			// Track unique connection.
+			$jetpack = self::init();
+
+			$jetpack->stat( 'connections', 'unique-connection' );
+			$jetpack->do_stats( 'server_side' );
+		}
+
+		// Increment number of times connected.
+		$jetpack_unique_connection['connected'] += 1;
+		Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
+	}
+
+	/**
+	 * This action fires at the end of the Manager::authorize method when a secondary user is
+	 * linked.
+	 */
+	public static function authorize_ending_linked() {
+		// Don't activate anything since we are just connecting a user.
+		self::state( 'message', 'linked' );
+	}
+
+	/**
+	 * This action fires at the end of the Manager::authorize method when the master user is
+	 * authorized.
+	 *
+	 * @param array $data The request data.
+	 */
+	public static function authorize_ending_authorized( $data ) {
+		// If this site has been through the Jetpack Onboarding flow, delete the onboarding token.
+		self::invalidate_onboarding_token();
+
+		// If redirect_uri is SSO, ensure SSO module is enabled.
+		parse_str( wp_parse_url( $data['redirect_uri'], PHP_URL_QUERY ), $redirect_options );
+
+		/** This filter is documented in class.jetpack-cli.php */
+		$jetpack_start_enable_sso = apply_filters( 'jetpack_start_enable_sso', true );
+
+		$activate_sso = (
+			isset( $redirect_options['action'] ) &&
+			'jetpack-sso' === $redirect_options['action'] &&
+			$jetpack_start_enable_sso
+		);
+
+		$do_redirect_on_error = ( 'client' === $data['auth_type'] );
+
+		self::handle_post_authorization_actions( $activate_sso, $do_redirect_on_error );
 	}
 
 	/**

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -5,7 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-options": "@dev"
+		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-roles": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -252,8 +252,7 @@ class Jetpack_XMLRPC_Server {
 
 		wp_set_current_user( $request['state'] );
 
-		$client_server = new Jetpack_Client_Server();
-		$result        = $client_server->authorize( $request );
+		$result = $this->connection->authorize( $request );
 
 		if ( is_wp_error( $result ) ) {
 			return $this->error( $result, 'remote_authorize' );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
 
 /**
@@ -1394,6 +1395,95 @@ class Manager {
 	 */
 	public function build_connect_url( $raw, $redirect, $from, $register ) {
 		return array( $raw, $redirect, $from, $register );
+	}
+
+	/**
+	 * Authorizes the user by obtaining and storing the user token.
+	 *
+	 * @param array $data The request data.
+	 * @return string|\WP_Error Returns a string on success.
+	 *                          Returns a \WP_Error on failure.
+	 */
+	public function authorize( $data = array() ) {
+		/**
+		 * Action fired when user authorization starts.
+		 *
+		 * @since 8.0.0
+		 */
+		do_action( 'jetpack_authorize_starting' );
+
+		$roles = new Roles();
+		$role  = $roles->translate_current_user_to_role();
+
+		if ( ! $role ) {
+			return new \WP_Error( 'no_role', 'Invalid request.', 400 );
+		}
+
+		$cap = $roles->translate_role_to_cap( $role );
+		if ( ! $cap ) {
+			return new \WP_Error( 'no_cap', 'Invalid request.', 400 );
+		}
+
+		if ( ! empty( $data['error'] ) ) {
+			return new \WP_Error( $data['error'], 'Error included in the request.', 400 );
+		}
+
+		if ( ! isset( $data['state'] ) ) {
+			return new \WP_Error( 'no_state', 'Request must include state.', 400 );
+		}
+
+		if ( ! ctype_digit( $data['state'] ) ) {
+			return new \WP_Error( $data['error'], 'State must be an integer.', 400 );
+		}
+
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id !== (int) $data['state'] ) {
+			return new \WP_Error( 'wrong_state', 'State does not match current user.', 400 );
+		}
+
+		if ( empty( $data['code'] ) ) {
+			return new \WP_Error( 'no_code', 'Request must include an authorization code.', 400 );
+		}
+
+		$client_server = new \Jetpack_Client_Server();
+		$token         = $client_server->get_token( $data );
+
+		if ( is_wp_error( $token ) ) {
+			$code = $token->get_error_code();
+			if ( empty( $code ) ) {
+				$code = 'invalid_token';
+			}
+			return new \WP_Error( $code, $token->get_error_message(), 400 );
+		}
+
+		if ( ! $token ) {
+			return new \WP_Error( 'no_token', 'Error generating token.', 400 );
+		}
+
+		$is_master_user = ! $this->is_active();
+
+		Utils::update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_master_user );
+
+		if ( ! $is_master_user ) {
+			/**
+			 * Action fired when a secondary user has been authorized.
+			 *
+			 * @since 8.0.0
+			 */
+			do_action( 'jetpack_authorize_ending_linked' );
+			return 'linked';
+		}
+
+		/**
+		 * Action fired when the master user has been authorized.
+		 *
+		 * @since 8.0.0
+		 *
+		 * @param array $data The request data.
+		 */
+		do_action( 'jetpack_authorize_ending_authorized', $data );
+
+		return 'authorized';
 	}
 
 	/**

--- a/tests/php/general/test_class.jetpack-client-server.php
+++ b/tests/php/general/test_class.jetpack-client-server.php
@@ -36,7 +36,7 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 			->setMethods( array( 'do_exit' ) )
 			->getMock();
 
-		$result = $client_server->authorize();
+		$result = Jetpack::connection()->authorize();
 
 		$this->assertNotEquals( 'no_role', $result->get_error_code() );
 		$this->assertNotEquals( 'no_cap', $result->get_error_code() );
@@ -57,7 +57,7 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 			->setMethods( array( 'do_exit' ) )
 			->getMock();
 
-		$result = $client_server->authorize();
+		$result = Jetpack::connection()->authorize();
 
 		$this->assertEquals( 'no_role', $result->get_error_code() );
 	}
@@ -77,7 +77,7 @@ class WP_Test_Jetpack_Client_Server extends WP_UnitTestCase {
 			->setMethods( array( 'do_exit' ) )
 			->getMock();
 
-		$result = $client_server->authorize( array( 'error' => 'test_error' ) );
+		$result = Jetpack::connection()->authorize( array( 'error' => 'test_error' ) );
 
 		$this->assertEquals( 'test_error', $result->get_error_code() );
 	}


### PR DESCRIPTION
Move the `authorize()` method from the Jetpack_Client_Server class to the connection package's Manager class. 



#### Changes proposed in this Pull Request:
*  Deprecate the existing `Jetpack_Client_Server::authorize()` method.
* Add the new `Manager::authorize()` method.
* Add actions to the Jetpack class that handle Jetpack specific code
   that was previously in `Jetpack_Client_Server::authorize()`. Fire
   these actions in the new `Manager::authorize()` method.
* Update the invocations of `Jetpack_Client_Server::authorize()` to
   `Manager::authorize()`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the Jetpack DNA project for the Connection package.

#### Testing instructions:
Verify that the connection process is successful for primary and secondary users:

* Deactivate and reactivate Jetpack.
* Connect the primary user.
* Create another user and log in as that user.
* Connect the second user.

Also run the Jetpack unit tests.

#### Proposed changelog entry for your changes:
* N/A
