### PR TITLE
Fix Map Block Crash With >2 Points

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -210,7 +210,9 @@ export class Map extends Component {
 				},
 			} );
 			this.setState( { boundsSetProgrammatically: true } );
-			map.removeControl( zoomControl );
+			try {
+				map.removeControl( zoomControl );
+			} catch ( e ) {}
 			return;
 		}
 		// If there is only one point, center map around it.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

As reported in https://github.com/Automattic/jetpack/issues/14177 the Map block crashes at the moment when a third point  is added. If a map has only one point the Mapbox zoom control is shown. When a second point is added the map's scale is calculated based on the two positions and the zoom control is removed. The crash occurs when we call `removeControl()` on a control that has already been removed. This is why the issue occurs only when a third point  is added to a map—it's removed when point 2 is added then removed again for point 3. It's difficult to say why this is popping up now—it could be related to  a change in the Mapbox library, but tough to guess. This PR resolves the issue by wrapping  `removeControl()` in a try/catch, suppressing the error. It does not appear that there are any side effects to the  error so this should be a solid solution.

Fixes https://github.com/Automattic/jetpack/issues/14177

#### Testing instructions:

* On `master` create new Map. 
* Add two points and observe no issues.
* Add a third point and observe the block crashes.
* Switch to this branch, rebuild blocks, and repeat.
* Observe the block does not crash no matter how many points are added.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Resolve an error that occurs when more  than two points are added to the Map block.
