### PR TITLE
WP.com Block Editor: Add Justify styles inline rather than by enqueuing.

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -328,14 +328,15 @@ class Jetpack_WPCOM_Block_Editor {
 	 * Enqueue WP.com block editor common styles.
 	 */
 	public function enqueue_styles() {
-		// Enqueue only for the block editor in WP Admin.
-		global $pagenow;
-		if ( is_admin() && ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
+		// On the front-end, add Justify styles inline when Gutenberg styles are also loaded.
+		if ( ! is_admin() ) {
+			wp_add_inline_style( 'wp-block-library', '.has-text-align-justify{text-align:justify;}' );
 			return;
 		}
 
-		// Enqueue on the front-end only if justified blocks are present.
-		if ( ! is_admin() && ! $this->has_justified_block() ) {
+		// Enqueue only for the block editor in WP Admin.
+		global $pagenow;
+		if ( ! in_array( $pagenow, array( 'post.php', 'post-new.php' ), true ) ) {
 			return;
 		}
 
@@ -351,24 +352,6 @@ class Jetpack_WPCOM_Block_Editor {
 			array(),
 			$version
 		);
-	}
-
-	/**
-	 * Determines if the current $post contains a justified paragraph block.
-	 *
-	 * @return boolean true if justified paragraph is found, false otherwise.
-	 */
-	public function has_justified_block() {
-		global $post;
-		if ( ! $post instanceof WP_Post ) {
-			return false;
-		};
-
-		if ( ! has_blocks( $post ) ) {
-			return false;
-		}
-
-		return false !== strpos( $post->post_content, '<!-- wp:paragraph {"align":"justify"' );
 	}
 
 	/**


### PR DESCRIPTION
The WP.com Block Editor feature includes a Justify formatting option.

<img width="743" alt="justify" src="https://user-images.githubusercontent.com/349751/70836401-de5a4c80-1db4-11ea-9fa6-0fb2582eb2e5.png">

The module currently [enqueues](https://github.com/Automattic/jetpack/pull/14070) its `common.css` stylesheet on the front-end if appropriate blocks are detected. This isn't great for a couple of reasons:

* It's such a small file, but we're adding another network round-trip for the stylesheet to be enqueued.
* Detecting a justified paragraph block is fragile, because we're relying on exact markup (the `align` attribute [has to be first](https://github.com/Automattic/jetpack/pull/14070/files#diff-5bc82dd7b78333ce5067bd34d92debc8R371)), and non-single views (blog listing, categories or tags listings) don't properly detect posts needing the styles.

Instead, let's drop the enqueuing on the front-end, and just inline the small amount of styling we need for justified posts. This will drop the extra stylesheet request, correct behaviour on index views, and won't be added if a plugin deregisters Gutenberg core styles (like in [this suggestion](https://wordpress.org/support/topic/block-editor-assets-still-enqueued/#post-10962191)).

#### Testing instructions:
* Create a new block editor post with a paragraph, and set that paragraph to Justify.
* Verify the post displays properly on the front-end in both single view, and amongst other posts in index views.
* Unenqueue the `wp-block-library` stylesheet, and verify the inline styles are not added.
* You can also verify the styles' presence in View Source:

<img width="1017" alt="Screen Shot 2019-12-13 at 2 14 00 PM" src="https://user-images.githubusercontent.com/349751/70836641-b0c1d300-1db5-11ea-8e84-d3c46e643d4e.png">


#### Proposed changelog entry for your changes:
* Fix: Fully-justified paragraph blocks now display properly in index views on the front-end.
