### PR TITLE
Add support for loading placeholder/skeleton to single product card

### DIFF
--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -20,6 +20,7 @@ export class Plans extends React.Component {
 	render() {
 		const { dailyBackupUpgradeUrl, products, realtimeBackupUpgradeUrl } = this.props;
 
+		const plan = get( this.props.sitePlan, 'product_slug' );
 		const upgradeLinks = {
 			daily: dailyBackupUpgradeUrl,
 			'real-time': realtimeBackupUpgradeUrl,
@@ -29,9 +30,7 @@ export class Plans extends React.Component {
 			<React.Fragment>
 				<QueryProducts />
 				<QuerySite />
-				{ products && 'jetpack_free' === get( this.props.sitePlan, 'product_slug' ) && (
-					<SingleProductBackup products={ products } upgradeLinks={ upgradeLinks } />
-				) }
+				<SingleProductBackup plan={ plan } products={ products } upgradeLinks={ upgradeLinks } />
 				<PlanGrid />
 			</React.Fragment>
 		);

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -13,8 +13,8 @@ import { SingleProductBackup } from './single-product-backup';
 import QueryProducts from 'components/data/query-products';
 import QuerySite from 'components/data/query-site';
 import { getUpgradeUrl } from 'state/initial-state';
-import { getSitePlan, isFetchingSiteData, isFetchingProducts } from 'state/site';
-import { getProducts } from 'state/products';
+import { getSitePlan, isFetchingSiteData } from 'state/site';
+import { getProducts, isFetchingProducts } from 'state/products';
 
 export class Plans extends React.Component {
 	render() {

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -13,12 +13,17 @@ import { SingleProductBackup } from './single-product-backup';
 import QueryProducts from 'components/data/query-products';
 import QuerySite from 'components/data/query-site';
 import { getUpgradeUrl } from 'state/initial-state';
+import { getSitePlan, isFetchingSiteData, isFetchingProducts } from 'state/site';
 import { getProducts } from 'state/products';
-import { getSitePlan } from 'state/site';
 
 export class Plans extends React.Component {
 	render() {
-		const { dailyBackupUpgradeUrl, products, realtimeBackupUpgradeUrl } = this.props;
+		const {
+			dailyBackupUpgradeUrl,
+			products,
+			realtimeBackupUpgradeUrl,
+			isFetchingData,
+		} = this.props;
 
 		const plan = get( this.props.sitePlan, 'product_slug' );
 		const upgradeLinks = {
@@ -30,7 +35,12 @@ export class Plans extends React.Component {
 			<React.Fragment>
 				<QueryProducts />
 				<QuerySite />
-				<SingleProductBackup plan={ plan } products={ products } upgradeLinks={ upgradeLinks } />
+				<SingleProductBackup
+					plan={ plan }
+					products={ products }
+					upgradeLinks={ upgradeLinks }
+					isFetchingData={ isFetchingData }
+				/>
 				<PlanGrid />
 			</React.Fragment>
 		);
@@ -43,5 +53,6 @@ export default connect( state => {
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
 		sitePlan: getSitePlan( state ),
+		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
 	};
 } )( Plans );

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
-import { get, isEmpty } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,9 +15,9 @@ import PlanPrice from 'components/plans/plan-price';
 
 import './single-product-backup.scss';
 
-export function SingleProductBackup( { plan, products, upgradeLinks } ) {
+export function SingleProductBackup( { plan, products, upgradeLinks, isFetchingData } ) {
 	// Don't show the product card for paid plans.
-	if ( ! isEmpty( products ) && ( plan || 'jetpack_free' !== plan ) ) {
+	if ( ! isFetchingData && 'jetpack_free' !== plan ) {
 		return null;
 	}
 
@@ -28,17 +28,17 @@ export function SingleProductBackup( { plan, products, upgradeLinks } ) {
 				{ __( "Just looking for backups? We've got you covered." ) }
 			</h2>
 			<div className="plans-section__single-product">
-				<SingleProductBackupCard products={ products } upgradeLinks={ upgradeLinks } />
+				{ isFetchingData ? (
+					<div className="plans-section__single-product-skeleton is-placeholder" />
+				) : (
+					<SingleProductBackupCard products={ products } upgradeLinks={ upgradeLinks } />
+				) }
 			</div>
 		</React.Fragment>
 	);
 }
 
 function SingleProductBackupCard( { products, upgradeLinks } ) {
-	if ( isEmpty( products ) ) {
-		return <div className="plans-section__single-product-skeleton is-placeholder" />;
-	}
-
 	const [ selectedBackupType, setSelectedBackupType ] = useState( 'real-time' );
 	const billingTimeFrame = 'yearly';
 	const currencyCode = get( products, [ 'jetpack_backup_daily', 'currency_code' ], '' );

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,12 +15,33 @@ import PlanPrice from 'components/plans/plan-price';
 
 import './single-product-backup.scss';
 
-export function SingleProductBackup( { products, upgradeLinks } ) {
-	const [ selectedBackupType, setSelectedBackupType ] = useState( 'real-time' );
+export function SingleProductBackup( { plan, products, upgradeLinks } ) {
+	// Don't show the product card for paid plans.
+	if ( ! isEmpty( products ) && ( plan || 'jetpack_free' !== plan ) ) {
+		return null;
+	}
 
+	return (
+		<React.Fragment>
+			<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+			<h2 className="plans-section__subheader">
+				{ __( "Just looking for backups? We've got you covered." ) }
+			</h2>
+			<div className="plans-section__single-product">
+				<SingleProductBackupCard products={ products } upgradeLinks={ upgradeLinks } />
+			</div>
+		</React.Fragment>
+	);
+}
+
+function SingleProductBackupCard( { products, upgradeLinks } ) {
+	if ( isEmpty( products ) ) {
+		return <div className="plans-section__single-product-skeleton is-placeholder" />;
+	}
+
+	const [ selectedBackupType, setSelectedBackupType ] = useState( 'real-time' );
 	const billingTimeFrame = 'yearly';
 	const currencyCode = get( products, [ 'jetpack_backup_daily', 'currency_code' ], '' );
-
 	const priceDaily = get( products, [ 'jetpack_backup_daily', 'cost' ], '' );
 	const priceDailyMonthly = get( products, [ 'jetpack_backup_daily_monthly', 'cost' ], '' );
 	const priceDailyMonthlyPerYear = '' === priceDailyMonthly ? '' : priceDailyMonthly * 12;
@@ -44,35 +65,27 @@ export function SingleProductBackup( { products, upgradeLinks } ) {
 	];
 
 	return (
-		<React.Fragment>
-			<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
-			<h2 className="plans-section__subheader">
-				{ __( "Just looking for backups? We've got you covered." ) }
-			</h2>
-			<div className="plans-section__single-product">
-				<div className="single-product-backup__accented-card dops-card">
-					<div className="single-product-backup__accented-card-header">
-						<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
-						<SingleProductBackupPriceGroup
-							billingTimeFrame={ billingTimeFrame }
-							currencyCode={ currencyCode }
-							discountedPrice={ [ priceDaily, priceRealtime ] }
-							fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
-						/>
-					</div>
-					<div className="single-product-backup__accented-card-body">
-						<SingleProductBackupBody
-							billingTimeFrame={ billingTimeFrame }
-							currencyCode={ currencyCode }
-							backupOptions={ backupOptions }
-							selectedBackupType={ selectedBackupType }
-							setSelectedBackupType={ setSelectedBackupType }
-							upgradeLinks={ upgradeLinks }
-						/>
-					</div>
-				</div>
+		<div className="single-product-backup__accented-card dops-card">
+			<div className="single-product-backup__accented-card-header">
+				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
+				<SingleProductBackupPriceGroup
+					billingTimeFrame={ billingTimeFrame }
+					currencyCode={ currencyCode }
+					discountedPrice={ [ priceDaily, priceRealtime ] }
+					fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
+				/>
 			</div>
-		</React.Fragment>
+			<div className="single-product-backup__accented-card-body">
+				<SingleProductBackupBody
+					billingTimeFrame={ billingTimeFrame }
+					currencyCode={ currencyCode }
+					backupOptions={ backupOptions }
+					selectedBackupType={ selectedBackupType }
+					setSelectedBackupType={ setSelectedBackupType }
+					upgradeLinks={ upgradeLinks }
+				/>
+			</div>
+		</div>
 	);
 }
 
@@ -87,10 +100,10 @@ function SingleProductBackupPriceGroup( {
 
 	if ( !! discountedPrice ) {
 		price = (
-			<Fragment>
+			<React.Fragment>
 				<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original />
 				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
-			</Fragment>
+			</React.Fragment>
 		);
 	}
 	return (

--- a/_inc/client/plans/single-product-backup.scss
+++ b/_inc/client/plans/single-product-backup.scss
@@ -79,6 +79,12 @@ input[type='radio'].plan-radio-button__input {
 	margin: 24px auto 40px;
 }
 
+.plans-section__single-product-skeleton {
+	width: 100%;
+	max-width: 518px;
+	height: 328px;
+}
+
 // Single product backup containers
 .single-product-backup__radio-buttons-container {
 	display: flex;

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -112,9 +112,9 @@ export const reducer = combineReducers( {
  */
 export function isFetchingSiteData( state ) {
 	return !! (
-		state.jetpack.siteData.requests.isFetchingSiteData &&
-		state.jetpack.siteData.requests.isFetchingSiteFeatures &&
-		state.jetpack.siteData.requests.isFetchingSitePlans &&
+		state.jetpack.siteData.requests.isFetchingSiteData ||
+		state.jetpack.siteData.requests.isFetchingSiteFeatures ||
+		state.jetpack.siteData.requests.isFetchingSitePlans ||
 		state.jetpack.siteData.requests.isFetchingSitePurchases
 	);
 }


### PR DESCRIPTION
![Screen Shot on 2019-11-22 at 10-42-42](https://user-images.githubusercontent.com/478735/69415417-ddce1900-0d14-11ea-999f-fa6a800daa9d.png)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add loading skeleton (placeholder) to the single product card (Jetpack Backup)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin/admin.php?page=jetpack#/plans
* Make sure you're on a Free plan
* Refresh the page and confirm that you see a pulsating rectangle that gets replaced with the product card once the data is fetched
* Purchase one of the Jetpack plans
* Go back to Plans page and confirm that the placeholder is still shown even if the product card is unavailable (this is sub-optimal, though we don't have the information about the user plan early enough)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add loading skeleton (placeholder) to the single product card
