### PR TITLE
Feature Hints: disable when plugins cannot be installed on site.

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -16,6 +16,7 @@ if (
 	Jetpack::is_active() &&
 	/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 	apply_filters( 'jetpack_show_promotions', true ) &&
+	// Disable feature hints when plugins cannot be installed.
 	! Constants::is_true( 'DISALLOW_FILE_MODS' ) &&
 	jetpack_is_psh_active()
 ) {

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Tracking;
 
 /**
@@ -15,6 +16,7 @@ if (
 	Jetpack::is_active() &&
 	/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 	apply_filters( 'jetpack_show_promotions', true ) &&
+	! Constants::is_true( 'DISALLOW_FILE_MODS' ) &&
 	jetpack_is_psh_active()
 ) {
 	Jetpack_Plugin_Search::init();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When one cannot install plugins, we do not have to do anything with feature hints.

Internal reference: p1571740982220600-slack-jetpack-crew

#### Testing instructions:

~I am not quite sure to be honest. @mjangda Any idea here?~

* Add `define( 'DISALLOW_FILE_MODS', true );` to your site's `wp-config.php` file.
* From that point on, you cannot access `wp-admin/plugin-install.php` on your site so Feature hints should not be triggered.
* Remove the constant, head over to Plugins > Add New, and type "cdn" in the search field.
* If the Asset CDN feature is not already enabled on your site, you should see a prompt to enable it.

#### Proposed changelog entry for your changes:

* Feature Hints: disable when plugins cannot be installed on site.
