### PR TITLE
Admin Page: update date format of Backup card to match "My Plan"

### DIFF
--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -40,7 +40,7 @@ class ProductSelector extends Component {
 			},
 		} );
 
-		const purchasedDate = __( 'Purchased %(purchaseDate)s', {
+		const purchasedDate = __( 'Purchased on %(purchaseDate)s', {
 			args: {
 				purchaseDate: moment( purchase.subscribedDate ).format( 'LL' ),
 			},

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -42,7 +42,7 @@ class ProductSelector extends Component {
 
 		const purchasedDate = __( 'Purchased %(purchaseDate)s', {
 			args: {
-				purchaseDate: moment( purchase.subscribedDate ).format( 'YYYY-MM-DD' ),
+				purchaseDate: moment( purchase.subscribedDate ).format( 'LL' ),
 			},
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

* On the "My Plan" page, we display full dates. On the "Plans" page, we should use a similar date format.

Related discussion:
p8oabR-qW-p2#comment-3635

Matching Calypso PR:
https://github.com/Automattic/wp-calypso/pull/38052

**Note**: this should only be a temporary solution. Ideally, we'd want to modify this further, to change the date we display depending on the date and your renewal settings. I think we could also aim to use the date format used by WordPress on the whole site.

#### Testing instructions:

* Go to Jetpack > Dashboard > Plans and follow the CTA to buy a Jetpack Backup.
* After your purchase, head back to wp-admin.
* The date formats on Jetpack > Dashboard > Plans and Jetpack > Dashboard > My Plan should be the same.

<img width="1114" alt="screenshot 2019-11-29 at 16 34 08" src="https://user-images.githubusercontent.com/426388/69879086-dbe0f880-12c6-11ea-8ce4-e5f3a62bd910.png">
<img width="681" alt="screenshot 2019-11-29 at 16 34 13" src="https://user-images.githubusercontent.com/426388/69879090-dc798f00-12c6-11ea-945c-bdb97891af16.png">

#### Proposed changelog entry for your changes:

* N/A
