### PR TITLE
Media: Fix the notices generated during remote media file updates

### DIFF
--- a/_inc/lib/class.media.php
+++ b/_inc/lib/class.media.php
@@ -73,7 +73,7 @@ class Jetpack_Media {
 	 * @param  number $media_id
 	 * @return string
 	 */
-	private function get_time_string_from_guid( $media_id ) {
+	private static function get_time_string_from_guid( $media_id ) {
 		$time = date( "Y/m", strtotime( current_time( 'mysql' ) ) );
 
 		if ( $media = get_post( $media_id ) ) {
@@ -459,4 +459,3 @@ function clean_revision_history( $media_id ) {
 };
 
 add_action( 'delete_attachment', 'clean_revision_history' );
-

--- a/_inc/lib/class.media.php
+++ b/_inc/lib/class.media.php
@@ -17,42 +17,45 @@ class Jetpack_Media {
 	 * The hash is built according to the filename trying to avoid name collisions
 	 * with other media files.
 	 *
-	 * @param  number $media_id - media post ID
-	 * @param  string $new_filename - the new filename
+	 * @param  number $media_id - media post ID.
+	 * @param  string $new_filename - the new filename.
 	 * @return string A random filename.
 	 */
 	public static function generate_new_filename( $media_id, $new_filename ) {
-		// get the right filename extension
+		// Get the right filename extension.
 		$new_filename_paths = pathinfo( $new_filename );
-		$new_file_ext = $new_filename_paths['extension'];
+		$new_file_ext       = $new_filename_paths['extension'];
 
-		// take out filename from the original file or from the current attachment
+		// Get the file parts from the current attachment.
+		$current_file         = get_attached_file( $media_id );
+		$current_file_parts   = pathinfo( $current_file );
+		$current_file_ext     = $current_file_parts['extension'];
+		$current_file_dirname = $current_file_parts['dirname'];
+
+		// Take out filename from the original file or from the current attachment.
 		$original_media = (array) self::get_original_media( $media_id );
 
 		if ( ! empty( $original_media ) ) {
 			$original_file_parts = pathinfo( $original_media['file'] );
-			$filename_base = $original_file_parts['filename'];
+			$filename_base       = $original_file_parts['filename'];
 		} else {
-			$current_file = get_attached_file( $media_id );
-			$current_file_parts = pathinfo( $current_file );
-			$current_file_ext = $current_file_parts['filename'];
 			$filename_base = $current_file_parts['filename'];
 		}
 
-		// add unique seed based on the filename
-		$filename_base .=  '-' . crc32( $filename_base ) . '-';
+		// Add unique seed based on the filename.
+		$filename_base .= '-' . crc32( $filename_base ) . '-';
 
 		$number_suffix = time() . rand( 100, 999 );
 
 		do {
-			$filename = $filename_base;
+			$filename  = $filename_base;
 			$filename .= $number_suffix;
-			$file_ext = $new_file_ext ? $new_file_ext : $current_file_ext;
+			$file_ext  = $new_file_ext ? $new_file_ext : $current_file_ext;
 
 			$new_filename = "{$filename}.{$file_ext}";
-			$new_path = "{$current_file_parts['dirname']}/$new_filename";
+			$new_path     = "{$current_file_dirname}/$new_filename";
 			$number_suffix++;
-		} while( file_exists( $new_path ) );
+		} while ( file_exists( $new_path ) );
 
 		return $new_filename;
 	}

--- a/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
@@ -345,10 +345,10 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 
 		$input = $this->input( true );
 
-		// images
-		$media_file = $input['media'] ? (array) $input['media'] : null;
-		$media_url = $input['media_url'];
-		$media_attrs = $input['attrs'] ? (array) $input['attrs'] : null;
+		// Images.
+		$media_file  = isset( $input['media'] ) ? (array) $input['media'] : null;
+		$media_url   = isset( $input['media_url'] ) ? $input['media_url'] : null;
+		$media_attrs = isset( $input['attrs'] ) ? (array) $input['attrs'] : null;
 
 		if ( isset( $media_url ) || $media_file ) {
 			$user_can_upload_files = current_user_can( 'upload_files' ) || $this->api->is_authorized_with_upload_token();
@@ -425,4 +425,3 @@ class WPCOM_JSON_API_Edit_Media_v1_2_Endpoint extends WPCOM_JSON_API_Update_Medi
 		return $response;
 	}
 }
-


### PR DESCRIPTION
Fixes #14303

#### Changes proposed in this Pull Request:
##### File _inc/lib/class.media.php
* In the `generate_new_filename()` method, the file parts of the currently attached media file are obtained in the else block. However, they're needed later in the method regardless of which path through the if-statement is used. So, obtain the file parts for the current attachment before the if-statement.
* Clean up some PHPCS notices for whitespace and comments in `generate_new_filename()`.
* The `get_time_string_from_guid()` method is being called statically, which causes a PHP warning to be generated. Declare the method as static to silence the warning.

##### File json-endpoints/class.wpcom-json-api-edit-media-v1-2-endpoint.php
* If the `$input` array keys `media`, `media_url`, or `attrs` do not exist, PHP notices will be generated. Prevent the notices by using `isset()` to check that the array keys exist before using them.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Jetpack must be activated and connected.
2. Add an image to the site.
3. Access the Calypso admin page and navigate to Media.
4. Edit an image.
5. Check the site’s debug.log and verify that no PHP notices were generated.
6. Verify that the updated image is displayed correctly in wp-admin.

#### Proposed changelog entry for your changes:
* Media: fix bugs that caused PHP notices when a file is remotely edited
