### PR TITLE
Map Block: Fix the Map Theme selector style in Gutenberg 6.7+

### DIFF
--- a/extensions/blocks/map/map-theme-picker/style.scss
+++ b/extensions/blocks/map/map-theme-picker/style.scss
@@ -1,6 +1,8 @@
 @import '../../../shared/styles/gutenberg-colors.scss';
 
 .component__map-theme-picker__button {
+	.block-editor-block-inspector &,
+	// @todo: .edit-post-settings-sidebar__panel-block selector can be removed when WP 5.4 is the minimum.
 	.edit-post-settings-sidebar__panel-block & {
 		border: 1px solid $light-gray-500;
 		border-radius: 100%;


### PR DESCRIPTION
WordPress/gutenberg#17880 landed in Gutenberg 6.7, which changed a class name that the Map block depended on for the Map Theme selector.

Fixes #14058.

#### Changes proposed in this Pull Request:

Add an additional class selector to the Map Theme CSS, so that it will work with the block editor in WordPress Core, and Gutenberg.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Bug fix.

#### Testing instructions:

* Install and activate the Gutenberg plugin.
* Add a Map block.
* Check that the Map Theme options show the mini preview images.
* Confirm that it appears the same when the Gutenberg plugin is deactivated.

#### Screenshots:

Before

<img width="279" alt="" src="https://user-images.githubusercontent.com/352291/69016806-2b394600-09f6-11ea-9c3e-8b8f9735ca71.png">

After

<img width="279" alt="" src="https://user-images.githubusercontent.com/352291/69016800-12309500-09f6-11ea-9c22-0e71ed51e710.png">

#### Proposed changelog entry for your changes:

* Map Block: Fixed display of the Map Theme selector in Gutenberg 6.7+.