### PR TITLE
Jetpack Backup / Plans: Change 'Solutions' to 'Single Products'

### DIFF
--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -23,7 +23,7 @@ export function SingleProductBackup( { plan, products, upgradeLinks, isFetchingD
 
 	return (
 		<React.Fragment>
-			<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+			<h1 className="plans-section__header">{ __( 'Single Products' ) }</h1>
 			<h2 className="plans-section__subheader">
 				{ __( "Just looking for backups? We've got you covered." ) }
 			</h2>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This updates the "Solutions" header for Jetpack Backup to be "Single Products" to match the Figma design.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:
* Go to `/wp-admin/admin.php?page=jetpack#/plans` on a free site
* Verify that the header above the Jetpack Backup card says "Single Products".

#### Proposed changelog entry for your changes:
* None needed
