### PR TITLE
Instant Search: trigger overlay on submit

### DIFF
--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -3,23 +3,41 @@
 /**
  * External dependencies
  */
-import { h } from 'preact';
+import { h, Component } from 'preact';
 import { __ } from '@wordpress/i18n';
 
-const Overlay = ( { showOverlay, toggleOverlay, children } ) => {
-	const classNames = [ 'jetpack-instant-search__overlay' ];
-	if ( ! showOverlay ) {
-		classNames.push( 'is-hidden' );
+class Overlay extends Component {
+	closeOnEscapeKey = event => {
+		if ( event.key === 'Escape' ) {
+			this.props.toggleOverlay();
+		}
+	};
+
+	componentDidMount() {
+		window.addEventListener( 'keydown', this.closeOnEscapeKey );
 	}
 
-	return (
-		<div className={ classNames.join( ' ' ) }>
-			<button className="jetpack-instant-search__overlay-close" onClick={ toggleOverlay }>
-				{ __( 'Close', 'jetpack' ) }
-			</button>
-			{ children }
-		</div>
-	);
-};
+	componentWillUnmount() {
+		window.removeEventListener( 'keydown', this.closeOnEscapeKey );
+	}
+
+	render() {
+		const { showOverlay, toggleOverlay, children } = this.props;
+
+		const classNames = [ 'jetpack-instant-search__overlay' ];
+		if ( ! showOverlay ) {
+			classNames.push( 'is-hidden' );
+		}
+
+		return (
+			<div className={ classNames.join( ' ' ) }>
+				<button className="jetpack-instant-search__overlay-close" onClick={ toggleOverlay }>
+					{ __( 'Close', 'jetpack' ) }
+				</button>
+				{ children }
+			</div>
+		);
+	}
+}
 
 export default Overlay;

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -3,41 +3,38 @@
 /**
  * External dependencies
  */
-import { h, Component } from 'preact';
+import { h } from 'preact';
+import { useEffect } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
 
-class Overlay extends Component {
-	closeOnEscapeKey = event => {
+const Overlay = ( { showOverlay, toggleOverlay, children } ) => {
+	const closeOnEscapeKey = event => {
 		if ( event.key === 'Escape' ) {
-			this.props.toggleOverlay();
+			toggleOverlay();
 		}
 	};
 
-	componentDidMount() {
-		window.addEventListener( 'keydown', this.closeOnEscapeKey );
+	useEffect( () => {
+		window.addEventListener( 'keydown', closeOnEscapeKey );
+		return () => {
+			// Cleanup after event
+			window.removeEventListener( 'keydown', closeOnEscapeKey );
+		};
+	}, [] );
+
+	const classNames = [ 'jetpack-instant-search__overlay' ];
+	if ( ! showOverlay ) {
+		classNames.push( 'is-hidden' );
 	}
 
-	componentWillUnmount() {
-		window.removeEventListener( 'keydown', this.closeOnEscapeKey );
-	}
-
-	render() {
-		const { showOverlay, toggleOverlay, children } = this.props;
-
-		const classNames = [ 'jetpack-instant-search__overlay' ];
-		if ( ! showOverlay ) {
-			classNames.push( 'is-hidden' );
-		}
-
-		return (
-			<div className={ classNames.join( ' ' ) }>
-				<button className="jetpack-instant-search__overlay-close" onClick={ toggleOverlay }>
-					{ __( 'Close', 'jetpack' ) }
-				</button>
-				{ children }
-			</div>
-		);
-	}
-}
+	return (
+		<div className={ classNames.join( ' ' ) }>
+			<button className="jetpack-instant-search__overlay-close" onClick={ toggleOverlay }>
+				{ __( 'Close', 'jetpack' ) }
+			</button>
+			{ children }
+		</div>
+	);
+};
 
 export default Overlay;

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -7,18 +7,16 @@ import { h } from 'preact';
 import { useEffect } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
 
-const Overlay = ( { showOverlay, toggleOverlay, children } ) => {
-	const closeOnEscapeKey = event => {
-		if ( event.key === 'Escape' ) {
-			toggleOverlay();
-		}
-	};
+const closeOnEscapeKey = callback => event => {
+	event.key === 'Escape' && callback();
+};
 
+const Overlay = ( { showOverlay, toggleOverlay, children } ) => {
 	useEffect( () => {
-		window.addEventListener( 'keydown', closeOnEscapeKey );
+		window.addEventListener( 'keydown', closeOnEscapeKey( toggleOverlay ) );
 		return () => {
 			// Cleanup after event
-			window.removeEventListener( 'keydown', closeOnEscapeKey );
+			window.removeEventListener( 'keydown', closeOnEscapeKey( toggleOverlay ) );
 		};
 	}, [] );
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -114,7 +114,14 @@ class SearchApp extends Component {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
 	};
 
-	showResults = () => this.setState( { showResults: true } );
+	showResults = () => {
+		this.setState( { showResults: true } );
+
+		// Not working as expected...
+		document.querySelector( '.jetpack-instant-search__overlay input' ).focus();
+		console.log( document.activeElement );
+	};
+
 	hideResults = () => this.setState( { showResults: false } );
 	toggleResults = () => this.setState( state => ( { showResults: ! state.showResults } ) );
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -55,10 +55,6 @@ class SearchApp extends Component {
 		if ( this.hasActiveQuery() ) {
 			this.showResults();
 		}
-
-		if ( this.props.grabFocus ) {
-			this.input.current.focus();
-		}
 	}
 
 	componentWillUnmount() {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -116,10 +116,6 @@ class SearchApp extends Component {
 
 	showResults = () => {
 		this.setState( { showResults: true } );
-
-		// Not working as expected...
-		document.querySelector( '.jetpack-instant-search__overlay input' ).focus();
-		console.log( document.activeElement );
 	};
 
 	hideResults = () => this.setState( { showResults: false } );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -65,11 +65,19 @@ class SearchApp extends Component {
 	addEventListeners() {
 		window.addEventListener( 'popstate', this.onChangeQueryString );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
+
+		document
+			.querySelectorAll( this.props.themeOptions.searchInputSelector )
+			.forEach( input => input.form.addEventListener( 'submit', this.handleSubmit ) );
 	}
 
 	removeEventListeners() {
 		window.removeEventListener( 'popstate', this.onChangeQueryString );
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
+
+		document
+			.querySelectorAll( this.props.themeOptions.searchInputSelector )
+			.forEach( input => input.form.removeEventListener( 'submit', this.handleSubmit ) );
 	}
 
 	hasActiveQuery() {
@@ -79,6 +87,11 @@ class SearchApp extends Component {
 	hasNextPage() {
 		return !! this.state.response.page_handle && ! this.state.hasError;
 	}
+
+	handleSubmit = event => {
+		event.preventDefault();
+		this.showResults();
+	};
 
 	showResults = () => this.setState( { showResults: true } );
 	hideResults = () => this.setState( { showResults: false } );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -23,6 +23,9 @@ import {
 	getResultFormatQuery,
 	hasFilter,
 	setSearchQuery,
+	setSortQuery,
+	getSortKeyFromSortOption,
+	getSortOptionFromSortKey,
 } from '../lib/query-string';
 
 class SearchApp extends Component {
@@ -70,6 +73,10 @@ class SearchApp extends Component {
 			input.form.addEventListener( 'submit', this.handleSubmit );
 			input.addEventListener( 'input', this.handleInput );
 		} );
+
+		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
+			select.addEventListener( 'change', this.handleSortChange );
+		} );
 	}
 
 	removeEventListeners() {
@@ -79,6 +86,10 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
+		} );
+
+		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
+			select.removeEventListener( 'change', this.handleSortChange );
 		} );
 	}
 
@@ -99,6 +110,10 @@ class SearchApp extends Component {
 		setSearchQuery( event.target.value );
 	};
 
+	handleSortChange = event => {
+		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
+	};
+
 	showResults = () => this.setState( { showResults: true } );
 	hideResults = () => this.setState( { showResults: false } );
 	toggleResults = () => this.setState( state => ( { showResults: ! state.showResults } ) );
@@ -110,6 +125,10 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.value = getSearchQuery();
+		} );
+
+		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
+			select.value = getSortOptionFromSortKey( getSortQuery() );
 		} );
 	};
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -107,6 +107,10 @@ class SearchApp extends Component {
 
 	onChangeQueryString = () => {
 		this.getResults();
+
+		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.value = getSearchQuery();
+		} );
 	};
 
 	loadNextPage = () => {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -65,19 +65,11 @@ class SearchApp extends Component {
 	addEventListeners() {
 		window.addEventListener( 'popstate', this.onChangeQueryString );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
-
-		document
-			.querySelectorAll( this.props.themeOptions.searchInputSelector )
-			.forEach( input => input.addEventListener( 'focus', this.showResults ) );
 	}
 
 	removeEventListeners() {
 		window.removeEventListener( 'popstate', this.onChangeQueryString );
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
-
-		document
-			.querySelectorAll( this.props.themeOptions.searchInputSelector )
-			.forEach( input => input.removeEventListener( 'focus', this.showResults ) );
 	}
 
 	hasActiveQuery() {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -66,18 +66,20 @@ class SearchApp extends Component {
 		window.addEventListener( 'popstate', this.onChangeQueryString );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
-		document
-			.querySelectorAll( this.props.themeOptions.searchInputSelector )
-			.forEach( input => input.form.addEventListener( 'submit', this.handleSubmit ) );
+		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.form.addEventListener( 'submit', this.handleSubmit );
+			input.addEventListener( 'input', this.handleInput );
+		} );
 	}
 
 	removeEventListeners() {
 		window.removeEventListener( 'popstate', this.onChangeQueryString );
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
 
-		document
-			.querySelectorAll( this.props.themeOptions.searchInputSelector )
-			.forEach( input => input.form.removeEventListener( 'submit', this.handleSubmit ) );
+		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.form.removeEventListener( 'submit', this.handleSubmit );
+			input.removeEventListener( 'input', this.handleInput );
+		} );
 	}
 
 	hasActiveQuery() {
@@ -91,6 +93,10 @@ class SearchApp extends Component {
 	handleSubmit = event => {
 		event.preventDefault();
 		this.showResults();
+	};
+
+	handleInput = event => {
+		setSearchQuery( event.target.value );
 	};
 
 	showResults = () => this.setState( { showResults: true } );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -110,10 +110,7 @@ class SearchApp extends Component {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
 	};
 
-	showResults = () => {
-		this.setState( { showResults: true } );
-	};
-
+	showResults = () => this.setState( { showResults: true } );
 	hideResults = () => this.setState( { showResults: false } );
 	toggleResults = () => this.setState( state => ( { showResults: ! state.showResults } ) );
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -14,13 +14,6 @@ import uniqueId from 'lodash/uniqueId';
  */
 import Gridicon from './gridicon';
 
-function ignoreEnterKey( event ) {
-	if ( event.key === 'Enter' ) {
-		// Prevent form submission
-		event.preventDefault();
-	}
-}
-
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 
@@ -33,7 +26,6 @@ const SearchBox = props => {
 			<input
 				id={ inputId }
 				className="search-field jetpack-instant-search__box-input"
-				onKeyPress={ ignoreEnterKey }
 				onInput={ props.onChangeQuery }
 				onFocus={ props.onFocus }
 				onBlur={ props.onBlur }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -15,11 +15,10 @@ import { SERVER_OBJECT_NAME } from './lib/constants';
 import { initializeTracks, identifySite, resetTrackingCookies } from './lib/tracks';
 import { buildFilterAggregations } from './lib/api';
 
-const injectSearchApp = grabFocus => {
+const injectSearchApp = () => {
 	render(
 		<SearchApp
 			aggregations={ buildFilterAggregations( window[ SERVER_OBJECT_NAME ].widgets ) }
-			grabFocus={ grabFocus }
 			initialHref={ window.location.href }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }
 			isSearchPage={ getSearchQuery() !== '' }

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -12,6 +12,7 @@ export function getThemeOptions( searchOptions ) {
 			'.searchform input.search-field',
 			'.jetpack-instant-search-wrapper input.search-field',
 		].join( ', ' ),
+		searchSortSelector: [ '.jetpack-search-sort' ],
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -59,6 +59,26 @@ const DEFAULT_SORT_MAP = {
 	'relevance|DESC': 'score_default',
 };
 
+// Convert a sort option like date|DESC to a sort key like date_desc
+export function getSortKeyFromSortOption( sortOption ) {
+	if ( ! Object.keys( DEFAULT_SORT_MAP ).includes( sortOption ) ) {
+		return null;
+	}
+
+	return DEFAULT_SORT_MAP[ sortOption ];
+}
+
+// Convert a sort key like date_desc to a sort option like date|DESC
+export function getSortOptionFromSortKey( sortKey ) {
+	const sortKeyValues = Object.values( DEFAULT_SORT_MAP );
+
+	if ( ! sortKeyValues.includes( sortKey ) ) {
+		return null;
+	}
+
+	return Object.keys( DEFAULT_SORT_MAP )[ sortKeyValues.indexOf( sortKey ) ];
+}
+
 export function determineDefaultSort( initialSort, initialSearchString ) {
 	const query = getQuery();
 	if ( 'orderby' in query ) {
@@ -70,8 +90,9 @@ export function determineDefaultSort( initialSort, initialSearchString ) {
 		return 'date_desc';
 	}
 
-	if ( Object.keys( DEFAULT_SORT_MAP ).includes( initialSort ) ) {
-		return DEFAULT_SORT_MAP[ initialSort ];
+	const sortKeyFromSortOption = getSortKeyFromSortOption( initialSort );
+	if ( sortKeyFromSortOption ) {
+		return sortKeyFromSortOption;
 	}
 
 	return 'score_default';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In the current `instant-search-master`, the search overlay is triggered on focus. This PR instead triggers the overlay on form submit.

![2019-12-18 17-20-10 2019-12-18 17_21_44](https://user-images.githubusercontent.com/17325/71146965-23d2ba00-228c-11ea-9c30-9b036048dff7.gif)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No - this is part of the Instant Search prototype.

#### Testing instructions:

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

#### Proposed changelog entry for your changes:

Not required.