### PR TITLE
Jetpack Backup: Use Purchases to Display Jetpack Backup States

### DIFF
--- a/_inc/client/components/product-card/action.jsx
+++ b/_inc/client/components/product-card/action.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const ProductCardAction = ( { intro, label, onClick, primary, href } ) => (
+	<div className="product-card__action">
+		{ intro && <h4 className="product-card__action-intro">{ intro }</h4> }
+		<Button
+			className="product-card__action-button"
+			href={ href }
+			onClick={ onClick }
+			primary={ primary }
+		>
+			{ label }
+		</Button>
+	</div>
+);
+
+ProductCardAction.propTypes = {
+	intro: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
+	label: PropTypes.string.isRequired,
+	onClick: PropTypes.func,
+	href: PropTypes.string,
+	primary: PropTypes.bool,
+};
+
+ProductCardAction.defaultProps = {
+	href: null,
+	onClick: noop,
+	primary: true,
+};
+
+export default ProductCardAction;

--- a/_inc/client/components/product-card/action.jsx
+++ b/_inc/client/components/product-card/action.jsx
@@ -18,6 +18,8 @@ const ProductCardAction = ( { intro, label, onClick, primary, href } ) => (
 			href={ href }
 			onClick={ onClick }
 			primary={ primary }
+			target="_blank"
+			rel="noopener noreferrer"
 		>
 			{ label }
 		</Button>

--- a/_inc/client/components/product-card/index.jsx
+++ b/_inc/client/components/product-card/index.jsx
@@ -34,7 +34,7 @@ class ProductCard extends Component {
 		isPlaceholder: PropTypes.bool,
 		purchase: PropTypes.object,
 		subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
-		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
 	};
 
 	getManagePurchaseLink( siteName, purchaseId ) {

--- a/_inc/client/components/product-card/index.jsx
+++ b/_inc/client/components/product-card/index.jsx
@@ -4,7 +4,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -12,13 +11,9 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
-// TODO:
-// import { managePurchase } from 'me/purchases/paths';
-const managePurchase = () => {};
+import analytics from 'lib/analytics';
 import ProductCardAction from './action';
 import ProductCardPriceGroup from './price-group';
-// import { recordTracksEvent } from 'state/analytics/actions';
-const recordTracksEvent = () => {};
 
 /**
  * Style dependencies
@@ -42,10 +37,15 @@ class ProductCard extends Component {
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 	};
 
+	getManagePurchaseLink( siteName, purchaseId ) {
+		return `https://wordpress.com/me/purchases/${ siteName }/${ purchaseId }`;
+	}
+
 	handleManagePurchase( productSlug ) {
 		return () => {
-			this.props.recordTracksEvent( 'calypso_manage_purchase_click', {
-				slug: productSlug,
+			analytics.tracks.recordJetpackClick( {
+				target: 'product-card-manage-purchase',
+				feature: productSlug,
 			} );
 		};
 	}
@@ -95,8 +95,8 @@ class ProductCard extends Component {
 					{ description && <p>{ description }</p> }
 					{ purchase && isCurrent && (
 						<ProductCardAction
-							onClick={ this.handleManagePurchase( purchase.productSlug ) }
-							href={ managePurchase( purchase.domain, purchase.id ) }
+							onClick={ this.handleManagePurchase( purchase.product_slug ) }
+							href={ this.getManagePurchaseLink( purchase.domain, purchase.ID ) }
 							label={ translate( 'Manage Subscription' ) }
 							primary={ false }
 						/>
@@ -108,7 +108,4 @@ class ProductCard extends Component {
 	}
 }
 
-export default connect(
-	null,
-	{ recordTracksEvent }
-)( localize( ProductCard ) );
+export default localize( ProductCard );

--- a/_inc/client/components/product-card/index.jsx
+++ b/_inc/client/components/product-card/index.jsx
@@ -9,9 +9,9 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import Card from 'components/card';
 import Gridicon from 'components/gridicon';
-import analytics from 'lib/analytics';
 import ProductCardAction from './action';
 import ProductCardPriceGroup from './price-group';
 

--- a/_inc/client/components/product-card/index.jsx
+++ b/_inc/client/components/product-card/index.jsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import Gridicon from 'components/gridicon';
+// TODO:
+// import { managePurchase } from 'me/purchases/paths';
+const managePurchase = () => {};
+import ProductCardAction from './action';
+import ProductCardPriceGroup from './price-group';
+// import { recordTracksEvent } from 'state/analytics/actions';
+const recordTracksEvent = () => {};
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ProductCard extends Component {
+	static propTypes = {
+		billingTimeFrame: PropTypes.string,
+		currencyCode: PropTypes.string,
+		description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+		discountedPrice: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.arrayOf( PropTypes.number ),
+		] ),
+		fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+		isCurrent: PropTypes.bool,
+		isPlaceholder: PropTypes.bool,
+		purchase: PropTypes.object,
+		subtitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element, PropTypes.node ] ),
+		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+	};
+
+	handleManagePurchase( productSlug ) {
+		return () => {
+			this.props.recordTracksEvent( 'calypso_manage_purchase_click', {
+				slug: productSlug,
+			} );
+		};
+	}
+
+	render() {
+		const {
+			billingTimeFrame,
+			children,
+			currencyCode,
+			description,
+			discountedPrice,
+			fullPrice,
+			isCurrent,
+			isPlaceholder,
+			purchase,
+			subtitle,
+			title,
+			translate,
+		} = this.props;
+		const cardClassNames = classNames( 'product-card', {
+			'is-placeholder': isPlaceholder,
+			'is-purchased': !! purchase,
+		} );
+
+		return (
+			<Card className={ cardClassNames }>
+				<div className="product-card__header">
+					{ title && (
+						<div className="product-card__header-primary">
+							{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
+							<h3 className="product-card__title">{ title }</h3>
+						</div>
+					) }
+					<div className="product-card__header-secondary">
+						{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
+						{ ! purchase && (
+							<ProductCardPriceGroup
+								billingTimeFrame={ billingTimeFrame }
+								currencyCode={ currencyCode }
+								discountedPrice={ discountedPrice }
+								fullPrice={ fullPrice }
+							/>
+						) }
+					</div>
+				</div>
+				<div className="product-card__description">
+					{ description && <p>{ description }</p> }
+					{ purchase && isCurrent && (
+						<ProductCardAction
+							onClick={ this.handleManagePurchase( purchase.productSlug ) }
+							href={ managePurchase( purchase.domain, purchase.id ) }
+							label={ translate( 'Manage Subscription' ) }
+							primary={ false }
+						/>
+					) }
+				</div>
+				{ children }
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( localize( ProductCard ) );

--- a/_inc/client/components/product-card/options.jsx
+++ b/_inc/client/components/product-card/options.jsx
@@ -1,0 +1,65 @@
+/* eslint-disable react/jsx-no-bind */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { isEmpty } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import ProductCardPriceGroup from './price-group';
+
+const ProductCardOptions = ( { handleSelect, options, optionsLabel, selectedSlug } ) => {
+	if ( isEmpty( options ) ) {
+		return null;
+	}
+
+	return (
+		<div className="product-card__options">
+			{ optionsLabel && <h4 className="product-card__options-label">{ optionsLabel }</h4> }
+			{ options.map( option => (
+				<FormLabel key={ `product-option-${ option.slug }` } className="product-card__option">
+					<FormRadio
+						checked={ option.slug === selectedSlug }
+						onChange={ () => handleSelect( option.slug ) }
+					/>
+					<div className="product-card__option-description">
+						<div className="product-card__option-name">{ option.title }</div>
+						<ProductCardPriceGroup
+							billingTimeFrame={ option.billingTimeFrame }
+							currencyCode={ option.currencyCode }
+							discountedPrice={ option.discountedPrice }
+							fullPrice={ option.fullPrice }
+						/>
+					</div>
+				</FormLabel>
+			) ) }
+		</div>
+	);
+};
+
+ProductCardOptions.propTypes = {
+	handleSelect: PropTypes.func,
+	options: PropTypes.arrayOf(
+		PropTypes.shape( {
+			billingTimeFrame: PropTypes.string,
+			currencyCode: PropTypes.string,
+			discountedPrice: PropTypes.oneOfType( [
+				PropTypes.number,
+				PropTypes.arrayOf( PropTypes.number ),
+			] ),
+			fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+			slug: PropTypes.string.isRequired,
+			title: PropTypes.string,
+		} )
+	),
+	optionsLabel: PropTypes.string,
+	selectedSlug: PropTypes.string,
+};
+
+export default ProductCardOptions;

--- a/_inc/client/components/product-card/price-group.jsx
+++ b/_inc/client/components/product-card/price-group.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import PlanPrice from 'components/plans/plan-price';
+
+const ProductCardPriceGroup = props => {
+	const { billingTimeFrame, currencyCode, discountedPrice, fullPrice } = props;
+	const isDiscounted = !! discountedPrice;
+	const priceGroupClasses = classNames( 'product-card__price-group', {
+		'is-discounted': isDiscounted,
+	} );
+
+	return (
+		<div className={ priceGroupClasses }>
+			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } original={ isDiscounted } />
+			{ isDiscounted && (
+				<PlanPrice currencyCode={ currencyCode } rawPrice={ discountedPrice } discounted />
+			) }
+			<div className="product-card__billing-timeframe">{ billingTimeFrame }</div>
+		</div>
+	);
+};
+
+ProductCardPriceGroup.propTypes = {
+	billingTimeFrame: PropTypes.string,
+	currencyCode: PropTypes.string,
+	discountedPrice: PropTypes.oneOfType( [
+		PropTypes.number,
+		PropTypes.arrayOf( PropTypes.number ),
+	] ),
+	fullPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
+};
+
+export default ProductCardPriceGroup;

--- a/_inc/client/components/product-card/style.scss
+++ b/_inc/client/components/product-card/style.scss
@@ -198,6 +198,10 @@
 	line-height: 20px;
 	color: #646970;
 
+	p {
+		text-align: center;
+	}
+
 	p:last-child {
 		margin: 0;
 	}

--- a/_inc/client/components/product-card/style.scss
+++ b/_inc/client/components/product-card/style.scss
@@ -1,0 +1,328 @@
+@import '../../scss/variables/colors';
+@import '../../scss/calypso-mixins';
+
+// Header
+.product-card__header {
+	margin: -16px -16px 16px;
+	border-bottom: solid 2px $blue-medium;
+
+	@include breakpoint( '>480px' ) {
+		margin: -24px -24px 24px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		display: flex;
+		flex-flow: row wrap;
+		align-items: baseline;
+	}
+}
+
+.product-card__header-primary,
+.product-card__header-secondary {
+	padding-left: 40px;
+	padding-right: 40px;
+
+	@include breakpoint( '>660px' ) {
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+}
+
+.product-card__header-primary {
+	display: flex;
+	padding-top: 16px;
+	padding-bottom: 4px;
+
+	@include breakpoint( '>480px' ) {
+		padding-top: 24px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		flex-grow: 1;
+		padding-top: 16px;
+	}
+
+	.gridicon {
+		align-self: center;
+		margin: 0 8px 0 -26px;
+
+		@include breakpoint( '>660px' ) {
+			width: 16px;
+			height: 16px;
+			margin-left: 0;
+		}
+	}
+}
+
+.product-card__header-secondary {
+	position: relative;
+	padding-bottom: 16px;
+
+	@include breakpoint( '>480px' ) {
+		padding-bottom: 24px;
+	}
+
+	@include breakpoint( '>660px' ) {
+		padding-bottom: 16px;
+	}
+
+	.is-purchased & {
+		@include breakpoint( '>660px' ) {
+			padding-left: 40px;
+		}
+	}
+}
+
+.product-card__title {
+	font-size: 20px;
+	line-height: 24px;
+
+	@include breakpoint( '>960px' ) {
+		font-size: 22px;
+	}
+
+	em,
+	strong,
+	span {
+		font-weight: 600;
+		font-style: italic;
+	}
+
+	.product-card:not( .is-purchased ) & {
+		color: #23282d;
+
+		@include breakpoint( '>660px' ) {
+			font-weight: 600;
+		}
+	}
+}
+
+.product-card__subtitle {
+	font-size: 12px;
+	line-height: 20px;
+	font-style: italic;
+	color: #646970;
+}
+
+// Price group
+.product-card__price-group {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: baseline;
+}
+
+.product-card {
+	.plan-price {
+		margin-right: 0.333em;
+
+		&,
+		& * {
+			@include breakpoint( '>660px' ) {
+				font-size: 14px;
+				vertical-align: baseline;
+			}
+		}
+	}
+}
+
+.product-card__billing-timeframe {
+	font-size: 13px;
+	font-weight: 400;
+	line-height: 13px;
+	color: #646970;
+
+	@include breakpoint( '<660px' ) {
+		font-style: italic;
+	}
+
+	@include breakpoint( '>960px' ) {
+		font-size: 12px;
+	}
+
+	.is-discounted & {
+		@include breakpoint( '>660px' ) {
+			color: #008a20;
+		}
+	}
+}
+
+// Adjust price group styles when part of product card header
+.product-card__header {
+	.plan-price,
+	.plan-price * {
+		@include breakpoint( '>660px' ) {
+			font-weight: 600;
+		}
+	}
+
+	.product-card__billing-timeframe {
+		width: 100%;
+
+		@include breakpoint( '>660px' ) {
+			width: auto;
+			font-size: 12px;
+			font-weight: 600;
+		}
+	}
+}
+
+// Adjust price group styles when part of product option
+.product-card__option {
+	.plan-price,
+	.plan-price * {
+		font-size: 16px;
+		font-weight: 400;
+		vertical-align: baseline;
+
+		@include breakpoint( '>960px' ) {
+			font-size: 14px;
+		}
+	}
+
+	.is-discounted .product-card__billing-timeframe {
+		color: #008a20;
+	}
+
+	@include breakpoint( '>960px' ) {
+		.plan-price.is-discounted,
+		.plan-price.is-discounted *,
+		.is-discounted .product-card__billing-timeframe {
+			color: #646970;
+		}
+	}
+}
+
+// Description
+.product-card__description {
+	font-size: 14px;
+	line-height: 20px;
+	color: #646970;
+
+	p:last-child {
+		margin: 0;
+	}
+}
+
+// Product options
+.product-card__options {
+	padding: 10px 0 0;
+
+	@include breakpoint( '>960px' ) {
+		display: flex;
+		flex-flow: row wrap;
+		justify-content: space-around; // IE11 fallback.
+		justify-content: space-evenly;
+	}
+}
+
+.product-card__options-label {
+	margin: 8px 0;
+	padding: 6px 0;
+	font-size: 14px;
+	color: #646970;
+	border-bottom: 1px solid #dcdcde;
+
+	@include breakpoint( '>960px' ) {
+		flex: 0 0 100%;
+	}
+}
+
+.product-card__option,
+.product-card__option-description {
+	display: flex;
+	align-items: center;
+}
+
+// We need a higher specificity here to override .form-label styles
+.product-card__option.form-label {
+	margin: 16px 0 0;
+	padding: 8px 0;
+
+	@include breakpoint( '>960px' ) {
+		flex: 0 0 40%;
+		align-items: flex-start;
+	}
+}
+
+.product-card__option-description {
+	margin-left: 8px;
+	flex-grow: 1;
+	flex-wrap: wrap;
+}
+
+.product-card__option-name {
+	flex-grow: 1;
+	font-size: 16px;
+	font-weight: 700;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 2px;
+		flex: 0 0 100%;
+		font-size: 14px;
+		line-height: 20px;
+	}
+}
+
+// Action
+.product-card__action {
+	margin: 16px auto;
+	text-align: center;
+}
+
+.product-card__action-intro {
+	margin-bottom: 12px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1d2327;
+}
+
+.product-card__action-button {
+	width: 100%;
+	max-width: 320px;
+}
+
+// Loading state
+.product-card.is-placeholder .product-card__price-group {
+	&::before {
+		@include placeholder();
+		content: '\00a0';
+		display: inline-block;
+		width: 150px;
+		height: 32px;
+		margin: 0 0 4px;
+
+		@include breakpoint( '>660px' ) {
+			height: 18px;
+		}
+	}
+
+	.product-card__billing-timeframe {
+		@include breakpoint( '>660px' ) {
+			display: none;
+		}
+	}
+
+	.product-card__billing-timeframe::before {
+		@include placeholder();
+		content: '\00a0';
+		display: inline-block;
+		width: 100px;
+		height: 11px;
+	}
+}
+
+.product-card.is-placeholder .product-card__option {
+	.product-card__price-group::before {
+		width: 125px;
+		height: 16px;
+		margin: 0;
+
+		@include breakpoint( '>660px' ) {
+			margin: 5px 0 0;
+		}
+	}
+
+	.product-card__billing-timeframe {
+		display: none;
+	}
+}

--- a/_inc/client/components/product-card/style.scss
+++ b/_inc/client/components/product-card/style.scss
@@ -76,6 +76,8 @@
 .product-card__title {
 	font-size: 20px;
 	line-height: 24px;
+	margin: 0;
+	font-weight: 400;
 
 	@include breakpoint( '>960px' ) {
 		font-size: 22px;
@@ -112,6 +114,7 @@
 }
 
 .product-card {
+	max-width: 512px;
 	.plan-price {
 		margin-right: 0.333em;
 

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -38,7 +38,12 @@ export class Plans extends React.Component {
 			'real-time': realtimeBackupUpgradeUrl,
 		};
 
-		const activePurchaseProductSlugs = activeSitePurchases.map( purchase => purchase.product_slug );
+		const activeJetpackBackupDailyPurchase = activeSitePurchases.find(
+			purchase => 'jetpack_backup_daily' === purchase.product_slug
+		);
+		const activeJetpackBackupRealtimePurchase = activeSitePurchases.find(
+			purchase => 'jetpack_backup_realtime' === purchase.product_slug
+		);
 		const planClass = getPlanClass( plan );
 
 		// singleProductContent should maintain this priority order for display:
@@ -66,12 +71,10 @@ export class Plans extends React.Component {
 						description: __(
 							'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
 						),
-						purchase: true,
-						isCurrent: true,
 					} }
 				/>
 			);
-		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_realtime' ) ) {
+		} else if ( undefined !== activeJetpackBackupRealtimePurchase ) {
 			singleProductContent = (
 				<ProductCard
 					{ ...{
@@ -92,7 +95,7 @@ export class Plans extends React.Component {
 						description: __(
 							'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
 						),
-						purchase: true,
+						purchase: activeJetpackBackupRealtimePurchase,
 						isCurrent: true,
 					} }
 				/>
@@ -112,8 +115,6 @@ export class Plans extends React.Component {
 							},
 						} ),
 						description: __( 'Always-on backups ensure you never lose your site.' ),
-						purchase: true,
-						isCurrent: true,
 					} }
 				/>
 			);
