### PR TITLE
Update dependencies to production versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 		"ext-json": "*",
 		"ext-openssl": "*",
 		"automattic/jetpack-abtest": "^1.0",
-		"automattic/jetpack-assets": "@dev",
+		"automattic/jetpack-assets": "^1.0",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-backup": "@dev",
 		"automattic/jetpack-compat": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		"automattic/jetpack-abtest": "^1.0",
 		"automattic/jetpack-assets": "^1.0",
 		"automattic/jetpack-autoloader": "^1.3",
-		"automattic/jetpack-backup": "@dev",
+		"automattic/jetpack-backup": "^1.0",
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"automattic/jetpack-assets": "^1.0",
 		"automattic/jetpack-autoloader": "^1.3",
 		"automattic/jetpack-backup": "^1.0",
-		"automattic/jetpack-compat": "@dev",
+		"automattic/jetpack-compat": "^1.0",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-error": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 		"automattic/jetpack-jitm": "^1.0",
 		"automattic/jetpack-logo": "^1.1",
 		"automattic/jetpack-options": "^1.1",
-		"automattic/jetpack-roles": "@dev",
+		"automattic/jetpack-roles": "^1.0",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-terms-of-service": "@dev",
 		"automattic/jetpack-tracking": "@dev"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"automattic/jetpack-options": "^1.1",
 		"automattic/jetpack-roles": "^1.0",
 		"automattic/jetpack-sync": "^1.5",
-		"automattic/jetpack-terms-of-service": "@dev",
+		"automattic/jetpack-terms-of-service": "^1.0",
 		"automattic/jetpack-tracking": "@dev"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"ext-openssl": "*",
 		"automattic/jetpack-abtest": "^1.0",
 		"automattic/jetpack-assets": "^1.0",
-		"automattic/jetpack-autoloader": "@dev",
+		"automattic/jetpack-autoloader": "^1.3",
 		"automattic/jetpack-backup": "@dev",
 		"automattic/jetpack-compat": "@dev",
 		"automattic/jetpack-connection": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"automattic/jetpack-autoloader": "^1.3",
 		"automattic/jetpack-backup": "^1.0",
 		"automattic/jetpack-compat": "^1.0",
-		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-connection": "^1.7",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-error": "@dev",
 		"automattic/jetpack-jitm": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"automattic/jetpack-error": "^1.0",
 		"automattic/jetpack-jitm": "^1.0",
 		"automattic/jetpack-logo": "^1.1",
-		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-options": "^1.1",
 		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-terms-of-service": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"automattic/jetpack-logo": "^1.1",
 		"automattic/jetpack-options": "^1.1",
 		"automattic/jetpack-roles": "^1.0",
-		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-sync": "^1.5",
 		"automattic/jetpack-terms-of-service": "@dev",
 		"automattic/jetpack-tracking": "@dev"
 	},

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"automattic/jetpack-backup": "^1.0",
 		"automattic/jetpack-compat": "^1.0",
 		"automattic/jetpack-connection": "^1.7",
-		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-constants": "^1.1",
 		"automattic/jetpack-error": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-logo": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"automattic/jetpack-compat": "^1.0",
 		"automattic/jetpack-connection": "^1.7",
 		"automattic/jetpack-constants": "^1.1",
-		"automattic/jetpack-error": "@dev",
+		"automattic/jetpack-error": "^1.0",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-options": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"automattic/jetpack-constants": "^1.1",
 		"automattic/jetpack-error": "^1.0",
 		"automattic/jetpack-jitm": "^1.0",
-		"automattic/jetpack-logo": "@dev",
+		"automattic/jetpack-logo": "^1.1",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-sync": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		"ext-fileinfo": "*",
 		"ext-json": "*",
 		"ext-openssl": "*",
-		"automattic/jetpack-abtest": "@dev",
+		"automattic/jetpack-abtest": "^1.0",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-backup": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"automattic/jetpack-connection": "^1.7",
 		"automattic/jetpack-constants": "^1.1",
 		"automattic/jetpack-error": "^1.0",
-		"automattic/jetpack-jitm": "@dev",
+		"automattic/jetpack-jitm": "^1.0",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 		"automattic/jetpack-roles": "^1.0",
 		"automattic/jetpack-sync": "^1.5",
 		"automattic/jetpack-terms-of-service": "^1.0",
