### PR TITLE
Adds notice in wp-admin if there's a conflict with backups and plan

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -25,6 +25,7 @@ import { isDevVersion, userCanConnectSite, userIsSubscriber } from 'state/initia
 import DismissableNotices from './dismissable';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
+import PlanConflictWarning from './plan-conflict-warning';
 
 export class DevVersionNotice extends React.Component {
 	static displayName = 'DevVersionNotice';
@@ -199,6 +200,7 @@ class JetpackNotices extends React.Component {
 					isStaging={ this.props.isStaging }
 					isInIdentityCrisis={ this.props.isInIdentityCrisis }
 				/>
+				<PlanConflictWarning />
 				<DismissableNotices />
 				<UserUnlinked
 					connectUrl={ this.props.connectUrl }

--- a/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
+++ b/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
@@ -61,9 +61,9 @@ export function PlanConflictWarning( {
 		return null;
 	}
 
-	let featureName = 'daily backups';
+	let featureName = __( 'daily backups' );
 	if ( 'jetpack_business' === sitePlanPurchase.product_slug ) {
-		featureName = 'real-time backups';
+		featureName = __( 'real-time backups' );
 	}
 
 	return (

--- a/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
+++ b/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import SimpleNotice from 'components/notice';
+import { getActiveSitePurchases } from 'state/site';
+
+class PlanConflictWarning extends React.Component {
+	render() {
+		const { activeSitePurchases } = this.props;
+
+		if ( activeSitePurchases.length <= 1 ) {
+			return false;
+		}
+
+		const featureName = 'real-time backups';
+		const planName = 'Jetpack Professional';
+		const productName = 'Jetpack Backup (Real-time)';
+
+		return (
+			<SimpleNotice
+				status="is-warning"
+				showDismiss={ false }
+				text={ __(
+					'Your %(planName)s Plan includes %(featureName)s. ' +
+						'Looks like you also purchased the %(productName)s product. ' +
+						'Consider removing %(productName)s.',
+					{
+						args: {
+							featureName,
+							planName,
+							productName,
+						},
+					}
+				) }
+			/>
+		);
+	}
+}
+
+export default connect( state => ( {
+	activeSitePurchases: getActiveSitePurchases( state ),
+} ) )( PlanConflictWarning );

--- a/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
+++ b/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
+import { withRouter } from 'react-router';
 
 /**
  * Internal dependencies
@@ -11,39 +12,82 @@ import { translate as __ } from 'i18n-calypso';
 import SimpleNotice from 'components/notice';
 import { getActiveSitePurchases } from 'state/site';
 
-class PlanConflictWarning extends React.Component {
-	render() {
-		const { activeSitePurchases } = this.props;
-
-		if ( activeSitePurchases.length <= 1 ) {
-			return false;
-		}
-
-		const featureName = 'real-time backups';
-		const planName = 'Jetpack Professional';
-		const productName = 'Jetpack Backup (Real-time)';
-
-		return (
-			<SimpleNotice
-				status="is-warning"
-				showDismiss={ false }
-				text={ __(
-					'Your %(planName)s Plan includes %(featureName)s. ' +
-						'Looks like you also purchased the %(productName)s product. ' +
-						'Consider removing %(productName)s.',
-					{
-						args: {
-							featureName,
-							planName,
-							productName,
-						},
-					}
-				) }
-			/>
-		);
+export function PlanConflictWarning( {
+	activeSitePurchases,
+	router: {
+		location: { pathname },
+	},
+} ) {
+	// Only show on plans page.
+	if ( '/plans' !== pathname ) {
+		return null;
 	}
+
+	// If we only have a single purchase, this isn't required.
+	if ( activeSitePurchases.length <= 1 ) {
+		return null;
+	}
+
+	// Strip "monthly" suffixes.
+	const activeSitePurchasesTrimmed = activeSitePurchases.map( ( { product_slug, ...props } ) => ( {
+		...props,
+		product_slug: product_slug.replace( '_monthly', '' ),
+	} ) );
+
+	// Gets the current backup, if any.
+	const backupPurchase = activeSitePurchasesTrimmed.find( ( { product_slug } ) =>
+		product_slug.includes( 'backup' )
+	);
+	if ( ! backupPurchase ) {
+		return null;
+	}
+
+	// Get the site plan purchase.
+	const sitePlanPurchase = activeSitePurchasesTrimmed.find(
+		( { product_slug } ) =>
+			'jetpack_personal' === product_slug ||
+			'jetpack_premium' === product_slug ||
+			'jetpack_business' === product_slug
+	);
+	if ( ! sitePlanPurchase ) {
+		return null;
+	}
+
+	// If the user purchased real-time backups and doesn't have Professional plan, it's not a conflict.
+	if (
+		'jetpack_backup_realtime' === backupPurchase.product_slug &&
+		'jetpack_business' !== sitePlanPurchase.product_slug
+	) {
+		return null;
+	}
+
+	let featureName = 'daily backups';
+	if ( 'jetpack_business' === sitePlanPurchase.product_slug ) {
+		featureName = 'real-time backups';
+	}
+
+	return (
+		<SimpleNotice
+			status="is-warning"
+			showDismiss={ false }
+			text={ __(
+				'Your %(planName)s Plan includes %(featureName)s. ' +
+					'Looks like you also purchased the %(productName)s product. ' +
+					'Consider removing %(productName)s.',
+				{
+					args: {
+						featureName,
+						planName: sitePlanPurchase.product_name,
+						productName: backupPurchase.product_name,
+					},
+				}
+			) }
+		/>
+	);
 }
+
+const PlanConflictWarningWithRouter = withRouter( PlanConflictWarning );
 
 export default connect( state => ( {
 	activeSitePurchases: getActiveSitePurchases( state ),
-} ) )( PlanConflictWarning );
+} ) )( PlanConflictWarningWithRouter );

--- a/_inc/client/components/jetpack-notices/test/component.js
+++ b/_inc/client/components/jetpack-notices/test/component.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { PlanConflictWarning } from '../plan-conflict-warning';
+
+describe( 'PlanConflictWarning', () => {
+	const router = { location: { pathname: '/plans' } };
+
+	const personalPlan = {
+		product_slug: 'jetpack_personal',
+		product_name: 'Jetpack Personal',
+	};
+
+	const professionalPlan = {
+		product_slug: 'jetpack_business',
+		product_name: 'Jetpack Professional',
+	};
+
+	const dailyBackups = {
+		product_slug: 'jetpack_backup_daily',
+		product_name: 'Jetpack Backup (Daily)',
+	};
+
+	const realTimeBackups = {
+		product_slug: 'jetpack_backup_realtime',
+		product_name: 'Jetpack Backup (Real-time)',
+	};
+
+	it( 'should not render when not in correct path', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ { location: { pathname: '/test' } } } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should not render when there are no purchases', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [] } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should not render when there is one purchase', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ {} ] } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should not render when there is no backup purchase', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ personalPlan ] } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should not render when there is no site plan purchase', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ dailyBackups ] } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should not render with both real-time backups and a non-professional plan', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ realTimeBackups, personalPlan ] } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should not render with both real-time monthly backups and a non-professional plan', () => {
+		const realTimeBackupsMontly = { product_slug: 'jetpack_backups_realtime_monthly', ...realTimeBackups };
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ realTimeBackupsMontly, personalPlan ] } /> );
+		expect( wrapper.isEmptyRender() ).to.equal( true );
+	} );
+
+	it( 'should show warning with both daily backups and a plan', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ dailyBackups, personalPlan ] } /> );
+		expect( wrapper.prop( 'text' ) ).to.equal(
+			'Your Jetpack Personal Plan includes daily backups. ' +
+			'Looks like you also purchased the Jetpack Backup (Daily) product. ' +
+			'Consider removing Jetpack Backup (Daily).'
+		);
+	} );
+
+	it( 'should show warning with both real-time backups and a Professional plan', () => {
+		const wrapper = shallow( <PlanConflictWarning router={ router } activeSitePurchases={ [ realTimeBackups, professionalPlan ] } /> );
+		expect( wrapper.prop( 'text' ) ).to.equal(
+			'Your Jetpack Professional Plan includes real-time backups. ' +
+			'Looks like you also purchased the Jetpack Backup (Real-time) product. ' +
+			'Consider removing Jetpack Backup (Real-time).'
+		);
+	} );
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds a new component that displays a warning if there's a conflict between a site and backup.
* The component is included manually in the `JetpackNotices` component, as the global notice state wasn't the desired space for this.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 1143508703416848-as-1153206214866137

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a Jetpack site, purchase a backup plan and site plan.
* Navigate to Jetpack -> Plans
* Observe warning message.

Screenshot:
<img width="1090" alt="Screen Shot 2020-01-08 at 12 54 21 PM" src="https://user-images.githubusercontent.com/1760168/72002836-2f275e80-3216-11ea-96ba-dcdf8a37a32e.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds warning for unnecessary backup plans.