@@ -132,12 +133,10 @@ export class Plans extends React.Component {
 							},
 						} ),
 						description: __( 'Always-on backups ensure you never lose your site.' ),
-						purchase: true,
-						isCurrent: true,
 					} }
 				/>
 			);
-		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_daily' ) ) {
+		} else if ( undefined !== activeJetpackBackupDailyPurchase ) {
 			singleProductContent = (
 				<ProductCard
 					{ ...{
@@ -171,7 +170,7 @@ export class Plans extends React.Component {
 								</p>
 							</>
 						),
-						purchase: true,
+						purchase: activeJetpackBackupDailyPurchase,
 						isCurrent: true,
 					} }
 				/>

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -49,7 +49,31 @@ export class Plans extends React.Component {
 		if ( 'is-business-plan' === planClass ) {
 			singleProductContent = <ProductCard title="Business Plan" />;
 		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_realtime' ) ) {
-			singleProductContent = <ProductCard title="Jetpack Backup Realtime" />;
+			singleProductContent = (
+				<ProductCard
+					{ ...{
+						title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+							components: {
+								em: <em />,
+							},
+						} ),
+						subtitle: __( 'Purchased %(purchaseDate)s', {
+							args: {
+								purchaseDate: moment(
+									activeSitePurchases.find(
+										purchase => 'jetpack_backup_realtime' === purchase.product_slug
+									).subscribedDate
+								).format( 'YYYY-MM-DD' ),
+							},
+						} ),
+						description: __(
+							'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+						),
+						purchase: true,
+						isCurrent: true,
+					} }
+				/>
+			);
 		} else if ( 'is-premium-plan' === planClass ) {
 			singleProductContent = <ProductCard title="Premium Plan" />;
 		} else if ( 'is-personal-plan' === planClass ) {
@@ -93,7 +117,7 @@ export class Plans extends React.Component {
 					} }
 				/>
 			);
-		} else if ( products && 'is-free-plan' === planClass ) {
+		} else if ( products && [ '', 'is-free-plan' ].includes( planClass ) ) {
 			singleProductContent = (
 				<SingleProductBackup
 					plan={ plan }

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -20,6 +20,111 @@ import { getProducts, isFetchingProducts } from 'state/products';
 import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from 'state/site';
 
 export class Plans extends React.Component {
+	getProductCardPropsForPlanClass( planClass ) {
+		const { siteRawlUrl } = this.props;
+
+		switch ( planClass ) {
+			case 'is-personal-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
+						components: {
+							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+						},
+					} ),
+					description: __( 'Always-on backups ensure you never lose your site.' ),
+				};
+			case 'is-premium-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
+						components: {
+							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+						},
+					} ),
+					description: __( 'Always-on backups ensure you never lose your site.' ),
+				};
+			case 'is-business-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
+						components: {
+							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+						},
+					} ),
+					description: __(
+						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+					),
+				};
+		}
+	}
+
+	getProductCardPropsForPurchase( purchase ) {
+		switch ( purchase.product_slug ) {
+			case 'jetpack_backup_daily':
+				return {
+					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Purchased %(purchaseDate)s', {
+						args: {
+							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+						},
+					} ),
+					description: (
+						<>
+							<p>
+								{ __( '{{strong}}Looking for more?{{/strong}}', {
+									components: {
+										strong: <strong />,
+									},
+								} ) }
+							</p>
+							<p>
+								{ __(
+									'With Real-time backups, we save as you edit and you’ll get unlimited backup archives.'
+								) }
+							</p>
+						</>
+					),
+					purchase,
+					isCurrent: true,
+				};
+			case 'jetpack_backup_realtime':
+				return {
+					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Purchased %(purchaseDate)s', {
+						args: {
+							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+						},
+					} ),
+					description: __(
+						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+					),
+					purchase,
+					isCurrent: true,
+				};
+		}
+	}
+
 	render() {
 		const {
 			activeSitePurchases,
@@ -28,10 +133,8 @@ export class Plans extends React.Component {
 			products,
 			realtimeBackupUpgradeUrl,
 			sitePlan,
-			siteRawlUrl,
 		} = this.props;
 
-		// const siteSlug = get( this.props.plan );
 		const plan = get( sitePlan, 'product_slug' );
 		const upgradeLinks = {
 			daily: dailyBackupUpgradeUrl,
@@ -46,135 +149,24 @@ export class Plans extends React.Component {
 		);
 		const planClass = getPlanClass( plan );
 
-		// singleProductContent should maintain this priority order for display:
-		// 1. Professional
-		// 2. Real-time
-		// 3. Premium
-		// 4. Personal
-		// 5. Daily
-		// 6. Free
-		let singleProductContent;
+		// The order here needs to be maintained so that cases with both a plan and a product
+		// display correctly.
+		let productCardProps = null;
 		if ( 'is-business-plan' === planClass ) {
-			singleProductContent = (
-				<ProductCard
-					{ ...{
-						title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-							components: {
-								em: <em />,
-							},
-						} ),
-						subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
-							components: {
-								planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
-							},
-						} ),
-						description: __(
-							'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-						),
-					} }
-				/>
-			);
+			productCardProps = this.getProductCardPropsForPlanClass( planClass );
 		} else if ( undefined !== activeJetpackBackupRealtimePurchase ) {
-			singleProductContent = (
-				<ProductCard
-					{ ...{
-						title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-							components: {
-								em: <em />,
-							},
-						} ),
-						subtitle: __( 'Purchased %(purchaseDate)s', {
-							args: {
-								purchaseDate: moment(
-									activeSitePurchases.find(
-										purchase => 'jetpack_backup_realtime' === purchase.product_slug
-									).subscribedDate
-								).format( 'YYYY-MM-DD' ),
-							},
-						} ),
-						description: __(
-							'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-						),
-						purchase: activeJetpackBackupRealtimePurchase,
-						isCurrent: true,
-					} }
-				/>
-			);
+			productCardProps = this.getProductCardPropsForPurchase( activeJetpackBackupRealtimePurchase );
 		} else if ( 'is-premium-plan' === planClass ) {
-			singleProductContent = (
-				<ProductCard
-					{ ...{
-						title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-							components: {
-								em: <em />,
-							},
-						} ),
-						subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
-							components: {
-								planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
-							},
-						} ),
-						description: __( 'Always-on backups ensure you never lose your site.' ),
-					} }
-				/>
-			);
+			productCardProps = this.getProductCardPropsForPlanClass( 'is-premium-plan' );
 		} else if ( 'is-personal-plan' === planClass ) {
-			singleProductContent = (
-				<ProductCard
-					{ ...{
-						title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-							components: {
-								em: <em />,
-							},
-						} ),
-						subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
-							components: {
-								planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
-							},
-						} ),
-						description: __( 'Always-on backups ensure you never lose your site.' ),
-					} }
-				/>
-			);
+			productCardProps = this.getProductCardPropsForPlanClass( 'is-personal-plan' );
 		} else if ( undefined !== activeJetpackBackupDailyPurchase ) {
-			singleProductContent = (
-				<ProductCard
-					{ ...{
-						title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-							components: {
-								em: <em />,
-							},
-						} ),
-						subtitle: __( 'Purchased %(purchaseDate)s', {
-							args: {
-								purchaseDate: moment(
-									activeSitePurchases.find(
-										purchase => 'jetpack_backup_daily' === purchase.product_slug
-									).subscribedDate
-								).format( 'YYYY-MM-DD' ),
-							},
-						} ),
-						description: (
-							<>
-								<p>
-									{ __( '{{strong}}Looking for more?{{/strong}}', {
-										components: {
-											strong: <strong />,
-										},
-									} ) }
-								</p>
-								<p>
-									{ __(
-										'With Real-time backups, we save as you edit and you’ll get unlimited backup archives.'
-									) }
-								</p>
-							</>
-						),
-						purchase: activeJetpackBackupDailyPurchase,
-						isCurrent: true,
-					} }
-				/>
-			);
+			productCardProps = this.getProductCardPropsForPurchase( activeJetpackBackupDailyPurchase );
+		}
+
+		let singleProductContent;
+		if ( null !== productCardProps ) {
+			singleProductContent = <ProductCard { ...productCardProps } />;
 		} else if ( products && [ '', 'is-free-plan' ].includes( planClass ) ) {
 			singleProductContent = (
 				<SingleProductBackup

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { translate as __, moment } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -125,6 +125,17 @@ export class Plans extends React.Component {
 		}
 	}
 
+	getTitleSection() {
+		return (
+			<Fragment>
+				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+				<h2 className="plans-section__subheader">
+					{ __( "Just looking for backups? We've got you covered." ) }
+				</h2>
+			</Fragment>
+		);
+	}
+
 	render() {
 		const {
 			activeSitePurchases,
@@ -166,15 +177,23 @@ export class Plans extends React.Component {
 
 		let singleProductContent;
 		if ( null !== productCardProps ) {
-			singleProductContent = <ProductCard { ...productCardProps } />;
+			singleProductContent = (
+				<Fragment>
+					{ this.getTitleSection() }
+					<ProductCard { ...productCardProps } />
+				</Fragment>
+			);
 		} else if ( products && [ '', 'is-free-plan' ].includes( planClass ) ) {
 			singleProductContent = (
-				<SingleProductBackup
-					plan={ plan }
-					products={ products }
-					upgradeLinks={ upgradeLinks }
-					isFetchingData={ isFetchingData }
-				/>
+				<Fragment>
+					{ this.getTitleSection() }
+					<SingleProductBackup
+						plan={ plan }
+						products={ products }
+						upgradeLinks={ upgradeLinks }
+						isFetchingData={ isFetchingData }
+					/>
+				</Fragment>
 			);
 		}
 

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -180,7 +180,9 @@ export class Plans extends React.Component {
 			singleProductContent = (
 				<Fragment>
 					{ this.getTitleSection() }
-					<ProductCard { ...productCardProps } />
+					<div className="plans-section__single-product">
+						<ProductCard { ...productCardProps } />
+					</div>
 				</Fragment>
 			);
 		} else if ( products && [ '', 'is-free-plan' ].includes( planClass ) ) {

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -15,7 +15,7 @@ import QueryProducts from 'components/data/query-products';
 import QuerySite from 'components/data/query-site';
 import ProductCard from 'components/product-card';
 import { getPlanClass } from 'lib/plans/constants';
-import { getUpgradeUrl } from 'state/initial-state';
+import { getSiteRawUrl, getUpgradeUrl } from 'state/initial-state';
 import { getProducts, isFetchingProducts } from 'state/products';
 import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from 'state/site';
 
@@ -27,16 +27,19 @@ export class Plans extends React.Component {
 			isFetchingData,
 			products,
 			realtimeBackupUpgradeUrl,
+			sitePlan,
+			siteRawlUrl,
 		} = this.props;
 
-		const plan = get( this.props.sitePlan, 'product_slug' );
+		// const siteSlug = get( this.props.plan );
+		const plan = get( sitePlan, 'product_slug' );
 		const upgradeLinks = {
 			daily: dailyBackupUpgradeUrl,
 			'real-time': realtimeBackupUpgradeUrl,
 		};
 
 		const activePurchaseProductSlugs = activeSitePurchases.map( purchase => purchase.product_slug );
-		const planClass = getPlanClass( this.props.sitePlan );
+		const planClass = getPlanClass( plan );
 
 		// singleProductContent should maintain this priority order for display:
 		// 1. Professional
@@ -47,7 +50,27 @@ export class Plans extends React.Component {
 		// 6. Free
 		let singleProductContent;
 		if ( 'is-business-plan' === planClass ) {
-			singleProductContent = <ProductCard title="Business Plan" />;
+			singleProductContent = (
+				<ProductCard
+					{ ...{
+						title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+							components: {
+								em: <em />,
+							},
+						} ),
+						subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
+							components: {
+								planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+							},
+						} ),
+						description: __(
+							'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+						),
+						purchase: true,
+						isCurrent: true,
+					} }
+				/>
+			);
 		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_realtime' ) ) {
 			singleProductContent = (
 				<ProductCard
@@ -75,9 +98,45 @@ export class Plans extends React.Component {
 				/>
 			);
 		} else if ( 'is-premium-plan' === planClass ) {
-			singleProductContent = <ProductCard title="Premium Plan" />;
+			singleProductContent = (
+				<ProductCard
+					{ ...{
+						title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+							components: {
+								em: <em />,
+							},
+						} ),
+						subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
+							components: {
+								planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+							},
+						} ),
+						description: __( 'Always-on backups ensure you never lose your site.' ),
+						purchase: true,
+						isCurrent: true,
+					} }
+				/>
+			);
 		} else if ( 'is-personal-plan' === planClass ) {
-			singleProductContent = <ProductCard title="Personal Plan" />;
+			singleProductContent = (
+				<ProductCard
+					{ ...{
+						title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+							components: {
+								em: <em />,
+							},
+						} ),
+						subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
+							components: {
+								planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+							},
+						} ),
+						description: __( 'Always-on backups ensure you never lose your site.' ),
+						purchase: true,
+						isCurrent: true,
+					} }
+				/>
+			);
 		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_daily' ) ) {
 			singleProductContent = (
 				<ProductCard
@@ -146,6 +205,7 @@ export default connect( state => {
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
 		sitePlan: getSitePlan( state ),
+		siteRawlUrl: getSiteRawUrl( state ),
 		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
 	};
 } )( Plans );

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { translate as __, moment } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
@@ -12,17 +13,20 @@ import PlanGrid from './plan-grid';
 import { SingleProductBackup } from './single-product-backup';
 import QueryProducts from 'components/data/query-products';
 import QuerySite from 'components/data/query-site';
