### PR TITLE
Instant Search: prototype instant search filters overlay

### DIFF
--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -176,12 +176,19 @@ class Jetpack_Search_Template_Tags {
 
 		// Temporarily add some dummy filters to demonstrate filter behaviour.
 		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
-				'<h3>Filters</h3>' .
+				'<h3>Post type</h3>' .
 				'<div><input type="checkbox" id="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Test filter 1</label></div>' .
+				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Post</label></div>' .
 				'<div><input type="checkbox" id="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Test filter 2</label></div>' .
+				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Page</label></div>' .
 				'</div>';
+
+		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
+				'<h3>Year</h3>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-3" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-3" class="jetpack-search-form__test-filter-label">2020</label></div>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-4" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-4" class="jetpack-search-form__test-filter-label">2019</label></div></div>';
 
 		echo '<div class="jetpack-search-form">';
 		echo $form;

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -174,6 +174,15 @@ class Jetpack_Search_Template_Tags {
 
 		$form = self::inject_hidden_form_fields( $form, $fields_to_inject );
 
+		// Temporarily add some dummy filters to demonstrate filter behaviour.
+		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
+				'<h3>Filters</h3>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Test filter 1</label></div>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Test filter 2</label></div>' .
+				'</div>';
+
 		echo '<div class="jetpack-search-form">';
 		echo $form;
 		echo '</div>';

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -4,7 +4,7 @@
 	width: 100vw;
 	height: 100vh;
 	opacity: 0.975;
-	transition: opacity 0.5s linear, 0.5s transform ease-in-out;
+	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
 	position: fixed;
 	background: white;
 	padding: 3em 1em;
@@ -14,7 +14,7 @@
 	animation-fill-mode: forwards;
 
 	&.is-hidden {
-		transform: translateX( 200vw );
+		transform: translateX( 100vw );
 	}
 }
 

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -4,16 +4,17 @@
 	width: 100vw;
 	height: 100vh;
 	opacity: 0.975;
-	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
+	transition: opacity 0.5s linear, 0.5s transform ease-in-out;
 	position: fixed;
 	background: white;
 	padding: 3em 1em;
 	overflow-y: auto;
 	overflow-x: hidden;
 	z-index: 9999999999999;
+	animation-fill-mode: forwards;
 
 	&.is-hidden {
-		transform: translateY( -100vh );
+		transform: translateX( 200vw );
 	}
 }
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -73,6 +73,10 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.addEventListener( 'change', this.handleSortChange );
 		} );
+
+		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
+			element.addEventListener( 'click', this.handleFilterInputClick );
+		} );
 	}
 
 	removeEventListeners() {
@@ -86,6 +90,10 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.removeEventListener( 'change', this.handleSortChange );
+		} );
+
+		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
+			element.removeEventListener( 'click', this.handleFilterInputClick );
 		} );
 	}
 
@@ -108,6 +116,10 @@ class SearchApp extends Component {
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
+	};
+
+	handleFilterInputClick = () => {
+		this.showResults();
 	};
 
 	showResults = () => this.setState( { showResults: true } );

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -21,3 +21,12 @@ $grid-size-large: 16px;
 .jetpack-instant-search__is-loading {
 	opacity: 0.2;
 }
+
+.jetpack-search-form__test-filter-checkbox {
+	display: none;
+}
+
+.jetpack-search-form__test-filter-label:hover {
+	text-decoration: underline;
+	cursor: pointer;
+}

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -22,6 +22,7 @@ $grid-size-large: 16px;
 	opacity: 0.2;
 }
 
+// Temporary test styles
 .jetpack-search-form__test-filter-checkbox {
 	display: none;
 }

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -13,6 +13,10 @@ export function getThemeOptions( searchOptions ) {
 			'.jetpack-instant-search-wrapper input.search-field',
 		].join( ', ' ),
 		searchSortSelector: [ '.jetpack-search-sort' ],
+		filterInputSelector: [
+			'.jetpack-search-form__test-filter-checkbox',
+			'.jetpack-search-form__test-filter-label',
+		],
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR offers a simple prototype of how filters may trigger the overlay, in order that we can evaluate the approach. The behaviour shown is:

- checking the filter checkbox opens the overlay instantly
- clicking the filter label opens the overlay instantly
- unchecking the filter checkbox opens the overlay instantly

The corresponding filters are not yet shown shown in the overlay - @jsnmoon is working on this in a separate PR.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No - this is part of the Instant Search prototype.

#### Testing instructions:

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

Try interacting with the filter checkboxes underneath the search input.

<img width="332" alt="Screen Shot 2020-01-10 at 14 34 23" src="https://user-images.githubusercontent.com/17325/72118557-5452d300-33b6-11ea-9439-49f0cb982546.png">

#### Proposed changelog entry for your changes:

Not required.