### PR TITLE
Mailchimp Block: Interests/SIGNUP merge field/AMP state hook

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Client;
+
 /**
  * Mailchimp: Get Mailchimp Status.
  * API to determine if current site has linked Mailchimp account and mailing list selected.
@@ -14,6 +16,7 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 		$this->wpcom_is_wpcom_only_endpoint = true;
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+
 	}
 
 	/**
@@ -27,6 +30,16 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 				array(
 					'methods'  => WP_REST_Server::READABLE,
 					'callback' => array( $this, 'get_mailchimp_status' ),
+				),
+			)
+		);
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/groups',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'get_mailchimp_groups' ),
 				),
 			)
 		);
@@ -73,6 +86,29 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 			'connect_url' => $connect_url,
 			'site_id'     => $site_id,
 		);
+	}
+
+	/**
+	 * Get all Mailchimp groups for the accounted connected to the current blog
+	 *
+	 * @return mixed
+	 * groups:array
+	 * site_id:int
+	 */
+	public function get_mailchimp_groups() {
+		$is_wpcom = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
+		$site_id  = $is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return new WP_Error(
+				'unavailable_site_id',
+				__( 'Sorry, something is wrong with your Jetpack connection.', 'jetpack' ),
+				403
+			);
+		}
+		$path    = sprintf( '/sites/%d/mailchimp/groups', $site_id );
+		$request = Client::wpcom_json_api_request_as_blog( $path );
+		$body    = wp_remote_retrieve_body( $request );
+		return json_decode( $body );
 	}
 }
 

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
@@ -105,7 +105,7 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 				403
 			);
 		}
