### PR TITLE
Fix sharing buttons and like buttons when copying a post

### DIFF
--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -200,10 +200,21 @@ class Jetpack_Copy_Post {
 	 * @return array Array with the results of each update action.
 	 */
 	protected function update_likes_sharing( $source_post, $target_post_id ) {
-		$likes          = get_post_meta( $source_post->ID, 'switch_like_status', true );
-		$sharing        = get_post_meta( $source_post->ID, 'sharing_disabled', false );
-		$likes_result   = update_post_meta( $target_post_id, 'switch_like_status', $likes );
-		$sharing_result = update_post_meta( $target_post_id, 'sharing_disabled', $sharing );
+		$likes   = get_post_meta( $source_post->ID, 'switch_like_status', true );
+		$sharing = get_post_meta( $source_post->ID, 'sharing_disabled', false );
+
+		if ( isset( $likes ) ) {
+			$likes_result = update_post_meta( $target_post_id, 'switch_like_status', $likes );
+		} else {
+			$likes_result = null;
+		}
+
+		if ( ! empty( $sharing ) ) {
+			$sharing_result = update_post_meta( $target_post_id, 'sharing_disabled', $sharing );
+		} else {
+			$sharing_result = null;
+		}
+
 		return array(
 			'likes'   => $likes_result,
 			'sharing' => $sharing_result,

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -203,7 +203,7 @@ class Jetpack_Copy_Post {
 		$likes   = get_post_meta( $source_post->ID, 'switch_like_status', true );
 		$sharing = get_post_meta( $source_post->ID, 'sharing_disabled', false );
 
-		if ( isset( $likes ) ) {
+		if ( '' !== $likes ) {
 			$likes_result = update_post_meta( $target_post_id, 'switch_like_status', $likes );
 		} else {
 			$likes_result = null;

--- a/modules/copy-post.php
+++ b/modules/copy-post.php
@@ -201,7 +201,7 @@ class Jetpack_Copy_Post {
 	 */
 	protected function update_likes_sharing( $source_post, $target_post_id ) {
 		$likes   = get_post_meta( $source_post->ID, 'switch_like_status', true );
-		$sharing = get_post_meta( $source_post->ID, 'sharing_disabled', false );
+		$sharing = get_post_meta( $source_post->ID, 'sharing_disabled', true );
 
 		if ( '' !== $likes ) {
 			$likes_result = update_post_meta( $target_post_id, 'switch_like_status', $likes );
@@ -209,7 +209,7 @@ class Jetpack_Copy_Post {
 			$likes_result = null;
 		}
 
-		if ( ! empty( $sharing ) ) {
+		if ( '' !== $sharing ) {
 			$sharing_result = update_post_meta( $target_post_id, 'sharing_disabled', $sharing );
 		} else {
 			$sharing_result = null;


### PR DESCRIPTION
Looks like we are explicitly setting `sharing_disabled` and `switch_like_status` meta despite the original post relying on the global setting for these to show. It is creating some inconsistencies as per: https://github.com/Automattic/jetpack/issues/14117

Fixes #14117 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR attempts to better handle missing meta values on the post being copied

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bug fix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

From the issue:

* Make sure the Copy Post module in Jetpack is activated, and that the Classic Editor plugin is not active.
* At WP-Admin ->Posts, make sure you have a post with sharing and Like buttons enabled, and check the buttons are visible in the published post on the front end
* Use the Copy Post feature to create a new post
* Before publishing, check the Jetpack sidebar and make sure sharing and Like buttons are enabled
* Publish the copied post
* Verify if the sharing and like buttons respect those of the original post and are output on the front end

**Note: Even if wp-admin is showing the correct values for these toggles, we have been seeing different results in the theme on the front end, so check both places.**

Digging deeper. The meta data before the fix is applied:

Original post:

![Screenshot 2020-01-02 at 16 41 57](https://user-images.githubusercontent.com/411945/71680747-d160c580-2d82-11ea-93b7-a48ccffac9a3.png)

Copied post:

![Screenshot 2020-01-02 at 16 45 16](https://user-images.githubusercontent.com/411945/71680766-dd4c8780-2d82-11ea-9f9c-eaee47b9e322.png)

The meta data after the fix is applied:

Original post:

![Screenshot 2020-01-02 at 17 03 41](https://user-images.githubusercontent.com/411945/71680794-edfcfd80-2d82-11ea-8d49-27678ccd2be5.png)

Copied post:

![Screenshot 2020-01-02 at 17 04 50](https://user-images.githubusercontent.com/411945/71680801-f2c1b180-2d82-11ea-9fcc-174c9cdbeb9c.png)

Ideally `switch_like_status` would not have been set at all in this scenario - but it does seem to work. I think we might need something better than the `isset` check.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Bug fix: Ensure correct sharing and like settings are copied when posts are duplicated
