### PR TITLE
Jetpack Backup: Add inline option to PlanPrice and refactor

### DIFF
--- a/_inc/client/components/plans/plan-price/README.md
+++ b/_inc/client/components/plans/plan-price/README.md
@@ -38,8 +38,9 @@ export default class extends React.Component {
 
 | Prop         | Type           | Description                                               |
 | ----         | -------        | -----------                                               |
-| rawPrice     | number / array | Price or price range of the plan                          |
-| original     | bool           | Is the price discounted and this is the original one?     |
-| discounted   | bool           | Is the price discounted and this is the discounted one?   |
-| currencyCode | string         | Currency of the price                                     |
 | className    | string         | If you need to add additional classes                     |
+| currencyCode | string         | Currency of the price                                     |
+| discounted   | bool           | Is the price discounted and this is the discounted one?   |
+| inline       | bool           | When set, a `span` will be returned instead of a `div`    |
+| original     | bool           | Is the price discounted and this is the original one?     |
+| rawPrice     | number / array | Price or price range of the plan                          |

--- a/_inc/client/components/plans/plan-price/README.md
+++ b/_inc/client/components/plans/plan-price/README.md
@@ -9,6 +9,8 @@ flexbox container.
 
 If you pass an array of two numbers in the `rawPrice` prop, a range of prices will be displayed.
 
+Note that a zero-value price is allowed.
+
 ## Usage
 
 ```jsx
@@ -39,7 +41,7 @@ export default class extends React.Component {
 | Prop         | Type           | Description                                               |
 | ----         | -------        | -----------                                               |
 | className    | string         | If you need to add additional classes                     |
-| currencyCode | string         | Currency of the price                                     |
+| currencyCode | string         | Currency of the price (default: `USD`)                    |
 | discounted   | bool           | Is the price discounted and this is the discounted one?   |
 | inline       | bool           | When set, a `span` will be returned instead of a `div`    |
 | original     | bool           | Is the price discounted and this is the original one?     |

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -26,9 +26,6 @@ export class PlanPrice extends Component {
 		} else {
 			rawPriceRange = [ rawPrice ];
 		}
-		if ( rawPriceRange.includes( 0 ) ) {
-			return null;
-		}
 
 		return rawPriceRange.map( item => {
 			return {
@@ -71,9 +68,9 @@ export class PlanPrice extends Component {
 	}
 
 	render() {
-		const { className, currencyCode, discounted, inline, original, rawPrice } = this.props;
+		const { className, discounted, inline, original, rawPrice } = this.props;
 
-		if ( ! currencyCode || ! rawPrice ) {
+		if ( rawPrice === undefined ) {
 			return null;
 		}
 

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -42,24 +42,13 @@ export class PlanPrice extends Component {
 		);
 	}
 
-	render() {
-		const { className, currencyCode, discounted, original, rawPrice } = this.props;
-
-		if ( ! currencyCode || ! rawPrice ) {
-			return null;
-		}
-
-		const classes = classNames( 'plan-price', className, {
-			'is-original': original,
-			'is-discounted': discounted,
-		} );
-
+	renderContent() {
 		const priceRange = this.getPriceRange();
 		const smallerPrice = this.renderPrice( priceRange[ 0 ] );
 		const higherPrice = priceRange[ 1 ] && this.renderPrice( priceRange[ 1 ] );
 
 		return (
-			<div className={ classes }>
+			<>
 				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
 				{ ! higherPrice && this.renderPrice( priceRange[ 0 ] ) }
 				{ higherPrice &&
@@ -70,7 +59,27 @@ export class PlanPrice extends Component {
 						},
 						comment: 'The price range for a particular product',
 					} ) }
-			</div>
+			</>
+		);
+	}
+
+	render() {
+		const { className, currencyCode, discounted, inline, original, rawPrice } = this.props;
+
+		if ( ! currencyCode || ! rawPrice ) {
+			return null;
+		}
+
+		const classes = classNames( 'plan-price', className, {
+			'is-discounted': discounted,
+			'is-inline': inline,
+			'is-original': original,
+		} );
+
+		return inline ? (
+			<span className={ classes }>{ this.renderContent() }</span>
+		) : (
+			<div className={ classes }>{ this.renderContent() }</div>
 		);
 	}
 }
@@ -81,6 +90,7 @@ PlanPrice.propTypes = {
 	className: PropTypes.string,
 	currencyCode: PropTypes.string,
 	discounted: PropTypes.bool,
+	inline: PropTypes.bool,
 	original: PropTypes.bool,
 	rawPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.arrayOf( PropTypes.number ) ] ),
 };

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -74,17 +74,14 @@ export class PlanPrice extends Component {
 			return null;
 		}
 
+		const WrapperComponent = inline ? 'span' : 'div';
 		const classes = classNames( 'plan-price', className, {
 			'is-discounted': discounted,
 			'is-inline': inline,
 			'is-original': original,
 		} );
 
-		return inline ? (
-			<span className={ classes }>{ this.renderContent() }</span>
-		) : (
-			<div className={ classes }>{ this.renderContent() }</div>
-		);
+		return <WrapperComponent className={ classes }>{ this.renderContent() }</WrapperComponent>;
 	}
 }
 

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -54,15 +54,15 @@ export class PlanPrice extends Component {
 		return (
 			<>
 				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
-				{ ! higherPrice && this.renderPrice( priceRange[ 0 ] ) }
-				{ higherPrice &&
-					__( '{{smallerPrice/}}-{{higherPrice/}}', {
-						components: {
-							smallerPrice,
-							higherPrice,
-						},
-						comment: 'The price range for a particular product',
-					} ) }
+				{ higherPrice
+					? __( '{{smallerPrice/}}-{{higherPrice/}}', {
+							components: {
+								smallerPrice,
+								higherPrice,
+							},
+							comment: 'The price range for a particular product',
+					  } )
+					: smallerPrice }
 			</>
 		);
 	}

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -17,8 +17,15 @@ export class PlanPrice extends Component {
 	getPriceRange() {
 		const { currencyCode, rawPrice } = this.props;
 
-		// "Normalize" the input price or price range.
-		const rawPriceRange = Array.isArray( rawPrice ) ? rawPrice.slice( 0, 2 ) : [ rawPrice ];
+		// "Normalize" the input price or price range
+		let rawPriceRange;
+		if ( Array.isArray( rawPrice ) ) {
+			const positivePrices = rawPrice.filter( price => price >= 0 );
+			// First array entry is lowest price, second is highest price.
+			rawPriceRange = [ Math.min( ...positivePrices ), Math.max( ...positivePrices ) ];
+		} else {
+			rawPriceRange = [ rawPrice ];
+		}
 		if ( rawPriceRange.includes( 0 ) ) {
 			return null;
 		}

--- a/_inc/client/components/plans/plan-price/style.scss
+++ b/_inc/client/components/plans/plan-price/style.scss
@@ -5,6 +5,10 @@
 	font-size: 14px;
 	font-weight: 400;
 	color: $gray-text;
+
+	&.is-inline {
+		display: inline-block;
+	}
 }
 
 .plan-price.is-original {


### PR DESCRIPTION
This PR adds an `inline` option to the `PlanPrice` and in general refactors the component code.

The most important change introduced by this PR is that now `PlanPrice` accepts an additional prop: `inline`. If it's present, a `span` (set to `display: inline-block`) will be returned. Otherwise, a `div` will be returned.

In the current implementation an `h4` tag was always returned. It made it impossible to use the `PlanPrice` component in another inline HTML element (improper semantics).

Other than that, a general refactor has been made, i.e. a few methods were added so that the code is now more organized.

**Please note that changes to `PlanPrice` can be regarded as *safe* since the only consumers of the component are the `ProductSelector` and the `ProductCard` and this update is made to better support use case in this context.**

Fixes n/a

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add inline option to `PlanPrice`
* Refactor `PlanPrice` component
* Support zero-value prices in `PlanPrice`

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to wp-admin/admin.php?page=jetpack#/plans
* Confirm that there are no regressions in how the prices are rendered in the ProductCard component

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add inline option to `PlanPrice` and refactor
* Support zero-value prices in `PlanPrice` component