+import ProductCard from 'components/product-card';
+import { getPlanClass } from 'lib/plans/constants';
 import { getUpgradeUrl } from 'state/initial-state';
-import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getProducts, isFetchingProducts } from 'state/products';
+import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from 'state/site';
 
 export class Plans extends React.Component {
 	render() {
 		const {
+			activeSitePurchases,
 			dailyBackupUpgradeUrl,
+			isFetchingData,
 			products,
 			realtimeBackupUpgradeUrl,
-			isFetchingData,
 		} = this.props;
 
 		const plan = get( this.props.sitePlan, 'product_slug' );
@@ -31,16 +35,80 @@ export class Plans extends React.Component {
 			'real-time': realtimeBackupUpgradeUrl,
 		};
 
-		return (
-			<React.Fragment>
-				<QueryProducts />
-				<QuerySite />
+		const activePurchaseProductSlugs = activeSitePurchases.map( purchase => purchase.product_slug );
+		const planClass = getPlanClass( this.props.sitePlan );
+
+		// singleProductContent should maintain this priority order for display:
+		// 1. Professional
+		// 2. Real-time
+		// 3. Premium
+		// 4. Personal
+		// 5. Daily
+		// 6. Free
+		let singleProductContent;
+		if ( 'is-business-plan' === planClass ) {
+			singleProductContent = <ProductCard title="Business Plan" />;
+		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_realtime' ) ) {
+			singleProductContent = <ProductCard title="Jetpack Backup Realtime" />;
+		} else if ( 'is-premium-plan' === planClass ) {
+			singleProductContent = <ProductCard title="Premium Plan" />;
+		} else if ( 'is-personal-plan' === planClass ) {
+			singleProductContent = <ProductCard title="Personal Plan" />;
+		} else if ( activePurchaseProductSlugs.includes( 'jetpack_backup_daily' ) ) {
+			singleProductContent = (
+				<ProductCard
+					{ ...{
+						title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+							components: {
+								em: <em />,
+							},
+						} ),
+						subtitle: __( 'Purchased %(purchaseDate)s', {
+							args: {
+								purchaseDate: moment(
+									activeSitePurchases.find(
+										purchase => 'jetpack_backup_daily' === purchase.product_slug
+									).subscribedDate
+								).format( 'YYYY-MM-DD' ),
+							},
+						} ),
+						description: (
+							<>
+								<p>
+									{ __( '{{strong}}Looking for more?{{/strong}}', {
+										components: {
+											strong: <strong />,
+										},
+									} ) }
+								</p>
+								<p>
+									{ __(
+										'With Real-time backups, we save as you edit and you’ll get unlimited backup archives.'
+									) }
+								</p>
+							</>
+						),
+						purchase: true,
+						isCurrent: true,
+					} }
+				/>
+			);
+		} else if ( products && 'is-free-plan' === planClass ) {
+			singleProductContent = (
 				<SingleProductBackup
 					plan={ plan }
 					products={ products }
 					upgradeLinks={ upgradeLinks }
 					isFetchingData={ isFetchingData }
 				/>
+			);
+		}
+
+		return (
+			<React.Fragment>
+				<QueryProducts />
+				<QuerySite />
+				{ singleProductContent }
 				<PlanGrid />
 			</React.Fragment>
 		);
@@ -49,6 +117,7 @@ export class Plans extends React.Component {
 
 export default connect( state => {
 	return {
+		activeSitePurchases: getActiveSitePurchases( state ),
 		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -2,229 +2,26 @@
  * External dependencies
  */
 import React, { Fragment } from 'react';
-import { connect } from 'react-redux';
-import { translate as __, moment } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import PlanGrid from './plan-grid';
-import { SingleProductBackup } from './single-product-backup';
 import QueryProducts from 'components/data/query-products';
 import QuerySite from 'components/data/query-site';
-import ProductCard from 'components/product-card';
-import { getPlanClass } from 'lib/plans/constants';
-import { getSiteRawUrl, getUpgradeUrl } from 'state/initial-state';
-import { getProducts, isFetchingProducts } from 'state/products';
-import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from 'state/site';
+import PlanGrid from './plan-grid';
+import ProductSelector from './product-selector';
 
 export class Plans extends React.Component {
-	getProductCardPropsForPurchase( purchase ) {
-		const { siteRawlUrl } = this.props;
-
-		const planClass = getPlanClass( purchase.product_slug );
-
-		switch ( planClass ) {
-			case 'is-daily-backup-plan':
-				return {
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Purchased %(purchaseDate)s', {
-						args: {
-							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
-						},
-					} ),
-					description: (
-						<>
-							<p>
-								{ __( '{{strong}}Looking for more?{{/strong}}', {
-									components: {
-										strong: <strong />,
-									},
-								} ) }
-							</p>
-							<p>
-								{ __(
-									'With Real-time backups, we save as you edit and you’ll get unlimited backup archives.'
-								) }
-							</p>
-						</>
-					),
-					purchase,
-					isCurrent: true,
-				};
-			case 'jetpack_backup_realtime':
-				return {
-					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Purchased %(purchaseDate)s', {
-						args: {
-							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
-						},
-					} ),
-					description: __(
-						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-					),
-					purchase,
-					isCurrent: true,
-				};
-			case 'is-personal-plan':
-				return {
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
-						components: {
-							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
-						},
-					} ),
-					description: __( 'Always-on backups ensure you never lose your site.' ),
-					purchase,
-					isCurrent: true,
-				};
-			case 'is-premium-plan':
-				return {
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
-						components: {
-							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
-						},
-					} ),
-					description: __( 'Always-on backups ensure you never lose your site.' ),
-					purchase,
-					isCurrent: true,
-				};
-			case 'is-business-plan':
-				return {
-					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
-						components: {
-							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
-						},
-					} ),
-					description: __(
-						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-					),
-					purchase,
-					isCurrent: true,
-				};
-		}
-	}
-
-	getTitleSection() {
+	render() {
 		return (
 			<Fragment>
-				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
-				<h2 className="plans-section__subheader">
-					{ __( "Just looking for backups? We've got you covered." ) }
-				</h2>
-			</Fragment>
-		);
-	}
-
-	findPrioritizedPurchase() {
-		const { activeSitePurchases } = this.props;
-
-		// Note: the order here is important, as it resolves cases where a site
-		// has both a plan and a product at the same time.
-		const planClasses = [
-			'is-business-plan',
-			'is-realtime-backup-plan',
-			'is-premium-plan',
-			'is-personal-plan',
-			'is-daily-backup-plan',
-		];
-
-		for ( const planClass of planClasses ) {
-			const purchase = activeSitePurchases.find(
-				item => getPlanClass( item.product_slug ) === planClass
-			);
-			if ( undefined !== purchase ) {
-				return purchase;
-			}
-		}
-
-		return false;
-	}
-
-	render() {
-		const {
-			dailyBackupUpgradeUrl,
-			isFetchingData,
-			products,
-			realtimeBackupUpgradeUrl,
-			sitePlan,
-		} = this.props;
-
-		const plan = get( sitePlan, 'product_slug' );
-		const upgradeLinks = {
-			daily: dailyBackupUpgradeUrl,
-			'real-time': realtimeBackupUpgradeUrl,
-		};
-
-		let singleProductContent;
-
-		const purchase = this.findPrioritizedPurchase();
-		if ( purchase ) {
-			const productCardProps = this.getProductCardPropsForPurchase( purchase );
-			singleProductContent = (
-				<Fragment>
-					{ this.getTitleSection() }
-					<div className="plans-section__single-product">
-						<ProductCard { ...productCardProps } />
-					</div>
-				</Fragment>
-			);
-		} else {
-			singleProductContent = (
-				<Fragment>
-					{ this.getTitleSection() }
-					<SingleProductBackup
-						plan={ plan }
-						products={ products }
-						upgradeLinks={ upgradeLinks }
-						isFetchingData={ isFetchingData }
-					/>
-				</Fragment>
-			);
-		}
-
-		return (
-			<React.Fragment>
 				<QueryProducts />
 				<QuerySite />
-				{ singleProductContent }
+				<ProductSelector />
 				<PlanGrid />
-			</React.Fragment>
+			</Fragment>
 		);
 	}
 }
 
