### PR TITLE
Components: Update QueryProducts to request data only if it is not present

### DIFF
--- a/_inc/client/components/data/query-products/index.js
+++ b/_inc/client/components/data/query-products/index.js
@@ -4,11 +4,12 @@
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { fetchProducts, isFetchingProducts } from 'state/products';
+import { fetchProducts, isFetchingProducts, getProducts } from 'state/products';
 
 class QueryProducts extends Component {
 	static propTypes = {
@@ -20,7 +21,7 @@ class QueryProducts extends Component {
 	};
 
 	componentDidMount() {
-		if ( ! this.props.isFetchingProducts ) {
+		if ( ! this.props.isFetchingProducts && isEmpty( this.props.products ) ) {
 			this.props.fetchProducts();
 		}
 	}
@@ -33,6 +34,7 @@ class QueryProducts extends Component {
 export default connect(
 	state => ( {
 		isFetchingProducts: isFetchingProducts( state ),
+		products: getProducts( state ),
 	} ),
 	dispatch => ( {
 		fetchProducts: () => dispatch( fetchProducts() ),


### PR DESCRIPTION
This PR updates the `QueryProducts` query component to request data only if it hasn't been fetched yet. This makes sense, since we never need to refresh this data and it should be persisted.

#### Changes proposed in this Pull Request:
* Components: Update QueryProducts to request data only if it is not present

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fix for a couple of issues pointed out in p8oabR-qW-p2

#### Testing instructions:
* Checkout this branch.
* Build Jetpack with `yarn build` or `yarn watch`.
* Go to /wp-admin/admin.php?page=jetpack#/plans for a site on a free plan without any product purchased.
* Verify the plans and backup product UI loads.
* Go to "My Plan"
* Go back to "Plans".
* Verify the Jetpack Backup UI is shown instantly, without the loading state.

#### Proposed changelog entry for your changes:
* Components: Update QueryProducts to request data only if it is not present
