### PR TITLE
Marked the xmlrpc_api_url method as deprecated.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5130,6 +5130,7 @@ endif;
 	 * @return string
 	 */
 	public static function xmlrpc_api_url() {
+		_deprecated_function( __METHOD__, 'jetpack-8.0' );
 		return self::connection()->xmlrpc_api_url();
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5130,7 +5130,7 @@ endif;
 	 * @return string
 	 */
 	public static function xmlrpc_api_url() {
-		_deprecated_function( __METHOD__, 'jetpack-8.0' );
+		_deprecated_function( __METHOD__, 'jetpack-8.0', 'Automattic\\Jetpack\\Connection\\Manager::xmlrpc_api_url()' );
 		return self::connection()->xmlrpc_api_url();
 	}
 

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -289,7 +289,8 @@ class Actions {
 		 */
 		$query_args = apply_filters( 'jetpack_sync_send_data_query_args', $query_args );
 
-		$url = add_query_arg( $query_args, \Jetpack::xmlrpc_api_url() );
+		$connection = new Jetpack_Connection();
+		$url        = add_query_arg( $query_args, $connection->xmlrpc_api_url() );
 
 		// If we're currently updating to Jetpack 7.7, the IXR client may be missing briefly
 		// because since 7.7 it's being autoloaded with Composer.


### PR DESCRIPTION
This changes the way the Actions class in the Sync package uses the `xmlrpc_api_url` method and adds the deprecation function call to the old one.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14048 

#### Changes proposed in this Pull Request:
* Changes the way we use the method in Actions.
* Adds a call do `_deprecated_function` in the main Jetpack class.

#### Testing instructions:
* Try connecting a new JN site, add something like a post, a new user, etc.
* Make sure the data is synchronized either using the cache site browser, or Calypso.

#### Proposed changelog entry for your changes:
* N/A
