### PR TITLE
Map Block: Use the A8C's Mapbox access token if the site doesn't provide one

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -126,7 +126,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 			default:
 				$option                 = self::key_for_api_service( $service );
 				$service_api_key        = Jetpack_Options::get_option( $option, '' );
-				$service_api_key_source = '';
+				$service_api_key_source = 'site';
 		};
 
 		$message = esc_html__( 'API key retrieved successfully.', 'jetpack' );

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -300,7 +300,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 			);
 		}
 
-		if ( ! Jetpack::is_active() ) {
+		if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) && ! jetpack_is_atomic_site() ) {
 			return array(
 				'key'    => '',
 				'source' => 'site',

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -1,16 +1,14 @@
 <?php
-
-use Automattic\Jetpack\Connection\Client;
-
-/*
+/**
  * Service API Keys: Exposes 3rd party api keys that are used on a site.
  *
  * [
  *   { # Availabilty Object. See schema for more detail.
- *      code:            (string) Displays success if the operation was successfully executed and an error code if it was not
- *      service:         (string) The name of the service in question
- *      service_api_key: (string) The API key used by the service empty if one is not set yet
- *      message:         (string) User friendly message
+ *      code:                   (string) Displays success if the operation was successfully executed and an error code if it was not
+ *      service:                (string) The name of the service in question
+ *      service_api_key:        (string) The API key used by the service empty if one is not set yet
+ *      service_api_key_source: (string) The source of the API key, defaults to "site"
+ *      message:                (string) User friendly message
  *   },
  *   ...
  * ]
@@ -80,19 +78,23 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 			'title'      => 'service-api-keys',
 			'type'       => 'object',
 			'properties' => array(
-				'code'          => array(
+				'code'                   => array(
 					'description' => __( 'Displays success if the operation was successfully executed and an error code if it was not', 'jetpack' ),
 					'type'        => 'string',
 				),
-				'service' => array(
+				'service'                => array(
 					'description' => __( 'The name of the service in question', 'jetpack' ),
 					'type'        => 'string',
 				),
-				'service_api_key'          => array(
+				'service_api_key'        => array(
 					'description' => __( 'The API key used by the service. Empty if none has been set yet', 'jetpack' ),
 					'type'        => 'string',
 				),
-				'message'          => array(
+				'service_api_key_source' => array(
+					'description' => __( 'The source of the API key. Defaults to "site"', 'jetpack' ),
+					'type'        => 'string',
+				),
+				'message'                => array(
 					'description' => __( 'User friendly message', 'jetpack' ),
 					'type'        => 'string',
 				),
@@ -319,8 +321,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		$response_body             = json_decode( wp_remote_retrieve_body( $response ) );
 		$wpcom_mapbox_access_token = $response_body->wpcom_mapbox_access_token;
 
-		// Cache the WordPress.com token for an hour.
-		set_transient( $transient_key, $wpcom_mapbox_access_token, 3600 );
+		set_transient( $transient_key, $wpcom_mapbox_access_token, HOUR_IN_SECONDS );
 		return self::format_api_key( $wpcom_mapbox_access_token, 'wpcom' );
 	}
 

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -305,7 +305,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		// If there is a cached token, return it.
 		$transient_key = 'wpcom_mapbox_access_token';
 		$cached_token  = get_transient( $transient_key );
-		if ( ! $cached_token ) {
+		if ( $cached_token ) {
 			return self::format_api_key( $cached_token, 'wpcom' );
 		}
 

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -34,6 +34,8 @@ import MapThemePicker from './map-theme-picker';
 import { settings } from './settings.js';
 import previewPlaceholder from './map-preview.jpg';
 
+const MAPBOX_A8C_ACCESS_TOKEN = window.Jetpack_Block_Map_Settings.mapbox_a8c_access_token;
+
 const API_STATE_LOADING = 0;
 const API_STATE_FAILURE = 1;
 const API_STATE_SUCCESS = 2;
@@ -85,7 +87,6 @@ class MapEdit extends Component {
 	};
 	apiCall( serviceApiKey = null, method = 'GET' ) {
 		const { noticeOperations } = this.props;
-		const { apiKey } = this.state;
 		const path = '/wpcom/v2/service-api-keys/mapbox';
 		const fetch = serviceApiKey
 			? { path, method, data: { service_api_key: serviceApiKey } }
@@ -95,8 +96,8 @@ class MapEdit extends Component {
 				result => {
 					noticeOperations.removeAllNotices();
 					this.setState( {
-						apiState: result.service_api_key ? API_STATE_SUCCESS : API_STATE_FAILURE,
-						apiKey: result.service_api_key,
+						apiState: API_STATE_SUCCESS,
+						apiKey: result.service_api_key || MAPBOX_A8C_ACCESS_TOKEN,
 						apiKeyControl: result.service_api_key,
 						apiRequestOutstanding: false,
 					} );
@@ -104,8 +105,8 @@ class MapEdit extends Component {
 				result => {
 					this.onError( null, result.message );
 					this.setState( {
+						apiState: API_STATE_FAILURE,
 						apiRequestOutstanding: false,
-						apiKeyControl: apiKey,
 					} );
 				}
 			);
@@ -191,7 +192,7 @@ class MapEdit extends Component {
 					<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
 						<TextControl
 							label={ __( 'Mapbox Access Token', 'jetpack' ) }
-							value={ apiKeyControl }
+							value={ apiKeyControl !== MAPBOX_A8C_ACCESS_TOKEN ? apiKeyControl : '' }
 							onChange={ value => this.setState( { apiKeyControl: value } ) }
 						/>
 						<ButtonGroup>

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -34,8 +34,6 @@ import MapThemePicker from './map-theme-picker';
 import { settings } from './settings.js';
 import previewPlaceholder from './map-preview.jpg';
 
-const MAPBOX_A8C_ACCESS_TOKEN = window.Jetpack_Block_Map_Settings.mapbox_a8c_access_token;
-
 const API_STATE_LOADING = 0;
 const API_STATE_FAILURE = 1;
 const API_STATE_SUCCESS = 2;
@@ -93,18 +91,22 @@ class MapEdit extends Component {
 			: { path, method };
 		this.setState( { apiRequestOutstanding: true }, () => {
 			apiFetch( fetch ).then(
-				result => {
+				( { service_api_key: apiKey, service_api_key_source: apiKeySource } ) => {
 					noticeOperations.removeAllNotices();
-					const apiKey = result.service_api_key || MAPBOX_A8C_ACCESS_TOKEN;
+
+					const apiState = apiKey ? API_STATE_SUCCESS : API_STATE_FAILURE;
+					const apiKeyControl = 'automattic' === apiKeySource ? '' : apiKey;
+
 					this.setState( {
-						apiState: apiKey ? API_STATE_SUCCESS : API_STATE_FAILURE,
+						apiState,
 						apiKey,
-						apiKeyControl: result.service_api_key,
+						apiKeyControl,
+						apiKeySource,
 						apiRequestOutstanding: false,
 					} );
 				},
-				result => {
-					this.onError( null, result.message );
+				( { message } ) => {
+					this.onError( null, message );
 					this.setState( {
 						apiState: API_STATE_FAILURE,
 						apiRequestOutstanding: false,
@@ -137,6 +139,7 @@ class MapEdit extends Component {
 			addPointVisibility,
 			apiKey,
 			apiKeyControl,
+			apiKeySource,
 			apiState,
 			apiRequestOutstanding,
 		} = this.state;
@@ -190,7 +193,7 @@ class MapEdit extends Component {
 							/>
 						</PanelBody>
 					) : null }
-					{ apiKey !== MAPBOX_A8C_ACCESS_TOKEN && (
+					{ 'automattic' !== apiKeySource && (
 						<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
 							<TextControl
 								label={ __( 'Mapbox Access Token', 'jetpack' ) }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -95,9 +95,10 @@ class MapEdit extends Component {
 			apiFetch( fetch ).then(
 				result => {
 					noticeOperations.removeAllNotices();
+					const apiKey = result.service_api_key || MAPBOX_A8C_ACCESS_TOKEN;
 					this.setState( {
-						apiState: API_STATE_SUCCESS,
-						apiKey: result.service_api_key || MAPBOX_A8C_ACCESS_TOKEN,
+						apiState: apiKey ? API_STATE_SUCCESS : API_STATE_FAILURE,
+						apiKey,
 						apiKeyControl: result.service_api_key,
 						apiRequestOutstanding: false,
 					} );

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -190,21 +190,23 @@ class MapEdit extends Component {
 							/>
 						</PanelBody>
 					) : null }
-					<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
-						<TextControl
-							label={ __( 'Mapbox Access Token', 'jetpack' ) }
-							value={ apiKeyControl !== MAPBOX_A8C_ACCESS_TOKEN ? apiKeyControl : '' }
-							onChange={ value => this.setState( { apiKeyControl: value } ) }
-						/>
-						<ButtonGroup>
-							<Button type="button" onClick={ this.updateAPIKey } isDefault>
-								{ __( 'Update Token', 'jetpack' ) }
-							</Button>
-							<Button type="button" onClick={ this.removeAPIKey } isDefault>
-								{ __( 'Remove Token', 'jetpack' ) }
-							</Button>
-						</ButtonGroup>
-					</PanelBody>
+					{ apiKey !== MAPBOX_A8C_ACCESS_TOKEN && (
+						<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
+							<TextControl
+								label={ __( 'Mapbox Access Token', 'jetpack' ) }
+								value={ apiKeyControl }
+								onChange={ value => this.setState( { apiKeyControl: value } ) }
+							/>
+							<ButtonGroup>
+								<Button type="button" onClick={ this.updateAPIKey } isDefault>
+									{ __( 'Update Token', 'jetpack' ) }
+								</Button>
+								<Button type="button" onClick={ this.removeAPIKey } isDefault>
+									{ __( 'Remove Token', 'jetpack' ) }
+								</Button>
+							</ButtonGroup>
+						</PanelBody>
+					) }
 				</InspectorControls>
 			</Fragment>
 		);

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -95,7 +95,7 @@ class MapEdit extends Component {
 					noticeOperations.removeAllNotices();
 
 					const apiState = apiKey ? API_STATE_SUCCESS : API_STATE_FAILURE;
-					const apiKeyControl = 'automattic' === apiKeySource ? '' : apiKey;
+					const apiKeyControl = 'wpcom' === apiKeySource ? '' : apiKey;
 
 					this.setState( {
 						apiState,
@@ -193,7 +193,7 @@ class MapEdit extends Component {
 							/>
 						</PanelBody>
 					) : null }
-					{ 'automattic' !== apiKeySource && (
+					{ 'wpcom' !== apiKeySource && (
 						<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
 							<TextControl
 								label={ __( 'Mapbox Access Token', 'jetpack' ) }

--- a/extensions/blocks/map/editor.scss
+++ b/extensions/blocks/map/editor.scss
@@ -1,4 +1,3 @@
-
 .wp-block-jetpack-map__delete-btn {
 	padding: 0;
 	svg {
@@ -12,6 +11,11 @@
 			margin-right: 6px;
 			margin-right: 1ch;
 		}
+	}
+
+	.components-placeholder__instructions .components-external-link {
+		display: inline-block;
+		margin: 1em auto;
 	}
 }
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -14,6 +14,26 @@ jetpack_register_block(
 	)
 );
 
+define( 'MAPBOX_A8C_ACCESS_TOKEN', 'test' );
+
+/**
+ * Add the A8C's Mapbox API key to the Map block script.
+ */
+function jetpack_localize_map_block_script() {
+	wp_localize_script( 'jetpack-blocks-editor', 'Jetpack_Block_Map_Settings', array( 'mapbox_a8c_access_token' => MAPBOX_A8C_ACCESS_TOKEN ) );
+}
+add_action( 'enqueue_block_editor_assets', 'jetpack_localize_map_block_script' );
+
+/**
+ * Return the site own Mapbox API key or the A8C one otherwise.
+ *
+ * @return string
+ */
+function jetpack_get_mapbox_api_key() {
+	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
+	return empty( $api_key ) ? MAPBOX_A8C_ACCESS_TOKEN : $api_key;
+}
+
 /**
  * Map block registration/dependency declaration.
  *
@@ -23,7 +43,7 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_map_block_load_assets( $attr, $content ) {
-	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
+	$api_key = jetpack_get_mapbox_api_key();
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		static $map_block_counter = array();
@@ -110,7 +130,7 @@ function jetpack_map_block_render_single_block_page() {
 
 	/* Put together a new complete document containing only the requested block markup and the scripts/styles needed to render it */
 	$block_markup = $post_html->saveHTML( $container );
-	$api_key      = Jetpack_Options::get_option( 'mapbox_api_key' );
+	$api_key      = jetpack_get_mapbox_api_key();
 	$page_html    = sprintf(
 		'<!DOCTYPE html><head><style>html, body { margin: 0; padding: 0; }</style>%s</head><body>%s</body>',
 		$head_content,

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -24,7 +24,9 @@ function jetpack_fetch_mapbox_a8c_access_token() {
 		return '';
 	}
 
-	$response = wp_remote_get( 'https://public-api.wordpress.com/wpcom/v2/mapbox' );
+	$site_id = Jetpack_Options::get_option( 'id' );
+
+	$response = wp_remote_get( 'https://public-api.wordpress.com/wpcom/v2/sites/' . $site_id . '/mapbox' );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 		return '';
 	}

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -20,7 +20,7 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_get_mapbox_api_key() {
-	if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys' ) ) {
+	if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys' ) || ! Jetpack::is_active() ) {
 		return Jetpack_Options::get_option( 'mapbox_api_key' );
 	}
 	$response = WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key( array( 'service' => 'mapbox' ) );

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -20,6 +20,11 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_fetch_mapbox_a8c_access_token() {
+	$current_user = wp_get_current_user();
+	if ( ! Jetpack::is_user_connected( $current_user->ID ) ) {
+		return '';
+	}
+
 	$response = wp_remote_get( 'https://public-api.wordpress.com/wpcom/v2/mapbox' );
 	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 		return '';
@@ -43,10 +48,10 @@ add_action( 'enqueue_block_editor_assets', 'jetpack_localize_map_block_script' )
  */
 function jetpack_get_mapbox_api_key() {
 	$api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
-	if ( ! empty( $api_key ) ) {
-		return $api_key;
+	if ( empty( $api_key ) ) {
+		return jetpack_fetch_mapbox_a8c_access_token();
 	}
-	return jetpack_fetch_mapbox_a8c_access_token();
+	return $api_key;
 }
 
 /**

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -20,8 +20,7 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_fetch_mapbox_a8c_access_token() {
-	$current_user = wp_get_current_user();
-	if ( ! Jetpack::is_user_connected( $current_user->ID ) ) {
+	if ( ! Jetpack::is_active() ) {
 		return '';
 	}
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -15,7 +15,7 @@ jetpack_register_block(
 );
 
 /**
- * Return the site's own Mapbox API key if set, or the Automattic's one otherwise.
+ * Return the site's own Mapbox API key if set, or the WordPress.com's one otherwise.
  *
  * @return string
  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fix https://github.com/Automattic/Dotcom-roadmap/issues/74

As this is a proof of concept, I haven't included the real A8C Mapbox access token yet.
For testing purpose, the `MAPBOX_A8C_ACCESS_TOKEN` constant can be locally updated with the real A8C token (a12s know where to find it), or with a personal one.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the Automattic's Mapbox access token if the site doesn't provide one.
* Hide the Mapbox Access Token field when using Automattic's.
* Add some spacing in the Map block placeholder text.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhancement of an existing feature.

Internal reference: pb5gDS-ev-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Prerequisites

- Have a Simple, Atomic, and Jetpack test sites ready.
- Make sure none of them has a Mapbox token saved. In that case, _before applying this PR_, please remove it in the Mapbox Access Token field in the Map block sidebar.

Jetpack

- Open the editor and insert a Map block.
- Make sure the Map block loads in the placeholder state, and asks for a token.
- Provide a token, and make sure the map loads correctly.
- Make sure it's possible to change and remove the token in the Mapbox Access Token field in the block sidebar.
- Save the post and check the front end.
- Make sure the Map block is rendered correctly.
- Update the token in the Mapbox Access Token field in the block sidebar with a random incorrect string.
- Wait a bit for the API call to complete and then make sure the block reverted to the placeholder state, with an "incorrect token" error notice.

Simple

- Apply D37418-code and sandbox the API.
- Open the editor and insert a Map block.
- Make sure the Map block loads without asking for an access token.
- Make sure there is no Mapbox Access Token field in the block sidebar.
- Save the post and check the front end.
- Make sure the Map block is rendered correctly.

Atomic

- Install and activate the [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases/latest) plugin.
- In wp-admin, navigate to Jetpack -> Jetpack Beta; search for the `update/mapbox-access-token` feature branch, and activate it.
- Repeat the same testing steps for a Simple site (skip the first step).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Map Block: Use the Automattic's Mapbox access token on WordPress.com sites.