### PR TITLE
Connection Owner Deletion Notice: Fix display bug and sanitize $_REQUEST

### DIFF
--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -183,13 +183,13 @@ class JITM {
 		// Bail if we're not trying to delete connection owner.
 		$user_ids_to_delete = array();
 		if ( isset( $_REQUEST['users'] ) ) {
-			$user_ids_to_delete = $_REQUEST['users'];
+			$user_ids_to_delete = array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['users'] ) );
 		} elseif ( isset( $_REQUEST['user'] ) ) {
-			$user_ids_to_delete[] = $_REQUEST['user'];
+			$user_ids_to_delete[] = sanitize_text_field( wp_unslash( $_REQUEST['user'] ) );
 		}
 
 		// phpcs:enable
-
+		$user_ids_to_delete        = array_map( 'absint', $user_ids_to_delete );
 		$deleting_connection_owner = in_array( $connection_owner_id, (array) $user_ids_to_delete, true );
 		if ( ! $deleting_connection_owner ) {
 			return;


### PR DESCRIPTION
The Connection Owner Deletion notice should display when the connection owner is
about to be deleted, but it doesn't. 

The notice is shown when the connection owner's id is found in the array of user ids that are about to be deleted. However, the arguments to `in_array()` are an integer and an array of strings, and the `in_array()` call uses strict matching. Since the connection owner's id is never found in the array of ids that are about to be deleted, the notice doesn't display. Fix this by converting the user ids in the array from strings to integers.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Convert the elements of the `$user_ids_to_delete` array to ints.
* Santize and unslash the $_REQUEST variable before using it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Install, activate, and connect Jetpack. The first connected user is the connection owner.
2) Create some users. At least one of these users must be an admin. So you'll have at least two admins: the connection owner and at least one secondary admin.
3) Log in as a secondary admin user.
4) Navigate to the Users page.
5) Verify that the Connection Owner Deletion notice displays when you attempt to delete the connection owner in different ways:
    a) Hover over the user name and click Delete. Verify that the notice displays and go back to the Users page.

    b) Check the box next to the connection owner’s user name, select the Delete action in the action dropdown box, and click Apply. Verify that the notice displays and go back to the Users page.

    c) Select multiple users, including the connection owner. Select the Delete action, and click Apply. Verify that the notice displays and go back to the Users page.

6) The warning notice should not display if you aren’t deleting the connection owner, so test these cases with a user that isn't the connection owner:
    a) Hover over the user name and click Delete. Verify that the notice does not display and go back to the Users page.

    b) Check the box next to a user name, select the Delete action in the action dropdown box, and click Apply. Verify that the notice does not display and go back to the Users page.

    c) Select multiple users (do not include the connection owner), select the Delete action, and click Apply. Verify that the notice does not display.


#### Proposed changelog entry for your changes:
* Fix bug that prevents the Connection Owner Deletion notice from displaying
