### PR TITLE
Trying to add deterministic initialization.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -563,9 +563,9 @@ class Jetpack {
 		 */
 		add_action( 'init', array( $this, 'deprecated_hooks' ) );
 
-		add_action( 'plugins_loaded', array( $this, 'early_initalization' ), 5 );
+		add_action( 'plugins_loaded', array( $this, 'early_initialization' ), 5 );
 		add_action( 'plugins_loaded', array( $this, 'after_plugins_loaded' ) );
-		add_action( 'plugins_loaded', array( $this, 'late_initalization' ), 90 );
+		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
 		add_filter(
 			'jetpack_connection_secret_generator',
@@ -738,7 +738,7 @@ class Jetpack {
 	 *
 	 * @action plugins_loaded
 	 */
-	public function early_initalization() {
+	public function early_initialization() {
 		/*
 		 * Enable enhanced handling of previewing sites in Calypso
 		 */
@@ -764,7 +764,7 @@ class Jetpack {
 	 *
 	 * @action plugins_loaded
 	 */
-	public function late_initalization() {
+	public function late_initialization() {
 		/*
 		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
 		 * with a high priority or sites that use alternate cron.
@@ -803,24 +803,6 @@ class Jetpack {
 		}
 
 		add_filter( 'map_meta_cap', array( $this, 'jetpack_custom_caps' ), 1, 4 );
-	}
-
-	/**
-	 * Runs on plugins_loaded. Use this to add code that needs to be executed later than other
-	 * initialization code.
-	 *
-	 * @action plugins_loaded
-	 */
-	public function late_initialization() {
-		/**
-		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe
-		 * to instantiate classes from packages and namespaces that are managed by the Jetpack Autoloader.
-		 *
-		 * @since 8.1.0
-		 *
-		 * @param Jetpack $jetpack the main plugin class object.
-		 */
-		do_action( 'jetpack_loaded', $this );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -737,7 +737,6 @@ class Jetpack {
 	 * before other hooks.
 	 *
 	 * @action plugins_loaded
-	 * @priority 5
 	 */
 	public function early_initalization() {
 		/*
@@ -760,10 +759,10 @@ class Jetpack {
 	}
 
 	/**
-	 * Runs on plugins_loaded but with a lower priority.
+	 * Runs on plugins_loaded. Use this to add code that needs to be executed later than other
+	 * initialization code.
 	 *
 	 * @action plugins_loaded
-	 * @priority 90
 	 */
 	public function late_initalization() {
 		/*
@@ -771,15 +770,6 @@ class Jetpack {
 		 * with a high priority or sites that use alternate cron.
 		 */
 		Sync_Actions::init();
-
-		self::plugin_textdomain();
-		self::load_modules();
-	}
-
-	/**
-	 * Runs after all the plugins have loaded but before init.
-	 */
-	function after_plugins_loaded() {
 
 		Partner::init();
 
@@ -793,6 +783,15 @@ class Jetpack {
 		 */
 		do_action( 'jetpack_loaded', $this );
 
+		self::plugin_textdomain();
+		self::load_modules();
+	}
+
+	/**
+	 * Runs after all the plugins have loaded but before init.
+	 */
+	public function after_plugins_loaded() {
+		$terms_of_service = new Terms_Of_Service();
 		$tracking = new Plugin_Tracking();
 		if ( $terms_of_service->has_agreed() ) {
 			add_action( 'init', array( $tracking, 'init' ) );
@@ -5197,7 +5196,6 @@ endif;
 	 * @return Automattic\Jetpack\Connection\Manager
 	 */
 	public static function connection() {
-		_deprecated_function( __METHOD__, 'jetpack-8.1', 'Jetpack::get_connection()' );
 		return self::init()->connection_manager;
 	}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -734,6 +734,8 @@ class Jetpack {
 	public function early_initialization() {
 		new Config( $this );
 
+		add_filter( 'jetpack_config', array( $this, 'filter_jetpack_config' ) );
+
 		/*
 		 * Enable enhanced handling of previewing sites in Calypso
 		 */
@@ -743,6 +745,19 @@ class Jetpack {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.jetpack-keyring-service-helper.php';
 			add_action( 'init', array( 'Jetpack_Keyring_Service_Helper', 'init' ), 9, 0 );
 		}
+	}
+
+	/**
+	 * Filters Jetpack initialization configuration.
+	 *
+	 * @param Array $config options for package initialization.
+	 */
+	public function filter_jetpack_config( $config ) {
+		foreach ( $config as $feature => $enabled ) {
+			$config[ $feature ] = true;
+		}
+
+		return $config;
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -736,8 +736,6 @@ class Jetpack {
 		foreach (
 			array(
 				'sync',
-				'sync_woocommerce',
-				'sync_wp_super_cache',
 				'tracking',
 				'tos',
 			)

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-backup": "@dev",
 		"automattic/jetpack-compat": "@dev",
+		"automattic/jetpack-config": "@dev",
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-error": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,15 +4,15 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23a3df0c752fcfb8b0a94250870ae7b9",
+    "content-hash": "9eb6218b5e3e36832a66b69ce23b6882",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/abtest",
-                "reference": "c3681b3eac3d0e5625de758218fd1e8994e06302"
+                "reference": "b873be98786907a49ac5cd21836167f662212aa0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -24,9 +24,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -41,11 +41,11 @@
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
-                "reference": "165b7d1cdba6e1609fb0a92e9809a58bbc17503a"
+                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -56,9 +56,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -73,7 +73,7 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
@@ -107,20 +107,20 @@
         },
         {
             "name": "automattic/jetpack-backup",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/backup",
-                "reference": "0ae8bfd8b87d9140066915c643fc6a00783d0032"
+                "reference": "3dd44f29c9c6ab41cc2492675078ba8b808caea7"
             },
             "type": "library",
             "autoload": {
                 "files": [
                     "actions.php"
                 ],
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\Backup\\": "src/"
+                }
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -129,7 +129,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -161,7 +161,7 @@
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "dev-master",
+            "version": "dev-add/deterministic-init",
             "dist": {
                 "type": "path",
                 "url": "./packages/config",
@@ -180,16 +180,15 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "ac53d3e65b1be0a24206dc32ef2d17a17e387fcd"
+                "reference": "59fa2bc973303b013ce63978ff8d875d1223f510"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-options": "@dev",
-                "automattic/jetpack-roles": "@dev"
+                "automattic/jetpack-options": "@dev"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -197,12 +196,14 @@
             },
             "type": "library",
             "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Connection\\": "src"
+                },
                 "files": [
                     "legacy/load-ixr.php"
                 ],
                 "classmap": [
-                    "legacy",
-                    "src/"
+                    "legacy"
                 ]
             },
             "scripts": {
@@ -218,20 +219,20 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "03403af14d39cec6fd826dbdc6675d0a23cf8d94"
+                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -246,20 +247,20 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/error",
-                "reference": "2f35acfb871c772dd3a81755d093b1cb295b8830"
+                "reference": "1707cf33a92fc66f1635dfe1e4215819101e9bb4"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -274,11 +275,11 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
-                "reference": "fd6393ba68829784166efc33f9946b55c321c289"
+                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -295,9 +296,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -312,11 +313,11 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "f2b7828deb34f7bb6da24380f2a88ab98d3733df"
+                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -324,9 +325,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\Assets\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -341,7 +342,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -367,7 +368,7 @@
         },
         {
             "name": "automattic/jetpack-partner",
-            "version": "dev-master",
+            "version": "dev-add/upgrade-url-subsidiary-id",
             "dist": {
                 "type": "path",
                 "url": "./packages/partner",
@@ -398,11 +399,11 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
-                "reference": "22dd28b575dc20f2a8e7d44f024223033c66517a"
+                "reference": "f38b3379c11a05e4711b4fb29b390c8107daccd7"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -410,9 +411,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -427,11 +428,11 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
-                "reference": "e066e8d051698a5a9b1460296f156bbf7555484e"
+                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -439,9 +440,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -456,11 +457,11 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "f163052f84a9656349985737f75c0e20c9a3c8e0"
+                "reference": "1cad05fcfd38ad123af0bbf08b5a1224bd95312a"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -471,9 +472,10 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\Sync\\": "src/",
+                    "Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
+                }
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -482,11 +484,11 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/terms-of-service",
-                "reference": "f97742a361eb772f8bc6f13ae9437b3e8233cb0e"
+                "reference": "6f53f2987be1c025edcd7820759df50c134065e6"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -499,9 +501,9 @@
             },
             "type": "library",
             "autoload": {
-                "classmap": [
-                    "src/"
-                ]
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                }
             },
             "scripts": {
                 "phpunit": [
@@ -516,11 +518,11 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-master",
+            "version": "dev-retry/phpcs-changed",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
-                "reference": "f4e52837194537e90f9fa10ac7b48f25519765bd"
+                "reference": "fd194dfc4f01a66de9c5b9caf239cdd806a8d3eb"
             },
             "require": {
                 "automattic/jetpack-options": "@dev",
@@ -532,9 +534,11 @@
             },
             "type": "library",
             "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\": "src/"
+                },
                 "classmap": [
-                    "legacy",
-                    "src/"
+                    "legacy"
                 ]
             },
             "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,11 +8,11 @@
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/abtest",
-                "reference": "b873be98786907a49ac5cd21836167f662212aa0"
+                "reference": "c3681b3eac3d0e5625de758218fd1e8994e06302"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -24,9 +24,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -41,11 +41,11 @@
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
-                "reference": "e93b5911e77ff0abfad498e99edbb5f6a8a124a9"
+                "reference": "165b7d1cdba6e1609fb0a92e9809a58bbc17503a"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev"
@@ -56,9 +56,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -73,7 +73,7 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
@@ -107,20 +107,20 @@
         },
         {
             "name": "automattic/jetpack-backup",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/backup",
-                "reference": "3dd44f29c9c6ab41cc2492675078ba8b808caea7"
+                "reference": "0ae8bfd8b87d9140066915c643fc6a00783d0032"
             },
             "type": "library",
             "autoload": {
                 "files": [
                     "actions.php"
                 ],
-                "psr-4": {
-                    "Automattic\\Jetpack\\Backup\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -129,7 +129,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -160,16 +160,36 @@
             "description": "Compatibility layer with previous versions of Jetpack"
         },
         {
+            "name": "automattic/jetpack-config",
+            "version": "dev-master",
+            "dist": {
+                "type": "path",
+                "url": "./packages/config",
+                "reference": "09edd078205d6fee2f8a46eaf0f736fd4ade1473"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage."
+        },
+        {
             "name": "automattic/jetpack-connection",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "59fa2bc973303b013ce63978ff8d875d1223f510"
+                "reference": "ac53d3e65b1be0a24206dc32ef2d17a17e387fcd"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-options": "@dev"
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-roles": "@dev"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -177,14 +197,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Connection\\": "src"
-                },
                 "files": [
                     "legacy/load-ixr.php"
                 ],
                 "classmap": [
-                    "legacy"
+                    "legacy",
+                    "src/"
                 ]
             },
             "scripts": {
@@ -200,20 +218,20 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
-                "reference": "a6ab6360f4b48962ec7d62b06b39d1470b1dbe95"
+                "reference": "03403af14d39cec6fd826dbdc6675d0a23cf8d94"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -228,20 +246,20 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/error",
-                "reference": "1707cf33a92fc66f1635dfe1e4215819101e9bb4"
+                "reference": "2f35acfb871c772dd3a81755d093b1cb295b8830"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -256,11 +274,11 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
-                "reference": "b0c2da6ce6a0137f3a1895ab82a93ad7769fddca"
+                "reference": "fd6393ba68829784166efc33f9946b55c321c289"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -277,9 +295,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -294,11 +312,11 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
-                "reference": "d8a31dfd40166c4867fa2c526a03d9df481d5610"
+                "reference": "f2b7828deb34f7bb6da24380f2a88ab98d3733df"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -306,9 +324,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Assets\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -323,7 +341,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -349,7 +367,7 @@
         },
         {
             "name": "automattic/jetpack-partner",
-            "version": "dev-add/upgrade-url-subsidiary-id",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/partner",
@@ -380,11 +398,11 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
-                "reference": "f38b3379c11a05e4711b4fb29b390c8107daccd7"
+                "reference": "22dd28b575dc20f2a8e7d44f024223033c66517a"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -392,9 +410,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -409,11 +427,11 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
-                "reference": "99ecd79ed31dc3432892df709ba745ebc6f747e9"
+                "reference": "e066e8d051698a5a9b1460296f156bbf7555484e"
             },
             "require-dev": {
                 "php-mock/php-mock": "^2.1",
@@ -421,9 +439,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -438,11 +456,11 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
-                "reference": "1cad05fcfd38ad123af0bbf08b5a1224bd95312a"
+                "reference": "f163052f84a9656349985737f75c0e20c9a3c8e0"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -453,10 +471,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Sync\\": "src/",
-                    "Automattic\\Jetpack\\Sync\\Modules\\": "src/modules/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "license": [
                 "GPL-2.0-or-later"
@@ -465,11 +482,11 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/terms-of-service",
-                "reference": "6f53f2987be1c025edcd7820759df50c134065e6"
+                "reference": "f97742a361eb772f8bc6f13ae9437b3e8233cb0e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -482,9 +499,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                }
+                "classmap": [
+                    "src/"
+                ]
             },
             "scripts": {
                 "phpunit": [
@@ -499,11 +516,11 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-retry/phpcs-changed",
+            "version": "dev-master",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",
-                "reference": "fd194dfc4f01a66de9c5b9caf239cdd806a8d3eb"
+                "reference": "f4e52837194537e90f9fa10ac7b48f25519765bd"
             },
             "require": {
                 "automattic/jetpack-options": "@dev",
@@ -515,11 +532,9 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\": "src/"
-                },
                 "classmap": [
-                    "legacy"
+                    "legacy",
+                    "src/"
                 ]
             },
             "scripts": {
@@ -968,6 +983,7 @@
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-backup": 20,
         "automattic/jetpack-compat": 20,
+        "automattic/jetpack-config": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-error": 20,

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -95,3 +95,5 @@ if ( JETPACK__SANDBOX_DOMAIN ) {
 }
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';
+
+Jetpack::init();

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -62,8 +62,6 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 
-Automattic\Jetpack\Sync\Main::init();
-
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
 	$jitm = new Automattic\Jetpack\JITM();
@@ -80,8 +78,6 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'init', array( 'Jetpack', 'init' ) );
-add_action( 'plugins_loaded', array( 'Jetpack', 'plugin_textdomain' ), 99 );
-add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 
@@ -99,5 +95,3 @@ if ( JETPACK__SANDBOX_DOMAIN ) {
 }
 
 require_once JETPACK__PLUGIN_DIR . '3rd-party/3rd-party.php';
-
-Jetpack::init();

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -78,6 +78,8 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'init', array( 'Jetpack', 'init' ) );
+add_action( 'plugins_loaded', array( 'Jetpack', 'plugin_textdomain' ), 99 );
+add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -85,7 +85,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Jetpack_Options',
 						'Jetpack_Signature',
 						'Jetpack_XMLRPC_Server',
-						'Automattic\Jetpack\Sync\Main',
 						'Automattic\Jetpack\Constants',
 						'Automattic\Jetpack\Tracking',
 						'Automattic\Jetpack\Plugin\Tracking',

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,48 @@
+# Jetpack Configuration
+
+Allows for enabling and initializing of Jetpack features provided by
+other packages.
+
+# Usage
+
+Add this package as a dependency to your project:
+
+```
+composer require automattic/jetpack-config
+```
+
+Add every other package you're planning to configure:
+
+```
+composer require automattic/jetpack-sync
+composer require automattic/jetpack-tracking
+composer require automattic/jetpack-terms-of-service
+```
+
+In your code initialize the configuration package at or before
+plugins_loaded priority 9:
+
+```
+use Automattic/Jetpack/Config;
+
+// Configuring Jetpack as early as plugins_loaded priority 1
+// to make sure every action handler gets properly set.
+add_action( 'plugins_loaded', 'configure_jetpack', 1 );
+
+function configure_jetpack() {
+    $config = new Config();
+
+    foreach (
+        array(
+            'sync',
+            'sync_woocommerce',
+            'sync_wp_super_cache',
+            'tracking',
+            'tos',
+        )
+        as $feature
+    ) {
+        $config->ensure( $feature );
+    }
+}
+```

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -35,8 +35,6 @@ function configure_jetpack() {
     foreach (
         array(
             'sync',
-            'sync_woocommerce',
-            'sync_wp_super_cache',
             'tracking',
             'tos',
         )
@@ -46,3 +44,83 @@ function configure_jetpack() {
     }
 }
 ```
+
+# Adding your package to the config class
+
+You can have your package initialized using the Config class by
+adding several things.
+
+## The configure method
+
+It's better to have one static configure method in your package
+class. That method will be called early on the `plugins_loaded`
+hook. This way you can add your own `plugins_loaded` handlers with
+standard priority and they will get executed:
+
+```
+class Configurable_Package {
+
+    public static function configure() {
+        add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded' );
+    }
+
+    public static function on_plugins_loaded() {
+        self::do_interesting_stuff();
+    }
+
+}
+```
+
+## The feature enabling method
+
+An enabling method should be added to the Config class and should only contain your configuration method call.
+
+```
+
+public function enable_configurable_package() {
+    Configurable_Package::configure();
+
+    return true;
+}
+```
+
+Note that the method name should use the feature slug, in this case
+your feature slug is `configurable_package` for the sake of
+simplicity. When you're adding your feature it should be unique and
+recognizable, like `sync` or `tracking`.
+
+## The feature slug
+
+To make sure the feature is supported by the Config class, you need to
+add its slug to the config class property:
+
+```
+    /**
+     * The initial setting values.
+     *
+     * @var Array
+     */
+    protected $config = array(
+        // ...
+        'configurable_package' => false,
+        // ...
+    );
+```
+
+## The ensure call
+
+Finally you need to add a block that will check if your package is
+loaded and mark it to be initialized:
+
+```
+if ( $this->config['configurable_package'] ) {
+    $this->ensure_class( 'Configurable_Package' ) && $this->ensure_feature( 'configurable_package' );
+}
+```
+
+This code does three things: it checks whether the current setup has
+requested your package to be loaded. Next it checks if the class that
+you need for the package to run is present, and then it adds the hook
+handlers that initialize your class. After that you can use the config
+package's interface in a Jetpack package consumer application and load
+your package as shown in the first section of this README.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -20,7 +20,7 @@ composer require automattic/jetpack-terms-of-service
 ```
 
 In your code initialize the configuration package at or before
-plugins_loaded priority 9:
+plugins_loaded priority 1:
 
 ```
 use Automattic/Jetpack/Config;

--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -1,0 +1,13 @@
+{
+	"name": "automattic/jetpack-config",
+	"description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"minimum-stability": "dev",
+	"require": {},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	}
+}

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -47,7 +47,7 @@ class Config {
 
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_early' ), 5 );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
-		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_late' ) );
+		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_late' ), 90 );
 	}
 
 	/**
@@ -111,6 +111,6 @@ class Config {
 		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
 		 * with a high priority or sites that use alternate cron.
 		 */
-		Sync_Actions::init();
+		Sync_Actions::init( $this->jetpack );
 	}
 }

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -18,13 +18,6 @@ use Automattic\Jetpack\Terms_Of_Service;
 class Config {
 
 	/**
-	 * The Jetpack class instance.
-	 *
-	 * @var Jetpack
-	 */
-	protected $jetpack;
-
-	/**
 	 * The initial setting values.
 	 *
 	 * @var Array
@@ -38,16 +31,23 @@ class Config {
 	);
 
 	/**
-	 * Creates the configuration class instance, initalized with the Jetpack object.
-	 *
-	 * @param \Jetpack $jetpack the main object to initalize everything with.
+	 * Creates the configuration class instance..
 	 */
-	public function __construct( \Jetpack $jetpack ) {
-		$this->jetpack = $jetpack;
-
+	public function __construct() {
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_early' ), 5 );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_late' ), 90 );
+	}
+
+	/**
+	 * Require a feature to be initialized. It's up to the package consumer to actually add
+	 * the package to their composer project. Declaring a requirement using this method
+	 * instructs the class to initalize it.
+	 *
+	 * @param String $feature the feature slug.
+	 */
+	public function ensure( $feature ) {
+		$this->config[ $feature ] = true;
 	}
 
 	/**
@@ -56,20 +56,6 @@ class Config {
 	 * @action plugins_loaded
 	 */
 	public function on_plugins_loaded_early() {
-
-		/**
-		 * Filters the settings for the Jetpack Config package, allowing package consumers to set
-		 * initialization options.
-		 *
-		 * @since 8.1.0
-		 *
-		 * @param Array An array of options that configure Jetpack package initialization details.
-		 */
-		$this->config = wp_parse_args(
-			apply_filters( 'jetpack_config', $this->config ),
-			$this->config
-		);
-
 		if ( $this->config['sync'] ) {
 			Sync_Main::init();
 
@@ -111,6 +97,6 @@ class Config {
 		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
 		 * with a high priority or sites that use alternate cron.
 		 */
-		Sync_Actions::init( $this->jetpack );
+		Sync_Actions::init();
 	}
 }

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * The base Jetpack configuration class file.
+ *
+ * @package automattic/jetpack-config
+ */
+
+namespace Automattic\Jetpack;
+
+use Automattic\Jetpack\Sync\Actions as Sync_Actions;
+use Automattic\Jetpack\Sync\Main as Sync_Main;
+use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
+use Automattic\Jetpack\Terms_Of_Service;
+
+/**
+ * The configuration class.
+ */
+class Config {
+
+	/**
+	 * The Jetpack class instance.
+	 *
+	 * @var Jetpack
+	 */
+	protected $jetpack;
+
+	/**
+	 * Creates the configuration class instance, initalized with the Jetpack object.
+	 *
+	 * @param \Jetpack $jetpack the main object to initalize everything with.
+	 */
+	public function __construct( \Jetpack $jetpack ) {
+		$this->jetpack = $jetpack;
+
+		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_early' ), 5 );
+		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ) );
+		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_late' ) );
+	}
+
+	/**
+	 * Runs early on plugins_loaded hook execution.
+	 *
+	 * @action plugins_loaded
+	 */
+	public function on_plugins_loaded_early() {
+		Sync_Main::init();
+
+		// Check for WooCommerce support.
+		Sync_Actions::initialize_woocommerce();
+
+		// Check for WP Super Cache.
+		Sync_Actions::initialize_wp_super_cache();
+	}
+
+	/**
+	 * Runs on default plugins_loaded hook priority.
+	 *
+	 * @action plugins_loaded
+	 */
+	public function on_plugins_loaded() {
+		$terms_of_service = new Terms_Of_Service();
+		$tracking         = new Plugin_Tracking();
+		if ( $terms_of_service->has_agreed() ) {
+			add_action( 'init', array( $tracking, 'init' ) );
+		} else {
+			/**
+			 * Initialize tracking right after the user agrees to the terms of service.
+			 */
+			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
+		}
+	}
+
+	/**
+	 * Runs after most of plugins_loaded hook functions have been run.
+	 *
+	 * @action plugins_loaded
+	 */
+	public function on_plugins_loaded_late() {
+		/*
+		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
+		 * with a high priority or sites that use alternate cron.
+		 */
+		Sync_Actions::init();
+	}
+}

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -31,7 +31,7 @@ class Config {
 	);
 
 	/**
-	 * Creates the configuration class instance..
+	 * Creates the configuration class instance.
 	 */
 	public function __construct() {
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded_early' ), 5 );

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -16,6 +16,10 @@ use Automattic\Jetpack\Terms_Of_Service;
  */
 class Config {
 
+	const FEATURE_ENSURED         = 1;
+	const FEATURE_NOT_AVAILABLE   = 0;
+	const FEATURE_ALREADY_ENSURED = -1;
+
 	/**
 	 * The initial setting values.
 	 *
@@ -100,16 +104,16 @@ class Config {
 	 * Ensures a feature is enabled, sets it up if it hasn't already been set up.
 	 *
 	 * @param String $feature slug of the feature.
-	 * @return Boolean whether the feature was enabled. If it was already enabled, returns false.
+	 * @return Integer either FEATURE_ENSURED, FEATURE_ALREADY_ENSURED or FEATURE_NOT_AVAILABLE constants.
 	 */
 	protected function ensure_feature( $feature ) {
-		if ( did_action( 'jetpack_feature_' . $feature . '_enabled' ) ) {
-			return false;
-		}
-
 		$method = 'enable_' . $feature;
 		if ( ! method_exists( $this, $method ) ) {
-			return false;
+			return self::FEATURE_NOT_AVAILABLE;
+		}
+
+		if ( did_action( 'jetpack_feature_' . $feature . '_enabled' ) ) {
+			return self::FEATURE_ALREADY_ENSURED;
 		}
 
 		$this->{ $method }();
@@ -120,6 +124,8 @@ class Config {
 		 * @since 8.1.0
 		 */
 		do_action( 'jetpack_feature_' . $feature . '_enabled' );
+
+		return self::FEATURE_ENSURED;
 	}
 
 	/**

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -51,7 +51,7 @@ class Config {
 	}
 
 	/**
-	 * Runs on default plugins_loaded hook priority.
+	 * Runs on plugins_loaded hook priority with priority 2.
 	 *
 	 * @action plugins_loaded
 	 */

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -121,7 +121,7 @@ class Config {
 		/**
 		 * Fires when a specific Jetpack package feature is initalized using the Config package.
 		 *
-		 * @since 8.1.0
+		 * @since 8.2.0
 		 */
 		do_action( 'jetpack_feature_' . $feature . '_enabled' );
 

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -82,9 +82,9 @@ class Config {
 		if ( ! $available && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 				sprintf(
-					/* translators: %1$s is a PHP class name, %2$s is a Jetpack feature code, like 'sync'. */
+					/* translators: %1$s is a PHP class name. */
 					esc_html__(
-						'Unable to load class %1$s, not enabling %2$s feature. Please add the package that contains it using composer and make sure you are requiring the Jetpack autoloader',
+						'Unable to load class %1$s. Please add the package that contains it using composer and make sure you are requiring the Jetpack autoloader',
 						'jetpack'
 					),
 					esc_html( $classname )

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -511,13 +511,6 @@ class Actions {
 	 */
 	public static function initialize_sender() {
 		self::$sender = Sender::get_instance();
-
-		// In case the plugins are already loaded, it means that we are initializing
-		// the sender too late for it to receive the Jetpack object naturally, so we're
-		// calling the hook manually.
-		if ( did_action( 'plugins_loaded' ) ) {
-			self::$sender->on_jetpack_loaded( self::$jetpack );
-		}
 		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 6 );
 	}
 

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -40,6 +40,13 @@ class Actions {
 	public static $listener = null;
 
 	/**
+	 * The Jetpack class instance.
+	 *
+	 * @var Jetpack
+	 */
+	protected static $jetpack;
+
+	/**
 	 * Name of the sync cron schedule.
 	 *
 	 * @access public
@@ -63,8 +70,11 @@ class Actions {
 	 *
 	 * @access public
 	 * @static
+	 * @param \Jetpack $jetpack the main Jetpack class object.
 	 */
-	public static function init() {
+	public static function init( \Jetpack $jetpack ) {
+		self::$jetpack = $jetpack;
+
 		// Everything below this point should only happen if we're a valid sync site.
 		if ( ! self::sync_allowed() ) {
 			return;
@@ -501,6 +511,13 @@ class Actions {
 	 */
 	public static function initialize_sender() {
 		self::$sender = Sender::get_instance();
+
+		// In case the plugins are already loaded, it means that we are initializing
+		// the sender too late for it to receive the Jetpack object naturally, so we're
+		// calling the hook manually.
+		if ( did_action( 'plugins_loaded' ) ) {
+			self::$sender->on_jetpack_loaded( self::$jetpack );
+		}
 		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 6 );
 	}
 

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -40,13 +40,6 @@ class Actions {
 	public static $listener = null;
 
 	/**
-	 * The Jetpack class instance.
-	 *
-	 * @var Jetpack
-	 */
-	protected static $jetpack;
-
-	/**
 	 * Name of the sync cron schedule.
 	 *
 	 * @access public
@@ -70,11 +63,8 @@ class Actions {
 	 *
 	 * @access public
 	 * @static
-	 * @param \Jetpack $jetpack the main Jetpack class object.
 	 */
-	public static function init( \Jetpack $jetpack ) {
-		self::$jetpack = $jetpack;
-
+	public static function init() {
 		// Everything below this point should only happen if we're a valid sync site.
 		if ( ! self::sync_allowed() ) {
 			return;

--- a/packages/sync/src/class-listener.php
+++ b/packages/sync/src/class-listener.php
@@ -70,7 +70,6 @@ class Listener {
 	 * This is necessary because you can't use "new" when you declare instance properties >:(
 	 */
 	protected function __construct() {
-		Main::init();
 		$this->set_defaults();
 		$this->init();
 	}

--- a/packages/sync/src/class-main.php
+++ b/packages/sync/src/class-main.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Sync\Actions;
+
 /**
  * Jetpack Sync main class.
  */
@@ -15,18 +17,6 @@ class Main {
 	 * Initialize the main sync actions.
 	 */
 	public static function init() {
-		// Check for WooCommerce support.
-		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'initialize_woocommerce' ), 5 );
-
-		// Check for WP Super Cache.
-		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'initialize_wp_super_cache' ), 5 );
-
-		/*
-		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
-		 * with a high priority or sites that use alternate cron.
-		 */
-		add_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'init' ), 90 );
-
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Automattic\\Jetpack\\Sync\\Actions', 'cleanup_on_upgrade' ), 10, 2 );
 		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );

--- a/packages/sync/src/class-main.php
+++ b/packages/sync/src/class-main.php
@@ -7,8 +7,6 @@
 
 namespace Automattic\Jetpack\Sync;
 
-use Automattic\Jetpack\Sync\Actions;
-
 /**
  * Jetpack Sync main class.
  */

--- a/packages/sync/src/class-main.php
+++ b/packages/sync/src/class-main.php
@@ -7,16 +7,56 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Sync\Actions as Sync_Actions;
+
 /**
  * Jetpack Sync main class.
  */
 class Main {
+
+	/**
+	 * Sets up event handlers for the Sync package. Is used from the Config package.
+	 *
+	 * @action plugins_loaded
+	 */
+	public static function configure() {
+		add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_early' ), 5 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_late' ), 90 );
+	}
+
 	/**
 	 * Initialize the main sync actions.
+	 *
+	 * @action plugins_loaded
 	 */
-	public static function init() {
+	public static function on_plugins_loaded_early() {
+		/**
+		 * Additional Sync modules can be carried out into their own packages and they
+		 * will get their own config settings.
+		 *
+		 * For now additional modules are enabled based on whether the third party plugin
+		 * class exists or not.
+		 */
+		Sync_Actions::initialize_woocommerce();
+		Sync_Actions::initialize_wp_super_cache();
+
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Automattic\\Jetpack\\Sync\\Actions', 'cleanup_on_upgrade' ), 10, 2 );
 		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 	}
+
+	/**
+	 * Runs after most of plugins_loaded hook functions have been run.
+	 *
+	 * @action plugins_loaded
+	 */
+	public static function on_plugins_loaded_late() {
+		/*
+		 * Init after plugins loaded and before the `init` action. This helps with issues where plugins init
+		 * with a high priority or sites that use alternate cron.
+		 */
+		Sync_Actions::init();
+	}
+
+
 }

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -150,6 +150,15 @@ class Sender {
 	private static $instance;
 
 	/**
+	 * Jetpack connection manager instance.
+	 *
+	 * @access protected
+	 *
+	 * @var null|Automattic\Jetpack\Connection\Manager
+	 */
+	protected $connection = null;
+
+	/**
 	 * Retrieve the singleton instance of this class.
 	 *
 	 * @access public
@@ -186,10 +195,20 @@ class Sender {
 	private function init() {
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_set_user_from_token' ), 1 );
 		add_action( 'jetpack_sync_before_send_queue_sync', array( $this, 'maybe_clear_user_from_token' ), 20 );
+		add_action( 'jetpack_loaded', array( $this, 'on_jetpack_loaded' ) );
 		add_filter( 'jetpack_xmlrpc_methods', array( $this, 'register_jetpack_xmlrpc_methods' ) );
 		foreach ( Modules::get_modules() as $module ) {
 			$module->init_before_send();
 		}
+	}
+
+	/**
+	 * Runs on Jetpack being ready to load its packages.
+	 *
+	 * @param Jetpack $jetpack object.
+	 */
+	public function on_jetpack_loaded( $jetpack ) {
+		$this->connection = $jetpack->get_connection();
 	}
 
 	/**
@@ -199,7 +218,7 @@ class Sender {
 	 * @access public
 	 */
 	public function maybe_set_user_from_token() {
-		$verified_user = \Jetpack::connection()->verify_xml_rpc_signature();
+		$verified_user = $this->connection->verify_xml_rpc_signature();
 		if ( Constants::is_true( 'XMLRPC_REQUEST' ) &&
 			! is_wp_error( $verified_user )
 			&& $verified_user

--- a/packages/sync/src/class-users.php
+++ b/packages/sync/src/class-users.php
@@ -110,7 +110,7 @@ class Users {
 	 * @return string Signed role of the user.
 	 */
 	public static function get_signed_role( $user_id ) {
-		return \Jetpack::connection()->sign_role( self::get_role( $user_id ), $user_id );
+		return self::$connection->sign_role( self::get_role( $user_id ), $user_id );
 	}
 
 	/**

--- a/packages/sync/src/class-users.php
+++ b/packages/sync/src/class-users.php
@@ -27,16 +27,6 @@ class Users {
 	public static $user_roles = array();
 
 	/**
-	 * Jetpack connection manager instance.
-	 *
-	 * @access public
-	 * @static
-	 *
-	 * @var null|Automattic\Jetpack\Connection\Manager
-	 */
-	public static $connection = null;
-
-	/**
 	 * Initialize sync for user data changes.
 	 *
 	 * @access public
@@ -44,13 +34,12 @@ class Users {
 	 * @todo Eventually, connection needs to be instantiated at the top level in the sync package.
 	 */
 	public static function init() {
-		self::$connection = new Jetpack_Connection();
-		if ( self::$connection->is_active() ) {
+		$connection = new Jetpack_Connection();
+		if ( $connection->is_active() ) {
 			// Kick off synchronization of user role when it changes.
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}
 	}
-
 
 	/**
 	 * Synchronize connected user role changes.
@@ -61,7 +50,8 @@ class Users {
 	 * @param int $user_id ID of the user.
 	 */
 	public static function user_role_change( $user_id ) {
-		if ( self::$connection->is_user_connected( $user_id ) ) {
+		$connection = new Jetpack_Connection();
+		if ( $connection->is_user_connected( $user_id ) ) {
 			self::update_role_on_com( $user_id );
 			// Try to choose a new master if we're demoting the current one.
 			self::maybe_demote_master_user( $user_id );
@@ -102,7 +92,8 @@ class Users {
 	 * @return string Signed role of the user.
 	 */
 	public static function get_signed_role( $user_id ) {
-		return self::$connection->sign_role( self::get_role( $user_id ), $user_id );
+		$connection = new Jetpack_Connection();
+		return $connection->sign_role( self::get_role( $user_id ), $user_id );
 	}
 
 	/**
@@ -141,9 +132,10 @@ class Users {
 				)
 			);
 			$new_master = false;
+			$connection = new Jetpack_Connection();
 			foreach ( $query->results as $result ) {
 				$found_user_id = absint( $result->id );
-				if ( $found_user_id && self::$connection->is_user_connected( $found_user_id ) ) {
+				if ( $found_user_id && $connection->is_user_connected( $found_user_id ) ) {
 					$new_master = $found_user_id;
 					break;
 				}

--- a/packages/sync/src/class-users.php
+++ b/packages/sync/src/class-users.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Sync;
 
-use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Roles;
 
 /**
@@ -44,12 +43,22 @@ class Users {
 	 * @todo Eventually, connection needs to be instantiated at the top level in the sync package.
 	 */
 	public static function init() {
-		self::$connection = new Jetpack_Connection();
+		add_action( 'jetpack_loaded', array( __CLASS__, 'on_jetpack_loaded' ) );
+	}
+
+	/**
+	 * Runs on Jetpack being ready to load its packages.
+	 *
+	 * @param Jetpack $jetpack object.
+	 */
+	public static function on_jetpack_loaded( $jetpack ) {
+		self::$connection = $jetpack->get_connection();
 		if ( self::$connection->is_active() ) {
 			// Kick off synchronization of user role when it changes.
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );
 		}
 	}
+
 
 	/**
 	 * Synchronize connected user role changes.

--- a/packages/sync/src/class-users.php
+++ b/packages/sync/src/class-users.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Sync;
 
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Roles;
 
 /**
@@ -43,16 +44,7 @@ class Users {
 	 * @todo Eventually, connection needs to be instantiated at the top level in the sync package.
 	 */
 	public static function init() {
-		add_action( 'jetpack_loaded', array( __CLASS__, 'on_jetpack_loaded' ) );
-	}
-
-	/**
-	 * Runs on Jetpack being ready to load its packages.
-	 *
-	 * @param Jetpack $jetpack object.
-	 */
-	public static function on_jetpack_loaded( $jetpack ) {
-		self::$connection = $jetpack->get_connection();
+		self::$connection = new Jetpack_Connection();
 		if ( self::$connection->is_active() ) {
 			// Kick off synchronization of user role when it changes.
 			add_action( 'set_user_role', array( __CLASS__, 'user_role_change' ) );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -71,6 +71,7 @@ function _manually_load_plugin() {
 		require JETPACK_WOOCOMMERCE_INSTALL_DIR . '/woocommerce.php';
 	}
 	require dirname( __FILE__ ) . '/../../jetpack.php';
+	Jetpack::configure();
 }
 
 function _manually_install_woocommerce() {

--- a/tests/php/sync/class.silent-upgrader-skin.php
+++ b/tests/php/sync/class.silent-upgrader-skin.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+
 class Silent_Upgrader_Skin extends WP_Upgrader_Skin {
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -10,8 +10,6 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 use Automattic\Jetpack\Sync\Modules\Posts;
 
-Jetpack::configure();
-
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 
 require_once $sync_server_dir . 'class.jetpack-sync-test-replicastore.php';

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -3,14 +3,11 @@
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Modules;
-use Automattic\Jetpack\Sync\Main;
 use Automattic\Jetpack\Sync\Modules\Constants;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 use Automattic\Jetpack\Sync\Modules\Posts;
-
-Main::init();
 
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -56,12 +56,6 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		$this->server_event_storage = new Jetpack_Sync_Server_Eventstore();
 		$this->server_event_storage->init();
-
-		$jetpack = Jetpack::init();
-
-		new Config( $jetpack );
-
-		add_filter( 'jetpack_config', array( $jetpack, 'filter_jetpack_config' ) );
 	}
 
 	public function tearDown() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,14 +1,16 @@
 <?php
 
-use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Modules;
+use Automattic\Jetpack\Sync\Main;
 use Automattic\Jetpack\Sync\Modules\Constants;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Server;
 use Automattic\Jetpack\Sync\Modules\Posts;
+
+Jetpack::configure();
 
 $sync_server_dir = dirname( __FILE__ ) . '/server/';
 

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -58,6 +58,8 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 
 		$this->server_event_storage = new Jetpack_Sync_Server_Eventstore();
 		$this->server_event_storage->init();
+
+		Jetpack::init()->late_initalization();
 	}
 
 	public function tearDown() {

--- a/tests/php/sync/test_class.jetpack-sync-base.php
+++ b/tests/php/sync/test_class.jetpack-sync-base.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Sync\Modules\Callables;
 use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Modules;
@@ -56,7 +57,11 @@ class WP_Test_Jetpack_Sync_Base extends WP_UnitTestCase {
 		$this->server_event_storage = new Jetpack_Sync_Server_Eventstore();
 		$this->server_event_storage->init();
 
-		Jetpack::init()->late_initalization();
+		$jetpack = Jetpack::init();
+
+		new Config( $jetpack );
+
+		add_filter( 'jetpack_config', array( $jetpack, 'filter_jetpack_config' ) );
 	}
 
 	public function tearDown() {

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -56,14 +56,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( '123', $this->server_replica_storage->get_option( 'foo_option_bar' ) );
 	}
 
-	public function test_sync_initalize_Jetpack_Sync_Action_on_init() {
-		// prioroty should be set so that plugins can set their own filers initialize the whitelist_filter before.
-		// Priority is set earlier now plugins_loaded but we plugins should still be able to set whitelist_filters by
-		// using the plugins_loaded action.
-
-		$this->assertEquals( 90, has_action( 'plugins_loaded', array( 'Automattic\\Jetpack\\Sync\\Actions', 'init' ) ) );
-	}
-
 	public function test_sync_default_options() {
 		$this->setSyncClientDefaults();
 		// check that these values exists in the whitelist options


### PR DESCRIPTION
This change tries several new ways to initialize objects by using hooks instead of initalizing manually. This tries to fix a chicken and egg problem where some classes run their code early, but need to be fully loaded to properly autoload the latest available version.

This is a proof of concept, more of a discussion piece than a real solution so far. I'm eager to hear your opinions.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added two new initialization methods to Jetpack to allow for various priority on `plugins_loaded`. 
* Added a new action that code can hook into to avoid calling `Jetpack::init` but instead waiting for the main object to become available on `jetpack_loaded`.
* Modified the way one Sync class handles Jetpack active checks to avoid instantiating the connection class before `plugins_loaded` as an example.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
*  TBA

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A