### PR TITLE
Instant Search: add filter icon toggle

### DIFF
--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -52,6 +52,8 @@ class Gridicon extends Component {
 				return <title>{ __( 'Tag' ) }</title>;
 			case 'gridicons-video':
 				return <title>{ __( 'Has a video.' ) }</title>;
+			case 'gridicons-filter':
+				return <title>{ __( 'Open search filters.' ) }</title>;
 		}
 	}
 
@@ -113,6 +115,12 @@ class Gridicon extends Component {
 						<path d="M20 4v2h-2V4H6v2H4V4c-1.105 0-2 .895-2 2v12c0 1.105.895 2 2 2v-2h2v2h12v-2h2v2c1.105 0 2-.895 2-2V6c0-1.105-.895-2-2-2zM6 16H4v-3h2v3zm0-5H4V8h2v3zm4 4V9l4.5 3-4.5 3zm10 1h-2v-3h2v3zm0-5h-2V8h2v3z" />
 					</g>
 				);
+			case 'gridicons-filter':
+				return (
+					<g>
+						<path d="M10 19h4v-2h-4v2zm-4-6h12v-2H6v2zM3 5v2h18V5H3z" />
+					</g>
+				);
 		}
 	}
 
@@ -126,6 +134,7 @@ class Gridicon extends Component {
 		if ( needsOffset ) {
 			iconClass.push( 'needs-offset' );
 		}
+
 		iconClass = iconClass.join( ' ' );
 
 		return (

--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -53,7 +53,7 @@ class Gridicon extends Component {
 			case 'gridicons-video':
 				return <title>{ __( 'Has a video.' ) }</title>;
 			case 'gridicons-filter':
-				return <title>{ __( 'Open search filters.' ) }</title>;
+				return <title>{ __( 'Toggle search filters.' ) }</title>;
 		}
 	}
 
@@ -134,7 +134,6 @@ class Gridicon extends Component {
 		if ( needsOffset ) {
 			iconClass.push( 'needs-offset' );
 		}
-
 		iconClass = iconClass.join( ' ' );
 
 		return (

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -43,11 +43,19 @@ const SearchBox = props => {
 				value={ props.query }
 			/>
 			{ ! props.widget && (
-				<Gridicon
-					icon="filter"
-					class_name="jetpack-instant-search__box-filter-icon"
+				/* Using role='button' rather than button element so we retain control over styling */
+				<div
+					role="button"
 					onClick={ props.toggleFilters }
-				/>
+					onKeyDown={ props.toggleFilters }
+					tabIndex="0"
+					className="jetpack-instant-search__box-filter-icon"
+				>
+					<Gridicon icon="filter" alt="Search filter icon" />
+					<span class="screen-reader-text">
+						{ props.showFilters ? __( 'Hide filters' ) : __( 'Show filters ' ) }
+					</span>
+				</div>
 			) }
 			<button className="screen-reader-text">{ __( 'Search', 'jetpack' ) }</button>
 		</div>

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -9,6 +9,11 @@ import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import uniqueId from 'lodash/uniqueId';
 
+/**
+ * Internal dependencies
+ */
+import Gridicon from './gridicon';
+
 function ignoreEnterKey( event ) {
 	if ( event.key === 'Enter' ) {
 		// Prevent form submission
@@ -36,6 +41,9 @@ const SearchBox = props => {
 				type="search"
 				value={ props.query }
 			/>
+			{ ! props.widget && (
+				<Gridicon icon="filter" class_name="jetpack-instant-search__box-filter-icon" />
+			) }
 			<button className="screen-reader-text">{ __( 'Search', 'jetpack' ) }</button>
 		</div>
 	);

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -51,7 +51,7 @@ const SearchBox = props => {
 					tabIndex="0"
 					className="jetpack-instant-search__box-filter-icon"
 				>
-					<Gridicon icon="filter" alt="Search filter icon" />
+					<Gridicon icon="filter" alt="Search filter icon" aria-hidden="true" />
 					<span class="screen-reader-text">
 						{ props.showFilters ? __( 'Hide filters' ) : __( 'Show filters ' ) }
 					</span>

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -23,6 +23,7 @@ function ignoreEnterKey( event ) {
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
+
 	return (
 		<div className="jetpack-instant-search__box">
 			{ /* TODO: Add support for preserving label text */ }
@@ -42,7 +43,11 @@ const SearchBox = props => {
 				value={ props.query }
 			/>
 			{ ! props.widget && (
-				<Gridicon icon="filter" class_name="jetpack-instant-search__box-filter-icon" />
+				<Gridicon
+					icon="filter"
+					class_name="jetpack-instant-search__box-filter-icon"
+					onClick={ props.toggleFilters }
+				/>
 			) }
 			<button className="screen-reader-text">{ __( 'Search', 'jetpack' ) }</button>
 		</div>

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -1,3 +1,11 @@
+.jetpack-instant-search__box {
+	display: flex;
+}
+
+.jetpack-instant-search__box-filter-icon {
+	margin-left: 4px;
+}
+
 /* apply to all the inputs to try and pick up any theme styling */
 .jetpack-instant-search__box input {
 	border-radius: 2px;

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -4,6 +4,7 @@
 
 .jetpack-instant-search__box-filter-icon {
 	margin-left: 4px;
+	cursor: pointer;
 }
 
 /* apply to all the inputs to try and pick up any theme styling */

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Component, h } from 'preact';
+import { Component, Fragment, h } from 'preact';
 
 /**
  * Internal dependencies
@@ -24,9 +24,19 @@ import {
 const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
+	state = {
+		showFilters: true,
+	};
+
 	onChangeFilter = ( filterName, filterValue ) => setFilterQuery( filterName, filterValue );
 	onChangeQuery = event => setSearchQuery( event.target.value );
 	onChangeSort = sort => setSortQuery( sort );
+
+	toggleFilters = () => {
+		this.setState( state => ( {
+			showFilters: ! state.showFilters,
+		} ) );
+	};
 
 	render() {
 		return (
@@ -38,18 +48,23 @@ class SearchForm extends Component {
 						onBlur={ this.props.onSearchBlur }
 						query={ getSearchQuery() }
 						widget={ this.props.widget }
+						toggleFilters={ this.toggleFilters }
 					/>
 				</div>
-				<SearchSort onChange={ this.onChangeSort } value={ getSortQuery() } />
-				<SearchFilters
-					filters={ getFilterQuery() }
-					loading={ this.props.isLoading }
-					locale={ this.props.locale }
-					onChange={ this.onChangeFilter }
-					postTypes={ this.props.postTypes }
-					results={ this.props.response }
-					widget={ this.props.widget }
-				/>
+				{ this.state.showFilters && (
+					<Fragment>
+						<SearchSort onChange={ this.onChangeSort } value={ getSortQuery() } />
+						<SearchFilters
+							filters={ getFilterQuery() }
+							loading={ this.props.isLoading }
+							locale={ this.props.locale }
+							onChange={ this.onChangeFilter }
+							postTypes={ this.props.postTypes }
+							results={ this.props.response }
+							widget={ this.props.widget }
+						/>
+					</Fragment>
+				) }
 			</form>
 		);
 	}

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -25,7 +25,7 @@ const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
 	state = {
-		showFilters: true,
+		showFilters: false,
 	};
 
 	onChangeFilter = ( filterName, filterValue ) => setFilterQuery( filterName, filterValue );
@@ -49,6 +49,7 @@ class SearchForm extends Component {
 						query={ getSearchQuery() }
 						widget={ this.props.widget }
 						toggleFilters={ this.toggleFilters }
+						showFilters={ this.state.showFilters }
 					/>
 				</div>
 				{ this.state.showFilters && (

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -37,6 +37,7 @@ class SearchForm extends Component {
 						onFocus={ this.props.onSearchFocus }
 						onBlur={ this.props.onSearchBlur }
 						query={ getSearchQuery() }
+						widget={ this.props.widget }
 					/>
 				</div>
 				<SearchSort onChange={ this.onChangeSort } value={ getSortQuery() } />

--- a/modules/search/instant-search/components/search-form.scss
+++ b/modules/search/instant-search/components/search-form.scss
@@ -1,0 +1,3 @@
+.jetpack-instant-search__search-results-search-form {
+	margin-bottom: 1em;
+}

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -12,6 +12,7 @@ $grid-size-large: 16px;
 @import './components/search-filters.scss';
 @import './components/search-sort.scss';
 @import './components/search-box.scss';
+@import './components/search-form.scss';
 @import './components/search-result-minimal.scss';
 @import './components/search-result-product.scss';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Adds the filter icon to our Gridicon set, and places it next to the search input.

<img width="359" alt="Screen Shot 2019-12-05 at 15 39 16" src="https://user-images.githubusercontent.com/17325/70199007-6ae18b00-1775-11ea-9d6c-8b8e316845de.png">

Currently, it does a simple show/hide toggle of the sort controls underneath.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No - it's part of the Instant Search prototype and merges into `instant-search-master`.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

Using the smallest breakpoint, verify that the filter icon appears next to the search box and successfully toggles the visibility of the sort controls underneath.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required.
