### PR TITLE
Blocks: move from editor to block-editor

### DIFF
--- a/extensions/blocks/business-hours/edit.js
+++ b/extensions/blocks/business-hours/edit.js
@@ -5,7 +5,7 @@ import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { __experimentalGetSettings } from '@wordpress/date';
-import { BlockIcon } from '@wordpress/editor';
+import { BlockIcon } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { Placeholder } from '@wordpress/components';
 

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId } from '@wordpress/compose';
-import { InnerBlocks, InspectorControls, URLInput } from '@wordpress/editor';
+import { InnerBlocks, InspectorControls, URLInput } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { BaseControl, PanelBody, TextControl, ToggleControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { withInstanceId } from '@wordpress/compose';
 
 /**

--- a/extensions/blocks/contact-form/components/jetpack-field-label.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-label.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PlainText } from '@wordpress/editor';
+import { PlainText } from '@wordpress/block-editor';
 import { ToggleControl } from '@wordpress/components';
 
 const JetpackFieldLabel = ( { setAttributes, label, resetFocus, isSelected, required } ) => {

--- a/extensions/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-multiple.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { BaseControl, IconButton, PanelBody, TextControl } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { withInstanceId } from '@wordpress/compose';
 
 /**

--- a/extensions/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-textarea.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextareaControl, TextControl } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/contact-form/components/jetpack-field.js
+++ b/extensions/blocks/contact-form/components/jetpack-field.js
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -5,7 +5,7 @@ import { __, _x } from '@wordpress/i18n';
 import { getBlockType, createBlock } from '@wordpress/blocks';
 import { Path, Circle } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/contact-info/address/edit.js
+++ b/extensions/blocks/contact-info/address/edit.js
@@ -4,7 +4,7 @@
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { PlainText } from '@wordpress/editor';
+import { PlainText } from '@wordpress/block-editor';
 import { ToggleControl } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/contact-info/edit.js
+++ b/extensions/blocks/contact-info/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import classnames from 'classnames';
 
 /**

--- a/extensions/blocks/contact-info/index.js
+++ b/extensions/blocks/contact-info/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { Path } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/gif/edit.js
+++ b/extensions/blocks/gif/edit.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { Button, PanelBody, Path, Placeholder, SVG, TextControl } from '@wordpress/components';
-import { InspectorControls, RichText } from '@wordpress/editor';
+import { InspectorControls, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -14,7 +14,7 @@ import {
 	TextControl,
 	withNotices,
 } from '@wordpress/components';
-import { InspectorControls, RichText } from '@wordpress/editor';
+import { InspectorControls, RichText } from '@wordpress/block-editor';
 import { Fragment, Component } from '@wordpress/element';
 
 /**

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -22,7 +22,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	PanelColorSettings,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/markdown/edit.js
+++ b/extensions/blocks/markdown/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockControls, PlainText } from '@wordpress/editor';
+import { BlockControls, PlainText } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -119,9 +119,9 @@ class MarkdownEdit extends Component {
 
 export default compose( [
 	withSelect( select => ( {
-		currentBlockId: select( 'core/editor' ).getSelectedBlockClientId(),
+		currentBlockId: select( 'core/block-editor' ).getSelectedBlockClientId(),
 	} ) ),
 	withDispatch( ( dispatch, { currentBlockId } ) => ( {
-		removeBlock: () => dispatch( 'core/editor' ).removeBlocks( currentBlockId ),
+		removeBlock: () => dispatch( 'core/block-editor' ).removeBlocks( currentBlockId ),
 	} ) ),
 ] )( MarkdownEdit );

--- a/extensions/blocks/pinterest/edit.js
+++ b/extensions/blocks/pinterest/edit.js
@@ -5,7 +5,7 @@ import { invoke } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Placeholder, SandBox, Button, IconButton, Spinner, Toolbar } from '@wordpress/components';
-import { BlockControls, BlockIcon } from '@wordpress/editor';
+import { BlockControls, BlockIcon } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
 
 /**

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -20,7 +20,7 @@ import {
 	withNotices,
 	SelectControl,
 } from '@wordpress/components';
-import { InspectorControls, BlockIcon } from '@wordpress/editor';
+import { InspectorControls, BlockIcon } from '@wordpress/block-editor';
 import { Fragment, Component } from '@wordpress/element';
 
 /**

--- a/extensions/blocks/related-posts/edit.js
+++ b/extensions/blocks/related-posts/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockControls, InspectorControls } from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, RangeControl, ToggleControl, Toolbar, Path, SVG } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import { get } from 'lodash';

--- a/extensions/blocks/repeat-visitor/components/edit.js
+++ b/extensions/blocks/repeat-visitor/components/edit.js
@@ -4,7 +4,7 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Notice, TextControl, RadioControl, Placeholder } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 import classNames from 'classnames';
 
@@ -107,7 +107,7 @@ class RepeatVisitorEdit extends Component {
 }
 
 export default withSelect( ( select, ownProps ) => {
-	const { isBlockSelected, hasSelectedInnerBlock } = select( 'core/editor' );
+	const { isBlockSelected, hasSelectedInnerBlock } = select( 'core/block-editor' );
 	return {
 		isSelected: isBlockSelected( ownProps.clientId ) || hasSelectedInnerBlock( ownProps.clientId ),
 	};

--- a/extensions/blocks/repeat-visitor/components/save.js
+++ b/extensions/blocks/repeat-visitor/components/save.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 export default ( { className } ) => {
 	return (

--- a/extensions/blocks/simple-payments/featured-media.js
+++ b/extensions/blocks/simple-payments/featured-media.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockControls, MediaPlaceholder, MediaUpload } from '@wordpress/editor';
+import { BlockControls, MediaPlaceholder, MediaUpload } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
 import { get } from 'lodash';
 import { Toolbar, ToolbarButton } from '@wordpress/components';

--- a/extensions/blocks/slideshow/controls.js
+++ b/extensions/blocks/slideshow/controls.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { BlockControls, InspectorControls, MediaUpload } from '@wordpress/editor';
+import { BlockControls, InspectorControls, MediaUpload } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	RangeControl,

--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -7,7 +7,7 @@ import { compose } from '@wordpress/compose';
 import { filter, get, map, pick } from 'lodash';
 import { isBlobURL } from '@wordpress/blob';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { BlockIcon, MediaPlaceholder, mediaUpload } from '@wordpress/editor';
+import { BlockIcon, MediaPlaceholder, mediaUpload } from '@wordpress/block-editor';
 import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/slideshow/slideshow.js
+++ b/extensions/blocks/slideshow/slideshow.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
 import { isEqual } from 'lodash';
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -11,7 +11,7 @@ import {
 	MediaPlaceholder,
 	MediaUpload,
 	mediaUpload,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import {
 	DropZone,
 	FormFileUpload,

--- a/extensions/blocks/videopress/deprecated/v1/save.js
+++ b/extensions/blocks/videopress/deprecated/v1/save.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 
 export default function VideoPressSave( { attributes } ) {
 	const { caption, guid } = attributes;

--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -22,7 +22,7 @@ import {
 	MediaUpload,
 	MediaUploadCheck,
 	RichText,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';

--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -3,7 +3,7 @@
  */
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
-import { mediaUpload } from '@wordpress/editor';
+import { mediaUpload } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
 import { every } from 'lodash';
 

--- a/extensions/blocks/videopress/save.js
+++ b/extensions/blocks/videopress/save.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/extensions/blocks/wordads/edit.js
+++ b/extensions/blocks/wordads/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockControls } from '@wordpress/editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { Component, Fragment } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 

