### PR TITLE
Sandbox utils: Use isolated backreference in URL replacement string

### DIFF
--- a/_inc/jetpack-server-sandbox.php
+++ b/_inc/jetpack-server-sandbox.php
@@ -25,7 +25,7 @@ function jetpack_server_sandbox_request_parameters( $sandbox, $url, $headers ) {
 		$host = isset( $headers['Host'] ) ? $headers['Host'] : $url_host;
 		$url = preg_replace(
 			'@^(https?://)' . preg_quote( $url_host, '@' ) . '(?=[/?#].*|$)@',
-			'\\1' . $sandbox,
+			'${1}' . $sandbox,
 			$url,
 			1
 		);


### PR DESCRIPTION
I was having trouble sandboxing some web server outbound requests to my Sandbox using the `JETPACK__SANDBOX_DOMAIN` constant.

After some debugging, I discovered that the `jetpack_server_sandbox_request_parameters` function was mangling my sandbox's URL because it begins with a digit (The prefixing digit got omitted sending traffic to an unrelated host 😱).

The [PHP doc for `preg_replace`](https://www.php.net/manual/en/function.preg-replace.php
) says:

> When working with a replacement pattern where a backreference is immediately followed by another number (i.e.: placing a literal number immediately after a matched pattern), you cannot use the familiar \\1 notation for your backreference. \\11, for example, would confuse preg_replace() since it does not know whether you want the \\1 backreference followed by a literal 1, or the \\11 backreference followed by nothing. In this case the solution is to use ${1}1. This creates an isolated $1 backreference, leaving the 1 as a literal. 

#### Changes proposed in this Pull Request:
* Change the backreference format in the replacement string from `//1` to `${1}`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No change to user-facing features. It's a fix for a bug that was preventing my (& potentially other devs) usage of the sandboxing tools

#### Testing instructions:

* Set the `JETPACK__SANDBOX_DOMAIN` constant to your sandbox
* Make some changes to site settings, etc.
  * You should see the requests hit your sandbox & they should be well-formed

Testing the case this fixes might be difficult if your sandbox's URL does not start with a digit.  A11s, please feel free to reach out to me privately if you'd like more info on my sandbox, server logs, etc. I'd rather not to publish its domain name here.

OP for requesting the sandbox is here: pMz3w-RE-p2

#### Proposed changelog entry for your changes:
* None
