### PR TITLE
Shortcodes: simplify YouTube AMP fallback link tag generation

### DIFF
--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -353,8 +353,7 @@ function jetpack_amp_youtube_shortcode( $url ) {
 	$video_id = jetpack_get_youtube_id( $url );
 	if ( empty( $video_id ) ) {
 		return sprintf(
-			'<a href="%s" class="amp-wp-embed-fallback">%s</a>',
-			esc_url( $url ),
+			'<a href="%1$s" class="amp-wp-embed-fallback">%1$s</a>',
 			esc_url( $url )
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Simplify YouTube AMP fallback link tag generation. Since we use the link as the anchor, let's simplify this `sprintf`.

#### Testing instructions:

* This should not need too much testing, to be honest.
* If needed, you can refer to #14010 for testing.

#### Proposed changelog entry for your changes:

* None
