### PR TITLE
Reverse old embed HTML if it has videopress URLs in it

### DIFF
--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -57,7 +57,7 @@ class VideoPress_Shortcode {
 
 				if ( $url_matched ) {
 					$video_id = $url_matches[1];
-					return "[videopress $video_id]";
+					return "https://videopress.com/v/$video_id";
 				}
 			},
 			$content

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -22,8 +22,6 @@ class VideoPress_Shortcode {
 
 		add_filter( 'oembed_fetch_url', array( $this, 'add_oembed_for_parameter' ) );
 
-		add_filter( 'the_content', array( $this, 'reverse_old_embeds' ) );
-
 		$this->add_video_embed_hander();
 	}
 
@@ -36,33 +34,6 @@ class VideoPress_Shortcode {
 		}
 
 		return self::$instance;
-	}
-
-	/**
-	 * Filters old <embed> codes out of the content
-	 *
-	 * @param string $content the content.
-	 * @return string filtered content
-	 */
-	public function reverse_old_embeds( $content ) {
-		$regex   = '%<embed[^>]*+>(?:\s*</embed>)?%i';
-		$content = preg_replace_callback(
-			$regex,
-			function( $matches, $orig_html = null ) {
-				$embed_code  = $matches[0];
-				$url_matches = array();
-
-				// get video ID from flash URL.
-				$url_matched = preg_match( '/src="http:\/\/v.wordpress.com\/([^"]+)"/', $embed_code, $url_matches );
-
-				if ( $url_matched ) {
-					$video_id = $url_matches[1];
-					return "https://videopress.com/v/$video_id";
-				}
-			},
-			$content
-		);
-		return $content;
 	}
 
 	/**

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -52,7 +52,7 @@ class VideoPress_Shortcode {
 				$embed_code  = $matches[0];
 				$url_matches = array();
 
-				// get src="http://v.wordpress.com/KllQxFVq" attribute.
+				// get video ID from flash URL.
 				$url_matched = preg_match( '/src="http:\/\/v.wordpress.com\/([^"]+)"/', $embed_code, $url_matches );
 
 				if ( $url_matched ) {

--- a/modules/videopress/shortcode.php
+++ b/modules/videopress/shortcode.php
@@ -22,6 +22,8 @@ class VideoPress_Shortcode {
 
 		add_filter( 'oembed_fetch_url', array( $this, 'add_oembed_for_parameter' ) );
 
+		add_filter( 'the_content', array( $this, 'reverse_old_embeds' ) );
+
 		$this->add_video_embed_hander();
 	}
 
@@ -34,6 +36,33 @@ class VideoPress_Shortcode {
 		}
 
 		return self::$instance;
+	}
+
+	/**
+	 * Filters old <embed> codes out of the content
+	 *
+	 * @param string $content the content.
+	 * @return string filtered content
+	 */
+	public function reverse_old_embeds( $content ) {
+		$regex   = '%<embed[^>]*+>(?:\s*</embed>)?%i';
+		$content = preg_replace_callback(
+			$regex,
+			function( $matches, $orig_html = null ) {
+				$embed_code  = $matches[0];
+				$url_matches = array();
+
+				// get src="http://v.wordpress.com/KllQxFVq" attribute.
+				$url_matched = preg_match( '/src="http:\/\/v.wordpress.com\/([^"]+)"/', $embed_code, $url_matches );
+
+				if ( $url_matched ) {
+					$video_id = $url_matches[1];
+					return "[videopress $video_id]";
+				}
+			},
+			$content
+		);
+		return $content;
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -60,6 +60,9 @@
 		<testsuite name="verification-tools">
 			<directory prefix="test_" suffix=".php">tests/php/modules/verification-tools</directory>
 		</testsuite>
+		<testsuite name="videopress">
+			<directory prefix="test_" suffix=".php">tests/php/modules/videopress</directory>
+		</testsuite>
 		<testsuite name="wpcom-block-editor">
 			<directory prefix="test_" suffix=".php">tests/php/modules/wpcom-block-editor</directory>
 		</testsuite>

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Class WP_Test_Jetpack_VideoPress_Utility_Functions
+ *
+ * Note that modules/videopress/utility-functions.php is automatically loaded and does not need to be required in this file.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Tests Jetpack_VideoPress_Utility_Functions
+ */
+class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
+
+	/**
+	 * Tests the VideoPress Flash to oEmbedable URL filter.
+	 *
+	 * @author kraftbj
+	 * @covers jetpack_videopress_flash_embed_filter
+	 * @since 8.1.0
+	 */
+	public function test_jetpack_videopress_flash_embed_filter_flash() {
+		$content  = '<p><embed src="http://v.wordpress.com/YtfS78jH" type="application/x-shockwave-flash" width="600" height="338"></embed></p>';
+		$contains = 'https://videopress.com/v/YtfS78jH';
+
+		$filtered = jetpack_videopress_flash_embed_filter( $content );
+
+		$this->assertContains( $contains, $filtered );
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Older versions of VideoPress may have embedded HTML in a post in this format:

```html
<p><embed src="http://v.wordpress.com/somevideoid" type="application/x-shockwave-flash" width="600" height="338"></embed></p>
```

Most browsers now block flash by default, so this old content cannot be viewed.

This patch fixes the issue in a minimal way by looking for embed codes with URLs matching v.videopress.com and extracting the ID from the URL.

It makes no attempt to extract the width and height. Nor does it "fix" your post by permanently changing the stored content. It simply intercepts the HTML during `the_content` and renders the shortcode, which then gets expanded to the full videopress tag at the default width and height.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Convert `<embed src="http://v.videpress...` markup into `[videpress SomEVideOiD]` shortcodes

#### Testing instructions:
* Create a VideoPress video and note the ID
* Edit raw HTML and add some markup like this: 

```html
<p><embed src="http://v.wordpress.com/[YOUR VIDEO ID]" type="application/x-shockwave-flash" width="600" height="338"></p>
```

* View the post, output should be the HTML5 video embed

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Automatically render old videopress flash embed code as HTML5 player
