### PR TITLE
Add social_notifications_subscribe option in WP Admin

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2056,6 +2056,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'validate_callback' => __CLASS__ . '::validate_boolean',
 				'jp_group'          => 'subscriptions',
 			),
+			'social_notifications_subscribe' => array(
+				'description'       => esc_html__( 'Send email notification when someone follows my blog', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'subscriptions',
+			),
 
 			// Related Posts
 			'show_headline' => array(

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -430,13 +430,14 @@ class Jetpack_Subscriptions {
 	 *
 	 * @since 8.1
 	 */
-	function social_notifications_subscribe_field() {
-		$checked = intval( 'on' == get_option( 'social_notifications_subscribe', 'on' ) ); ?>
+	public function social_notifications_subscribe_field() {
+		$checked = intval( 'on' === get_option( 'social_notifications_subscribe', 'on' ) );
+		?>
 
 		<label>
 			<input type="checkbox" name="social_notifications_subscribe" id="social_notifications_subscribe" value="1" <?php checked( $checked ); ?> />
 			/* translators: this is a label for a setting that starts with "Email me whenever" */
-			<?php _e( 'Someone follows my blog', 'jetpack' ); ?>
+			<?php esc_html_e( 'Someone follows my blog', 'jetpack' ); ?>
 		</label>
 		<?php
 	}
@@ -446,14 +447,16 @@ class Jetpack_Subscriptions {
 	 *
 	 * @since 8.1
 	 *
+	 * @param String $input the input string to be validated.
 	 * @return string on|off
 	 */
 	public function social_notifications_subscribe_validate( $input ) {
 		// If it's not set (was unchecked during form submission) or was set to off (during option update), return 'off'.
-		if ( ! $input || 'off' == $input )
+		if ( ! $input || 'off' === $input ) {
 			return 'off';
+		}
 
-		// Otherwise, return 'on'.
+		// Otherwise we return 'on'.
 		return 'on';
 	}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -436,8 +436,10 @@ class Jetpack_Subscriptions {
 
 		<label>
 			<input type="checkbox" name="social_notifications_subscribe" id="social_notifications_subscribe" value="1" <?php checked( $checked ); ?> />
-			/* translators: this is a label for a setting that starts with "Email me whenever" */
-			<?php esc_html_e( 'Someone follows my blog', 'jetpack' ); ?>
+			<?php
+				/* translators: this is a label for a setting that starts with "Email me whenever" */
+				esc_html_e( 'Someone follows my blog', 'jetpack' );
+			?>
 		</label>
 		<?php
 	}

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -413,7 +413,7 @@ class Jetpack_Subscriptions {
 					header = table.prevAll( 'h2:first' ),
 					newParent = $( '#moderation_notify' ).parent( 'label' ).parent();
 
-				if ( !table.length || !header.length || !newParent.length ) {
+				if ( ! table.length || ! header.length || ! newParent.length ) {
 					return;
 				}
 
@@ -431,11 +431,12 @@ class Jetpack_Subscriptions {
 	 * @since 8.1
 	 */
 	function social_notifications_subscribe_field() {
-		$checked = intval ('on' == get_option( 'social_notifications_subscribe', 'on' ) ); ?>
+		$checked = intval( 'on' == get_option( 'social_notifications_subscribe', 'on' ) ); ?>
 
 		<label>
 			<input type="checkbox" name="social_notifications_subscribe" id="social_notifications_subscribe" value="1" <?php checked( $checked ); ?> />
-			<?php _e( 'Someone follows my blog	', 'jetpack' ); ?>
+			/* translators: this is a label for a setting that starts with "Email me whenever" */
+			<?php _e( 'Someone follows my blog', 'jetpack' ); ?>
 		</label>
 		<?php
 	}
@@ -449,7 +450,7 @@ class Jetpack_Subscriptions {
 	 */
 	public function social_notifications_subscribe_validate( $input ) {
 		// If it's not set (was unchecked during form submission) or was set to off (during option update), return 'off'.
-		if ( !$input || 'off' == $input )
+		if ( ! $input || 'off' == $input )
 			return 'off';
 
 		// Otherwise, return 'on'.

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -92,6 +92,10 @@ class Jetpack_Subscriptions {
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
 
 		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 18, 1 );
+
+		// Set and delete "social_notifications_subscribe" option during activation / deactivation
+		add_action( 'jetpack_activate_module_subscriptions',   array( $this, 'set_social_notifications_subscribe' ) );
+		add_action( 'jetpack_deactivate_module_subscriptions', array( $this, 'delete_social_notifications_subscribe' ) );
 	}
 
 	/**
@@ -297,6 +301,30 @@ class Jetpack_Subscriptions {
 			'stc_enabled'
 		);
 
+		/** Email me whenever: Someone follows my blog ***************************************************/
+		/* @since 8.1 */
+
+		add_settings_section(
+			'notifications_section',
+			__( 'Someone follows my blog', 'jetpack' ),
+			array( $this, 'social_notifications_subscribe_section' ),
+			'discussion'
+		);
+
+		add_settings_field(
+			'jetpack_subscriptions_social_notifications_subscribe',
+			__( 'Email me whenever', 'jetpack' ),
+			array( $this, 'social_notifications_subscribe_field' ),
+			'discussion',
+			'notifications_section'
+		);
+
+		register_setting(
+			'discussion',
+			'social_notifications_subscribe',
+			array( $this, 'social_notifications_subscribe_validate' )
+		);
+
 		/** Subscription Messaging Options ******************************************************/
 
 		register_setting(
@@ -369,6 +397,63 @@ class Jetpack_Subscriptions {
 		</p>
 
 	<?php
+	}
+
+	/**
+	 * Someone follows my blog section
+	 *
+	 * @since 8.1
+	 */
+	public function social_notifications_subscribe_section() {
+		// Atypical usage here. We emit jquery to move subscribe notification checkbox to be with the rest of the email notification settings
+		?>
+		<script type="text/javascript">
+			jQuery( function( $ )  {
+				var table = $( '#social_notifications_subscribe' ).parents( 'table:first' ),
+					header = table.prevAll( 'h2:first' ),
+					newParent = $( '#moderation_notify' ).parent( 'label' ).parent();
+
+				if ( !table.length || !header.length || !newParent.length ) {
+					return;
+				}
+
+				newParent.append( '<br/>' ).append( table.end().parent( 'label' ).siblings().andSelf() );
+				header.remove();
+				table.remove();
+			} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Someone follows my blog Toggle
+	 *
+	 * @since 8.1
+	 */
+	function social_notifications_subscribe_field() {
+		$checked = intval ('on' == get_option( 'social_notifications_subscribe', 'on' ) ); ?>
+
+		<label>
+			<input type="checkbox" name="social_notifications_subscribe" id="social_notifications_subscribe" value="1" <?php checked( $checked ); ?> />
+			<?php _e( 'Someone follows my blog	', 'jetpack' ); ?>
+		</label>
+		<?php
+	}
+
+	/**
+	 * Validate "Someone follows my blog" option
+	 *
+	 * @since 8.1
+	 *
+	 * @return string on|off
+	 */
+	public function social_notifications_subscribe_validate( $input ) {
+		// If it's not set (was unchecked during form submission) or was set to off (during option update), return 'off'.
+		if ( !$input || 'off' == $input )
+			return 'off';
+
+		// Otherwise, return 'on'.
+		return 'on';
 	}
 
 	function validate_settings( $settings ) {
@@ -771,6 +856,28 @@ class Jetpack_Subscriptions {
 		} else {
 			setcookie( 'jetpack_blog_subscribe_' . self::$hash, '', time() - 3600, $cookie_path, $cookie_domain );
 		}
+	}
+
+	/**
+	 * Set the social_notifications_subscribe option to `off` when the Subscriptions module is activated.
+	 *
+	 * @since 8.1
+	 *
+	 * @return null
+	 */
+	function set_social_notifications_subscribe() {
+		update_option( 'social_notifications_subscribe', 'off' );
+	}
+
+	/**
+	 * Delete the social_notifications_subscribe option that was set to `off` on the module activation.
+	 *
+	 * @since 8.1
+	 *
+	 * @return null
+	 */
+	function delete_social_notifications_subscribe() {
+		delete_option( 'social_notifications_subscribe' );
 	}
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #709

When /wp-admin/options-discussion.php is fully loaded, the option looks like this: 

![Screen Shot on 2019-12-15 at 21:22:50](https://user-images.githubusercontent.com/10045087/70864067-39409f00-1f81-11ea-89e0-0a60cf1cabfe.png)
 
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Basically, I followed the same approach for another similar option ` Someone likes one of my posts` in "Likes" module https://github.com/Automattic/jetpack/search?q=social_notifications_like&type=Code

- Handle `social_notifications_subscribe` option when "Subscriptions" module is activated/deactivated.
- Add `Someone follows my blog` in WP Admin -> Settings -> Discussions.
- Use jQuery to align up this option in the `Email me whenever` section.
- Validate its value to only on/off.
- Add this option to \Jetpack_Core_Json_Api_Endpoints class. 

I do not add tests as `social_notifications_subscribe` is covered already. Can a dev help to double check this?

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This is more an enhancement. See p9o2xV-3Q-p2 and https://github.com/Automattic/jetpack/issues/709#issuecomment-381045292

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Disable Subscriptions module => the option should not display in "Discussions" settings 
* Enable Subscriptions => the checkbox of this option should not be selected by default.
* Enable this option, try to subscribe with a new email => the Jetpack connection owner gets an email notification about the new email. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Add `Email me whenever: Someone follows my blog` option to wp-admin settings.  
