### PR TITLE
README: Update path mapping for /docker/wordpress directory

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -451,7 +451,7 @@ Below are instructions for starting a debug session in PhpStorm that will listen
 
 1. In the server configuration window, check the 'Use path mappings' check box.
 
-1. In the server configuration window, map the main Jetpack folder to '/var/www/html/wp-content/plugins/jetpack' and map '/docker/wordpress' to '/var/www'
+1. In the server configuration window, map the main Jetpack folder to '/var/www/html/wp-content/plugins/jetpack' and map '/docker/wordpress' to '/var/www/html'
 
 1. In the server configuration window, click 'Apply' then 'Ok'.
 


### PR DESCRIPTION
Update path mapping for `/docker/wordpress` in PhpStorm setup.

First of all, Thanks for the easy dev setup guide, while testing Xdebug Config for Docker, had a minor issue with the path mapping, using the current one i.e `/var/www` would throw the following error.

```
Cannot find a local copy of the file on server /var/www/html/wp-admin/plugins.php
Local path is ../../jetpack/docker/wordpress/html/wp-admin/plugins.php
```

#### Changes proposed in this Pull Request:
- Updates path mapping to WordPress source directory for PhpStorm setup.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Testing instructions:
- Using the current mapping specified in README should throw an error, debugging using that mapping would help in testing.

Before
![path-mapping-before](https://user-images.githubusercontent.com/13589980/70855217-65aadb80-1eed-11ea-864c-bacf4ada7bd8.png)

After
![path-mapping-after](https://user-images.githubusercontent.com/13589980/70855216-65124500-1eed-11ea-9bf8-755d20cd0cd9.png)

#### Proposed changelog entry for your changes:
No entry needed
