### PR TITLE
Jetpack: call add_remote_request_handlers() in plugins_loaded

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -608,9 +608,6 @@ class Jetpack {
 		add_action( 'deleted_user', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 
-		// Initialize remote file upload request handlers.
-		$this->add_remote_request_handlers();
-
 		if ( self::is_active() ) {
 			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );
 
@@ -740,6 +737,9 @@ class Jetpack {
 		) {
 			$config->ensure( $feature );
 		}
+
+		// Initialize remote file upload request handlers.
+		$this->add_remote_request_handlers();
 
 		/*
 		 * Enable enhanced handling of previewing sites in Calypso

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -558,7 +558,7 @@ class Jetpack {
 		 */
 		add_action( 'init', array( $this, 'deprecated_hooks' ) );
 
-		add_action( 'plugins_loaded', array( __CLASS__, 'configure' ), 1 );
+		add_action( 'plugins_loaded', array( $this, 'configure' ), 1 );
 		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
 		add_filter(
@@ -724,7 +724,7 @@ class Jetpack {
 	 * Before everything else starts getting initalized, we need to initialize Jetpack using the
 	 * Config object.
 	 */
-	public static function configure() {
+	public function configure() {
 		$config = new Config();
 
 		foreach (

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -71,7 +71,8 @@ function _manually_load_plugin() {
 		require JETPACK_WOOCOMMERCE_INSTALL_DIR . '/woocommerce.php';
 	}
 	require dirname( __FILE__ ) . '/../../jetpack.php';
-	Jetpack::configure();
+	$jetpack = Jetpack::init();
+	$jetpack->configure();
 }
 
 function _manually_install_woocommerce() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Classes from the packages cannot be used until all of the plugins have been loaded. The `add_remote_request_handlers()` method uses classes from the packages. So, move the `add_remote_request_handlers()` call from the Jetpack constructor to a function hooked to the `plugins_loaded` action.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

The `add_remote_request_handlers{}` method is used when media files are remotely uploaded and updated. Testing will consist of remotely uploading and updating files.
##### Test Site
* Jetpack must be active and connected.
* Debug logging must be enabled.

##### Test Instructions
1. Navigate to Calypso admin -> Media.
2. Upload a new media file.
3. Navigate to wp-admin -> Media and verify that the uploaded file is displayed.
4. Navigate to Calypso admin -> Media.
5. Edit an uploaded file.
6. Navigate to wp-admin -> Media and verify that the updated file is displayed correctly.
7. Verify that no errors, warnings, or notices have been generated in the debug.log.

#### Proposed changelog entry for your changes:
* n/a
