### PR TITLE
Only use two arguments of is_protected_meta

### DIFF
--- a/modules/sharedaddy/sharedaddy.php
+++ b/modules/sharedaddy/sharedaddy.php
@@ -204,14 +204,14 @@ function sharing_meta_box_save( $post_id ) {
   	return $post_id;
 }
 
-function sharing_meta_box_protected( $protected, $meta_key, $meta_type ) {
+function sharing_meta_box_protected( $protected, $meta_key ) {
 	if ( 'sharing_disabled' == $meta_key )
 		$protected = true;
 
 	return $protected;
 }
 
-add_filter( 'is_protected_meta', 'sharing_meta_box_protected', 10, 3 );
+add_filter( 'is_protected_meta', 'sharing_meta_box_protected', 10, 2 );
 
 function sharing_plugin_settings( $links ) {
 	$settings_link = '<a href="options-general.php?page=sharing.php">'.__( 'Settings', 'jetpack' ).'</a>';


### PR DESCRIPTION
Fixes #14216

#### Changes proposed in this Pull Request:
* Since we don't use the third parameter of the `is_protected_meta` hook and the documentation can be read as "third paramter is optional," let's just not insist on it being there.

#### Testing instructions
No instructions since this is a precautious fix that doesn't change any behavior but just doesn't expect an argument that is ignored anyway.