### PR TITLE
Notes: avoid being targetted by 2020's instrinsic video resizes

### DIFF
--- a/modules/notes.php
+++ b/modules/notes.php
@@ -194,7 +194,7 @@ class Jetpack_Notifications {
 					<span class="noticon noticon-notification"></span>
 					</span>',
 			'meta'   => array(
-				'html'  => '<div id="wpnt-notes-panel2" style="display:none" lang="'. esc_attr( $wpcom_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
+				'html'  => '<div id="wpnt-notes-panel2" class="intrinsic-ignore" style="display:none" lang="' . esc_attr( $wpcom_locale ) . '" dir="' . ( is_rtl() ? 'rtl' : 'ltr' ) . '"><div class="wpnt-notes-panel-header"><span class="wpnt-notes-header">' . __( 'Notifications', 'jetpack' ) . '</span><span class="wpnt-notes-panel-link"></span></div></div>',
 				'class' => 'menupop',
 			),
 			'parent' => 'top-secondary',


### PR DESCRIPTION
Fixes #14257

#### Changes proposed in this Pull Request:

Twenty Twenty bundles a functionality named "Intrinsic Ratio Embeds", allowing videos (iframe, object, video) to be automatically resized on demand.
This is practical, but can be problematic for some elements on the page that may not behave like a video, or that may not be in the post content at all.

The Notifications iFrame is one such element. Let's use the CSS class provided within Twenty Twenty to be excluded from that behaviour:
https://core.trac.wordpress.org/browser/branches/5.3/src/wp-content/themes/twentytwenty/assets/js/index.js#L301

#### Testing instructions:

* Enable the Twenty Twenty theme on your site.
* Make sure the Notifications module is active.
* Load your site's frontend 
* Ensure you can load the Notifications panel.

#### Proposed changelog entry for your changes:
* Notifications: avoid conflicts with Twenty Twenty's instrinsic video resizes.
