### PR TITLE
Use PricePlan component for displaying prices and fix various CSS issues

### DIFF
--- a/_inc/client/components/plans/plan-price/README.md
+++ b/_inc/client/components/plans/plan-price/README.md
@@ -1,0 +1,45 @@
+PlanPrice Component
+=============
+
+PlanPrice component is a React component used to display plan's price with a currency and a discount, if any.
+It can be used anywhere where a plan's price is required.
+
+If you want to emphasize that a plan's price is discounted, use two `<PlanPrice>` components as below and wrap them in a
+flexbox container.
+
+If you pass an array of two numbers in the `rawPrice` prop, a range of prices will be displayed.
+
+## Usage
+
+```jsx
+import PlanPrice from 'components/plans/plan-price';
+
+export default class extends React.Component {
+	static displayName = 'MyPlanPrice';
+
+	render() {
+		return (
+			<div>
+				<span className="my-plan-price-with-flexbox">
+					<PlanPrice rawPrice={ 99 } original />
+					<PlanPrice rawPrice={ 30 } discounted />
+				</span>
+				<span className="my-plan-price-with-flexbox">
+					<PlanPrice rawPrice={ [ 132.2, 110.4 ] } original />
+					<PlanPrice rawPrice={ [ 99.99, 87 ] } discounted />
+				</span>
+			</div>
+		);
+	}
+}
+```
+
+## Props
+
+| Prop         | Type           | Description                                               |
+| ----         | -------        | -----------                                               |
+| rawPrice     | number / array | Price or price range of the plan                          |
+| original     | bool           | Is the price discounted and this is the original one?     |
+| discounted   | bool           | Is the price discounted and this is the discounted one?   |
+| currencyCode | string         | Currency of the price                                     |
+| className    | string         | If you need to add additional classes                     |

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import classNames from 'classnames';
+import { translate as __ } from 'i18n-calypso';
+import { getCurrencyObject } from '@automattic/format-currency';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export class PlanPrice extends Component {
+	render() {
+		const { currencyCode, rawPrice, original, discounted, className } = this.props;
+
+		if ( ! currencyCode || ! rawPrice ) {
+			return null;
+		}
+
+		// "Normalize" the input price or price range.
+		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
+		if ( rawPriceRange.includes( 0 ) ) {
+			return null;
+		}
+
+		const priceRange = rawPriceRange.map( item => {
+			return {
+				price: getCurrencyObject( item, currencyCode ),
+				raw: item,
+			};
+		} );
+
+		const classes = classNames( 'plan-price', className, {
+			'is-original': original,
+			'is-discounted': discounted,
+		} );
+
+		const renderPriceHtml = priceObj => {
+			return (
+				<>
+					<span className="plan-price__integer">{ priceObj.price.integer }</span>
+					<sup className="plan-price__fraction">
+						{ priceObj.raw - priceObj.price.integer > 0 && priceObj.price.fraction }
+					</sup>
+				</>
+			);
+		};
+
+		const smallerPriceHtml = renderPriceHtml( priceRange[ 0 ] );
+		const higherPriceHtml = priceRange[ 1 ] && renderPriceHtml( priceRange[ 1 ] );
+
+		return (
+			<h4 className={ classes }>
+				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+				{ ! higherPriceHtml && renderPriceHtml( priceRange[ 0 ] ) }
+				{ higherPriceHtml &&
+					__( '{{smallerPrice/}}-{{higherPrice/}}', {
+						components: { smallerPrice: smallerPriceHtml, higherPrice: higherPriceHtml },
+						comment: 'The price range for a particular product',
+					} ) }
+			</h4>
+		);
+	}
+}
+
+export default PlanPrice;
+
+PlanPrice.propTypes = {
+	rawPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+	original: PropTypes.bool,
+	discounted: PropTypes.bool,
+	currencyCode: PropTypes.string,
+	className: PropTypes.string,
+};
+
+PlanPrice.defaultProps = {
+	currencyCode: 'USD',
+	original: false,
+	discounted: false,
+	className: '',
+};

