### PR TITLE
fixed color contrast according to WCAG AA

### DIFF
--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -89,7 +89,7 @@ body.highlander-dark h3.sd-title:before {
 	font-family: "Open Sans", sans-serif;
 	font-weight: normal;
 	border-radius: 3px;
-	color: #545454 !important;
+	color: #656565 !important;
 	background: #f8f8f8;
 	border: 1px solid #cccccc;
 	box-shadow: 0 1px 0 rgba(0,0,0,.08);


### PR DESCRIPTION
Fixes #12866

#### Changes proposed in this Pull Request:

* accessibility fix for social media buttons color contrast

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* fix for existing social media buttons module sharedaddy

#### Testing instructions:

* Open Chrome browser
* Install [aXe](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd) Web accessibility testing extension 
* Go to page with sharedaddy social media buttons
* Open developer tools, go to `aXe` tab, click Analyze
![image](https://user-images.githubusercontent.com/26386660/69319597-0e10ab80-0c72-11ea-9a63-876649024463.png)
* With PR changes applied, there should be no "Elements must have sufficient color contrast" issue in aXe results.

#### Proposed changelog entry for your changes:

* accessibility fix for social media buttons color contrast