-export default connect( state => {
-	return {
-		activeSitePurchases: getActiveSitePurchases( state ),
-		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
-		products: getProducts( state ),
-		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
-		sitePlan: getSitePlan( state ),
-		siteRawlUrl: getSiteRawUrl( state ),
-		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
-	};
-} )( Plans );
+export default Plans;

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -34,95 +34,79 @@ class ProductSelector extends Component {
 
 		const planClass = getPlanClass( purchase.product_slug );
 
+		const dailyBackupTitle = __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+			components: {
+				em: <em />,
+			},
+		} );
+
+		const realTimeBackupTitle = __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+			components: {
+				em: <em />,
+			},
+		} );
+
+		const purchasedDate = __( 'Purchased %(purchaseDate)s', {
+			args: {
+				purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+			},
+		} );
+
+		const backupDescription = __( 'Always-on backups ensure you never lose your site.' );
+		const backupDescriptionRealtime = __(
+			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+		);
+
 		switch ( planClass ) {
 			case 'is-daily-backup-plan':
 				return {
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Purchased %(purchaseDate)s', {
-						args: {
-							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
-						},
-					} ),
-					description: __(
-						'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',
-						{
-							components: {
-								strong: <strong />,
-							},
-						}
-					),
+					title: dailyBackupTitle,
+					subtitle: purchasedDate,
+					description: backupDescription,
 					purchase,
 					isCurrent: true,
 				};
 			case 'is-realtime-backup-plan':
 				return {
-					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
-					subtitle: __( 'Purchased %(purchaseDate)s', {
-						args: {
-							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
-						},
-					} ),
-					description: __(
-						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-					),
+					title: realTimeBackupTitle,
+					subtitle: purchasedDate,
+					description: backupDescriptionRealtime,
 					purchase,
 					isCurrent: true,
 				};
 			case 'is-personal-plan':
 				return {
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
+					title: dailyBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
 						components: {
 							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
 						},
 					} ),
