### PR TITLE
Migrate to Jetpack the [instagram] shortcode AMP handling

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -267,8 +267,7 @@ function jetpack_shortcode_instagram( $atts ) {
 		preg_match( $url_pattern, $atts['url'], $matches );
 		if ( ! $matches ) {
 			return sprintf(
-				'<a href="%1$s" class="amp-wp-embed-fallback">%2$s</a>',
-				esc_url( $atts['url'] ),
+				'<a href="%1$s" class="amp-wp-embed-fallback">%1$s</a>',
 				esc_url( $atts['url'] )
 			);
 		}

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -262,6 +262,28 @@ function jetpack_shortcode_instagram( $atts ) {
 		return '';
 	}
 
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$url_pattern = '#http(s?)://(www\.)?instagr(\.am|am\.com)/p/([^/?]+)#i';
+		preg_match( $url_pattern, $atts['url'], $matches );
+		if ( ! $matches ) {
+			return sprintf(
+				'<a href="%1$s" class="amp-wp-embed-fallback">%2$s</a>',
+				esc_url( $atts['url'] ),
+				esc_url( $atts['url'] )
+			);
+		}
+
+		$shortcode_id = end( $matches );
+		$width        = ! empty( $atts['width'] ) ? $atts['width'] : 600;
+		$height       = ! empty( $atts['height'] ) ? $atts['height'] : 600;
+		return sprintf(
+			'<amp-instagram data-shortcode="%1$s" layout="responsive" width="%2$d" height="%3$d" data-captioned></amp-instagram>',
+			esc_attr( $shortcode_id ),
+			absint( $width ),
+			absint( $height )
+		);
+	}
+
 	return $wp_embed->shortcode( $atts, $atts['url'] );
 }
 add_shortcode( 'instagram', 'jetpack_shortcode_instagram' );

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -302,6 +302,11 @@ BODY;
 	 * @param string $expected The expected return value of the function.
 	 */
 	public function test_shortcodes_instagram_amp( $shortcode_content, $expected ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
+			return;
+		}
+
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
 	}

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -243,4 +243,79 @@ BODY;
 			$shortcode_content
 		);
 	}
