### PR TITLE
Change 'See all features' buttons to regular links in the plans grid

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -340,12 +340,12 @@ class PlanGrid extends React.Component {
 					key={ 'bottom-' + planType }
 					className="plan-features__table-item is-bottom-buttons has-border-bottom"
 				>
-					<Button
+					<a
 						href={ this.props.plansLearnMoreUpgradeUrl }
 						onClick={ this.handleSeeFeaturesClick( planType ) }
 					>
 						{ plan.strings.see_all }
-					</Button>
+					</a>
 				</td>
 			);
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Change 'See all features' buttons to regular links in the plans grid.

**Before**
![linksnotbuttons](https://user-images.githubusercontent.com/478735/69635445-b056d780-1054-11ea-843d-51b12b6215ec.jpg)

**After**
<img width="948" alt="Screenshot 2019-11-26 at 13 54 16" src="https://user-images.githubusercontent.com/478735/69635455-b8167c00-1054-11ea-9f2d-c39f2bac5a4c.png">

Fixes n/a

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change 'See all features' buttons to regular links in the plans grid

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to /wp-admin/admin.php?page=jetpack#/plans
* Confirm that there are regular links and not buttons in the last row of the plans grid ('See all features')

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Change 'See all features' buttons to regular links in the plans grid