-		"automattic/jetpack-tracking": "@dev"
+		"automattic/jetpack-tracking": "^1.2"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d5e639cb4feec768c5cb23317759737",
+    "content-hash": "bcf3df8d7afa310be0d9dde4a426f5f2",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -277,7 +277,7 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-master",
+            "version": "v1.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-jitm.git",
@@ -308,16 +308,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Just in time messages for Jetpack"
+            "description": "Just in time messages for Jetpack",
+            "time": "2019-11-21T09:35:32+00:00"
         },
         {
             "name": "automattic/jetpack-logo",
@@ -998,7 +994,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-jitm": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-options": 20,
         "automattic/jetpack-roles": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6d513cbb9230949f715b485a3272a9e",
+    "content-hash": "9d78eccc58f8d736ad0f5d9d41873cb0",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -382,7 +382,7 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-master",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-roles.git",
@@ -404,16 +404,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Utilities, related with user roles and capabilities."
+            "description": "Utilities, related with user roles and capabilities.",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-status",
@@ -992,7 +988,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-roles": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-terms-of-service": 20,
         "automattic/jetpack-tracking": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89cf707c0147bfd41943486307678e5e",
+    "content-hash": "43b0d244bab91f3cc9e5a36dbb9acfcb",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -143,7 +143,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-master",
+            "version": "v1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-compat.git",
@@ -168,16 +168,12 @@
                     "legacy"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Compatibility layer with previous versions of Jetpack"
+            "description": "Compatibility layer with previous versions of Jetpack",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
@@ -1014,7 +1010,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-compat": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-error": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43b0d244bab91f3cc9e5a36dbb9acfcb",
+    "content-hash": "b85a12fad54c992216c47831ee1dc010",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -177,7 +177,7 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-master",
+            "version": "v1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
@@ -208,16 +208,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to connect to the Jetpack infrastructure"
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "time": "2019-11-25T13:53:28+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -1010,7 +1006,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-connection": 20,
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-error": 20,
         "automattic/jetpack-jitm": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6c70497accac222fcf0282f087b4d51",
+    "content-hash": "89cf707c0147bfd41943486307678e5e",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -113,7 +113,7 @@
         },
         {
             "name": "automattic/jetpack-backup",
-            "version": "dev-master",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-backup.git",
@@ -134,10 +134,12 @@
                     "src/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Tools to assist with backing up Jetpack sites."
+            "description": "Tools to assist with backing up Jetpack sites.",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-compat",
@@ -1012,7 +1014,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-backup": 20,
         "automattic/jetpack-compat": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-constants": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a606d1aa24b8469685ff147a81530cb4",
+    "content-hash": "f6d513cbb9230949f715b485a3272a9e",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -348,7 +348,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-master",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
@@ -373,10 +373,12 @@
                     "legacy"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for wp-options to manage specific Jetpack options."
+            "description": "A wrapper for wp-options to manage specific Jetpack options.",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
@@ -990,7 +992,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-options": 20,
         "automattic/jetpack-roles": 20,
         "automattic/jetpack-sync": 20,
         "automattic/jetpack-terms-of-service": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d78eccc58f8d736ad0f5d9d41873cb0",
+    "content-hash": "f08c839b40c39b825267dd14786e95a8",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -448,7 +448,7 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-master",
+            "version": "v1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-sync.git",
@@ -473,10 +473,12 @@
                     "src/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything needed to allow syncing to the WP.com infrastructure."
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "time": "2019-11-25T16:08:47+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",
@@ -988,7 +990,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-sync": 20,
         "automattic/jetpack-terms-of-service": 20,
         "automattic/jetpack-tracking": 20,
         "sirbrillig/phpcs-changed": 20

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcf3df8d7afa310be0d9dde4a426f5f2",
+    "content-hash": "a606d1aa24b8469685ff147a81530cb4",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -317,7 +317,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-master",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-logo.git",
@@ -339,16 +339,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A logo for Jetpack"
+            "description": "A logo for Jetpack",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-options",
@@ -994,7 +990,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-logo": 20,
         "automattic/jetpack-options": 20,
         "automattic/jetpack-roles": 20,
         "automattic/jetpack-sync": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26568b6bd8f4d299ce067b02000181f2",
+    "content-hash": "d6c70497accac222fcf0282f087b4d51",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -77,7 +77,7 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-master",
+            "version": "v1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
@@ -104,16 +104,12 @@
                     "Automattic\\Jetpack\\Autoloader\\": "src"
                 }
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Creates a custom autoloader for a plugin or theme."
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "time": "2019-11-25T12:37:57+00:00"
         },
         {
             "name": "automattic/jetpack-backup",
@@ -1016,7 +1012,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,
         "automattic/jetpack-compat": 20,
         "automattic/jetpack-connection": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "613ce23d6f4bde7c09a8c38fe8feaabc",
+    "content-hash": "9d5e639cb4feec768c5cb23317759737",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -247,7 +247,7 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-master",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-error.git",
@@ -268,16 +268,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Jetpack Error - a wrapper around WP_Error."
+            "description": "Jetpack Error - a wrapper around WP_Error.",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-jitm",
@@ -1002,7 +998,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-error": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-options": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f08c839b40c39b825267dd14786e95a8",
+    "content-hash": "4690a190b746cb8e2d32cf2acd87d17f",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -482,7 +482,7 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-master",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
@@ -509,16 +509,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Everything need to manage the terms of service state"
+            "description": "Everything need to manage the terms of service state",
+            "time": "2019-11-15T16:03:27+00:00"
         },
         {
             "name": "automattic/jetpack-tracking",
@@ -990,7 +986,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-terms-of-service": 20,
         "automattic/jetpack-tracking": 20,
         "sirbrillig/phpcs-changed": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b85a12fad54c992216c47831ee1dc010",
+    "content-hash": "613ce23d6f4bde7c09a8c38fe8feaabc",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -217,7 +217,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-master",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
@@ -238,16 +238,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "A wrapper for defining constants in a more testable way."
+            "description": "A wrapper for defining constants in a more testable way.",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-error",
@@ -1006,7 +1002,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-constants": 20,
         "automattic/jetpack-error": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-logo": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4690a190b746cb8e2d32cf2acd87d17f",
+    "content-hash": "37c794ce02c5ceba01a15bd7732ecdb2",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -518,7 +518,7 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-master",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-tracking.git",
@@ -545,16 +545,12 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Tracking for Jetpack"
+            "description": "Tracking for Jetpack",
+            "time": "2019-11-08T21:16:05+00:00"
         }
     ],
     "packages-dev": [
@@ -986,7 +982,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-tracking": 20,
         "sirbrillig/phpcs-changed": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d62924d83ea2fe288963e56841e556b4",
+    "content-hash": "26568b6bd8f4d299ce067b02000181f2",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -43,11 +43,17 @@
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-master",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-assets.git",
+                "reference": "efe031e2d123524d96ba55c41df70c6430868c10"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/assets",
-                "reference": "165b7d1cdba6e1609fb0a92e9809a58bbc17503a"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-assets/zipball/efe031e2d123524d96ba55c41df70c6430868c10",
+                "reference": "efe031e2d123524d96ba55c41df70c6430868c10",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -62,24 +68,26 @@
                     "src/"
                 ]
             },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Asset management utilities for Jetpack ecosystem packages"
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-autoloader",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "efa1cec37282cf60efaf57724ae2532c7c21bf94"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/autoloader",
-                "reference": "43bb413915e6aad7e4a088490cb76d72df22a8fb"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/efa1cec37282cf60efaf57724ae2532c7c21bf94",
+                "reference": "efa1cec37282cf60efaf57724ae2532c7c21bf94",
+                "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.1"
@@ -110,10 +118,16 @@
         {
             "name": "automattic/jetpack-backup",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-backup.git",
+                "reference": "ea2aaa9be3697d8b885a74a11411c7818fba5a75"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/backup",
-                "reference": "0ae8bfd8b87d9140066915c643fc6a00783d0032"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-backup/zipball/ea2aaa9be3697d8b885a74a11411c7818fba5a75",
+                "reference": "ea2aaa9be3697d8b885a74a11411c7818fba5a75",
+                "shasum": ""
             },
             "type": "library",
             "autoload": {
@@ -132,10 +146,16 @@
         {
             "name": "automattic/jetpack-compat",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-compat.git",
+                "reference": "2a4a2fd64bbcaab0a6af6dfe3a5ea8342eca9cbf"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/compat",
-                "reference": "2138cbc8b0b1aecb290608b5d82e873c7330aac5"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-compat/zipball/2a4a2fd64bbcaab0a6af6dfe3a5ea8342eca9cbf",
+                "reference": "2a4a2fd64bbcaab0a6af6dfe3a5ea8342eca9cbf",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -164,10 +184,16 @@
         {
             "name": "automattic/jetpack-connection",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-connection.git",
+                "reference": "5348680ad171cf7e6bdb2de511ac37e8e6db9d16"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/connection",
-                "reference": "ac53d3e65b1be0a24206dc32ef2d17a17e387fcd"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/5348680ad171cf7e6bdb2de511ac37e8e6db9d16",
+                "reference": "5348680ad171cf7e6bdb2de511ac37e8e6db9d16",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
@@ -202,10 +228,16 @@
         {
             "name": "automattic/jetpack-constants",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-constants.git",
+                "reference": "5fdd94dec1151e7defd684a97e0b64fe6ff1bd3a"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/constants",
-                "reference": "03403af14d39cec6fd826dbdc6675d0a23cf8d94"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/5fdd94dec1151e7defd684a97e0b64fe6ff1bd3a",
+                "reference": "5fdd94dec1151e7defd684a97e0b64fe6ff1bd3a",
+                "shasum": ""
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -230,10 +262,16 @@
         {
             "name": "automattic/jetpack-error",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-error.git",
+                "reference": "2128dd5a666154506727010350518529cc87b23d"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/error",
-                "reference": "2f35acfb871c772dd3a81755d093b1cb295b8830"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-error/zipball/2128dd5a666154506727010350518529cc87b23d",
+                "reference": "2128dd5a666154506727010350518529cc87b23d",
+                "shasum": ""
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -258,10 +296,16 @@
         {
             "name": "automattic/jetpack-jitm",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-jitm.git",
+                "reference": "068a054680fa7f51d6f58fc010a87a21884fc7eb"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/jitm",
-                "reference": "fd6393ba68829784166efc33f9946b55c321c289"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-jitm/zipball/068a054680fa7f51d6f58fc010a87a21884fc7eb",
+                "reference": "068a054680fa7f51d6f58fc010a87a21884fc7eb",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -296,10 +340,16 @@
         {
             "name": "automattic/jetpack-logo",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-logo.git",
+                "reference": "7da178a529f772cddfd0bbf1775eb30a852739c2"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/logo",
-                "reference": "f2b7828deb34f7bb6da24380f2a88ab98d3733df"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-logo/zipball/7da178a529f772cddfd0bbf1775eb30a852739c2",
+                "reference": "7da178a529f772cddfd0bbf1775eb30a852739c2",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -325,10 +375,16 @@
         {
             "name": "automattic/jetpack-options",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-options.git",
+                "reference": "cc81a75b7b3fecd1155a517a057ca74975ca8b5d"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/options",
-                "reference": "78220bf7d3c1a3a5ed4edb77462e84982b3c408f"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/cc81a75b7b3fecd1155a517a057ca74975ca8b5d",
+                "reference": "cc81a75b7b3fecd1155a517a057ca74975ca8b5d",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -351,10 +407,16 @@
         {
             "name": "automattic/jetpack-roles",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-roles.git",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/roles",
-                "reference": "22dd28b575dc20f2a8e7d44f024223033c66517a"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "reference": "0cdcff4fdc489c79f20a361c084ec48e326ce483",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -380,10 +442,16 @@
         {
             "name": "automattic/jetpack-status",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-status.git",
+                "reference": "dd1034fd2120b5e8e7380d80da9fa9ef6fa3a85d"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/status",
-                "reference": "e066e8d051698a5a9b1460296f156bbf7555484e"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/dd1034fd2120b5e8e7380d80da9fa9ef6fa3a85d",
+                "reference": "dd1034fd2120b5e8e7380d80da9fa9ef6fa3a85d",
+                "shasum": ""
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -409,10 +477,16 @@
         {
             "name": "automattic/jetpack-sync",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-sync.git",
+                "reference": "bf910f1441a3f355233655ff7f1e6b794561d5ae"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/sync",
-                "reference": "f163052f84a9656349985737f75c0e20c9a3c8e0"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/bf910f1441a3f355233655ff7f1e6b794561d5ae",
+                "reference": "bf910f1441a3f355233655ff7f1e6b794561d5ae",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -435,10 +509,16 @@
         {
             "name": "automattic/jetpack-terms-of-service",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-terms-of-service.git",
+                "reference": "fcee8e9de7f37d36bd68ac1ebabdb15cf6e10952"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/terms-of-service",
-                "reference": "f97742a361eb772f8bc6f13ae9437b3e8233cb0e"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-terms-of-service/zipball/fcee8e9de7f37d36bd68ac1ebabdb15cf6e10952",
+                "reference": "fcee8e9de7f37d36bd68ac1ebabdb15cf6e10952",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -469,10 +549,16 @@
         {
             "name": "automattic/jetpack-tracking",
             "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-tracking.git",
+                "reference": "d337a8f4234c684e80a43ff9ad3051a46a1f35d6"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/tracking",
-                "reference": "f4e52837194537e90f9fa10ac7b48f25519765bd"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/d337a8f4234c684e80a43ff9ad3051a46a1f35d6",
+                "reference": "d337a8f4234c684e80a43ff9ad3051a46a1f35d6",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-options": "@dev",
@@ -930,7 +1016,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,
         "automattic/jetpack-compat": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01d6dcf2001c7b2ae0bd259e0e05d904",
+    "content-hash": "d62924d83ea2fe288963e56841e556b4",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
-            "version": "dev-retry/phpcs-changed",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-abtest.git",
+                "reference": "faed5181e0dbe596b7e083e40affceed686928ba"
+            },
             "dist": {
-                "type": "path",
-                "url": "./packages/abtest",
-                "reference": "b873be98786907a49ac5cd21836167f662212aa0"
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-abtest/zipball/faed5181e0dbe596b7e083e40affceed686928ba",
+                "reference": "faed5181e0dbe596b7e083e40affceed686928ba",
+                "shasum": ""
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -24,28 +30,24 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
-            },
-            "scripts": {
-                "phpunit": [
-                    "@composer install",
-                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                "classmap": [
+                    "src/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Provides an interface to the WP.com A/B tests."
+            "description": "Provides an interface to the WP.com A/B tests.",
+            "time": "2019-11-08T21:16:05+00:00"
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
-                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9"
+                "reference": "165b7d1cdba6e1609fb0a92e9809a58bbc17503a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -56,9 +58,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -73,7 +75,7 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
@@ -107,20 +109,20 @@
         },
         {
             "name": "automattic/jetpack-backup",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/backup",
-                "reference": "3dd44f29c9c6ab41cc2492675078ba8b808caea7"
+                "reference": "0ae8bfd8b87d9140066915c643fc6a00783d0032"
             },
             "type": "library",
             "autoload": {
                 "files": [
                     "actions.php"
                 ],
-                "psr-4": {
-                    "Automattic\\Jetpack\\Backup\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -129,7 +131,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -161,15 +163,16 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "59fa2bc973303b013ce63978ff8d875d1223f510"
+                "reference": "ac53d3e65b1be0a24206dc32ef2d17a17e387fcd"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-options": "@dev"
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-roles": "@dev"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -177,14 +180,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Connection\\": "src"
-                },
                 "files": [
                     "legacy/load-ixr.php"
                 ],
                 "classmap": [
-                    "legacy"
+                    "legacy",
+                    "src/"
                 ]
             },
             "scripts": {
@@ -200,20 +201,20 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
+                "reference": "03403af14d39cec6fd826dbdc6675d0a23cf8d94"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -228,20 +229,20 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/error",
-                "reference": "1707cf33a92fc66f1635dfe1e4215819101e9bb4"
+                "reference": "2f35acfb871c772dd3a81755d093b1cb295b8830"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -256,11 +257,11 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
-                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca"
+                "reference": "fd6393ba68829784166efc33f9946b55c321c289"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -277,9 +278,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -294,11 +295,11 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610"
+                "reference": "f2b7828deb34f7bb6da24380f2a88ab98d3733df"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -306,9 +307,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Assets\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -323,7 +324,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -349,11 +350,11 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
-                "reference": "f38b3379c11a05e4711b4fb29b390c8107daccd7"
+                "reference": "22dd28b575dc20f2a8e7d44f024223033c66517a"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -361,9 +362,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -378,11 +379,11 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
-                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9"
+                "reference": "e066e8d051698a5a9b1460296f156bbf7555484e"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -390,9 +391,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -407,11 +408,11 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "1cad05fcfd38ad123af0bbf08b5a1224bd95312a"
+                "reference": "f163052f84a9656349985737f75c0e20c9a3c8e0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -422,10 +423,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Sync\\": "src/",
-                    "Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -434,11 +434,11 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/terms-of-service",
-                "reference": "6f53f2987be1c025edcd7820759df50c134065e6"
+                "reference": "f97742a361eb772f8bc6f13ae9437b3e8233cb0e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -451,9 +451,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -468,11 +468,11 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
-                "reference": "fd194dfc4f01a66de9c5b9caf239cdd806a8d3eb"
+                "reference": "f4e52837194537e90f9fa10ac7b48f25519765bd"
             },
             "require": {
                 "automattic/jetpack-options": "@dev",
@@ -484,11 +484,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                },
                 "classmap": [
-                    "legacy"
+                    "legacy",
+                    "src/"
                 ]
             },
             "scripts": {
@@ -572,16 +570,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.2",
+            "version": "9.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58"
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/bfca2be3992f40e92206e5a7ebe5eaee37280b58",
-                "reference": "bfca2be3992f40e92206e5a7ebe5eaee37280b58",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/1f37659196e4f3113ea506a7efba201c52303bf1",
+                "reference": "1f37659196e4f3113ea506a7efba201c52303bf1",
                 "shasum": ""
             },
             "require": {
@@ -626,7 +624,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-10-16T21:24:24+00:00"
+            "time": "2019-11-15T04:12:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -932,7 +930,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-abtest": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,

--- a/packages/abtest/composer.json
+++ b/packages/abtest/composer.json
@@ -4,8 +4,8 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-error": "@dev"
+		"automattic/jetpack-connection": "^1.7",
+		"automattic/jetpack-error": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/assets/composer.json
+++ b/packages/assets/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-constants": "@dev"
+		"automattic/jetpack-constants": "^1.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -4,9 +4,9 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-roles": "@dev"
+		"automattic/jetpack-constants": "^1.1",
+		"automattic/jetpack-options": "^1.1",
+		"automattic/jetpack-roles": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -4,12 +4,12 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-assets": "@dev",
-		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-logo": "@dev",
-		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-tracking": "@dev"
+		"automattic/jetpack-assets": "^1.0",
+		"automattic/jetpack-connection": "^1.7",
+		"automattic/jetpack-logo": "^1.1",
+		"automattic/jetpack-constants": "^1.1",
+		"automattic/jetpack-options": "^1.1",
+		"automattic/jetpack-tracking": "^1.2"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/options/composer.json
+++ b/packages/options/composer.json
@@ -4,7 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-constants": "@dev"
+		"automattic/jetpack-constants": "^1.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "7.*.*",

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -4,11 +4,11 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-constants": "@dev",
-		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-roles": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-connection": "^1.7",
+		"automattic/jetpack-constants": "^1.1",
+		"automattic/jetpack-options": "^1.1",
+		"automattic/jetpack-roles": "^1.0",
+		"automattic/jetpack-status": "^1.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/packages/terms-of-service/composer.json
+++ b/packages/terms-of-service/composer.json
@@ -4,9 +4,9 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-options": "^1.1",
+		"automattic/jetpack-status": "^1.0",
+		"automattic/jetpack-connection": "^1.7"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/tracking/composer.json
+++ b/packages/tracking/composer.json
@@ -4,8 +4,8 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-terms-of-service": "@dev"
+		"automattic/jetpack-options": "^1.1",
+		"automattic/jetpack-terms-of-service": "^1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adds production version to be used instead of `@dev` for the main Jetpack project, as well as for every package. This will make sure that all subsequent releases of Jetpack packages will be correctly loaded by the autoloader.

Giving precedence to development versions will only be needed for testing new packages code. For example, if you need the repository to switch to your local development code from the `packages` folder, you can run this command for any package:

```
composer require  automattic/jetpack-connection:dev-`git branch | grep \* | cut -d ' ' -f2-`
```

The `git branch | grep \* | cut -d ' ' -f2-` part gets your local branch name, which makes composer symlink the folder to vendor from the local repository.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves all package composer dependencies to published versions.
* Updates the composer.lock file of the master repo.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* There are no functional changes here, everything should work as expected. Especially the things that are now shipped in packages. Test everything :)
* Seriously though, a smoke test should be fine - connection process, logo, tracking, etc.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
