### PR TITLE
Instant search: sync master merge changes

### DIFF
--- a/modules/search/instant-search/README.md
+++ b/modules/search/instant-search/README.md
@@ -9,13 +9,13 @@ Eventually, we expect this module to enhance all front-end views that enable the
 ### High-level overview of the development flow
 
 1. Use the [Jetpack Docker environment](https://github.com/Automattic/jetpack/tree/master/docker#readme).
-1. Start a new branch.
-1. Modify/Improve the code in the instant-search directories. New libs get added to the common package.json.
-1. Run `yarn build-search [--watch]` to compile your changes.
-1. Now test your changes on the front end of your test site.
-1. Open a PR, and a WordPress.com diff will be automatically generated with your changes.
-1. Test the WordPress.com diff
-1. Once the code works well in both environments and has been approved by a Jetpack crew member, you can merge your branch!
+2. Start a new branch.
+3. Modify/Improve the code in the instant-search directories. New libs get added to the common package.json.
+4. Run `yarn build-search [--watch]` to compile your changes.
+5. Now test your changes on the front end of your test site.
+6. Open a PR, and a WordPress.com diff will be automatically generated with your changes.
+7. Test the WordPress.com diff
+8. Once the code works well in both environments and has been approved by a Jetpack crew member, you can merge your branch!
 
 ### Beta Features
 
@@ -23,13 +23,13 @@ TBD
 
 ### Testing Instructions
 
-Add define( "JETPACK_SEARCH_PROTOTYPE", true ); to your wp-config.php. If using Jetpack's Docker development environment, you can create a file at /docker/mu-plugins/instant-search.php and add the define there.
+1. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your `wp-config.php`. If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.
 
-Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).
+2. Ensure that your site has the Jetpack Pro plan and Jetpack Search enabled. You can enable Jetpack Search in the Performance tab within the Jetpack menu (/wp-admin/admin.php?page=jetpack#/performance).
 
-Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.
+3. Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.
 
-If using a theme with a sidebar widget, you can navigate to / to start the search experience. Otherwise, navigate to your search page (e.g. /?s=hello).
+4. If using a theme with a sidebar widget, you can navigate to / to start the search experience. Otherwise, navigate to your search page (e.g. `/?s=hello`).
 
 ## Architectural Choices
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -42,7 +42,7 @@ const SearchBox = props => {
 				type="search"
 				value={ props.query }
 			/>
-			{ ! props.widget && (
+			{ props.enableFilters && ! props.widget && (
 				/* Using role='button' rather than button element so we retain control over styling */
 				<div
 					role="button"

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -25,7 +25,7 @@ const noop = event => event.preventDefault();
 
 class SearchForm extends Component {
 	state = {
-		showFilters: false,
+		showFilters: !! this.props.widget,
 	};
 
 	onChangeFilter = ( filterName, filterValue ) => setFilterQuery( filterName, filterValue );
@@ -33,9 +33,7 @@ class SearchForm extends Component {
 	onChangeSort = sort => setSortQuery( sort );
 
 	toggleFilters = () => {
-		this.setState( state => ( {
-			showFilters: ! state.showFilters,
-		} ) );
+		this.setState( state => ( { showFilters: ! state.showFilters } ) );
 	};
 
 	render() {
@@ -43,6 +41,7 @@ class SearchForm extends Component {
 			<form onSubmit={ noop } role="search" className={ this.props.className }>
 				<div className="search-form">
 					<SearchBox
+						enableFilters
 						onChangeQuery={ this.onChangeQuery }
 						onFocus={ this.props.onSearchFocus }
 						onBlur={ this.props.onSearchBlur }

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -100,11 +100,11 @@ class SearchResultMinimal extends Component {
 				<h3 className="jetpack-instant-search__search-result-title">
 					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 					<a
-						href={ `//${ fields[ 'permalink.url.raw' ] }` }
 						className="jetpack-instant-search__search-result-minimal-title"
+						href={ `//${ fields[ 'permalink.url.raw' ] }` }
+						onClick={ this.props.onClick }
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
-						onClick={ this.onClick }
 					/>
 				</h3>
 				{ noMatchingContent ? this.renderNoMatchingContent() : this.renderMatchingContent() }

--- a/modules/search/instant-search/components/search-result-product.jsx
+++ b/modules/search/instant-search/components/search-result-product.jsx
@@ -26,10 +26,11 @@ class SearchResultProduct extends Component {
 			<li className="jetpack-instant-search__search-result-product">
 				<h3>
 					<a
-						href={ `//${ fields[ 'permalink.url.raw' ] }` }
-						target="_blank"
-						rel="noopener noreferrer"
 						className="jetpack-instant-search__result-product-title"
+						href={ `//${ fields[ 'permalink.url.raw' ] }` }
+						onClick={ this.props.onClick }
+						rel="noopener noreferrer"
+						target="_blank"
 						//eslint-disable-next-line react/no-danger
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -26,6 +26,7 @@ class SearchResult extends Component {
 			railcar: this.props.result.railcar.railcar,
 			rec_blog_id: this.props.result.railcar.rec_blog_id,
 			rec_post_id: this.props.result.railcar.rec_post_id,
+			// TODO: Add a way to differentiate between different result formats
 			ui_algo: 'jetpack-instant-search-ui/v1',
 			ui_position: this.props.index,
 		};
@@ -38,10 +39,10 @@ class SearchResult extends Component {
 
 	render() {
 		if ( this.props.resultFormat === RESULT_FORMAT_PRODUCT ) {
-			return <SearchResultProduct { ...this.props } />;
+			return <SearchResultProduct onClick={ this.onClick } { ...this.props } />;
 		}
 
-		return <SearchResultMinimal { ...this.props } />;
+		return <SearchResultMinimal onClick={ this.onClick } { ...this.props } />;
 	}
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,8 +30,7 @@ const sharedWebpackConfig = {
 	devtool: isDevelopment ? 'source-map' : false,
 };
 
-// We export two main configuration files: One for admin.js, and one for static.jsx. The latter produces pre-rendered HTML.
-// The third configuration file is for Jetpack Search's Preact app.
+// We export two configuration files: One for admin.js, and one for static.jsx. The latter produces pre-rendered HTML.
 module.exports = [
 	{
 		...sharedWebpackConfig,

--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -44,8 +44,8 @@ module.exports = [
 					hints: 'error',
 			  }
 			: {
-					maxAssetSize: 71680,
-					maxEntrypointSize: 71680,
+					maxAssetSize: 122880,
+					maxEntrypointSize: 122880,
 					hints: 'error',
 			  },
 	},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
In #14247 we're merging our `instant-search-master` branch back into Jetpack `master`. As part of the review process, we've made a number of fixes. This PR adds those fixes to the `instant-search-master` branch.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No - this pulls fixes from another PR into the `instant-search-master`.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. If you haven't already, set up Instant Search following the instructions in the [readme](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions).
2. Enter a search query into your site's search input. Ensure that the search results render onto your site's main content area.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not required.
