### PR TITLE
Autoloader: Remove Manager_Interface and Plugin\Tracking from ignore list

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -79,7 +79,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 					array(
 						'Automattic\Jetpack\JITM',
 						'Automattic\Jetpack\Connection\Manager',
-						'Automattic\Jetpack\Connection\Manager_Interface',
 						'Automattic\Jetpack\Connection\XMLRPC_Connector',
 						'Jetpack_IXR_Client',
 						'Jetpack_Options',
@@ -88,7 +87,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\Sync\Main',
 						'Automattic\Jetpack\Constants',
 						'Automattic\Jetpack\Tracking',
-						'Automattic\Jetpack\Plugin\Tracking',
 					),
 					true
 				);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The [Automattic\Jetpack\Connection\Manager_Interface class](https://github.com/Automattic/jetpack/blob/master/packages/connection/src/interface-manager.php) has been deprecated, so remove this class from the autoloader ignore list.
* The Automattic\Jetpack\Plugin\Tracking class is only [used after all of the plugins have been loaded](https://github.com/Automattic/jetpack/blob/master/class.jetpack.php#L746), so remove it from the autoloader ignore list.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
##### Test Site Setup
* Jetpack must be installed.
* To ensure that the changes in this PR are tested, VaultPress must not be active.
* Enable debug logging.

##### Test Steps
1) Access pages and verify that no PHP notices are generated in the debug log.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
