### PR TITLE
Instant Search: Add error/offline handling for API

### DIFF
--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -3,4 +3,4 @@ export const SORT_DIRECTION_ASC = 'ASC';
 export const SORT_DIRECTION_DESC = 'DESC';
 export const RESULT_FORMAT_MINIMAL = 'minimal';
 export const RESULT_FORMAT_PRODUCT = 'product';
-export const FIVE_MINUTES_IN_MILLISECONDS = 5 * 60 * 1000;
+export const MINUTE_IN_MILLISECONDS = 60 * 1000;


### PR DESCRIPTION
Addresses part of #13751.

#### Changes proposed in this Pull Request:
This PR adds falling back to an in-memory cache with a 30-minute time-to-live whenever we encounter an offline network state or any network errors.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes, it adds error/offline handling for Instant Search's API library. 

#### Testing instructions:
1. Setup Instant Search as per instructions in the [readme](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions).
2. Enter a query and ensure the results render as expected.
3. Enter a different query and ensure the results render as expected.
4. Use your browser's developer console to simulate an offline network state.
5. Enter the same query from step 2 and ensure the results still render as expected. You can also try entering the query from step 3 and expect the same.

#### Proposed changelog entry for your changes:
* None.
