### PR TITLE
Add a check on Marker Popup to be displayed only when block is…

### DIFF
--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -266,7 +266,7 @@ class MapEdit extends Component {
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
 						onError={ this.onError }
 					>
-						{ addPointVisibility && (
+						{ this.props.isSelected && addPointVisibility && (
 							<AddPoint
 								onAddPoint={ this.addPoint }
 								onClose={ () => this.setState( { addPointVisibility: false } ) }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -120,7 +120,7 @@ class MapEdit extends Component {
 		noticeOperations.createErrorNotice( message );
 	};
 	render() {
-		const { className, setAttributes, attributes, noticeUI, notices } = this.props;
+		const { className, setAttributes, attributes, noticeUI, notices, isSelected } = this.props;
 		const {
 			mapStyle,
 			mapDetails,
@@ -266,7 +266,7 @@ class MapEdit extends Component {
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
 						onError={ this.onError }
 					>
-						{ this.props.isSelected && addPointVisibility && (
+						{ isSelected && addPointVisibility && (
 							<AddPoint
 								onAddPoint={ this.addPoint }
 								onClose={ () => this.setState( { addPointVisibility: false } ) }


### PR DESCRIPTION
Add a check on Marker Popup to be displayed only when block is selected

Fixes #14057

#### Changes proposed in this Pull Request:
* Add a condition to add `<AddPoint>` component only when the block is selected.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It updates the Map block, and adds a check on the Marker Popup so that it is only displayed when block is selected.

#### Testing instructions:
- Refer `Steps to reproduce the issue` in #14057, you should see the popup when block is not selected.
- Use the patch from this PR and repeat above steps, the popup should now only be visible only on block selection.

**Before**
Here the `Markdown` block is selected, but the popup is still present.
![before](https://user-images.githubusercontent.com/13589980/70865704-680d4400-1f86-11ea-9098-3080afdc0c65.png)

**After**
Popup behaviour when `Map` block is selected.
![after-1](https://user-images.githubusercontent.com/13589980/70865716-94c15b80-1f86-11ea-9836-02c081097276.png)
Popup behaviour when `Map` block is not selected.
![after-2](https://user-images.githubusercontent.com/13589980/70865717-94c15b80-1f86-11ea-86fd-fb3082f8661d.png)

#### Proposed changelog entry for your changes:
Fix Marker Popup UI issue in `Map` block.