### PR TITLE
Autoloader: Use long-form sytax for array

### DIFF
--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -267,7 +267,7 @@ function enqueue_packages_$suffix() {
 	\$autoload_file = __DIR__ . '/composer/autoload_files.php';
 	\$includeFiles = file_exists( \$autoload_file )
 		? require \$autoload_file
-		: [];
+		: array();
 
 	foreach ( \$includeFiles as \$fileIdentifier => \$file ) {
 		if ( empty( \$GLOBALS['__composer_autoload_files'][ \$fileIdentifier ] ) ) {


### PR DESCRIPTION
WPCS requests `array()` over `[]`, plus `[]` is PHP 5.4+ while Composer assumes a site could be PHP 5.3.

Since functionally this is the same, let's just use the long-form.

#### Changes proposed in this Pull Request:
* Switched `[]` to `array()`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* None

#### Proposed changelog entry for your changes:
* n/a
