### PR TITLE
Remove Jetpack Sync Testing Instructions

### DIFF
--- a/to-test.md
+++ b/to-test.md
@@ -1,9 +1,5 @@
 ## 8.1
 
-### Sync
-
-This release brings in significant changes to "Sync", the synchronization process that keeps your site's data up to date with WordPress.com. You'll consequently want to check that on newly connected sites as well as existing sites, data gets properly synchronized with WordPress.com. That means that features like Notifications, Publicize, Related Posts should keep working properly on your site.
-
 ### Site Accelerator
 
 The devicepx library has been disabled by default, unless explicitly enabled via theme support. This library was previously used to compensate for lack of browser support. To quote Joseph Scott:


### PR DESCRIPTION
Immediate Sync is not being rolled out in 8.1. It requires opt-in to utilize with sites still utilizing the queue based approach. This removes the Sync comment from to-test.md to ensure users are not confused as to the scope of changes occurring.

#### Changes proposed in this Pull Request:

* No functional changes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* N/A

#### Testing instructions:

* N/A

#### Proposed changelog entry for your changes:

* No changelog entry needed.
