### PR TITLE
Gutenberg extensions: use variable for block bottom margin

### DIFF
--- a/extensions/blocks/contact-info/style.scss
+++ b/extensions/blocks/contact-info/style.scss
@@ -1,3 +1,5 @@
+@import '../../shared/styles/jetpack-variables.scss';
+
 .wp-block-jetpack-contact-info {
-	margin-bottom: 1.5em;
+	margin-bottom: $jetpack-block-margin-bottom;
 }

--- a/extensions/blocks/mailchimp/view.scss
+++ b/extensions/blocks/mailchimp/view.scss
@@ -1,4 +1,5 @@
 @import '../../shared/styles/gutenberg-colors.scss';
+@import '../../shared/styles/jetpack-variables.scss';
 
 .wp-block-jetpack-mailchimp {
 	&.is-processing {
@@ -9,7 +10,7 @@
 
 	.wp-block-jetpack-mailchimp_notification {
 		display: none;
-		margin-bottom: 1.5em;
+		margin-bottom: $jetpack-block-margin-bottom;
 		padding: 0.75em;
 		&.is-visible {
 			display: block;


### PR DESCRIPTION
Just a tiny janitorial to use the variable instead of a fixed value. This will make it easier to update the value consistently across all blocks.

#### Changes proposed in this Pull Request:
* Use `$jetpack-block-margin-bottom` SASS variable for bottom margin for two blocks that were using fixed value.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- janitorial update

#### Testing instructions:
- Confirm that MailChimp and Contact info block have the same bottom margin as they always had

#### Proposed changelog entry for your changes:
*
