### PR TITLE
Plans: Move Plans grid above Jetpack Backup

### DIFF
--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -17,8 +17,8 @@ export class Plans extends React.Component {
 			<Fragment>
 				<QueryProducts />
 				<QuerySite />
-				<ProductSelector />
 				<PlanGrid />
+				<ProductSelector />
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
This PR moves the plans grid above Jetpack Backup in the plans and plans prompt pages.

#### Changes proposed in this Pull Request:
* Plans: Move Plans grid above Jetpack Backup

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* See p6TEKc-3ow-p2

#### Preview

Plans page - before:
![](https://cldup.com/3Py3p7htW4.png)

Plans page - after:
![](https://cldup.com/VRWgYu_wyK.png)

Plans prompt page - before:
![](https://cldup.com/N4AZzdw7A8.png)

Plans prompt page - after:
![](https://cldup.com/uZ1ftCFGOK.png)

#### Testing instructions:
* Checkout this branch.
* Build Jetpack with `yarn build` or `yarn watch`.
* Go to /wp-admin/admin.php?page=jetpack#/plans
* Verify plans are above Jetpack Backup and things look good.
* Go to /wp-admin/admin.php?page=jetpack#/plans-prompt
* Verify plans are above Jetpack Backup and things look good.

#### Proposed changelog entry for your changes:
* Plans: Move Plans grid above Jetpack Backup
