### PR TITLE
Added a late initialization step.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -571,6 +571,7 @@ class Jetpack {
 		}
 
 		add_action( 'plugins_loaded', array( $this, 'after_plugins_loaded' )  );
+		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
 		add_filter(
 			'jetpack_connection_secret_generator',
@@ -753,6 +754,24 @@ class Jetpack {
 			 */
 			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
 		}
+	}
+
+	/**
+	 * Runs on plugins_loaded. Use this to add code that needs to be executed later than other
+	 * initialization code.
+	 *
+	 * @action plugins_loaded
+	 */
+	public function late_initalization() {
+		/**
+		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe
+		 * to instantiate classes from packages and namespaces that are managed by the Jetpack Autoloader.
+		 *
+		 * @since 8.1.0
+		 *
+		 * @param Jetpack $jetpack the main plugin class object.
+		 */
+		do_action( 'jetpack_loaded', $this );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -570,7 +570,7 @@ class Jetpack {
 			add_action( 'init', array( 'Jetpack_Keyring_Service_Helper', 'init' ), 9, 0 );
 		}
 
-		add_action( 'plugins_loaded', array( $this, 'after_plugins_loaded' )  );
+		add_action( 'plugins_loaded', array( $this, 'after_plugins_loaded' ) );
 		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
 		add_filter(
@@ -762,7 +762,7 @@ class Jetpack {
 	 *
 	 * @action plugins_loaded
 	 */
-	public function late_initalization() {
+	public function late_initialization() {
 		/**
 		 * Fires when Jetpack is fully loaded and ready. This is the point where it's safe
 		 * to instantiate classes from packages and namespaces that are managed by the Jetpack Autoloader.


### PR DESCRIPTION
This will allow us to migrate code that has been working before plugins are loaded to this later stage where plugin code is available and the autoloader has a way to figure out the latest version of bundled libraries.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Replaces a part of #14168 .
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new `late_initialization` method to the `Jetpack` class.
* Adds a new hook that runs in that method when every plugin's code has already been loaded and it's safe to autoload classes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
No logic is changed here, just an event added that will later help us migrate to a new way of initializing packages.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
