### PR TITLE
WP.com Block Editor: Enqueue missing common styles on the front-end.

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -328,6 +328,10 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueue WP.com block editor common styles.
 	 */
 	public function enqueue_styles() {
+		if ( ! WP_Screen::is_block_editor() && ! has_block( 'core/paragraph' ) ) {
+			return;
+		}
+
 		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 		$version = gmdate( 'Ymd' );
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -328,7 +328,7 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueue WP.com block editor common styles.
 	 */
 	public function enqueue_styles() {
-		if ( ! WP_Screen::is_block_editor() && ! has_block( 'core/paragraph' ) ) {
+		if ( ! WP_Screen::is_block_editor() && ! has_block( 'paragraph' ) ) {
 			return;
 		}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -42,6 +42,8 @@ class Jetpack_WPCOM_Block_Editor {
 
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts' ), 9 );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_styles' ), 9 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_filter( 'mce_external_plugins', array( $this, 'add_tinymce_plugins' ) );
 	}
 
@@ -297,16 +299,6 @@ class Jetpack_WPCOM_Block_Editor {
 			)
 		);
 
-		$src_styles = $debug
-			? '//widgets.wp.com/wpcom-block-editor/common.css?minify=false'
-			: '//widgets.wp.com/wpcom-block-editor/common.min.css';
-		wp_enqueue_style(
-			'wpcom-block-editor-styles',
-			$src_styles,
-			array(),
-			$version
-		);
-
 		if ( $this->is_iframed_block_editor() ) {
 			$src_calypso_iframe_bridge = $debug
 				? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.js?minify=false'
@@ -331,6 +323,24 @@ class Jetpack_WPCOM_Block_Editor {
 				true
 			);
 		}
+	}
+
+	/**
+	 * Enqueue WP.com block editor common styles.
+	 */
+	public function enqueue_styles() {
+		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		$version = gmdate( 'Ymd' );
+
+		$src_styles = $debug
+			? '//widgets.wp.com/wpcom-block-editor/common.css?minify=false'
+			: '//widgets.wp.com/wpcom-block-editor/common.min.css';
+		wp_enqueue_style(
+			'wpcom-block-editor-styles',
+			$src_styles,
+			array(),
+			$version
+		);
 	}
 
 	/**

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -328,7 +328,8 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueue WP.com block editor common styles.
 	 */
 	public function enqueue_styles() {
-		if ( ! WP_Screen::is_block_editor() && ! has_block( 'paragraph' ) ) {
+		$screen = get_current_screen();
+		if ( ! $screen->is_block_editor() && ! has_block( 'paragraph' ) ) {
 			return;
 		}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -328,8 +328,14 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueue WP.com block editor common styles.
 	 */
 	public function enqueue_styles() {
-		$screen = get_current_screen();
-		if ( ! $screen->is_block_editor() && ! has_block( 'paragraph' ) ) {
+		// Enqueue only for the block editor in WP Admin.
+		global $pagenow;
+		if ( is_admin() && ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
+		// Enqueue on the front-end only if justified blocks are present.
+		if ( ! is_admin() && ! $this->has_justified_block() ) {
 			return;
 		}
 
@@ -345,6 +351,24 @@ class Jetpack_WPCOM_Block_Editor {
 			array(),
 			$version
 		);
+	}
+
+	/**
+	 * Determines if the current $post contains a justified paragraph block.
+	 *
+	 * @return boolean true if justified paragraph is found, false otherwise.
+	 */
+	public function has_justified_block() {
+		global $post;
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		};
+
+		if ( ! has_blocks( $post ) ) {
+			return false;
+		}
+
+		return false !== strpos( $post->post_content, '<!-- wp:paragraph {"align":"justify"' );
 	}
 
 	/**

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -42,8 +42,7 @@ class Jetpack_WPCOM_Block_Editor {
 
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts' ), 9 );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_styles' ), 9 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+		add_action( 'enqueue_block_assets', array( $this, 'enqueue_styles' ) );
 		add_filter( 'mce_external_plugins', array( $this, 'add_tinymce_plugins' ) );
 	}
 


### PR DESCRIPTION
Up to now, both the script and styles for the `common` module have been enqueued on the `enqueue_block_editor_assets` hook; this left out necessary styles for justified text from being displayed on the front-end.

This PR splits out the styles from `enqueue_scripts`, and enqueues them for both the editor and the front-end.

_Editor_
<img width="743" alt="Screen Shot 2019-11-18 at 12 48 25 PM" src="https://user-images.githubusercontent.com/349751/69092730-e1eef380-0a01-11ea-93ff-2a91afc300fd.png">

_Front-end_
<img width="696" alt="Screen Shot 2019-11-18 at 12 48 43 PM" src="https://user-images.githubusercontent.com/349751/69092743-e74c3e00-0a01-11ea-819a-4695fba3fa2f.png">


**Testing instructions**
- Switch to this branch.
- Create a new post, add multiple lines of content to a Paragraph block.
- Format the content as "Justify", and verify it formats the content properly in the editor.
- Publish the post, and verify the text is justified on the front-end too.

**Proposed changelog entry**
[BUG] Fixed Justify styling for the WP.com Block Editor.