### PR TITLE
Removed Jetpack references in the IXR client.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5120,11 +5120,11 @@ endif;
 	/**
 	 * Returns the Jetpack XML-RPC API
 	 *
+	 * @deprecated 8.0 Use Connection_Manager instead.
 	 * @return string
 	 */
 	public static function xmlrpc_api_url() {
-		$base = preg_replace( '#(https?://[^?/]+)(/?.*)?$#', '\\1', JETPACK__API_BASE );
-		return untrailingslashit( $base ) . '/xmlrpc.php';
+		return self::connection()->xmlrpc_api_url();
 	}
 
 	public static function connection() {

--- a/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -9,6 +9,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
 
 /**
  * A Jetpack implementation of the WordPress core IXR client.
@@ -31,8 +32,10 @@ class Jetpack_IXR_Client extends IXR_Client {
 	 * @param int         $timeout The connection timeout, in seconds.
 	 */
 	public function __construct( $args = array(), $path = false, $port = 80, $timeout = 15 ) {
+		$connection = new Manager();
+
 		$defaults = array(
-			'url'     => Jetpack::xmlrpc_api_url(),
+			'url'     => $connection->xmlrpc_api_url(),
 			'user_id' => 0,
 		);
 
@@ -96,7 +99,7 @@ class Jetpack_IXR_Client extends IXR_Client {
 	 *
 	 * @param int    $fault_code   Fault code.
 	 * @param string $fault_string Fault string.
-	 * @return Jetpack_Error Error object.
+	 * @return WP_Error Error object.
 	 */
 	public function get_jetpack_error( $fault_code = null, $fault_string = null ) {
 		if ( is_null( $fault_code ) ) {
@@ -111,9 +114,9 @@ class Jetpack_IXR_Client extends IXR_Client {
 			$code    = $match[1];
 			$message = $match[2];
 			$status  = $fault_code;
-			return new Jetpack_Error( $code, $message, $status );
+			return new \WP_Error( $code, $message, $status );
 		}
 
-		return new Jetpack_Error( "IXR_{$fault_code}", $fault_string );
+		return new \WP_Error( "IXR_{$fault_code}", $fault_string );
 	}
 }

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -739,6 +739,20 @@ class Manager {
 	}
 
 	/**
+	 * Returns the Jetpack XMLRPC WordPress.com API endpoint URL.
+	 *
+	 * @return String XMLRPC API URL.
+	 */
+	public function xmlrpc_api_url() {
+		$base = preg_replace(
+			'#(https?://[^?/]+)(/?.*)?$#',
+			'\\1',
+			Constants::get_constant( 'JETPACK__API_BASE' )
+		);
+		return untrailingslashit( $base ) . '/xmlrpc.php';
+	}
+
+	/**
 	 * Attempts Jetpack registration which sets up the site for connection. Should
 	 * remain public because the call to action comes from the current site, not from
 	 * WordPress.com.


### PR DESCRIPTION
This change allows the package to be used outside of Jetpack, relying on the methods provided by the Manager, plus using the WP_Error class instead of the Jetpack_Error wrapper.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
* Removes a reference to the `Jetpack` class and uses a new method from the connection manager class.
* Changes `Jetpack_Error` to `WP_Error`.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* The main thing to test here is the connection and disconnection of users. The flow should work as before, bonus points for checking if the user is actually marked disconnected on WordPress.com side.
* Extra bonus points for testing with the client-example package, but it's rather hard to do before the connection package is published, so it's unnecessary for now.

#### Proposed changelog entry for your changes:
* N/A