-					description: __( 'Always-on backups ensure you never lose your site.' ),
+					description: backupDescription,
 					purchase,
 					isCurrent: true,
 				};
 			case 'is-premium-plan':
 				return {
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
+					title: dailyBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
 						components: {
 							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
 						},
 					} ),
-					description: __( 'Always-on backups ensure you never lose your site.' ),
+					description: backupDescription,
 					purchase,
 					isCurrent: true,
 				};
 			case 'is-business-plan':
 				return {
-					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-						components: {
-							em: <em />,
-						},
-					} ),
+					title: realTimeBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
 						components: {
 							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
 						},
 					} ),
-					description: __(
-						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
-					),
+					description: backupDescriptionRealtime,
 					purchase,
 					isCurrent: true,
 				};

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -22,6 +22,7 @@ class ProductSelector extends Component {
 
 		const planClass = getPlanClass( purchase.product_slug );
 
+		// TODO: Move out those somewhere else to make this a flexible and fully reusable component.
 		const dailyBackupTitle = __( 'Jetpack Backup {{em}}Daily{{/em}}', {
 			components: {
 				em: <em />,

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -52,6 +52,10 @@ class ProductSelector extends Component {
 				rel="noopener noreferrer"
 			/>
 		);
+		const additionalProps = {
+			purchase,
+			isCurrent: true,
+		};
 
 		switch ( planClass ) {
 			case 'is-daily-backup-plan':
@@ -59,16 +63,14 @@ class ProductSelector extends Component {
 					title: dailyBackupTitle,
 					subtitle: purchasedDate,
 					description: backupDescription,
-					purchase,
-					isCurrent: true,
+					...additionalProps,
 				};
 			case 'is-realtime-backup-plan':
 				return {
 					title: realTimeBackupTitle,
 					subtitle: purchasedDate,
 					description: backupDescriptionRealtime,
-					purchase,
-					isCurrent: true,
+					...additionalProps,
 				};
 			case 'is-personal-plan':
 				return {
@@ -79,8 +81,7 @@ class ProductSelector extends Component {
 						},
 					} ),
 					description: backupDescription,
-					purchase,
-					isCurrent: true,
+					...additionalProps,
 				};
 			case 'is-premium-plan':
 				return {
@@ -91,8 +92,7 @@ class ProductSelector extends Component {
 						},
 					} ),
 					description: backupDescription,
-					purchase,
-					isCurrent: true,
+					...additionalProps,
 				};
 			case 'is-business-plan':
 				return {
@@ -103,8 +103,7 @@ class ProductSelector extends Component {
 						},
 					} ),
 					description: backupDescriptionRealtime,
