### PR TITLE
Jetpack Plan: ensure that the class does not block wpcom sync

### DIFF
--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -44,9 +44,11 @@ class Jetpack_Tiled_Gallery_Block {
 
 		$is_squareish_layout = self::is_squareish_layout( $attr );
 
-		$jetpack_plan = Jetpack_Plan::get();
-
-		wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
+		// Jetpack_Plan does not exist on WordPress.com.
+		if ( class_exists( 'Jetpack_Plan' ) ) {
+			$jetpack_plan = Jetpack_Plan::get();
+			wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
+		}
 
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {
 			/**

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -13,7 +13,10 @@ use Automattic\Jetpack\Status;
 add_action( 'widgets_init', 'jetpack_search_widget_init' );
 
 function jetpack_search_widget_init() {
-	if ( ! Jetpack::is_active() || ! Jetpack_Plan::supports( 'search' ) ) {
+	if (
+		! Jetpack::is_active()
+		|| ( method_exists( 'Jetpack_Plan', 'supports' ) && ! Jetpack_Plan::supports( 'search' ) )
+	) {
 		return;
 	}
 
@@ -312,7 +315,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper" class="<?php 
+		?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper" class="<?php
 		echo Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ? 'jetpack-instant-search-wrapper' : '' ?>">
 		<?php
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 
The class does not exist on WordPress.com, so we should be careful when using it in files that are synchronized with WordPress.com.

The class is currently used in other synced files as well, but in all cases there are early returns before the use of the class when one is on WordPress.com.

This should unblock D31801-code as well as #14005. 

#### Testing instructions:

* Nothing should change with the features touched by that change.

#### Proposed changelog entry for your changes:

* N/A
