### PR TITLE
Blocks: Calendly block

### DIFF
--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -1,0 +1,90 @@
+/**
+ * External Dependencies
+ */
+import { reduce } from 'lodash';
+import { __ } from '@wordpress/i18n';
+
+const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
+
+const colourValidator = value => hexRegex.test( value );
+
+const urlValidator = url => ! url || url.startsWith( 'https://calendly.com/' );
+
+export default {
+	backgroundColor: {
+		type: 'string',
+		default: 'ffffff',
+		validator: colourValidator,
+	},
+	submitButtonText: {
+		type: 'string',
+		default: __( 'Schedule time with me', 'jetpack' ),
+	},
+	submitButtonTextColor: {
+		type: 'string',
+		validator: colourValidator,
+	},
+	submitButtonBackgroundColor: {
+		type: 'string',
+		validator: colourValidator,
+	},
+	submitButtonClasses: { type: 'string' },
+	hideEventTypeDetails: {
+		type: 'boolean',
+		default: false,
+	},
+	primaryColor: {
+		type: 'string',
+		default: '00A2FF',
+		validator: colourValidator,
+	},
+	textColor: {
+		type: 'string',
+		default: '4D5055',
+		validator: colourValidator,
+	},
+	style: {
+		type: 'string',
+		default: 'inline',
+		validValues: [ 'inline', 'link' ],
+	},
+	url: {
+		type: 'string',
+		validator: urlValidator,
+	},
+	backgroundButtonColor: {
+		type: 'string',
+	},
+	textButtonColor: {
+		type: 'string',
+	},
+	customBackgroundButtonColor: {
+		type: 'string',
+		validator: colourValidator,
+	},
+	customTextButtonColor: {
+		type: 'string',
+		validator: colourValidator,
+	},
+};
+
+export const getValidatedAttributes = ( attributeDetails, attributes ) =>
+	reduce(
+		attributes,
+		( ret, attribute, attributeKey ) => {
+			const { type, validator, validValues, default: defaultVal } = attributeDetails[
+				attributeKey
+			];
+			if ( 'boolean' === type ) {
+				ret[ attributeKey ] = !! attribute;
+			} else if ( validator ) {
+				ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
+			} else if ( validValues ) {
+				ret[ attributeKey ] = validValues.includes( attribute ) ? attribute : defaultVal;
+			} else {
+				ret[ attributeKey ] = attribute;
+			}
+			return ret;
+		},
+		{}
+	);

