### PR TITLE
Mobile Theme: do not display settings when module is inactive.

### DIFF
--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -37,7 +37,7 @@ export const SettingsGroup = props => {
 	}
 
 	return (
-		<div className="jp-form-settings-group">
+		<div className={ classNames( 'jp-form-settings-group', props.className ) }>
 			<Card
 				className={ classNames( {
 					'jp-form-has-child': props.hasChild,
@@ -61,6 +61,7 @@ SettingsGroup.propTypes = {
 	userCanManageModules: PropTypes.bool.isRequired,
 	isLinked: PropTypes.bool.isRequired,
 	isUnavailableInDevMode: PropTypes.func.isRequired,
+	className: PropTypes.string,
 };
 
 SettingsGroup.defaultProps = {
@@ -72,6 +73,7 @@ SettingsGroup.defaultProps = {
 	userCanManageModules: false,
 	isLinked: false,
 	isUnavailableInDevMode: noop,
+	className: '',
 };
 
 export default connect( state => {

--- a/_inc/client/settings/style.scss
+++ b/_inc/client/settings/style.scss
@@ -25,3 +25,12 @@
 	box-shadow: none;
 	border: none;
 }
+
+/* Mobile Theme Card */
+.jp-form-settings-group.minileven {
+	&.inactive {
+		p, .form-toggle__label {
+			color: $gray;
+		}
+	}
+}

--- a/_inc/client/settings/style.scss
+++ b/_inc/client/settings/style.scss
@@ -28,9 +28,14 @@
 
 /* Mobile Theme Card */
 .jp-form-settings-group.minileven {
+	.jp-form-settings-notice {
+		margin: 15px 0;
+	}
+
 	&.inactive {
 		p, .form-toggle__label {
 			color: $gray;
+			transition: all 0.75s;
 		}
 	}
 }

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -233,7 +233,11 @@ class ThemeEnhancements extends React.Component {
 						) }
 					>
 						<FormLegend className="jp-form-label-wide">{ __( 'Mobile Theme' ) }</FormLegend>
-						<SimpleNotice showDismiss={ false } status="is-info" className="mobile-deprecation">
+						<SimpleNotice
+							showDismiss={ false }
+							status="is-info"
+							className="jp-form-settings-notice"
+						>
 							{ __(
 								'{{b}}Note:{{/b}} This feature is being discontinued ' +
 									'and will be removed from Jetpack in March. ' +

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -225,6 +225,18 @@ class ThemeEnhancements extends React.Component {
 									'still see your regular theme on other screen sizes.'
 							) }
 						</p>
+						<p>
+							{ __(
+								'{{b}}Note:{{/b}} This feature is being discontinued ' +
+									'and will be removed from Jetpack in a future release. ' +
+									'If you disable this setting, you will not be able to re-activate it.',
+								{
+									components: {
+										b: <strong />,
+									},
+								}
+							) }
+						</p>
 						<ModuleToggle
 							slug={ minileven.module }
 							activated={ isMinilevenActive }

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -18,6 +18,7 @@ import { isModuleFound } from 'state/search';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import SimpleNotice from 'components/notice';
 import ModuleOverriddenBanner from 'components/module-overridden-banner';
 
 class ThemeEnhancements extends React.Component {
@@ -118,6 +119,14 @@ class ThemeEnhancements extends React.Component {
 		return () => this.updateOptions( optionName, module );
 	};
 
+	trackMinilevenLearnMore = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'learn-more',
+			feature: 'minileven',
+			extra: 'deprecated-link',
+		} );
+	};
+
 	render() {
 		const foundInfiniteScroll = this.props.isModuleFound( 'infinite-scroll' ),
 			foundCustomCSS = this.props.isModuleFound( 'custom-css' ),
@@ -205,7 +214,7 @@ class ThemeEnhancements extends React.Component {
 						) }
 					</SettingsGroup>
 				) }
-				{ foundMinileven && isMinilevenActive && (
+				{ foundMinileven && (
 					<SettingsGroup
 						hasChild
 						module={ { module: minileven.module } }
@@ -219,22 +228,32 @@ class ThemeEnhancements extends React.Component {
 						} }
 					>
 						<FormLegend className="jp-form-label-wide">{ __( 'Mobile Theme' ) }</FormLegend>
+						<SimpleNotice showDismiss={ false } status="is-info" className="mobile-deprecation">
+							{ __(
+								'{{b}}Note:{{/b}} This feature is being discontinued ' +
+									'and will be removed from Jetpack in March. ' +
+									'Please ensure your current theme is mobile-ready or find a new one. ' +
+									'{{link}}Learn more{{/link}}',
+								{
+									components: {
+										b: <strong />,
+										link: (
+											<a
+												href="https://jetpack.com/support/mobile-theme/"
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ this.trackMinilevenLearnMore }
+											/>
+										),
+									},
+									context: 'Link leads to a support document.',
+								}
+							) }
+						</SimpleNotice>
 						<p>
 							{ __(
 								'Give your site a fast-loading, streamlined look for mobile devices. Visitors will ' +
 									'still see your regular theme on other screen sizes.'
-							) }
-						</p>
-						<p>
-							{ __(
-								'{{b}}Note:{{/b}} This feature is being discontinued ' +
-									'and will be removed from Jetpack in a future release. ' +
-									'If you disable this setting, you will not be able to re-activate it.',
-								{
-									components: {
-										b: <strong />,
-									},
-								}
 							) }
 						</p>
 						<ModuleToggle
@@ -242,6 +261,7 @@ class ThemeEnhancements extends React.Component {
 							activated={ isMinilevenActive }
 							toggling={ this.props.isSavingAnyOption( minileven.module ) }
 							toggleModule={ this.props.toggleModuleNow }
+							disabled={ ! isMinilevenActive }
 						>
 							<span className="jp-form-toggle-explanation">{ minileven.description }</span>
 						</ModuleToggle>

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import CompactFormToggle from 'components/form/form-toggle/compact';
@@ -226,6 +227,10 @@ class ThemeEnhancements extends React.Component {
 							),
 							link: 'https://jetpack.com/support/mobile-theme',
 						} }
+						className={ classNames(
+							'minileven',
+							`${ isMinilevenActive ? `active` : `inactive` }`
+						) }
 					>
 						<FormLegend className="jp-form-label-wide">{ __( 'Mobile Theme' ) }</FormLegend>
 						<SimpleNotice showDismiss={ false } status="is-info" className="mobile-deprecation">

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -205,7 +205,7 @@ class ThemeEnhancements extends React.Component {
 						) }
 					</SettingsGroup>
 				) }
