### PR TITLE
Twenty Twenty: ensure that recipe shortcodes are properly aligned

### DIFF
--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -208,6 +208,15 @@
 }
 
 /**
+ * Shortcodes
+ */
+
+/* Recipe */
+.entry-content .jetpack-recipe {
+	margin: 1em auto;
+}
+
+/**
  * Blocks
  */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

* Twenty Twenty can mess margins up a bit at times, like in #14020. This PR makes sure that recipes inserted via a shortcode are properly displayed.

**Before**

![image](https://user-images.githubusercontent.com/426388/69733404-90471700-112d-11ea-9687-0ed398e0ce5b.png)

**After**

![image](https://user-images.githubusercontent.com/426388/69733410-9210da80-112d-11ea-8d49-46877d5a5bc1.png)

#### Testing instructions:

* Start from a site using the Twenty Twenty Theme.
* Add a recipe to a classic block, using the following content:
https://gist.github.com/jeherve/dd9d8e9503d08a69f81e56d2bee516dd
* Publish, and ensure that the recipe is aligned properly.

#### Proposed changelog entry for your changes:

* None
