### PR TITLE
3rd Party: Remove code from the global scope

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -6,26 +6,35 @@
  * @package Jetpack
  */
 
-// Array of third-party compat files to always require.
-$compat_files = array(
-	'bbpress.php',
-	'beaverbuilder.php',
-	'bitly.php',
-	'buddypress.php',
-	'class.jetpack-amp-support.php',
-	'class.jetpack-modules-overrides.php', // Special case. Tools to be used to override module settings.
-	'debug-bar.php',
-	'domain-mapping.php',
-	'polldaddy.php',
-	'qtranslate-x.php',
-	'vaultpress.php',
-	'wpml.php',
-	'woocommerce.php',
-	'woocommerce-services.php',
-);
+namespace Automattic\Jetpack;
 
-foreach ( $compat_files as $file ) {
-	if ( file_exists( JETPACK__PLUGIN_DIR . '/3rd-party/' . $file ) ) {
-		require_once JETPACK__PLUGIN_DIR . '/3rd-party/' . $file;
+/**
+ * Loads the individual 3rd-party compat files.
+ */
+function load_3rd_party() {
+	// Array of third-party compat files to always require.
+	$compat_files = array(
+		'bbpress.php',
+		'beaverbuilder.php',
+		'bitly.php',
+		'buddypress.php',
+		'class.jetpack-amp-support.php',
+		'class.jetpack-modules-overrides.php', // Special case. Tools to be used to override module settings.
+		'debug-bar.php',
+		'domain-mapping.php',
+		'polldaddy.php',
+		'qtranslate-x.php',
+		'vaultpress.php',
+		'wpml.php',
+		'woocommerce.php',
+		'woocommerce-services.php',
+	);
+
+	foreach ( $compat_files as $file ) {
+		if ( file_exists( JETPACK__PLUGIN_DIR . '/3rd-party/' . $file ) ) {
+			require_once JETPACK__PLUGIN_DIR . '/3rd-party/' . $file;
+		}
 	}
 }
+
+load_3rd_party();


### PR DESCRIPTION
Browsing the codebase and saw that we had this globally scoped. I'd hate to somehow run into a conflict with other globally scoped things.

#### Changes proposed in this Pull Request:
* Encapsulate loading code in a function.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
Confirm the 3rd-party code loads. Debug bar is an easy way to verify JP code is loading as a panel.

* Run `yarn docker:wp jetpack module activate search` on a test site with Professional.
* Install Debug Bar
* Confirm a Jetpack Search panel.

#### Proposed changelog entry for your changes:
* I'd include it in a general line item about improved adherence to coding standards.
