### PR TITLE
Add/purchases api endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -217,8 +217,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'jetpack/v4',
 			'/site/purchases',
 			array(
-				'methods' => WP_REST_Server::READABLE,
-				'callback' => array( $site_endpoint, 'get_purchases' ),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $site_endpoint, 'get_purchases' ),
 				'permission_callback' => array( $site_endpoint, 'can_request' ),
 			)
 		);

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -212,6 +212,17 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'permission_callback' => array( $site_endpoint , 'can_request' ),
 		) );
 
+		// Get current site purchases.
+		register_rest_route(
+			'jetpack/v4',
+			'/site/purchases',
+			array(
+				'methods' => WP_REST_Server::READABLE,
+				'callback' => array( $site_endpoint, 'get_purchases' ),
+				'permission_callback' => array( $site_endpoint, 'can_request' ),
+			)
+		);
+
 		// Get current site benefits
 		register_rest_route( 'jetpack/v4', '/site/benefits', array(
 			'methods'             => WP_REST_Server::READABLE,

--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -57,6 +57,47 @@ class Jetpack_Core_API_Site_Endpoint {
 		);
 	}
 
+
+	/**
+	 * Returns the result of `/sites/%s/purchases` endpoint call.
+	 *
+	 * @return array of site purchases.
+	 */
+	public static function get_purchases() {
+		// Make the API request.
+		$request  = sprintf( '/sites/%d/purchases', Jetpack_Options::get_option( 'id' ) );
+		$response = Client::wpcom_json_api_request_as_blog( $request, '1.1' );
+
+		// Bail if there was an error or malformed response.
+		if ( is_wp_error( $response ) || ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return new WP_Error(
+				'failed_to_fetch_data',
+				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		// Decode the results.
+		$results = json_decode( $response['body'], true );
+
+		// Bail if there were no results or purchase details returned.
+		if ( ! is_array( $results ) ) {
+			return new WP_Error(
+				'failed_to_fetch_data',
+				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'code'    => 'success',
+				'message' => esc_html__( 'Site purchases correctly received.', 'jetpack' ),
+				'data'    => wp_remote_retrieve_body( $response ),
+			)
+		);
+	}
+
 	/**
 	 * Check that the current user has permissions to request information about this site.
 	 *


### PR DESCRIPTION
This is the PR that compliments #14088 

It adds a new purchases api endpoint. 

After:
![Screen Shot 2019-11-21 at 5 00 08 PM](https://user-images.githubusercontent.com/115071/69354457-6babf480-0c80-11ea-9177-d5c9e06dbb43.png)


#### Changes proposed in this Pull Request:
* Add a new purchases api endpoint. 

#### Testing instructions:
Check the network settings in your inspector do you get what you would expect? 
