### PR TITLE
Jetpack Backup: Update AAG scan to work with Jetpack Backup

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -77,7 +77,7 @@ class DashScan extends Component {
 	};
 
 	getVPContent() {
-		const { sitePlan, fetchingSiteData } = this.props;
+		const { sitePlan, planClass, fetchingSiteData } = this.props;
 		const hasSitePlan = false !== sitePlan;
 		const vpData = this.props.vaultPressData;
 		const scanEnabled = get( vpData, [ 'data', 'features', 'security' ], false );
@@ -135,7 +135,6 @@ class DashScan extends Component {
 		const inactiveOrUninstalled = this.props.isVaultPressInstalled
 			? 'pro-inactive'
 			: 'pro-uninstalled';
-		const planClass = getPlanClass( get( sitePlan, 'product_slug', '' ) );
 		const hasPremium = 'is-premium-plan' === planClass;
 		const hasBusiness = 'is-business-plan' === planClass;
 
@@ -159,19 +158,7 @@ class DashScan extends Component {
 				</p>
 			) : null;
 
-		const overrideContent =
-			null === scanContent ? (
-				<JetpackBanner
-					callToAction={ __( 'Upgrade' ) }
-					title={ __( 'Find threats early so we can help fix them fast.' ) }
-					disableHref="false"
-					href={ this.props.upgradeUrl }
-					eventFeature="scan"
-					path="dashboard"
-					plan={ PLAN_JETPACK_PREMIUM }
-					icon="lock"
-				/>
-			) : null;
+		const overrideContent = null === scanContent ? this.getUpgradeBanner() : null;
 
 		return renderCard( {
 			className: 'jp-dash-item__is-inactive',
@@ -179,6 +166,21 @@ class DashScan extends Component {
 			content: [ scanContent ],
 			overrideContent,
 		} );
+	}
+
+	getUpgradeBanner() {
+		return (
+			<JetpackBanner
+				callToAction={ __( 'Upgrade' ) }
+				title={ __( 'Find threats early so we can help fix them fast.' ) }
+				disableHref="false"
+				href={ this.props.upgradeUrl }
+				eventFeature="scan"
+				path="dashboard"
+				plan={ PLAN_JETPACK_PREMIUM }
+				icon="lock"
+			/>
+		);
 	}
 
 	getRewindContent() {
@@ -236,6 +238,13 @@ class DashScan extends Component {
 		return false;
 	}
 
+	getUpgradeContent() {
+		return renderCard( {
+			className: 'jp-dash-item__is-inactive',
+			overrideContent: this.getUpgradeBanner(),
+		} );
+	}
+
 	render() {
 		if ( ! this.props.showBackups ) {
 			return null;
@@ -248,24 +257,41 @@ class DashScan extends Component {
 			} );
 		}
 
+		// If the plan class does not support Scan, prompt an upgrade
+		// Otherwise, use either VaultPress or Rewind to determine what to show
+		let content;
+		if (
+			[
+				'is-free-plan',
+				'is-personal-plan',
+				'is-daily-backup-plan',
+				'is-realtime-backup-plan',
+			].includes( this.props.planClass )
+		) {
+			content = this.getUpgradeContent();
+		} else if ( 'unavailable' === this.props.rewindStatus ) {
+			content = this.getVPContent( this.props.planClass );
+		} else {
+			content = <div className="jp-dash-item">{ this.getRewindContent() }</div>;
+		}
+
 		return (
 			<div>
 				<QueryVaultPressData />
-				{ 'unavailable' === this.props.rewindStatus ? (
-					this.getVPContent()
-				) : (
-					<div className="jp-dash-item">{ this.getRewindContent() }</div>
-				) }
+				{ content }
 			</div>
 		);
 	}
 }
 
 export default connect( state => {
+	const sitePlan = getSitePlan( state );
+
 	return {
 		vaultPressData: getVaultPressData( state ),
 		scanThreats: getVaultPressScanThreatCount( state ),
-		sitePlan: getSitePlan( state ),
+		sitePlan,
+		planClass: getPlanClass( get( sitePlan, 'product_slug', '' ) ),
 		isDevMode: isDevMode( state ),
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		fetchingSiteData: isFetchingSiteData( state ),

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -13,6 +13,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getPlanClass } from 'lib/plans/constants';
 import { getSiteRawUrl, getSiteAdminUrl, getUpgradeUrl } from 'state/initial-state';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
@@ -188,7 +189,10 @@ class ProStatus extends React.Component {
 			hasFree = /jetpack_free*/.test( sitePlan.product_slug ),
 			hasPremium = /jetpack_premium*/.test( sitePlan.product_slug ),
 			hasBackups = get( vpData, [ 'data', 'features', 'backups' ], false ),
-			hasScan = get( vpData, [ 'data', 'features', 'security' ], false );
+			hasScan = get( vpData, [ 'data', 'features', 'security' ], false ),
+			hasJetpackBackup = [ 'is-daily-backup-plan', 'is-realtime-backup-plan' ].includes(
+				this.props.planClass
+			);
 
 		const getStatus = ( feature, active, installed ) => {
 			switch ( feature ) {
@@ -202,7 +206,11 @@ class ProStatus extends React.Component {
 					break;
 
 				case 'scan':
-					if ( this.props.fetchingSiteData || this.props.isFetchingVaultPressData ) {
+					if (
+						this.props.fetchingSiteData ||
+						this.props.isFetchingVaultPressData ||
+						hasJetpackBackup
+					) {
 						return '';
 					}
 					if ( ( hasFree || hasPersonal ) && ! hasScan ) {
@@ -276,6 +284,8 @@ class ProStatus extends React.Component {
 }
 
 export default connect( state => {
+	const sitePlan = getSitePlan( state );
+
 	return {
 		siteRawUrl: getSiteRawUrl( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
@@ -283,7 +293,8 @@ export default connect( state => {
 		getVaultPressData: () => getVaultPressData( state ),
 		getAkismetData: () => getAkismetData( state ),
 		isFetchingVaultPressData: isFetchingVaultPressData( state ),
-		sitePlan: () => getSitePlan( state ),
+		sitePlan: () => sitePlan,
+		planClass: getPlanClass( get( sitePlan, 'product_slug', '' ) ),
 		fetchingPluginsData: isFetchingPluginsData( state ),
 		pluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
 		pluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Jetpack Backup uses Rewind. Previously the AAG Scan card used the Rewind status to determine if scan is working. Because of this, when a site was on a Single Product Jetpack Backup plan Rewind would be active, and thus the Scan card displayed as if the user had Scan when they did not.

This PR updates the Scan AAG card to explicitly check the plan class to determine when the upgrade card needs to be displayed, displaying it whenever the site is on a plan that does not have Xcan (Free, Personal, Free or Personal + Jetpack Backup). Otherwise (Premium, Pro) it keeps to the prior functionality, using either VaultPress or Rewind to determine what to display.

Before:
<img width="437" alt="image" src="https://user-images.githubusercontent.com/42627630/69289015-e1508b80-0bc0-11ea-8d71-a7b88e395271.png">

After:
<img width="442" alt="image" src="https://user-images.githubusercontent.com/42627630/69289041-edd4e400-0bc0-11ea-9f3c-70bf0a3f6738.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:

Testing should verify that the presence or absence of Jetpack Backup does not affect the Scan card, so test each plan type with and without Jetpack Backup Daily and Jetpack Backup Realtime. It is not enough to use the dev tools to change the site plan, as the Scan card looks at the presence of plugins and the Rewind status in addition to the site plan.

Expected behavior regardless of Jetpack Backup purchases:
Free plan: prompts upgrade
Personal plan: prompts upgrade
Premium plan: shows Scan info
Pro plan: shows Scan info

#### Proposed changelog entry for your changes:
* None needed