--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -4,7 +4,7 @@
 import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch } from '@wordpress/data';
-import { Warning } from '@wordpress/editor';
+import { Warning } from '@wordpress/block-editor';
 
 import './style.scss';
 

--- a/extensions/shared/simple-input.js
+++ b/extensions/shared/simple-input.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PlainText } from '@wordpress/editor';
+import { PlainText } from '@wordpress/block-editor';
 
 const simpleInput = ( type, props, label, view, onChange ) => {
 	const { isSelected } = props;

--- a/extensions/shared/submit-button.js
+++ b/extensions/shared/submit-button.js
@@ -12,7 +12,7 @@ import {
 	ContrastChecker,
 	RichText,
 	withColors,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import { isEqual, get } from 'lodash';
 
 const { getComputedStyle } = window;
@@ -99,7 +99,7 @@ class SubmitButton extends Component {
 						className={ buttonClasses }
 						style={ buttonStyle }
 						keepPlaceholderOnFocus
-						formattingControls={ [] }
+						allowedFormats={ [] }
 					/>
 				</div>
 				<InspectorControls>


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

Now that Jetpack will require WordPress 5.2 (see #13620), we can update our blocks to use the `@wordpress/block-editor` package that was added in WP 5.2.
This will get rid of a few deprecated messages that were present when using the block editor.

#### Testing instructions:

* Test **all the blocks** and their settings in the block sidebar, as well as when addding content to blocks.

#### Proposed changelog entry for your changes:

* Blocks: start using the @wordpress/block-editor package introduced in WordPress 5.2.
