### PR TITLE
Related Posts Styles in TwentyTwenty

### DIFF
--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -207,7 +207,17 @@
 	width: 100%;
 }
 
+/**
+ * Blocks
+ */
+
 /* Related Posts Block */
 .jp-related-posts-i2__post li {
 	margin: 0;
+}
+
+/* GIF Block */
+.wp-block-jetpack-gif {
+	/* !important because the gif block styles are loaded in the footer after this file */
+	margin: 1em auto !important;
 }

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -151,10 +151,60 @@
 
 /* Related Posts */
 
+.entry-content #jp-relatedposts {
+	max-width: 120rem;
+	margin: 1em auto;
+	width: calc(100% - 4rem);
+}
+
+@media (min-width: 700px) {
+	.entry-content #jp-relatedposts {
+		width: calc(100% - 8rem);
+	}
+}
+
+#jp-relatedposts .jp-relatedposts-grid {
+	display: flex;
+	flex-grow: 1;
+	flex-basis: 0;
+	justify-content: space-between;
+	box-sizing: border-box;
+}
+
+#jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post,
+#jp-relatedposts .jp-relatedposts-post {
+	width: calc(33% - 2rem);
+	margin-left: 0;
+	margin-right: 0;
+}
+
+@media only screen and (max-width: 640px) {
+	#jp-relatedposts .jp-relatedposts-grid {
+		flex-direction: column;
+	}
+
+	#jp-relatedposts .jp-relatedposts-items .jp-relatedposts-post,
+	#jp-relatedposts .jp-relatedposts-post {
+		width: 100%;
+	}
+}
+
+#jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post  {
+	padding-right: 0;
+}
+
 #jp-relatedposts#jp-relatedposts .jp-relatedposts-items p,
 #jp-relatedposts#jp-relatedposts .jp-relatedposts-items-visual h4.jp-relatedposts-post-title {
 	font-size: inherit;
 	line-height: 1.5;
+}
+
+#jp-relatedposts .jp-relatedposts-items-visual {
+	margin-right: 0;
+}
+
+#jp-relatedposts .jp-relatedposts-items-visual .jp-relatedposts-post img.jp-relatedposts-post-img {
+	width: 100%;
 }
 
 /* Related Posts Block */


### PR DESCRIPTION
This PR supersedes: https://github.com/Automattic/jetpack/pull/14023 
Fixes #14020

#### Changes proposed in this Pull Request:
* Fix related posts module styles in TwentyTwenty, use widths and sizes that are similar to the theme. 
* Fix a bug in the GIF block which impacts the position of that block in TwentyTwenty

#### Testing instructions:

* Enable TwentyTwenty
* Use the GIF block and test the output on the front end of the site
* Create a number of related posts (in the same category)
* Ensure related posts are turned on
* Open one of the posts and test the related post module at the bottom of the site. 

It should look like this:

![Screenshot 2019-11-18 at 16 14 39](https://user-images.githubusercontent.com/411945/69070094-7ddb2800-0a1f-11ea-8410-2fec41215390.png)

I have given it the same width as the footer area below the post, it uses the same widths and sizes provided by the theme. It also behaves more similarly to the inline related posts block (using flexbox rather than floats).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve TwentyTwenty compatibility
