### PR TITLE
Subscriptions: Add a clear message when an email having many pending confirmations tries to subscribe a site.

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -568,6 +568,9 @@ class Jetpack_Subscriptions {
 			case 'pending':
 				$result = 'already';
 				break;
+			case 'flooded_email':
+				$result = 'many_pending_subs';
+				break;
 			default:
 				$result = 'error';
 				break;

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -150,6 +150,12 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							__( 'Manage your email preferences.', 'jetpack' )
 						); ?></p>
 					<?php break;
+				case 'many_pending_subs' : ?>
+					<p class="error"><?php printf( __( 'You have a few pending subscriptions. <br /> You can manage your preferences at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a> before continuing.', 'jetpack' ),
+							'https://subscribe.wordpress.com/',
+							__( 'Manage your email preferences.', 'jetpack' )
+						); ?></p>
+					<?php break;
 				case 'success' : ?>
                     <div class="success"><?php echo wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total['value'] ), $success_message ) ); ?></div>
 					<?php break;

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -151,7 +151,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						); ?></p>
 					<?php break;
 				case 'many_pending_subs' : ?>
-					<p class="error"><?php printf( __( 'You have a few pending subscriptions. <br /> You can manage your preferences at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a> before continuing.', 'jetpack' ),
+					<p class="error"><?php printf( __( 'You already have several pending email subscriptions. <br /> Approve or delete a few subscriptions at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a> before continuing.', 'jetpack' ),
 							'https://subscribe.wordpress.com/',
 							__( 'Manage your email preferences.', 'jetpack' )
 						); ?></p>

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -6,6 +6,19 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	 * @var array When printing the submit button, what tags are allowed
 	 */
 	static $allowed_html_tags_for_submit_button = array( 'br' => array() );
+	/**
+	 * Use this variable when printing the message after submitting an email in subscription widgets
+	 *
+	 * @var array what tags are allowed
+	 */
+	public static $allowed_html_tags_for_message = array(
+		'a'  => array(
+			'href'  => array(),
+			'title' => array(),
+			'rel'   => array(),
+		),
+		'br' => array(),
+	);
 
 	function __construct() {
 		$widget_ops = array(
@@ -150,11 +163,21 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 							__( 'Manage your email preferences.', 'jetpack' )
 						); ?></p>
 					<?php break;
-				case 'many_pending_subs' : ?>
-					<p class="error"><?php printf( __( 'You already have several pending email subscriptions. <br /> Approve or delete a few subscriptions at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a> before continuing.', 'jetpack' ),
+				case 'many_pending_subs':
+					?>
+					<p class="error">
+						<?php
+						printf(
+							wp_kses(
+								/* translators: this message is displayed after submitting an email in subscription widgets  */
+								__( 'You already have several pending email subscriptions. <br /> Approve or delete a few subscriptions at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a> before continuing.', 'jetpack' ),
+								self::$allowed_html_tags_for_message
+							),
 							'https://subscribe.wordpress.com/',
-							__( 'Manage your email preferences.', 'jetpack' )
-						); ?></p>
+							esc_attr__( 'Manage your email preferences.', 'jetpack' )
+						);
+						?>
+					</p>
 					<?php break;
 				case 'success' : ?>
                     <div class="success"><?php echo wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total['value'] ), $success_message ) ); ?></div>

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -13,9 +13,10 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 	 */
 	public static $allowed_html_tags_for_message = array(
 		'a'  => array(
-			'href'  => array(),
-			'title' => array(),
-			'rel'   => array(),
+			'href'   => array(),
+			'title'  => array(),
+			'rel'    => array(),
+			'target' => array(),
 		),
 		'br' => array(),
 	);
@@ -169,7 +170,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						<?php
 						printf(
 							wp_kses(
-								/* translators: this message is displayed after submitting an email in subscription widgets  */
+								/* translators: 1: Link to Subscription Management page https://subscribe.wordpress.com/, 2: Description of this link */
 								__( 'You already have several pending email subscriptions. <br /> Approve or delete a few subscriptions at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a> before continuing.', 'jetpack' ),
 								self::$allowed_html_tags_for_message
 							),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #2278
Similar PRs: https://github.com/Automattic/jetpack/pull/9093 and https://github.com/Automattic/jetpack/pull/2599

#### Changes proposed in this Pull Request:

- For A12s, see 23696-pb for the reason I am implementing `flooded_email` status. 

Before - unclear message: 

![Screen Shot on 2019-12-22 at 20:03:36](https://user-images.githubusercontent.com/10045087/71322150-05bcc200-24f7-11ea-849a-39235f1f8d11.png)

After (with this fix) - clearer error message: 

![Screen Shot on 2019-12-22 at 20:11:29](https://user-images.githubusercontent.com/10045087/71322178-49173080-24f7-11ea-815e-01547d722668.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It improves the current Subscription feature. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use your test email, try to subscribe at least 5 WP.com and Jetpack sites without clicking confirmation links. Some suggestions: jetpack.com, en.blog.wordpress.com (es, ja, fr blog sites too). 
* Go to your testing Jetpack site 
* Try to subscribe with this email
* Get redirected to a link like this http://site.com/?subscribe=many_pending_subs#blog_subscription-3, AND see the message in the "after" screenshot above. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Subscriptions: Add a clear message when an email having many pending confirmations tries to subscribe a site.
