### PR TITLE
Instant Search: Improve UX for offline network state

### DIFF
--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -17,7 +17,12 @@ import './style.scss';
 
 class Gridicon extends Component {
 	needsOffset( icon, size ) {
-		const iconNeedsOffset = [ 'gridicons-calendar', 'gridicons-cart', 'gridicons-folder' ];
+		const iconNeedsOffset = [
+			'gridicons-calendar',
+			'gridicons-cart',
+			'gridicons-folder',
+			'gridicons-info',
+		];
 
 		if ( iconNeedsOffset.indexOf( icon ) >= 0 ) {
 			return size % 18 === 0;
@@ -93,6 +98,12 @@ class Gridicon extends Component {
 				return (
 					<g>
 						<path d="M15 7.5c0-.828.672-1.5 1.5-1.5s1.5.672 1.5 1.5S17.328 9 16.5 9 15 8.328 15 7.5zM4 20h14c0 1.105-.895 2-2 2H4c-1.1 0-2-.9-2-2V8c0-1.105.895-2 2-2v14zM22 4v12c0 1.105-.895 2-2 2H8c-1.105 0-2-.895-2-2V4c0-1.105.895-2 2-2h12c1.105 0 2 .895 2 2zM8 4v6.333L11 7l4.855 5.395.656-.73c.796-.886 2.183-.886 2.977 0l.513.57V4H8z" />
+					</g>
+				);
+			case 'gridicons-info':
+				return (
+					<g>
+						<path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z" />
 					</g>
 				);
 			case 'gridicons-pages':

--- a/modules/search/instant-search/components/notice.jsx
+++ b/modules/search/instant-search/components/notice.jsx
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from './gridicon';
+
+const Notice = ( { type, children } ) => {
+	if ( type !== 'warning' ) {
+		return null;
+	}
+
+	return (
+		<div className="jetpack-instant-search__notice jetpack-instant-search__notice--warning">
+			<Gridicon icon="info" size={ 20 } />
+			{ children }
+		</div>
+	);
+};
+
+export default Notice;

--- a/modules/search/instant-search/components/notice.scss
+++ b/modules/search/instant-search/components/notice.scss
@@ -1,0 +1,18 @@
+@import 'modules/calypsoify/_studio-wpcom.scss';
+
+.jetpack-instant-search__notice {
+	padding: 0.75em;
+	margin-bottom: 1em;
+	font-size: 14px;
+
+	&.jetpack-instant-search__notice--warning {
+		background-color: $studio-yellow-5;
+		color: $studio-yellow-70;
+	}
+
+	.gridicon {
+		vertical-align: middle;
+		margin-top: -5px;
+		margin-right: 0.5em;
+	}
+}

--- a/modules/search/instant-search/components/notice.scss
+++ b/modules/search/instant-search/components/notice.scss
@@ -7,7 +7,7 @@
 
 	&.jetpack-instant-search__notice--warning {
 		background-color: $studio-yellow-5;
-		color: $studio-yellow-70;
+		color: $studio-yellow-80;
 	}
 
 	.gridicon {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -84,7 +84,7 @@ class SearchApp extends Component {
 	}
 
 	hasNextPage() {
-		return !! this.state.response.page_handle;
+		return !! this.state.response.page_handle && ! this.state.hasError;
 	}
 
 	showResults = () => {

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -4,10 +4,11 @@
 	position: relative;
 
 	.jetpack-instant-search__search-result-date {
-		margin: 0.5em 0;
-		float: right;
-		display: block;
 		font-size: 0.85em;
+		margin: 0.5em 0;
+		position: absolute;
+		right: 0;
+		top: 0;
 	}
 }
 

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -86,7 +86,7 @@ class SearchResults extends Component {
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
 					<Notice type="warning">
 						{ /* TODO: Wrap these in __ translation calls when copy is finalized. */ }
-						It looks like you're offline and these results could be out of date.
+						It looks like you're offline. Please reconnect to load the latest results.
 					</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && (

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -77,7 +77,11 @@ class SearchResults extends Component {
 						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
 					</p>
 				) }
-				{ hasResults && (
+				{ this.props.hasError && (
+					<Notice type="warning">
+						It looks like you're offline. Please reconnect for results.
+					</Notice>
+				) }
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
 					<Notice type="warning">
 						It looks like you're offline and the results below could be out of date. Please

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -22,7 +22,7 @@ class SearchResults extends Component {
 		const hasCorrectedQuery = corrected_query !== false;
 		const num = new Intl.NumberFormat().format( total );
 
-		if ( total === 0 ) {
+		if ( total === 0 || this.props.hasError ) {
 			return sprintf( __( 'No results for "%s".', 'jetpack' ), this.props.query );
 		}
 		if ( hasQuery && hasCorrectedQuery ) {

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -13,6 +13,7 @@ import SearchResult from './search-result';
 import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
 import SearchForm from './search-form';
+import Notice from './notice';
 
 class SearchResults extends Component {
 	getSearchTitle() {
@@ -77,6 +78,13 @@ class SearchResults extends Component {
 					</p>
 				) }
 				{ hasResults && (
+				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
+					<Notice type="warning">
+						It looks like you're offline and the results below could be out of date. Please
+						reconnect for live results.
+					</Notice>
+				) }
+				{ hasResults && ! this.props.hasError && (
 					<ol
 						className={ `jetpack-instant-search__search-results-list is-format-${
 							this.props.resultFormat

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -79,14 +79,15 @@ class SearchResults extends Component {
 				) }
 				{ this.props.hasError && (
 					<Notice type="warning">
-						{ /* TODO: Wrap these in __ translation calls when copy is finalized. */ }
-						It looks like you're offline. Please reconnect for results.
+						{ __( "It looks like you're offline. Please reconnect for results.", 'jetpack' ) }
 					</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
 					<Notice type="warning">
-						{ /* TODO: Wrap these in __ translation calls when copy is finalized. */ }
-						It looks like you're offline. Please reconnect to load the latest results.
+						{ __(
+							"It looks like you're offline. Please reconnect to load the latest results.",
+							'jetpack'
+						) }
 					</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && (

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -79,11 +79,13 @@ class SearchResults extends Component {
 				) }
 				{ this.props.hasError && (
 					<Notice type="warning">
+						{ /* TODO: Wrap these in __ translation calls when copy is finalized. */ }
 						It looks like you're offline. Please reconnect for results.
 					</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
 					<Notice type="warning">
+						{ /* TODO: Wrap these in __ translation calls when copy is finalized. */ }
 						It looks like you're offline and the results below could be out of date. Please
 						reconnect for live results.
 					</Notice>

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -21,6 +21,9 @@ class SearchResults extends Component {
 		const hasCorrectedQuery = corrected_query !== false;
 		const num = new Intl.NumberFormat().format( total );
 
+		if ( total === 0 ) {
+			return sprintf( __( 'No results for "%s".', 'jetpack' ), this.props.query );
+		}
 		if ( hasQuery && hasCorrectedQuery ) {
 			return sprintf(
 				_n( 'Showing %s result for "%s"', 'Showing %s results for "%s"', total, 'jetpack' ),
@@ -58,11 +61,16 @@ class SearchResults extends Component {
 			>
 				<SearchForm className="jetpack-instant-search__search-results-search-form" />
 
-				{ hasResults && (
-					<p className="jetpack-instant-search__search-results-real-query">
-						{ this.getSearchTitle() }
-					</p>
-				) }
+				<div
+					className={
+						hasResults
+							? 'jetpack-instant-search__search-results-real-query'
+							: 'etpack-instant-search__search-results-empty'
+					}
+				>
+					{ this.getSearchTitle() }
+				</div>
+
 				{ hasResults && hasCorrectedQuery && (
 					<p className="jetpack-instant-search__search-results-unused-query">
 						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
@@ -84,11 +92,6 @@ class SearchResults extends Component {
 							/>
 						) ) }
 					</ol>
-				) }
-				{ ! hasResults && (
-					<div className="jetpack-instant-search__search-results-empty">
-						<h3>{ sprintf( __( 'No results for "%s".', 'jetpack' ), this.props.query ) }</h3>
-					</div>
 				) }
 				{ hasResults && this.props.hasNextPage && (
 					<div className="jetpack-instant-search__search-pagination">

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -66,7 +66,7 @@ class SearchResults extends Component {
 					className={
 						hasResults
 							? 'jetpack-instant-search__search-results-real-query'
-							: 'etpack-instant-search__search-results-empty'
+							: 'jetpack-instant-search__search-results-empty'
 					}
 				>
 					{ this.getSearchTitle() }
@@ -86,8 +86,7 @@ class SearchResults extends Component {
 				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
 					<Notice type="warning">
 						{ /* TODO: Wrap these in __ translation calls when copy is finalized. */ }
-						It looks like you're offline and the results below could be out of date. Please
-						reconnect for live results.
+						It looks like you're offline and these results could be out of date.
 					</Notice>
 				) }
 				{ hasResults && ! this.props.hasError && (

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -43,6 +43,9 @@
 	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
 	li:before {
 		content: '\200B';
+		height: 1px;
+		position: absolute;
+		width: 1px;
 	}
 }
 

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -8,6 +8,7 @@ $grid-size-large: 16px;
 }
 
 @import './components/gridicon/style.scss';
+@import './components/notice.scss';
 @import './components/search-results.scss';
 @import './components/search-filters.scss';
 @import './components/search-sort.scss';

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -128,11 +128,15 @@ export function search( { aggregations, filter, pageHandle, query, resultFormat,
 
 	// Use cached value from the last 30 minutes if browser is offline
 	if ( ! navigator.onLine && backupCache.get( key ) ) {
-		return backupCache.get( key );
+		return backupCache
+			.get( key )
+			.then( data => ( { _isCached: true, _isError: false, _isOffline: true, ...data } ) );
 	}
 	// Use cached value from the last 5 minutes
 	if ( cache.get( key ) ) {
-		return cache.get( key );
+		return cache
+			.get( key )
+			.then( data => ( { _isCached: true, _isError: false, _isOffline: false, ...data } ) );
 	}
 
 	let fields = [
@@ -172,7 +176,7 @@ export function search( { aggregations, filter, pageHandle, query, resultFormat,
 			// Fallback to either cache if we run into any errors
 			const fallbackValue = cache.get( key ) || backupCache.get( key );
 			if ( fallbackValue ) {
-				return fallbackValue;
+				return { _isCached: true, _isError: true, _isOffline: false, ...fallbackValue };
 			}
 			throw error;
 		} )

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -126,13 +126,13 @@ function buildFilterObject( filterQuery ) {
 export function search( { aggregations, filter, pageHandle, query, resultFormat, siteId, sort } ) {
 	const key = stringify( Array.from( arguments ) );
 
-	// Use cached value from the last 5 minutes
-	if ( cache.get( key ) ) {
-		return cache.get( key );
-	}
 	// Use cached value from the last 30 minutes if browser is offline
 	if ( ! navigator.onLine && backupCache.get( key ) ) {
 		return backupCache.get( key );
+	}
+	// Use cached value from the last 5 minutes
+	if ( cache.get( key ) ) {
+		return cache.get( key );
 	}
 
 	let fields = [


### PR DESCRIPTION
Follow-up on #14125.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Shows a notice when the user attempts a search while offline.
* Renders cached results for offline searches if they've performed an identical search in the last 30 minutes.
* Adds a warning notice component.
* Fixes a styling regression with search result titles and dates.

> <img width="806" alt="Screen Shot 2019-12-05 at 4 16 14 PM" src="https://user-images.githubusercontent.com/4044428/70282362-c6fade00-177a-11ea-9414-dc14b7da24b2.png">

> <img width="806" alt="Screen Shot 2019-12-05 at 4 17 26 PM" src="https://user-images.githubusercontent.com/4044428/70282369-c9f5ce80-177a-11ea-84ec-ec0cf1d92841.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It's an enhancement for the currently unreleased Jetpack Instant Search.

#### Testing instructions:

1. Setup Instant Search as per instructions in the [readme](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions).
2. Enter a query and ensure the results render as expected.
3. Use your browser's developer console to simulate an offline network state.
4. Enter the same query from step 2 and ensure the cached results render along with a warning notice.
5. Enter a new query and ensure that a warning notice renders with no cached results.

#### Proposed changelog entry for your changes:
None.
