### PR TITLE
Sync: adapt checkout endpoint for immediate full sync

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -194,6 +194,11 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		if ( ! empty( $args['queue'] ) && 'immediate' === $args['queue'] ) {
 			return $this->immediate_full_sync_pull( $number_of_items );
 		}
+
+		return $this->queue_pull( $queue_name, $number_of_items, $args );
+	}
+
+	function queue_pull( $queue_name, $number_of_items, $args ){
 		$queue = new Queue( $queue_name );
 
 		if ( 0 === $queue->size() ) {

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -253,11 +253,14 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		// try to give ourselves as much time as possible.
 		set_time_limit( 0 );
 
-		remove_filter( 'jetpack_sync_send_data', array( 'Automattic\Jetpack\Sync\Actions', 'send_data' ), 10, 6 );
-		add_filter( 'jetpack_sync_send_data', array( $this, 'jetpack_sync_send_data_listener' ), 10, 6 );
+		$original_send_data_cb = array( 'Automattic\Jetpack\Sync\Actions', 'send_data' );
+		$temp_send_data_cb     = array( $this, 'jetpack_sync_send_data_listener' );
+
+		remove_filter( 'jetpack_sync_send_data', $original_send_data_cb );
+		add_filter( 'jetpack_sync_send_data', $temp_send_data_cb, 10, 6 );
 		Sender::get_instance()->do_full_sync();
-		remove_filter( 'jetpack_sync_send_data', array( $this, 'jetpack_sync_send_data_listener' ), 10, 6 );
-		add_filter( 'jetpack_sync_send_data', array( 'Automattic\Jetpack\Sync\Actions', 'send_data' ), 10, 6 );
+		remove_filter( 'jetpack_sync_send_data', $temp_send_data_cb );
+		add_filter( 'jetpack_sync_send_data', $original_send_data_cb, 10, 6 );
 
 		return array(
 			'items'          => $this->items,

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -49,7 +49,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 		}
 
 		if ( ! in_array( $query, array( 'sync', 'full_sync', 'immediate' ) ) ) {
-			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
+			return new WP_Error( 'invalid_queue', 'Queue name should be sync, full_sync or immediate', 400 );
 		}
 		return $query;
 	}

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -191,7 +191,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 		$number_of_items = absint( $args['number_of_items'] );
 
-		if ( ! empty( $args['queue'] ) && 'immediate' === $args['queue'] ) {
+		if ( 'immediate' === $queue_name ) {
 			return $this->immediate_full_sync_pull( $number_of_items );
 		}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -245,7 +245,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 	public function jetpack_sync_send_data_listener() {
 		foreach ( func_get_args()[0] as $key => $item ) {
-			$items[ $key ] = $item;
+			$this->items[ $key ] = $item;
 		}
 	}
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -256,6 +256,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 		$original_send_data_cb = array( 'Automattic\Jetpack\Sync\Actions', 'send_data' );
 		$temp_send_data_cb     = array( $this, 'jetpack_sync_send_data_listener' );
 
+		Sender::get_instance()->set_enqueue_wait_time( 0 );
 		remove_filter( 'jetpack_sync_send_data', $original_send_data_cb );
 		add_filter( 'jetpack_sync_send_data', $temp_send_data_cb, 10, 6 );
 		Sender::get_instance()->do_full_sync();

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -48,7 +48,7 @@ class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
 			return new WP_Error( 'invalid_queue', 'Queue name is required', 400 );
 		}
 
-		if ( ! in_array( $query, array( 'sync', 'full_sync' ) ) ) {
+		if ( ! in_array( $query, array( 'sync', 'full_sync', 'immediate' ) ) ) {
 			return new WP_Error( 'invalid_queue', 'Queue name should be sync or full_sync', 400 );
 		}
 		return $query;
@@ -191,6 +191,9 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 		$number_of_items = absint( $args['number_of_items'] );
 
+		if ( ! empty( $args['queue'] ) && 'immediate' === $args['queue'] ) {
+			return $this->immediate_full_sync_pull( $number_of_items );
+		}
 		$queue = new Queue( $queue_name );
 
 		if ( 0 === $queue->size() ) {
@@ -230,6 +233,32 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 			'skipped_items'  => $skipped_items_ids,
 			'codec'          => $args['encode'] ? $sender->get_codec()->name() : null,
 			'sent_timestamp' => time(),
+		);
+	}
+
+	public $items = [];
+
+	public function jetpack_sync_send_data_listener() {
+		foreach ( func_get_args()[0] as $key => $item ) {
+			$items[ $key ] = $item;
+		}
+	}
+
+	public function immediate_full_sync_pull( $number_of_items ) {
+		// try to give ourselves as much time as possible.
+		set_time_limit( 0 );
+
+		remove_filter( 'jetpack_sync_send_data', array( 'Automattic\Jetpack\Sync\Actions', 'send_data' ), 10, 6 );
+		add_filter( 'jetpack_sync_send_data', array( $this, 'jetpack_sync_send_data_listener' ), 10, 6 );
+		Sender::get_instance()->do_full_sync();
+		remove_filter( 'jetpack_sync_send_data', array( $this, 'jetpack_sync_send_data_listener' ), 10, 6 );
+		add_filter( 'jetpack_sync_send_data', array( 'Automattic\Jetpack\Sync\Actions', 'send_data' ), 10, 6 );
+
+		return array(
+			'items'          => $this->items,
+			'codec'          => Sender::get_instance()->get_codec()->name(),
+			'sent_timestamp' => time(),
+			'status'         => Actions::get_sync_status(),
 		);
 	}
 


### PR DESCRIPTION
This will make the `pull` command work again with D36239

### Testing instructions

* See D36239