+
+	/**
+	 * Gets the test data for test_shortcodes_instagram_amp().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_instagram_amp_data() {
+		$shortcode_id      = 'BnMOk_FFsxg';
+		$url_with_id       = 'https://www.instagram.com/p/' . $shortcode_id;
+		$short_url_with_id = 'https://instagr.am/p/' . $shortcode_id;
+		$wrong_url_with_id = 'https://www.twitter.com/p/' . $shortcode_id;
+		$default_dimension = 600;
+
+		return array(
+			'no_attribute'                   => array(
+				'[instagram]',
+				'',
+			),
+			'plain_url'                      => array(
+				'[instagram ' . $url_with_id . ']',
+				'',
+			),
+			'non_instagram_url'              => array(
+				'[instagram url=' . $wrong_url_with_id . ']',
+				'<a href="' . $wrong_url_with_id . '" class="amp-wp-embed-feedback">' . $wrong_url_with_id . '</a>',
+			),
+			'url_value_as_attribute'         => array(
+				'[instagram url=' . $url_with_id . ']',
+				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="' . $default_dimension . '" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+			),
+			'short_url_value_as_attribute'   => array(
+				'[instagram url=' . $short_url_with_id . ']',
+				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="' . $default_dimension . '" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+			),
+			'width_in_attributes'            => array(
+				'[instagram url=' . $url_with_id . ' width=300]',
+				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="300" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+			),
+			'width_and_height_in_attributes' => array(
+				'[instagram url=' . $url_with_id . ' width=300 height="200"]',
+				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="300" height="200" data-captioned></amp-instagram>',
+			),
+			'0_width_in_attributes'          => array(
+				'[instagram url=' . $url_with_id . ' width=0]',
+				'<amp-instagram data-shortcode="'. $shortcode_id .'" layout="responsive" width="' . $default_dimension . '" height="' . $default_dimension . '" data-captioned></amp-instagram>',
+			),
+		);
+	}
+
+	/**
+	 * Test the AMP-compatible [instagram] shortcode on an AMP endpoint.
+	 *
+	 * @dataProvider get_instagram_amp_data
+	 * @since 8.0.0
+	 *
+	 * @param string $shortcode_content The shortcode content, as entered in the editor.
+	 * @param string $expected The expected return value of the function.
+	 */
+	public function test_shortcodes_instagram_amp( $shortcode_content, $expected ) {
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
+	}
+
+	/**
+	 * Test that the AMP [instagram] shortcode logic doesn't run on a non-AMP endpoint.
+	 *
+	 * @dataProvider get_instagram_amp_data
+	 * @since 8.0.0
+	 *
+	 * @param string $shortcode_content The shortcode as entered in the editor.
+	 */
+	public function test_shortcodes_instagram_non_amp( $shortcode_content ) {
+		add_filter( 'jetpack_is_amp_request', '__return_false' );
+		$this->assertNotContains( 'amp-instagram', do_shortcode( $shortcode_content ) );
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -267,7 +267,7 @@ BODY;
 			),
 			'non_instagram_url'              => array(
 				'[instagram url=' . $wrong_url_with_id . ']',
-				'<a href="' . $wrong_url_with_id . '" class="amp-wp-embed-feedback">' . $wrong_url_with_id . '</a>',
+				'<a href="' . $wrong_url_with_id . '" class="amp-wp-embed-fallback">' . $wrong_url_with_id . '</a>',
 			),
 			'url_value_as_attribute'         => array(
 				'[instagram url=' . $url_with_id . ']',


### PR DESCRIPTION
#### Summary

Migrates to Jetpack the [AMP plugin's](https://github.com/ampproject/amp-wp) handling of the Jetpack `[instagram]` shortcode


Fixes https://github.com/ampproject/amp-wp/issues/3309

#### Changes proposed in this Pull Request:
* Migrate `[instagram]` shortcode handling to Jetpack from the AMP plugin

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature for Jetpack, but migrated from the [AMP plugin](https://github.com/ampproject/amp-wp)

#### Testing instructions:
1. Ensure that `wp-config.php` has `define( 'JETPACK_DEV_DEBUG', true);`
2. In `/wp-admin`, in the Jetpack 'Settings' page, and in the 'Writing' tab, ensure this is toggled on:

<img width="818" alt="jetpack-here" src="https://user-images.githubusercontent.com/4063887/67992321-dded6400-fc01-11e9-81ea-9a05716d1eca.png">

3. Fetch this PR's branch
4. Clone the AMP plugin 
```
$ git clone --recursive https://github.com/ampproject/amp-wp.git amp && cd amp
```
5. Fetch this PR of the AMP plugin, which removes the AMP plugin's `[instagram]` shortcode callback: https://github.com/ampproject/amp-wp/pull/3678
6. Do `$ npm install && composer install`
7. Activate the AMP plugin
8. Create a new post with a Shortcode block
9. Add a shortcode, like:
```
[instagram url="https://www.instagram.com/p/B43aaRuhoCj/" width="400" height="450"]
```
10. Preview the front-end of the AMP URL, like by adding `&amp` or `?amp`to the URL, and look at how the Instagram shortcode looks
11. `checkout` the `master` branch of Jetpack, not this PR's branch, and `checkout` the `develop` branch of the AMP plugin
12. Preview the front-end of the AMP URL, and notice how the Instagram shortcode looks
13. Expected: The shortcode should look similar, whether using this PR's branch, or the Jetpack plugin's `master` branch
14. Test more shortcodes [here](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/instagram.php#L7-L8)

#### Proposed changelog entry for your changes:
Migrate AMP handling of `[instagram]` shortcode to Jetpack from the AMP plugin

