### PR TITLE
Instant Search: refactor search php for the different experiences

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -1,6 +1,9 @@
-<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+<?php
 /**
  * Jetpack Search: Instant Front-End Search and Filtering
+ *
+ * @since 8.3.0
+ * @package jetpack
  */
 
 use Automattic\Jetpack\Connection\Client;
@@ -26,8 +29,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function load_php() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
-	}
+		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 
+		if ( class_exists( 'WP_Customize_Manager' ) ) {
+			require_once dirname( __FILE__ ) . '/class-jetpack-search-customize.php';
+			new Jetpack_Search_Customize();
+		}
+	}
 
 	/**
 	 * Setup the various hooks needed for the plugin to take over search duties.

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -214,24 +214,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$query->found_posts   = 1;
 		$query->max_num_pages = 1;
 
-		return array(
-			new WP_Post(
-				array(
-					'ID'             => 1,
-					'post_author'    => 1,
-					'post_date'      => current_time( 'mysql' ),
-					'post_date_gmt'  => current_time( 'mysql', 1 ),
-					'post_title'     => 'Some title or other',
-					'post_content'   => 'Whatever you want here. Maybe some cat pictures....',
-					'post_status'    => 'publish',
-					'comment_status' => 'closed',
-					'ping_status'    => 'closed',
-					'post_name'      => 'fake-page',
-					'post_type'      => 'page',
-					'filter'         => 'raw',
-				)
-			),
-		);
+		return array();
 	}
 
 	/**
@@ -375,7 +358,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @return array Array of Aggregations performed on the search.
 	 */
 	public function get_search_aggregations_results() {
-		if ( empty( $this->search_result ) || ! isset( $this->search_result['aggregations'] ) ) {
+		if ( empty( $this->search_result ) || is_wp_error( $this->search_result ) || ! isset( $this->search_result['aggregations'] ) ) {
 			return array();
 		}
 

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -12,16 +12,6 @@ use Automattic\Jetpack\Constants;
 class Jetpack_Instant_Search extends Jetpack_Search {
 
 	/**
-	 * Jetpack_Instant_Search constructor.
-	 *
-	 * @since 5.0.0
-	 *
-	 * Doesn't do anything. This class needs to be initialized via the instance() method instead.
-	 */
-	protected function __construct() {
-	}
-
-	/**
 	 * Loads the php for this version of search
 	 *
 	 * @since 8.3.0
@@ -29,7 +19,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function load_php() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
-		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 
 		if ( class_exists( 'WP_Customize_Manager' ) ) {
 			require_once dirname( __FILE__ ) . '/class-jetpack-search-customize.php';
@@ -62,7 +51,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 */
 	public function load_assets() {
 		$script_relative_path = '_inc/build/instant-search/jp-search.bundle.js';
-		if ( ! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
+		$style_relative_path  = '_inc/build/instant-search/instant-search.min.css';
+		if ( ! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) || ! file_exists( JETPACK__PLUGIN_DIR . $style_relative_path ) ) {
 			return;
 		}
 
@@ -70,20 +60,17 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 		$this->load_and_initialize_tracks();
-		$this->load_options();
+		$this->inject_javascript_options();
 
-		$style_relative_path = '_inc/build/instant-search/instant-search.min.css';
-		if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
-			$style_version = self::get_asset_version( $style_relative_path );
-			$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-			wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
-		}
+		$style_version = self::get_asset_version( $style_relative_path );
+		$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
 	}
 
 	/**
 	 * Passes all options to the JS app.
 	 */
-	protected function load_options() {
+	protected function inject_javascript_options() {
 		$widget_options = Jetpack_Search_Helpers::get_widgets_from_option();
 		if ( is_array( $widget_options ) ) {
 			$widget_options = end( $widget_options );
@@ -113,11 +100,11 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$prefix  = Jetpack_Search_Options::OPTION_PREFIX;
 		$options = array(
 			// overlay options.
-			'colorTheme'      => (bool) get_option( $prefix . 'color_theme', 'light' ),
-			'opacity'         => (bool) get_option( $prefix . 'opacity', 97 ),
 			'closeColor'      => (bool) get_option( $prefix . 'close_color', '#BD3854' ),
-			'highlightColor'  => (bool) get_option( $prefix . 'highlight_color', '#FFC' ),
+			'colorTheme'      => (bool) get_option( $prefix . 'color_theme', 'light' ),
 			'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', true ),
+			'highlightColor'  => (bool) get_option( $prefix . 'highlight_color', '#FFC' ),
+			'opacity'         => (bool) get_option( $prefix . 'opacity', 97 ),
 			'showLogo'        => (bool) get_option( $prefix . 'show_logo', true ),
 			'showPoweredBy'   => (bool) get_option( $prefix . 'show_powered_by', true ),
 

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -42,7 +42,7 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_section(
 			$section_id,
 			array(
-				'title'       => esc_html__( 'Jetpack Instant Search', 'jetpack' ),
+				'title'       => esc_html__( 'Jetpack Search', 'jetpack' ),
 				'description' => __( 'Use these settings to customize the search overlay.', 'jetpack' ),
 				'capability'  => 'edit_theme_options',
 				'priority'    => 200,

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -49,7 +49,7 @@ class Jetpack_Search_Customize {
 			)
 		);
 
-		$id = $setting_prefix . 'theme';
+		$id = $setting_prefix . 'color_theme';
 		$wp_customize->add_setting(
 			$id,
 			array(
@@ -134,6 +134,23 @@ class Jetpack_Search_Customize {
 			)
 		);
 
+		$id = $setting_prefix . 'inf_scroll';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => true,
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'type'    => 'checkbox',
+				'section' => $section_id,
+				'label'   => __( 'Infinite Scroll Results', 'jetpack' ),
+			)
+		);
+
 		$id = $setting_prefix . 'show_logo';
 		$wp_customize->add_setting(
 			$id,
@@ -142,6 +159,7 @@ class Jetpack_Search_Customize {
 				'type'    => 'option',
 			)
 		);
+
 		$wp_customize->add_control(
 			$id,
 			array(

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Jetpack Search Overlay Customization
+ *
+ * @package jetpack
+ */
+
+// Exit if file is accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once dirname( __FILE__ ) . '/class.jetpack-search-options.php';
+
+/**
+ * Class to customize search on the site.
+ *
+ * @since 8.3.0
+ */
+class Jetpack_Search_Customize {
+
+	/**
+	 * Class initialization.
+	 *
+	 * @since 8.3.0
+	 */
+	public function __construct() {
+		add_action( 'customize_register', array( $this, 'customize_register' ) );
+	}
+
+	/**
+	 * Initialize Customizer controls.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param WP_Customize_Manager $wp_customize Customizer instance.
+	 */
+	public function customize_register( $wp_customize ) {
+		$section_id     = 'jetpack_search';
+		$setting_prefix = Jetpack_Search_Options::OPTION_PREFIX;
+
+		$wp_customize->add_section(
+			$section_id,
+			array(
+				'title'       => esc_html__( 'Jetpack Instant Search', 'jetpack' ),
+				'description' => __( 'Use these settings to customize the search overlay.', 'jetpack' ),
+				'capability'  => 'edit_theme_options',
+				'priority'    => 200,
+			)
+		);
+
+		$id = $setting_prefix . 'theme';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => 'light',
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'label'       => __( 'Theme', 'jetpack' ),
+				'description' => __( 'A light or dark theme for your search overlay.', 'jetpack' ),
+				'section'     => $section_id,
+				'type'        => 'radio',
+				'choices'     => array(
+					'light' => 'Light',
+					'dark'  => 'Dark',
+				),
+			)
+		);
+
+		$id = $setting_prefix . 'opacity';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => 97,
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'type'        => 'range',
+				'section'     => $section_id,
+				'label'       => __( 'Background Opacity', 'jetpack' ),
+				'description' => __( 'Select and opacity for the search overlay.', 'jetpack' ),
+				'input_attrs' => array(
+					'min'  => 0,
+					'max'  => 100,
+					'step' => 1,
+				),
+			)
+		);
+
+		$id = $setting_prefix . 'close_color';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => '#BD3854',
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			new WP_Customize_Color_Control(
+				$wp_customize,
+				$id,
+				array(
+					'label'       => __( 'Close Button', 'jetpack' ),
+					'description' => __( 'Select a color and position for the close button.', 'jetpack' ),
+					'section'     => $section_id,
+				)
+			)
+		);
+
+		$id = $setting_prefix . 'highlight_color';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => '#FFC',
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			new WP_Customize_Color_Control(
+				$wp_customize,
+				$id,
+				array(
+					'label'       => __( 'Highlight Search Terms', 'jetpack' ),
+					'description' => __( 'Choose a color to highlight matching search terms.', 'jetpack' ),
+					'section'     => $section_id,
+				)
+			)
+		);
+
+		$id = $setting_prefix . 'show_logo';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => true,
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'type'    => 'checkbox',
+				'section' => $section_id,
+				'label'   => __( 'Display Magnifying Glass Logo', 'jetpack' ),
+			)
+		);
+
+		$id = $setting_prefix . 'show_powered_by';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => true,
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'type'    => 'checkbox',
+				'section' => $section_id,
+				'label'   => __( 'Display "Powered by Jetpack"', 'jetpack' ),
+			)
+		);
+
+	}
+
+}
+

