### PR TITLE
Hulu shortcode: fix failing tests after WP 5.3.1 update

### DIFF
--- a/tests/php/modules/shortcodes/test-class.hulu.php
+++ b/tests/php/modules/shortcodes/test-class.hulu.php
@@ -129,7 +129,7 @@ class WP_Test_Jetpack_Shortcodes_Hulu extends WP_UnitTestCase {
 
 	public function test_hulu_embed_to_shortcode() {
 		$embed     = '<iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=' . $this->video_eid . '&et=20&st=10&it=i11" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>';
-		$shortcode = apply_filters( 'pre_kses', $embed );
+		$shortcode = apply_filters( 'pre_kses', $embed, 'post', wp_allowed_protocols() );
 
 		$expected_shortcode = "[hulu id=$this->video_eid width=512 height=288 start_time=10 end_time=20 thumbnail_frame=11]";
 

--- a/tests/php/modules/shortcodes/test-shortcode-defense.php
+++ b/tests/php/modules/shortcodes/test-shortcode-defense.php
@@ -20,7 +20,7 @@ class WP_Test_Jetpack_Modules_Shortcode_Defense extends WP_UnitTestCase {
 	 * @see https://github.com/Automattic/jetpack/issues/4795
 	 */
 	public function test_handle_poor_content_variable() {
-		$content = array();
+		$content = '';
 
 		$content = wp_kses_post( $content );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* [WordPress 5.3.1](https://wordpress.org/news/2019/12/wordpress-5-3-1-security-and-maintenance-release/) introduced some changes that break our tests. Let's fix that.


#### Testing instructions:

* Do the tests pass?

#### Proposed changelog entry for your changes:

* N/A
