### PR TITLE
Package Script: Only commit if there are dependency changes

### DIFF
--- a/bin/release-package.php
+++ b/bin/release-package.php
@@ -70,7 +70,7 @@ execute( $command, 'Could not create new release branch.' );
 
 // Commit those changes.
 $command = sprintf(
-	'git add packages/%1$s && git commit -m "Updating dependencies for %1$s"',
+	'git add packages/%1$s && ( git diff-index --quiet HEAD || git commit -m "Updating dependencies for %1$s")',
 	escapeshellarg( $package_name )
 );
 execute( $command, 'Could not commit dependency version updates.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When a Jetpack package is being released and does not have any Jetpack dependencies, the script will fail. This will only commit if there's something to commit.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Release a new version of the Autoloader package. For the sake of testing, may want to duplicate into a `autoloader-test` package with a corresponding jetpack-autoloader-test repo.
* For me, the script failed after everything by not resetting my Jetpack directory back to the actual repo (kept it within the package), but that may be due to me doing this a bit backwards to get a release out. (error was `fatal: ambiguous argument 'refs/original/refs/heads/master': unknown revision or path not in the working tree.` from L188 of bin/release-package.php)

#### Proposed changelog entry for your changes:
* n/a
