### PR TITLE
Remove sync settings cache

### DIFF
--- a/packages/sync/src/class-settings.php
+++ b/packages/sync/src/class-settings.php
@@ -96,16 +96,6 @@ class Settings {
 	public static $is_sending;
 
 	/**
-	 * Some settings can be expensive to compute - let's cache them.
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @var array
-	 */
-	public static $settings_cache = array();
-
-	/**
 	 * Retrieve all settings with their current values.
 	 *
 	 * @access public
@@ -137,18 +127,12 @@ class Settings {
 			return false;
 		}
 
-		if ( isset( self::$settings_cache[ $setting ] ) ) {
-			return self::$settings_cache[ $setting ];
-		}
-
 		if ( self::is_network_setting( $setting ) ) {
 			if ( is_multisite() ) {
 				$value = get_site_option( self::SETTINGS_OPTION_PREFIX . $setting );
 			} else {
 				// On single sites just return the default setting.
-				$value                            = Defaults::get_default_setting( $setting );
-				self::$settings_cache[ $setting ] = $value;
-				return $value;
+				return Defaults::get_default_setting( $setting );
 			}
 		} else {
 			$value = get_option( self::SETTINGS_OPTION_PREFIX . $setting );
@@ -194,8 +178,6 @@ class Settings {
 			}
 		}
 
-		self::$settings_cache[ $setting ] = $value;
-
 		return $value;
 	}
 
@@ -218,8 +200,6 @@ class Settings {
 			} else {
 				update_option( self::SETTINGS_OPTION_PREFIX . $setting, $value, true );
 			}
-
-			unset( self::$settings_cache[ $setting ] );
 
 			// If we set the disabled option to true, clear the queues.
 			if ( ( 'disable' === $setting || 'network_disable' === $setting ) && ! ! $value ) {
@@ -315,8 +295,7 @@ class Settings {
 	 * @static
 	 */
 	public static function reset_data() {
-		$valid_settings       = self::$valid_settings;
-		self::$settings_cache = array();
+		$valid_settings = self::$valid_settings;
 		foreach ( $valid_settings as $option => $value ) {
 			delete_option( self::SETTINGS_OPTION_PREFIX . $option );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14095

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the sync settings cache
* Enable sync settings values to be filtered by hooks initialised on `init`. Currently settings must be filtered very early otherwise the cache gets polluted with the DB value.

#### Testing instructions:
* Try setting and unsetting some Sync settings (e.g. `jetpack_sync_settings_disable`)
* Ensure setting is applied correctly