### PR TITLE
Fix close card button position on close apps card

### DIFF
--- a/_inc/client/components/apps-card/style.scss
+++ b/_inc/client/components/apps-card/style.scss
@@ -17,8 +17,12 @@
 
 .jp-apps-card__dismiss {
 	position: absolute;
-	top: 1px;
+	top: 8px;
 	right: 8px;
+
+	&.dops-button.is-compact {
+		padding: 8px 8px 2px 8px;
+	}
 }
 
 .jp-apps-card__top {


### PR DESCRIPTION
Button has been re-positioned and given a larger hit area.

Fixes #14128

#### Changes proposed in this Pull Request:
* Move close card button position

#### Testing instructions:

* Pull this branch
* Go to `admin.php?page=jetpack#/dashboard` (aka At a glance)
* Scroll to the bottom of the page and look for the apps card (advertising mobile apps)
* Check the close button at the top right is neatly positioned and easily pressed

![Screenshot 2019-11-26 at 12 34 53](https://user-images.githubusercontent.com/411945/69634305-d6c34580-1049-11ea-8f3f-238c1e5c9e78.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