--- a/_inc/client/components/plans/plan-price/style.scss
+++ b/_inc/client/components/plans/plan-price/style.scss
@@ -1,0 +1,56 @@
+@import '../../../scss/variables/_colors.scss';
+
+.plan-price {
+	margin: 0;
+	font-size: 14px;
+	font-weight: 400;
+	color: $gray-text;
+}
+
+.plan-price.is-original {
+	color: $gray-text-min;
+}
+
+.plan-price.is-discounted {
+	color: $gray-text;
+}
+
+.plan-price.is-discounted,
+.plan-price.is-original {
+	position: relative;
+	align-items: stretch;
+	margin-right: 0.25em;
+}
+
+.plan-price.is-original + .plan-price.is-discounted {
+	margin-left: 0.25em;
+}
+
+.plan-price.is-original::before {
+	position: absolute;
+	content: '';
+	left: 0;
+	top: 50%;
+	right: 0;
+	border-top: 2px solid $blue-medium;
+	transform: rotate( -16deg );
+	opacity: 0.9;
+}
+
+.plan-price__currency-symbol,
+.plan-price__fraction {
+	font-size: 14px;
+	vertical-align: baseline;
+}
+
+.plan-price.is-discounted .plan-price__currency-symbol {
+	color: $gray-text;
+}
+
+.plan-price__currency-symbol {
+	color: $gray-text-min;
+}
+
+.plan-price__integer {
+	margin: 0 1px;
+}

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -23,7 +23,7 @@ export function SingleProductBackup( { products, upgradeLinks } ) {
 
 	const priceDaily = get( products, [ 'jetpack_backup_daily', 'cost' ], '' );
 	const priceDailyMonthly = get( products, [ 'jetpack_backup_daily_monthly', 'cost' ], '' );
-	const priceDailyMonthlyPerYear = priceDailyMonthly * 12;
+	const priceDailyMonthlyPerYear = '' === priceDailyMonthly ? '' : priceDailyMonthly * 12;
 	const priceRealtime = get( products, [ 'jetpack_backup_realtime', 'cost' ], '' );
 	const priceRealtimeMonthly = get( products, [ 'jetpack_backup_realtime_monthly', 'cost' ], '' );
 	const priceRealtimeMonthlyPerYear = priceRealtimeMonthly * 12;

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -18,7 +18,7 @@ import './single-product-backup.scss';
 export function SingleProductBackup( { products, upgradeLinks } ) {
 	const [ selectedBackupType, setSelectedBackupType ] = useState( 'real-time' );
 
-	const billingTimeFrame = __( 'per year' );
+	const billingTimeFrame = 'yearly';
 	const currencyCode = get( products, [ 'jetpack_backup_daily', 'currency_code' ], '' );
 
 	const priceDaily = get( products, [ 'jetpack_backup_daily', 'cost' ], '' );
@@ -50,7 +50,7 @@ export function SingleProductBackup( { products, upgradeLinks } ) {
 				{ __( "Just looking for backups? We've got you covered." ) }
 			</h2>
 			<div className="plans-section__single-product">
-				<div className="single-product-backup__accented-card">
+				<div className="single-product-backup__accented-card dops-card">
 					<div className="single-product-backup__accented-card-header">
 						<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
 						<SingleProductBackupPriceGroup
@@ -82,17 +82,31 @@ function SingleProductBackupPriceGroup( {
 	discountedPrice,
 	fullPrice,
 } ) {
-	const isDiscounted = !! discountedPrice;
+	const timeframe = <div className="single-product-backup__price-group-billing-timeframe" />;
+	let price = <PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } />;
 
+	if ( !! discountedPrice ) {
+		price = (
+			<Fragment>
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original />
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
+			</Fragment>
+		);
+	}
 	return (
 		<div className="single-product-backup__price-group">
-			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original={ isDiscounted } />
-			{ isDiscounted && (
-				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
-			) }
-			<div className="single-product-backup__price-group-billing-timeframe">
-				{ billingTimeFrame }
-			</div>
+			{ billingTimeFrame === 'yearly' &&
+				__( '{{price/}} {{timeframe}}per year{{/timeframe}}', {
+					components: { price, timeframe },
+					comment:
+						'Describes how much a product costs. {{price/}} can be a single value or a range of values',
+				} ) }
+			{ billingTimeFrame === 'monthly' &&
+				__( '{{price/}} {{timeframe}}per month{{/timeframe}}', {
+					components: { price, timeframe },
+					comment:
+						'Describes how much a product costs. {{price/}} can be a single value or a range of values',
+				} ) }
 		</div>
 	);
 }

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -26,7 +26,7 @@ export function SingleProductBackup( { products, upgradeLinks } ) {
 	const priceDailyMonthlyPerYear = '' === priceDailyMonthly ? '' : priceDailyMonthly * 12;
 	const priceRealtime = get( products, [ 'jetpack_backup_realtime', 'cost' ], '' );
 	const priceRealtimeMonthly = get( products, [ 'jetpack_backup_realtime_monthly', 'cost' ], '' );
-	const priceRealtimeMonthlyPerYear = priceRealtimeMonthly * 12;
+	const priceRealtimeMonthlyPerYear = '' === priceRealtimeMonthly ? '' : priceRealtimeMonthly * 12;
 
 	const backupOptions = [
 		{

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -3,7 +3,6 @@
  */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { getCurrencyDefaults } from '@automattic/format-currency';
 import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
 
@@ -12,25 +11,37 @@ import { get } from 'lodash';
  */
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
+import PlanPrice from 'components/plans/plan-price';
 
 import './single-product-backup.scss';
 
 export function SingleProductBackup( { products, upgradeLinks } ) {
 	const [ selectedBackupType, setSelectedBackupType ] = useState( 'real-time' );
 
-	const backupPlanPrices = {
-		jetpack_backup_daily: {
-			monthly: get( products, [ 'jetpack_backup_daily_monthly', 'cost' ], '' ),
-			yearly: get( products, [ 'jetpack_backup_daily', 'cost' ], '' ),
-		},
-		jetpack_backup_realtime: {
-			monthly: get( products, [ 'jetpack_backup_realtime_monthly', 'cost' ], '' ),
-			yearly: get( products, [ 'jetpack_backup_realtime', 'cost' ], '' ),
-		},
-	};
+	const billingTimeFrame = __( 'per year' );
+	const currencyCode = get( products, [ 'jetpack_backup_daily', 'currency_code' ], '' );
 
-	const currency_code = get( products, [ 'jetpack_backup_daily', 'currency_code' ], '' );
-	const currencySymbol = getCurrencyDefaults( currency_code ).symbol;
+	const priceDaily = get( products, [ 'jetpack_backup_daily', 'cost' ], '' );
+	const priceDailyMonthly = get( products, [ 'jetpack_backup_daily_monthly', 'cost' ], '' );
+	const priceDailyMonthlyPerYear = priceDailyMonthly * 12;
+	const priceRealtime = get( products, [ 'jetpack_backup_realtime', 'cost' ], '' );
+	const priceRealtimeMonthly = get( products, [ 'jetpack_backup_realtime_monthly', 'cost' ], '' );
+	const priceRealtimeMonthlyPerYear = priceRealtimeMonthly * 12;
+
+	const backupOptions = [
+		{
+			type: 'daily',
+			name: __( 'Daily Backups' ),
+			discountedPrice: priceDaily,
+			fullPrice: priceDailyMonthlyPerYear,
+		},
+		{
+			type: 'real-time',
+			name: __( 'Real-Time Backups' ),
+			discountedPrice: priceRealtime,
+			fullPrice: priceRealtimeMonthlyPerYear,
+		},
+	];
 
 	return (
 		<React.Fragment>
@@ -41,15 +52,19 @@ export function SingleProductBackup( { products, upgradeLinks } ) {
 			<div className="plans-section__single-product">
 				<div className="single-product-backup__accented-card">
 					<div className="single-product-backup__accented-card-header">
-						<SingleProductBackupHeader
-							currencySymbol={ currencySymbol }
-							backupPlanPrices={ backupPlanPrices }
+						<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
+						<SingleProductBackupPriceGroup
+							billingTimeFrame={ billingTimeFrame }
+							currencyCode={ currencyCode }
+							discountedPrice={ [ priceDaily, priceRealtime ] }
+							fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
 						/>
 					</div>
 					<div className="single-product-backup__accented-card-body">
 						<SingleProductBackupBody
-							backupPlanPrices={ backupPlanPrices }
-							currencySymbol={ currencySymbol }
+							billingTimeFrame={ billingTimeFrame }
+							currencyCode={ currencyCode }
+							backupOptions={ backupOptions }
 							selectedBackupType={ selectedBackupType }
 							setSelectedBackupType={ setSelectedBackupType }
 							upgradeLinks={ upgradeLinks }
@@ -61,63 +76,39 @@ export function SingleProductBackup( { products, upgradeLinks } ) {
 	);
 }
 
-function SingleProductBackupHeader( { currencySymbol, backupPlanPrices } ) {
-	return (
-		<div className="single-product-backup__header-container">
-			<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
-			<PlanPriceDisplay currencySymbol={ currencySymbol } backupPlanPrices={ backupPlanPrices } />
-		</div>
-	);
-}
-
-export function PlanPriceDisplay( { backupPlanPrices, currencySymbol } ) {
-	const dailyBackupYearlyPrice = backupPlanPrices.jetpack_backup_daily.yearly;
-	const dailyBackupMonthlyPrice = backupPlanPrices.jetpack_backup_daily.monthly;
-
-	const realtimeBackupYearlyPrice = backupPlanPrices.jetpack_backup_realtime.yearly;
-	const realtimeBackupMonthlyPrice = backupPlanPrices.jetpack_backup_realtime.monthly;
-
-	const fullDailyBackupYearlyCost = dailyBackupMonthlyPrice * 12;
-	const fullRealtimeBackupYearlyCost = realtimeBackupMonthlyPrice * 12;
-
-	const perYearPriceRange = __(
-		'%(currencySymbol)s%(dailyBackupYearlyPrice)s-%(realtimeBackupYearlyPrice)s per year',
-		{
-			args: {
-				currencySymbol,
-				dailyBackupYearlyPrice,
-				realtimeBackupYearlyPrice,
-			},
-			comment: 'Shows a range of prices, such as $12-15 per year',
-		}
-	);
+function SingleProductBackupPriceGroup( {
+	billingTimeFrame,
+	currencyCode,
+	discountedPrice,
+	fullPrice,
+} ) {
+	const isDiscounted = !! discountedPrice;
 
 	return (
-		<div className="single-product-backup__header-price">
-			<div className="discounted-price__container">
-				<div className="discounted-price__slash"></div>
-				<div className="discounted-price__price">
-					{ __( '%(currencySymbol)s%(lowPrice)s-%(highPrice)s', {
-						args: {
-							currencySymbol,
-							lowPrice: fullDailyBackupYearlyCost,
-							highPrice: fullRealtimeBackupYearlyCost,
-						},
-						comment:
-							"Describes how much a plan will cost per year. %(currencySymbol) is the currency symbol of the user's locale (e.g. $). %(planPrice) is the cost of a plan (e.g. 20).",
-					} ) }
-				</div>
-			</div>
-			<div className="plans-price__container">
-				<span className="plans-price__price-range">{ perYearPriceRange }</span>
+		<div className="single-product-backup__price-group">
+			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original={ isDiscounted } />
+			{ isDiscounted && (
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
+			) }
+			<div className="single-product-backup__price-group-billing-timeframe">
+				{ billingTimeFrame }
 			</div>
 		</div>
 	);
 }
 
-function PlanRadioButton( { checked, currencySymbol, onChange, planName, radioValue, planPrice } ) {
+function PlanRadioButton( {
+	checked,
+	billingTimeFrame,
+	currencyCode,
+	discountedPrice,
+	fullPrice,
+	onChange,
+	planName,
+	radioValue,
+} ) {
 	return (
-		<label className="plan-radio-button__label">
+		<label className="plan-radio-button">
 			<input
 				type="radio"
 				className="plan-radio-button__input"
@@ -125,16 +116,15 @@ function PlanRadioButton( { checked, currencySymbol, onChange, planName, radioVa
 				checked={ checked }
 				onChange={ onChange }
 			/>
-			{ planName }
-			<br />
-			{ __( '%(currencySymbol)s%(planPrice)s per year', {
-				args: {
-					currencySymbol: currencySymbol,
-					planPrice: planPrice,
-				},
-				comment:
-					"Describes how much a plan will cost per year. %(currencySymbol) is the currency symbol of the user's locale (e.g. $). %(planPrice) is the cost of a plan (e.g. 20).",
-			} ) }
+			<div className="plan-radio-button__label">
+				<span className="plan-radio-button__title">{ planName }</span>
+				<SingleProductBackupPriceGroup
+					billingTimeFrame={ billingTimeFrame }
+					currencyCode={ currencyCode }
+					discountedPrice={ discountedPrice }
+					fullPrice={ fullPrice }
+				/>
+			</div>
 		</label>
 	);
 }
@@ -142,8 +132,9 @@ function PlanRadioButton( { checked, currencySymbol, onChange, planName, radioVa
 // eslint-disable-next-line no-unused-vars
 class SingleProductBackupBody extends React.Component {
 	static propTypes = {
-		backupPlanPrices: PropTypes.object,
-		currencySymbol: PropTypes.string,
+		backupOptions: PropTypes.array,
+		billingTimeFrame: PropTypes.string,
+		currencyCode: PropTypes.string,
 		setSelectedBackupType: PropTypes.func,
 		selectedBackupType: PropTypes.string,
 		upgradeLinks: PropTypes.object,
@@ -154,25 +145,18 @@ class SingleProductBackupBody extends React.Component {
 	};
 
 	render() {
-		const { currencySymbol, backupPlanPrices, selectedBackupType, upgradeLinks } = this.props;
+		const {
+			backupOptions,
+			billingTimeFrame,
+			currencyCode,
+			selectedBackupType,
+			upgradeLinks,
+		} = this.props;
 
 		const upgradeTitles = {
 			'real-time': __( 'Upgrade to Real-Time Backups' ),
 			daily: __( 'Upgrade to Daily Backups' ),
 		};
-
-		const backupOptions = [
-			{
-				type: 'daily',
-				name: __( 'Daily Backups' ),
-				price: backupPlanPrices.jetpack_backup_daily.yearly,
-			},
-			{
-				type: 'real-time',
-				name: __( 'Real-Time Backups' ),
-				price: backupPlanPrices.jetpack_backup_realtime.yearly,
-			},
-		];
 
 		return (
 			<React.Fragment>
@@ -198,12 +182,14 @@ class SingleProductBackupBody extends React.Component {
 					{ backupOptions.map( option => (
 						<PlanRadioButton
 							key={ option.type }
+							billingTimeFrame={ billingTimeFrame }
 							checked={ option.type === selectedBackupType }
-							currencySymbol={ currencySymbol }
-							planName={ option.name }
-							planPrice={ option.price }
+							currencyCode={ currencyCode }
+							fullPrice={ option.fullPrice }
+							discountedPrice={ option.discountedPrice }
 							onChange={ this.handleSelectedBackupTypeChange }
 							radioValue={ option.type }
+							planName={ option.name }
 						/>
 					) ) }
 				</div>

--- a/_inc/client/plans/single-product-backup.scss
+++ b/_inc/client/plans/single-product-backup.scss
@@ -1,65 +1,54 @@
 @import '../scss/variables/_colors.scss';
 
+// Plan radio button
+.plan-radio-button {
+	display: flex;
+}
+
 .plan-radio-button__label {
 	display: flex;
+	flex-flow: column nowrap;
+	margin-left: 8px;
 }
 
 input[type='radio'].plan-radio-button__input {
-	margin-top: 0px;
+	margin-top: 2px;
 }
 
-.plans-price__container {
-	height: 50px;
-	line-height: 50px;
-	text-align: center;
+.plan-radio-button__title {
+	font-weight: 600;
 }
 
-.plans-price__price-range {
-	display: inline-block;
-	vertical-align: middle;
-	line-height: normal;
+// Single product backup
+.single-product-backup__header-title {
+	margin: 5px 0;
+	font-size: 17px;
 }
 
-.discounted-price__container {
-	position: relative;
-	display: inline-block;
-	line-height: 50px;
-	margin-right: 14px;
-}
-
-.discounted-price__slash {
-	position: relative;
-	width: 100%;
-	height: 0;
-	border-top: 2px solid $blue-medium;
-	transform: rotate( -16deg );
-	top: 27px;
-}
-
-.discounted-price__price {
-	color: #a7aaad;
-}
-
-.single-product-backup__header-price {
+.single-product-backup__price-group {
 	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-content: center;
+	flex-flow: row nowrap;
+	align-items: baseline;
 }
 
 .single-product-backup__options-header {
+	padding-bottom: 8px;
 	font-size: 14px;
+	font-weight: 400;
 	color: $gray-text-min;
-	border-bottom: solid 2px #e6e6e6;
+	border-bottom: solid 1px #e6e6e6;
 }
 
+// Plans section
 .plans-section__header {
+	margin: 24px auto 8px;
 	text-align: center;
 	font-weight: normal;
 	font-size: 22px;
 }
 
 .plans-section__subheader {
+	margin: 8px auto;
 	color: $gray-text-min;
 	text-align: center;
 	font-weight: normal;
@@ -69,44 +58,45 @@ input[type='radio'].plan-radio-button__input {
 .plans-section__single-product {
 	display: flex;
 	justify-content: center;
-	margin-bottom: 10px;
+	margin: 24px auto 40px;
 }
 
-.single-product-backup__header-container {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-content: center;
-}
-
+// Single product backup containers
 .single-product-backup__radio-buttons-container {
 	display: flex;
 	flex-direction: row;
+	justify-content: space-around; // IE11 fallback.
 	justify-content: space-evenly;
 }
 
 .single-product-backup__upgrade-button-container {
 	text-align: center;
-	margin-top: 23px;
-	margin-bottom: 10px;
+	margin-top: 24px;
+	margin-bottom: 16px;
 }
 
+// Accented card
 .single-product-backup__accented-card {
 	max-width: 518px;
-	min-height: 313px;
+	font-size: 14px;
 	background-color: #fff;
 	border: solid 1px #e6e6e6;
 }
 
 .single-product-backup__accented-card-header {
-	padding: 15px;
+	display: flex;
+	flex-flow: row wrap;
+	justify-content: space-between;
+	align-items: center;
+	padding: 10px 16px;
 	border-bottom: solid 2px $blue-medium;
 }
 
-.single-product-backup__header-title {
-	font-size: 17px;
-}
-
 .single-product-backup__accented-card-body {
-	padding: 15px;
+	padding: 16px;
+
+	p {
+		margin-top: 8px;
+		font-size: 14px;
+	}
 }

--- a/_inc/client/plans/single-product-backup.scss
+++ b/_inc/client/plans/single-product-backup.scss
@@ -1,33 +1,51 @@
+@import '../scss/mixin_breakpoint';
 @import '../scss/variables/_colors.scss';
 
 // Plan radio button
 .plan-radio-button {
 	display: flex;
+
+	& + & {
+		margin-top: 16px;
+
+		@include breakpoint( ">660px" ) {
+			margin-top: 0;
+		}
+	}
 }
 
 .plan-radio-button__label {
 	display: flex;
-	flex-flow: column nowrap;
+	flex-flow: row wrap;
+	align-items: center;
+	width: 100%;
 	margin-left: 8px;
+
+	@include breakpoint( ">660px" ) {
+		flex-flow: column nowrap;
+		align-items: flex-start;
+	}
 }
 
 input[type='radio'].plan-radio-button__input {
+	flex: 0 0 auto;
 	margin-top: 2px;
 }
 
 .plan-radio-button__title {
 	font-weight: 600;
+	flex: 1;
 }
 
 // Single product backup
 .single-product-backup__header-title {
-	margin: 5px 0;
+	margin: 5px 20px 5px 0;
 	font-size: 17px;
 }
 
 .single-product-backup__price-group {
 	display: flex;
-	flex-flow: row nowrap;
+	flex-flow: row wrap;
 	align-items: baseline;
 }
 
@@ -64,23 +82,25 @@ input[type='radio'].plan-radio-button__input {
 // Single product backup containers
 .single-product-backup__radio-buttons-container {
 	display: flex;
-	flex-direction: row;
-	justify-content: space-around; // IE11 fallback.
-	justify-content: space-evenly;
+	flex-flow: column nowrap;
+
+	@include breakpoint( ">660px" ) {
+		flex-flow: row wrap;
+		justify-content: space-around; // IE11 fallback.
+		justify-content: space-evenly;
+	}
 }
 
 .single-product-backup__upgrade-button-container {
 	text-align: center;
 	margin-top: 24px;
-	margin-bottom: 16px;
+	margin-bottom: 8px;
 }
 
 // Accented card
 .single-product-backup__accented-card {
 	max-width: 518px;
 	font-size: 14px;
-	background-color: #fff;
-	border: solid 1px #e6e6e6;
 }
 
 .single-product-backup__accented-card-header {
@@ -88,15 +108,17 @@ input[type='radio'].plan-radio-button__input {
 	flex-flow: row wrap;
 	justify-content: space-between;
 	align-items: center;
-	padding: 10px 16px;
+	padding: 8px 16px;
+	margin: -16px -16px 16px;
 	border-bottom: solid 2px $blue-medium;
+
+	@include breakpoint( ">480px" ) {
+		padding: 8px 24px;
+		margin: -24px -24px 24px;
+	}
 }
 
-.single-product-backup__accented-card-body {
-	padding: 16px;
-
-	p {
-		margin-top: 8px;
-		font-size: 14px;
-	}
+.single-product-backup__accented-card-body p {
+	margin-top: 16px;
+	font-size: 14px;
 }

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -196,16 +196,18 @@ $plan-features-sidebar-width: 272px;
 	color: $gray;
  }
 
-.plan-price {
-	padding-top: 15px;
-	padding-bottom: 15px;
-}
+.plan-features {
+	.plan-price {
+		padding-top: 15px;
+		padding-bottom: 15px;
+	}
 
-.plan-price__yearly {
-	color: $gray-dark;
+	.plan-price__yearly {
+		color: $gray-dark;
 
-	abbr {
-		text-underline-position: under;
+		abbr {
+			text-underline-position: under;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
This PR supersedes #14085 

The main purpose of this PR is to fix product price rendering. It adds a simplified version of `PlanPrice` component from Calypso and makes use of it in the `SingleProductBackup` component.

Also, the `SingleProductBackup` component has been cleaned up in a few places. The CSS/appearance of the product card has been improved so that now it matches the designs in Figma more closely.

**Before**
![Screenshot 2019-11-21 at 15 24 53](https://user-images.githubusercontent.com/478735/69346465-1ae1cf00-0c73-11ea-8e4d-42c2640908ef.png)

**After**
![Screenshot 2019-11-21 at 15 14 59](https://user-images.githubusercontent.com/478735/69346422-01d91e00-0c73-11ea-9629-fbc5e59d1856.png)


Fixes n/a

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Migrate `PlanPrice` UI component from Calypso
* Use `PricePlan` component for displaying prices in `SingleProductBackup`
* Clean up `SingleProductBackup`
* Fix various CSS issues in `SingleProductBackup`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin/admin.php?page=jetpack#/plans
* Confirm that the prices/price ranges in Jetpack Backup product card are displayed correctly
* Confirm that the Jetpack Backup product card looks as in the designs in Figma

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Introduce `PlanPrice` UI component.
* Improve `SingleProductBackup` appearance