--- a/modules/search/class.jetpack-instant-search.php
+++ b/modules/search/class.jetpack-instant-search.php
@@ -1,0 +1,180 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Jetpack Search: Instant Front-End Search and Filtering
+ */
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Constants;
+
+class Jetpack_Instant_Search extends Jetpack_Search {
+
+	/**
+	 * Jetpack_Instant_Search constructor.
+	 *
+	 * @since 5.0.0
+	 *
+	 * Doesn't do anything. This class needs to be initialized via the instance() method instead.
+	 */
+	protected function __construct() {
+	}
+
+	/**
+	 * Loads the php for this version of search
+	 *
+	 * @since 8.3.0
+	 */
+	public function load_php() {
+		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
+	}
+
+
+	/**
+	 * Setup the various hooks needed for the plugin to take over search duties.
+	 *
+	 * @since 5.0.0
+	 */
+	public function init_hooks() {
+		if ( ! is_admin() ) {
+			add_filter( 'posts_pre_query', array( $this, 'filter__posts_pre_query' ), 10, 2 );
+
+			add_action( 'init', array( $this, 'set_filters_from_widgets' ) );
+
+			add_action( 'wp_enqueue_scripts', array( $this, 'load_assets' ) );
+		} else {
+			add_action( 'update_option', array( $this, 'track_widget_updates' ), 10, 3 );
+		}
+
+		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
+	}
+
+	/**
+	 * Loads assets for Jetpack Instant Search Prototype featuring Search As You Type experience.
+	 */
+	public function load_assets() {
+		$script_relative_path = '_inc/build/instant-search/jp-search.bundle.js';
+		if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
+			$script_version = self::get_asset_version( $script_relative_path );
+			$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+			wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
+			$this->load_and_initialize_tracks();
+
+			$widget_options = Jetpack_Search_Helpers::get_widgets_from_option();
+			if ( is_array( $widget_options ) ) {
+				$widget_options = end( $widget_options );
+			}
+
+			$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
+			$widgets = array();
+			foreach ( $filters as $key => $filter ) {
+				if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
+					$widgets[ $filter['widget_id'] ]['filters']   = array();
+					$widgets[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+				}
+				$new_filter                                   = $filter;
+				$new_filter['filter_id']                      = $key;
+				$widgets[ $filter['widget_id'] ]['filters'][] = $new_filter;
+			}
+
+			$post_type_objs   = get_post_types( array(), 'objects' );
+			$post_type_labels = array();
+			foreach ( $post_type_objs as $key => $obj ) {
+				$post_type_labels[ $key ] = array(
+					'singular_name' => $obj->labels->singular_name,
+					'name'          => $obj->labels->name,
+				);
+			}
+			// This is probably a temporary filter for testing the prototype.
+			$options = array(
+				'enableLoadOnScroll' => false,
+				'homeUrl'            => home_url(),
+				'locale'             => str_replace( '_', '-', get_locale() ),
+				'postTypeFilters'    => $widget_options['post_types'],
+				'postTypes'          => $post_type_labels,
+				'siteId'             => Jetpack::get_option( 'id' ),
+				'sort'               => $widget_options['sort'],
+				'widgets'            => array_values( $widgets ),
+			);
+			/**
+			 * Customize Instant Search Options.
+			 *
+			 * @module search
+			 *
+			 * @since 7.7.0
+			 *
+			 * @param array $options Array of parameters used in Instant Search queries.
+			 */
+			$options = apply_filters( 'jetpack_instant_search_options', $options );
+
+			wp_localize_script(
+				'jetpack-instant-search',
+				'JetpackInstantSearchOptions',
+				$options
+			);
+		}
+
+		$style_relative_path = '_inc/build/instant-search/instant-search.min.css';
+		if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
+			$style_version = self::get_asset_version( $style_relative_path );
+			$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+			wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
+		}
+	}
+
+	/**
+	 * Loads scripts for Tracks analytics library
+	 */
+	public function load_and_initialize_tracks() {
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+	}
+
+	/**
+	 * Get the version number to use when loading the file. Allows us to bypass cache when developing.
+	 *
+	 * @param string $file Path of the file we are looking for.
+	 * @return string $script_version Version number.
+	 */
+	public static function get_asset_version( $file ) {
+		return Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $file )
+			? filemtime( JETPACK__PLUGIN_DIR . $file )
+			: JETPACK__VERSION;
+	}
+
+	/**
+	 * Bypass the normal Search query since we will run it with instant search.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array    $posts Current array of posts (still pre-query).
+	 * @param WP_Query $query The WP_Query being filtered.
+	 *
+	 * @return array Array of matching posts.
+	 */
+	public function filter__posts_pre_query( $posts, $query ) {
+		//TODO: run search aggs for the filtering
+
+		if ( ! $this->should_handle_query( $query ) ) {
+			// Intentionally not adding the 'jetpack_search_abort' action since this should fire for every request except for search.
+			return $posts;
+		}
+
+		//TODO: pre-render search results
+
+		return array(
+			new WP_Post( array(
+				'ID' => 0;
+				'post_author'     => 1,
+				'post_date'       => current_time( 'mysql' ),
+				'post_date_gmt'   => current_time( 'mysql', 1 ),
+				'post_title'      => 'Some title or other',
+				'post_content'    => 'Whatever you want here. Maybe some cat pictures....',
+				'post_status'     => 'publish',
+				'comment_status'  => 'closed',
+				'ping_status'     => 'closed',
+				'post_name'       => 'fake-page-' . rand( 1, 99999 ),
+				'post_type'       => 'page',
+				'filter'          => 'raw',
+			) );
+		);
+	}
+
+}

