### PR TITLE
General: fix PHP notices that may pop up with PHP 7.4.

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -342,11 +342,20 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
  * @return array
  */
 function jetpack_current_user_data() {
-	$current_user = wp_get_current_user();
+	$current_user   = wp_get_current_user();
 	$is_master_user = $current_user->ID == Jetpack_Options::get_option( 'master_user' );
 	$dotcom_data    = Jetpack::get_connected_user_data();
+
 	// Add connected user gravatar to the returned dotcom_data.
-	$dotcom_data['avatar'] = get_avatar_url( $dotcom_data['email'], array( 'size' => 64, 'default' => 'mysteryman' ) );
+	$dotcom_data['avatar'] = ( ! empty( $dotcom_data['email'] ) ?
+		get_avatar_url(
+			$dotcom_data['email'],
+			array(
+				'size'    => 64,
+				'default' => 'mysteryman',
+			)
+		)
+		: false );
 
 	$current_user_data = array(
 		'isConnected' => Jetpack::is_user_connected( $current_user->ID ),

--- a/src/class-tracking.php
+++ b/src/class-tracking.php
@@ -91,8 +91,10 @@ class Tracking {
 		}
 
 		$connection_manager = new Connection_Manager();
-		$wpcom_user_data = $connection_manager->get_connected_user_data( $user_id );
-		update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'] );
+		$wpcom_user_data    = $connection_manager->get_connected_user_data( $user_id );
+		if ( isset( $wpcom_user_data['ID'] ) ) {
+			update_user_meta( $user_id, 'jetpack_tracks_wpcom_id', $wpcom_user_data['ID'] );
+		}
 
 		$this->tracking->record_user_event( 'wpa_user_linked', array() );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* PHP 7.4 now throws a notice if you try to access a resource as an array, when it is not an array, a string, or an object.
https://wiki.php.net/rfc/notice-for-non-valid-array-container

```
PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-content/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-react-page.php on line 349
PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-content/plugins/jetpack/src/class-tracking.php on line 95
```

#### Testing instructions:

* Update your Docker container to PHP 7.4 as per #13773 
* Connect your site to WordPress.com, and visit a few Jetpack dashboard pages.
* You should not see any notices in your logs.

#### Proposed changelog entry for your changes:

* General: fix PHP warnings that may appear on sites running PHP 7.4.
