### PR TITLE
Admin Page: Fix initialization order

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -30,8 +30,21 @@ abstract class Jetpack_Admin_Page {
 	 */
 	function additional_styles() {}
 
-	function __construct() {
-		$this->jetpack                      = Jetpack::init();
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		add_action( 'jetpack_loaded', array( $this, 'on_jetpack_loaded' ) );
+	}
+
+	/**
+	 * Runs on Jetpack being ready to load its packages.
+	 *
+	 * @param Jetpack $jetpack object.
+	 */
+	public function on_jetpack_loaded( $jetpack ) {
+		$this->jetpack = $jetpack;
+
 		self::$block_page_rendering_for_idc = (
 			Jetpack::validate_sync_error_idc_option() && ! Jetpack_Options::get_option( 'safe_mode_confirmed' )
 		);

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -10,11 +10,6 @@ class Jetpack_Admin {
 	 **/
 	private static $instance = null;
 
-	/**
-	 * @var Jetpack
-	 **/
-	private $jetpack;
-
 	static function init() {
 		if ( isset( $_GET['page'] ) && $_GET['page'] === 'jetpack' ) {
 			add_filter( 'nocache_headers', array( 'Jetpack_Admin', 'add_no_store_header' ), 100 );
@@ -32,8 +27,6 @@ class Jetpack_Admin {
 	}
 
 	private function __construct() {
-		$this->jetpack = Jetpack::init();
-
 		jetpack_require_lib( 'admin-pages/class.jetpack-react-page' );
 		$this->jetpack_react = new Jetpack_React_Page();
 
@@ -177,7 +170,7 @@ class Jetpack_Admin {
 			}
 		}
 
-		uasort( $modules, array( $this->jetpack, 'sort_modules' ) );
+		uasort( $modules, array( 'Jetpack', 'sort_modules' ) );
 
 		if ( ! Jetpack::is_active() ) {
 			uasort( $modules, array( __CLASS__, 'sort_requires_connection_last' ) );


### PR DESCRIPTION
Package classes should be used only after all of the plugins have been loaded. The changes in this PR ensure that package classes are not being used during the initialization of the Jetpack_Admin and Jetpack_Admin_Page objects.

Fixes #13048 (specifically [this path to the notice](https://github.com/Automattic/jetpack/issues/13048#issuecomment-525619758))

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The `Jetpack_Admin` constructor calls `Jetpack::init()`, which uses a package class. Fix this by removing the Jetpack instance from Jetpack_Admin. It's currently used only to call `Jetpack::sort_modules()`, which is a static method.

* The `Jetpack_Admin_Page` constructor calls `Jetpack::init()`, `Jetpack::validate_sync_error_idc_option()`, and `Jetpack_Options::get_option()`, which all use package classes. Move them to a method that is hooked to `jetpack_loaded`,  which [fires during `plugins_loaded`](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L776).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This change affects an existing part of Jetpack.

#### Testing instructions:

The test site must have Jetpack activated and connected. Debug logging must be enabled.

This change affects the admin pages and remote requests that use methods from the admin page classes. Test these changes by:
* Accessing the Jetpack admin pages.
* Accessing the Jetpack modules page.
* Performing a remote request by accessing the Jetpack settings in Calypso or by accessing the site's blog rc.

Verify that no notices are generated in the debug log.

#### Proposed changelog entry for your changes:
* tbd
