### PR TITLE
Set response code for ads.txt requests

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -174,6 +174,7 @@ class WordAds {
 			 */
 			$ads_txt_content = apply_filters( 'wordads_ads_txt', $ads_txt_transient );
 
+			http_response_code( 200 );
 			header( 'Content-Type: text/plain; charset=utf-8' );
 			echo esc_html( $ads_txt_content );
 			die();


### PR DESCRIPTION
Fixes #14169

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Sends an HTTP 200 OK response code for /ads.txt requests. Previously no response code was set.

#### Testing instructions:
* Make a request for domain.com/ads.txt
* When Ads are enabled, the generated ads.txt should be returned with a 200 HTTP response code.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Set response code of 200 OK for ads.txt requests