### PR TITLE
Migrate the [dailymotion] shortcode AMP handling to Jetpack

### DIFF
--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -151,6 +151,15 @@ function dailymotion_shortcode( $atts ) {
 		$width = $height / 334 * 425;
 	}
 
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		return sprintf(
+			'<amp-dailymotion data-videoid="%1$s" layout="responsive" width="%2$d" height="%3$d"></amp-dailymotion>',
+			esc_attr( $id ),
+			absint( $width ),
+			absint( $height )
+		);
+	}
+
 	/**
 	 * Let's add parameters if needed.
 	 *

--- a/tests/php/modules/shortcodes/test-class.dailymotion.php
+++ b/tests/php/modules/shortcodes/test-class.dailymotion.php
@@ -3,6 +3,13 @@
 class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 
 	/**
+	 * The global $content_width value.
+	 *
+	 * @var string
+	 */
+	const CONTENT_WIDTH = 600;
+
+	/**
 	 * @author scotchfield
 	 * @covers ::dailymotion_shortcode
 	 * @since 3.2
@@ -139,6 +146,77 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 		$this->assertContains( 'ui-logo=0', $shortcode_content );
 		$this->assertContains( 'ui-start-screen-info=0', $shortcode_content );
 		$this->assertContains( 'ui-theme=dark', $shortcode_content );
+	}
+
+	/**
+	 * Gets the test data for test_shortcodes_dailymotion_amp().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_dailymotion_amp_data() {
+		global $content_width;
+		$content_width = self::CONTENT_WIDTH;
+
+		$id             = 26423151;
+		$default_height = 471;
+
+		return array(
+			'no_attribute'            => array(
+				'[dailymotion]',
+				'<!--Dailymotion error: bad or missing ID-->',
+			),
+			'plain_id'                => array(
+				'[dailymotion ' . $id . ']',
+				'<amp-dailymotion data-videoid="'. $id .'" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height .'"></amp-dailymotion>',
+			),
+			'id_value_as_attribute'   => array(
+				'[dailymotion id=' . $id . ']',
+				'<amp-dailymotion data-videoid="'. $id .'" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height .'"></amp-dailymotion>',
+			),
+			'dailymotion_value'       => array(
+				'[dailymotion=' . $id . ']',
+				'<amp-dailymotion data-videoid="'. $id .'" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height .'"></amp-dailymotion>',
+			),
+			'width_in_attributes'     => array(
+				'[dailymotion ' . $id . ' width=300]',
+				'<amp-dailymotion data-videoid="'. $id .'" layout="responsive" width="300" height="235"></amp-dailymotion>',
+			),
+			'0_width_in_attributes'   => array(
+				'[dailymotion ' . $id . ' width=0]',
+				'<amp-dailymotion data-videoid="'. $id .'" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height .'"></amp-dailymotion>',
+			),
+			'id_as_dailymotion_value' => array(
+				'[dailymotion=' . $id . ']',
+				'<amp-dailymotion data-videoid="'. $id .'" layout="responsive" width="' . self::CONTENT_WIDTH . '" height="' . $default_height .'"></amp-dailymotion>',
+			),
+		);
+	}
+
+	/**
+	 * Test the AMP-compatible [dailymotion] shortcode on an AMP endpoint.
+	 *
+	 * @dataProvider get_dailymotion_amp_data
+	 * @since 8.0.0
+	 *
+	 * @param string $shortcode_content The shortcode, like [dailymotion 1234].
+	 * @param string $expected The expected return value of the function.
+	 */
+	public function test_shortcodes_dailymotion_amp( $shortcode_content, $expected ) {
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
+	}
+
+	/**
+	 * Test that the AMP [dailymotion] shortcode logic doesn't run on a non-AMP endpoint.
+	 *
+	 * @dataProvider get_dailymotion_amp_data
+	 * @since 8.0.0
+	 *
+	 * @param string $shortcode_content The shortcode as entered in the editor.
+	 */
+	public function test_shortcodes_dailymotion_non_amp( $shortcode_content ) {
+		add_filter( 'jetpack_is_amp_request', '__return_false' );
+		$this->assertNotContains( 'amp-dailymotion', do_shortcode( $shortcode_content ) );
 	}
 
 }

--- a/tests/php/modules/shortcodes/test-class.dailymotion.php
+++ b/tests/php/modules/shortcodes/test-class.dailymotion.php
@@ -154,9 +154,6 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 	 * @return array The test data.
 	 */
 	public function get_dailymotion_amp_data() {
-		global $content_width;
-		$content_width = self::CONTENT_WIDTH;
-
 		$id             = 26423151;
 		$default_height = 471;
 
@@ -202,6 +199,9 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 	 * @param string $expected The expected return value of the function.
 	 */
 	public function test_shortcodes_dailymotion_amp( $shortcode_content, $expected ) {
+		global $content_width;
+		$content_width = self::CONTENT_WIDTH;
+
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
 		$this->assertEquals( $expected, do_shortcode( $shortcode_content ) );
 	}

--- a/tests/php/modules/shortcodes/test-class.dailymotion.php
+++ b/tests/php/modules/shortcodes/test-class.dailymotion.php
@@ -199,6 +199,11 @@ class WP_Test_Jetpack_Shortcodes_Dailymotion extends WP_UnitTestCase {
 	 * @param string $expected The expected return value of the function.
 	 */
 	public function test_shortcodes_dailymotion_amp( $shortcode_content, $expected ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
+			return;
+		}
+
 		global $content_width;
 		$content_width = self::CONTENT_WIDTH;
 


### PR DESCRIPTION
#### Summary

Migrates to Jetpack the [AMP plugin's](https://github.com/ampproject/amp-wp) handling of the `[dailymotion]` shortcode

Fixes https://github.com/ampproject/amp-wp/issues/3309

#### Changes proposed in this Pull Request:
* Migrate `[dailymotion]` shortcode handling to Jetpack from the AMP plugin

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature for Jetpack, but migrated from the [AMP plugin](https://github.com/ampproject/amp-wp)

#### Testing instructions:
1. Ensure that `wp-config.php` has `define( 'JETPACK_DEV_DEBUG', true);`
2. In `/wp-admin`, in the Jetpack 'Settings' page, and in the 'Writing' tab, ensure 'Compose using shortcodes...' is toggled on

3. Fetch this PR's branch
4. Clone the AMP plugin 
```
$ git clone --recursive https://github.com/ampproject/amp-wp.git amp && cd amp
```
5. Fetch this PR of the AMP plugin, which removes the AMP plugin's `[dailymotion]` shortcode callback: https://github.com/ampproject/amp-wp/pull/3678
6. Do `$ npm install && composer install`
7. Activate the AMP plugin
8. Create a new post with a Shortcode block
9. Add a shortcode, [like](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/dailymotion.php#L72):
```
[dailymotion id=x8oma9]
```
10. Preview the front-end of the AMP URL, like by adding `&amp` or `?amp`to the URL, and look at how the dailymotion shortcode looks
11. `checkout` the `master` branch of Jetpack, not this PR's branch, and `checkout` the `develop` branch of the AMP plugin
12. Preview the front-end of the AMP URL, and notice how the dailymotion shortcode looks
13. Expected: The shortcode should look similar, whether using this PR's branch, or the Jetpack plugin's `master` branch
14. Test [more shortcodes](https://github.com/Automattic/jetpack/blob/master/modules/shortcodes/dailymotion.php#L72), like:

```
[dailymotion x8oma9 width=400 height=300]
```

#### Proposed changelog entry for your changes:
Migrate to Jetpack the AMP handling of the `[dailymotion]` shortcode

