### PR TITLE
Instant Search: Add sidebar widget area

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -923,7 +923,7 @@ class Jetpack_Search {
 					$date_start = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $date_day . ' 00:00:00';
 					$date_end   = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $date_day . ' 23:59:59';
 				} else {
-					$days_in_month = date( 't', mktime( 0, 0, 0, $query->get( 'monthnum' ), 14, $query->get( 'year' ) ) ); // 14 = middle of the month so no chance of DST issues
+					$days_in_month = gmdate( 't', mktime( 0, 0, 0, $query->get( 'monthnum' ), 14, $query->get( 'year' ) ) ); // 14 = middle of the month so no chance of DST issues
 
 					$date_start = $query->get( 'year' ) . '-' . $date_monthnum . '-01 00:00:00';
 					$date_end   = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $days_in_month . ' 23:59:59';
@@ -1135,7 +1135,7 @@ class Jetpack_Search {
 		$decay_params = apply_filters(
 			'jetpack_search_recency_score_decay',
 			array(
-				'origin' => date( 'Y-m-d' ),
+				'origin' => gmdate( 'Y-m-d' ),
 				'scale'  => '360d',
 				'decay'  => 0.9,
 			),
@@ -1734,7 +1734,7 @@ class Jetpack_Search {
 
 						switch ( $this->aggregations[ $label ]['interval'] ) {
 							case 'year':
-								$year = (int) date( 'Y', $timestamp );
+								$year = (int) gmdate( 'Y', $timestamp );
 
 								$query_vars = array(
 									'year'     => $year,
@@ -1754,8 +1754,8 @@ class Jetpack_Search {
 								break;
 
 							case 'month':
-								$year  = (int) date( 'Y', $timestamp );
-								$month = (int) date( 'n', $timestamp );
+								$year  = (int) gmdate( 'Y', $timestamp );
+								$month = (int) gmdate( 'n', $timestamp );
 
 								$query_vars = array(
 									'year'     => $year,
@@ -1763,7 +1763,7 @@ class Jetpack_Search {
 									'day'      => false,
 								);
 
-								$name = date( 'F Y', $timestamp );
+								$name = gmdate( 'F Y', $timestamp );
 
 								// Is this month currently selected?
 								if ( ! empty( $current_year ) && (int) $current_year === $year &&
@@ -1776,9 +1776,9 @@ class Jetpack_Search {
 								break;
 
 							case 'day':
-								$year  = (int) date( 'Y', $timestamp );
-								$month = (int) date( 'n', $timestamp );
-								$day   = (int) date( 'j', $timestamp );
+								$year  = (int) gmdate( 'Y', $timestamp );
+								$month = (int) gmdate( 'n', $timestamp );
+								$day   = (int) gmdate( 'j', $timestamp );
 
 								$query_vars = array(
 									'year'     => $year,
@@ -1786,7 +1786,7 @@ class Jetpack_Search {
 									'day'      => $day,
 								);
 
-								$name = date( 'F jS, Y', $timestamp );
+								$name = gmdate( 'F jS, Y', $timestamp );
 
 								// Is this day currently selected?
 								if ( ! empty( $current_year ) && (int) $current_year === $year &&

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -296,9 +296,9 @@ class Jetpack_Search {
 	 */
 	public function register_jetpack_instant_sidebar() {
 		$args = array(
-			'name'          => 'Jetpack Instant Search Sidebar',
+			'name'          => 'Jetpack Search Sidebar',
 			'id'            => 'jetpack-instant-search-sidebar',
-			'description'   => 'Customize the Jetpack Instant Search overlay sidebar',
+			'description'   => 'Customize the sidebar inside the Jetpack Search overlay',
 			'class'         => '',
 			'before_widget' => '<div id="%1$s" class="widget %2$s">',
 			'after_widget'  => '</div>',

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -200,9 +200,17 @@ class Jetpack_Search {
 			add_action( 'init', array( $this, 'set_filters_from_widgets' ) );
 
 			add_action( 'pre_get_posts', array( $this, 'maybe_add_post_type_as_var' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'load_assets' ) );
+
+			if ( Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ) {
+				add_action( 'wp_footer', array( $this, 'print_instant_search_sidebar' ) );
+				add_action( 'wp_enqueue_scripts', array( $this, 'load_instant_search_assets' ) );
+			}
 		} else {
 			add_action( 'update_option', array( $this, 'track_widget_updates' ), 10, 3 );
+		}
+
+		if ( Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ) {
+			add_action( 'widgets_init', array( $this, 'register_jetpack_instant_sidebar' ) );
 		}
 
 		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
@@ -211,7 +219,7 @@ class Jetpack_Search {
 	/**
 	 * Loads assets for Jetpack Instant Search Prototype featuring Search As You Type experience.
 	 */
-	public function load_assets() {
+	public function load_instant_search_assets() {
 		if ( Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ) {
 			$script_relative_path = '_inc/build/instant-search/jp-search.bundle.js';
 			if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
@@ -281,6 +289,36 @@ class Jetpack_Search {
 				wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
 			}
 		}
+	}
+
+	/**
+	 * Registers a widget sidebar for Instant Search.
+	 */
+	public function register_jetpack_instant_sidebar() {
+		$args = array(
+			'name'          => 'Jetpack Instant Search Sidebar',
+			'id'            => 'jetpack-instant-search-sidebar',
+			'description'   => 'Customize the Jetpack Instant Search overlay sidebar',
+			'class'         => '',
+			'before_widget' => '<div id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h2 class="widgettitle">',
+			'after_title'   => '</h2>',
+		);
+		register_sidebar( $args );
+	}
+
+	/**
+	 * Prints Instant Search sidebar.
+	 */
+	public function print_instant_search_sidebar() {
+		?>
+		<div class="jetpack-instant-search__widget-area" style="display: none">
+			<?php if ( is_active_sidebar( 'jetpack-instant-search-sidebar' ) ) { ?>
+				<?php dynamic_sidebar( 'jetpack-instant-search-sidebar' ); ?>
+			<?php } ?>
+		</div>
+		<?php
 	}
 
 	/**

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -1,18 +1,19 @@
 .jetpack-instant-search__overlay {
-	bottom: 0;
-	left: 0;
-	opacity: 0.975;
-	transition: opacity 0.5s linear;
-	position: fixed;
-	right: 0;
 	top: 0;
+	left: 0;
+	width: 100vw;
+	height: 100vh;
+	opacity: 0.975;
+	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
+	position: fixed;
 	background: white;
 	padding: 3em 1em;
 	overflow-y: auto;
+	overflow-x: hidden;
 	z-index: 9999999999999;
 
 	&.is-hidden {
-		display: none;
+		transform: translateY( -100vh );
 	}
 }
 

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -4,13 +4,12 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { h, Component } from 'preact';
+import { h, Component, Fragment } from 'preact';
 
 /**
  * Internal dependencies
  */
 import SearchResult from './search-result';
-import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
 import SearchForm from './search-form';
 import SearchSidebar from './search-sidebar';
@@ -42,17 +41,75 @@ class SearchResults extends Component {
 		return sprintf( _n( '%s result', '%s results', total, 'jetpack' ), num );
 	}
 
-	render() {
+	renderPrimarySection() {
 		const { query } = this.props;
 		const { results = [], total = 0, corrected_query = false } = this.props.response;
-		const hasQuery = query !== '';
 		const hasCorrectedQuery = corrected_query !== false;
 		const hasResults = total > 0;
 
-		if ( ! hasQuery && ! hasFilter() ) {
-			return null;
-		}
+		return (
+			<Fragment>
+				<SearchForm className="jetpack-instant-search__search-results-search-form" />
 
+				<div
+					className={
+						hasResults
+							? 'jetpack-instant-search__search-results-real-query'
+							: 'jetpack-instant-search__search-results-empty'
+					}
+				>
+					{ this.getSearchTitle() }
+				</div>
+
+				{ hasResults && hasCorrectedQuery && (
+					<p className="jetpack-instant-search__search-results-unused-query">
+						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
+					</p>
+				) }
+				{ this.props.hasError && (
+					<Notice type="warning">
+						{ __( "It looks like you're offline. Please reconnect for results.", 'jetpack' ) }
+					</Notice>
+				) }
+				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
+					<Notice type="warning">
+						{ __(
+							"It looks like you're offline. Please reconnect to load the latest results.",
+							'jetpack'
+						) }
+					</Notice>
+				) }
+				{ hasResults && ! this.props.hasError && (
+					<ol
+						className={ `jetpack-instant-search__search-results-list is-format-${
+							this.props.resultFormat
+						}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
+					>
+						{ results.map( ( result, index ) => (
+							<SearchResult
+								index={ index }
+								locale={ this.props.locale }
+								query={ this.props.query }
+								result={ result }
+								resultFormat={ this.props.resultFormat }
+							/>
+						) ) }
+					</ol>
+				) }
+				{ hasResults && this.props.hasNextPage && (
+					<div className="jetpack-instant-search__search-pagination">
+						<ScrollButton
+							enableLoadOnScroll={ this.props.enableLoadOnScroll }
+							isLoading={ this.props.isLoading }
+							onLoadNextPage={ this.props.onLoadNextPage }
+						/>
+					</div>
+				) }
+			</Fragment>
+		);
+	}
+
+	render() {
 		return (
 			<main
 				aria-hidden={ this.props.isLoading === true }
@@ -62,62 +119,7 @@ class SearchResults extends Component {
 				}` }
 			>
 				<div className="jetpack-instant-search__search-results-primary">
-					<SearchForm className="jetpack-instant-search__search-results-search-form" />
-
-					<div
-						className={
-							hasResults
-								? 'jetpack-instant-search__search-results-real-query'
-								: 'jetpack-instant-search__search-results-empty'
-						}
-					>
-						{ this.getSearchTitle() }
-					</div>
-
-					{ hasResults && hasCorrectedQuery && (
-						<p className="jetpack-instant-search__search-results-unused-query">
-							{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
-						</p>
-					) }
-					{ this.props.hasError && (
-						<Notice type="warning">
-							{ __( "It looks like you're offline. Please reconnect for results.", 'jetpack' ) }
-						</Notice>
-					) }
-					{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
-						<Notice type="warning">
-							{ __(
-								"It looks like you're offline. Please reconnect to load the latest results.",
-								'jetpack'
-							) }
-						</Notice>
-					) }
-					{ hasResults && ! this.props.hasError && (
-						<ol
-							className={ `jetpack-instant-search__search-results-list is-format-${
-								this.props.resultFormat
-							}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
-						>
-							{ results.map( ( result, index ) => (
-								<SearchResult
-									index={ index }
-									locale={ this.props.locale }
-									query={ this.props.query }
-									result={ result }
-									resultFormat={ this.props.resultFormat }
-								/>
-							) ) }
-						</ol>
-					) }
-					{ hasResults && this.props.hasNextPage && (
-						<div className="jetpack-instant-search__search-pagination">
-							<ScrollButton
-								enableLoadOnScroll={ this.props.enableLoadOnScroll }
-								isLoading={ this.props.isLoading }
-								onLoadNextPage={ this.props.onLoadNextPage }
-							/>
-						</div>
-					) }
+					{ this.renderPrimarySection() }
 				</div>
 				<div className="jetpack-instant-search__search-results-secondary">
 					<SearchSidebar />

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -13,6 +13,7 @@ import SearchResult from './search-result';
 import { hasFilter } from '../lib/query-string';
 import ScrollButton from './scroll-button';
 import SearchForm from './search-form';
+import SearchSidebar from './search-sidebar';
 import Notice from './notice';
 
 class SearchResults extends Component {
@@ -60,62 +61,67 @@ class SearchResults extends Component {
 					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
 				}` }
 			>
-				<SearchForm className="jetpack-instant-search__search-results-search-form" />
+				<div className="jetpack-instant-search__search-results-primary">
+					<SearchForm className="jetpack-instant-search__search-results-search-form" />
 
-				<div
-					className={
-						hasResults
-							? 'jetpack-instant-search__search-results-real-query'
-							: 'jetpack-instant-search__search-results-empty'
-					}
-				>
-					{ this.getSearchTitle() }
-				</div>
-
-				{ hasResults && hasCorrectedQuery && (
-					<p className="jetpack-instant-search__search-results-unused-query">
-						{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
-					</p>
-				) }
-				{ this.props.hasError && (
-					<Notice type="warning">
-						{ __( "It looks like you're offline. Please reconnect for results.", 'jetpack' ) }
-					</Notice>
-				) }
-				{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
-					<Notice type="warning">
-						{ __(
-							"It looks like you're offline. Please reconnect to load the latest results.",
-							'jetpack'
-						) }
-					</Notice>
-				) }
-				{ hasResults && ! this.props.hasError && (
-					<ol
-						className={ `jetpack-instant-search__search-results-list is-format-${
-							this.props.resultFormat
-						}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
+					<div
+						className={
+							hasResults
+								? 'jetpack-instant-search__search-results-real-query'
+								: 'jetpack-instant-search__search-results-empty'
+						}
 					>
-						{ results.map( ( result, index ) => (
-							<SearchResult
-								index={ index }
-								locale={ this.props.locale }
-								query={ this.props.query }
-								result={ result }
-								resultFormat={ this.props.resultFormat }
-							/>
-						) ) }
-					</ol>
-				) }
-				{ hasResults && this.props.hasNextPage && (
-					<div className="jetpack-instant-search__search-pagination">
-						<ScrollButton
-							enableLoadOnScroll={ this.props.enableLoadOnScroll }
-							isLoading={ this.props.isLoading }
-							onLoadNextPage={ this.props.onLoadNextPage }
-						/>
+						{ this.getSearchTitle() }
 					</div>
-				) }
+
+					{ hasResults && hasCorrectedQuery && (
+						<p className="jetpack-instant-search__search-results-unused-query">
+							{ sprintf( __( 'No results for "%s"', 'jetpack' ), query ) }
+						</p>
+					) }
+					{ this.props.hasError && (
+						<Notice type="warning">
+							{ __( "It looks like you're offline. Please reconnect for results.", 'jetpack' ) }
+						</Notice>
+					) }
+					{ hasResults && ! this.props.hasError && this.props.response._isOffline && (
+						<Notice type="warning">
+							{ __(
+								"It looks like you're offline. Please reconnect to load the latest results.",
+								'jetpack'
+							) }
+						</Notice>
+					) }
+					{ hasResults && ! this.props.hasError && (
+						<ol
+							className={ `jetpack-instant-search__search-results-list is-format-${
+								this.props.resultFormat
+							}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
+						>
+							{ results.map( ( result, index ) => (
+								<SearchResult
+									index={ index }
+									locale={ this.props.locale }
+									query={ this.props.query }
+									result={ result }
+									resultFormat={ this.props.resultFormat }
+								/>
+							) ) }
+						</ol>
+					) }
+					{ hasResults && this.props.hasNextPage && (
+						<div className="jetpack-instant-search__search-pagination">
+							<ScrollButton
+								enableLoadOnScroll={ this.props.enableLoadOnScroll }
+								isLoading={ this.props.isLoading }
+								onLoadNextPage={ this.props.onLoadNextPage }
+							/>
+						</div>
+					) }
+				</div>
+				<div className="jetpack-instant-search__search-results-secondary">
+					<SearchSidebar />
+				</div>
 			</main>
 		);
 	}

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -3,8 +3,8 @@
 	margin: 0 auto;
 	position: relative;
 	max-width: 1080px;
-	min-height: 400px;
 	text-align: left;
+	display: flex;
 
 	mark {
 		background-color: #ffc;
@@ -12,6 +12,14 @@
 		color: inherit;
 		padding: 0;
 	}
+}
+
+.jetpack-instant-search__search-results-primary {
+	flex: 5;
+	margin-right: 4em;
+}
+.jetpack-instant-search__search-results-secondary {
+	flex: 2;
 }
 
 .jetpack-instant-search__search-results-real-query {

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -8,7 +8,7 @@ import { h, Component, createRef } from 'preact';
 // NOTE:
 //
 // We use Preact.Component instead of a Hooks based component because
-// we need to set shouldComponentUpdate to alway return false.
+// we need to set shouldComponentUpdate to always return false.
 //
 // We could implement such in a Hooks based component using React.memo,
 // but doing so would require importing (and bloating the bundle with)

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -1,0 +1,35 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component, createRef } from 'preact';
+
+// NOTE:
+//
+// We use Preact.Component instead of a Hooks based component because
+// we need to set shouldComponentUpdate to alway return false.
+//
+// We could implement such in a Hooks based component using React.memo,
+// but doing so would require importing (and bloating the bundle with)
+// preact/compat.
+
+export default class SearchSidebar extends Component {
+	sidebar = createRef();
+
+	componentDidMount() {
+		this.children = document.getElementsByClassName( 'jetpack-instant-search__widget-area' );
+		[ ...this.children ].forEach( child => {
+			child.style.removeProperty( 'display' );
+			this.sidebar.current.appendChild( child );
+		} );
+	}
+
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render() {
+		return <div className="jetpack-instant-search__sidebar" ref={ this.sidebar }></div>;
+	}
+}


### PR DESCRIPTION
<img width="1036" alt="Screen Shot 2019-12-27 at 5 23 56 PM" src="https://user-images.githubusercontent.com/4044428/71536532-af23ff00-28cd-11ea-82a5-187df7655905.png">

#### Changes proposed in this Pull Request:
* Adds a widget area named "Jetpack Instant Search Sidebar"
* Renders the said widget area into the Instant Search overlay

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, this adds a sidebar widget area into the Jetpack Instant Search overlay.

#### Testing instructions:
1. If you haven't already, set up Instant Search following the instructions in the [readme](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions).
2. Open `/wp-admin/widgets.php` and ensure that `Jetpack Instant Search Sidebar` has been added.
3. Add some widgets to the Sidebar. 
4. Navigate to your WordPress site and enter a search query. Ensure that:
  a. An overlay renders on top of your current page.
  b. The widget sidebar renders with changes you've made from step 3.

#### Proposed changelog entry for your changes:
* None.
