### PR TITLE
Ensure headers have not been sent before attempting to set a cookie

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5614,7 +5614,9 @@ endif;
 				$value = $value[0];
 			}
 			$state[ $key ] = $value;
-			setcookie( "jetpackState[$key]", $value, 0, $path, $domain );
+			if ( ! headers_sent() ) {
+				setcookie( "jetpackState[$key]", $value, 0, $path, $domain );
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Checks for headers_sent before setting a cookie.

This can be seen via `wp jetpack module activate minileven` which results a notice in the logs:

```
[17-Dec-2019 23:07:31 UTC] PHP Warning:  Cannot modify header information - headers already sent by (output started at /usr/local/bin/psysh:1) in /var/www/html/wp-content/plugins/jetpack/class.jetpack.php on line 5617
[17-Dec-2019 23:07:31 UTC] PHP Stack trace:
[17-Dec-2019 23:07:31 UTC] PHP   1. {main}() /usr/local/bin/wp:0
[17-Dec-2019 23:07:31 UTC] PHP   2. include() /usr/local/bin/wp:4
[17-Dec-2019 23:07:31 UTC] PHP   3. include() phar:///usr/local/bin/wp/php/boot-phar.php:11
[17-Dec-2019 23:07:31 UTC] PHP   4. WP_CLI\bootstrap() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php:27
[17-Dec-2019 23:07:31 UTC] PHP   5. WP_CLI\Bootstrap\LaunchRunner->process() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php:74
[17-Dec-2019 23:07:31 UTC] PHP   6. WP_CLI\Runner->start() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23
[17-Dec-2019 23:07:31 UTC] PHP   7. WP_CLI\Runner->run_command_and_exit() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:1160
[17-Dec-2019 23:07:31 UTC] PHP   8. WP_CLI\Runner->run_command() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:394
[17-Dec-2019 23:07:31 UTC] PHP   9. WP_CLI\Dispatcher\Subcommand->invoke() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php:371
[17-Dec-2019 23:07:31 UTC] PHP  10. call_user_func:{phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451}() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451
[17-Dec-2019 23:07:31 UTC] PHP  11. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure:phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:95-102}() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:451
[17-Dec-2019 23:07:31 UTC] PHP  12. call_user_func:{phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98}() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98
[17-Dec-2019 23:07:31 UTC] PHP  13. Jetpack_CLI->module() phar:///usr/local/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:98
[17-Dec-2019 23:07:31 UTC] PHP  14. Jetpack::activate_module() /var/www/html/wp-content/plugins/jetpack/class.jetpack-cli.php:531
[17-Dec-2019 23:07:31 UTC] PHP  15. Jetpack::state() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:3041
[17-Dec-2019 23:07:31 UTC] PHP  16. setcookie() /var/www/html/wp-content/plugins/jetpack/class.jetpack.php:5617
```

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* See above.
*

#### Proposed changelog entry for your changes:
* CLI: Prevents a PHP notice when running some Jetpack CLI commands.