-		$path    = sprintf( '/sites/%d/mailchimp/groups', $site_id );
+		$path    = sprintf( '/sites/%d/mailchimp/groups', absint( $site_id ) );
 		$request = Client::wpcom_json_api_request_as_blog( $path );
 		$body    = wp_remote_retrieve_body( $request );
 		return json_decode( $body );

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -198,10 +198,14 @@ class MailchimpSubscribeEdit extends Component {
 					<MailchimpGroups
 						interests={ interests }
 						onChange={ ( id, checked ) => {
+							// Create a Set to insure no duplicate interests
+							const deDupedInterests = [ ...new Set( [ ...interests, id ] ) ];
+							// Filter the clicked interest based on checkbox's state.
+							const updatedInterests = deDupedInterests.filter( item =>
+								item === id && ! checked ? false : item
+							);
 							setAttributes( {
-								interests: [ ...new Set( [ ...interests, id ] ) ].filter( item =>
-									item === id && ! checked ? false : item
-								),
+								interests: updatedInterests,
 							} );
 						} }
 					/>

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -21,6 +21,7 @@ import { Fragment, Component } from '@wordpress/element';
  * Internal dependencies
  */
 import { icon } from '.';
+import MailchimpGroups from './mailchimp-groups';
 
 const API_STATE_LOADING = 0;
 const API_STATE_CONNECTED = 1;
@@ -133,10 +134,12 @@ class MailchimpSubscribeEdit extends Component {
 		const {
 			emailPlaceholder,
 			consentText,
+			interests,
 			processingLabel,
 			successLabel,
 			errorLabel,
 			preview,
+			signupLocation,
 		} = attributes;
 		const classPrefix = 'wp-block-jetpack-mailchimp_';
 		const waiting = (
@@ -188,6 +191,22 @@ class MailchimpSubscribeEdit extends Component {
 						label={ __( 'Error text', 'jetpack' ) }
 						value={ errorLabel }
 						onChange={ this.updateErrorText }
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Mailchimp Groups', 'jetpack' ) }>
+					<MailchimpGroups
+						interests={ interests }
+						onChange={ ( id, checked ) =>
+							setAttributes( { interests: { ...interests, [ id ]: checked } } )
+						}
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Merge Fields', 'jetpack' ) }>
+					<TextControl
+						label={ __( 'Signup Location', 'jetpack' ) }
+						placeholder={ __( 'website' ) }
+						value={ signupLocation }
+						onChange={ value => setAttributes( { signupLocation: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Mailchimp Connection', 'jetpack' ) }>

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -196,9 +196,13 @@ class MailchimpSubscribeEdit extends Component {
 				<PanelBody title={ __( 'Mailchimp Groups', 'jetpack' ) }>
 					<MailchimpGroups
 						interests={ interests }
-						onChange={ ( id, checked ) =>
-							setAttributes( { interests: { ...interests, [ id ]: checked } } )
-						}
+						onChange={ ( id, checked ) => {
+							setAttributes( {
+								interests: [ ...new Set( [ ...interests, id ] ) ].filter( item =>
+									item === id && ! checked ? false : item
+								),
+							} );
+						} }
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Merge Fields', 'jetpack' ) }>

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -139,7 +139,8 @@ class MailchimpSubscribeEdit extends Component {
 			successLabel,
 			errorLabel,
 			preview,
-			signupLocation,
+			signupFieldTag,
+			signupFieldValue,
 		} = attributes;
 		const classPrefix = 'wp-block-jetpack-mailchimp_';
 		const waiting = (
@@ -204,14 +205,26 @@ class MailchimpSubscribeEdit extends Component {
 							} );
 						} }
 					/>
+					<ExternalLink href="https://mailchimp.com/help/send-groups-audience/">
+						{ __( 'Learn about groups', 'jetpack' ) }
+					</ExternalLink>
 				</PanelBody>
-				<PanelBody title={ __( 'Merge Fields', 'jetpack' ) }>
+				<PanelBody title={ __( 'Signup Location Tracking', 'jetpack' ) }>
 					<TextControl
-						label={ __( 'Signup Location', 'jetpack' ) }
-						placeholder={ __( 'website' ) }
-						value={ signupLocation }
-						onChange={ value => setAttributes( { signupLocation: value } ) }
+						label={ __( 'Signup Field Tag', 'jetpack' ) }
+						placeholder={ __( 'SIGNUP' ) }
+						value={ signupFieldTag }
+						onChange={ value => setAttributes( { signupFieldTag: value } ) }
 					/>
+					<TextControl
+						label={ __( 'Signup Field Value', 'jetpack' ) }
+						placeholder={ __( 'website' ) }
+						value={ signupFieldValue }
+						onChange={ value => setAttributes( { signupFieldValue: value } ) }
+					/>
+					<ExternalLink href="https://mailchimp.com/help/determine-webpage-signup-location/">
+						{ __( 'Learn about signup location tracking', 'jetpack' ) }
+					</ExternalLink>
 				</PanelBody>
 				<PanelBody title={ __( 'Mailchimp Connection', 'jetpack' ) }>
 					<ExternalLink href={ connectURL }>{ __( 'Manage Connection', 'jetpack' ) }</ExternalLink>

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -59,7 +59,10 @@ export const settings = {
 			type: 'string',
 			default: __( 'Processing…', 'jetpack' ),
 		},
-		signupLocation: {
+		signupFieldTag: {
+			type: 'string',
+		},
+		signupFieldValue: {
 			type: 'string',
 		},
 		successLabel: {

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -52,8 +52,8 @@ export const settings = {
 			),
 		},
 		interests: {
-			type: 'object',
-			default: {},
+			type: 'array',
+			default: [],
 		},
 		processingLabel: {
 			type: 'string',

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -51,9 +51,16 @@ export const settings = {
 				'jetpack'
 			),
 		},
+		interests: {
+			type: 'object',
+			default: {},
+		},
 		processingLabel: {
 			type: 'string',
 			default: __( 'Processing…', 'jetpack' ),
+		},
+		signupLocation: {
+			type: 'string',
 		},
 		successLabel: {
 			type: 'string',

--- a/extensions/blocks/mailchimp/mailchimp-groups.js
+++ b/extensions/blocks/mailchimp/mailchimp-groups.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { CheckboxControl } from '@wordpress/components';
+import { Fragment, Component } from '@wordpress/element';
+
+class MailchimpGroups extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			groups: [],
+		};
+	}
+	componentDidMount() {
+		this.retrieveGroups();
+	}
+	retrieveGroups = () => {
+		const args = {
+			method: 'GET',
+			path: '/wpcom/v2/mailchimp/groups',
+		};
+		apiFetch( args ).then( response => {
+			const { interest_categories } = response;
+			this.setState( { interest_categories } );
+		} );
+	};
+	render = () => {
+		const { interest_categories } = this.state;
+		const { interests, onChange } = this.props;
+		return ( interest_categories || [] ).map( interest_category => (
+			<Fragment>
+				<h1>{ interest_category.title }</h1>
+				{ interest_category.interests.map( interest => (
+					<CheckboxControl
+						label={ interest.name }
+						value={ interest.id }
+						checked={ interests[ interest.id ] }
+						onChange={ checked => onChange( interest.id, checked ) }
+					/>
+				) ) }
+			</Fragment>
+		) );
+	};
+}
+
+export default MailchimpGroups;
+
+MailchimpGroups.defaultProps = {
+	interests: {},
+	onChange: () => null,
+};

--- a/extensions/blocks/mailchimp/mailchimp-groups.js
+++ b/extensions/blocks/mailchimp/mailchimp-groups.js
@@ -33,7 +33,7 @@ class MailchimpGroups extends Component {
 							<CheckboxControl
 								label={ interest.name }
 								value={ interest.id }
-								checked={ interests.indexOf( interest.id ) > -1 }
+								checked={ interests.includes( interest.id ) }
 								onChange={ checked => onChange( interest.id, checked ) }
 								key={ interest.id }
 							/>

--- a/extensions/blocks/mailchimp/mailchimp-groups.js
+++ b/extensions/blocks/mailchimp/mailchimp-groups.js
@@ -6,12 +6,9 @@ import { CheckboxControl } from '@wordpress/components';
 import { Fragment, Component } from '@wordpress/element';
 
 class MailchimpGroups extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			groups: [],
-		};
-	}
+	state = {
+		interest_categories: [],
+	};
 	componentDidMount() {
 		this.retrieveGroups();
 	}

--- a/extensions/blocks/mailchimp/mailchimp-groups.js
+++ b/extensions/blocks/mailchimp/mailchimp-groups.js
@@ -28,19 +28,21 @@ class MailchimpGroups extends Component {
 	render = () => {
 		const { interest_categories } = this.state;
 		const { interests, onChange } = this.props;
-		return ( interest_categories || [] ).map( interest_category => (
+		return (
 			<Fragment>
 				{ interest_categories &&
-					interest_category.interests.map( interest => (
-						<CheckboxControl
-							label={ interest.name }
-							value={ interest.id }
-							checked={ interests.indexOf( interest.id ) > -1 }
-							onChange={ checked => onChange( interest.id, checked ) }
-						/>
-					) ) }
+					( interest_categories || [] ).map( interest_category =>
+						interest_category.interests.map( interest => (
+							<CheckboxControl
+								label={ interest.name }
+								value={ interest.id }
+								checked={ interests.indexOf( interest.id ) > -1 }
+								onChange={ checked => onChange( interest.id, checked ) }
+							/>
+						) )
+					) }
 			</Fragment>
-		) );
+		);
 	};
 }
 

--- a/extensions/blocks/mailchimp/mailchimp-groups.js
+++ b/extensions/blocks/mailchimp/mailchimp-groups.js
@@ -38,6 +38,7 @@ class MailchimpGroups extends Component {
 								value={ interest.id }
 								checked={ interests.indexOf( interest.id ) > -1 }
 								onChange={ checked => onChange( interest.id, checked ) }
+								key={ interest.id }
 							/>
 						) )
 					) }

