### PR TITLE
Migrate the [tweet] shortcode AMP handling to Jetpack

### DIFF
--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -80,6 +80,18 @@ class Jetpack_Tweet {
 			}
 		}
 
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			$initial_width = absint( $attr['width'] );
+			$width         = ! empty( $initial_width ) ? $initial_width : 600;
+			$height        = 480;
+			return sprintf(
+				'<amp-twitter data-tweetid="%1$s" layout="responsive" width="%2$d" height="%3$d"></amp-twitter>',
+				esc_attr( $tweet_id ),
+				absint( $width ),
+				absint( $height )
+			);
+		}
+
 		/*
 		 * Fetch tweet.
 		 *

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -81,9 +81,8 @@ class Jetpack_Tweet {
 		}
 
 		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-			$initial_width = absint( $attr['width'] );
-			$width         = ! empty( $initial_width ) ? $initial_width : 600;
-			$height        = 480;
+			$width  = ! empty( $attr['width'] ) ? $attr['width'] : 600;
+			$height = 480;
 			return sprintf(
 				'<amp-twitter data-tweetid="%1$s" layout="responsive" width="%2$d" height="%3$d"></amp-twitter>',
 				esc_attr( $tweet_id ),

--- a/modules/shortcodes/tweet.php
+++ b/modules/shortcodes/tweet.php
@@ -80,17 +80,6 @@ class Jetpack_Tweet {
 			}
 		}
 
-		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-			$width  = ! empty( $attr['width'] ) ? $attr['width'] : 600;
-			$height = 480;
-			return sprintf(
-				'<amp-twitter data-tweetid="%1$s" layout="responsive" width="%2$d" height="%3$d"></amp-twitter>',
-				esc_attr( $tweet_id ),
-				absint( $width ),
-				absint( $height )
-			);
-		}
-
 		/*
 		 * Fetch tweet.
 		 *
@@ -215,11 +204,22 @@ class Jetpack_Tweet {
 			remove_filter( 'oembed_fetch_url', array( 'Jetpack_Tweet', 'jetpack_tweet_url_extra_args' ), 10 );
 		}
 
-		// Add Twitter widgets.js script to the footer.
-		add_action( 'wp_footer', array( 'Jetpack_Tweet', 'jetpack_tweet_shortcode_script' ) );
-
 		/** This action is documented in modules/widgets/social-media-icons.php */
 		do_action( 'jetpack_bump_stats_extras', 'embeds', 'tweet' );
+
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			$width  = ! empty( $attr['width'] ) ? $attr['width'] : 600;
+			$height = 480;
+			$output = sprintf(
+				'<amp-twitter data-tweetid="%1$s" layout="responsive" width="%2$d" height="%3$d"></amp-twitter>',
+				esc_attr( $tweet_id ),
+				absint( $width ),
+				absint( $height )
+			);
+		} else {
+			// Add Twitter widgets.js script to the footer.
+			add_action( 'wp_footer', array( 'Jetpack_Tweet', 'jetpack_tweet_shortcode_script' ) );
+		}
 
 		return $output;
 	}

--- a/tests/php/modules/shortcodes/test-class.tweet.php
+++ b/tests/php/modules/shortcodes/test-class.tweet.php
@@ -169,4 +169,64 @@ BODY;
 		$this->assertContains( '<blockquote class="twitter-tweet"', $shortcode_content );
 		// Not testing here for actual URL because wp_oembed_get might return a shortened Twitter URL with t.co domain
 	}
+
+	/**
+	 * Gets the test data for test_shortcodes_tweet_amp().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_tweet_amp_data() {
+		$tweet_id       = 95234262;
+		$default_height = 480;
+		$default_width  = 600;
+
+		return array(
+			'no_attributes'         => array(
+				'[tweet]',
+				'<!-- Invalid tweet id -->',
+			),
+			'id_in_attributes'      => array(
+				'[tweet ' . $tweet_id . ']',
+				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="' . $default_width . '" height="' . $default_height .'"></amp-twitter>',
+			),
+			'width_in_attributes'   => array(
+				'[tweet ' . $tweet_id . ' width=300]',
+				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="300" height="' . $default_height .'"></amp-twitter>',
+			),
+			'id_as_part_of_url'     => array(
+				'[tweet https://twitter.com/jetpack/status/' . $tweet_id . ']',
+				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="' . $default_width . '" height="' . $default_height .'"></amp-twitter>',
+			),
+			'id_in_tweet_attribute' => array(
+				'[tweet tweet=' . $tweet_id . ']',
+				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="' . $default_width . '" height="' . $default_height .'"></amp-twitter>',
+			),
+		);
+	}
+
+	/**
+	 * Test the AMP-compatible [tweet] shortcode on an AMP endpoint.
+	 *
+	 * @dataProvider get_tweet_amp_data
+	 *
+	 * @since 8.0.0
+	 *
+	 * @param string $shortcode_content
+	 */
+	public function test_shortcodes_tweet_amp( $shortcode_content, $expected ) {
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
+	}
+
+	/**
+	 * Test that the AMP-compatible [tweet] shortcode logic doesn't run on a non-AMP endpoint.
+	 *
+	 * @dataProvider get_tweet_amp_data
+	 *
+	 * @since 8.0.0
+	 */
+	public function test_shortcodes_tweet_non_amp( $shortcode_content ) {
+		add_filter( 'jetpack_is_amp_request', '__return_false' );
+		$this->assertNotContains( 'amp-twitter', do_shortcode( $shortcode_content ) );
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.tweet.php
+++ b/tests/php/modules/shortcodes/test-class.tweet.php
@@ -218,6 +218,11 @@ BODY;
 	 * @param string $expected The expected return value of the function.
 	 */
 	public function test_shortcodes_tweet_amp( $shortcode_content, $expected ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
+			return;
+		}
+
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
 	}

