### PR TITLE
Allow mobile theme to be removed via query string for testing

### DIFF
--- a/modules/minileven.php
+++ b/modules/minileven.php
@@ -13,11 +13,6 @@
  * Additional Search Queries: mobile, theme, minileven
  */
 
-// allow mobile theme to be disabled via query string for testing during deprecation.
-if ( isset( $_GET['jptest'] ) && 'responsivetheme' === $_GET['jptest'] ) {
-	return true;
-}
-
 function jetpack_load_minileven() {
 	include dirname( __FILE__ ) . "/minileven/minileven.php";
 

--- a/modules/minileven.php
+++ b/modules/minileven.php
@@ -13,6 +13,11 @@
  * Additional Search Queries: mobile, theme, minileven
  */
 
+// allow mobile theme to be disabled via query string for testing during deprecation.
+if ( isset( $_GET['jptest'] ) && 'responsivetheme' === $_GET['jptest'] ) {
+	return true;
+}
+
 function jetpack_load_minileven() {
 	include dirname( __FILE__ ) . "/minileven/minileven.php";
 

--- a/modules/minileven/minileven.php
+++ b/modules/minileven/minileven.php
@@ -28,6 +28,9 @@ Version: 2.1a-WPCOM
 $_SERVER['REQUEST_URI'] = ( isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : $_SERVER['SCRIPT_NAME'] . (( isset($_SERVER['QUERY_STRING']) ? '?' . $_SERVER['QUERY_STRING'] : '')));
 
 function jetpack_check_mobile() {
+	// allow mobile theme to be disabled via query string for testing during deprecation.
+	if ( isset( $_GET['jetpack-preview'] ) && 'responsivetheme' === $_GET['jetpack-preview'] )
+		return false;
 	if ( ( defined('XMLRPC_REQUEST') && XMLRPC_REQUEST ) || ( defined('APP_REQUEST') && APP_REQUEST ) )
 		return false;
 	if ( !isset($_SERVER["HTTP_USER_AGENT"]) || (isset($_COOKIE['akm_mobile']) && $_COOKIE['akm_mobile'] == 'false') )


### PR DESCRIPTION
Testing an idea to allow temporary removal of minileven for testing within a responsive website test tool.

#### Changes proposed in this Pull Request:
* Allow mobile theme to be removed via query string for testing

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Modify existing part of Jetpack: p6TEKc-3iM-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable the mobile theme
* Test the mobile theme works
* Add `?jetpack-preview=responsivetheme` to the URL and test the original theme loads
* Remove or modify query string to ensure mobile theme still works

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