--- a/extensions/blocks/mailchimp/mailchimp-groups.js
+++ b/extensions/blocks/mailchimp/mailchimp-groups.js
@@ -30,15 +30,15 @@ class MailchimpGroups extends Component {
 		const { interests, onChange } = this.props;
 		return ( interest_categories || [] ).map( interest_category => (
 			<Fragment>
-				<h1>{ interest_category.title }</h1>
-				{ interest_category.interests.map( interest => (
-					<CheckboxControl
-						label={ interest.name }
-						value={ interest.id }
-						checked={ interests[ interest.id ] }
-						onChange={ checked => onChange( interest.id, checked ) }
-					/>
-				) ) }
+				{ interest_categories &&
+					interest_category.interests.map( interest => (
+						<CheckboxControl
+							label={ interest.name }
+							value={ interest.id }
+							checked={ interests.indexOf( interest.id ) > -1 }
+							onChange={ checked => onChange( interest.id, checked ) }
+						/>
+					) ) }
 			</Fragment>
 		) );
 	};
@@ -47,6 +47,6 @@ class MailchimpGroups extends Component {
 export default MailchimpGroups;
 
 MailchimpGroups.defaultProps = {
-	interests: {},
+	interests: [],
 	onChange: () => null,
 };

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -41,6 +41,8 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 		'processingLabel'  => esc_html__( 'Processing…', 'jetpack' ),
 		'successLabel'     => esc_html__( 'Success! You\'re on the list.', 'jetpack' ),
 		'errorLabel'       => esc_html__( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
+		'interests'        => [],
+		'signupLocation'   => '',
 	);
 	foreach ( $defaults as $id => $default ) {
 		$values[ $id ] = isset( $attr[ $id ] ) ? $attr[ $id ] : $default;
@@ -97,6 +99,20 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						name="email"
 					/>
 				</p>
+				<?php foreach ( array_keys( $values['interests'] ) as $interest ) : ?>
+					<input
+						name="interests[<?php echo esc_attr( $interest ); ?>]"
+						type="hidden"
+						value=1
+					/>
+				<?php endforeach; ?>
+				<?php if ( $values['signupLocation'] ) : ?>
+					<input
+						name="merge_fields[signupLocation]"
+						type="hidden"
+						value="<?php echo esc_attr( $values['signupLocation'] ); ?>"
+					/>
+				<?php endif; ?>
 				<p>
 					<button type="submit" class="components-button is-button is-primary" style="<?php echo esc_attr( $button_styles ); ?>">
 						<?php echo wp_kses_post( $values['submitButtonText'] ); ?>

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -42,7 +42,8 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 		'successLabel'     => esc_html__( 'Success! You\'re on the list.', 'jetpack' ),
 		'errorLabel'       => esc_html__( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
 		'interests'        => array(),
-		'signupLocation'   => '',
+		'signupFieldTag'   => '',
+		'signupFieldValue' => '',
 	);
 	foreach ( $defaults as $id => $default ) {
 		$values[ $id ] = isset( $attr[ $id ] ) ? $attr[ $id ] : $default;
@@ -110,12 +111,12 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						value=1
 					/>
 				<?php endforeach; ?>
-				<?php if ( $values['signupLocation'] ) : ?>
+				<?php if ( $values['signupFieldTag'] && strlen( $values['signupFieldTag'] ) && $values['signupFieldValue'] && strlen( $values['signupFieldValue'] ) ) : ?>
 					<input
-						name="merge_fields[SIGNUP]"
+						name="merge_fields[<?php echo esc_attr( $values['signupFieldTag'] ); ?>]"
 						type="hidden"
 						class="mc-submit-param"
-						value="<?php echo esc_attr( $values['signupLocation'] ); ?>"
+						value="<?php echo esc_attr( $values['signupFieldValue'] ); ?>"
 					/>
 				<?php endif; ?>
 				<p>

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -41,7 +41,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 		'processingLabel'  => esc_html__( 'Processing…', 'jetpack' ),
 		'successLabel'     => esc_html__( 'Success! You\'re on the list.', 'jetpack' ),
 		'errorLabel'       => esc_html__( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
-		'interests'        => [],
+		'interests'        => array(),
 		'signupLocation'   => '',
 	);
 	foreach ( $defaults as $id => $default ) {

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -99,17 +99,19 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						name="email"
 					/>
 				</p>
-				<?php foreach ( array_keys( $values['interests'] ) as $interest ) : ?>
+				<?php foreach ( $values['interests'] as $interest ) : ?>
 					<input
 						name="interests[<?php echo esc_attr( $interest ); ?>]"
 						type="hidden"
+						class="mc-submit-param"
 						value=1
 					/>
 				<?php endforeach; ?>
 				<?php if ( $values['signupLocation'] ) : ?>
 					<input
-						name="merge_fields[signupLocation]"
+						name="merge_fields[SIGNUP]"
 						type="hidden"
+						class="mc-submit-param"
 						value="<?php echo esc_attr( $values['signupLocation'] ); ?>"
 					/>
 				<?php endif; ?>

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -87,6 +87,9 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 					method="post"
 					id="mailchimp_form"
 					target="_top"
+					<?php if ( $is_amp_request ) : ?>
+					on="submit-success:AMP.setState( { mailing_list_status: 'subscribed', mailing_list_email: event.response.email } )"
+					<?php endif; ?>
 				<?php endif; ?>
 			>
 				<p>

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -111,7 +111,12 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						value="1"
 					/>
 				<?php endforeach; ?>
-				<?php if ( $values['signupFieldTag'] && strlen( $values['signupFieldTag'] ) && $values['signupFieldValue'] && strlen( $values['signupFieldValue'] ) ) : ?>
+				<?php
+				if (
+					! empty( $values['signupFieldTag'] )
+					&& ! empty( $values['signupFieldValue'] )
+					) :
+					?>
 					<input
 						name="merge_fields[<?php echo esc_attr( $values['signupFieldTag'] ); ?>]"
 						type="hidden"

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -108,7 +108,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						name="interests[<?php echo esc_attr( $interest ); ?>]"
 						type="hidden"
 						class="mc-submit-param"
-						value=1
+						value="1"
 					/>
 				<?php endforeach; ?>
 				<?php if ( $values['signupFieldTag'] && strlen( $values['signupFieldTag'] ) && $values['signupFieldValue'] && strlen( $values['signupFieldValue'] ) ) : ?>

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -102,7 +102,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 						name="email"
 					/>
 				</p>
-				<?php foreach ( $values['interests'] as $interest ) : ?>
+				<?php foreach ( is_array( $values['interests'] ) ? $values['interests'] : array() as $interest ) : ?>
 					<input
 						name="interests[<?php echo esc_attr( $interest ); ?>]"
 						type="hidden"

--- a/extensions/blocks/mailchimp/view.js
+++ b/extensions/blocks/mailchimp/view.js
@@ -23,7 +23,7 @@ function fetchSubscription( blogId, email, params ) {
 		encodeURIComponent( email );
 
 	for ( const param in params ) {
-		url += '&' + param + '=' + params[ param ];
+		url += '&' + encodeURIComponent( param ) + '=' + encodeURIComponent( params[ param ] );
 	}
 	return new Promise( function( resolve, reject ) {
 		const xhr = new XMLHttpRequest();

--- a/extensions/blocks/mailchimp/view.js
+++ b/extensions/blocks/mailchimp/view.js
@@ -15,12 +15,16 @@ import './view.scss';
 
 const blockClassName = 'wp-block-jetpack-mailchimp';
 
-function fetchSubscription( blogId, email ) {
-	const url =
+function fetchSubscription( blogId, email, params ) {
+	let url =
 		'https://public-api.wordpress.com/rest/v1.1/sites/' +
 		encodeURIComponent( blogId ) +
 		'/email_follow/subscribe?email=' +
 		encodeURIComponent( email );
+
+	for ( const param in params ) {
+		url += '&' + param + '=' + params[ param ];
+	}
 	return new Promise( function( resolve, reject ) {
 		const xhr = new XMLHttpRequest();
 		xhr.open( 'GET', url );
@@ -45,7 +49,10 @@ function activateSubscription( block, blogId ) {
 	const successEl = block.querySelector( '.' + blockClassName + '_success' );
 	form.addEventListener( 'submit', e => {
 		e.preventDefault();
-		const emailField = form.querySelector( 'input' );
+		const emailField = form.querySelector( 'input[name=email]' );
+		const params = [].slice
+			.call( form.querySelectorAll( 'input[type=hidden].mc-submit-param' ) )
+			.reduce( ( accumulator, node ) => ( { ...accumulator, [ node.name ]: node.value } ), {} );
 		emailField.classList.remove( errorClass );
 		const email = emailField.value;
 		if ( ! emailValidator.validate( email ) ) {
@@ -54,7 +61,7 @@ function activateSubscription( block, blogId ) {
 		}
 		block.classList.add( 'is-processing' );
 		processingEl.classList.add( 'is-visible' );
-		fetchSubscription( blogId, email ).then(
+		fetchSubscription( blogId, email, params ).then(
 			response => {
 				processingEl.classList.remove( 'is-visible' );
 				if ( response.error && response.error !== 'member_exists' ) {


### PR DESCRIPTION
Introduces a few new features to the Mailchimp block:

* Support for Audience Groups. These allow subscribers to be grouped based on their interests, which allows for superior communication and segmentation. Mailchimp charges by the subscriber, so it's more cost effective to maintain one list with multiple groups as opposed to creating separate groups for topics. Also, the WPCOM Mailchimp implementation currently supports only one list per site.
* Support for a SIGNUP merge field which is used to know where a subscriber came from.
* AMP State. After a successful signup AMP state will be updated. This is needed by the [Newspack Pop-ups](https://github.com/Automattic/newspack-popups) block, to enable the logic that suppresses pop-ups if the current user has already subscribed.

#### Preparation

* This PR must be tested with `D35074-code`.
* You will need a WPCOM sandbox sandboxed for Jetpack development, since this PR uses `Client::wpcom_json_api_request_as_blog()`
* You will need a  Mailchimp account.
* Local Jetpack instance will need to have the [AMP plugin](https://github.com/ampproject/amp-wp) installed and in Transitional Mode. 
* Testing site will need a secure public URL. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Discussion here: `p1HpG7-7WS-p2`

#### Testing instructions:

* Create a Mailchimp account (if you don't have one already).
* Create a List, and add some Groups. Documentation here: https://mailchimp.com/help/send-groups-audience/
* **[UPDATED 11.20]** Set up a `SIGNUP` field following the instructions [here](https://mailchimp.com/help/determine-webpage-signup-location/). The name of the field must be "SIGNUP"
* Apply D35074-code to WPCOM Sandbox, and be sure `JETPACK__SANDBOX_DOMAIN` is configured for Jetpack development.
* Add Mailchimp block to a  post, follow flow to connect the Mailchimp account and select the correct list.
* In the Mailchimp block sidebar, verify you see  a "Mailchimp Groups" pane with a checkbox for every group created in Mailchimp dashboard.
* In Mailchimp block sidebar verify there is a "Merge Fields" pane with a single "Signup Location" field.
* In "Mailchimp Groups" select one or more groups.
* Set Signup location to an arbitrary value, e.g. "My Blog"
* Publish the post and view the published page. 
* In a non-AMP request, subscribe. Verify the email appears on the list in the Mailchimp dashboard and that it is in the correct  groups and has the correct SIGNUP value. 
* In an AMP request (append `?amp` to the URL), subscribe. Verify the email appears on the list in the Mailchimp dashboard and that it is in the correct  groups and has the correct SIGNUP value. 
* To verify the AMP state elements, append `?amp#development=1` to the end of the URL and reload. In the console you should be able to execute `AMP.printState()` and get a valid response. Subscribe with a new email address. After success, execute `AMP.printState()` again. Verify the state contains `mailing_list_status: "subscribed"` and `mailing_list_email: {SUBSCRIBED_EMAIL_ADDRESS}`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Support for Mailchimp Audience Groups.
* Support for Mailchimp SIGNUP merge field.
