### PR TITLE
Plans: Load Plans and Backup at the same time

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -13,8 +13,9 @@ import analytics from 'lib/analytics';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import { getSiteRawUrl, getUpgradeUrl, getUserId, showBackups } from 'state/initial-state';
-import { getSitePlan, getAvailablePlans } from 'state/site/reducer';
+import { getSitePlan, getAvailablePlans, isFetchingSiteData } from 'state/site/reducer';
 import { getPlanClass } from 'lib/plans/constants';
+import { isFetchingProducts } from '../state/products';
 import { translate as __ } from 'i18n-calypso';
 import TopButton from './top-button';
 import FeatureItem from './feture-item';
@@ -61,7 +62,7 @@ class PlanGrid extends React.Component {
 	}
 
 	render() {
-		if ( ! this.props.plans ) {
+		if ( ! this.props.plans || this.props.isFetchingData ) {
 			return (
 				<div className="plan-features">
 					{ this.renderMobileCard() }
@@ -419,6 +420,7 @@ export default connect(
 			showBackups: showBackups( state ),
 			plansUpgradeUrl: planType => getUpgradeUrl( state, `plans-${ planType }`, userId ),
 			plansLearnMoreUpgradeUrl: getUpgradeUrl( state, 'plans-learn-more', userId ),
+			isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
 		};
 	},
 	null

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -12,7 +12,12 @@ import { get } from 'lodash';
 import ProductCard from '../components/product-card';
 import { SingleProductBackup } from './single-product-backup';
 import { getPlanClass } from '../lib/plans/constants';
-import { getActiveSitePurchases, getSitePlan, isFetchingSiteData } from '../state/site';
+import {
+	getActiveSitePurchases,
+	getAvailablePlans,
+	getSitePlan,
+	isFetchingSiteData,
+} from '../state/site';
 import { getSiteRawUrl, getUpgradeUrl } from '../state/initial-state';
 import { getProducts, isFetchingProducts } from '../state/products';
 
@@ -148,6 +153,7 @@ class ProductSelector extends Component {
 		const {
 			dailyBackupUpgradeUrl,
 			isFetchingData,
+			plans,
 			products,
 			realtimeBackupUpgradeUrl,
 			sitePlan,
@@ -173,7 +179,7 @@ class ProductSelector extends Component {
 				plan={ plan }
 				products={ products }
 				upgradeLinks={ upgradeLinks }
-				isFetchingData={ isFetchingData }
+				isFetchingData={ isFetchingData || ! plans }
 			/>
 		);
 	}
@@ -192,6 +198,7 @@ export default connect( state => {
 	return {
 		activeSitePurchases: getActiveSitePurchases( state ),
 		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
+		plans: getAvailablePlans( state ),
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
 		sitePlan: getSitePlan( state ),


### PR DESCRIPTION
Currently, the plans and backup UI will often load in different times, making the UI look odd for a short period of time. This PR updates them so they will always load in the same time, regardless of which one's endpoint loads first.

#### Changes proposed in this Pull Request:
* Plans: Load Plans and Backup at the same time

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fix for an issue pointed out in p8oabR-qW-p2

#### Testing instructions:

* Checkout this branch.
* Build Jetpack with yarn build or yarn watch.
* Go to `/wp-admin/admin.php?page=jetpack#/plans` for a site on a free plan without any product purchased.
* Try refreshing several times and verify that each time, the plans and backup UI load in the same time.

#### Proposed changelog entry for your changes:
* Plans: Load Plans and Backup at the same time
