### PR TITLE
Run phpcs-changed via composer so that the binary is in the path

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -128,7 +128,7 @@ function runPHPCSChanged( phpFilesToCheck ) {
 		process.env.PHPCS = 'vendor/bin/phpcs';
 
 		phpFilesToCheck.forEach( function( file ) {
-			phpFileChangedResult = spawnSync( 'vendor/bin/phpcs-changed', [ '--git', file ], {
+			phpFileChangedResult = spawnSync( 'composer', [ 'run', 'php:changed', file ], {
 				env: process.env,
 				shell: true,
 				stdio: 'inherit',

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
 	"scripts": {
 		"php:compatibility": "vendor/bin/phpcs -p -s --runtime-set testVersion '5.6-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
 		"php:lint": "vendor/bin/phpcs -p -s",
+		"php:changed": "vendor/sirbrillig/phpcs-changed/bin/phpcs-changed --git",
 		"php:autofix": "vendor/bin/phpcbf",
 		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
 	},


### PR DESCRIPTION
I was getting an issue with the pre-commit hooks like this:

```
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-callables.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-comments.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-full.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-integration.php'
phpcs-changed: Fatal error!
Cannot get new phpcs output for file 'tests/php/sync/test_class.jetpack-sync-lock.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-plugins-updates.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-sender.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/sync/test_class.jetpack-sync-themes.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/test_class.jetpack_photon.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/test_deprecation.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/test_functions.photon.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'tests/php/test_php-lint.php'
phpcs-changed: Fatal error!
Cannot get old phpcs output for file 'uninstall.php'
COMMIT ABORTED: The linter reported some problems. If you are aware of them and it is OK, repeat the commit command with --no-verify to avoid this check. But please don't. Code is poetry.
```

The fix for me was running `phpcs` via a `composer run` so that the `phpcs` binary is in the path (it's in `vendor/bin/phpcs`)