### PR TITLE
Connection package: Add new methods to for disconnecting/deleting tokens

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3250,8 +3250,6 @@ p {
 		$connection = self::connection();
 		$connection->clean_nonces( true );
 
-		$connection = new Connection_Manager();
-
 		// If the site is in an IDC because sync is not allowed,
 		// let's make sure to not disconnect the production site.
 		if ( ! self::validate_sync_error_idc_option() ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3250,29 +3250,19 @@ p {
 		$connection = self::connection();
 		$connection->clean_nonces( true );
 
+		$connection = new Connection_Manager();
+
 		// If the site is in an IDC because sync is not allowed,
 		// let's make sure to not disconnect the production site.
 		if ( ! self::validate_sync_error_idc_option() ) {
 			$tracking = new Tracking();
 			$tracking->record_user_event( 'disconnect_site', array() );
 
-			$xml = new Jetpack_IXR_Client();
-			$xml->query( 'jetpack.deregister', get_current_user_id() );
+			$connection->disconnect_site_wpcom();
 		}
 
-		Jetpack_Options::delete_option(
-			array(
-				'blog_token',
-				'user_token',
-				'user_tokens',
-				'master_user',
-				'time_diff',
-				'fallback_no_verify_ssl_certs',
-			)
-		);
-
+		$connection->delete_all_connection_tokens();
 		Jetpack_IDC::clear_all_idc_options();
-		Jetpack_Options::delete_raw_option( 'jetpack_secrets' );
 
 		if ( $update_activated_state ) {
 			Jetpack_Options::update_option( 'activated', 4 );
@@ -3296,10 +3286,6 @@ p {
 
 			Jetpack_Options::update_option( 'unique_connection', $jetpack_unique_connection );
 		}
-
-		// Delete cached connected user data
-		$transient_key = 'jetpack_connected_user_data_' . get_current_user_id();
-		delete_transient( $transient_key );
 
 		// Delete all the sync related data. Since it could be taking up space.
 		Sender::get_instance()->uninstall();

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1246,6 +1246,36 @@ class Manager {
 	}
 
 	/**
+	 * Deletes all connection tokens and transients from the local Jetpack site.
+	 */
+	public function delete_all_connection_tokens() {
+		\Jetpack_Options::delete_option(
+			array(
+				'blog_token',
+				'user_token',
+				'user_tokens',
+				'master_user',
+				'time_diff',
+				'fallback_no_verify_ssl_certs',
+			)
+		);
+
+		\Jetpack_Options::delete_raw_option( 'jetpack_secrets' );
+
+		// Delete cached connected user data.
+		$transient_key = 'jetpack_connected_user_data_' . get_current_user_id();
+		delete_transient( $transient_key );
+	}
+
+	/**
+	 * Tells wpcom to disconnect the site and clear all tokens from cached site.
+	 */
+	public function disconnect_site_wpcom() {
+		$xml = new \Jetpack_IXR_Client();
+		$xml->query( 'jetpack.deregister', get_current_user_id() );
+	}
+
+	/**
 	 * Responds to a WordPress.com call to register the current site.
 	 * Should be changed to protected.
 	 *

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1268,7 +1268,7 @@ class Manager {
 	}
 
 	/**
-	 * Tells wpcom to disconnect the site and clear all tokens from cached site.
+	 * Tells WordPress.com to disconnect the site and clear all tokens from cached site.
 	 */
 	public function disconnect_site_wpcom() {
 		$xml = new \Jetpack_IXR_Client();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

What do you think of the naming? 
What do you think about keeping these separate? I kinda like the idea of keeping wpcom queries in separate methods. For one, it makes it easier to integrate and makes it more flexible (such as in `Jetpack::disconnect()`).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Two new methods in the Connection Manager class for: 
- Deleting all tokens (both user and blog) from the local client's DB.
- Telling wpcom to do the same.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- No, refactoring existing. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Disconnect the Jetpack site! 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
