### PR TITLE
Rating Star: rename default style to filled

### DIFF
--- a/extensions/blocks/rating-star/index.js
+++ b/extensions/blocks/rating-star/index.js
@@ -30,8 +30,8 @@ export const settings = {
 	example: {},
 	styles: [
 		{
-			name: 'default',
-			label: _x( 'Default', 'block style', 'jetpack' ),
+			name: 'filled',
+			label: _x( 'Filled', 'block style', 'jetpack' ),
 			isDefault: true,
 		},
 		{


### PR DESCRIPTION
This PR renames the `Default` style to `Filled` to better describe it.

Before | After
--- | ---
![rating-style-default](https://user-images.githubusercontent.com/583546/69805700-7e26b080-11e1-11ea-9b89-05ff179866c8.png) | ![rating-style-filled](https://user-images.githubusercontent.com/583546/69805577-3d2e9c00-11e1-11ea-9e02-59b6e152269e.png)

## Testing instructions

Note that the rating star block is a new release for Jetpack but it isn't for WordPress.com simple sites. Hence that we have to check that blocks aren't invalidated or styles messed up due to this change.

* Create a post that includes the rating star block.
* Set the default style to "Default".
* Add new rating block and make sure the "Advanced Class" is `is-style-default`.
* Apply this patch.
* Test that the default style for the block is `Not Set` and that block styles work as before (editor and frontend).
