### PR TITLE
Extensions: add a new option to deliver an "Experimental" subset of blocks.

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1974,6 +1974,16 @@ class Jetpack_CLI extends WP_CLI_Command {
 				}
 			}
 
+			if ( 'beta' === $variation || 'experimental' === $variation ) {
+				$block_constant = sprintf(
+					/* translators: the placeholder is a constant name */
+					esc_html__( 'To load the block, add the constant %1$s as true to your wp-config.php file', 'jetpack' ),
+					( 'beta' === $variation ? 'JETPACK_BETA_BLOCKS' : 'JETPACK_EXPERIMENTAL_BLOCKS' )
+				);
+			} else {
+				$block_constant = '';
+			}
+
 			WP_CLI::success(
 				sprintf(
 					/* translators: the placeholders are a human readable title, and a series of words separated by dashes */
@@ -1984,14 +1994,15 @@ class Jetpack_CLI extends WP_CLI_Command {
 					esc_html__( 'To start using the block, build the blocks with yarn run build-extensions', 'jetpack' ) . "\n" .
 					/* translators: the placeholder is a file path */
 					esc_html__( 'The block slug has been added to the %4$s list at %5$s', 'jetpack' ) . "\n" .
-					esc_html__( 'To load the block, add the constant JETPACK_BETA_BLOCKS as true to your wp-config.php file', 'jetpack' ) . "\n" .
+					'%6$s' . "\n" .
 					/* translators: the placeholder is a URL */
-					"\n" . esc_html__( 'Read more at %6$s', 'jetpack' ) . "\n",
+					"\n" . esc_html__( 'Read more at %7$s', 'jetpack' ) . "\n",
 					$title,
 					$slug,
 					$path,
 					$variation,
 					$block_list_path,
+					$block_constant,
 					'https://github.com/Automattic/jetpack/blob/master/extensions/README.md#develop-new-blocks'
 				) . '--------------------------------------------------------------------------------------------------------------------'
 			);

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1939,7 +1939,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		if ( empty( $files_written ) ) {
 			WP_CLI::log( esc_html__( 'No files were created', 'jetpack' ) );
 		} else {
-			// Load index.json and insert the slug of the new block in the production array
+			// Load index.json and insert the slug of the new block in the beta array.
 			$block_list_path = JETPACK__PLUGIN_DIR . 'extensions/index.json';
 			$block_list      = $wp_filesystem->get_contents( $block_list_path );
 			if ( empty( $block_list ) ) {

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -734,13 +734,9 @@ class Jetpack_Gutenberg {
 		}
 
 		/*
-		 * Switch to experimental blocks if you use Gutenberg, the FSE plugin, or the constant.
+		 * Switch to experimental blocks if you use the JETPACK_EXPERIMENTAL_BLOCKS constant.
 		 */
-		if (
-			Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' )
-			|| Jetpack::is_plugin_active( 'gutenberg/gutenberg.php' )
-			|| Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' )
-		) {
+		if ( Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' ) ) {
 			return 'experimental';
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -717,4 +717,61 @@ class Jetpack_Gutenberg {
 
 		return implode( ' ', $classes );
 	}
+
+	/**
+	 * Determine whether a site should use the default set of blocks, or a custom set.
+	 * Possible variations are currently beta, experimental, and production.
+	 *
+	 * @since 8.1.0
+	 *
+	 * @return string $block_varation production|beta|experimental
+	 */
+	public function blocks_variation() {
+		if ( Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
+			return 'beta';
+		}
+
+		/*
+		 * Switch to experimental blocks if you use Gutenberg, the FSE plugin, or the constant.
+		 */
+		if (
+			Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' )
+			|| Jetpack::is_plugin_active( 'gutenberg/gutenberg.php' )
+			|| Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' )
+		) {
+			return 'experimental';
+		}
+
+		/**
+		 * Allow customizing the variation of blocks in use on a site.
+		 *
+		 * @since 8.1.0
+		 *
+		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
+		 */
+		return apply_filters( 'jetpack_blocks_variation', 'production' );
+	}
+
+	/**
+	 * Get a list of extensions available for the variation you chose.
+	 *
+	 * @since 8.1.0
+	 *
+	 * @param obj    $preset_extensions_manifest List of extensions available in Jetpack.
+	 * @param string $blocks_variation           Subset of blocks. production|beta|experimental.
+	 * @param array  $additional_extensions      Array of other extensions to add to our variation (preexisting set).
+	 *
+	 * @return array $preset_extensions Array of extensions for that variation
+	 */
+	public function get_extensions_preset_for_variation( $preset_extensions_manifest, $blocks_variation, $additional_extensions = array() ) {
+		$preset_extensions = isset( $preset_extensions_manifest->{ $blocks_variation } )
+				? (array) $preset_extensions_manifest->{ $blocks_variation }
+				: array();
+
+		if ( ! empty( $additional_extensions ) ) {
+			$preset_extensions = array_unique( array_merge( $preset_extensions, $additional_extensions ) );
+		}
+
+		return $preset_extensions;
+	}
 }

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -729,15 +729,18 @@ class Jetpack_Gutenberg {
 	 * @return string $block_varation production|beta|experimental
 	 */
 	public static function blocks_variation() {
+		// Default to production blocks.
+		$block_varation = 'production';
+
 		if ( Constants::is_true( 'JETPACK_BETA_BLOCKS' ) ) {
-			return 'beta';
+			$block_varation = 'beta';
 		}
 
 		/*
 		 * Switch to experimental blocks if you use the JETPACK_EXPERIMENTAL_BLOCKS constant.
 		 */
 		if ( Constants::is_true( 'JETPACK_EXPERIMENTAL_BLOCKS' ) ) {
-			return 'experimental';
+			$block_varation = 'experimental';
 		}
 
 		/**
@@ -747,7 +750,7 @@ class Jetpack_Gutenberg {
 		 *
 		 * @param string $block_variation Can be beta, experimental, and production. Defaults to production.
 		 */
-		return apply_filters( 'jetpack_blocks_variation', 'production' );
+		return apply_filters( 'jetpack_blocks_variation', $block_varation );
 	}
 
 	/**

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -55,13 +55,16 @@ Generally, all new extensions should start out as a beta.
 
 - Before you develop, remember to add your extension's slug to the beta array in `extensions/index.json`.
 - In the `wp-config.php` for your Docker environment (`docker/wordpress/wp-config.php`) or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
+- When you use this constant, you'll get all blocks: Beta blocks, Experimental blocks, and Production blocks.
 - In the WordPress.com environment, Automatticians will be able to see beta extensions with no further configuration
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.
 
 ### Experimental Extensions
 
-We also offer an "experimental" state for extensions. Those extensions will be made available to anyone having the `JETPACK_EXPERIMENTAL_BLOCKS` constant defined in `wp-config.php`.
+We also offer an "experimental" state for extensions. Those extensions will be made available to anyone having the `JETPACK_EXPERIMENTAL_BLOCKS` constant defined in `wp-config.php`. When you use this constant, you'll get Experimental blocks as well as Production blocks.
+
+Experimental extensions are usually considered ready for production, but are served only to sites requesting them.
 
 ### Testing
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -76,7 +76,7 @@ Note that adding [Jest snapshot tests](https://jestjs.io/docs/en/snapshot-testin
 
 We have a command in WP-CLI that allows to scaffold Jetpack blocks. Its syntax is as follows:
 
-`wp jetpack scaffold <type> <title> [--slug] [--description] [--keywords]`
+`wp jetpack scaffold <type> <title> [--slug] [--description] [--keywords] [--variation]`
 
 **Currently the only `type` is `block`.**
 
@@ -86,6 +86,7 @@ We have a command in WP-CLI that allows to scaffold Jetpack blocks. Its syntax i
 - **--slug**: Specific slug to identify the block that overrides the one generated base don the title.
 - **--description**: Allows to provide a text description of the block.
 - **--keywords**: Provide up to three keywords separated by a comma so users when they search for a block in the editor.
+- **--variation**: Allows to decide whether the block should be a production block, experimental, or beta. Defaults to Beta when arg not provided.
 
 ### Files
 
@@ -108,6 +109,8 @@ Since it's added to the beta array, you need to load the beta blocks as explaine
 `wp jetpack scaffold block "Amazing Rock" --slug="good-music" --description="Rock the best music on your site"`
 
 `wp jetpack scaffold block "Jukebox" --keywords="music, audio, media"`
+
+`wp jetpack scaffold block "Jukebox" --variation="experimental"`
 
 ### Can I use Jurassic Ninja to test blocks?
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -59,6 +59,13 @@ Generally, all new extensions should start out as a beta.
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.
 
+### Experimental Extensions
+
+We also offer an "experimental" state for extensions. Those extensions will be made available to anyone:
+- Running the Gutenberg plugin, or;
+- Running the FSE plugin, or;
+- having the `JETPACK_EXPERIMENTAL_BLOCKS` constant defined in `wp-config.php`.
+
 ### Testing
 
 Run `yarn test-extensions [--watch]` to run tests written in [Jest](https://jestjs.io/en/).

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -61,10 +61,7 @@ Generally, all new extensions should start out as a beta.
 
 ### Experimental Extensions
 
-We also offer an "experimental" state for extensions. Those extensions will be made available to anyone:
-- Running the Gutenberg plugin, or;
-- Running the FSE plugin, or;
-- having the `JETPACK_EXPERIMENTAL_BLOCKS` constant defined in `wp-config.php`.
+We also offer an "experimental" state for extensions. Those extensions will be made available to anyone having the `JETPACK_EXPERIMENTAL_BLOCKS` constant defined in `wp-config.php`.
 
 ### Testing
 

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -38,6 +38,7 @@ const presetExperimentalBlocks = [
 	...presetProductionBlocks,
 	..._.get( presetIndex, [ 'experimental' ], [] ),
 ];
+// Beta Blocks include all blocks: beta, experimental, and production blocks.
 const presetBetaBlocks = [ ...presetExperimentalBlocks, ..._.get( presetIndex, [ 'beta' ], [] ) ];
 
 // Helps split up each block into its own folder view script

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -33,12 +33,15 @@ function blockScripts( type, inputDir, presetBlocks ) {
 
 const presetPath = path.join( __dirname, 'extensions', 'index.json' );
 const presetIndex = require( presetPath );
-const presetBlocks = _.get( presetIndex, [ 'production' ], [] );
-const presetBetaBlocks = _.get( presetIndex, [ 'beta' ], [] );
-const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
+const presetProductionBlocks = _.get( presetIndex, [ 'production' ], [] );
+const presetExperimentalBlocks = [
+	...presetProductionBlocks,
+	..._.get( presetIndex, [ 'experimental' ], [] ),
+];
+const presetBetaBlocks = [ ...presetExperimentalBlocks, ..._.get( presetIndex, [ 'beta' ], [] ) ];
 
 // Helps split up each block into its own folder view script
-const viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
+const viewBlocksScripts = presetBetaBlocks.reduce( ( viewBlocks, block ) => {
 	const viewScriptPath = path.join( __dirname, 'extensions', 'blocks', block, 'view.js' );
 	if ( fs.existsSync( viewScriptPath ) ) {
 		viewBlocks[ block + '/view' ] = [ viewSetup, ...[ viewScriptPath ] ];
@@ -46,16 +49,22 @@ const viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
 	return viewBlocks;
 }, {} );
 
-// Combines all the different blocks into one editor.js script
+// Combines all the different production blocks into one editor.js script
 const editorScript = [
 	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetBlocks ),
+	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetProductionBlocks ),
+];
+
+// Combines all the different Experimental blocks into one editor.js script
+const editorExperimentalScript = [
+	editorSetup,
+	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetExperimentalBlocks ),
 ];
 
 // Combines all the different blocks into one editor-beta.js script
 const editorBetaScript = [
 	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), allPresetBlocks ),
+	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetBetaBlocks ),
 ];
 
 const extensionsWebpackConfig = getBaseWebpackConfig(
@@ -63,6 +72,7 @@ const extensionsWebpackConfig = getBaseWebpackConfig(
 	{
 		entry: {
 			editor: editorScript,
+			'editor-experimental': editorExperimentalScript,
 			'editor-beta': editorBetaScript,
 			...viewBlocksScripts,
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

We currently have 2 options when building and loading Jetpack blocks in the editor:
    - Production blocks
    - Beta blocks (loading production blocks and a small set of Beta blocks), available when using the `JETPACK_BETA_BLOCKS` constant.

This PR introduces a third option, aka variation, named "Experimental". This option loads both production blocks and a set of experimental blocks. It is automatically enabled if you use the Gutenberg plugin or the Full Site Editing plugin on your site. In practice, that would make that option available on all Atomic sites right away. The option can also be used when you don't use those plugins, via the `JETPACK_EXPERIMENTAL_BLOCKS` constant.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Internal reference: p4hfux-50G-p2#comment-7336

cc @dereksmart @kraftbj since we recently discussed different options.

#### Testing instructions:

* Check out this PR.
* Add `define( 'JETPACK_BETA_BLOCKS', true );` to your site's `wp-config.php` file and make sure you can still see all blocks, including the Pinterest block (currently in Beta).
* Remove that line.
* Add `define( 'JETPACK_EXPERIMENTAL_BLOCKS', true );` to your site's `wp-config.php` file and make sure you cannot still see the Pinterest block (currently in Beta).
* Remove that line.
* Activate the Gutenberg plugin.
* Make sure you still cannot see the Pinterest block (currently in Beta).
* Use `yarn docker:wp jetpack scaffold block jeremy --variation="experimental"` to create a brand new block.
* Run `yarn build-extensions` to build that new block.
* Make sure that:
    - that block was added to the `experimental` subset in `extensions/index.json`
    - that block is available to you as long as the Gutenberg plugin is active.
    - that block disappears from the block picker as soon as you deactivate Gutenberg.

#### Proposed changelog entry for your changes:

* Extensions: add a new option to deliver an "Experimental" subset of blocks.
