### PR TITLE
WooCommerce_Services: Set the Jetpack object with the jetpack_loaded action

### DIFF
--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -39,10 +39,18 @@ class WC_Services_Installer {
 	 * Constructor
 	 */
 	public function __construct() {
-		$this->jetpack = Jetpack::init();
-
+		add_action( 'jetpack_loaded', array( $this, 'on_jetpack_loaded' ) );
 		add_action( 'admin_init', array( $this, 'add_error_notice' ) );
 		add_action( 'admin_init', array( $this, 'try_install' ) );
+	}
+
+	/**
+	 * Runs on Jetpack being ready to load its packages.
+	 *
+	 * @param Jetpack $jetpack object.
+	 */
+	public function on_jetpack_loaded( $jetpack ) {
+		$this->jetpack = $jetpack;
 	}
 
 	/**


### PR DESCRIPTION
Currently, the `WC_Services_Installer` class calls `Jetpack::init()` when the file is loaded. `Jetpack::init()` should be called only after all of the plugins have been loaded. To fix this, set the Jetpack instance using the `jetpack_loaded` action hook, which provides the Jetpack object after all of the plugins have been loaded.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Set the Jetpack instance using the `jetpack_loaded` action hook.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

We'll test this by checking that the WooCommerce Services plugin is successfully installed via the JITM.

##### Test Site Setup
- Jetpack must be installed, activated, and connected.
- WooCommerce must be installed and activated.
- WooCommerces Services must not be installed.

##### Test Steps
1. On wp-admin, navigate to WooCommerce -> Orders.
2. You should see a JITM at the top of the page with an "INSTALL WOOCOMMERCE SERVICES" button. Click that button to install the WooCommerce Services plugin.
3. Navigate to Plugins and ensure that the WooCommerce Services plugin was successfully installed and activated.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* tbd
