### PR TITLE
Instant Search: move date into new component and use <time> element

### DIFF
--- a/modules/search/instant-search/components/search-result-date.jsx
+++ b/modules/search/instant-search/components/search-result-date.jsx
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+const SearchResultDate = ( { date, locale = 'en-US' } ) => {
+	if ( ! date ) {
+		return null;
+	}
+
+	const resultDate = new Date( date.split( ' ' )[ 0 ] );
+	return (
+		<time
+			className="jetpack-instant-search__search-result-date"
+			datetime={ resultDate.toISOString() }
+		>
+			{ resultDate.toLocaleDateString( locale, {
+				dateStyle: 'short',
+			} ) }
+		</time>
+	);
+};
+
+export default SearchResultDate;

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -11,6 +11,7 @@ import { h, Component } from 'preact';
 import Gridicon from './gridicon';
 import PostTypeIcon from './post-type-icon';
 import SearchResultComments from './search-result-comments';
+import SearchResultDate from './search-result-date';
 
 class SearchResultMinimal extends Component {
 	getIconSize() {
@@ -86,19 +87,16 @@ class SearchResultMinimal extends Component {
 	}
 
 	render() {
-		const { locale = 'en-US' } = this.props;
+		const { locale } = this.props;
 		const { result_type, fields, highlight } = this.props.result;
 		if ( result_type !== 'post' ) {
 			return null;
 		}
 		const noMatchingContent = ! highlight.content || highlight.content[ 0 ] === '';
+
 		return (
 			<li className="jetpack-instant-search__search-result-minimal">
-				<span className="jetpack-instant-search__search-result-minimal-date">
-					{ new Date( fields.date.split( ' ' )[ 0 ] ).toLocaleDateString( locale, {
-						dateStyle: 'short',
-					} ) }
-				</span>
+				<SearchResultDate date={ fields.date } locale={ locale } />
 				<h3 className="jetpack-instant-search__search-result-title">
 					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 					<a

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -2,6 +2,13 @@
 	padding: 0.125em 0;
 	margin: 1em 0;
 	position: relative;
+
+	.jetpack-instant-search__search-result-date {
+		margin: 0.5em 0;
+		float: right;
+		display: block;
+		font-size: 0.85em;
+	}
 }
 
 .jetpack-instant-search__search-result-minimal h3 {
@@ -19,13 +26,6 @@
 
 .jetpack-instant-search__search-result-minimal h3 {
 	overflow: hidden;
-}
-
-.jetpack-instant-search__search-result-minimal-date {
-	margin: 0.5em 0;
-	float: right;
-	display: block;
-	font-size: 0.85em;
 }
 
 .jetpack-instant-search__search-result-minimal-tag,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the `<time>` element for the result date
* Move the result date into a separate component so it can be easily reused across result types

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No - it's part of the Instant Search prototype and merges into instant-search-master.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

Example query: /?s=card&blog_id=84860689

Verify that the date continues to display correctly on minimal search results, and that the element is now a  `<time>` rather than a `<span>`:

<img width="727" alt="Screen Shot 2019-11-27 at 15 52 30" src="https://user-images.githubusercontent.com/17325/69689567-28dd9700-112e-11ea-9850-f4f2cd0c9dc7.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required.

