### PR TITLE
REST API: Update products to use a wpcom/v2 endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -530,15 +530,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_products( $request ) {
 		$wpcom_request = Client::wpcom_json_api_request_as_user(
 			'/products?_locale=' . get_user_locale() . '&type=jetpack',
-			'v1.1',
+			'2',
 			array(
 				'method'  => 'GET',
 				'headers' => array(
 					'X-Forwarded-For' => Jetpack::current_user_ip( true ),
 				),
-			),
-			null,
-			'rest'
+			)
 		);
 
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );


### PR DESCRIPTION
This updates the products endpoint to use the new wpcom/v2 products endpoint. The reason for that is to be able to use the Jetpack user token auth, and preserve the logged in user, in order to retrieve the right currency for the current user.

Fixes #14060

#### Changes proposed in this Pull Request:

* REST API: Update products to use a wpcom/v2 endpoint

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* #14060

#### Testing instructions:
* Apply D36105-code on your WP.com sandbox and follow the instructions there.
* Checkout this branch
* Open the Plans page
* Verify products still load well
* Verify currency of the products is the same as the rest of your interface.

#### Proposed changelog entry for your changes:
* REST API: Update products to use a wpcom/v2 endpoint
