### PR TITLE
Rewind: differenciate provisioning/active states only when needed

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -169,12 +169,6 @@ class DashBackups extends Component {
 			} );
 
 		switch ( rewindStatus ) {
-			case 'provisioning':
-				return (
-					<React.Fragment>
-						{ buildCard( __( "We are configuring your site's backups." ) ) }
-					</React.Fragment>
-				);
 			case 'awaiting_credentials':
 				return (
 					<React.Fragment>
@@ -187,6 +181,7 @@ class DashBackups extends Component {
 						) }
 					</React.Fragment>
 				);
+			case 'provisioning':
 			case 'active':
 				return (
 					<React.Fragment>

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -101,10 +101,11 @@ class AtAGlance extends Component {
 		}
 
 		// Maybe add the rewind card
-		'active' === rewindStatus &&
+		if ( 'active' === rewindStatus || 'provisioning' === rewindStatus ) {
 			securityCards.unshift(
 				<DashActivity { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } />
 			);
+		}
 
 		// If user can manage modules, we're in an admin view, otherwise it's a non-admin view.
 		if ( this.props.userCanManageModules ) {

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -199,12 +199,6 @@ class DashScan extends Component {
 			} );
 
 		switch ( rewindStatus ) {
-			case 'provisioning':
-				return (
-					<React.Fragment>
-						{ buildCard( __( 'We are configuring your site protection.' ) ) }
-					</React.Fragment>
-				);
 			case 'awaiting_credentials':
 				return (
 					<React.Fragment>
@@ -217,6 +211,7 @@ class DashScan extends Component {
 						) }
 					</React.Fragment>
 				);
+			case 'provisioning':
 			case 'active':
 				return (
 					<React.Fragment>

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -72,16 +72,12 @@ class ProStatus extends React.Component {
 
 	getRewindMessage() {
 		switch ( this.props.rewindStatus.state ) {
-			case 'provisioning':
-				return {
-					status: 'is-info',
-					text: __( 'Setting up' ),
-				};
 			case 'awaiting_credentials':
 				return {
 					status: 'is-warning',
 					text: __( 'Action needed' ),
 				};
+			case 'provisioning':
 			case 'active':
 				return {
 					status: 'is-success',

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -67,9 +67,12 @@ class BackupsScanRewind extends Component {
 		switch ( rewindState ) {
 			case 'provisioning':
 				return {
-					title: __( 'Provisioning' ),
+					title: __( 'Your backup is underway' ),
 					icon: 'info',
-					description: __( 'Backups and Scan are being configured for your site.' ),
+					description: __(
+						"We're currently backing up your site for the first time, and we'll let you know when we're finished. " +
+							"After this initial backup, we'll save future changes in real time."
+					),
 					url: '',
 				};
 			case 'awaiting_credentials':

--- a/_inc/client/security/jetpack-backup.jsx
+++ b/_inc/client/security/jetpack-backup.jsx
@@ -51,7 +51,7 @@ export class JetpackBackup extends Component {
 				return {
 					title: __( 'Provisioning' ),
 					icon: 'info',
-					description: __( 'Jetpack Backup is being configured for your site.' ),
+					description: __( 'Your backup is underway.' ),
 					url: '',
 				};
 			case 'awaiting_credentials':


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

Until now, we've shown different messages in the UI when Rewind was being set-up (i.e until the first backup is complete) vs. after that first backup.
While this can be useful, messaging can be a bit confusing as we would say that Rewind was being configured, when in fact the site owner already did all the configuring they had to do.

This commit does a few things:
- In some cases, it is actually less confusing to just not differenciate provisioning and active because we don't necessarily need to highlight that this is a first backup vs. just another backup.
- In other cases, I've updated the wording to match what's currently shown in Calypso (in the Activity log), to say that a backup was under way instead of saying that something was being configured.
- As soon as Rewind is enabled, and even before the first backup is complete, we now show the Activity log card. This allows site owners to go to the Activity Log to check on the status of their site, where they will eventually see the first backup listed.

**Before**

![image](https://user-images.githubusercontent.com/426388/69738308-30a13980-1136-11ea-9a65-4dccc0e74faa.png)

![image](https://user-images.githubusercontent.com/426388/69738354-44e53680-1136-11ea-812a-18e9023659fe.png)

**After**

![image](https://user-images.githubusercontent.com/426388/69738326-372fb100-1136-11ea-9359-7bb0953de12c.png)

![image](https://user-images.githubusercontent.com/426388/69739583-3ef05500-1138-11ea-80f4-2dc1a847d348.png)

For reference, here is a bit more info about the Provisioning state in Rewind:

> Provisioning state means that the customer has enabled Rewind and provided all necessary information but that Rewind isn’t yet protecting their site.
> This may never actually be seen by a site owner because it should only exist during the nominally short initialization of the Rewind process.
> A site remains in this state until Rewind has its first complete backup.
> If a site gets stuck preparing the first backup this state could stick around for an extended period of time.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This is discussed internally at p8oabR-qW-p2#comment-3604

#### Testing instructions:

* You can rely on the Admin Page "Dev Tools" panel to help you with this:
![image](https://user-images.githubusercontent.com/426388/69737462-b6bc8080-1134-11ea-98b0-3538e721ce88.png)
* In the tools, switch between different statues in the `Backup & Scan` section, and navigate in the Jetpack Dashboard (AAG and settings page). 
* Make sure that the different messaging makes sense based on your status.

#### Proposed changelog entry for your changes:

* Admin Page: clarify wording when a site is being backed up for the first time.
