### PR TITLE
Full Site Editing: Add `is_fse_eligible` property to the Site object in the REST API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -52,6 +52,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
+		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
 	);
 
 	protected static $no_member_fields = array(
@@ -72,6 +73,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'meta',
 		'launch_status',
 		'is_fse_active',
+		'is_fse_eligible',
 	);
 
 	protected static $site_options_format = array(
@@ -382,6 +384,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_fse_active':
 				$response[ $key ] = $this->site->is_fse_active();
+				break;
+			case 'is_fse_eligible':
+				$response[ $key ] = $this->site->is_fse_eligible();
 				break;
 		}
 

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -49,6 +49,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
+		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
 	);
 
 

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -210,6 +210,23 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Check if site should be considered as eligible for full site editing. Full site editing
+	 * requires the FSE plugin to be installed and activated. For this method to return true
+	 * the current theme does not need to be FSE compatible. The plugin can also be explicitly
+	 * disabled via the a8c_disable_full_site_editing filter.
+	 *
+	 * @since 8.1.0
+	 *
+	 * @return bool true if site is eligible for full site editing
+	 */
+	public function is_fse_eligible() {
+		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {
+			return false;
+		}
+		return function_exists( '\A8C\FSE\is_site_eligible_for_full_site_editing' ) && \A8C\FSE\is_site_eligible_for_full_site_editing();
+	}
+
+	/**
 	 * Return the last engine used for an import on the site.
 	 *
 	 * This option is not used in Jetpack.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This syncs changes in WPCOM from D36164-code and D36219-code, where an `is_fse_eligible` property is added to the Site object in the REST API. For Full Site Editing this allows the site to flag whether or not it's _eligible_ for FSE (e.g. the plugin is installed and activated), even if the current theme doesn't support FSE.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `is_fse_eligible` property to the Get Site endpoint, e.g. `https://public-api.wordpress.com/rest/v1.1/sites/<site_id>`
* Add `is_fse_eligible` function that calls `is_site_eligible_for_full_site_editing()` within the Full Site Editing function — returning whether the site is eligible for FSE irrespective of whether the current theme supports FSE.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This expands on the change introduced in https://github.com/Automattic/jetpack/pull/13196 that added the `is_fse_active` property. This new property `is_fse_eligible` is slightly different, but has a similar implementation and has already been deployed to WPCOM in D36164-code and D36219-code, so now needs synced to Jetpack so that Jetpack sites can support the additional property.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Before checking out this change

* Connect your local site to WordPress.com via ngrok.io and activate Jetpack
* Call `https://public-api.wordpress.com/rest/v1.1/sites/<site_id>` from an authenticated environment, e.g. https://developer.wordpress.com/docs/api/console/ or using `wpcom.req.get('/sites/<site_id_or_domain>').then( function( result ) { console.log( result ) } );');` from the console in `calypso.localhost:3000`.
* In the site response object you should see `is_fse_active` and _no_ `is_fse_eligible` property.
* In the ngrok.io dashboard `http://localhost:4040/inspect/http` you should see that the POST request to `/xmlrpc.php` includes the string `is_fse_eligible` in its payload.

##### Apply this change

* Follow the above steps, and after running the API call, in the response object you should see `is_fse_eligible: false`
* Install the Full Site Editing plugin by Automattic from the plugins directory (/wp-admin/plugin-install.php), but don't activate it just yet
* Run the API call again, and you should still see `is_fse_eligible: false`
* Activate the Full Site Editing plugin, run the API call again, and you should see `is_fse_eligible: true` in the response object.

![image](https://user-images.githubusercontent.com/14988353/70208569-07118f00-1782-11ea-8d34-41ce1cf2dd4c.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* WordPress.com REST API: add flag to determine site eligibility for Full Site Editing.

