### PR TITLE
[not verified] Refresh the autoloader after a plugin update.

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -93,6 +93,21 @@ if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' )
  */
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
 if ( is_readable( $jetpack_autoloader ) ) {
+	add_filter( 'upgrader_post_install', 'jetpack_refresh_autoloader_post_install', 1, 2 );
+	function jetpack_refresh_autoloader_post_install( $worked, $hook_extras ) {
+		error_log( print_r( $hook_extras, 1 ) );
+		if (
+			! isset( $hook_extras['plugin'] )
+			|| JETPACK__PLUGIN_FILE !== $hook_extras['plugin']
+		) {
+			return $worked;
+		}
+		// Include the new autoloader since the classes might have been shifter.
+		include JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
+
+		return $worked;
+	}
+
 	require $jetpack_autoloader;
 } else {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/jetpack.php
+++ b/jetpack.php
@@ -94,8 +94,14 @@ if ( version_compare( $GLOBALS['wp_version'], JETPACK__MINIMUM_WP_VERSION, '<' )
 $jetpack_autoloader = JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
 if ( is_readable( $jetpack_autoloader ) ) {
 	add_filter( 'upgrader_post_install', 'jetpack_refresh_autoloader_post_install', 1, 2 );
+	/**
+	 * Refreshes the autoloader if the 'upgrader_post_install' hook fires. This
+	 * occurs when the plugin is updated.
+	 *
+	 * @param bool  $worked Installation response.
+	 * @param array $hook_extras Extra arguments passed to hooked filters.
+	 */
 	function jetpack_refresh_autoloader_post_install( $worked, $hook_extras ) {
-		error_log( print_r( $hook_extras, 1 ) );
 		if (
 			! isset( $hook_extras['plugin'] )
 			|| JETPACK__PLUGIN_FILE !== $hook_extras['plugin']

--- a/jetpack.php
+++ b/jetpack.php
@@ -108,7 +108,7 @@ if ( is_readable( $jetpack_autoloader ) ) {
 		) {
 			return $worked;
 		}
-		// Include the new autoloader since the classes might have been shifter.
+		// Include the new autoloader since the classes might have been shifted.
 		include JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
 
 		return $worked;

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -254,12 +254,13 @@ INCLUDE_CLASSMAP;
 	private function getAutoloadPackageFile( $suffix ) {
 		$sourceLoader   = fopen( __DIR__ . '/autoload.php', 'r' );
 		$file_contents  = stream_get_contents( $sourceLoader );
+		$function_name  = '$enqueue_packages_' . $suffix;
 		$file_contents .= <<<INCLUDE_FILES
 /**
  * Prepare all the classes for autoloading.
  */
-function enqueue_packages_$suffix() {
-	\$class_map = require_once dirname( __FILE__ ) . '/composer/autoload_classmap_package.php';
+$function_name = function() {
+	\$class_map = require dirname( __FILE__ ) . '/composer/autoload_classmap_package.php';
 	foreach ( \$class_map as \$class_name => \$class_info ) {
 		enqueue_package_class( \$class_name, \$class_info['version'], \$class_info['path'] );
 	}
@@ -276,8 +277,8 @@ function enqueue_packages_$suffix() {
 			\$GLOBALS['__composer_autoload_files'][ \$fileIdentifier ] = true;
 		}
 	}
-}
-enqueue_packages_$suffix();
+};
+$function_name();
 
 INCLUDE_FILES;
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,9 @@
 		<testsuite name="php-lint">
 			<file>tests/php/test_php-lint.php</file>
 		</testsuite>
+		<testsuite name="php-autoloader">
+			<file>tests/php/test_include-autoloader.php</file>
+		</testsuite>
 		<testsuite name="core-api">
 			<directory prefix="test" suffix=".php">tests/php/core-api</directory>
 		</testsuite>

--- a/tests/php/test_include-autoloader.php
+++ b/tests/php/test_include-autoloader.php
@@ -1,25 +1,40 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
-class WP_Test_Jetpack_Autoloader_Lint extends WP_UnitTestCase {
+/**
+ * Contains tests for the Jetpack Autoloader.
+ */
+class WP_Test_Jetpack_Include_Autoloader extends WP_UnitTestCase {
 
+	/**
+	 * Tests that the Autoloader properly includes class files when the files
+	 * are renamed.
+	 */
 	public function test_renaming_files_in_autoloader_does_not_cause_errors() {
 		$packages = $this->get_packages_classes();
-		 $this->unset_package_classes();
+		$this->unset_package_classes();
 
-		 $empty_packages = $this->get_packages_classes();
-		 $this->assertTrue( empty( $empty_packages ), 'package classes are not empty!' );
+		$empty_packages = $this->get_packages_classes();
+		$this->assertTrue( empty( $empty_packages ), 'package classes are not empty!' );
 
-		// Fake the plugin update
+		// Fake the plugin update.
 		apply_filters( 'upgrader_post_install', true, array( 'plugin' => JETPACK__PLUGIN_FILE ), array() );
 
 		$this->assertEquals( $packages, $this->get_packages_classes(), 'package classes are not the same as before' );
 	}
 
-	public function get_packages_classes( ) {
+	/**
+	 * Returns the global $jetpack_packages_classes variable.
+	 *
+	 * @return array
+	 */
+	public function get_packages_classes() {
 		global $jetpack_packages_classes;
 		return $jetpack_packages_classes;
 	}
 
+	/**
+	 * Unsets the global $jetpack_packages_classes variable.
+	 */
 	public function unset_package_classes() {
 		global $jetpack_packages_classes;
 		$jetpack_packages_classes = array();

--- a/tests/php/test_include-autoloader.php
+++ b/tests/php/test_include-autoloader.php
@@ -21,7 +21,6 @@ class WP_Test_Jetpack_Autoloader_Lint extends WP_UnitTestCase {
 	}
 
 	public function unset_package_classes() {
-		error_log( 'UNSET PACKAGE CLASSES' );
 		global $jetpack_packages_classes;
 		$jetpack_packages_classes = array();
 	}

--- a/tests/php/test_include-autoloader.php
+++ b/tests/php/test_include-autoloader.php
@@ -1,0 +1,28 @@
+<?php
+
+class WP_Test_Jetpack_Autoloader_Lint extends WP_UnitTestCase {
+
+	public function test_renaming_files_in_autoloader_does_not_cause_errors() {
+		$packages = $this->get_packages_classes();
+		 $this->unset_package_classes();
+
+		 $empty_packages = $this->get_packages_classes();
+		 $this->assertTrue( empty( $empty_packages ), 'package classes are not empty!' );
+
+		// Fake the plugin update
+		apply_filters( 'upgrader_post_install', true, array( 'plugin' => JETPACK__PLUGIN_FILE ), array() );
+
+		$this->assertEquals( $packages, $this->get_packages_classes(), 'package classes are not the same as before' );
+	}
+
+	public function get_packages_classes( ) {
+		global $jetpack_packages_classes;
+		return $jetpack_packages_classes;
+	}
+
+	public function unset_package_classes() {
+		error_log( 'UNSET PACKAGE CLASSES' );
+		global $jetpack_packages_classes;
+		$jetpack_packages_classes = array();
+	}
+}


### PR DESCRIPTION
Currently when we update Jetpack and we move files around we end up throwing an PHP fatal because the classes are being included in a way that doesn't match the file system any more. 

This PR tires to fix this by hooking into the plugin update mechanism and updating mapping of the classes user by the autoloader.

One thing that currently is not considered the the way that the individual files are loaded twice. This is not idea because it means that in some cases we are loading the add action multiple times. 

I think a fix for this should be to move away from loading of any individual files. 

#### Changes proposed in this Pull Request:
* Hook into the plugin update and update the autoloader class mapping. 
* Update the unique function to an anonymous function so that it can be declared and executed multiple times. When we include the autoloader multiple times. 

#### Testing instructions:
* Do the tests pass? 
* I need help testing this. I am not sure what is a good way to do this. 

#### Proposed changelog entry for your changes:
* Improve the plugin update so that we end up with less fatal errors. 