-					purchase,
-					isCurrent: true,
+					...additionalProps,
 				};
 		}
 	}

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -15,7 +15,6 @@ import { getPlanClass } from '../lib/plans/constants';
 import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from '../state/site';
 import { getSiteRawUrl, getUpgradeUrl } from '../state/initial-state';
 import { getProducts, isFetchingProducts } from '../state/products';
-// import { JETPACK_PRODUCTS } from '../lib/products/constants';
 
 class ProductSelector extends Component {
 	getTitleSection() {

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -44,6 +44,13 @@ class ProductSelector extends Component {
 		const backupDescriptionRealtime = __(
 			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
 		);
+		const planLink = (
+			<a
+				href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
+				target="_blank"
+				rel="noopener noreferrer"
+			/>
+		);
 
 		switch ( planClass ) {
 			case 'is-daily-backup-plan':
@@ -67,13 +74,7 @@ class ProductSelector extends Component {
 					title: dailyBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
 						components: {
-							planLink: (
-								<a
-									href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+							planLink,
 						},
 					} ),
 					description: backupDescription,
@@ -85,13 +86,7 @@ class ProductSelector extends Component {
 					title: dailyBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
 						components: {
-							planLink: (
-								<a
-									href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+							planLink,
 						},
 					} ),
 					description: backupDescription,
@@ -103,13 +98,7 @@ class ProductSelector extends Component {
 					title: realTimeBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
 						components: {
-							planLink: (
-								<a
-									href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
+							planLink,
 						},
 					} ),
 					description: backupDescriptionRealtime,

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -85,7 +85,7 @@ class ProductSelector extends Component {
 					} ),
 					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
 						components: {
-							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
 						},
 					} ),
 					description: __( 'Always-on backups ensure you never lose your site.' ),
@@ -101,7 +101,7 @@ class ProductSelector extends Component {
 					} ),
 					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
 						components: {
-							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
 						},
 					} ),
 					description: __( 'Always-on backups ensure you never lose your site.' ),
