### PR TITLE
Docker container: revert changes to docker permissions

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     build: .
     image: jetpack_wordpress:localbuild
     volumes:
-      - ..:/var/www/html/wp-content/plugins/jetpack:ro
+      - ..:/var/www/html/wp-content/plugins/jetpack
       ## Kludge for not having docker contain recursive stuff
       ## You will see on your filesystem that this dir gets created
       - dockerdirectory:/var/www/html/wp-content/plugins/jetpack/docker


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This reverts commit 895d4599c41cc9e76a78662550c0ae6b7fbd9b13.
Revert "Makes JP repo read only from inside docker container. (#14186)"

This commit was causing Jetpack's `wp jetpack scaffold` command to fail, since we use this command to create files in the container.

cc @ChaosExAnima 

#### Testing instructions:

* Run `yarn docker:wp jetpack scaffold block testing`
* You should not get any issues.

#### Proposed changelog entry for your changes:

* N/A
