### PR TITLE
Jetpack Backup: do not show card on multisite sites.

### DIFF
--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -18,7 +18,7 @@ import {
 	getSitePlan,
 	isFetchingSiteData,
 } from '../state/site';
-import { getSiteRawUrl, getUpgradeUrl } from '../state/initial-state';
+import { getSiteRawUrl, getUpgradeUrl, isMultisite } from '../state/initial-state';
 import { getProducts, isFetchingProducts } from '../state/products';
 
 class ProductSelector extends Component {
@@ -153,11 +153,18 @@ class ProductSelector extends Component {
 		const {
 			dailyBackupUpgradeUrl,
 			isFetchingData,
+			multisite,
 			plans,
 			products,
 			realtimeBackupUpgradeUrl,
 			sitePlan,
 		} = this.props;
+
+		// Jetpack Backup does not support Multisite yet.
+		if ( multisite ) {
+			return null;
+		}
+
 		const plan = get( sitePlan, 'product_slug' );
 		const upgradeLinks = {
 			daily: dailyBackupUpgradeUrl,
@@ -198,6 +205,7 @@ export default connect( state => {
 	return {
 		activeSitePurchases: getActiveSitePurchases( state ),
 		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
+		multisite: isMultisite( state ),
 		plans: getAvailablePlans( state ),
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -264,7 +264,7 @@ export function showBackups( state ) {
  * @return {boolean} True if the site is part of a Multisite network.
  */
 export function isMultisite( state ) {
-	return get( state.jetpack.initialState.siteData, 'isMultisite', true );
+	return get( state.jetpack.initialState.siteData, 'isMultisite', false );
 }
 
 /**

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -257,6 +257,17 @@ export function showBackups( state ) {
 }
 
 /**
+ * Check if the site is part of a Multisite network.
+ *
+ * @param {object} state Global state tree
+ *
+ * @return {boolean} True if the site is part of a Multisite network.
+ */
+export function isMultisite( state ) {
+	return get( state.jetpack.initialState.siteData, 'isMultisite', true );
+}
+
+/**
  * Returns the affiliate code, if it exists. Otherwise an empty string.
  *
  * @param {object} state Global state tree

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -272,10 +272,10 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'currentUser'  => $current_user_data,
 			),
 			'siteData' => array(
-				'icon' => has_site_icon()
+				'icon'                       => has_site_icon()
 					? apply_filters( 'jetpack_photon_url', get_site_icon_url(), array( 'w' => 64 ) )
 					: '',
-				'siteVisibleToSearchEngines' => '1' == get_option( 'blog_public' ),
+				'siteVisibleToSearchEngines' => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 				/**
 				 * Whether promotions are visible or not.
 				 *
@@ -283,10 +283,11 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				 *
 				 * @param bool $are_promotions_active Status of promotions visibility. True by default.
 				 */
-				'showPromotions' => apply_filters( 'jetpack_show_promotions', true ),
-				'isAtomicSite' => jetpack_is_atomic_site(),
-				'plan' => Jetpack_Plan::get(),
-				'showBackups' => Jetpack::show_backups_ui(),
+				'showPromotions'             => apply_filters( 'jetpack_show_promotions', true ),
+				'isAtomicSite'               => jetpack_is_atomic_site(),
+				'plan'                       => Jetpack_Plan::get(),
+				'showBackups'                => Jetpack::show_backups_ui(),
+				'isMultisite'                => is_multisite(),
 			),
 			'themeData' => array(
 				'name'      => $current_theme->get( 'Name' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Jetpack Backup does not support Multisite yet, so let's not offer the option on sites that are part of a Multisite network.

Internal reference: p8oabR-qW-p2#comment-3724

Matching Calypso PR:
https://github.com/Automattic/wp-calypso/pull/38060

#### Testing instructions:

* Start with 2 Jetpack sites. One of them must be a single site, the other must be part of a Multisite network. You can check the Calypso PR to help you get set up with this.
* Go to Jetpack > Dashboard > Plans
* You should see the Jetpack Backup card on the single site, but not on the Multisite site.

#### Proposed changelog entry for your changes:

* N/A
