### PR TITLE
REST API: Load files during plugins_loaded action

### DIFF
--- a/_inc/lib/core-api/load-wpcom-endpoints.php
+++ b/_inc/lib/core-api/load-wpcom-endpoints.php
@@ -35,6 +35,11 @@ function wpcom_rest_api_v2_load_plugin( $class_name ) {
 
 require dirname( __FILE__ ) . '/class-wpcom-rest-field-controller.php';
 
-// Now load the endpoint files.
-wpcom_rest_api_v2_load_plugin_files( 'wpcom-endpoints/*.php' );
-wpcom_rest_api_v2_load_plugin_files( 'wpcom-fields/*.php' );
+/**
+ * Load the REST API v2 plugin files during the plugins_loaded action.
+ */
+function load_wpcom_rest_api_v2_plugin_files() {
+	wpcom_rest_api_v2_load_plugin_files( 'wpcom-endpoints/*.php' );
+	wpcom_rest_api_v2_load_plugin_files( 'wpcom-fields/*.php' );
+}
+add_action( 'plugins_loaded', 'load_wpcom_rest_api_v2_plugin_files' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Package classes shouldn't be used until all of the plugins are loaded. Some of the REST API endpoint files use package classes, so load the files in a new function that is hooked to the 
plugins_loaded action.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

Verify that the REST API endpoints still work. For example:
* Access `https://public-api.wordpress.com/wpcom/v2/sites/{your site's URL}/hello` and verify that the result is `{"hello":"world"}`.
* Activate and deactivate modules in Blog RC.

#### Proposed changelog entry for your changes:
* n/a
