### PR TITLE
Changes wording to either show renewal date or purchase date

### DIFF
--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -7,39 +7,40 @@ import { moment, translate as __ } from 'i18n-calypso';
 
 class ProductExpiration extends React.PureComponent {
 	static propTypes = {
-		expiry_date: PropTypes.string,
-		subscribed_date: PropTypes.string,
-		is_refundable: PropTypes.bool,
+		expiryDate: PropTypes.string.isRequired,
+		purchaseDate: PropTypes.string,
+		isRefundable: PropTypes.bool,
+		dateFormat: PropTypes.string,
 	};
 
 	static defaultProps = {
-		expiry_date: '',
-		subscribed_date: '',
-		is_refundable: false,
+		purchaseDate: '',
+		isRefundable: false,
+		dateFormat: 'LL',
 	};
 
 	render() {
-		const { expiry_date, subscribed_date, is_refundable } = this.props;
+		const { expiryDate, purchaseDate, isRefundable, dateFormat } = this.props;
 
 		// Return nothing if we don't have any dates.
-		if ( ! expiry_date && ! subscribed_date ) {
+		if ( ! expiryDate && ! purchaseDate ) {
 			return null;
 		}
 
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
-		if ( ! expiry_date || is_refundable ) {
-			return __( 'Purchased on %s.', { args: moment( subscribed_date ).format( 'LL' ) } );
+		if ( ! expiryDate || isRefundable ) {
+			return __( 'Purchased on %s.', { args: moment( purchaseDate ).format( dateFormat ) } );
 		}
 
-		const expiry = moment( expiry_date );
+		const expiry = moment( expiryDate );
 
 		// If the expiry date is in the past, show the expiration date.
 		if ( expiry.diff( new Date() ) < 0 ) {
-			return __( 'Expired on %s.', { args: expiry.format( 'LL' ) } );
+			return __( 'Expired on %s.', { args: expiry.format( dateFormat ) } );
 		}
 
 		// Lastly, return the renewal date.
-		return __( 'Renews on %s.', { args: expiry.format( 'LL' ) } );
+		return __( 'Renews on %s.', { args: expiry.format( dateFormat ) } );
 	}
 }
 

--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { moment, translate as __, localize } from 'i18n-calypso';
+
+class ProductExpiration extends React.PureComponent {
+	static propTypes = {
+		expiry_date: PropTypes.string,
+		subscribed_date: PropTypes.string,
+		is_refundable: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		expiry_date: '',
+		subscribed_date: '',
+		is_refundable: false,
+	};
+
+	render() {
+		const { expiry_date, subscribed_date, is_refundable } = this.props;
+
+		// Return nothing if we don't have any dates.
+		if ( ! expiry_date && ! subscribed_date ) {
+			return null;
+		}
+
+		// Return the subscription date if we don't have the expiry date or the plan is refundable.
+		if ( ! expiry_date || is_refundable ) {
+			return __( 'Purchased on %s.', { args: moment( subscribed_date ).format( 'LL' ) } );
+		}
+
+		const expiry = moment( expiry_date );
+
+		// If the expiry date is in the past, show the expiration date.
+		if ( expiry.diff( new Date() ) < 0 ) {
+			return __( 'Expired on %s.', { args: expiry.format( 'LL' ) } );
+		}
+
+		// Lastly, return the renewal date.
+		return __( 'Renews on %s.', { args: expiry.format( 'LL' ) } );
+	}
+}
+
+export default localize( ProductExpiration );

--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -32,7 +32,7 @@ class ProductExpiration extends React.PureComponent {
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
 		if ( ! expiryDate || isRefundable ) {
 			const purchase = moment( purchaseDate );
-			if ( moment.isValid() ) {
+			if ( purchase.isValid() ) {
 				return __( 'Purchased on %s.', { args: purchase.format( dateFormat ) } );
 			}
 			return fallback;

--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -11,28 +11,39 @@ class ProductExpiration extends React.PureComponent {
 		purchaseDate: PropTypes.string,
 		isRefundable: PropTypes.bool,
 		dateFormat: PropTypes.string,
+		fallback: PropTypes.string,
 	};
 
 	static defaultProps = {
 		purchaseDate: '',
 		isRefundable: false,
 		dateFormat: 'LL',
+		fallback: '',
 	};
 
 	render() {
-		const { expiryDate, purchaseDate, isRefundable, dateFormat } = this.props;
+		const { expiryDate, purchaseDate, isRefundable, dateFormat, fallback } = this.props;
 
 		// Return nothing if we don't have any dates.
 		if ( ! expiryDate && ! purchaseDate ) {
-			return null;
+			return fallback;
 		}
 
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
 		if ( ! expiryDate || isRefundable ) {
-			return __( 'Purchased on %s.', { args: moment( purchaseDate ).format( dateFormat ) } );
+			const purchase = moment( purchaseDate );
+			if ( moment.isValid() ) {
+				return __( 'Purchased on %s.', { args: purchase.format( dateFormat ) } );
+			}
+			return fallback;
 		}
 
 		const expiry = moment( expiryDate );
+
+		// Return fallback if date is not parsable.
+		if ( ! expiry.isValid() ) {
+			return fallback;
+		}
 
 		// If the expiry date is in the past, show the expiration date.
 		if ( expiry.diff( new Date() ) < 0 ) {

--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -7,51 +7,50 @@ import { moment, translate as __ } from 'i18n-calypso';
 
 class ProductExpiration extends React.PureComponent {
 	static propTypes = {
-		expiryDate: PropTypes.string.isRequired,
+		expiryDate: PropTypes.string,
 		purchaseDate: PropTypes.string,
 		isRefundable: PropTypes.bool,
 		dateFormat: PropTypes.string,
-		fallback: PropTypes.string,
 	};
 
 	static defaultProps = {
+		expiryDate: '',
 		purchaseDate: '',
 		isRefundable: false,
 		dateFormat: 'LL',
-		fallback: '',
 	};
 
 	render() {
-		const { expiryDate, purchaseDate, isRefundable, dateFormat, fallback } = this.props;
+		const { expiryDate, purchaseDate, isRefundable, dateFormat } = this.props;
 
-		// Return nothing if we don't have any dates.
+		// Return null if we don't have any dates.
 		if ( ! expiryDate && ! purchaseDate ) {
-			return fallback;
+			return null;
 		}
 
 		// Return the subscription date if we don't have the expiry date or the plan is refundable.
 		if ( ! expiryDate || isRefundable ) {
-			const purchase = moment( purchaseDate );
-			if ( purchase.isValid() ) {
-				return __( 'Purchased on %s.', { args: purchase.format( dateFormat ) } );
+			const purchaseMoment = moment( purchaseDate );
+			if ( purchaseMoment.isValid() ) {
+				return __( 'Purchased on %s.', { args: purchaseMoment.format( dateFormat ) } );
 			}
-			return fallback;
+			return null;
 		}
 
-		const expiry = moment( expiryDate );
+		const expiryMoment = moment( expiryDate );
 
-		// Return fallback if date is not parsable.
-		if ( ! expiry.isValid() ) {
-			return fallback;
+		// Return null if date is not parsable.
+		if ( ! expiryMoment.isValid() ) {
+			return null;
 		}
 
 		// If the expiry date is in the past, show the expiration date.
-		if ( expiry.diff( new Date() ) < 0 ) {
-			return __( 'Expired on %s.', { args: expiry.format( dateFormat ) } );
+		if ( expiryMoment.diff( new Date() ) < 0 ) {
+			return __( 'Expired on %s.', { args: expiryMoment.format( dateFormat ) } );
 		}
 
 		// Lastly, return the renewal date.
-		return __( 'Renews on %s.', { args: expiry.format( dateFormat ) } );
+		return __( 'Renews on %s.', { args: expiryMoment.format( dateFormat ) } );
 	}
 }
 

--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { moment, translate as __, localize } from 'i18n-calypso';
+import { moment, translate as __ } from 'i18n-calypso';
 
 class ProductExpiration extends React.PureComponent {
 	static propTypes = {
@@ -43,4 +43,4 @@ class ProductExpiration extends React.PureComponent {
 	}
 }
 
-export default localize( ProductExpiration );
+export default ProductExpiration;

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -32,13 +32,16 @@ class MyPlanHeader extends React.Component {
 		}
 
 		const purchase = find( purchases, purchaseObj => purchaseObj.product_slug === productSlug );
-		const expiration = (
-			<ProductExpiration
-				expiryDate={ purchase.expiry_date }
-				purchaseDate={ purchase.subscribed_date }
-				isRefundable={ purchase.is_refundable }
-			/>
-		);
+		let expiration;
+		if ( purchase ) {
+			expiration = (
+				<ProductExpiration
+					expiryDate={ purchase.expiry_date }
+					purchaseDate={ purchase.subscribed_date }
+					isRefundable={ purchase.is_refundable }
+				/>
+			);
+		}
 
 		switch ( getPlanClass( productSlug ) ) {
 			case 'is-free-plan':

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -34,9 +34,9 @@ class MyPlanHeader extends React.Component {
 		const purchase = find( purchases, purchaseObj => purchaseObj.product_slug === productSlug );
 		const expiration = (
 			<ProductExpiration
-				expiry_date={ purchase.expiry_date }
-				subscribed_date={ purchase.subscribed_date }
-				is_refundable={ purchase.is_refundable }
+				expiryDate={ purchase.expiry_date }
+				purchaseDate={ purchase.subscribed_date }
+				isRefundable={ purchase.is_refundable }
 			/>
 		);
 

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -32,7 +32,13 @@ class MyPlanHeader extends React.Component {
 		}
 
 		const purchase = find( purchases, purchaseObj => purchaseObj.product_slug === productSlug );
-		const expiration = <ProductExpiration { ...purchase } />;
+		const expiration = (
+			<ProductExpiration
+				expiry_date={ purchase.expiry_date }
+				subscribed_date={ purchase.subscribed_date }
+				is_refundable={ purchase.is_refundable }
+			/>
+		);
 
 		switch ( getPlanClass( productSlug ) ) {
 			case 'is-free-plan':

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { moment, translate as __ } from 'i18n-calypso';
+import { translate as __ } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { find, filter, isEmpty } from 'lodash';
 
@@ -14,6 +14,7 @@ import ChecklistCta from './checklist-cta';
 import ChecklistProgress from './checklist-progress-card';
 import MyPlanCard from '../my-plan-card';
 import UpgradeLink from 'components/upgrade-link';
+import ProductExpiration from 'components/product-expiration';
 import { getPlanClass, isJetpackBackup } from 'lib/plans/constants';
 import { getUpgradeUrl, getSiteRawUrl, showBackups } from 'state/initial-state';
 import { getSitePurchases } from 'state/site';
@@ -31,10 +32,7 @@ class MyPlanHeader extends React.Component {
 		}
 
 		const purchase = find( purchases, purchaseObj => purchaseObj.product_slug === productSlug );
-		const expiration =
-			purchase && purchase.expiry_date
-				? __( 'Expires on %s.', { args: moment( purchase.expiry_date ).format( 'LL' ) } )
-				: null;
+		const expiration = <ProductExpiration { ...purchase } />;
 
 		switch ( getPlanClass( productSlug ) ) {
 			case 'is-free-plan':

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -43,9 +43,9 @@ class ProductSelector extends Component {
 
 		const subtitle = (
 			<ProductExpiration
-				expiry_date={ purchase.expiry_date }
-				subscribed_date={ purchase.subscribed_date }
-				is_refundable={ purchase.is_refundable }
+				expiryDate={ purchase.expiry_date }
+				purchaseDate={ purchase.subscribed_date }
+				isRefundable={ purchase.is_refundable }
 			/>
 		);
 

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -41,7 +41,13 @@ class ProductSelector extends Component {
 			},
 		} );
 
-		const subtitleText = <ProductExpiration { ...purchase } />;
+		const subtitle = (
+			<ProductExpiration
+				expiry_date={ purchase.expiry_date }
+				subscribed_date={ purchase.subscribed_date }
+				is_refundable={ purchase.is_refundable }
+			/>
+		);
 
 		const backupDescription = __( 'Always-on backups ensure you never lose your site.' );
 		const backupDescriptionRealtime = __(
@@ -63,14 +69,14 @@ class ProductSelector extends Component {
 			case 'is-daily-backup-plan':
 				return {
 					title: dailyBackupTitle,
-					subtitle: subtitleText,
+					subtitle,
 					description: backupDescription,
 					...additionalProps,
 				};
 			case 'is-realtime-backup-plan':
 				return {
 					title: realTimeBackupTitle,
-					subtitle: subtitleText,
+					subtitle,
 					description: backupDescriptionRealtime,
 					...additionalProps,
 				};

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -3,13 +3,14 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { moment, translate as __ } from 'i18n-calypso';
+import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ProductCard from '../components/product-card';
+import ProductExpiration from 'components/product-expiration';
 import { SingleProductBackup } from './single-product-backup';
 import { getPlanClass } from '../lib/plans/constants';
 import {
@@ -40,19 +41,7 @@ class ProductSelector extends Component {
 			},
 		} );
 
-		const purchasedDate = __( 'Purchased on %(purchaseDate)s', {
-			args: {
-				purchaseDate: moment( purchase.subscribed_date ).format( 'LL' ),
-			},
-		} );
-
-		const renewalDate = __( 'Renews on %(renewalDate)s', {
-			args: {
-				renewalDate: moment( purchase.expiry_date ).format( 'LL' ),
-			},
-		} );
-
-		const subtitleText = purchase.is_refundable ? purchasedDate : renewalDate;
+		const subtitleText = <ProductExpiration { ...purchase } />;
 
 		const backupDescription = __( 'Always-on backups ensure you never lose your site.' );
 		const backupDescriptionRealtime = __(

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -9,7 +9,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import ProductCard from '../components/product-card';
+import ProductCard from 'components/product-card';
 import ProductExpiration from 'components/product-expiration';
 import { SingleProductBackup } from './single-product-backup';
 import { getPlanClass } from '../lib/plans/constants';

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -46,6 +46,14 @@ class ProductSelector extends Component {
 			},
 		} );
 
+		const renewalDate = __( 'Renews on %(renewalDate)s', {
+			args: {
+				renewalDate: moment( purchase.expiry_date ).format( 'LL' ),
+			},
+		} );
+
+		const subtitleText = purchase.is_refundable ? purchasedDate : renewalDate;
+
 		const backupDescription = __( 'Always-on backups ensure you never lose your site.' );
 		const backupDescriptionRealtime = __(
 			'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
@@ -66,14 +74,14 @@ class ProductSelector extends Component {
 			case 'is-daily-backup-plan':
 				return {
 					title: dailyBackupTitle,
-					subtitle: purchasedDate,
+					subtitle: subtitleText,
 					description: backupDescription,
 					...additionalProps,
 				};
 			case 'is-realtime-backup-plan':
 				return {
 					title: realTimeBackupTitle,
-					subtitle: purchasedDate,
+					subtitle: subtitleText,
 					description: backupDescriptionRealtime,
 					...additionalProps,
 				};


### PR DESCRIPTION
Varies the wording depending on refundable status.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds logic to show the purchase date when in refund window of Jetpack Backup, or the renewal date otherwise.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p8oabR-qW-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Purchase JP Backup plan.
* Visit plans page.
* Date should show purchase date.
* Disable refund window via altering API response.
* Date should show renewal date.

Screenshot of inside refund window:
![Screenshot from 2019-12-03 14-33-34](https://user-images.githubusercontent.com/1760168/70083262-0d650700-15da-11ea-97f1-fa22b8b81038.png)

Screenshot of outside refund window:
![Screenshot from 2019-12-03 14-33-13](https://user-images.githubusercontent.com/1760168/70083261-0d650700-15da-11ea-84eb-46923345cec6.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
