### PR TITLE
Masterbar: Update the Reader link

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -305,7 +305,7 @@ class Jetpack_Calypsoify {
 		$wp_admin_bar->add_node( $my_sites_node );
 
 		$reader_node       = (object) $wp_admin_bar->get_node( 'newdash' );
-		$reader_node->href = 'https://wordpress.com';
+		$reader_node->href = 'https://wordpress.com/read';
 		$wp_admin_bar->add_node( $reader_node );
 
 		$me_node       = (object) $wp_admin_bar->get_node( 'my-account' );

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -428,7 +428,7 @@ class A8C_WPCOM_Masterbar {
 
 		$following_title = $this->create_menu_item_pair(
 			array(
-				'url'   => 'https://wordpress.com/',
+				'url'   => 'https://wordpress.com/read',
 				'id'    => 'wp-admin-bar-followed-sites',
 				'label' => esc_html__( 'Followed Sites', 'jetpack' ),
 			),


### PR DESCRIPTION
Fixes N/A

#### Changes proposed in this Pull Request:
We're updating the masterbar Reader link to explicitly go to `wordpress.com/read`

For background context, we'd like to set up an A/B test to redirect a (logged-in) test group to Customer Home instead of the Reader upon visiting `wordpress.com`

In order to achieve that we need to ensure we can manipulate the default landing page for `/`. Currently it is `/read`.

By updating instances of `/` to `/read`, we'll ensure that links to the Reader work regardless of which A/B test cohort the clicker is in.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
For context see:
* p58i-89H-p2
* EPIC Issue: https://github.com/Automattic/zelda-private/issues/173
* Calypso PR: https://github.com/Automattic/wp-calypso/pull/37547

#### Testing instructions
* Connect your local ngroked Jetpack application to a wordpress.com site
* Visit `http://{yoursiteurl}/wp-admin/plugins.php?calypsoify=1`
* The Reader link in the masterbar should link to https://wordpress.com/read

<img width="867" alt="Screen Shot 2019-12-12 at 2 50 05 pm" src="https://user-images.githubusercontent.com/6458278/70681733-7c381380-1cf0-11ea-8c79-fd8779791d0f.png">

* Now enable the WordPress.com toolbar
<img width="764" alt="Screen Shot 2019-12-13 at 11 34 49 am" src="https://user-images.githubusercontent.com/6458278/70760563-215cf580-1d9e-11ea-8f8b-6ecbea2781e2.png">

* The Followed Sites link in the sidebar should link to https://wordpress.com/read
<img width="499" alt="Screen Shot 2019-12-13 at 11 38 24 am" src="https://user-images.githubusercontent.com/6458278/70760564-215cf580-1d9e-11ea-82f1-ba4e3f04c7dc.png">


#### Proposed changelog entry for your changes:

* Updated the link to the Reader in the masterbar to point to https://wordpress.com/read