@@ -117,7 +117,7 @@ class ProductSelector extends Component {
 					} ),
 					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
 						components: {
-							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
 						},
 					} ),
 					description: __(

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -67,7 +67,13 @@ class ProductSelector extends Component {
 					title: dailyBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
 						components: {
-							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
+							planLink: (
+								<a
+									href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						},
 					} ),
 					description: backupDescription,
@@ -79,7 +85,13 @@ class ProductSelector extends Component {
 					title: dailyBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
 						components: {
-							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
+							planLink: (
+								<a
+									href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						},
 					} ),
 					description: backupDescription,
@@ -91,7 +103,13 @@ class ProductSelector extends Component {
 					title: realTimeBackupTitle,
 					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
 						components: {
-							planLink: <a href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` } />,
+							planLink: (
+								<a
+									href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 						},
 					} ),
 					description: backupDescriptionRealtime,

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -17,17 +17,6 @@ import { getSiteRawUrl, getUpgradeUrl } from '../state/initial-state';
 import { getProducts, isFetchingProducts } from '../state/products';
 
 class ProductSelector extends Component {
-	getTitleSection() {
-		return (
-			<Fragment>
-				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
-				<h2 className="plans-section__subheader">
-					{ __( "Just looking for backups? We've got you covered." ) }
-				</h2>
-			</Fragment>
-		);
-	}
-
 	getProductCardPropsForPurchase( purchase ) {
 		const { siteRawlUrl } = this.props;
 
@@ -137,8 +126,18 @@ class ProductSelector extends Component {
 		return false;
 	}
 
-	render() {
-		let singleProductContent;
+	renderTitleSection() {
+		return (
+			<Fragment>
+				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+				<h2 className="plans-section__subheader">
+					{ __( "Just looking for backups? We've got you covered." ) }
+				</h2>
+			</Fragment>
+		);
+	}
+
+	renderSingleProductContent() {
 		const {
 			dailyBackupUpgradeUrl,
 			isFetchingData,
@@ -146,7 +145,6 @@ class ProductSelector extends Component {
 			realtimeBackupUpgradeUrl,
 			sitePlan,
 		} = this.props;
-
 		const plan = get( sitePlan, 'product_slug' );
 		const upgradeLinks = {
 			daily: dailyBackupUpgradeUrl,
@@ -156,26 +154,28 @@ class ProductSelector extends Component {
 		const purchase = this.findPrioritizedPurchase();
 		if ( purchase ) {
 			const productCardProps = this.getProductCardPropsForPurchase( purchase );
-			singleProductContent = (
+			return (
 				<div className="plans-section__single-product">
 					<ProductCard { ...productCardProps } />
 				</div>
 			);
-		} else {
-			singleProductContent = (
-				<SingleProductBackup
-					plan={ plan }
-					products={ products }
-					upgradeLinks={ upgradeLinks }
-					isFetchingData={ isFetchingData }
-				/>
-			);
 		}
 
 		return (
+			<SingleProductBackup
+				plan={ plan }
+				products={ products }
+				upgradeLinks={ upgradeLinks }
+				isFetchingData={ isFetchingData }
+			/>
+		);
+	}
+
+	render() {
+		return (
 			<Fragment>
-				{ this.getTitleSection() }
-				{ singleProductContent }
+				{ this.renderTitleSection() }
+				{ this.renderSingleProductContent() }
 			</Fragment>
 		);
 	}

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -1,0 +1,211 @@
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { moment, translate as __ } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import ProductCard from '../components/product-card';
+import { SingleProductBackup } from './single-product-backup';
+import { getPlanClass } from '../lib/plans/constants';
+import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from '../state/site';
+import { getSiteRawUrl, getUpgradeUrl } from '../state/initial-state';
+import { getProducts, isFetchingProducts } from '../state/products';
+// import { JETPACK_PRODUCTS } from '../lib/products/constants';
+
+class ProductSelector extends Component {
+	getTitleSection() {
+		return (
+			<Fragment>
+				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+				<h2 className="plans-section__subheader">
+					{ __( "Just looking for backups? We've got you covered." ) }
+				</h2>
+			</Fragment>
+		);
+	}
+
+	getProductCardPropsForPurchase( purchase ) {
+		const { siteRawlUrl } = this.props;
+
+		const planClass = getPlanClass( purchase.product_slug );
+
+		switch ( planClass ) {
+			case 'is-daily-backup-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Purchased %(purchaseDate)s', {
+						args: {
+							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+						},
+					} ),
+					description: __(
+						'{{strong}}Looking for more?{{/strong}} With Real-time backups, we save as you edit and you’ll get unlimited backup archives.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					),
+					purchase,
+					isCurrent: true,
+				};
+			case 'is-jetpack-backup-realtime':
+				return {
+					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Purchased %(purchaseDate)s', {
+						args: {
+							purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+						},
+					} ),
+					description: __(
+						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+					),
+					purchase,
+					isCurrent: true,
+				};
+			case 'is-personal-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
+						components: {
+							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+						},
+					} ),
+					description: __( 'Always-on backups ensure you never lose your site.' ),
+					purchase,
+					isCurrent: true,
+				};
+			case 'is-premium-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
+						components: {
+							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+						},
+					} ),
+					description: __( 'Always-on backups ensure you never lose your site.' ),
+					purchase,
+					isCurrent: true,
+				};
+			case 'is-business-plan':
+				return {
+					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+						components: {
+							em: <em />,
+						},
+					} ),
+					subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
+						components: {
+							planLink: <a href={ `/plans/my-plan/${ siteRawlUrl }` } />,
+						},
+					} ),
+					description: __(
+						'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+					),
+					purchase,
+					isCurrent: true,
+				};
+		}
+	}
+
+	findPrioritizedPurchase() {
+		const { activeSitePurchases } = this.props;
+
+		// Note: the order here is important, as it resolves cases where a site
+		// has both a plan and a product at the same time.
+		const planClasses = [
+			'is-business-plan',
+			'is-realtime-backup-plan',
+			'is-premium-plan',
+			'is-personal-plan',
+			'is-daily-backup-plan',
+		];
+
+		for ( const planClass of planClasses ) {
+			const purchase = activeSitePurchases.find(
+				item => getPlanClass( item.product_slug ) === planClass
+			);
+			if ( undefined !== purchase ) {
+				return purchase;
+			}
+		}
+
+		return false;
+	}
+
+	render() {
+		let singleProductContent;
+		const {
+			dailyBackupUpgradeUrl,
+			isFetchingData,
+			products,
+			realtimeBackupUpgradeUrl,
+			sitePlan,
+		} = this.props;
+
+		const plan = get( sitePlan, 'product_slug' );
+		const upgradeLinks = {
+			daily: dailyBackupUpgradeUrl,
+			'real-time': realtimeBackupUpgradeUrl,
+		};
+
+		const purchase = this.findPrioritizedPurchase();
+		if ( purchase ) {
+			const productCardProps = this.getProductCardPropsForPurchase( purchase );
+			singleProductContent = (
+				<div className="plans-section__single-product">
+					<ProductCard { ...productCardProps } />
+				</div>
+			);
+		} else {
+			singleProductContent = (
+				<SingleProductBackup
+					plan={ plan }
+					products={ products }
+					upgradeLinks={ upgradeLinks }
+					isFetchingData={ isFetchingData }
+				/>
+			);
+		}
+
+		return (
+			<Fragment>
+				{ this.getTitleSection() }
+				{ singleProductContent }
+			</Fragment>
+		);
+	}
+}
+
+export default connect( state => {
+	return {
+		activeSitePurchases: getActiveSitePurchases( state ),
+		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
+		products: getProducts( state ),
+		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
+		sitePlan: getSitePlan( state ),
+		siteRawlUrl: getSiteRawUrl( state ),
+		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
+	};
+} )( ProductSelector );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -58,7 +58,7 @@ class ProductSelector extends Component {
 					purchase,
 					isCurrent: true,
 				};
-			case 'is-jetpack-backup-realtime':
+			case 'is-realtime-backup-plan':
 				return {
 					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
 						components: {

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -27,6 +27,7 @@ export function SingleProductBackup( { plan, products, upgradeLinks, isFetchingD
 			<h2 className="plans-section__subheader">
 				{ __( "Just looking for backups? We've got you covered." ) }
 			</h2>
+
 			<div className="plans-section__single-product">
 				{ isFetchingData ? (
 					<div className="plans-section__single-product-skeleton is-placeholder" />

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -23,11 +23,6 @@ export function SingleProductBackup( { plan, products, upgradeLinks, isFetchingD
 
 	return (
 		<React.Fragment>
-			<h1 className="plans-section__header">{ __( 'Single Products' ) }</h1>
-			<h2 className="plans-section__subheader">
-				{ __( "Just looking for backups? We've got you covered." ) }
-			</h2>
-
 			<div className="plans-section__single-product">
 				{ isFetchingData ? (
 					<div className="plans-section__single-product-skeleton is-placeholder" />

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -45,6 +45,7 @@ function SingleProductBackupCard( { products, upgradeLinks } ) {
 	const priceRealtimeMonthly = get( products, [ 'jetpack_backup_realtime_monthly', 'cost' ], '' );
 	const priceRealtimeMonthlyPerYear = '' === priceRealtimeMonthly ? '' : priceRealtimeMonthly * 12;
 
+	// TODO: Move out those somewhere else to make this a flexible and fully reusable component.
 	const backupOptions = [
 		{
 			type: 'daily',
@@ -176,6 +177,7 @@ class SingleProductBackupBody extends React.Component {
 			upgradeLinks,
 		} = this.props;
 
+		// TODO: Move out those somewhere else to make this a flexible and fully reusable component.
 		const upgradeTitles = {
 			'real-time': __( 'Upgrade to Real-Time Backups' ),
 			daily: __( 'Upgrade to Daily Backups' ),

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -186,7 +186,7 @@ export function getSitePurchases( state ) {
 /**
  * Returns the active purchases for a site
  * @param {*} state Global state tree
- * @return {Array}  Active purchse for the site
+ * @return {Array}  Active purchases for the site
  */
 export function getActiveSitePurchases( state ) {
 	return getSitePurchases( state ).filter( purchase => '1' === purchase.active );

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -180,7 +180,16 @@ export function getAvailablePlans( state ) {
 }
 
 export function getSitePurchases( state ) {
-	return get( state.jetpack.siteData, [ 'data', 'sitePurchases' ] );
+	return get( state.jetpack.siteData, [ 'data', 'sitePurchases' ], [] );
+}
+
+/**
+ * Returns the active purchases for a site
+ * @param {*} state Global state tree
+ * @return {Array}  Active purchse for the site
+ */
+export function getActiveSitePurchases( state ) {
+	return getSitePurchases( state ).filter( purchase => '1' === purchase.active );
 }
 
 export function getSiteID( state ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This updates the Plans page to use the `purchases` state to decide what to show for Jetpack Backup.

To accomplish this:
1. `purchases` is added to the Plans component via `getActiveSitePurchases()`
2. The `ProductCard` from Calypso is copied over to Jetpack. (I found it required very little modification to do so, and doing this greatly sped up the UI development.)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:
Go to `/wp-admin/admin.php?page=jetpack#/plans` and test the Jetpack Backup card:
1. A free plan should show the upgrade card.
2. Both Jetpack Backup Daily and Realtime should be shown on the card when purchased by themselves.
3. Premium and Professional plans should show Jetpack Daily and Realtime, respectively.

An easy way to test is to use one site, and use the "Manage Subscription" button to remove the plan/product to purchase a new one. Note that in cases of overlap such as a premium plan having also purchased Jetpack Backup Realtime, the highest tier option is picked for display.

#### Proposed changelog entry for your changes:
* None needed, part of Jetpack Backup project.
