### PR TITLE
Adding new managed WordPress hosts to be identified in class-functions.php.

### DIFF
--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -161,8 +161,6 @@ class Functions {
 	 * @return string Hosting provider.
 	 */
 	public static function get_hosting_provider() {
-		$hosting_provider = 'unknown';
-
 		$hosting_provider_detection_methods = array(
 			'get_hosting_provider_by_known_constant',
 			'get_hosting_provider_by_known_class',
@@ -177,7 +175,7 @@ class Functions {
 			}
 		}
 
-		return $hosting_provider;
+		return 'unknown';
 	}
 
 	/**

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -185,7 +185,7 @@ class Functions {
 	 *
 	 * @return mixed A host identifier string or false.
 	 */
-	public static function get_hosting_provider_by_known_constant() {
+	public function get_hosting_provider_by_known_constant() {
 		$hosting_provider = false;
 
 		switch ( true ) {
@@ -220,7 +220,7 @@ class Functions {
 	 *
 	 * @return mixed A host identifier string or false.
 	 */
-	public static function get_hosting_provider_by_known_class() {
+	public function get_hosting_provider_by_known_class() {
 		$hosting_provider = false;
 
 		switch ( true ) {
@@ -237,7 +237,7 @@ class Functions {
 	 *
 	 * @return mixed A host identifier string or false.
 	 */
-	public static function get_hosting_provider_by_known_function() {
+	public function get_hosting_provider_by_known_function() {
 		$hosting_provider = false;
 
 		switch ( true ) {

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -175,7 +175,9 @@ class Functions {
 				return $constant_value;
 			}
 		}
-
+		if ( class_exists( '\\WPaaS\\Plugin' ) ) {
+			return 'gd-managed-wp';
+		}
 		if ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ) {
 			return 'wpe';
 		}

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -161,30 +161,36 @@ class Functions {
 	 * @return string Hosting provider.
 	 */
 	public static function get_hosting_provider() {
-		$hosting_provider_constants = array(
-			'GD_SYSTEM_PLUGIN_DIR' => 'gd-managed-wp',
-			'MM_BASE_DIR'          => 'bh',
-			'PAGELYBIN'            => 'pagely',
-			'KINSTAMU_VERSION'     => 'kinsta',
-			'FLYWHEEL_CONFIG_DIR'  => 'flywheel',
-			'IS_PRESSABLE'         => 'pressable',
-		);
+		$hosting_provider = 'unknown';
 
-		foreach ( $hosting_provider_constants as $constant => $hosting_provider ) {
-			if ( defined( $constant ) ) {
-				return $hosting_provider;
-			}
+		switch ( true ) {
+			case ( Constants::is_defined( 'GD_SYSTEM_PLUGIN_DIR' ) || class_exists( '\\WPaaS\\Plugin' ) ):
+				$hosting_provider = 'gd-managed-wp';
+				break;
+			case ( Constants::is_defined( 'MM_BASE_DIR' ) ):
+				$hosting_provider = 'bh';
+				break;
+			case ( Constants::is_defined( 'PAGELYBIN' ) ):
+				$hosting_provider = 'pagely';
+				break;
+			case ( Constants::is_defined( 'KINSTAMU_VERSION' ) ):
+				$hosting_provider = 'kinsta';
+				break;
+			case ( Constants::is_defined( 'FLYWHEEL_CONFIG_DIR' ) ):
+				$hosting_provider = 'flywheel';
+				break;
+			case ( Constants::is_defined( 'IS_PRESSABLE' ) ):
+				$hosting_provider = 'pressable';
+				break;
+			case ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ):
+				$hosting_provider = 'wpe';
+				break;
+			case ( Constants::is_defined( 'VIP_GO_ENV' ) && false !== Constants::get_constant( 'VIP_GO_ENV' ) ):
+				$hosting_provider = 'vip-go';
+				break;
 		}
-		if ( class_exists( '\\WPaaS\\Plugin' ) ) {
-			return 'gd-managed-wp';
-		}
-		if ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ) {
-			return 'wpe';
-		}
-		if ( defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV ) {
-			return 'vip-go';
-		}
-		return 'unknown';
+
+		return $hosting_provider;
 	}
 
 	/**

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -163,8 +163,33 @@ class Functions {
 	public static function get_hosting_provider() {
 		$hosting_provider = 'unknown';
 
+		$hosting_provider_detection_methods = array(
+			'get_hosting_provider_by_known_constant',
+			'get_hosting_provider_by_known_class',
+			'get_hosting_provider_by_known_function',
+		);
+
+		$functions = new Functions();
+		foreach ( $hosting_provider_detection_methods as $method ) {
+			$hosting_provider = call_user_func( array( $functions, $method ) );
+			if ( false !== $hosting_provider ) {
+				return $hosting_provider;
+			}
+		}
+
+		return $hosting_provider;
+	}
+
+	/**
+	 * Return a hosting provider using a set of known constants.
+	 *
+	 * @return mixed A host identifier string or false.
+	 */
+	public static function get_hosting_provider_by_known_constant() {
+		$hosting_provider = false;
+
 		switch ( true ) {
-			case ( Constants::is_defined( 'GD_SYSTEM_PLUGIN_DIR' ) || class_exists( '\\WPaaS\\Plugin' ) ):
+			case ( Constants::is_defined( 'GD_SYSTEM_PLUGIN_DIR' ) ):
 				$hosting_provider = 'gd-managed-wp';
 				break;
 			case ( Constants::is_defined( 'MM_BASE_DIR' ) ):
@@ -182,11 +207,42 @@ class Functions {
 			case ( Constants::is_defined( 'IS_PRESSABLE' ) ):
 				$hosting_provider = 'pressable';
 				break;
-			case ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ):
-				$hosting_provider = 'wpe';
-				break;
 			case ( Constants::is_defined( 'VIP_GO_ENV' ) && false !== Constants::get_constant( 'VIP_GO_ENV' ) ):
 				$hosting_provider = 'vip-go';
+				break;
+		}
+
+		return $hosting_provider;
+	}
+
+	/**
+	 * Return a hosting provider using a set of known classes.
+	 *
+	 * @return mixed A host identifier string or false.
+	 */
+	public static function get_hosting_provider_by_known_class() {
+		$hosting_provider = false;
+
+		switch ( true ) {
+			case ( class_exists( '\\WPaaS\\Plugin' ) ):
+				$hosting_provider = 'gd-managed-wp';
+				break;
+		}
+
+		return $hosting_provider;
+	}
+
+	/**
+	 * Return a hosting provider using a set of known functions.
+	 *
+	 * @return mixed A host identifier string or false.
+	 */
+	public static function get_hosting_provider_by_known_function() {
+		$hosting_provider = false;
+
+		switch ( true ) {
+			case ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ):
+				$hosting_provider = 'wpe';
 				break;
 		}
 

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -167,6 +167,15 @@ class Functions {
 		if ( defined( 'MM_BASE_DIR' ) ) {
 			return 'bh';
 		}
+		if ( defined( 'PAGELYBIN' ) ) {
+			return 'pagely';
+		}
+		if ( defined( 'KINSTAMU_VERSION' ) ) {
+			return 'kinsta';
+		}
+		if ( defined( 'FLYWHEEL_CONFIG_DIR' ) ) {
+			return 'flywheel';
+		}
 		if ( defined( 'IS_PRESSABLE' ) ) {
 			return 'pressable';
 		}

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -161,24 +161,21 @@ class Functions {
 	 * @return string Hosting provider.
 	 */
 	public static function get_hosting_provider() {
-		if ( defined( 'GD_SYSTEM_PLUGIN_DIR' ) || class_exists( '\\WPaaS\\Plugin' ) ) {
-			return 'gd-managed-wp';
+		$hosting_provider_constants = array(
+			'GD_SYSTEM_PLUGIN_DIR' => 'gd-managed-wp',
+			'MM_BASE_DIR'          => 'bh',
+			'PAGELYBIN'            => 'pagely',
+			'KINSTAMU_VERSION'     => 'kinsta',
+			'FLYWHEEL_CONFIG_DIR'  => 'flywheel',
+			'IS_PRESSABLE'         => 'pressable',
+		);
+
+		foreach ( $hosting_provider_constants as $constant => $constant_value ) {
+			if ( defined( $constant ) ) {
+				return $constant_value;
+			}
 		}
-		if ( defined( 'MM_BASE_DIR' ) ) {
-			return 'bh';
-		}
-		if ( defined( 'PAGELYBIN' ) ) {
-			return 'pagely';
-		}
-		if ( defined( 'KINSTAMU_VERSION' ) ) {
-			return 'kinsta';
-		}
-		if ( defined( 'FLYWHEEL_CONFIG_DIR' ) ) {
-			return 'flywheel';
-		}
-		if ( defined( 'IS_PRESSABLE' ) ) {
-			return 'pressable';
-		}
+
 		if ( function_exists( 'is_wpe' ) || function_exists( 'is_wpe_snapshot' ) ) {
 			return 'wpe';
 		}

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -184,33 +184,26 @@ class Functions {
 	 * @return mixed A host identifier string or false.
 	 */
 	public function get_hosting_provider_by_known_constant() {
-		$hosting_provider = false;
+		$hosting_provider_constants = array(
+			'GD_SYSTEM_PLUGIN_DIR' => 'gd-managed-wp',
+			'MM_BASE_DIR'          => 'bh',
+			'PAGELYBIN'            => 'pagely',
+			'KINSTAMU_VERSION'     => 'kinsta',
+			'FLYWHEEL_CONFIG_DIR'  => 'flywheel',
+			'IS_PRESSABLE'         => 'pressable',
+			'VIP_GO_ENV'           => 'vip-go',
+		);
 
-		switch ( true ) {
-			case ( Constants::is_defined( 'GD_SYSTEM_PLUGIN_DIR' ) ):
-				$hosting_provider = 'gd-managed-wp';
-				break;
-			case ( Constants::is_defined( 'MM_BASE_DIR' ) ):
-				$hosting_provider = 'bh';
-				break;
-			case ( Constants::is_defined( 'PAGELYBIN' ) ):
-				$hosting_provider = 'pagely';
-				break;
-			case ( Constants::is_defined( 'KINSTAMU_VERSION' ) ):
-				$hosting_provider = 'kinsta';
-				break;
-			case ( Constants::is_defined( 'FLYWHEEL_CONFIG_DIR' ) ):
-				$hosting_provider = 'flywheel';
-				break;
-			case ( Constants::is_defined( 'IS_PRESSABLE' ) ):
-				$hosting_provider = 'pressable';
-				break;
-			case ( Constants::is_defined( 'VIP_GO_ENV' ) && false !== Constants::get_constant( 'VIP_GO_ENV' ) ):
-				$hosting_provider = 'vip-go';
-				break;
+		foreach ( $hosting_provider_constants as $constant => $constant_value ) {
+			if ( Constants::is_defined( $constant ) ) {
+				if ( 'VIP_GO_ENV' === $constant && false === Constants::get_constant( 'VIP_GO_ENV' ) ) {
+					continue;
+				}
+				return $constant_value;
+			}
 		}
 
-		return $hosting_provider;
+		return false;
 	}
 
 	/**

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -170,9 +170,9 @@ class Functions {
 			'IS_PRESSABLE'         => 'pressable',
 		);
 
-		foreach ( $hosting_provider_constants as $constant => $constant_value ) {
+		foreach ( $hosting_provider_constants as $constant => $hosting_provider ) {
 			if ( defined( $constant ) ) {
-				return $constant_value;
+				return $hosting_provider;
 			}
 		}
 		if ( class_exists( '\\WPaaS\\Plugin' ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1053,6 +1053,50 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( ! empty( $synced_value ), 'We couldn\'t synced a value!' );
 	}
 
+	/**
+	 * Test get_hosting_provider() callable to ensure that known hosts have the
+	 * right hosting provider returned.
+	 *
+	 * @return void
+	 */
+	public function test_get_hosting_provider_callable() {
+		Constants::set_constant( 'GD_SYSTEM_PLUGIN_DIR', 'set' );
+		if ( Constants::is_defined( 'GD_SYSTEM_PLUGIN_DIR' ) || class_exists( '\\WPaaS\\Plugin' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'gd-managed-wp' );
+			Constants::clear_constants();
+		}
+		Constants::set_constant( 'MM_BASE_DIR', 'set' );
+		if ( Constants::is_defined( 'MM_BASE_DIR' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'bh' );
+			Constants::clear_constants();
+		}
+		Constants::set_constant( 'PAGELYBIN', 'set' );
+		if ( Constants::is_defined( 'PAGELYBIN' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'pagely' );
+			Constants::clear_constants();
+		}
+		Constants::set_constant( 'KINSTAMU_VERSION', 'set' );
+		if ( Constants::is_defined( 'KINSTAMU_VERSION' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'kinsta' );
+			Constants::clear_constants();
+		}
+		Constants::set_constant( 'FLYWHEEL_CONFIG_DIR', 'set' );
+		if ( Constants::is_defined( 'FLYWHEEL_CONFIG_DIR' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'flywheel' );
+			Constants::clear_constants();
+		}
+		Constants::set_constant( 'IS_PRESSABLE', 'set' );
+		if ( Constants::is_defined( 'IS_PRESSABLE' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'pressable' );
+			Constants::clear_constants();
+		}
+		Constants::set_constant( 'VIP_GO_ENV', 'set' );
+		if ( Constants::is_defined( 'VIP_GO_ENV' ) && false !== Constants::get_constant( 'VIP_GO_ENV' ) ) {
+			$this->assertEquals( Functions::get_hosting_provider(), 'vip-go' );
+			Constants::clear_constants();
+		}
+	}
+
 }
 
 function jetpack_recursive_banana() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1059,8 +1059,16 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	 *
 	 * @return void
 	 */
-	public function test_get_hosting_provider_callable() {
-		// Get hosting provider by known constant.
+	public function test_get_hosting_provider_callable_with_unknown_host() {
+		$this->assertEquals( Functions::get_hosting_provider(), 'unknown' );
+	}
+
+	/**
+	 * Test getting a hosting provider by a known constant
+	 *
+	 * @return void
+	 */
+	public function test_get_hosting_provider_by_known_constant() {
 		$functions = new Functions();
 		Constants::set_constant( 'GD_SYSTEM_PLUGIN_DIR', 'set' );
 		$this->assertEquals( $functions->get_hosting_provider_by_known_constant(), 'gd-managed-wp' );
@@ -1069,8 +1077,16 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		Constants::set_constant( 'UNKNOWN', 'set' );
 		$this->assertFalse( $functions->get_hosting_provider_by_known_constant() );
 		Constants::clear_constants();
+	}
 
-		// Get hosting provider by known class.
+	/**
+	 * Test getting a hosting provider by a known class
+	 *
+	 * @return void
+	 */
+	public function test_get_hosting_provider_by_known_class() {
+		$functions = new Functions();
+
 		$this->assertFalse( $functions->get_hosting_provider_by_known_class() );
 
 		$class_mock = $this->getMockBuilder( '\\WPaaS\\Plugin' )
@@ -1078,20 +1094,30 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 
 		$this->assertEquals( $functions->get_hosting_provider_by_known_class(), 'gd-managed-wp' );
 
-		// Get hosting provider by known function.
-		$this->assertEquals( $functions->get_hosting_provider_by_known_function(), 'wpe' );
-
 	}
 
-}
+	/**
+	 * Test getting a hosting provider by a known function
+	 *
+	 * @return bool
+	 */
+	public function test_get_hosting_provider_by_known_function() {
 
-/**
- * Used for test_get_hosting_provider_callable()
- *
- * @return boolean
- */
-function is_wpe() {
-	return true;
+		/**
+		 * Stub is_wpe for testing function exists
+		 *
+		 * @return boolean
+		 */
+		function is_wpe() {
+			return true;
+		}
+
+		$functions = new Functions();
+
+		// Get hosting provider by known function.
+		$this->assertEquals( $functions->get_hosting_provider_by_known_function(), 'wpe' );
+	}
+
 }
 
 function jetpack_recursive_banana() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1060,43 +1060,38 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 	 * @return void
 	 */
 	public function test_get_hosting_provider_callable() {
+		// Get hosting provider by known constant.
+		$functions = new Functions();
 		Constants::set_constant( 'GD_SYSTEM_PLUGIN_DIR', 'set' );
-		if ( Constants::is_defined( 'GD_SYSTEM_PLUGIN_DIR' ) || class_exists( '\\WPaaS\\Plugin' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'gd-managed-wp' );
-			Constants::clear_constants();
-		}
-		Constants::set_constant( 'MM_BASE_DIR', 'set' );
-		if ( Constants::is_defined( 'MM_BASE_DIR' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'bh' );
-			Constants::clear_constants();
-		}
-		Constants::set_constant( 'PAGELYBIN', 'set' );
-		if ( Constants::is_defined( 'PAGELYBIN' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'pagely' );
-			Constants::clear_constants();
-		}
-		Constants::set_constant( 'KINSTAMU_VERSION', 'set' );
-		if ( Constants::is_defined( 'KINSTAMU_VERSION' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'kinsta' );
-			Constants::clear_constants();
-		}
-		Constants::set_constant( 'FLYWHEEL_CONFIG_DIR', 'set' );
-		if ( Constants::is_defined( 'FLYWHEEL_CONFIG_DIR' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'flywheel' );
-			Constants::clear_constants();
-		}
-		Constants::set_constant( 'IS_PRESSABLE', 'set' );
-		if ( Constants::is_defined( 'IS_PRESSABLE' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'pressable' );
-			Constants::clear_constants();
-		}
-		Constants::set_constant( 'VIP_GO_ENV', 'set' );
-		if ( Constants::is_defined( 'VIP_GO_ENV' ) && false !== Constants::get_constant( 'VIP_GO_ENV' ) ) {
-			$this->assertEquals( Functions::get_hosting_provider(), 'vip-go' );
-			Constants::clear_constants();
-		}
+		$this->assertEquals( $functions->get_hosting_provider_by_known_constant(), 'gd-managed-wp' );
+		Constants::clear_constants();
+
+		Constants::set_constant( 'UNKNOWN', 'set' );
+		$this->assertFalse( $functions->get_hosting_provider_by_known_constant() );
+		Constants::clear_constants();
+
+		// Get hosting provider by known class.
+		$this->assertFalse( $functions->get_hosting_provider_by_known_class() );
+
+		$class_mock = $this->getMockBuilder( '\\WPaaS\\Plugin' )
+					->getMock(); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+		$this->assertEquals( $functions->get_hosting_provider_by_known_class(), 'gd-managed-wp' );
+
+		// Get hosting provider by known function.
+		$this->assertEquals( $functions->get_hosting_provider_by_known_function(), 'wpe' );
+
 	}
 
+}
+
+/**
+ * Used for test_get_hosting_provider_callable()
+ *
+ * @return boolean
+ */
+function is_wpe() {
+	return true;
 }
 
 function jetpack_recursive_banana() {


### PR DESCRIPTION
Adding more hosting providers to get_hosting_provider() function to be able to identify managed WordPress hosts.
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes N/A

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adding options to identify new hosts specifically Managed WordPress hosts.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* New Feature pbtFPC-1M-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Unit Tests: phpunit --filter=WP_Test_Jetpack_Sync_Functions
#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add more managed WordPress hosts to hosting provider detection.
