### PR TITLE
Jetpack Backup: Remove outdated copy from My Plan page

### DIFF
--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -748,8 +748,6 @@ class MyPlanBody extends React.Component {
 									{ __( 'Take your site to the next level!' ) }
 								</h3>
 								<ul className="jp-landing__plan-features-list">
-									<li>{ __( 'Get peace of mind with automated backups.' ) }</li>
-									<li>{ __( 'Resolve issues quickly with priority support.' ) }</li>
 									<li>{ __( 'Expand your audience with pro SEO tools.' ) }</li>
 									<li>{ __( 'Customize your social posting schedule.' ) }</li>
 									<li>{ __( 'Monetize your site by running high quality ads.' ) }</li>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Jetpack Backup provides both backups and priority support, so this upgrade prompt shouldn't advertise those features as Jetpack Backup users will already have them.

See:
* p1HpG7-82A-p2#comment-35708
* p1HpG7-82A-p2#comment-35710

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No


#### Testing instructions:
* Go to Dashboard > My Plan
* Under the "Take your site to the next level!" section, verify that the lines referring to backup and priority support are gone.

#### Proposed changelog entry for your changes:
* None needed
