### PR TITLE
WP.com block editor: Ensure scripts are loaded before blocks are registered

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -269,12 +269,13 @@ class Jetpack_WPCOM_Block_Editor {
 				'lodash',
 				'wp-compose',
 				'wp-data',
+				'wp-dom-ready',
 				'wp-editor',
 				'wp-element',
 				'wp-rich-text',
 			),
 			$version,
-			true
+			false
 		);
 
 		wp_localize_script(
@@ -304,10 +305,11 @@ class Jetpack_WPCOM_Block_Editor {
 					'wp-blocks',
 					'wp-data',
 					'wp-dom-ready',
+					'wp-hooks',
 					'wp-plugins',
 				),
 				$version,
-				true
+				false
 			);
 		}
 
@@ -329,7 +331,7 @@ class Jetpack_WPCOM_Block_Editor {
 					'wp-url',
 				),
 				$version,
-				true
+				false
 			);
 
 			wp_enqueue_style(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Ensures that the WP.com block editor integration scripts are loaded before blocks are registered by enqueuing them on the head rather than on the footer.

This is needed since there are some features (i.e deprecate CoBlocks Buttons block) that overrides the block settings by adding a `blocks.registerBlockType` filter that needs to be executed before the block registration.

It also updates the deps needed by these scripts.

Related: https://github.com/Automattic/wp-calypso/pull/38724, D37423-code

#### Testing instructions:
* Apply D37423-code and sandbox `widgets.wp.com`.
* Activate the Jetpack Beta plugin on an Atomic site and load this branch.
* Load the block editor.
* Try finding the CoBlocks 'Buttons' block in the block inserter: It shouldn't be there.
* Previously created posts that include the CoBlocks 'Buttons' block should continue to work.
* On a Jetpack site, verify the justify format is still available on paragraph blocks.

#### Proposed changelog entry for your changes:
* WP.com block editor: Ensure scripts are loaded before blocks are registered