-				{ foundMinileven && (
+				{ foundMinileven && isMinilevenActive && (
 					<SettingsGroup
 						hasChild
 						module={ { module: minileven.module } }

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -239,9 +239,8 @@ class ThemeEnhancements extends React.Component {
 							className="jp-form-settings-notice"
 						>
 							{ __(
-								'{{b}}Note:{{/b}} This feature is being discontinued ' +
+								'{{b}}Note:{{/b}} This feature is being retired ' +
 									'and will be removed from Jetpack in March. ' +
-									'Please ensure your current theme is mobile-ready or find a new one. ' +
 									'{{link}}Learn more{{/link}}',
 								{
 									components: {

--- a/class.jetpack-modules-list-table.php
+++ b/class.jetpack-modules-list-table.php
@@ -97,7 +97,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
 				if ( item === undefined ) return;
-				if ( 'pwa' == item.module && ! item.activated ) return;
+				if ( 'minileven' == item.module && ! item.activated ) return;
 				if ( 'manage' == item.module && item.activated ) return; #>
 				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">


### PR DESCRIPTION
Fixes #13385
Fixes #7602

Matching Calypso PR: https://github.com/Automattic/wp-calypso/pull/37857

#### Changes proposed in this Pull Request:

This PR comes as a first step to deprecate the Mobile Theme feature. We'll start by hiding Mobile Theme Settings from the Jetpack UI when the feature is not active. Folks that still use the feature can access its settings and disable it. Folks who do not use it cannot turn it on via the UI.

The Mobile theme was developed 8 years ago, back when responsive themes weren't a thing. It isn't as useful today, and can even be harmful when one enables it on their site without realizing the consequences, as outlined in #7602.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Internal references:
    - p1HpG7-84F-p2
    - p6TEKc-3iM-p2
    - p6TEKc-3jj-p2
    - p6TEKc-3l7-p2

#### Testing instructions:

* Run `yarn docker:wp jetpack module activate minileven` to enable the module on your site.
* Go to Jetpack > Settings > Writing.
* Notice that the Mobile Theme settings are there. 
* Note that there is now a mention of the upcoming deprecation in the card.
![image](https://user-images.githubusercontent.com/426388/71005927-cb14ed00-20e4-11ea-88ef-dc8a8f8c21ac.png)
* Disable the feature.
* The settings should turn grey and be disabled.
* The settings should also be gone from the old module list.
* When clicking on the "Learn more" link in the notice, the support doc should open in a new window and you should stop a Tracks event if you add `localStorage.setItem( 'debug', 'dops:analytics' );` to your browser's console.

#### Proposed changelog entry for your changes:

* Mobile Theme: disable settings when feature is inactive.
