### PR TITLE
Travis: Update to support PHPUnit versions and allow for PHP 8…

### DIFF
--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -31,6 +31,7 @@ function print_build_info {
 		echo " - Because WordPress is in master branch, will also attempt to test multisite."
 	fi
 	echo "--------------------------------------------"
+	echo
 }
 
 function run_php_compatibility {

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -31,7 +31,7 @@ function print_build_info {
 		echo " - Because WordPress is in master branch, will also attempt to test multisite."
 	fi
 	echo "--------------------------------------------"
-	echo
+	echo "TEST: $TRAVIS_PHP_VERSION"
 }
 
 function run_php_compatibility {

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -31,7 +31,6 @@ function print_build_info {
 		echo " - Because WordPress is in master branch, will also attempt to test multisite."
 	fi
 	echo "--------------------------------------------"
-	echo "TEST: $TRAVIS_PHP_VERSION"
 }
 
 function run_php_compatibility {

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -9,8 +9,8 @@ phpenv config-rm xdebug.ini
 
 # Configure PHP and PHPUnit environment
 if [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then
-	composer install
-	composer global require "phpunit/phpunit=5.7.*"
+	composer install --ignore-platform-reqs
+	composer global require "phpunit/phpunit=5.7.*" --ignore-platform-reqs
 elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
   composer remove sirbrillig/phpcs-changed --dev
   composer install

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -8,17 +8,20 @@ fi
 phpenv config-rm xdebug.ini
 
 # Configure PHP and PHPUnit environment
-if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+if [[ ${TRAVIS_PHP_VERSION:0:2} == "8." ]]; then
+	composer install
+	composer global require "phpunit/phpunit=7.5.*"
+elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
   composer remove sirbrillig/phpcs-changed --dev
   composer install
-	composer global require "phpunit/phpunit=5.7.*" --no-suggest
+	composer global require "phpunit/phpunit=6.5.*" --no-suggest
 elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
   composer install
-  composer global require "phpunit/phpunit=5.7.*" --no-suggest
+  composer global require "phpunit/phpunit=7.5.*" --no-suggest
 elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
   composer remove sirbrillig/phpcs-changed --dev
   composer install
-	composer global require "phpunit/phpunit=4.8.*" --no-suggest
+	composer global require "phpunit/phpunit=5.7.*" --no-suggest
 fi
 
 mysql -e "set global wait_timeout = 3600;"

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -10,14 +10,14 @@ phpenv config-rm xdebug.ini
 # Configure PHP and PHPUnit environment
 if [[ ${TRAVIS_PHP_VERSION:0:2} == "8." ]]; then
 	composer install
-	composer global require "phpunit/phpunit=7.5.*"
+	composer global require "phpunit/phpunit=5.7.*"
 elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
   composer remove sirbrillig/phpcs-changed --dev
   composer install
-	composer global require "phpunit/phpunit=6.5.*" --no-suggest
+	composer global require "phpunit/phpunit=5.7.*" --no-suggest
 elif [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
   composer install
-  composer global require "phpunit/phpunit=7.5.*" --no-suggest
+  composer global require "phpunit/phpunit=5.7.*" --no-suggest
 elif [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
   composer remove sirbrillig/phpcs-changed --dev
   composer install

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -8,7 +8,7 @@ fi
 phpenv config-rm xdebug.ini
 
 # Configure PHP and PHPUnit environment
-if [[ ${TRAVIS_PHP_VERSION:0:2} == "8." ]]; then
+if [[ ${TRAVIS_PHP_VERSION} == "nightly" ]]; then
 	composer install
 	composer global require "phpunit/phpunit=5.7.*"
 elif [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then


### PR DESCRIPTION
PHP Nightly is the in-dev PHP 8, which defaults to PHPUnit 8—not yet supported by WordPress Core until https://core.trac.wordpress.org/ticket/46149 lands.

This updates the existing phpunit commands to the newer versions where supported and adds support for PHP 8.

#### Changes proposed in this Pull Request:
* Updates the Travis config for PHPUnit.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Do the unit tests run?
*

#### Proposed changelog entry for your changes:
* n/a