--- a/extensions/blocks/calendly/blockStylesPreviewAndSelector.js
+++ b/extensions/blocks/calendly/blockStylesPreviewAndSelector.js
@@ -1,0 +1,72 @@
+/**
+ * External Dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockType, cloneBlock, getBlockFromExample } from '@wordpress/blocks';
+import { BlockPreview } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+import { ENTER, SPACE } from '@wordpress/keycodes';
+
+export default function BlockStylesPreviewAndSelector( {
+	attributes,
+	clientId,
+	styleOptions,
+	onSelectStyle,
+	activeStyle,
+} ) {
+	const block = useSelect( select => {
+		const { getBlock } = select( 'core/block-editor' );
+		return getBlock( clientId );
+	} );
+
+	const type = getBlockType( block.name );
+
+	return (
+		<div className="block-editor-block-styles">
+			{ styleOptions.map( styleOption => {
+				return (
+					<div
+						key={ styleOption.name }
+						className={ classnames( 'block-editor-block-styles__item', {
+							'is-active': styleOption.name === activeStyle,
+						} ) }
+						onClick={ () => {
+							onSelectStyle( { style: styleOption.name } );
+						} }
+						onKeyDown={ event => {
+							if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+								event.preventDefault();
+								onSelectStyle( { style: styleOption.name } );
+							}
+						} }
+						role="button"
+						tabIndex="0"
+						aria-label={ styleOption.label }
+					>
+						<div className="block-editor-block-styles__item-preview editor-styles-wrapper">
+							<BlockPreview
+								viewportWidth={ 500 }
+								blocks={
+									type.example
+										? getBlockFromExample( block.name, {
+												attributes: { ...type.example.attributes, style: styleOption.name },
+												innerBlocks: type.example.innerBlocks,
+										  } )
+										: cloneBlock( block, {
+												...attributes,
+												style: styleOption.name,
+										  } )
+								}
+							/>
+						</div>
+						<div className="block-editor-block-styles__item-label">{ styleOption.label }</div>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Calendly Block.
+ *
+ * @since 8.2.0
+ *
+ * @package Jetpack
+ */
+
+jetpack_register_block(
+	'jetpack/calendly',
+	array( 'render_callback' => 'jetpack_calendly_block_load_assets' )
+);
+
+/**
+ * Calendly block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Calendly block attributes.
+ * @param string $content String containing the Calendly block content.
+ *
+ * @return string
+ */
+function jetpack_calendly_block_load_assets( $attr, $content ) {
+	$url = jetpack_calendly_block_get_attribute( $attr, 'url' );
+	if ( empty( $url ) ) {
+		return;
+	}
+
+	/*
+	 * Enqueue necessary scripts and styles.
+	 */
+	Jetpack_Gutenberg::load_assets_as_required( 'calendly' );
+	wp_enqueue_script(
+		'jetpack-calendly-external-js',
+		'https://assets.calendly.com/assets/external/widget.js',
+		null,
+		JETPACK__VERSION,
+		false
+	);
+
+	$style                          = jetpack_calendly_block_get_attribute( $attr, 'style' );
+	$hide_event_type_details        = jetpack_calendly_block_get_attribute( $attr, 'hideEventTypeDetails' );
+	$background_color               = jetpack_calendly_block_get_attribute( $attr, 'backgroundColor' );
+	$text_color                     = jetpack_calendly_block_get_attribute( $attr, 'textColor' );
+	$primary_color                  = jetpack_calendly_block_get_attribute( $attr, 'primaryColor' );
+	$submit_button_text             = jetpack_calendly_block_get_attribute( $attr, 'submitButtonText' );
+	$submit_button_text_color       = jetpack_calendly_block_get_attribute( $attr, 'customTextButtonColor' );
+	$submit_button_background_color = jetpack_calendly_block_get_attribute( $attr, 'customBackgroundButtonColor' );
+	$classes                        = Jetpack_Gutenberg::block_classes( 'calendly', $attr );
+
+	$url = add_query_arg(
+		array(
+			'hide_event_type_details' => (int) $hide_event_type_details,
+			'background_color'        => sanitize_hex_color_no_hash( $background_color ),
+			'text_color'              => sanitize_hex_color_no_hash( $text_color ),
+			'primary_color'           => sanitize_hex_color_no_hash( $primary_color ),
+		),
+		$url
+	);
+
+	if ( 'link' === $style ) {
+		wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
+
+		/*
+		 * If we have some additional styles from the editor
+		 * (a custom text color, custom bg color, or both )
+		 * Let's add that CSS inline.
+		 */
+		if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
+			$inline_styles = sprintf(
+				'.wp-block-jetpack-calendly .button{%1$s%2$s}',
+				! empty( $submit_button_text_color )
+					? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
+					: '',
+				! empty( $submit_button_background_color )
+					? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
+					: ''
+			);
+			wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+		}
+
+		$content = sprintf(
+			'<div class="%1$s"><a class="button" href="" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;">%3$s</a></div>',
+			esc_attr( $classes ),
+			esc_url( $url ),
+			esc_html( $submit_button_text )
+		);
+	} else { // Button style.
+		$content = sprintf(
+			'<div class="calendly-inline-widget %1$s" data-url="%2$s" style="min-width:320px;height:630px;"></div>',
+			esc_attr( $classes ),
+			esc_url( $url )
+		);
+	}
+
+	return $content;
+}
+
+/**
+ * Get filtered attributes.
+ *
+ * @param array  $attributes     Array containing the Calendly block attributes.
+ * @param string $attribute_name String containing the attribute name to get.
+ *
+ * @return string
+ */
+function jetpack_calendly_block_get_attribute( $attributes, $attribute_name ) {
+	if ( isset( $attributes[ $attribute_name ] ) ) {
+		return $attributes[ $attribute_name ];
+	}
+
+	$default_attributes = array(
+		'url'                  => 'url',
+		'style'                => 'inline',
+		'submitButtonText'     => esc_html__( 'Schedule time with me', 'jetpack' ),
+		'backgroundColor'      => 'ffffff',
+		'textColor'            => '4D5055',
+		'primaryColor'         => '00A2FF',
+		'hideEventTypeDetails' => false,
+	);
+
+	return $default_attributes[ $attribute_name ];
+}

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -29,7 +29,7 @@ import icon from './icon';
 import attributeDetails, { getValidatedAttributes } from './attributes';
 import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
