### PR TITLE
Plans: Add tracks events on links and buttons in Jetpack Backup

### DIFF
--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -64,36 +64,18 @@ function SingleProductBackupCard( { products, upgradeLinks } ) {
 	];
 
 	return (
-		<React.Fragment>
-			<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
-			<h2 className="plans-section__subheader">
-				{ __( "Just looking for backups? We've got you covered." ) }
-			</h2>
-			<div className="plans-section__single-product">
-				<div className="single-product-backup__accented-card dops-card">
-					<div className="single-product-backup__accented-card-header">
-						<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
-						<SingleProductBackupBodyWithRouter
-							billingTimeFrame={ billingTimeFrame }
-							currencyCode={ currencyCode }
-							discountedPrice={ [ priceDaily, priceRealtime ] }
-							fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
-						/>
-					</div>
-					<div className="single-product-backup__accented-card-body">
-						<SingleProductBackupBodyWithRouter
-							billingTimeFrame={ billingTimeFrame }
-							currencyCode={ currencyCode }
-							backupOptions={ backupOptions }
-							selectedBackupType={ selectedBackupType }
-							setSelectedBackupType={ setSelectedBackupType }
-							upgradeLinks={ upgradeLinks }
-						/>
-					</div>
-				</div>
+		<div className="single-product-backup__accented-card dops-card">
+			<div className="single-product-backup__accented-card-header">
+				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
+				<SingleProductBackupPriceGroup
+					billingTimeFrame={ billingTimeFrame }
+					currencyCode={ currencyCode }
+					discountedPrice={ [ priceDaily, priceRealtime ] }
+					fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
+				/>
 			</div>
 			<div className="single-product-backup__accented-card-body">
-				<SingleProductBackupBody
+				<SingleProductBackupBodyWithRouter
 					billingTimeFrame={ billingTimeFrame }
 					currencyCode={ currencyCode }
 					backupOptions={ backupOptions }
@@ -102,7 +84,7 @@ function SingleProductBackupCard( { products, upgradeLinks } ) {
 					upgradeLinks={ upgradeLinks }
 				/>
 			</div>
-		</React.Fragment>
+		</div>
 	);
 }
 

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -4,7 +4,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
-import { get, startCase } from 'lodash';
+import { get } from 'lodash';
+import { withRouter } from 'react-router';
 
 /**
  * Internal dependencies
@@ -63,15 +64,33 @@ function SingleProductBackupCard( { products, upgradeLinks } ) {
 	];
 
 	return (
-		<div className="single-product-backup__accented-card dops-card">
-			<div className="single-product-backup__accented-card-header">
-				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
-				<SingleProductBackupPriceGroup
-					billingTimeFrame={ billingTimeFrame }
-					currencyCode={ currencyCode }
-					discountedPrice={ [ priceDaily, priceRealtime ] }
-					fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
-				/>
+		<React.Fragment>
+			<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+			<h2 className="plans-section__subheader">
+				{ __( "Just looking for backups? We've got you covered." ) }
+			</h2>
+			<div className="plans-section__single-product">
+				<div className="single-product-backup__accented-card dops-card">
+					<div className="single-product-backup__accented-card-header">
+						<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
+						<SingleProductBackupBodyWithRouter
+							billingTimeFrame={ billingTimeFrame }
+							currencyCode={ currencyCode }
+							discountedPrice={ [ priceDaily, priceRealtime ] }
+							fullPrice={ [ priceDailyMonthlyPerYear, priceRealtimeMonthlyPerYear ] }
+						/>
+					</div>
+					<div className="single-product-backup__accented-card-body">
+						<SingleProductBackupBodyWithRouter
+							billingTimeFrame={ billingTimeFrame }
+							currencyCode={ currencyCode }
+							backupOptions={ backupOptions }
+							selectedBackupType={ selectedBackupType }
+							setSelectedBackupType={ setSelectedBackupType }
+							upgradeLinks={ upgradeLinks }
+						/>
+					</div>
+				</div>
 			</div>
 			<div className="single-product-backup__accented-card-body">
 				<SingleProductBackupBody
@@ -83,7 +102,7 @@ function SingleProductBackupCard( { products, upgradeLinks } ) {
 					upgradeLinks={ upgradeLinks }
 				/>
 			</div>
-		</div>
+		</React.Fragment>
 	);
 }
 
@@ -170,13 +189,11 @@ class SingleProductBackupBody extends React.Component {
 	};
 
 	handleUpgradeButtonClick = selectedBackupType => () => {
-		const page = startCase( window.location.hash.replace( /#\//g, ' ' ).trim() );
-
 		analytics.tracks.recordJetpackClick( {
 			target: `upgrade-${ selectedBackupType }`,
 			type: 'upgrade',
 			product: selectedBackupType,
-			page,
+			page: this.props.routes[ 0 ] && this.props.routes[ 0 ].name,
 		} );
 	};
 
@@ -256,3 +273,5 @@ class SingleProductBackupBody extends React.Component {
 		);
 	}
 }
+
+const SingleProductBackupBodyWithRouter = withRouter( SingleProductBackupBody );

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -177,6 +177,14 @@ class SingleProductBackupBody extends React.Component {
 		} );
 	};
 
+	handleLandingPageLinkClick = selectedBackupType => () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'landing-page-link',
+			feature: 'single-product-backup',
+			extra: selectedBackupType,
+		} );
+	};
+
 	render() {
 		const {
 			backupOptions,
@@ -205,6 +213,7 @@ class SingleProductBackupBody extends React.Component {
 										href="https://jetpack.com/upgrade/backup/"
 										icon
 										iconSize={ 12 }
+										onClick={ this.handleLandingPageLinkClick( selectedBackupType ) }
 									/>
 								),
 							},

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -4,7 +4,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
-import { get } from 'lodash';
+import { get, startCase } from 'lodash';
 
 /**
  * Internal dependencies
@@ -170,11 +170,13 @@ class SingleProductBackupBody extends React.Component {
 	};
 
 	handleUpgradeButtonClick = selectedBackupType => () => {
+		const page = startCase( window.location.hash.replace( /#\//g, ' ' ).trim() );
+
 		analytics.tracks.recordJetpackClick( {
 			target: `upgrade-${ selectedBackupType }`,
 			type: 'upgrade',
 			product: selectedBackupType,
-			page: 'Plans',
+			page,
 		} );
 	};
 

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -171,9 +171,10 @@ class SingleProductBackupBody extends React.Component {
 
 	handleUpgradeButtonClick = selectedBackupType => () => {
 		analytics.tracks.recordJetpackClick( {
-			target: 'upgrade-button',
-			feature: 'single-product-backup',
-			extra: selectedBackupType,
+			target: `upgrade-${ selectedBackupType }`,
+			type: 'upgrade',
+			product: selectedBackupType,
+			page: 'Plans',
 		} );
 	};
 

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -9,6 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Button from 'components/button';
 import ExternalLink from 'components/external-link';
 import PlanPrice from 'components/plans/plan-price';
@@ -168,6 +169,14 @@ class SingleProductBackupBody extends React.Component {
 		this.props.setSelectedBackupType( event.target.value );
 	};
 
+	handleUpgradeButtonClick = selectedBackupType => () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'upgrade-button',
+			feature: 'single-product-backup',
+			extra: selectedBackupType,
+		} );
+	};
+
 	render() {
 		const {
 			backupOptions,
@@ -222,7 +231,11 @@ class SingleProductBackupBody extends React.Component {
 					upgradeLinks[ selectedBackupType ] &&
 					upgradeTitles[ selectedBackupType ] && (
 						<div className="single-product-backup__upgrade-button-container">
-							<Button href={ upgradeLinks[ selectedBackupType ] } primary>
+							<Button
+								href={ upgradeLinks[ selectedBackupType ] }
+								onClick={ this.handleUpgradeButtonClick( selectedBackupType ) }
+								primary
+							>
 								{ upgradeTitles[ selectedBackupType ] }
 							</Button>
 						</div>


### PR DESCRIPTION
This PR adds 2 new tracks events to the Jetpack Backup purchase UI:

* The upgrade button when purchasing a Backup product.
* The "Which one do I need?" link.

![](https://cldup.com/JU0CcjPwlM.png)
![](https://cldup.com/hNzHDvNAm7.png)

#### Changes proposed in this Pull Request:
* Plans: Add tracks events on links and buttons in Jetpack Backup

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of the Jetpack Backup project.

#### Testing instructions:
* Checkout this branch.
* Build Jetpack (`yarn build` or `yarn watch`)
* Go to /wp-admin/admin.php?page=jetpack#/plans when your site is on a free plan without a purchased Backup product.
* Click on the "Which one do I need?" link.
* Verify it works well and records an event as shown on the screenshot.
* Click the relevant upgrade button.
* Verify it works well and records an event as shown on the screenshot.

#### Proposed changelog entry for your changes:
* Plans: Add tracks events on links and buttons in Jetpack Backup
