### PR TITLE
Autoloader: Remove Jetpack_IXR_Client from ignore list

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -81,7 +81,6 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 						'Automattic\Jetpack\Connection\Manager',
 						'Automattic\Jetpack\Connection\Manager_Interface',
 						'Automattic\Jetpack\Connection\XMLRPC_Connector',
-						'Jetpack_IXR_Client',
 						'Jetpack_Options',
 						'Jetpack_Signature',
 						'Jetpack_XMLRPC_Server',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The Jetpack_IXR_Client class doesn't seem to be used before the plugins have been loaded, so remove it from the Autoloader's ignore list.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
##### Test Site
* Jetpack must be installed.
* VaultPress must not be installed. VaultPress also uses the autoloader. If VaultPress is installed, its autoloader could be used instead of Jetpack's autoloader.
* Debug logging must be enabled.

##### Test Instructions

Try different actions and ensure that no PHP notices are generated in the debug log.
* Connecting/reconnecting Jetpack to WP.com.
* Disconnecting Jetpack from WP.com
* Saving some Jetpack settings in wp-admin (toggles for example)
* Saving some Jetpack settings in Calypso (toggles for example)
* Incremental sync - trigger an incremental sync by creating a new draft post
* Full sync - trigger a full sync from the debugger
* Plugin/theme autoupdate
* Optional: some Jetpack modules
  * Monitor - enable it and try breaking your site
  * Protect - enable it and try requesting the site from a forbidden IP
  * Post by email - try posting by email
  * Publicize - try it with a connected service and verify it publicized properly on it
  * Subscriptions - verify emails for new posts are still sent
  * SSO - try logging in with SSO.

(The test instructions were copied from #13270.)

#### Proposed changelog entry for your changes:
* n/a
