### PR TITLE
Code coverage: Fix coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
       - WP_BRANCH=previous
       - DO_COVERAGE=true
     before_script:
+      - composer install --ignore-platform-reqs
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       - chmod +x ./cc-test-reporter
       - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
-      - echo "$(readlink -f .)
+      - echo "$(readlink -f .)"
       - ls -la
       - ls -la build/logs
       - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ matrix:
       - WP_BRANCH=previous
       - DO_COVERAGE=true
     before_script:
-      - composer install --ignore-platform-reqs
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       - chmod +x ./cc-test-reporter
       - ./cc-test-reporter before-build
@@ -67,14 +66,6 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
-      - echo "$(readlink -f .)"
-      - pwd
-      - echo $TRAVIS_BUILD_DIR
-      - ls -la
-      - ls -la build/logs
-      - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack
-      - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack/build/logs
-      - ls -la $TRAVIS_BUILD_DIR
       - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p /tmp/wordpress-previous/src/wp-content/plugins/jetpack
 
   - php: "7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,20 +63,19 @@ matrix:
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       - chmod +x ./cc-test-reporter
       - ./cc-test-reporter before-build
-      - which phpunit
-      - echo $(which phpunit)
       - export PATH="$HOME/.composer/vendor/bin:$PATH"
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
       - echo "$(readlink -f .)"
+      - pwd
+      - echo $TRAVIS_BUILD_DIR
       - ls -la
       - ls -la build/logs
       - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack
       - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack/build/logs
-      - pwd
-      - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p $(readlink -f .)build/logs
+      - ls -la $TRAVIS_BUILD_DIR
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p $(readlink -f .)
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ matrix:
       - WP_BRANCH=previous
       - DO_COVERAGE=true
     before_script:
-      - yarn build
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       - chmod +x ./cc-test-reporter
       - ./cc-test-reporter before-build
@@ -68,7 +67,7 @@ matrix:
       - ./tests/setup-travis.sh
     after_script:
       - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)"
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p ./
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,12 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
-      - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR"
+      - echo "--exit-code $TRAVIS_TEST_RESULT -t clover -p $TRAVIS_BUILD_DIR"
       - ls -la
-      - ls -la logs
+      - ls -la build/logs
       - pwd
       - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p build/logs
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p build/logs
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
+      - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)"
       - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)
 
   - php: "7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,10 @@ matrix:
       - ./tests/setup-travis.sh
     after_script:
       - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR"
-      - echo ls
-      - echo pwd
+      - ls -la
+      - pwd
       - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR/logs
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,8 @@ matrix:
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       - chmod +x ./cc-test-reporter
       - ./cc-test-reporter before-build
+      - which phpunit
+      - echo $(which phpunit)
       - export PATH="$HOME/.composer/vendor/bin:$PATH"
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,12 +67,12 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
-      - echo "--exit-code $TRAVIS_TEST_RESULT -t clover -p $TRAVIS_BUILD_DIR"
+      - echo "$(readlink -f .)
       - ls -la
       - ls -la build/logs
       - pwd
       - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p build/logs
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p $(readlink -f .)build/logs
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
       - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack
       - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack/build/logs
       - ls -la $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p $(readlink -f .)
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p /tmp/wordpress-previous/src/wp-content/plugins/jetpack
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,10 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
-      - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)"
+      - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR"
+      - echo ls
+      - echo pwd
+      - echo $TRAVIS_BUILD_DIR
       - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR
 
   - php: "7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
       - ./tests/setup-travis.sh
     after_script:
       - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)"
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p ./
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
   - php: "7.3"
     name: "Code Coverage"
     env:
-      - WP_BRANCH=latest
+      - WP_BRANCH=previous
       - DO_COVERAGE=true
     before_script:
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -66,7 +66,7 @@ matrix:
       - export PLUGIN_SLUG=$(basename $(pwd))
       - ./tests/setup-travis.sh
     after_script:
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $(readlink -f .)
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ matrix:
       - ls -la
       - pwd
       - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR/logs
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p logs
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
       - ls -la logs
       - pwd
       - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p logs
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p /home/travis
 
   - php: "7.0"
     name: "E2E tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ matrix:
       - WP_BRANCH=previous
       - DO_COVERAGE=true
     before_script:
+      - yarn build
       - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
       - chmod +x ./cc-test-reporter
       - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,7 @@ matrix:
     after_script:
       - echo "--exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p $TRAVIS_BUILD_DIR"
       - ls -la
