### PR TITLE
Move external link to Jetpack Backup landing page to Plans page header

### DIFF
--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -192,7 +192,6 @@ class ProductSelector extends Component {
 			dailyBackupUpgradeUrl,
 			isFetchingData,
 			multisite,
-			plans,
 			products,
 			realtimeBackupUpgradeUrl,
 			sitePlan,
@@ -214,11 +213,10 @@ class ProductSelector extends Component {
 			);
 		}
 
-		const isFetching = isFetchingData || ! plans;
 		const plan = get( sitePlan, 'product_slug' );
 
 		// Don't show the product card for paid plans.
-		if ( ! isFetching && 'jetpack_free' !== plan ) {
+		if ( ! isFetchingData && 'jetpack_free' !== plan ) {
 			return null;
 		}
 
@@ -229,7 +227,7 @@ class ProductSelector extends Component {
 
 		return (
 			<SingleProductBackup
-				isFetching={ isFetching }
+				isFetching={ isFetchingData }
 				products={ products }
 				upgradeLinks={ upgradeLinks }
 				selectedBackupType={ selectedBackupType }
@@ -253,12 +251,12 @@ export default connect( state => {
 		activeSitePurchases: getActiveSitePurchases( state ),
 		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
 		multisite: isMultisite( state ),
-		plans: getAvailablePlans( state ),
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
 		sitePlan: getSitePlan( state ),
 		siteRawlUrl: getSiteRawUrl( state ),
-		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
+		isFetchingData:
+			isFetchingSiteData( state ) || isFetchingProducts( state ) || ! getAvailablePlans( state ),
 		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ), // Redirect to https://jetpack.com/upgrade/backup/
 	};
 } )( ProductSelector );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -160,22 +160,28 @@ class ProductSelector extends Component {
 	};
 
 	renderTitleSection() {
-		const { backupInfoUrl } = this.props;
+		const { backupInfoUrl, isFetchingData } = this.props;
+		const purchase = this.findPrioritizedPurchase();
+
 		return (
 			<Fragment>
 				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
 				<h2 className="plans-section__subheader">
 					{ __( "Just looking for backups? We've got you covered." ) }
-					<br />
-					<ExternalLink
-						target="_blank"
-						href={ backupInfoUrl }
-						icon
-						iconSize={ 12 }
-						onClick={ this.handleLandingPageLinkClick }
-					>
-						{ __( 'Which backup option is best for me?' ) }
-					</ExternalLink>
+					{ ! isFetchingData && ! purchase && (
+						<>
+							<br />
+							<ExternalLink
+								target="_blank"
+								href={ backupInfoUrl }
+								icon
+								iconSize={ 12 }
+								onClick={ this.handleLandingPageLinkClick }
+							>
+								{ __( 'Which backup option is best for me?' ) }
+							</ExternalLink>
+						</>
+					) }
 				</h2>
 			</Fragment>
 		);

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -25,13 +25,9 @@ import { getSiteRawUrl, getUpgradeUrl, isMultisite } from '../state/initial-stat
 import { getProducts, isFetchingProducts } from '../state/products';
 
 class ProductSelector extends Component {
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			selectedBackupType: 'real-time',
-		};
-	}
+	state = {
+		selectedBackupType: 'real-time',
+	};
 
 	getProductCardPropsForPurchase( purchase ) {
 		const { siteRawlUrl } = this.props;

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -257,6 +257,6 @@ export default connect( state => {
 		sitePlan: getSitePlan( state ),
 		siteRawlUrl: getSiteRawUrl( state ),
 		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
-		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ),
+		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ), // Redirect to https://jetpack.com/upgrade/backup/
 	};
 } )( ProductSelector );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -164,6 +164,7 @@ class ProductSelector extends Component {
 	};
 
 	renderTitleSection() {
+		const { backupInfoUrl } = this.props;
 		return (
 			<Fragment>
 				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
@@ -172,7 +173,7 @@ class ProductSelector extends Component {
 					<br />
 					<ExternalLink
 						target="_blank"
-						href="https://jetpack.com/upgrade/backup/"
+						href={ backupInfoUrl }
 						icon
 						iconSize={ 12 }
 						onClick={ this.handleLandingPageLinkClick }
@@ -256,5 +257,6 @@ export default connect( state => {
 		sitePlan: getSitePlan( state ),
 		siteRawlUrl: getSiteRawUrl( state ),
 		isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
+		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ),
 	};
 } )( ProductSelector );

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -17,14 +17,19 @@ import PlanPrice from 'components/plans/plan-price';
 import './single-product-backup.scss';
 
 export function SingleProductBackup( props ) {
-	const { isFetching, ...backupCardProps } = props;
+	const { isFetching, products, upgradeLinks, selectedBackupType, setSelectedBackupType } = props;
 
 	return (
 		<div className="plans-section__single-product">
 			{ isFetching ? (
 				<div className="plans-section__single-product-skeleton is-placeholder" />
 			) : (
-				<SingleProductBackupCard { ...backupCardProps } />
+				<SingleProductBackupCard
+					products={ products }
+					upgradeLinks={ upgradeLinks }
+					selectedBackupType={ selectedBackupType }
+					setSelectedBackupType={ setSelectedBackupType }
+				/>
 			) }
 		</div>
 	);

--- a/_inc/client/plans/single-product-backup.jsx
+++ b/_inc/client/plans/single-product-backup.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -12,32 +12,30 @@ import { withRouter } from 'react-router';
  */
 import analytics from 'lib/analytics';
 import Button from 'components/button';
-import ExternalLink from 'components/external-link';
 import PlanPrice from 'components/plans/plan-price';
 
 import './single-product-backup.scss';
 
-export function SingleProductBackup( { plan, products, upgradeLinks, isFetchingData } ) {
-	// Don't show the product card for paid plans.
-	if ( ! isFetchingData && 'jetpack_free' !== plan ) {
-		return null;
-	}
+export function SingleProductBackup( props ) {
+	const { isFetching, ...backupCardProps } = props;
 
 	return (
-		<React.Fragment>
-			<div className="plans-section__single-product">
-				{ isFetchingData ? (
-					<div className="plans-section__single-product-skeleton is-placeholder" />
-				) : (
-					<SingleProductBackupCard products={ products } upgradeLinks={ upgradeLinks } />
-				) }
-			</div>
-		</React.Fragment>
+		<div className="plans-section__single-product">
+			{ isFetching ? (
+				<div className="plans-section__single-product-skeleton is-placeholder" />
+			) : (
+				<SingleProductBackupCard { ...backupCardProps } />
+			) }
+		</div>
 	);
 }
 
-function SingleProductBackupCard( { products, upgradeLinks } ) {
-	const [ selectedBackupType, setSelectedBackupType ] = useState( 'real-time' );
+function SingleProductBackupCard( {
+	products,
+	selectedBackupType,
+	setSelectedBackupType,
+	upgradeLinks,
+} ) {
 	const billingTimeFrame = 'yearly';
 	const currencyCode = get( products, [ 'jetpack_backup_daily', 'currency_code' ], '' );
 	const priceDaily = get( products, [ 'jetpack_backup_daily', 'cost' ], '' );
@@ -179,14 +177,6 @@ class SingleProductBackupBody extends React.Component {
 		} );
 	};
 
-	handleLandingPageLinkClick = selectedBackupType => () => {
-		analytics.tracks.recordJetpackClick( {
-			target: 'landing-page-link',
-			feature: 'single-product-backup',
-			extra: selectedBackupType,
-		} );
-	};
-
 	render() {
 		const {
 			backupOptions,
@@ -204,24 +194,7 @@ class SingleProductBackupBody extends React.Component {
 
 		return (
 			<React.Fragment>
-				<p>
-					{ __(
-						'Always-on backups ensure you never lose your site. Choose from real-time or daily backups. {{a}}Which one do I need?{{/a}}',
-						{
-							components: {
-								a: (
-									<ExternalLink
-										target="_blank"
-										href="https://jetpack.com/upgrade/backup/"
-										icon
-										iconSize={ 12 }
-										onClick={ this.handleLandingPageLinkClick( selectedBackupType ) }
-									/>
-								),
-							},
-						}
-					) }
-				</p>
+				<p>{ __( 'Always-on backups ensure you never lose your site.' ) }</p>
 				<h4 className="single-product-backup__options-header">{ __( 'Backup options:' ) }</h4>
 				<div className="single-product-backup__radio-buttons-container">
 					{ backupOptions.map( option => (

--- a/_inc/client/plans/single-product-backup.scss
+++ b/_inc/client/plans/single-product-backup.scss
@@ -106,6 +106,7 @@ input[type='radio'].plan-radio-button__input {
 // Accented card
 .single-product-backup__accented-card {
 	max-width: 518px;
+	width: 100%;
 	font-size: 14px;
 }
 

--- a/_inc/client/plans/single-product-backup.scss
+++ b/_inc/client/plans/single-product-backup.scss
@@ -59,14 +59,14 @@ input[type='radio'].plan-radio-button__input {
 
 // Plans section
 .plans-section__header {
-	margin: 24px auto 8px;
+	margin: 32px auto 8px;
 	text-align: center;
 	font-weight: normal;
 	font-size: 22px;
 }
 
 .plans-section__subheader {
-	margin: 8px auto;
+	margin: 8px auto 32px;
 	color: $gray-text-min;
 	text-align: center;
 	font-weight: normal;


### PR DESCRIPTION
As part of the work related to p1HpG7-87V-p2, this PR moves the link to Jetpack Backup landing page from `SingleProductBackupBody` to the parent `ProductSelector` component.

**Before**
<img width="565" alt="Screenshot 2019-12-13 at 14 22 26" src="https://user-images.githubusercontent.com/478735/70803291-06957b80-1db4-11ea-9e7a-396b85284fc8.png">

**After**
<img width="567" alt="Screenshot 2019-12-13 at 14 21 17" src="https://user-images.githubusercontent.com/478735/70803300-09906c00-1db4-11ea-9ff7-96b48cd66660.png">

Fixes n/a

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move external link to Jetpack Backup landing page from `SingleProductBackupBody` to the parent `ProductSelector` component.
* Decide whether to show `SingleProductBackup` component in `ProductSelector`.
* Add some spacing before and after the section header to better match the mockups.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open WP admin of a Jetpack site that's on a Free plan and has no Jetpack Backup product
* Go to /wp-admin/admin.php?page=jetpack#/plans
* Confirm that the external link "Which backup option is best for me?" is no longer inside the product card and instead in the section header.
* Turn on analytics debugging using the console:
```js
localStorage.setItem( 'debug', 'dops:analytics' );
```
* Having a Daily option selected, click on the external link and confirm that a proper event is being logged in the console.
* Having a Real-Time option selected, click on the external link and confirm that a proper event is being logged in the console.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Move external link to Jetpack Backup landing page from `SingleProductBackupBody` to the parent `ProductSelector` component.
