### PR TITLE
Avoid PHP warnings by loading Gutenberg blocks later

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -609,8 +609,8 @@ class Jetpack {
 		 * Prepare Gutenberg Editor functionality
 		 */
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
-		Jetpack_Gutenberg::init();
-		Jetpack_Gutenberg::load_independent_blocks();
+		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'init' ) );
+		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );


### PR DESCRIPTION
Follow-up from #14030, to address similar issues

#### Changes proposed in this Pull Request:

* This avoids the following PHP warnings:
```
[25-Nov-2019 21:54:08 UTC] PHP Notice:  Automattic\Jetpack\Status was called <strong>incorrectly</strong>. Not all plugins have loaded yet but we requested the class Automattic\Jetpack\Status Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version dev-retry/phpcs-changed.) in /var/www/html/wp-includes/functions.php on line 4903
[25-Nov-2019 21:54:08 UTC] PHP Stack trace:
[25-Nov-2019 21:54:08 UTC] PHP   1. {main}() /var/www/html/wp-admin/admin-ajax.php:0
[25-Nov-2019 21:54:08 UTC] PHP   2. require_once() /var/www/html/wp-admin/admin-ajax.php:22
[25-Nov-2019 21:54:08 UTC] PHP   3. require_once() /var/www/html/wp-load.php:37
[25-Nov-2019 21:54:08 UTC] PHP   4. require_once() /var/www/html/wp-config.php:104
[25-Nov-2019 21:54:08 UTC] PHP   5. include_once() /var/www/html/wp-settings.php:360
[25-Nov-2019 21:54:08 UTC] PHP   6. require_once() /var/www/html/wp-content/plugins/jetpack/jetpack.php:146
[25-Nov-2019 21:54:08 UTC] PHP   7. require_once() /var/www/html/wp-content/plugins/jetpack/load-jetpack.php:68
[25-Nov-2019 21:54:08 UTC] PHP   8. Jetpack_Admin::init() /var/www/html/wp-content/plugins/jetpack/class.jetpack-admin.php:286
[25-Nov-2019 21:54:08 UTC] PHP   9. Jetpack_Admin->__construct() /var/www/html/wp-content/plugins/jetpack/class.jetpack-admin.php:24
[25-Nov-2019 21:54:08 UTC] PHP  10. Jetpack::init() /var/www/html/wp-content/plugins/jetpack/class.jetpack-admin.php:35
[25-Nov-2019 21:54:08 UTC] PHP  11. Jetpack->__construct() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:399
[25-Nov-2019 21:54:08 UTC] PHP  12. Jetpack_Gutenberg::load_independent_blocks() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:614
[25-Nov-2019 21:54:08 UTC] PHP  13. Jetpack_Gutenberg::should_load() /var/www/html/wp-content/plugins/jetpack/class.jetpack-gutenberg.php:665
[25-Nov-2019 21:54:08 UTC] PHP  14. spl_autoload_call() /var/www/html/wp-content/plugins/jetpack/class.jetpack-gutenberg.php:449
[25-Nov-2019 21:54:08 UTC] PHP  15. Automattic\Jetpack\Autoloader\autoloader() /var/www/html/wp-content/plugins/jetpack/class.jetpack-gutenberg.php:449
[25-Nov-2019 21:54:08 UTC] PHP  16. _doing_it_wrong() /var/www/html/wp-content/plugins/jetpack/vendor/autoload_packages.php:104
[25-Nov-2019 21:54:08 UTC] PHP  17. trigger_error() /var/www/html/wp-includes/functions.php:4903
```

#### Testing instructions:

* Check out this branch on a brand new site (JN would do the trick).
* You should not see any warnings in the logs.
* Blocks should still be available in the editor. Check `Jetpack_Editor_Initial_State.available_blocks` in the browser console to see that every block is there.

#### Proposed changelog entry for your changes:

* N/A
