### PR TITLE
Sync: Unhook shutdown sender from `start` and `pull` endpoints.

### DIFF
--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -127,9 +127,24 @@ class Actions {
 			self::should_initialize_sender()
 		) ) {
 			self::initialize_sender();
-			add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
-			add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
+			self::hook_sender();
 		}
+	}
+
+	/**
+	 * Send on shutdown.
+	 */
+	public static function hook_sender() {
+		add_action( 'shutdown', array( self::$sender, 'do_sync' ) );
+		add_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
+	}
+
+	/**
+	 * Don't Send on shutdown.
+	 */
+	public static function unhook_sender() {
+		remove_action( 'shutdown', array( self::$sender, 'do_sync' ) );
+		remove_action( 'shutdown', array( self::$sender, 'do_full_sync' ), 9999 );
 	}
 
 	/**

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -160,6 +160,10 @@ class Actions {
 			return self::sync_via_cron_allowed();
 		}
 
+		if ( isset( $_GET['jp_no_sender'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return false;
+		}
+
 		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 			return true;
 		}


### PR DESCRIPTION
Before:

Wild sync.

After:

Peaceful sync.