### PR TITLE
Twenty Twenty / Tiled Galleries: fix layout

### DIFF
--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -221,6 +221,11 @@
 	width: 100%;
 }
 
+/* Tiled Galleries in Classic Blocks */
+.entry-content .tiled-gallery {
+	margin: 0 auto 1.5em;
+}
+
 /**
  * Shortcodes
  */


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* When inserting a Tiled Gallery inside a classic block, you'll notice some layout issues with the Twenty Twenty theme. Those do not apply to the Tiled Gallery block since it uses its own CSS Class.

#### Testing instructions:

* Go to Jetpack > Settings > Performance and enable the Image CDN (this turns on the Tiled Galleries module behind the scenes).
* Go to Posts > Add New
* Add a Classic Block to the post content.
* In that classic block, add some text and a tiled gallery
* Publish post
* Before the patch is applied, you'll see that the tiled gallery is missing margin and completely to the left in your browser. After the patch is applied, you should see the gallery matching the text's width.

#### Proposed changelog entry for your changes:

* Tiled Galleries: fix layout when using a gallery inside a Classic block with the Twenty Twenty theme.
