### PR TITLE
Plans Page: Change / to per

### DIFF
--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -81,14 +81,14 @@ export function PlanPriceDisplay( { backupPlanPrices, currencySymbol } ) {
 	const fullRealtimeBackupYearlyCost = realtimeBackupMonthlyPrice * 12;
 
 	const perYearPriceRange = __(
-		'%(currencySymbol)s%(dailyBackupYearlyPrice)s-%(realtimeBackupYearlyPrice)s /year',
+		'%(currencySymbol)s%(dailyBackupYearlyPrice)s-%(realtimeBackupYearlyPrice)s per year',
 		{
 			args: {
 				currencySymbol,
 				dailyBackupYearlyPrice,
 				realtimeBackupYearlyPrice,
 			},
-			comment: 'Shows a range of prices, such as $12-15 /year',
+			comment: 'Shows a range of prices, such as $12-15 per year',
 		}
 	);
 
@@ -127,7 +127,7 @@ function PlanRadioButton( { checked, currencySymbol, onChange, planName, radioVa
 			/>
 			{ planName }
 			<br />
-			{ __( '%(currencySymbol)s%(planPrice)s /year', {
+			{ __( '%(currencySymbol)s%(planPrice)s per year', {
 				args: {
 					currencySymbol: currencySymbol,
 					planPrice: planPrice,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This changes the copy of the Jetpack Backup card on the Plans page to use "per" instead of "/"

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Testing instructions:
1. Go to `/wp-admin/admin.php?page=jetpack#/plans`.
2. Verify that the copy says "per year" instead of "/year" in each price display.

#### Proposed changelog entry for your changes:
* None needed.
