### PR TITLE
Fixes the package release script.

### DIFF
--- a/bin/release-package.php
+++ b/bin/release-package.php
@@ -67,6 +67,15 @@ $command       = sprintf(
 );
 execute( $command, 'Could not tag the new package version in the main repository.' );
 
+// Update the version numbers of each dependency of the package we are releasing.
+execute( 'bin/version-packages.sh --no-update', 'Could not update sub-package dependency versions.', true, true );
+
+// Stage the changes before committing.
+execute( 'git add --all', 'Could not stage version changes.' );
+
+// Commit the version changes.
+execute( 'git commit -m "Updating versions of packages to production strings."', 'Could not commit version changes.' );
+
 // Do the magic: bring the subdirectory contents (and history of non-empty commits) onto the master branch.
 $command = sprintf(
 	'git filter-branch -f --prune-empty --subdirectory-filter %s master',
@@ -84,9 +93,6 @@ $command          = sprintf(
 	escapeshellarg( $package_repo_url )
 );
 execute( $command, 'Could not add the new package repository remote.', true, true );
-
-// Update the version numbers of each dependency of the package we are releasing.
-execute( 'bin/version-packages.sh --no-update', 'Could not update sub-package dependency versions.', true, true );
 
 // Create a new branch to prepare our release.
 $release_branch = sprintf(


### PR DESCRIPTION
After a recent refactoring a problem has surfaced. The package release script uses a feature of git that allows us to rewrite the tree to only include the needed package at the root. This has worked well before, but now that we have added the package version script, it broke. The reason is that after calling `git filter-branch`, the files get replaced, and the call to `bin/version-packages.sh` fails, because there's no such file anymore.

@jeherve or @kbrown9 please feel free to take over, I'm not sure that it works the way I'm expecting it to, I had to scramble at the last moment to at least make it release a package. My worries are:
* should we be updating dependency versions to production? If we should, then it doesn't work as expected, because 1.6.2 of Sync is still pointing at dev dependencies;
* after rewriting the tree with `filter-branch`, do the changes that we are committing before persist? Maybe that's the reason the version numbers don't get updated?

#### Changes proposed in this Pull Request:
* moves the `version-packages.sh` call before we call `git filter-branch`;
* adds a commit call so that the version changes persist and allow calling `git filter-branch`.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Try to release any package and make sure the versions are properly updated to production versions.

#### Proposed changelog entry for your changes:
* N/A
