### PR TITLE
Migration: return migration status in sites endpoint and lock target …

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -51,6 +51,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
+		'migration_status'  => '(string) A string describing the migration status of the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
 	);
@@ -72,6 +73,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_following',
 		'meta',
 		'launch_status',
+		'migration_status',
 		'is_fse_active',
 		'is_fse_eligible',
 	);
@@ -140,6 +142,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 	protected static $jetpack_response_field_additions = array(
 		'subscribers_count',
+		'migration_status',
 	);
 
 	protected static $jetpack_response_field_member_additions = array(
@@ -381,6 +384,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'launch_status' :
 				$response[ $key ] = $this->site->get_launch_status();
+				break;
+			case 'migration_status' :
+				$response[ $key ] = $this->site->get_migration_status();
 				break;
 			case 'is_fse_active':
 				$response[ $key ] = $this->site->is_fse_active();

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -48,6 +48,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
+		'migration_status'  => '(string) A string describing the migration status of the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
 	);

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -641,6 +641,10 @@ abstract class SAL_Site {
 		return false;
 	}
 
+	function get_migration_status() {
+		return false;
+	}
+
 	function get_site_segment() {
 		return false;
 	}


### PR DESCRIPTION
Differential Revision: D35642-code

This commit syncs r200876-wpcom.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR adds `migration_status` to the response of the sites endpoint. The SAL returns `false`, as this value is calculated on the shadow-site.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This supports the changes in D35642-code so that we can retrieve the migration status of a site from the sites endpoint. See pbkcP4-8-p2.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify that with the PR applied, the endpoint returns an empty string

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry required
