### PR TITLE
Photon: Remove the duplicate add_filter('jetpack_photon_url', 'jetpack_photon_url') call

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -220,6 +220,12 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 
 	return jetpack_photon_url_scheme( $photon_url, $scheme );
 }
+
+/**
+ * Add an easy way to photon-ize a URL that is safe to call even if Jetpack isn't active.
+ *
+ * See: https://jetpack.com/2013/07/11/photon-and-themes/
+ */
 add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
 
 /**

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -83,15 +83,6 @@ add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 
-/**
- * Add an easy way to photon-ize a URL that is safe to call even if Jetpack isn't active.
- *
- * See: https://jetpack.com/2013/07/11/photon-and-themes/
- */
-if ( Jetpack::is_module_active( 'photon' ) ) {
-	add_filter( 'jetpack_photon_url', 'jetpack_photon_url', 10, 3 );
-}
-
 if ( JETPACK__SANDBOX_DOMAIN ) {
 	require_once JETPACK__PLUGIN_DIR . '_inc/jetpack-server-sandbox.php';
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
There are two calls to `add_filter('jetpack_photon_url', 'jetpack_photon_url')`: one
is in `load_jetpack.php`, and one is in `functions.photon.php`. Clean up this
duplication by removing the `add_filter()` call in `load_jetpack.php`. I chose to keep the `add_filter()` call in `functions.photon.php` (rather than in `load_jetpack.php`) because it looks like this will be easier to sync with wpcom.

This change should not affect existing behavior. Note that the `functions.photon.php` file is [required](https://github.com/Automattic/jetpack/blob/master/load-jetpack.php#L53) in the `load_jetpack.php` file.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

Testing will consist of verifying that the image source URL is correct when the Image CDN module is activated and deactivated. Also, we'll verify that the Tiled Gallery still displays correctly.

##### Test Site
* Jetpack must be activated and connected.
* The site must have a post with at least one image.
* The site must have a post with Tiled Gallery block in Mosaic mode.

##### Test Steps
1. Navigate to wp-admin -> Jetpack -> Modules. 
2. Deactivate the Image CDN module.
3. Access a post with an image and verify that the image source URL is not a CDN URL.
4. Access a post with a tiled gallery in mosaic mode and verify that the gallery displays correctly.
5. Navigate to wp-admin -> Jetpack -> Modules. 
6. Activate the Image CDN module.
7. Access a post with an image and verify that the image source URL is a CDN URL.
8. Access a post with a tiled gallery in mosaic mode and verify that the gallery displays correctly.


#### Proposed changelog entry for your changes:
* n/a