-import BlockStylesPreviewAndSelector from './BlockStylesPreviewAndSelector';
+import BlockStylesPreviewAndSelector from './blockStylesPreviewAndSelector';
 
 export default function CalendlyEdit( { attributes, className, clientId, setAttributes } ) {
 	const validatedAttributes = getValidatedAttributes( attributeDetails, attributes );

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -1,0 +1,253 @@
+/**
+ * External Dependencies
+ */
+import 'url-polyfill';
+import { isEqual } from 'lodash';
+import queryString from 'query-string';
+
+/**
+ * WordPress dependencies
+ */
+import { BlockControls, BlockIcon, InspectorControls } from '@wordpress/block-editor';
+import {
+	Button,
+	ExternalLink,
+	Notice,
+	PanelBody,
+	Placeholder,
+	ToggleControl,
+	Toolbar,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __, _x } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import icon from './icon';
+import attributeDetails, { getValidatedAttributes } from './attributes';
+import SubmitButton from '../../shared/submit-button';
+import { getAttributesFromEmbedCode } from './utils';
+import BlockStylesPreviewAndSelector from './BlockStylesPreviewAndSelector';
+
+export default function CalendlyEdit( { attributes, className, clientId, setAttributes } ) {
+	const validatedAttributes = getValidatedAttributes( attributeDetails, attributes );
+
+	if ( ! isEqual( validatedAttributes, attributes ) ) {
+		setAttributes( validatedAttributes );
+	}
+
+	const {
+		backgroundColor,
+		submitButtonText,
+		hideEventTypeDetails,
+		primaryColor,
+		textColor,
+		style,
+		url,
+	} = validatedAttributes;
+	const [ embedCode, setEmbedCode ] = useState( '' );
+	const [ notice, setNotice ] = useState();
+
+	const setErrorNotice = () =>
+		setNotice(
+			<>
+				{ __(
+					"Your calendar couldn't be embedded. Please double check your URL or code.",
+					'jetpack'
+				) }
+			</>
+		);
+
+	const parseEmbedCode = event => {
+		if ( ! event ) {
+			setErrorNotice();
+			return;
+		}
+
+		event.preventDefault();
+
+		const newAttributes = getAttributesFromEmbedCode( embedCode );
+		if ( ! newAttributes ) {
+			setErrorNotice();
+			return;
+		}
+
+		const newValidatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
+
+		setAttributes( newValidatedAttributes );
+	};
+
+	const embedCodeForm = (
+		<form onSubmit={ parseEmbedCode }>
+			<input
+				type="text"
+				id="embedCode"
+				onChange={ event => setEmbedCode( event.target.value ) }
+				placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
+				value={ embedCode }
+				className="components-placeholder__input"
+			/>
+			<div>
+				<Button isSecondary isLarge type="submit">
+					{ _x( 'Embed', 'button label', 'jetpack' ) }
+				</Button>
+			</div>
+			<div className={ `${ className }-learn-more` }>
+				<ExternalLink
+					href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview"
+					target="_blank"
+				>
+					{ __( 'Need help finding your embed code?', 'jetpack' ) }
+				</ExternalLink>
+			</div>
+		</form>
+	);
+
+	const blockPlaceholder = (
+		<Placeholder
+			label={ __( 'Calendly', 'jetpack' ) }
+			instructions={ __( 'Enter your Calendly web address or embed code below.', 'jetpack' ) }
+			icon={ <BlockIcon icon={ icon } /> }
+			notices={
+				notice && (
+					<Notice status="error" isDismissible={ false }>
+						{ notice }
+					</Notice>
+				)
+			}
+		>
+			{ embedCodeForm }
+		</Placeholder>
+	);
+
+	const iframeSrc = () => {
+		const query = queryString.stringify( {
+			embed_domain: 'wordpress.com',
+			embed_type: 'Inline',
+			hide_event_type_details: hideEventTypeDetails ? 1 : 0,
+			background_color: backgroundColor,
+			primary_color: primaryColor,
+			text_color: textColor,
+		} );
+		return `${ url }?${ query }`;
+	};
+
+	const inlinePreview = (
+		<>
+			<div className={ `${ className }-overlay` }></div>
+			<iframe
+				src={ iframeSrc() }
+				width="100%"
+				height="100%"
+				frameBorder="0"
+				data-origwidth="100%"
+				data-origheight="100%"
+				style={ { minWidth: '320px', height: '630px', width: '100%' } }
+				title="Calendly"
+			></iframe>
+		</>
+	);
+
+	const submitButtonPreview = (
+		<SubmitButton
+			submitButtonText={ submitButtonText }
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+		/>
+	);
+
+	const linkPreview = (
+		<>
+			<a style={ { alignSelf: 'flex-start', border: 'none' } } className="wp-block-button__link">
+				{ submitButtonText }
+			</a>
+		</>
+	);
+
+	const blockPreview = ( previewStyle, disabled ) => {
+		if ( previewStyle === 'inline' ) {
+			return inlinePreview;
+		}
+
+		if ( disabled ) {
+			return linkPreview;
+		}
+
+		return submitButtonPreview;
+	};
+
+	const styleOptions = [
+		{ name: 'inline', label: __( 'Inline', 'jetpack' ) },
+		{ name: 'link', label: __( 'Link', 'jetpack' ) },
+	];
+
+	const blockControls = (
+		<BlockControls>
+			{ url && (
+				<Toolbar
+					isCollapsed={ true }
+					icon="admin-appearance"
+					label={ __( 'Style', 'jetpack' ) }
+					controls={ styleOptions.map( styleOption => ( {
+						title: styleOption.label,
+						isActive: styleOption.name === style,
+						onClick: () => setAttributes( { style: styleOption.name } ),
+					} ) ) }
+					popoverProps={ { className: 'is-calendly' } }
+				/>
+			) }
+		</BlockControls>
+	);
+
+	const inspectorControls = (
+		<InspectorControls>
+			{ url && (
+				<>
+					<PanelBody title={ __( 'Styles', 'jetpack' ) }>
+						<BlockStylesPreviewAndSelector
+							clientId={ clientId }
+							styleOptions={ styleOptions }
+							onSelectStyle={ setAttributes }
+							activeStyle={ style }
+							attributes={ attributes }
+						/>
+					</PanelBody>
+				</>
+			) }
+
+			<PanelBody title={ __( 'Calendar Settings', 'jetpack' ) } initialOpen={ false }>
+				<form onSubmit={ parseEmbedCode } className={ `${ className }-embed-form-sidebar` }>
+					<input
+						type="text"
+						id="embedCode"
+						onChange={ event => setEmbedCode( event.target.value ) }
+						placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
+						value={ embedCode }
+						className="components-placeholder__input"
+					/>
+					<div>
+						<Button isSecondary isLarge type="submit">
+							{ _x( 'Embed', 'button label', 'jetpack' ) }
+						</Button>
+					</div>
+				</form>
+
+				<ToggleControl
+					label={ __( 'Hide Event Type Details', 'jetpack' ) }
+					checked={ hideEventTypeDetails }
+					onChange={ () => setAttributes( { hideEventTypeDetails: ! hideEventTypeDetails } ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	return (
+		<>
+			{ inspectorControls }
+			{ blockControls }
+			{ url ? blockPreview( style ) : blockPlaceholder }
+		</>
+	);
+}

--- a/extensions/blocks/calendly/editor.js
+++ b/extensions/blocks/calendly/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/extensions/blocks/calendly/editor.scss
+++ b/extensions/blocks/calendly/editor.scss
@@ -1,0 +1,31 @@
+/**
+ * Editor styles for Calendly
+ */
+
+.wp-block-jetpack-calendly {
+	&-overlay {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+		z-index: 10;
+	}
+
+	&-link-editable {
+		cursor: text;
+	}
+
+	&-embed-form-sidebar {
+		display: flex;
+		margin-bottom: 1em;
+	}
+
+	&-learn-more {
+		margin-top: 1em;
+	}
+}
+
+.is-calendly {
+	.is-active {
+		font-weight: bold;
+	}
+}

--- a/extensions/blocks/calendly/icon.js
+++ b/extensions/blocks/calendly/icon.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { SVG, G, Path, Rect } from '@wordpress/components';
+
+export default (
+	<SVG height="24" viewBox="0 0 23 24" width="23" xmlns="http://www.w3.org/2000/svg">
+		<G fill="none" fillRule="evenodd">
+			<Rect
+				height="20.956522"
+				rx="3"
+				stroke="#656a74"
+				strokeWidth="2"
+				width="20.956522"
+				x="1"
+				y="2.043478"
+			/>
+			<Rect fill="#656a74" height="4.869565" rx="1" width="2" x="6.565217" />
+			<Rect fill="#656a74" height="4.869565" rx="1" width="2" x="14.652174" />
+			<Path
+				d="m14.6086957 10.0869565c-.6956522-.57971012-1.6231885-.8695652-2.7826087-.8695652-1.7391305 0-3.47826091 1.5652174-3.47826091 3.6521739s1.73913041 3.6521739 3.47826091 3.6521739c1.1594202 0 2.0869565-.3478261 2.7826087-1.0434782"
+				stroke="#656a74"
+			/>
+		</G>
+	</SVG>
+);

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -38,7 +38,7 @@ export const settings = {
 			submitButtonText: __( 'Schedule time with me', 'jetpack' ),
 			hideEventTypeDetails: false,
 			style: 'inline',
-			url: 'https://calendly.com/scruffian/usability-test',
+			url: 'https://calendly.com/wordpresscom/jetpack-block-example',
 		},
 	},
 };

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import edit from './edit';
+import icon from './icon';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'calendly';
+export const title = __( 'Calendly', 'jetpack' );
+export const settings = {
+	title,
+	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
+	icon,
+	category: 'jetpack',
+	keywords: [
+		__( 'calendar', 'jetpack' ),
+		__( 'schedule', 'jetpack' ),
+		__( 'appointments', 'jetpack' ),
+	],
+	supports: {
+		html: false,
+	},
+	edit,
+	save: () => null,
+	attributes,
+	example: {
+		attributes: {
+			submitButtonText: __( 'Schedule time with me', 'jetpack' ),
+			hideEventTypeDetails: false,
+			style: 'inline',
+			url: 'https://calendly.com/scruffian/usability-test',
+		},
+	},
+};

--- a/extensions/blocks/calendly/test/utils.js
+++ b/extensions/blocks/calendly/test/utils.js
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getAttributesFromEmbedCode } from '../utils';
+
+const inlineEmbedCode = '<!-- Calendly inline widget begin -->' +
+	'<div class="calendly-inline-widget" data-url="https://calendly.com/scruffian/usability-test" style="min-width:320px;height:630px;"></div>' +
+	'<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>' +
+	'<!-- Calendly inline widget end -->';
+
+const widgetEmbedCode = '<!-- Calendly badge widget begin -->' +
+	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
+	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
+	'<script type="text/javascript">Calendly.initBadgeWidget({ url: \'https://calendly.com/scruffian/usability-test\', text: \'Schedule time with me\', color: \'#00a2ff\', textColor: \'#ffffff\', branding: true });</script>' +
+	'<!-- Calendly badge widget end -->';
+
+const textEmbedCode = '<!-- Calendly link widget begin -->' +
+	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
+	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
+	'<a href="" onclick="Calendly.initPopupWidget({url: \'https://calendly.com/scruffian/usability-test\'});return false;">Schedule time with me</a>' +
+	'<!-- Calendly link widget end -->';
+
+const customInlineEmbedCode = '<!-- Calendly inline widget begin -->' +
+	'<div class="calendly-inline-widget" data-url="https://calendly.com/scruffian/usability-test?hide_event_type_details=1&background_color=691414&text_color=2051a3&primary_color=1d6e9c" style="min-width:320px;height:630px;"></div>' +
+	'<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>' +
+	'<!-- Calendly inline widget end -->';
+
+const customWidgetEmbedCode = '<!-- Calendly badge widget begin -->' +
+	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
+	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
+	'<script type="text/javascript">Calendly.initBadgeWidget({ url: \'https://calendly.com/scruffian/usability-test?background_color=c51414&text_color=2563ca&primary_color=1d73a4\', text: \'Schedule some time with me\', color: \'#000609\', textColor: \'#b50000\', branding: true });</script>' +
+	'<!-- Calendly badge widget end -->';
+
+const customTextEmbedCode = '<!-- Calendly link widget begin -->' +
+	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
+	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
+	'<a href="" onclick="Calendly.initPopupWidget({url: \'https://calendly.com/scruffian/usability-test?background_color=e32424&text_color=2a74ef&primary_color=0e425f\'});return false;">Schedule some time with me</a>' +
+	'<!-- Calendly link widget end -->';
+
+describe( 'getAttributesFromEmbedCode', () => {
+	test( 'URL with http', () => {
+		expect(
+			getAttributesFromEmbedCode( 'https://calendly.com/scruffian/usability-test' )
+		).toEqual(
+			{
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+	
+	test( 'URL without http', () => {
+		expect(
+			getAttributesFromEmbedCode( 'calendly.com/scruffian/usability-test' )
+		).toEqual(
+			{
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'URL with query string', () => {
+		expect(
+			getAttributesFromEmbedCode( '//calendly.com/scruffian/usability-test?month=2019-12' )
+		).toEqual(
+			{
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'Inline embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( inlineEmbedCode )
+		).toEqual(
+			{
+				"style": "inline",
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'Widget embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( widgetEmbedCode )
+		).toEqual(
+			{
+				"style": "link",
+				"submitButtonText": "Schedule time with me",
+				"customBackgroundButtonColor": "#00a2ff",
+				"customTextButtonColor": "#ffffff",
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'Text embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( textEmbedCode )
+		).toEqual(
+			{
+				"style": "link",
+				"submitButtonText": "Schedule time with me",
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'Customised inline embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( customInlineEmbedCode )
+		).toEqual(
+			{
+				"backgroundColor": "691414",
+				"hideEventTypeDetails": "1",
+				"primaryColor": "1d6e9c",
+				"style": "inline",
+				"textColor": "2051a3",
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'Customised widget embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( customWidgetEmbedCode )
+		).toEqual(
+			{
+				"backgroundColor": "c51414",
+				"customBackgroundButtonColor": "#000609",
+				"customTextButtonColor": "#b50000",
+				"primaryColor": "1d73a4",
+				"style": "link",
+				"submitButtonText": "Schedule some time with me",
+				"textColor": "2563ca",
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} );
+
+	test( 'Customised text embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( customTextEmbedCode )
+		).toEqual(
+			{
+				"backgroundColor": "e32424",
+				"primaryColor": "0e425f",
+				"style": "link",
+				"submitButtonText": "Schedule some time with me",
+				"textColor": "2a74ef",
+				"url": "https://calendly.com/scruffian/usability-test"
+			}
+		);
+	} )
+} );

--- a/extensions/blocks/calendly/test/utils.js
+++ b/extensions/blocks/calendly/test/utils.js
@@ -8,66 +8,66 @@
 import { getAttributesFromEmbedCode } from '../utils';
 
 const inlineEmbedCode = '<!-- Calendly inline widget begin -->' +
-	'<div class="calendly-inline-widget" data-url="https://calendly.com/scruffian/usability-test" style="min-width:320px;height:630px;"></div>' +
+	'<div class="calendly-inline-widget" data-url="https://calendly.com/wordpresscom/jetpack-block-example" style="min-width:320px;height:630px;"></div>' +
 	'<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>' +
 	'<!-- Calendly inline widget end -->';
 
 const widgetEmbedCode = '<!-- Calendly badge widget begin -->' +
 	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
 	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
-	'<script type="text/javascript">Calendly.initBadgeWidget({ url: \'https://calendly.com/scruffian/usability-test\', text: \'Schedule time with me\', color: \'#00a2ff\', textColor: \'#ffffff\', branding: true });</script>' +
+	'<script type="text/javascript">Calendly.initBadgeWidget({ url: \'https://calendly.com/wordpresscom/jetpack-block-example\', text: \'Schedule time with me\', color: \'#00a2ff\', textColor: \'#ffffff\', branding: true });</script>' +
 	'<!-- Calendly badge widget end -->';
 
 const textEmbedCode = '<!-- Calendly link widget begin -->' +
 	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
 	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
-	'<a href="" onclick="Calendly.initPopupWidget({url: \'https://calendly.com/scruffian/usability-test\'});return false;">Schedule time with me</a>' +
+	'<a href="" onclick="Calendly.initPopupWidget({url: \'https://calendly.com/wordpresscom/jetpack-block-example\'});return false;">Schedule time with me</a>' +
 	'<!-- Calendly link widget end -->';
 
 const customInlineEmbedCode = '<!-- Calendly inline widget begin -->' +
-	'<div class="calendly-inline-widget" data-url="https://calendly.com/scruffian/usability-test?hide_event_type_details=1&background_color=691414&text_color=2051a3&primary_color=1d6e9c" style="min-width:320px;height:630px;"></div>' +
+	'<div class="calendly-inline-widget" data-url="https://calendly.com/wordpresscom/jetpack-block-example?hide_event_type_details=1&background_color=691414&text_color=2051a3&primary_color=1d6e9c" style="min-width:320px;height:630px;"></div>' +
 	'<script type="text/javascript" src="https://assets.calendly.com/assets/external/widget.js"></script>' +
 	'<!-- Calendly inline widget end -->';
 
 const customWidgetEmbedCode = '<!-- Calendly badge widget begin -->' +
 	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
 	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
-	'<script type="text/javascript">Calendly.initBadgeWidget({ url: \'https://calendly.com/scruffian/usability-test?background_color=c51414&text_color=2563ca&primary_color=1d73a4\', text: \'Schedule some time with me\', color: \'#000609\', textColor: \'#b50000\', branding: true });</script>' +
+	'<script type="text/javascript">Calendly.initBadgeWidget({ url: \'https://calendly.com/wordpresscom/jetpack-block-example?background_color=c51414&text_color=2563ca&primary_color=1d73a4\', text: \'Schedule some time with me\', color: \'#000609\', textColor: \'#b50000\', branding: true });</script>' +
 	'<!-- Calendly badge widget end -->';
 
 const customTextEmbedCode = '<!-- Calendly link widget begin -->' +
 	'<link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet">' +
 	'<script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript"></script>' +
-	'<a href="" onclick="Calendly.initPopupWidget({url: \'https://calendly.com/scruffian/usability-test?background_color=e32424&text_color=2a74ef&primary_color=0e425f\'});return false;">Schedule some time with me</a>' +
+	'<a href="" onclick="Calendly.initPopupWidget({url: \'https://calendly.com/wordpresscom/jetpack-block-example?background_color=e32424&text_color=2a74ef&primary_color=0e425f\'});return false;">Schedule some time with me</a>' +
 	'<!-- Calendly link widget end -->';
 
 describe( 'getAttributesFromEmbedCode', () => {
 	test( 'URL with http', () => {
 		expect(
-			getAttributesFromEmbedCode( 'https://calendly.com/scruffian/usability-test' )
+			getAttributesFromEmbedCode( 'https://calendly.com/wordpresscom/jetpack-block-example' )
 		).toEqual(
 			{
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
 	
 	test( 'URL without http', () => {
 		expect(
-			getAttributesFromEmbedCode( 'calendly.com/scruffian/usability-test' )
+			getAttributesFromEmbedCode( 'calendly.com/wordpresscom/jetpack-block-example' )
 		).toEqual(
 			{
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
 
 	test( 'URL with query string', () => {
 		expect(
-			getAttributesFromEmbedCode( '//calendly.com/scruffian/usability-test?month=2019-12' )
+			getAttributesFromEmbedCode( '//calendly.com/wordpresscom/jetpack-block-example?month=2020-01' )
 		).toEqual(
 			{
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
@@ -78,7 +78,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 		).toEqual(
 			{
 				"style": "inline",
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
@@ -92,7 +92,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"submitButtonText": "Schedule time with me",
 				"customBackgroundButtonColor": "#00a2ff",
 				"customTextButtonColor": "#ffffff",
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
@@ -104,7 +104,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 			{
 				"style": "link",
 				"submitButtonText": "Schedule time with me",
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
@@ -119,7 +119,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"primaryColor": "1d6e9c",
 				"style": "inline",
 				"textColor": "2051a3",
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
@@ -136,7 +136,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"style": "link",
 				"submitButtonText": "Schedule some time with me",
 				"textColor": "2563ca",
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} );
@@ -151,7 +151,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"style": "link",
 				"submitButtonText": "Schedule some time with me",
 				"textColor": "2a74ef",
-				"url": "https://calendly.com/scruffian/usability-test"
+				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
 	} )

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -1,0 +1,111 @@
+export const getURLFromEmbedCode = embedCode => {
+	const url = embedCode.match( /(?<!\.)calendly\.com.+?([^"']*)/i );
+	if ( url ) {
+		return 'https://' + url[ 0 ];
+	}
+};
+
+export const getSubmitButtonTextFromEmbedCode = embedCode => {
+	let submitButtonText = embedCode.match( /(?<=false;"\>).+(?=<\/)/ );
+	if ( submitButtonText ) {
+		return submitButtonText[ 0 ];
+	}
+
+	submitButtonText = embedCode.match( /(?<=text: ').*?(?=')/ );
+	if ( submitButtonText ) {
+		return submitButtonText[ 0 ];
+	}
+};
+
+const getSubmitButtonTextColorFromEmbedCode = embedCode => {
+	const submitButtonTextColor = embedCode.match( /(?<= textColor: ').*?(?=')/ );
+	if ( submitButtonTextColor ) {
+		return submitButtonTextColor[ 0 ];
+	}
+};
+
+const getSubmitButtonBackgroundColorFromEmbedCode = embedCode => {
+	const submitButtonBackgroundColor = embedCode.match( /(?<= color: ').*?(?=')/ );
+	if ( submitButtonBackgroundColor ) {
+		return submitButtonBackgroundColor[ 0 ];
+	}
+};
+
+export const getAttributesFromUrl = url => {
+	const attributes = {};
+	const urlObject = new URL( url );
+	attributes.url = urlObject.origin + urlObject.pathname;
+
+	if ( ! urlObject.search ) {
+		return attributes;
+	}
+
+	const searchParams = new URLSearchParams( urlObject.search );
+	const backgroundColor = searchParams.get( 'background_color' );
+	const primaryColor = searchParams.get( 'primary_color' );
+	const textColor = searchParams.get( 'text_color' );
+	const hexRegex = /^[A-Za-z0-9]{6}$/;
+
+	if ( searchParams.get( 'hide_event_type_details' ) ) {
+		attributes.hideEventTypeDetails = searchParams.get( 'hide_event_type_details' );
+	}
+
+	if ( backgroundColor && backgroundColor.match( hexRegex ) ) {
+		attributes.backgroundColor = backgroundColor;
+	}
+
+	if ( primaryColor && primaryColor.match( hexRegex ) ) {
+		attributes.primaryColor = primaryColor;
+	}
+
+	if ( textColor && textColor.match( hexRegex ) ) {
+		attributes.textColor = textColor;
+	}
+
+	return attributes;
+};
+
+const getStyleFromEmbedCode = embedCode => {
+	if ( embedCode.indexOf( 'data-url' ) > 0 ) {
+		return 'inline';
+	}
+
+	if ( embedCode.indexOf( 'initPopupWidget' ) > 0 || embedCode.indexOf( 'initBadgeWidget' ) > 0 ) {
+		return 'link';
+	}
+};
+
+export const getAttributesFromEmbedCode = embedCode => {
+	if ( ! embedCode ) {
+		return;
+	}
+
+	const newUrl = getURLFromEmbedCode( embedCode );
+	if ( ! newUrl ) {
+		return;
+	}
+
+	const newAttributes = getAttributesFromUrl( newUrl );
+
+	const newStyle = getStyleFromEmbedCode( embedCode );
+	if ( newStyle ) {
+		newAttributes.style = newStyle;
+	}
+
+	const submitButtonText = getSubmitButtonTextFromEmbedCode( embedCode );
+	if ( submitButtonText ) {
+		newAttributes.submitButtonText = submitButtonText;
+	}
+
+	const submitButtonTextColor = getSubmitButtonTextColorFromEmbedCode( embedCode );
+	if ( submitButtonTextColor ) {
+		newAttributes.customTextButtonColor = submitButtonTextColor;
+	}
+
+	const submitButtonBackgroundColor = getSubmitButtonBackgroundColorFromEmbedCode( embedCode );
+	if ( submitButtonBackgroundColor ) {
+		newAttributes.customBackgroundButtonColor = submitButtonBackgroundColor;
+	}
+
+	return newAttributes;
+};

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -23,5 +23,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "seo", "opentable" ]
+	"beta": [ "seo", "opentable", "calendly" ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This adds a new Jetpack block for Calendly.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The block supports all the different embed options that Calendly offer, as well as pasting the embed code.

Screenshots:
<img width="660" alt="Screenshot 2020-01-13 at 18 04 53" src="https://user-images.githubusercontent.com/275961/72280054-5b384a80-362f-11ea-80b2-9a1ef04efc72.png">
<img width="668" alt="Screenshot 2020-01-13 at 18 05 08" src="https://user-images.githubusercontent.com/275961/72280052-5b384a80-362f-11ea-8b20-add9f7513565.png">
<img width="654" alt="Screenshot 2020-01-13 at 18 05 34" src="https://user-images.githubusercontent.com/275961/72280050-5a9fb400-362f-11ea-9820-8da3ddaf45a4.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Master Thread: pb5gDS-fs-p2

#### Testing instructions:
* Enable Beta Blocks
* Create a new post
* Add a Calendly block
* Paste in each of the following:
- A Calendly URL
- A Calendly URL without https://
- The inline embed code
- The popup widget embed code
- The text widget embed code
* Repeat the previous steps but customise the colours (requires a pro account)
* Edit the block from the sidebar:
- Styles
- Hide event details
- Update the block using the embed code
* Check that the block renders correctly on the user's site

#### Using Calendly
To get the different embed codes from Calendly you will need a Calendly account:

<img width="1026" alt="Screenshot 2020-01-13 at 17 54 59" src="https://user-images.githubusercontent.com/275961/72279719-a0a84800-362e-11ea-8a31-d9b1f62adb8b.png">
<img width="450" alt="Screenshot 2020-01-13 at 17 54 54" src="https://user-images.githubusercontent.com/275961/72279722-a0a84800-362e-11ea-8b8c-d05bdff6e597.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add Calendly block
