### PR TITLE
Pinterest: make the block available to everyone.

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -8,6 +8,7 @@
 		"mailchimp",
 		"map",
 		"markdown",
+		"pinterest",
 		"publicize",
 		"recurring-payments",
 		"related-posts",
@@ -21,5 +22,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "pinterest", "seo" ]
+	"beta": [ "seo" ]
 }


### PR DESCRIPTION
Follow up from #13905 

#### Changes proposed in this Pull Request:

* Now that the block is in Jetpack in Beta, we may need to move it to the list of Stable blocks before the 8.0 Beta release next Tuesday, and we'll need to commit the matching WordPress.com patch on release day on December 3.

@pento What do you think about this? Is this what you had in mind as well, or did you want the block to stay in Beta for another release?

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Internal reference: pb5gDS-af-p2

#### Testing instructions:

* Go to Posts > Add New on a site connected to WordPres.com and running this branch.
* You should see the Pinterest block in the block picker without the Beta indicator next to it, and you should still see it even if you don't use `JETPACK_BETA_BLOCKS`.

#### Proposed changelog entry for your changes:

* None
