### PR TITLE
Correctly validate on/off values for the boolean type in REST API 

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2907,9 +2907,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		if ( isset( $definition['type'] ) ) {
 			switch ( $definition['type'] ) {
 				case 'boolean':
-					if ( 'true' === $value ) {
+					if ( 'true' === $value || 'on' === $value ) {
 						return true;
-					} elseif ( 'false' === $value ) {
+					} elseif ( 'false' === $value || 'off' === $value ) {
 						return false;
 					}
 					return (bool) $value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

When working and testing https://github.com/Automattic/jetpack/pull/14239, I notice that it's not possible to _really_ switch off `Someone likes one of my posts` from /wp-admin/options-discussion.php. This PR is to fix this issue. 

#### Steps to replicate this issue 

- Go to /wp-admin/options-discussion.php
- Disable `Someone likes one of my posts` option.
- Check https://wordpress.com/settings/discussion/site.com, `Someone likes one of my posts` is always enabled when it should NOT. 
- Try to disable and enable a few times to notice the issue. 

#### Debugging and changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

With [\Jetpack_Likes::admin_discussion_likes_settings_validate()](https://github.com/Automattic/jetpack/blob/master/modules/likes.php#L237-L244), `social_notifications_like` can be only `on` or `off` if trying to update this option in /wp-admin/options-discussion.php

[\Jetpack_Core_Json_Api_Endpoints::cast_value()](https://github.com/Automattic/jetpack/blob/master/_inc/lib/class.core-rest-api-endpoints.php#L2902) is responsible to check and return boolean types. However, it does not check two strings `on` and `off` values at all. 

That's why even with `off`, it will be return `true` with this assessment:  

> return (bool) $value;

This PR will help check `on` and `off` strings to return expected values (false / true) for REST API. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* General: Correctly validate on/off values for the boolean type in REST API 
