### PR TITLE
JITM: Move the JITM::register call to the Config class

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -704,6 +704,7 @@ class Jetpack {
 		foreach (
 			array(
 				'connection',
+				'jitm',
 				'sync',
 				'tracking',
 				'tos',

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -65,8 +65,6 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
-	$jitm = new Automattic\Jetpack\JITM();
-	add_action( 'plugins_loaded', array( $jitm, 'register' ) );
 	jetpack_require_lib( 'debugger' );
 }
 

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -77,7 +77,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 				$ignore = in_array(
 					$class_name,
 					array(
-						'Automattic\Jetpack\JITM',
 						'Automattic\Jetpack\Connection\Manager',
 						'Automattic\Jetpack\Connection\XMLRPC_Connector',
 						'Jetpack_Options',

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -83,7 +83,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Jetpack_Signature',
 						'Jetpack_XMLRPC_Server',
 						'Automattic\Jetpack\Constants',
-						'Automattic\Jetpack\Tracking',
 					),
 					true
 				);

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -192,9 +192,7 @@ class Config {
 	 * Enables the JITM feature.
 	 */
 	protected function enable_jitm() {
-		if ( is_admin() ) {
-			( new JITM() )->register();
-		}
+		JITM::configure();
 
 		return true;
 	}

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -28,6 +28,7 @@ class Config {
 	 */
 	protected $config = array(
 		'connection' => false,
+		'jitm'       => false,
 		'sync'       => false,
 		'tracking'   => false,
 		'tos'        => false,
@@ -77,6 +78,11 @@ class Config {
 		if ( $this->config['sync'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Sync\Main' )
 				&& $this->ensure_feature( 'sync' );
+		}
+
+		if ( $this->config['jitm'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\JITM' )
+				&& $this->ensure_feature( 'jitm' );
 		}
 	}
 
@@ -178,6 +184,17 @@ class Config {
 	 */
 	protected function enable_connection() {
 		Manager::configure();
+
+		return true;
+	}
+
+	/**
+	 * Enables the JITM feature.
+	 */
+	protected function enable_jitm() {
+		if ( is_admin() ) {
+			( new JITM() )->register();
+		}
 
 		return true;
 	}

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -41,6 +41,16 @@ class JITM {
 	}
 
 	/**
+	 * Initializes a JITM object and registers it. This method is called by the
+	 * Config package when the JITM feature has been enabled.
+	 */
+	public static function configure() {
+		if ( is_admin() ) {
+			( new self() )->register();
+		}
+	}
+
+	/**
 	 * Determines if JITMs are enabled.
 	 *
 	 * @return bool Enable JITMs.


### PR DESCRIPTION
We should not use package classes before all of the plugins have been loaded. The JITM class is currently used before the plugins have been loaded in `load-jetpack.php`.

#### Changes proposed in this Pull Request:
* Add a new method, `JITM::configure()`. Move the instantiation of the JITM object and the `JITM::register()` call to this method.
* Add the `jitm` feature to the Config class.
* Enable the `jitm` feature in `Jetpack::configure()`.
* Remove `Automattic\Jetpack\JITM` from the autoloader's ignore list.
* Remove `Automattic\Jetpack\Tracking` from the autoloader's ignore list.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

##### Test Site Setup
* Jetpack must be installed, activated, and connected.
* VaultPress must be deactivated. If VP is activated, VP's autoloader might be used instead of the updated Autoloader in this PR.
* Ensure that debug logging is enabled.

##### Test Steps
1. Run `composer install` to update the `autoload_packages.php` file. 
2. Navigate to pages that display JITMs and ensure that they are properly displayed. For example, the Jetpack dashboard should display a JITM (assuming you haven’t dismissed them.)
3. Ensure that no PHP notices have been generated in the debug.log.

#### Proposed changelog entry for your changes:
* n/a