+      - ls -la logs
       - pwd
       - echo $TRAVIS_BUILD_DIR
       - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,8 @@ matrix:
       - echo "$(readlink -f .)"
       - ls -la
       - ls -la build/logs
+      - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack
+      - ls -la /tmp/wordpress-previous/src/wp-content/plugins/jetpack/build/logs
       - pwd
       - echo $TRAVIS_BUILD_DIR
       - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT -t clover -p $(readlink -f .)build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
       - ls -la logs
       - pwd
       - echo $TRAVIS_BUILD_DIR
-      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p /home/travis
+      - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT --coverage-input-type clover -p build/logs
 
   - php: "7.0"
     name: "E2E tests"

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -77,7 +77,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	elif [[ "$DO_COVERAGE" == "true" && -x "$(command -v phpdbg)" ]]; then
 		mkdir -p $TRAVIS_BUILD_DIR/build/logs
-		export WP_TRAVISCI="phpdbg -qrr phpunit --coverage-clover $TRAVIS_BUILD_DIR/build/logs/clover.xml"
+		export WP_TRAVISCI="phpdbg -qrr /home/travis/.phpenv/shims/phpunit --coverage-clover $TRAVIS_BUILD_DIR/clover.xml"
 	fi
 
   if [ "$SYNC_BETA" == "1" ]; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -76,8 +76,8 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
 		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	elif [[ "$DO_COVERAGE" == "true" && -x "$(command -v phpdbg)" ]]; then
-		mkdir $TRAVIS_BUILD_DIR/logs
-		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/logs/clover.xml"
+		mkdir /home/travis/build/logs
+		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover /home/travis/build/logs/clover.xml"
 	fi
 
   if [ "$SYNC_BETA" == "1" ]; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -76,8 +76,8 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
 		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	elif [[ "$DO_COVERAGE" == "true" && -x "$(command -v phpdbg)" ]]; then
-		mkdir /home/travis/build/logs
-		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover /home/travis/build/logs/clover.xml"
+		mkdir -p $TRAVIS_BUILD_DIR/build/logs
+		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/build/logs/clover.xml"
 	fi
 
   if [ "$SYNC_BETA" == "1" ]; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -76,7 +76,8 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
 		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	elif [[ "$DO_COVERAGE" == "true" && -x "$(command -v phpdbg)" ]]; then
-		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/clover.xml"
+		mkdir $TRAVIS_BUILD_DIR/logs
+		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/logs/clover.xml"
 	fi
 
   if [ "$SYNC_BETA" == "1" ]; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -77,7 +77,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	elif [[ "$DO_COVERAGE" == "true" && -x "$(command -v phpdbg)" ]]; then
 		mkdir -p $TRAVIS_BUILD_DIR/build/logs
-		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/build/logs/clover.xml"
+		export WP_TRAVISCI="phpdbg -qrr phpunit --coverage-clover $TRAVIS_BUILD_DIR/build/logs/clover.xml"
 	fi
 
   if [ "$SYNC_BETA" == "1" ]; then

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -76,8 +76,7 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 	elif [[ "$TRAVIS_EVENT_TYPE" == "api" && ! -z $PHPUNIT_COMMAND_OVERRIDE ]]; then
 		export WP_TRAVISCI="${PHPUNIT_COMMAND_OVERRIDE}"
 	elif [[ "$DO_COVERAGE" == "true" && -x "$(command -v phpdbg)" ]]; then
-		mkdir -p $TRAVIS_BUILD_DIR/build/logs
-		export WP_TRAVISCI="phpdbg -qrr /home/travis/.phpenv/shims/phpunit --coverage-clover $TRAVIS_BUILD_DIR/clover.xml"
+		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/clover.xml"
 	fi
 
   if [ "$SYNC_BETA" == "1" ]; then


### PR DESCRIPTION
We are colleting code coverage reports, but it seems codeclimate not happy with the absolute paths in these reports, so all these reports are considered as invalid: https://codeclimate.com/repos/5375d01ee30ba03a8300f1a6/settings/test_reporter

Explicitly passing `prefix` did fix the reports. Props to: 
https://github.com/codeclimate/test-reporter/issues/375#issuecomment-438828920

Also, I switched to `previous` WP branch so it won't trigger package tests. Later on, we can revisit it, and start collecting coverage for packages too.

We might need to merge it before we can see coverage on CC dashboard. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* fix codeClimate reports

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to check codeClimate: https://codeclimate.com/repos/5375d01ee30ba03a8300f1a6/settings/test_reporter
* Is `fix/codeclimate-reporting` build's state is 'Done'?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
