### PR TITLE
Connection: Loose Comparison for Port Number in Signatures

### DIFF
--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -92,7 +92,7 @@ class Jetpack_Signature {
 			// X-Forwarded-Port and the back end's port is *not* 80. It's better,
 			// though, to configure the proxy to send X-Forwarded-Port.
 			$https_port = defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) ? JETPACK_SIGNATURE__HTTPS_PORT : 443;
-			$port       = in_array( $host_port, array( 443, 80, $https_port ), true ) ? '' : $host_port;
+			$port       = in_array( $host_port, array( 443, 80, $https_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 		} else {
 			// 80: Standard Port
 			// JETPACK_SIGNATURE__HTTPS_PORT: Set this constant in wp-config.php to the back end webserver's port
@@ -100,7 +100,7 @@ class Jetpack_Signature {
 			// X-Forwarded-Port. It's better, though, to configure the proxy to
 			// send X-Forwarded-Port.
 			$http_port = defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) ? JETPACK_SIGNATURE__HTTP_PORT : 80;
-			$port      = in_array( $host_port, array( 80, $http_port ), true ) ? '' : $host_port;
+			$port      = in_array( $host_port, array( 80, $http_port ), false ) ? '' : $host_port; // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 		}
 
 		$this->current_request_url = "{$scheme}://{$_SERVER['HTTP_HOST']}:{$port}" . stripslashes( $_SERVER['REQUEST_URI'] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When WordPress is hosted behind a reverse proxy, we ask site owners to add a `X-Forwarded-Port` header from the reverse proxy to the origin so that Jetpack can know what port to use in the signature's input.

We also allow site owners to define `JETPACK_SIGNATURE__HTTPS_PORT` and `JETPACK_SIGNATURE__HTTP_PORT` constants if adding a header is not possible.

Often, site owners will add the following snippet to their wp-config.php to make use of those constants:

```
define( 'JETPACK_SIGNATURE__HTTP_PORT', $_SERVER['SERVER_PORT'] );
define( 'JETPACK_SIGNATURE__HTTPS_PORT', $_SERVER['SERVER_PORT'] );
```

Unfortunately, we broke that snippet in https://github.com/Automattic/jetpack/pull/13489, since we moved to strict comparisons in:
* https://github.com/Automattic/jetpack/blob/97cc7bb9b26d4184ba4915efd5928e59d4456b38/packages/connection/legacy/class-jetpack-signature.php#L95
* https://github.com/Automattic/jetpack/blob/97cc7bb9b26d4184ba4915efd5928e59d4456b38/packages/connection/legacy/class-jetpack-signature.php#L103

`$_SERVER['SERVER_PORT']` is a string in most environments, and the new code demands integers.

Switch back to loose comparison.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No: bug fix

#### Testing instructions:
There's not a good way to test this unless you have a site running on a custom port behind a reverse proxy running on a normal port :(

#### Proposed changelog entry for your changes:
* Fix communication between Jetpack sites and WordPress.com for some sites hosted on non-standard ports.