### PR TITLE
Move the add_filter() call for Jetpack::jetpack_custom_caps()

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -673,7 +673,6 @@ class Jetpack {
 		add_action( 'style_loader_src', array( 'Jetpack', 'set_suffix_on_min' ), 10, 2 );
 		add_filter( 'style_loader_tag', array( 'Jetpack', 'maybe_inline_style' ), 10, 2 );
 
-		add_filter( 'map_meta_cap', array( $this, 'jetpack_custom_caps' ), 1, 4 );
 		add_filter( 'profile_update', array( 'Jetpack', 'user_meta_cleanup' ) );
 
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_default_modules' ) );
@@ -756,6 +755,8 @@ class Jetpack {
 			 */
 			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
 		}
+
+		add_filter( 'map_meta_cap', array( $this, 'jetpack_custom_caps' ), 1, 4 );
 	}
 
 	/**


### PR DESCRIPTION
Classes from the Jetpack packages must not be used before all of the plugins have been loaded. The `Jetpack::jetpack_custom_caps()` method uses the Status package, so this method should not be called until the plugins have been loaded.

Fixes #14245 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move `add_filter( 'map_meta_cap', array( $this, 'jetpack_custom_caps' )...)` from the constructor to `Jetpack::after_plugins_loaded()`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

Verify that the PHP notices described in #14245 are not generated:
1. Install, activate, and register VaultPress.
2. During the backup process, check the debug log. Verify that no PHP notices are generated.

Verify that the change did not introduce new bugs by doing things like:
* Accessing the admin pages.
* Performing remote requests to the Jetpack site.
* Activating and deactivating modules.
* Connecting and disconnecting Jetpack.

#### Proposed changelog entry for your changes:
* TBD
