### PR TITLE
Photon: Remove old subdomain determination

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -175,20 +175,6 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	 */
 	$subdomain = abs( crc32( $image_host_path ) % 3 );
 
-	/*
-	 * Need to perform a slowroll out per pMz3w-arH-p2
-	 *
-	 * 7.9 - Use the old method if the value is not 0 (thus 1 or 2).
-	 * 8.0 - Use the old method if the value is 2 (thus not 0 or 1). [current step]
-	 * 8.1 - Remove this completely.
-	 */
-	if ( 2 === $subdomain ) {
-		// Figure out which CDN subdomain to use.
-		srand( crc32( $image_host_path ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_srand
-		$subdomain = rand( 0, 2 ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
-		srand(); // phpcs:ignore WordPress.WP.AlternativeFunctions.rand_seeding_srand
-	}
-
 	/**
 	 * Filters the domain used by the Photon module.
 	 *


### PR DESCRIPTION
As part of the three-release rollout of the new subdomain determination code, this finally removes it all. Everyone is using the new code now.

Follow-up to #12159 and #14009

#### Changes proposed in this Pull Request:
* Removes fallback in use for 1/3rd of image URLs.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* pMz3w-arH-p2

#### Testing instructions:
* None, already tested. Just rolling out to more images.
*

#### Proposed changelog entry for your changes:
* Photon: Expand to all images using the new subdomain determination function.

