### PR TITLE
Instant Search: fix Esc key behaviour

### DIFF
--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -11,23 +11,23 @@ const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
 };
 
-const Overlay = ( { showOverlay, toggleOverlay, children } ) => {
+const Overlay = ( { shouldShowOverlay, closeOverlay, children } ) => {
 	useEffect( () => {
-		window.addEventListener( 'keydown', closeOnEscapeKey( toggleOverlay ) );
+		window.addEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
 		return () => {
 			// Cleanup after event
-			window.removeEventListener( 'keydown', closeOnEscapeKey( toggleOverlay ) );
+			window.removeEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
 		};
 	}, [] );
 
 	const classNames = [ 'jetpack-instant-search__overlay' ];
-	if ( ! showOverlay ) {
+	if ( ! shouldShowOverlay ) {
 		classNames.push( 'is-hidden' );
 	}
 
 	return (
 		<div className={ classNames.join( ' ' ) }>
-			<button className="jetpack-instant-search__overlay-close" onClick={ toggleOverlay }>
+			<button className="jetpack-instant-search__overlay-close" onClick={ closeOverlay }>
 				{ __( 'Close', 'jetpack' ) }
 			</button>
 			{ children }

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -11,7 +11,7 @@ const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
 };
 
-const Overlay = ( { shouldShowOverlay, closeOverlay, children } ) => {
+const Overlay = ( { isVisible, closeOverlay, children } ) => {
 	useEffect( () => {
 		window.addEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
 		return () => {
@@ -21,7 +21,7 @@ const Overlay = ( { shouldShowOverlay, closeOverlay, children } ) => {
 	}, [] );
 
 	const classNames = [ 'jetpack-instant-search__overlay' ];
-	if ( ! shouldShowOverlay ) {
+	if ( ! isVisible ) {
 		classNames.push( 'is-hidden' );
 	}
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -112,7 +112,6 @@ class SearchApp extends Component {
 
 	showResults = () => this.setState( { showResults: true } );
 	hideResults = () => this.setState( { showResults: false } );
-	toggleResults = () => this.setState( state => ( { showResults: ! state.showResults } ) );
 
 	onChangeQuery = event => setSearchQuery( event.target.value );
 
@@ -183,7 +182,7 @@ class SearchApp extends Component {
 
 	render() {
 		return createPortal(
-			<Overlay showOverlay={ this.state.showResults } toggleOverlay={ this.toggleResults }>
+			<Overlay shouldShowOverlay={ this.state.showResults } closeOverlay={ this.hideResults }>
 				<SearchResults
 					enableLoadOnScroll={ this.props.options.enableLoadOnScroll }
 					hasError={ this.state.hasError }

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -182,7 +182,7 @@ class SearchApp extends Component {
 
 	render() {
 		return createPortal(
-			<Overlay shouldShowOverlay={ this.state.showResults } closeOverlay={ this.hideResults }>
+			<Overlay isVisible={ this.state.showResults } closeOverlay={ this.hideResults }>
 				<SearchResults
 					enableLoadOnScroll={ this.props.options.enableLoadOnScroll }
 					hasError={ this.state.hasError }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Fixes the behaviour of the 'Escape' key for the Instant Search overlay.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No - this is part of the Instant Search prototype.

#### Testing instructions:

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

1. Try pressing 'Esc' on a page with a search widget. It should not open the overlay.
2. Try entering a search query and hitting Enter. That should open the overlay.
3. Hit 'Esc' - this should close the overlay.

#### Proposed changelog entry for your changes:

Not required.