### PR TITLE
Jetpack logo in Gutenberg: use correct color variable

### DIFF
--- a/extensions/shared/jetpack-plugin-sidebar.scss
+++ b/extensions/shared/jetpack-plugin-sidebar.scss
@@ -31,7 +31,7 @@
 			}
 
 			.jetpack-logo__icon-circle {
-				fill: var( --color-jetpack ) !important;
+				fill: var( --studio-jetpack-green ) !important;
 			}
 
 			.jetpack-logo__icon-triangle {


### PR DESCRIPTION
Fix broken color in Jetpack logo at Gutenberg sidebar:

<img width="316" alt="Screenshot 2019-11-22 at 13 07 12" src="https://user-images.githubusercontent.com/87168/69421206-1b3ca180-0d29-11ea-9ddf-9f6d125154a4.png">
<img width="309" alt="Screenshot 2019-11-22 at 13 07 07" src="https://user-images.githubusercontent.com/87168/69421207-1b3ca180-0d29-11ea-8377-9957e38644c8.png">

After:


#### Changes proposed in this Pull Request:
* Switch non-existing `--color-jetpack` to `--studio-jetpack-green`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- bugfix

#### Testing instructions:
Open Gutenberg and check that the logo looks good again.

#### Proposed changelog entry for your changes:
*
