### PR TITLE
Contact Form: Add IP & date to CSV Export

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -853,7 +853,7 @@ class Grunion_Contact_Form_Plugin {
 		$md                  = get_post_meta( $post_id, '_feedback_extra_fields', true );
 		$md['feedback_date'] = get_the_date( 'Y-m-d H:i:sT', $post_id );
 		$content_fields      = self::parse_fields_from_content( $post_id );
-		$md['feedback_ip']   = $content_fields['_feedback_ip'];
+		$md['feedback_ip']   = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;
 		return $md;
 	}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -851,7 +851,7 @@ class Grunion_Contact_Form_Plugin {
 	 */
 	public function get_post_meta_for_csv_export( $post_id ) {
 		$md                  = get_post_meta( $post_id, '_feedback_extra_fields', true );
-		$md['feedback_date'] = get_the_date( 'Y-m-d H:i:sT', $post_id );
+		$md['feedback_date'] = get_the_date( DATE_RFC3339, $post_id );
 		$content_fields      = self::parse_fields_from_content( $post_id );
 		$md['feedback_ip']   = ( isset( $content_fields['_feedback_ip'] ) ) ? $content_fields['_feedback_ip'] : 0;
 		return $md;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -890,8 +890,8 @@ class Grunion_Contact_Form_Plugin {
 			'_feedback_author_email' => '2_Email',
 			'_feedback_author_url'   => '3_Website',
 			'_feedback_main_comment' => '4_Comment',
-				'_feedback_author_ip'   => '5_IP',
-	);
+			'_feedback_author_ip'    => '5_IP',
+		);
 
 		foreach ( $field_mapping as $parsed_field_name => $field_name ) {
 			if (

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -848,15 +848,12 @@ class Grunion_Contact_Form_Plugin {
 	 * @param int $post_id Id of the post to fetch meta data for.
 	 *
 	 * @return mixed
-	 *
-	 * @codeCoverageIgnore - No need to be covered.
 	 */
-	public function get_post_meta_for_csv_export( $post_id ) 
-	{
-		$md = get_post_meta( $post_id, '_feedback_extra_fields', true );
+	public function get_post_meta_for_csv_export( $post_id ) {
+		$md                  = get_post_meta( $post_id, '_feedback_extra_fields', true );
 		$md['feedback_date'] = get_the_date( 'Y-m-d H:i:sT', $post_id );
- 	    $content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post_id );
-	    $md['feedback_ip'] = $content_fields['_feedback_ip'];
+		$content_fields      = self::parse_fields_from_content( $post_id );
+		$md['feedback_ip']   = $content_fields['_feedback_ip'];
 		return $md;
 	}
 

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -851,8 +851,13 @@ class Grunion_Contact_Form_Plugin {
 	 *
 	 * @codeCoverageIgnore - No need to be covered.
 	 */
-	public function get_post_meta_for_csv_export( $post_id ) {
-		return get_post_meta( $post_id, '_feedback_extra_fields', true );
+	public function get_post_meta_for_csv_export( $post_id ) 
+	{
+		$md = get_post_meta( $post_id, '_feedback_extra_fields', true );
+		$md['feedback_date'] = get_the_date( 'Y-m-d H:i:sT', $post_id );
+ 	    $content_fields = Grunion_Contact_Form_Plugin::parse_fields_from_content( $post_id );
+	    $md['feedback_ip'] = $content_fields['_feedback_ip'];
+		return $md;
 	}
 
 	/**
@@ -888,7 +893,8 @@ class Grunion_Contact_Form_Plugin {
 			'_feedback_author_email' => '2_Email',
 			'_feedback_author_url'   => '3_Website',
 			'_feedback_main_comment' => '4_Comment',
-		);
+				'_feedback_author_ip'   => '5_IP',
+	);
 
 		foreach ( $field_mapping as $parsed_field_name => $field_name ) {
 			if (

--- a/tests/php/modules/contact-form/test-class.grunion-contact-form.php
+++ b/tests/php/modules/contact-form/test-class.grunion-contact-form.php
@@ -1402,7 +1402,7 @@ class WP_Test_Grunion_Contact_Form extends WP_UnitTestCase {
 			$this->assertSame( 'feedback', $data['group_id'], 'group_id matches' );
 			$this->assertSame( 'Feedback', $data['group_label'], 'group_label matches' );
 			$this->assertSame( true, ! empty( $data['item_id'] ), 'has item_id key' );
-			$this->assertSame( 6, count( $data['data'] ), 'has total expected data keys' );
+			$this->assertSame( 8, count( $data['data'] ), 'has total expected data keys' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #
Changes proposed in this Pull Request:

add feedback ip & date to csv export

Testing instructions:

    Start with a connected Jetpack site.
    Add a Contact Form in the usual manner - block or classic editor.
    Add 4-5 contact form responses.
    Export via CSV by going to wp-admin, Feedback-> Export
    Open the CSV and confirm the date/IP are included.

Proposed changelog entry for your changes:

add feedback ip & date to csv export