### PR TITLE
Makes JP repo read only from inside docker container.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     build: .
     image: jetpack_wordpress:localbuild
     volumes:
-      - ..:/var/www/html/wp-content/plugins/jetpack
+      - ..:/var/www/html/wp-content/plugins/jetpack:ro
       ## Kludge for not having docker contain recursive stuff
       ## You will see on your filesystem that this dir gets created
       - dockerdirectory:/var/www/html/wp-content/plugins/jetpack/docker


### PR DESCRIPTION
This prevents upgrades from happening via WP-CLI.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This makes the JP repo read only, so `wp plugin update --all` does not erase the repo if there's an update available.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It does not affect the product itself.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jetpack via Docker using this branch.
* Trick WordPress into thinking an older version is installed via editing `jetpack.php`.
* Attempt to update the repo.

Before:
Repo was erased by WP-CLI.

After:
WP-CLI is blocked from deleting repo files.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