--- a/tests/php/modules/shortcodes/test-class.tweet.php
+++ b/tests/php/modules/shortcodes/test-class.tweet.php
@@ -193,6 +193,10 @@ BODY;
 				'[tweet ' . $tweet_id . ' width=300]',
 				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="300" height="' . $default_height .'"></amp-twitter>',
 			),
+			'0_width_in_attributes' => array(
+				'[tweet ' . $tweet_id . ' width=0]',
+				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="' . $default_width . '" height="' . $default_height .'"></amp-twitter>',
+			),
 			'id_as_part_of_url'     => array(
 				'[tweet https://twitter.com/jetpack/status/' . $tweet_id . ']',
 				'<amp-twitter data-tweetid="'. $tweet_id .'" layout="responsive" width="' . $default_width . '" height="' . $default_height .'"></amp-twitter>',
@@ -208,10 +212,10 @@ BODY;
 	 * Test the AMP-compatible [tweet] shortcode on an AMP endpoint.
 	 *
 	 * @dataProvider get_tweet_amp_data
-	 *
 	 * @since 8.0.0
 	 *
-	 * @param string $shortcode_content
+	 * @param string $shortcode_content The shortcode, like [tweet 1234].
+	 * @param string $expected The expected return value of the function.
 	 */
 	public function test_shortcodes_tweet_amp( $shortcode_content, $expected ) {
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
@@ -219,11 +223,12 @@ BODY;
 	}
 
 	/**
-	 * Test that the AMP-compatible [tweet] shortcode logic doesn't run on a non-AMP endpoint.
+	 * Test that the AMP [tweet] shortcode logic doesn't run on a non-AMP endpoint.
 	 *
 	 * @dataProvider get_tweet_amp_data
-	 *
 	 * @since 8.0.0
+	 *
+	 * @param string $shortcode_content The shortcode as entered in the editor.
 	 */
 	public function test_shortcodes_tweet_non_amp( $shortcode_content ) {
 		add_filter( 'jetpack_is_amp_request', '__return_false' );


### PR DESCRIPTION
#### Summary

Migrates to Jetpack the [AMP plugin's](https://github.com/ampproject/amp-wp) handling of the Jetpack `[tweet]` shortcode


Fixes https://github.com/ampproject/amp-wp/issues/3309

#### Changes proposed in this Pull Request:
* Migrate `[tweet]` shortcode handling to Jetpack from the AMP plugin

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature for Jetpack, but migrated from the [AMP plugin](https://github.com/ampproject/amp-wp)

#### Testing instructions:
1. Ensure that `wp-config.php` has `define( 'JETPACK_DEV_DEBUG', true);`
2. In `/wp-admin`, in the Jetpack 'Settings' page, and in the 'Writing' tab, ensure 'Compose using shortcodes...' is toggled on:

3. Fetch this PR's branch
4. Clone the AMP plugin 
```
$ git clone --recursive https://github.com/ampproject/amp-wp.git amp && cd amp
```
5. Fetch this PR of the AMP plugin, which removes the AMP plugin's `[tweet]` shortcode callback: https://github.com/ampproject/amp-wp/pull/3678
6. Do `$ npm install && composer install`
7. Activate the AMP plugin
8. Create a new post with a Shortcode block
9. Add a shortcode, [like](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/tweet.php#L13):
```
[tweet https://twitter.com/jack/statuses/20 width="350"]
```
10. Preview the front-end of the AMP URL, like by adding `&amp` or `?amp`to the URL, and look at how the tweet shortcode looks
11. `checkout` the `master` branch of Jetpack, not this PR's branch, and `checkout` the `develop` branch of the AMP plugin
12. Preview the front-end of the AMP URL, and notice how the tweet shortcode looks
13. Expected: The shortcode should look similar, whether using this PR's branch, or the Jetpack plugin's `master` branch
14. Test [more shortcodes](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/tweet.php#L16), like:
```
[tweet 20]
[tweet https://twitter.com/photomatt/status/1191968085093343234]
```

#### Proposed changelog entry for your changes:
Migrate to Jetpack the AMP handling of the `[tweet]` shortcode

