### PR TITLE
Preload the admin.js script for faster connection experiance.

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -121,6 +121,13 @@ jQuery( document ).ready( function( $ ) {
 			} );
 			jetpackConnectIframe.hide();
 			$( '.jp-connect-full__button-container' ).after( jetpackConnectIframe );
+
+			// At this point we are pretty sure if things work out that we will be loading the admin script
+			var link = document.createElement( 'link' );
+			link.rel = 'preload';
+			link.as = 'script';
+			link.href = jpConnect.preFetchScript;
+			document.head.appendChild( link );
 		},
 		fetchPlanType: function() {
 			$.ajax( {

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -186,6 +186,7 @@ class Jetpack_Connection_Banner {
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
 				'plansPromptUrl'        => Jetpack::admin_url( 'page=jetpack#/plans-prompt' ),
 				'identity'              => $identity,
+				'preFetchScript'        => plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ) . '?ver=' . JETPACK__VERSION,
 			)
 		);
 	}


### PR DESCRIPTION
This PR tries to improve the loading experience of the user that use the connect in place flow. By prefetching the admin.js files while the user is also in the process of connecting. 

Since the admin.js file is pretty large prefetching is improved the load experiance quite a bit. 
This improvement currently only work in the latest Chrome browser. It doesn't load the resource twice in Firefox. ( Safari doesn't support the new connect in place flow.

#### Testing instructions:
Use the constant `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );` 
So that your site gets places in the new connect in place flow. 
In Chrome:
Have the network panel open. 
Notice that the admin.js file gets loaded before we navigate to the admin page. 

In Firefox.
Notice that admin.js file doesn't get loaded twice. 

#### Proposed changelog entry for your changes:
* Add prefetch of the admin.js file to the connection flow.