--- a/modules/search/class.jetpack-instant-search.php
+++ b/modules/search/class.jetpack-instant-search.php
@@ -24,6 +24,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @since 8.3.0
 	 */
 	public function load_php() {
+		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
 	}
 
@@ -36,6 +37,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	public function init_hooks() {
 		if ( ! is_admin() ) {
 			add_filter( 'posts_pre_query', array( $this, 'filter__posts_pre_query' ), 10, 2 );
+			add_action( 'parse_query', array( $this, 'action__parse_query' ), 10, 1 );
 
 			add_action( 'init', array( $this, 'set_filters_from_widgets' ) );
 
@@ -150,31 +152,183 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @return array Array of matching posts.
 	 */
 	public function filter__posts_pre_query( $posts, $query ) {
-		//TODO: run search aggs for the filtering
-
 		if ( ! $this->should_handle_query( $query ) ) {
 			// Intentionally not adding the 'jetpack_search_abort' action since this should fire for every request except for search.
 			return $posts;
 		}
 
-		//TODO: pre-render search results
+		/**
+		 * Bypass the main query and return dummy data
+		 *  WP Core doesn't call the set_found_posts and its filters when filtering
+		 *  posts_pre_query like we do, so need to do these manually.
+		 */
+		$query->found_posts   = 1;
+		$query->max_num_pages = 1;
 
 		return array(
-			new WP_Post( array(
-				'ID' => 0;
-				'post_author'     => 1,
-				'post_date'       => current_time( 'mysql' ),
-				'post_date_gmt'   => current_time( 'mysql', 1 ),
-				'post_title'      => 'Some title or other',
-				'post_content'    => 'Whatever you want here. Maybe some cat pictures....',
-				'post_status'     => 'publish',
-				'comment_status'  => 'closed',
-				'ping_status'     => 'closed',
-				'post_name'       => 'fake-page-' . rand( 1, 99999 ),
-				'post_type'       => 'page',
-				'filter'          => 'raw',
-			) );
+			new WP_Post(
+				array(
+					'ID'             => 1,
+					'post_author'    => 1,
+					'post_date'      => current_time( 'mysql' ),
+					'post_date_gmt'  => current_time( 'mysql', 1 ),
+					'post_title'     => 'Some title or other',
+					'post_content'   => 'Whatever you want here. Maybe some cat pictures....',
+					'post_status'    => 'publish',
+					'comment_status' => 'closed',
+					'ping_status'    => 'closed',
+					'post_name'      => 'fake-page',
+					'post_type'      => 'page',
+					'filter'         => 'raw',
+				)
+			),
 		);
 	}
+
+	/**
+	 * Run the aggregations API query for any filtering
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param WP_Query $query The WP_Query being filtered.
+	 */
+	public function action__parse_query( $query ) {
+		if ( is_admin() ) {
+			return;
+		}
+
+		if ( empty( $this->aggregations ) ) {
+			return;
+		}
+
+		jetpack_require_lib( 'jetpack-wpes-query-builder/jetpack-wpes-query-builder' );
+
+		$builder = new Jetpack_WPES_Query_Builder();
+		$this->add_aggregations_to_es_query_builder( $this->aggregations, $builder );
+		$es_args = array(
+			'aggregations' => $builder->build_aggregation(),
+			'size'         => 0,
+		);
+
+	}
+
+	/**
+	 * Run an instant search on the WordPress.com public API.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $args Args conforming to the WP.com /sites/<blog_id>/search endpoint.
+	 *
+	 * @return object|WP_Error The response from the public API, or a WP_Error.
+	 */
+	public function instant_api( array $args ) {
+		$endpoint    = sprintf( '/sites/%s/search', $this->jetpack_blog_id );
+		$service_url = 'https://public-api.wordpress.com/rest/v1.3' . $endpoint;
+
+		$do_authenticated_request = false;
+		if ( class_exists( 'Automattic\\Jetpack\\Connection\\Client' ) &&
+			isset( $args['authenticated_request'] ) &&
+			true === $args['authenticated_request'] ) {
+			$do_authenticated_request = true;
+		}
+
+		unset( $args['authenticated_request'] );
+
+		$request_args = array(
+			'headers'    => array(
+				'Content-Type' => 'application/json',
+			),
+			'timeout'    => 10,
+			'user-agent' => 'jetpack_search',
+		);
+
+		$request_body = wp_json_encode( $args );
+
+		$start_time = microtime( true );
+
+		if ( $do_authenticated_request ) {
+			$request_args['method'] = 'POST';
+
+			$request = Client::wpcom_json_api_request_as_blog( $endpoint, Client::WPCOM_JSON_API_VERSION, $request_args, $request_body );
+		} else {
+			$request_args = array_merge(
+				$request_args,
+				array(
+					'body' => $request_body,
+				)
+			);
+
+			$request = wp_remote_post( $service_url, $request_args );
+		}
+
+		$end_time = microtime( true );
+
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		$response_code = wp_remote_retrieve_response_code( $request );
+
+		$response = json_decode( wp_remote_retrieve_body( $request ), true );
+
+		$took = is_array( $response ) && ! empty( $response['took'] )
+			? $response['took']
+			: null;
+
+		$query = array(
+			'args'          => $args,
+			'response'      => $response,
+			'response_code' => $response_code,
+			'elapsed_time'  => ( $end_time - $start_time ) * 1000, // Convert from float seconds to ms.
+			'es_time'       => $took,
+			'url'           => $service_url,
+		);
+
+		/**
+		 * Fires after a search request has been performed.
+		 *
+		 * Includes the following info in the $query parameter:
+		 *
+		 * array args Array of Elasticsearch arguments for the search
+		 * array response Raw API response, JSON decoded
+		 * int response_code HTTP response code of the request
+		 * float elapsed_time Roundtrip time of the search request, in milliseconds
+		 * float es_time Amount of time Elasticsearch spent running the request, in milliseconds
+		 * string url API url that was queried
+		 *
+		 * @module search
+		 *
+		 * @since  5.0.0
+		 * @since  5.8.0 This action now fires on all queries instead of just successful queries.
+		 *
+		 * @param array $query Array of information about the query performed
+		 */
+		do_action( 'did_jetpack_search_query', $query );
+
+		if ( ! $response_code || $response_code < 200 || $response_code >= 300 ) {
+			/**
+			 * Fires after a search query request has failed
+			 *
+			 * @module search
+			 *
+			 * @since  5.6.0
+			 *
+			 * @param array Array containing the response code and response from the failed search query
+			 */
+			do_action(
+				'failed_jetpack_search_query',
+				array(
+					'response_code' => $response_code,
+					'json'          => $response,
+				)
+			);
+
+			return new WP_Error( 'invalid_search_api_response', 'Invalid response from API - ' . $response_code );
+		}
+
+		return $response;
+	}
+
+
 
 }

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -653,31 +653,6 @@ class Jetpack_Search_Helpers {
 	}
 
 	/**
-	 * Returns a boolean for whether the current site has a VIP index.
-	 *
-	 * @since 5.8.0
-	 *
-	 * @return bool
-	 */
-	public static function site_has_vip_index() {
-		$has_vip_index = (
-			Constants::is_defined( 'JETPACK_SEARCH_VIP_INDEX' ) &&
-			Constants::get_constant( 'JETPACK_SEARCH_VIP_INDEX' )
-		);
-
-		/**
-		 * Allows developers to filter whether the current site has a VIP index.
-		 *
-		 * @module search
-		 *
-		 * @since  5.8.0
-		 *
-		 * @param bool $has_vip_index Whether the current site has a VIP index.
-		 */
-		return apply_filters( 'jetpack_search_has_vip_index', $has_vip_index );
-	}
-
-	/**
 	 * Returns the maximum posts per page for a search query.
 	 *
 	 * @since 5.8.0

--- a/modules/search/class.jetpack-search-options.php
+++ b/modules/search/class.jetpack-search-options.php
@@ -17,6 +17,22 @@ use Automattic\Jetpack\Constants;
 class Jetpack_Search_Options {
 
 	/**
+	 * The search widget's base ID.
+	 *
+	 * @since 5.8.0
+	 * @var string
+	 */
+	const FILTER_WIDGET_BASE = 'jetpack-search-filters';
+
+	/**
+	 * Prefix for options in DB.
+	 *
+	 * @since 8.3.0
+	 * @var string
+	 */
+	const OPTION_PREFIX = 'jetpack_search_';
+
+	/**
 	 * Returns a boolean for whether instant search is enabled.
 	 *
 	 * @since 8.3.0

--- a/modules/search/class.jetpack-search-options.php
+++ b/modules/search/class.jetpack-search-options.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Jetpack Search: Jetpack_Search_Options class
+ *
+ * @package    Jetpack
+ * @subpackage Jetpack Search
+ * @since      8.3.0
+ */
+
+use Automattic\Jetpack\Constants;
+
+/**
+ * Helpers for parsing the various Search options
+ *
+ * @since 8.3.0
+ */
+class Jetpack_Search_Options {
+
+	/**
+	 * Returns a boolean for whether instant search is enabled.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @return bool
+	 */
+	public static function instant_enabled() {
+		return Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' );
+	}
+
+
+	/**
+	 * Returns a boolean for whether the current site has a VIP index.
+	 *
+	 * @since 5.8.0
+	 *
+	 * @return bool
+	 */
+	public static function site_has_vip_index() {
+		$has_vip_index = (
+			Constants::is_defined( 'JETPACK_SEARCH_VIP_INDEX' ) &&
+			Constants::get_constant( 'JETPACK_SEARCH_VIP_INDEX' )
+		);
+
+		/**
+		 * Allows developers to filter whether the current site has a VIP index.
+		 *
+		 * @module search
+		 *
+		 * @since  5.8.0
+		 *
+		 * @param bool $has_vip_index Whether the current site has a VIP index.
+		 */
+		return apply_filters( 'jetpack_search_has_vip_index', $has_vip_index );
+	}
+
+
+}

--- a/modules/search/class.jetpack-search-options.php
+++ b/modules/search/class.jetpack-search-options.php
@@ -39,7 +39,7 @@ class Jetpack_Search_Options {
 	 *
 	 * @return bool
 	 */
-	public static function instant_enabled() {
+	public static function is_instant_enabled() {
 		return Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' );
 	}
 

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -141,7 +141,7 @@ class Jetpack_Search {
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
 			if ( Jetpack_Search_Options::instant_enabled() ) {
-				require_once dirname( __FILE__ ) . '/class.jetpack-instant-search.php';
+				require_once dirname( __FILE__ ) . '/class-jetpack-instant-search.php';
 				self::$instance = new Jetpack_Instant_Search();
 			} else {
 				self::$instance = new Jetpack_Search();
@@ -843,7 +843,7 @@ class Jetpack_Search {
 					$date_start = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $date_day . ' 00:00:00';
 					$date_end   = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $date_day . ' 23:59:59';
 				} else {
-					$days_in_month = date( 't', mktime( 0, 0, 0, $query->get( 'monthnum' ), 14, $query->get( 'year' ) ) ); // 14 = middle of the month so no chance of DST issues
+					$days_in_month = gmdate( 't', mktime( 0, 0, 0, $query->get( 'monthnum' ), 14, $query->get( 'year' ) ) ); // 14 = middle of the month so no chance of DST issues
 
 					$date_start = $query->get( 'year' ) . '-' . $date_monthnum . '-01 00:00:00';
 					$date_end   = $query->get( 'year' ) . '-' . $date_monthnum . '-' . $days_in_month . ' 23:59:59';
@@ -1055,7 +1055,7 @@ class Jetpack_Search {
 		$decay_params = apply_filters(
 			'jetpack_search_recency_score_decay',
 			array(
-				'origin' => date( 'Y-m-d' ),
+				'origin' => gmdate( 'Y-m-d' ),
 				'scale'  => '360d',
 				'decay'  => 0.9,
 			),
@@ -1654,7 +1654,7 @@ class Jetpack_Search {
 
 						switch ( $this->aggregations[ $label ]['interval'] ) {
 							case 'year':
-								$year = (int) date( 'Y', $timestamp );
+								$year = (int) gmdate( 'Y', $timestamp );
 
 								$query_vars = array(
 									'year'     => $year,
@@ -1674,8 +1674,8 @@ class Jetpack_Search {
 								break;
 
 							case 'month':
-								$year  = (int) date( 'Y', $timestamp );
-								$month = (int) date( 'n', $timestamp );
+								$year  = (int) gmdate( 'Y', $timestamp );
+								$month = (int) gmdate( 'n', $timestamp );
 
 								$query_vars = array(
 									'year'     => $year,
@@ -1683,7 +1683,7 @@ class Jetpack_Search {
 									'day'      => false,
 								);
 
-								$name = date( 'F Y', $timestamp );
+								$name = gmdate( 'F Y', $timestamp );
 
 								// Is this month currently selected?
 								if ( ! empty( $current_year ) && (int) $current_year === $year &&
@@ -1696,9 +1696,9 @@ class Jetpack_Search {
 								break;
 
 							case 'day':
-								$year  = (int) date( 'Y', $timestamp );
-								$month = (int) date( 'n', $timestamp );
-								$day   = (int) date( 'j', $timestamp );
+								$year  = (int) gmdate( 'Y', $timestamp );
+								$month = (int) gmdate( 'n', $timestamp );
+								$day   = (int) gmdate( 'j', $timestamp );
 
 								$query_vars = array(
 									'year'     => $year,
@@ -1706,7 +1706,7 @@ class Jetpack_Search {
 									'day'      => $day,
 								);
 
-								$name = date( 'F jS, Y', $timestamp );
+								$name = gmdate( 'F jS, Y', $timestamp );
 
 								// Is this day currently selected?
 								if ( ! empty( $current_year ) && (int) $current_year === $year &&

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -11,6 +11,8 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
 
+require_once dirname( __FILE__ ) . '/class.jetpack-search-options.php';
+
 /**
  * The main class for the Jetpack Search module.
  *
@@ -138,7 +140,12 @@ class Jetpack_Search {
 	 */
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			self::$instance = new Jetpack_Search();
+			if ( Jetpack_Search_Options::instant_enabled() ) {
+				require_once dirname( __FILE__ ) . '/class.jetpack-instant-search.php';
+				self::$instance = new Jetpack_Instant_Search();
+			} else {
+				self::$instance = new Jetpack_Search();
+			}
 
 			self::$instance->setup();
 		}
@@ -176,11 +183,19 @@ class Jetpack_Search {
 			return;
 		}
 
+		$this->load_php();
+		$this->init_hooks();
+	}
+
+	/**
+	 * Loads the php for this version of search
+	 *
+	 * @since 8.3.0
+	 */
+	public function load_php() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
 		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
-
-		$this->init_hooks();
 	}
 
 	/**
@@ -200,87 +215,11 @@ class Jetpack_Search {
 			add_action( 'init', array( $this, 'set_filters_from_widgets' ) );
 
 			add_action( 'pre_get_posts', array( $this, 'maybe_add_post_type_as_var' ) );
-			add_action( 'wp_enqueue_scripts', array( $this, 'load_assets' ) );
 		} else {
 			add_action( 'update_option', array( $this, 'track_widget_updates' ), 10, 3 );
 		}
 
 		add_action( 'jetpack_deactivate_module_search', array( $this, 'move_search_widgets_to_inactive' ) );
-	}
-
-	/**
-	 * Loads assets for Jetpack Instant Search Prototype featuring Search As You Type experience.
-	 */
-	public function load_assets() {
-		if ( Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ) {
-			$script_relative_path = '_inc/build/instant-search/jp-search.bundle.js';
-			if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
-				$script_version = self::get_asset_version( $script_relative_path );
-				$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
-				wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
-				$this->load_and_initialize_tracks();
-
-				$widget_options = Jetpack_Search_Helpers::get_widgets_from_option();
-				if ( is_array( $widget_options ) ) {
-					$widget_options = end( $widget_options );
-				}
-
-				$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
-				$widgets = array();
-				foreach ( $filters as $key => $filter ) {
-					if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
-						$widgets[ $filter['widget_id'] ]['filters']   = array();
-						$widgets[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
-					}
-					$new_filter                                   = $filter;
-					$new_filter['filter_id']                      = $key;
-					$widgets[ $filter['widget_id'] ]['filters'][] = $new_filter;
-				}
-
-				$post_type_objs   = get_post_types( array(), 'objects' );
-				$post_type_labels = array();
-				foreach ( $post_type_objs as $key => $obj ) {
-					$post_type_labels[ $key ] = array(
-						'singular_name' => $obj->labels->singular_name,
-						'name'          => $obj->labels->name,
-					);
-				}
-				// This is probably a temporary filter for testing the prototype.
-				$options = array(
-					'enableLoadOnScroll' => false,
-					'homeUrl'            => home_url(),
-					'locale'             => str_replace( '_', '-', get_locale() ),
-					'postTypeFilters'    => $widget_options['post_types'],
-					'postTypes'          => $post_type_labels,
-					'siteId'             => Jetpack::get_option( 'id' ),
-					'sort'               => $widget_options['sort'],
-					'widgets'            => array_values( $widgets ),
-				);
-				/**
-				 * Customize Instant Search Options.
-				 *
-				 * @module search
-				 *
-				 * @since 7.7.0
-				 *
-				 * @param array $options Array of parameters used in Instant Search queries.
-				 */
-				$options = apply_filters( 'jetpack_instant_search_options', $options );
-
-				wp_localize_script(
-					'jetpack-instant-search',
-					'JetpackInstantSearchOptions',
-					$options
-				);
-			}
-
-			$style_relative_path = '_inc/build/instant-search/instant-search.min.css';
-			if ( file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) ) {
-				$style_version = self::get_asset_version( $style_relative_path );
-				$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
-				wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
-			}
-		}
 	}
 
 	/**
@@ -305,25 +244,6 @@ class Jetpack_Search {
 	 */
 	public function has_vip_index() {
 		return defined( 'JETPACK_SEARCH_VIP_INDEX' ) && JETPACK_SEARCH_VIP_INDEX;
-	}
-
-	/**
-	 * Loads scripts for Tracks analytics library
-	 */
-	public function load_and_initialize_tracks() {
-		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
-	}
-
-	/**
-	 * Get the version number to use when loading the file. Allows us to bypass cache when developing.
-	 *
-	 * @param string $file Path of the file we are looking for.
-	 * @return string $script_version Version number.
-	 */
-	public static function get_asset_version( $file ) {
-		return Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $file )
-			? filemtime( JETPACK__PLUGIN_DIR . $file )
-			: JETPACK__VERSION;
 	}
 
 	/**

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -140,7 +140,7 @@ class Jetpack_Search {
 	 */
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			if ( Jetpack_Search_Options::instant_enabled() ) {
+			if ( Jetpack_Search_Options::is_instant_enabled() ) {
 				require_once dirname( __FILE__ ) . '/class-jetpack-instant-search.php';
 				self::$instance = new Jetpack_Instant_Search();
 			} else {

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -21,6 +21,7 @@ function jetpack_search_widget_init() {
 	}
 
 	require_once JETPACK__PLUGIN_DIR . 'modules/search/class.jetpack-search-helpers.php';
+	require_once JETPACK__PLUGIN_DIR . 'modules/search/class.jetpack-search-options.php';
 
 	register_widget( 'Jetpack_Search_Widget' );
 }
@@ -170,7 +171,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @since 5.8.0
 	 */
 	public function enqueue_frontend_scripts() {
-		if ( ! is_active_widget( false, false, $this->id_base, true ) || Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ) {
+		if ( ! is_active_widget( false, false, $this->id_base, true ) || Jetpack_Search_Options::instant_enabled() ) {
 			return;
 		}
 
@@ -270,10 +271,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$instance = $this->jetpack_search_populate_defaults( $instance );
 
-		$display_filters = false;
-
 		if ( ( new Status() )->is_development_mode() ) {
-			echo $args['before_widget'];
+			echo $args['before_widget']; //phpcs:ignore
 			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
 				<div class="jetpack-search-sort-wrapper">
 					<label>
@@ -281,9 +280,27 @@ class Jetpack_Search_Widget extends WP_Widget {
 					</label>
 				</div>
 			</div><?php
-			echo $args['after_widget'];
+			echo $args['after_widget']; //phpcs:ignore
 			return;
 		}
+
+		if ( Jetpack_Search_Options::instant_enabled() ) {
+			$this->widget_instant( $args, $instance );
+		} else {
+			$this->widget_non_instant( $args, $instance );
+		}
+	}
+
+	/**
+	 * Render the non-instant frontend widget.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $args     Widgets args supplied by the theme.
+	 * @param array $instance The current widget instance.
+	 */
+	public function widget_non_instant( $args, $instance ) {
+		$display_filters = false;
 
 		if ( is_search() ) {
 			if ( Jetpack_Search_Helpers::should_rerun_search_in_customizer_preview() ) {
@@ -314,9 +331,9 @@ class Jetpack_Search_Widget extends WP_Widget {
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		echo $args['before_widget'];
-		?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper" class="<?php
-		echo Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ? 'jetpack-instant-search-wrapper' : '' ?>">
+		echo $args['before_widget']; //phpcs:ignore
+		?>
+			<div id="<?php echo esc_attr( $this->id ); ?>-wrapper" >
 		<?php
 
 		if ( ! empty( $title ) ) {
@@ -382,7 +399,88 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$this->maybe_render_sort_javascript( $instance, $order, $orderby );
 
 		echo '</div>';
-		echo $args['after_widget'];
+		echo $args['after_widget']; //phpcs:ignore
+	}
+
+	/**
+	 * Render the instant frontend widget.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $args     Widgets args supplied by the theme.
+	 * @param array $instance The current widget instance.
+	 */
+	public function widget_instant( $args, $instance ) {
+		if ( Jetpack_Search_Helpers::should_rerun_search_in_customizer_preview() ) {
+			Jetpack_Search::instance()->update_search_results_aggregations();
+		}
+
+		$filters = Jetpack_Search::instance()->get_filters();
+
+		if ( ! Jetpack_Search_Helpers::are_filters_by_widget_disabled() && ! $this->should_display_sitewide_filters() ) {
+			$filters = array_filter( $filters, array( $this, 'is_for_current_widget' ) );
+		}
+
+		$display_filters = ! empty( $filters );
+
+		if ( ! $display_filters && empty( $instance['search_box_enabled'] ) ) {
+			return;
+		}
+
+		$title = isset( $instance['title'] ) ? $instance['title'] : '';
+
+		if ( empty( $title ) ) {
+			$title = '';
+		}
+
+		/** This filter is documented in core/src/wp-includes/default-widgets.php */
+		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
+
+		echo $args['before_widget']; //phpcs:ignore
+		?>
+			<div id="<?php echo esc_attr( $this->id ); ?>-wrapper" class="jetpack-instant-search-wrapper">
+		<?php
+
+		if ( ! empty( $title ) ) {
+			/**
+			 * Responsible for displaying the title of the Jetpack Search filters widget.
+			 *
+			 * @module search
+			 *
+			 * @since  5.7.0
+			 *
+			 * @param string $title                The widget's title
+			 * @param string $args['before_title'] The HTML tag to display before the title
+			 * @param string $args['after_title']  The HTML tag to display after the title
+			 */
+			do_action( 'jetpack_search_render_filters_widget_title', $title, $args['before_title'], $args['after_title'] );
+		}
+
+		// TODO: create new search box?
+		if ( ! empty( $instance['search_box_enabled'] ) ) {
+			Jetpack_Search_Template_Tags::render_widget_search_form( array(), '', '' );
+		}
+
+		if ( $display_filters ) {
+			/**
+			 * Responsible for rendering filters to narrow down search results.
+			 *
+			 * @module search
+			 *
+			 * @since  5.8.0
+			 *
+			 * @param array $filters    The possible filters for the current query.
+			 * @param array $post_types An array of post types to limit filtering to.
+			 */
+			do_action(
+				'jetpack_search_render_filters',
+				$filters,
+				null
+			);
+		}
+
+		echo '</div>';
+		echo $args['after_widget']; //phpcs:ignore
 	}
 
 	/**
@@ -400,7 +498,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @param string $orderby  The orderby to initialize the select with.
 	 */
 	private function maybe_render_sort_javascript( $instance, $order, $orderby ) {
-		if ( Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ) ) {
+		if ( Jetpack_Search_Options::instant_enabled() ) {
 			return;
 		}
 

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -171,7 +171,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @since 5.8.0
 	 */
 	public function enqueue_frontend_scripts() {
-		if ( ! is_active_widget( false, false, $this->id_base, true ) || Jetpack_Search_Options::instant_enabled() ) {
+		if ( ! is_active_widget( false, false, $this->id_base, true ) || Jetpack_Search_Options::is_instant_enabled() ) {
 			return;
 		}
 
@@ -272,7 +272,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$instance = $this->jetpack_search_populate_defaults( $instance );
 
 		if ( ( new Status() )->is_development_mode() ) {
-			echo $args['before_widget']; //phpcs:ignore
+			echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
 				<div class="jetpack-search-sort-wrapper">
 					<label>
@@ -280,11 +280,11 @@ class Jetpack_Search_Widget extends WP_Widget {
 					</label>
 				</div>
 			</div><?php
-			echo $args['after_widget']; //phpcs:ignore
+			echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			return;
 		}
 
-		if ( Jetpack_Search_Options::instant_enabled() ) {
+		if ( Jetpack_Search_Options::is_instant_enabled() ) {
 			$this->widget_instant( $args, $instance );
 		} else {
 			$this->widget_non_instant( $args, $instance );
@@ -331,7 +331,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		echo $args['before_widget']; //phpcs:ignore
+		echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 			<div id="<?php echo esc_attr( $this->id ); ?>-wrapper" >
 		<?php
@@ -399,7 +399,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$this->maybe_render_sort_javascript( $instance, $order, $orderby );
 
 		echo '</div>';
-		echo $args['after_widget']; //phpcs:ignore
+		echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -436,7 +436,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		echo $args['before_widget']; //phpcs:ignore
+		echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 			<div id="<?php echo esc_attr( $this->id ); ?>-wrapper" class="jetpack-instant-search-wrapper">
 		<?php
@@ -480,7 +480,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		echo '</div>';
-		echo $args['after_widget']; //phpcs:ignore
+		echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
@@ -498,7 +498,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @param string $orderby  The orderby to initialize the select with.
 	 */
 	private function maybe_render_sort_javascript( $instance, $order, $orderby ) {
-		if ( Jetpack_Search_Options::instant_enabled() ) {
+		if ( Jetpack_Search_Options::is_instant_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
Refactor php code and prep for search overlay:
- move all instant search code into a separate class
- create a new options class and port some of the options there from the helper class (will probably want more of this later on too)
- Add the new customizer section and pass the options to the front end

<img width="301" alt="Screen Shot 2020-01-03 at 10 56 10 AM" src="https://user-images.githubusercontent.com/820871/71739785-b2604300-2e17-11ea-9e06-7ff0b845d952.png">
