### PR TITLE
Jetpack Backup: fix reference to purchase date.

### DIFF
--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -42,7 +42,7 @@ class ProductSelector extends Component {
 
 		const purchasedDate = __( 'Purchased on %(purchaseDate)s', {
 			args: {
-				purchaseDate: moment( purchase.subscribedDate ).format( 'LL' ),
+				purchaseDate: moment( purchase.subscribed_date ).format( 'LL' ),
 			},
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* `subscribedDate` does not exist, and thus `moment( purchase.subscribedDate ).format()` would just return the current day.

#### Testing instructions:

* Go to Jetpack > Dashboard > Plans on a site where you purchased a Jetpack Backup solution a few days ago.
* The date mentioned in the product card should be correct.

#### Proposed changelog entry for your changes:

* N/A
