### PR TITLE
Unit tests: Update @covers annotations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -110,6 +110,8 @@
 			<directory suffix=".php">.</directory>
 			<exclude>
 				<directory suffix=".php">tests</directory>
+				<directory suffix=".php">vendor</directory>
+				<directory suffix=".php">views</directory>
 			</exclude>
 		</whitelist>
 	</filter>

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -3,6 +3,11 @@
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
 
+/**
+ * Test class for Jetpack
+ *
+ * @covers Jetpack
+ */
 class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testcase {
 	protected static $admin_id;
 
@@ -58,7 +63,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author roccotripaldi
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_token_or_signature() {
 		global $wp_version;
@@ -76,7 +80,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_token() {
 		$_GET['signature'] = 'invalid';
@@ -88,7 +91,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_authentication_fail_no_signature() {
 		$_GET['token'] = 'invalid';
@@ -100,7 +102,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author roccotripaldi
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_authentication_fail_invalid_token() {
 		$_GET['token'] = 'invalid';
@@ -113,7 +114,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_authentication_fail_bad_nonce() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -133,7 +133,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_authentication_fail_bad_signature() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -150,7 +149,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_get_authentication_success() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -179,7 +177,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_post_authentication_fail_bad_signature() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -198,7 +195,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_post_authentication_fail_bad_body_hash() {
 		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
@@ -228,7 +224,6 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 
 	/**
 	 * @author jnylen0
-	 * @covers Jetpack->wp_rest_authenticate
 	 */
 	public function test_jetpack_rest_api_post_authentication_success() {
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/json';
@@ -267,7 +262,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	}
 
 	/**
-	 * @covers Jetpack->wp_rest_authenticate
+	 * Test for urlencoded request
 	 */
 	public function test_jetpack_rest_api_post_urlencoded_authentication_success() {
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
@@ -309,7 +304,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	}
 
 	/**
-	 * @covers Jetpack->wp_rest_authenticate
+	 * Test for multipart request
 	 */
 	public function test_jetpack_rest_api_post_multipart_authentication_success() {
 		$_SERVER['HTTP_CONTENT_TYPE'] = 'multipart/form-data; boundary=------------------------test';

--- a/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-module-endpoints.php
@@ -6,7 +6,7 @@ require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server
 class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_REST_Testcase {
 	/**
 	 * @author zinigor
-	 * @covers Jetpack_Core_API_Module_Activate_Endpoint
+	 * @covers Jetpack_Core_Json_Api_Endpoints
 	 * @dataProvider api_routes
 	 */
 	public function test_register_routes( $route_string = false, $method = false, $classname = false ) {
@@ -17,6 +17,7 @@ class WP_Test_Jetpack_Core_Api_Module_Activate_Endpoint extends WP_Test_Jetpack_
 		foreach ( $routes[ $route_string ] as $item ) {
 			if ( isset( $item['methods'][ $method ] ) ) {
 				$route = $item;
+				break;
 			}
 		}
 

--- a/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
+++ b/tests/php/core-api/test_class.jetpack-core-api-xmlrpc-consumer-endpoint.php
@@ -2,16 +2,13 @@
 require_once JETPACK__PLUGIN_DIR . '/_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
 
 class WP_Test_Jetpack_Core_Api_Xmlrpc_Consumer_Endpoint extends WP_UnitTestCase {
-
-	private $home_url = 'http://example.com';
-
 	public function setUp() {
 		parent::setUp();
 	}
 
 	/**
 	 * @author zinigor
-	 * @covers Jetpack_Core_XMLRPC_Consumer_Endpoint
+	 * @covers Jetpack_Core_API_XMLRPC_Consumer_Endpoint
 	 * @dataProvider true_false_provider
 	 */
 	public function test_Jetpack_Core_API_XMLRPC_Consumer_Endpoint_privacy_check( $query_success, $result ) {

--- a/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -1,6 +1,11 @@
 <?php
 require_jetpack_file( 'modules/contact-form/grunion-contact-form.php' );
 
+/**
+ * Test class for Grunion_Contact_Form
+ *
+ * @covers Grunion_Contact_Form
+ */
 class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	public static function setUpBeforeClass() {
@@ -68,7 +73,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 *
 	 * Tests that the submission as a whole will produce something in the
 	 * database when required information is provided
@@ -92,7 +96,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 *
 	 * Tests that the submission as a whole will produce something in the
 	 * database when some labels are provided
@@ -134,7 +137,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 *
 	 * Tests that the submission will store the subject when specified
 	 */
@@ -156,7 +158,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_will_store_subject_with_token_replaced_from_name_and_text_field() {
 		// Fill field values
@@ -183,7 +184,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_will_store_subject_with_token_replaced_from_radio_button_field() {
 		// Fill field values
@@ -209,7 +209,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_will_store_subject_with_token_replaced_from_dropdown_field() {
 		// Fill field values
@@ -235,7 +234,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_will_store_fields_and_their_values_to_post_content() {
 		// Fill field values
@@ -268,7 +266,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_will_store_fields_and_their_values_to_email_meta() {
 		// Fill field values
@@ -308,7 +305,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_sends_correct_single_email() {
 		// Fill field values
@@ -346,7 +342,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_sends_correct_multiple_email() {
 		// Fill field values
@@ -372,7 +367,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_fails_if_spam_marked_with_WP_Error() {
 		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'pre_test_process_submission_fails_if_spam_marked_with_WP_Error' ), 11 ); // Run after akismet filter
@@ -390,7 +384,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_wont_send_spam_if_marked_as_spam_with_true() {
 		add_filter( 'jetpack_contact_form_is_spam', '__return_true', 11 ); // Run after akismet filter
@@ -408,7 +401,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::process_submission
 	 */
 	public function test_process_submission_labels_message_as_spam_in_subject_if_marked_as_spam_with_true_and_sending_spam() {
 		add_filter( 'jetpack_contact_form_is_spam', '__return_true' , 11 ); // Run after akismet filter
@@ -458,7 +450,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
+	 * @covers Grunion_Contact_Form_Plugin
 	 */
 	public function test_token_left_intact_when_no_matching_field() {
 		$plugin = Grunion_Contact_Form_Plugin::init();
@@ -472,7 +464,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
+	 * @covers Grunion_Contact_Form_Plugin
 	 */
 	public function test_replaced_with_empty_string_when_no_value_in_field() {
 		$plugin = Grunion_Contact_Form_Plugin::init();
@@ -486,7 +478,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
+	 * @covers Grunion_Contact_Form_Plugin
 	 */
 	public function test_token_can_replace_entire_subject_with_token_field_whose_name_has_whitespace() {
 		$plugin = Grunion_Contact_Form_Plugin::init();
@@ -500,7 +492,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form_Plugin::replace_tokens_with_input
+	 * @covers Grunion_Contact_Form_Plugin
 	 */
 	public function test_token_with_curly_brackets_can_be_replaced() {
 		$plugin = Grunion_Contact_Form_Plugin::init();
@@ -514,7 +506,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::parse_contact_field
 	 */
 	public function test_parse_contact_field_keeps_string_unchaned_when_no_escaping_necesssary() {
 		add_shortcode( 'contact-field', array( 'Grunion_Contact_Form', 'parse_contact_field' ) );
@@ -539,6 +530,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertEquals( "[contact-field type=\"select\" required=\"1\" options=\"fun,run\" label=\"fun times\" values=\"go,have some fun\"/]", $html );
 	}
 
+	/**
+	 * Test for text field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_text_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -552,6 +548,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'text' ) );
 		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
 	}
+
+	/**
+	 * Test for email field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_email_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -566,6 +568,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for url field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_url_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -580,6 +587,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for telephone field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_telephone_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -594,6 +606,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for date field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_date_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -608,6 +625,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for textarea field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_textarea_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -622,6 +644,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for checkbox field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_checkbox_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -635,7 +662,12 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$expected_attributes = array_merge( $attributes, array( 'input_type' => 'checkbox' ) );
 		$this->assertValidCheckboxField( $this->render_field( $attributes ), $expected_attributes );
 	}
-	// Multiple fields
+
+	/**
+	 * Multiple fields
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_checkbox_multiple_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -651,6 +683,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for radio field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_radio_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -666,6 +703,11 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$this->assertValidFieldMultiField( $this->render_field( $attributes ), $expected_attributes );
 	}
 
+	/**
+	 * Test for select field_renders
+	 *
+	 * @covers Grunion_Contact_Form_Field
+	 */
 	public function test_make_sure_select_field_renders_as_expected() {
 		$attributes = array(
 			'label' => 'fun',
@@ -852,7 +894,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author tonykova
-	 * @covers Grunion_Contact_Form::parse_contact_field
 	 */
 	public function test_parse_contact_field_escapes_things_inside_a_value_and_attribute_and_the_content() {
 		global $wp_version;
@@ -874,6 +915,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with fully vaid data input.
 	 *
+	 * @covers Grunion_Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_fully_valid_data() {
@@ -975,6 +1017,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for post meta
 	 *
+	 * @covers Grunion_Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_single_entry_meta() {
@@ -1066,6 +1109,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with invalid all entries for post meta
 	 *
+	 * @covers Grunion_Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_invalid_all_entries_meta() {
@@ -1148,6 +1192,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with single invalid entry for parsed fields.
 	 *
+	 * @covers Grunion_Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_single_invalid_entry_for_parse_fields() {
@@ -1247,6 +1292,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test get_export_data_for_posts with all entries for parsed fields invalid.
 	 *
+	 * @covers Grunion_Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_get_export_data_for_posts_all_entries_for_parse_fields_invalid() {
@@ -1284,6 +1330,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 	/**
 	 * Test map_parsed_field_contents_of_post_to_field_names
 	 *
+	 * @covers Grunion_Contact_Form_Plugin
 	 * @group csvexport
 	 */
 	public function test_map_parsed_field_contents_of_post_to_field_names() {
@@ -1315,9 +1362,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author jaswrks
-	 * @covers Grunion_Contact_Form::personal_data_exporter
-	 * @covers Grunion_Contact_Form::personal_data_post_ids_by_email
-	 * @covers Grunion_Contact_Form::personal_data_search_filter
 	 */
 	public function test_personal_data_exporter() {
 		$this->add_field_values( array(
@@ -1364,9 +1408,6 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 
 	/**
 	 * @author jaswrks
-	 * @covers Grunion_Contact_Form::personal_data_eraser
-	 * @covers Grunion_Contact_Form::personal_data_post_ids_by_email
-	 * @covers Grunion_Contact_Form::personal_data_search_filter
 	 */
 	public function test_personal_data_eraser() {
 		$this->add_field_values( array(
@@ -1463,5 +1504,4 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 		$posts = get_posts( array( 'post_type' => 'feedback' ) );
 		$this->assertSame( 0, count( $posts ), 'posts count matches after deleting the other feedback responder' );
 	}
-
 } // end class

--- a/tests/php/modules/publicize/test_class.publicize.php
+++ b/tests/php/modules/publicize/test_class.publicize.php
@@ -3,6 +3,7 @@ require dirname( __FILE__ ) . '/../../../../modules/publicize.php';
 
 /**
  * @group publicize
+ * @covers Publicize
  */
 class WP_Test_Publicize extends WP_UnitTestCase {
 
@@ -166,7 +167,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 *
 	 * @see https://jetpack.com/support/publicize/
 	 *
-	 * @covers Publicize::post_type_is_publicizeable()
 	 * @since 4.6.0
 	 */
 	public function test_publicize_post_type_is_publicizeable_cpt() {
@@ -247,7 +247,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * the helper method that checks post flags to prevent re-sharing
 	 * of already shared post.
 	 *
-	 * @covers Publicize::post_is_done_sharing()
 	 * @since 6.7.0
 	 */
 	public function test_post_is_done_sharing_for_done_all() {
@@ -266,7 +265,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * Verifies that "done sharing post" logic is correct. Checks
 	 * that already published post is correctly reported as 'done'.
 	 *
-	 * @covers Publicize::post_is_done_sharing()
 	 * @since 6.7.0
 	 */
 	public function test_post_is_done_sharing_for_published() {
@@ -289,7 +287,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * Verifies that get_services_connected returns all test
 	 * connections that are valid for the current user.
 	 *
-	 * @covers Publicize::get_services_connected()
 	 * @since 6.7.0
 	 */
 	public function test_get_services_connected() {
@@ -303,7 +300,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * when there are no connection filters and the post
 	 * has not been shared yet.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_get_filtered_connection_data_no_filters() {
@@ -349,7 +345,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * no current post. 'Done' return value should be false
 	 * so a new post will not have connections disabled.
 	 *
-	 * @covers Publicize::post_is_done_sharing()
 	 * @since 6.7.0
 	 */
 	public function test_post_is_done_sharing_null_post() {
@@ -369,7 +364,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * no current post. Connections data should be passed
 	 * through without disabling connections.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_get_filtered_connection_data_null_post() {
@@ -394,7 +388,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * connection list before and after a 'no facebook' filter has
 	 * been applied.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_filter_wpas_submit_post() {
@@ -430,7 +423,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * 'publicize_checkbox_global_default' filter can be used to
 	 * uncheck such a global connection.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_filter_publicize_checkbox_global_default_for_global_connection() {
@@ -472,7 +464,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * This test verifies that the 'publicize_checkbox_global_default'
 	 * filter has no effect on a normal connection.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_filter_publicize_checkbox_global_default_for_normal_connection() {
@@ -507,7 +498,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * This test confirms that the 'publicize_checkbox_default'
 	 * can correctly set a normal connection unchecked.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_filter_publicize_checkbox_default_for_normal_connection() {
@@ -533,7 +523,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * This test confirms that the 'publicize_checkbox_default'
 	 * can be used to set a global connection to unchecked.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_filter_publicize_checkbox_default_for_global_connection() {
@@ -560,7 +549,6 @@ class WP_Test_Publicize extends WP_UnitTestCase {
 	 * If a post has already been published, its checkbox should be
 	 * disabled.
 	 *
-	 * @covers Publicize::get_filtered_connection_data()
 	 * @since 6.7.0
 	 */
 	public function test_get_filtered_connection_data_disabled_after_publish() {

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Test class for CrowdsignalShortcode
+ *
+ * @covers CrowdsignalShortcode
+ */
 class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 	public function setUp() {
@@ -11,7 +16,6 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers CrowdSignal::crowdsignal_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_crowdsignal_exists() {
@@ -21,7 +25,6 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers CrowdSignal::crowdsignal_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_crowdsignal() {
@@ -34,7 +37,6 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 	/**
 	 * @author scotchfield
-	 * @covers CrowdSignal::crowdsignal_shortcode
 	 * @since 3.2
 	 */
 	public function test_shortcodes_polldaddy() {

--- a/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/tests/php/modules/shortcodes/test-class.recipe.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Test class for Jetpack_Recipes
+ *
+ * @covers Jetpack_Recipes
+ */
 class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
@@ -17,8 +21,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the shortcodes exist.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_exists() {
@@ -33,8 +35,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe shortcode outputs prep time in HTML.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_preptime() {
@@ -46,8 +46,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the recipe shortcode outputs cook time in HTML.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */
@@ -61,8 +59,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe shortcode outputs rating in HTML.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_rating() {
@@ -74,8 +70,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the recipe shortcode does not output an image with an empty source.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */
@@ -89,8 +83,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe shortcode does not output an image with an invalid source string.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_invalid_src() {
@@ -103,8 +95,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe shortcode does not output an image with an invalid attachment ID.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_invalid_attachment() {
@@ -116,8 +106,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the recipe shortcode outputs an image with a valid attachment ID.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */
@@ -142,8 +130,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe shortcode outputs an image with a src string.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_src() {
@@ -155,8 +141,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the recipe shortcode does not output an image if an empty recipe-image shortcode exists.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */
@@ -170,8 +154,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-image shortcode does not output an image with no parameters.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_shortcode_empty() {
@@ -184,8 +166,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-image shortcode does not output an image with an empty image attribute.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_shortcode_empty_attr() {
@@ -197,8 +177,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the recipe-image shortcode outputs an image with a string parameter.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */
@@ -213,8 +191,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-image shortcode outputs an image with a string parameter.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_shortcode_src_attr() {
@@ -228,8 +204,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-image shortcode does not output an image with an invalid attachment.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_shortcode_invalid_attachment() {
@@ -242,8 +216,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-image shortcode does not output an image with an invalid attachment attribute.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_shortcode_invalid_attachment_attr() {
@@ -255,8 +227,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
 	 * Verify that the recipe-image shortcode outputs an image with a valid attachment ID.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */
@@ -281,8 +251,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-image shortcode outputs an image with a valid attachment ID attribute.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_image_shortcode_attachment_attr() {
@@ -306,8 +274,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	/**
 	 * Verify that the recipe-nutrition shortcode formats a list of nutrition info.
 	 *
-	 * @covers ::recipe_shortcode
-	 *
 	 * @since 8.0.0
 	 */
 	public function test_shortcodes_recipe_nutrition() {
@@ -326,8 +292,6 @@ EOT;
 
 	/**
 	 * Verify that the recipe shortcode allows needed content via KSES.
-	 *
-	 * @covers ::recipe_shortcode
 	 *
 	 * @since 8.0.0
 	 */

--- a/tests/php/modules/shortcodes/test-class.vr.php
+++ b/tests/php/modules/shortcodes/test-class.vr.php
@@ -4,7 +4,7 @@ class WP_Test_Jetpack_Shortcodes_VR extends WP_UnitTestCase {
 
 	/**
 	 * @author mkaz
-	 * @covers ::vr_shortcode
+	 * @covers ::jetpack_vr_viewer_shortcode
 	 * @since 4.5
 	 */
 	public function test_shortcodes_vr_exists() {
@@ -13,7 +13,7 @@ class WP_Test_Jetpack_Shortcodes_VR extends WP_UnitTestCase {
 
 	/**
 	 * @author mkaz
-	 * @covers ::vr_shortcode
+	 * @covers ::jetpack_vr_viewer_shortcode
 	 * @since 4.5
 	 */
 	public function test_shortcodes_vr() {
@@ -26,7 +26,7 @@ class WP_Test_Jetpack_Shortcodes_VR extends WP_UnitTestCase {
 
 	/**
 	 * @author mkaz
-	 * @covers ::vr_shortcode
+	 * @covers ::jetpack_vr_viewer_shortcode
 	 * @since 4.5
 	 */
 	public function test_shortcodes_vr_url() {
@@ -40,7 +40,7 @@ class WP_Test_Jetpack_Shortcodes_VR extends WP_UnitTestCase {
 
 	/**
 	 * @author mkaz
-	 * @covers ::vr_shortcode
+	 * @covers ::jetpack_vr_viewer_shortcode
 	 * @since 4.5
 	 */
 	public function test_shortcodes_vr_url_missing() {
@@ -48,6 +48,4 @@ class WP_Test_Jetpack_Shortcodes_VR extends WP_UnitTestCase {
 		$shortcode_content = do_shortcode( $content );
 		$this->assertEmpty( $shortcode_content );
 	}
-
-
 }

--- a/tests/php/modules/sitemaps/test-class.sitemap-constants.php
+++ b/tests/php/modules/sitemaps/test-class.sitemap-constants.php
@@ -23,9 +23,6 @@ class WP_Test_Jetpack_Sitemap_Constants extends WP_UnitTestCase {
 	 * @link http://www.sitemaps.org/ Sitemap protocol.
 	 * @link https://support.google.com/news/publisher/answer/74288?hl=en News sitemap extension.
 	 *
-	 * @covers JP_SITEMAP_MAX_BYTES
-	 * @covers JP_SITEMAP_MAX_ITEMS
-	 * @covers JP_NEWS_SITEMAP_MAX_ITEMS
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -49,11 +46,6 @@ class WP_Test_Jetpack_Sitemap_Constants extends WP_UnitTestCase {
 	/**
 	 * Sitemap type constants are all distinct.
 	 *
-	 * @covers JP_MASTER_SITEMAP_TYPE
-	 * @covers JP_SITEMAP_TYPE
-	 * @covers JP_SITEMAP_INDEX_TYPE
-	 * @covers JP_IMAGE_SITEMAP_TYPE
-	 * @covers JP_IMAGE_SITEMAP_INDEX_TYPE
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */

--- a/tests/php/modules/sitemaps/test-class.sitemap-librarian.php
+++ b/tests/php/modules/sitemaps/test-class.sitemap-librarian.php
@@ -12,6 +12,7 @@ require_jetpack_file( 'modules/sitemaps/sitemap-librarian.php' );
 /**
  * Test class for Jetpack_Sitemap_Librarian.
  *
+ * @covers Jetpack_Sitemap_Librarian
  * @since 4.7.0
  */
 class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
@@ -19,7 +20,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Constructor does not throw a fatal error.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::__construct
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -31,7 +31,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Getting an unset row returns null.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::read_sitemap_data
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -44,7 +43,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Deleting an unset row returns false.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::delete_sitemap_data
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -57,7 +55,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Deleting a set row returns true.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::delete_sitemap_data
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -71,7 +68,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Getting a set row is the identity(ish).
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::store_sitemap_data
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -95,7 +91,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Setting the same name/type twice overwrites old data.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::store_sitemap_data
 	 * @since 4.7.0
 	 */
 	public function test_sitemap_librarian_set_then_set_overwrites_data() {
@@ -118,7 +113,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Getting the text of a set row is the identity.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::get_sitemap_text
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */
@@ -139,7 +133,6 @@ class WP_Test_Jetpack_Sitemap_Librarian extends WP_UnitTestCase {
 	/**
 	 * Delete contiguously named rows.
 	 *
-	 * @covers Jetpack_Sitemap_Librarian::delete_numbered_sitemap_rows_after
 	 * @group jetpack-sitemap
 	 * @since 4.7.0
 	 */

--- a/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
+++ b/tests/php/modules/verification-tools/test_functions.verification-tools-utils.php
@@ -5,7 +5,7 @@ class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
 
 	/**
 	 * @author cbauerman
-	 * @covers jetpack_verification_validate
+	 * @covers ::jetpack_verification_validate
 	 * @since 6.5.0
 	 */
 	public function test_jetpack_verification_validate_google_raw_code() {
@@ -18,7 +18,7 @@ class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
 
 	/**
 	 * @author cbauerman
-	 * @covers jetpack_verification_validate
+	 * @covers ::jetpack_verification_validate
 	 * @since 6.5.0
 	 */
 	public function test_jetpack_verification_validate_google_code_in_meta_double_quotes() {
@@ -31,7 +31,7 @@ class WP_Test_Jetpack_Verification_Tools_Utils extends WP_UnitTestCase {
 
 	/**
 	 * @author cbauerman
-	 * @covers jetpack_verification_validate
+	 * @covers ::jetpack_verification_validate
 	 * @since 6.5.0
 	 */
 	public function test_jetpack_verification_validate_google_code_in_meta_single_quotes() {

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -16,7 +16,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * Tests the VideoPress Flash to oEmbedable URL filter.
 	 *
 	 * @author kraftbj
-	 * @covers jetpack_videopress_flash_embed_filter
+	 * @covers ::jetpack_videopress_flash_embed_filter
 	 * @since 8.1.0
 	 */
 	public function test_jetpack_videopress_flash_embed_filter_flash() {

--- a/tests/php/modules/wpcom-block-editor/test_class-jetpack-wpcom-block-editor.php
+++ b/tests/php/modules/wpcom-block-editor/test_class-jetpack-wpcom-block-editor.php
@@ -27,8 +27,6 @@ class WP_Test_Jetpack_WPCOM_Block_Editor extends WP_UnitTestCase {
 	}
 	/**
 	 * Test_verify_frame_nonce.
-	 *
-	 * @covers ::verify_frame_nonce
 	 */
 	public function test_verify_frame_nonce() {
 		$wpcom_block_editor = Jetpack_WPCOM_Block_Editor::init();

--- a/tests/php/test_functions.photon.php
+++ b/tests/php/test_functions.photon.php
@@ -22,7 +22,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author kraftbj
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since 3.9.2
 	 */
 	public function test_photonizing_https_image_adds_ssl_query_arg() {
@@ -33,7 +33,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author kraftbj
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  3.9.2
 	 */
 	public function test_photonizing_http_image_no_ssl_query_arg() {
@@ -44,7 +44,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -59,7 +59,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -74,7 +74,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -86,7 +86,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -98,7 +98,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_no_filter
 	 */
@@ -110,7 +110,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -123,7 +123,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -136,7 +136,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -149,7 +149,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -162,7 +162,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_http
 	 */
@@ -175,7 +175,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -188,7 +188,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -201,7 +201,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -214,7 +214,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -227,7 +227,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url
+	 * @covers ::jetpack_photon_url
 	 * @since  4.5.0
 	 * @group  jetpack_photon_filter_network_path
 	 */
@@ -240,7 +240,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -252,7 +252,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -264,7 +264,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -276,7 +276,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -288,7 +288,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -300,7 +300,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -312,7 +312,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_url_scheme
+	 * @covers ::jetpack_photon_url_scheme
 	 * @since  4.5.0
 	 * @group  jetpack_photon_url_scheme
 	 */
@@ -324,7 +324,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_banned_domains
+	 * @covers ::jetpack_photon_banned_domains
 	 * @since  5.0.0
 	 * @group  jetpack_photon_banned_domains
 	 */
@@ -335,7 +335,7 @@ class WP_Test_Jetpack_Photon_Functions extends WP_UnitTestCase {
 
 	/**
 	 * @author aduth
-	 * @covers jetpack_photon_banned_domains
+	 * @covers ::jetpack_photon_banned_domains
 	 * @since  5.0.0
 	 * @group  jetpack_photon_banned_domains
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* fix incorrectly defined @covers annotations

Also, I updated some of the annotations to use class scope instead of method scope as recommended in PHPUnit docs: https://phpunit.readthedocs.io/en/8.4/annotations.html#appendixes-annotations-covers-tables-annotations

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check Code coverage build in CI
* There should be no warnings related to @covers annotations such as:
`Trying to @cover or @use not existing class or interface "Jetpack->wp_rest_authenticate".`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
