### PR TITLE
WP.com block editor: Exclude WP.com features from Jetpack sites

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -294,7 +294,7 @@ class Jetpack_WPCOM_Block_Editor {
 			)
 		);
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( jetpack_is_atomic_site() ) {
 			wp_enqueue_script(
 				'wpcom-block-editor-wpcom-script',
 				$debug

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -41,8 +41,8 @@ class Jetpack_WPCOM_Block_Editor {
 		}
 
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts' ), 9 );
-		add_action( 'enqueue_block_assets', array( $this, 'enqueue_styles' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 9 );
+		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_assets' ) );
 		add_filter( 'mce_external_plugins', array( $this, 'add_tinymce_plugins' ) );
 	}
 
@@ -253,37 +253,33 @@ class Jetpack_WPCOM_Block_Editor {
 	}
 
 	/**
-	 * Enqueue the scripts for the WordPress.com block editor integration.
+	 * Enqueues the WordPress.com block editor integration assets for the editor.
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_block_editor_assets() {
 		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 		$version = gmdate( 'Ymd' );
 
-		$src_common = $debug
-			? '//widgets.wp.com/wpcom-block-editor/common.js?minify=false'
-			: '//widgets.wp.com/wpcom-block-editor/common.min.js';
-
 		wp_enqueue_script(
-			'wpcom-block-editor-common',
-			$src_common,
+			'wpcom-block-editor-default-script',
+			$debug
+				? '//widgets.wp.com/wpcom-block-editor/default.js?minify=false'
+				: '//widgets.wp.com/wpcom-block-editor/default.min.js',
 			array(
 				'jquery',
 				'lodash',
-				'wp-blocks',
 				'wp-compose',
 				'wp-data',
-				'wp-dom-ready',
 				'wp-editor',
-				'wp-nux',
+				'wp-element',
 				'wp-plugins',
-				'wp-polyfill',
 				'wp-rich-text',
 			),
 			$version,
 			true
 		);
+
 		wp_localize_script(
-			'wpcom-block-editor-common',
+			'wpcom-block-editor-default-script',
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
@@ -298,14 +294,29 @@ class Jetpack_WPCOM_Block_Editor {
 			)
 		);
 
-		if ( $this->is_iframed_block_editor() ) {
-			$src_calypso_iframe_bridge = $debug
-				? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.js?minify=false'
-				: '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.min.js';
-
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			wp_enqueue_script(
-				'wpcom-block-editor-calypso-iframe-bridge',
-				$src_calypso_iframe_bridge,
+				'wpcom-block-editor-wpcom-script',
+				$debug
+					? '//widgets.wp.com/wpcom-block-editor/wpcom.js?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/wpcom.min.js',
+				array(
+					'wp-blocks',
+					'wp-data',
+					'wp-dom-ready',
+					'wp-nux',
+				),
+				$version,
+				true
+			);
+		}
+
+		if ( $this->is_iframed_block_editor() ) {
+			wp_enqueue_script(
+				'wpcom-block-editor-calypso-iframe-script',
+				$debug
+					? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.js?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.min.js',
 				array(
 					'calypsoify_wpadminmods_js',
 					'jquery',
@@ -314,20 +325,28 @@ class Jetpack_WPCOM_Block_Editor {
 					'wp-blocks',
 					'wp-data',
 					'wp-hooks',
-					'wp-polyfill',
 					'wp-tinymce',
 					'wp-url',
 				),
 				$version,
 				true
 			);
+
+			wp_enqueue_style(
+				'wpcom-block-editor-calypso-iframe-styles',
+				$debug
+					? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.css?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.min.css',
+				array(),
+				$version
+			);
 		}
 	}
 
 	/**
-	 * Enqueue WP.com block editor common styles.
+	 * Enqueues the WordPress.com block editor integration assets for both editor and front-end.
 	 */
-	public function enqueue_styles() {
+	public function enqueue_block_assets() {
 		// Enqueue only for the block editor in WP Admin.
 		global $pagenow;
 		if ( is_admin() && ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
@@ -339,17 +358,15 @@ class Jetpack_WPCOM_Block_Editor {
 			return;
 		}
 
-		$debug   = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		$version = gmdate( 'Ymd' );
+		$debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 
-		$src_styles = $debug
-			? '//widgets.wp.com/wpcom-block-editor/common.css?minify=false'
-			: '//widgets.wp.com/wpcom-block-editor/common.min.css';
 		wp_enqueue_style(
-			'wpcom-block-editor-styles',
-			$src_styles,
+			'wpcom-block-editor-default-styles',
+			$debug
+				? '//widgets.wp.com/wpcom-block-editor/default.css?minify=false'
+				: '//widgets.wp.com/wpcom-block-editor/default.min.css',
 			array(),
-			$version
+			gmdate( 'Ymd' )
 		);
 	}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -260,10 +260,10 @@ class Jetpack_WPCOM_Block_Editor {
 		$version = gmdate( 'Ymd' );
 
 		wp_enqueue_script(
-			'wpcom-block-editor-default-script',
+			'wpcom-block-editor-default-editor-script',
 			$debug
-				? '//widgets.wp.com/wpcom-block-editor/default.js?minify=false'
-				: '//widgets.wp.com/wpcom-block-editor/default.min.js',
+				? '//widgets.wp.com/wpcom-block-editor/default.editor.js?minify=false'
+				: '//widgets.wp.com/wpcom-block-editor/default.editor.min.js',
 			array(
 				'jquery',
 				'lodash',
@@ -271,7 +271,6 @@ class Jetpack_WPCOM_Block_Editor {
 				'wp-data',
 				'wp-editor',
 				'wp-element',
-				'wp-plugins',
 				'wp-rich-text',
 			),
 			$version,
@@ -279,7 +278,7 @@ class Jetpack_WPCOM_Block_Editor {
 		);
 
 		wp_localize_script(
-			'wpcom-block-editor-default-script',
+			'wpcom-block-editor-default-editor-script',
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
@@ -296,15 +295,16 @@ class Jetpack_WPCOM_Block_Editor {
 
 		if ( jetpack_is_atomic_site() ) {
 			wp_enqueue_script(
-				'wpcom-block-editor-wpcom-script',
+				'wpcom-block-editor-wpcom-editor-script',
 				$debug
-					? '//widgets.wp.com/wpcom-block-editor/wpcom.js?minify=false'
-					: '//widgets.wp.com/wpcom-block-editor/wpcom.min.js',
+					? '//widgets.wp.com/wpcom-block-editor/wpcom.editor.js?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/wpcom.editor.min.js',
 				array(
+					'lodash',
 					'wp-blocks',
 					'wp-data',
 					'wp-dom-ready',
-					'wp-nux',
+					'wp-plugins',
 				),
 				$version,
 				true
@@ -313,10 +313,10 @@ class Jetpack_WPCOM_Block_Editor {
 
 		if ( $this->is_iframed_block_editor() ) {
 			wp_enqueue_script(
-				'wpcom-block-editor-calypso-iframe-script',
+				'wpcom-block-editor-calypso-editor-script',
 				$debug
-					? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.js?minify=false'
-					: '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.min.js',
+					? '//widgets.wp.com/wpcom-block-editor/calypso.editor.js?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/calypso.editor.min.js',
 				array(
 					'calypsoify_wpadminmods_js',
 					'jquery',
@@ -333,10 +333,10 @@ class Jetpack_WPCOM_Block_Editor {
 			);
 
 			wp_enqueue_style(
-				'wpcom-block-editor-calypso-iframe-styles',
+				'wpcom-block-editor-calypso-editor-styles',
 				$debug
-					? '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.css?minify=false'
-					: '//widgets.wp.com/wpcom-block-editor/calypso-iframe-bridge-server.min.css',
+					? '//widgets.wp.com/wpcom-block-editor/calypso.editor.css?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/calypso.editor.min.css',
 				array(),
 				$version
 			);
@@ -361,10 +361,10 @@ class Jetpack_WPCOM_Block_Editor {
 		$debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 
 		wp_enqueue_style(
-			'wpcom-block-editor-default-styles',
+			'wpcom-block-editor-default-view-styles',
 			$debug
-				? '//widgets.wp.com/wpcom-block-editor/default.css?minify=false'
-				: '//widgets.wp.com/wpcom-block-editor/default.min.css',
+				? '//widgets.wp.com/wpcom-block-editor/default.view.css?minify=false'
+				: '//widgets.wp.com/wpcom-block-editor/default.view.min.css',
 			array(),
 			gmdate( 'Ymd' )
 		);
@@ -402,8 +402,8 @@ class Jetpack_WPCOM_Block_Editor {
 				'v',
 				gmdate( 'YW' ),
 				$debug
-					? '//widgets.wp.com/wpcom-block-editor/calypso-tinymce.js?minify=false'
-					: '//widgets.wp.com/wpcom-block-editor/calypso-tinymce.min.js'
+					? '//widgets.wp.com/wpcom-block-editor/calypso.tinymce.js?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/calypso.tinymce.min.js'
 			);
 		}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -347,27 +347,9 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueues the WordPress.com block editor integration assets for both editor and front-end.
 	 */
 	public function enqueue_block_assets() {
-		// Enqueue only for the block editor in WP Admin.
-		global $pagenow;
-		if ( is_admin() && ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
-			return;
-		}
-
-		// Enqueue on the front-end only if justified blocks are present.
-		if ( ! is_admin() && ! $this->has_justified_block() ) {
-			return;
-		}
-
-		$debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-
-		wp_enqueue_style(
-			'wpcom-block-editor-default-view-styles',
-			$debug
-				? '//widgets.wp.com/wpcom-block-editor/default.view.css?minify=false'
-				: '//widgets.wp.com/wpcom-block-editor/default.view.min.css',
-			array(),
-			gmdate( 'Ymd' )
-		);
+		// These styles are manually copied from //widgets.wp.com/wpcom-block-editor/default.view.css in order to
+		// improve the performance by avoiding an extra network request to download the CSS file on every page.
+		wp_add_inline_style( 'wp-block-library', '.has-text-align-justify{text-align:justify;}' );
 	}
 
 	/**

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -396,15 +396,14 @@ class Jetpack_WPCOM_Block_Editor {
 	 */
 	public function add_tinymce_plugins( $plugin_array ) {
 		if ( $this->is_iframed_block_editor() ) {
-			$debug               = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-			$src_calypso_tinymce = $debug
-				? '//widgets.wp.com/wpcom-block-editor/calypso-tinymce.js?minify=false'
-				: '//widgets.wp.com/wpcom-block-editor/calypso-tinymce.min.js';
+			$debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 
 			$plugin_array['gutenberg-wpcom-iframe-media-modal'] = add_query_arg(
 				'v',
 				gmdate( 'YW' ),
-				$src_calypso_tinymce
+				$debug
+					? '//widgets.wp.com/wpcom-block-editor/calypso-tinymce.js?minify=false'
+					: '//widgets.wp.com/wpcom-block-editor/calypso-tinymce.min.js'
 			);
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In order to don't expose some `@automattic/wpcom-block-editor` features to Jetpack sites that are specific of WP.com sites, the `common` bundle has been split into two new bundles `default` and `wpcom` in https://github.com/Automattic/wp-calypso/pull/38248.

This PRs changes the WordPress.com block editor module to replace the `common` bundle with the new  `default` and to load `wpcom` only when the site is a WP.com site (Atomic).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Changes the existing WordPress.com block editor module.

#### Testing instructions:

* Spin up a new [JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=update/wpcom-block-editor-exclude-features-jetpack).
* Verify the following features still work in both Calypso and WP Admin block editors:
  - Justify and underline format.
* Verify the following features still work only in the Calypso block editor:
  - Switch to classic (from the "More tools" menu).
  - Core media modal replaced by Calypso media modal.
  - Posts are previewed with the Calypso preview modal.
  - Revisions are managed with the Calypso revisions modal.
  - Media images in classic blocks are added with the Calypso media modal.
* Verify the following features are no longer available in both Calypso and WP Admin block editors:
  - Disable welcome guide tour on new sites (users should see the welcome guide the first time they use the block editor).
  - Reorder block categories (if CoBlocks is installed, it should be at the top).
  - Disable experimental blocks (those blocks should be available).
  - Attempt block recovery on editor load (invalid blocks should remain invalid).

#### Proposed changelog entry for your changes:

* WP.com block editor: Exclude WP.com features from Jetpack sites
