### PR TITLE
Debugger: Makes SELF test optional

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -158,7 +158,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		if ( function_exists( 'xml_parser_create' ) ) {
 			$result = self::passing_test( $name );
 		} else {
-			$result = self::failing_test( $name, __( 'PHP XML manipluation libraries are not available.', 'jetpack' ), __( "Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ and enable PHP's XML module.", 'jetpack' ) );
+			$result = self::failing_test( $name, __( 'PHP XML manipulation libraries are not available.', 'jetpack' ), __( "Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ and enable PHP's XML module.", 'jetpack' ) );
 		}
 
 		return $result;

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -40,10 +40,11 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		 * Determines if the WP.com testing suite should be included.
 		 *
 		 * @since 7.1.0
+		 * @since 8.1.0 Default false.
 		 *
-		 * @param bool $run_test To run the WP.com testing suite. Default true.
+		 * @param bool $run_test To run the WP.com testing suite. Default false.
 		 */
-		if ( apply_filters( 'jetpack_debugger_run_self_test', true ) ) {
+		if ( apply_filters( 'jetpack_debugger_run_self_test', false ) ) {
 			/**
 			 * Intentionally added last as it checks for an existing failure state before attempting.
 			 * Generally, any failed location condition would result in the WP.com check to fail too, so


### PR DESCRIPTION
Fixes #12881

The SELF test is of an older method of Jetpack and will increasingly not yield useful information. Keeping the test, but only running it when intentionally set, for the time-being.

#### Changes proposed in this Pull Request:
* Skips the SELF test by default.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Visit Tools->Site Info and confirm no failures.
*

#### Proposed changelog entry for your changes:
* Site Info: Improve the Jetpack testing suite to reduce false positives.
