### PR TITLE
Instant Search: Add a button to clear applied filters

### DIFF
--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -136,11 +136,11 @@ export default class SearchFilter extends Component {
 	render() {
 		return (
 			<div>
-				<h4 className="jetpack-search-filters-widget__sub-heading">
+				<h4 className="jetpack-instant-search__filter-sub-heading">
 					{ this.props.configuration.name }
 				</h4>
 				{ this.props.aggregation && 'buckets' in this.props.aggregation && (
-					<div className="jetpack-search-filters-widget__filter-list" ref={ this.filtersList }>
+					<div className="jetpack-instant-search__filter-list" ref={ this.filtersList }>
 						{ this.props.type === 'date' && this.renderDates() }
 						{ this.props.type === 'postType' && this.renderPostTypes() }
 						{ this.props.type === 'taxonomy' && this.renderTaxonomies() }

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -13,8 +13,27 @@ import get from 'lodash/get';
  * Internal dependencies
  */
 import SearchFilter from './search-filter';
+import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/query-string';
 
 export default class SearchFilters extends Component {
+	onChangeFilter = ( filterName, filterValue ) => {
+		setFilterQuery( filterName, filterValue );
+	};
+
+	onClearFilters = () => {
+		clearFiltersFromQuery();
+	};
+
+	hasActiveFilters() {
+		return Object.keys( this.getFilters() )
+			.map( key => this.getFilters()[ key ] )
+			.some( value => Array.isArray( value ) && value.length );
+	}
+
+	getFilters() {
+		return getFilterQuery();
+	}
+
 	renderFilterComponent = ( { configuration, results } ) => {
 		switch ( configuration.type ) {
 			case 'date_histogram':
@@ -25,8 +44,8 @@ export default class SearchFilters extends Component {
 							configuration={ configuration }
 							locale={ this.props.locale }
 							type="date"
-							value={ this.props.filters[ `${ configuration.interval }_${ configuration.field }` ] }
-							onChange={ this.props.onChange }
+							value={ this.getFilters()[ `${ configuration.interval }_${ configuration.field }` ] }
+							onChange={ this.onChangeFilter }
 						/>
 					)
 				);
@@ -36,8 +55,8 @@ export default class SearchFilters extends Component {
 						<SearchFilter
 							aggregation={ results }
 							configuration={ configuration }
-							value={ this.props.filters[ configuration.taxonomy ] }
-							onChange={ this.props.onChange }
+							value={ this.getFilters()[ configuration.taxonomy ] }
+							onChange={ this.onChangeFilter }
 							type="taxonomy"
 						/>
 					)
@@ -48,8 +67,8 @@ export default class SearchFilters extends Component {
 						<SearchFilter
 							aggregation={ results }
 							configuration={ configuration }
-							value={ this.props.filters.post_types }
-							onChange={ this.props.onChange }
+							value={ this.getFilters().post_types }
+							onChange={ this.onChangeFilter }
 							postTypes={ this.props.postTypes }
 							type="postType"
 						/>
@@ -66,11 +85,19 @@ export default class SearchFilters extends Component {
 		const aggregations = get( this.props.results, 'aggregations' );
 		const cls =
 			this.props.loading === true
-				? 'jetpack-instant-search__filters-widget jetpack-instant-search__is-loading'
-				: 'jetpack-instant-search__filters-widget';
+				? 'jetpack-instant-search__filters jetpack-instant-search__is-loading'
+				: 'jetpack-instant-search__filters';
 
 		return (
 			<div className={ cls }>
+				{ this.hasActiveFilters() && (
+					<button
+						class="jetpack-instant-search__clear-filters-button"
+						onClick={ this.onClearFilters }
+					>
+						Clear Filters
+					</button>
+				) }
 				{ get( this.props.widget, 'filters' )
 					.map( configuration =>
 						aggregations

--- a/modules/search/instant-search/components/search-filters.scss
+++ b/modules/search/instant-search/components/search-filters.scss
@@ -7,3 +7,7 @@
 	margin-bottom: 10px;
 	text-align: left;
 }
+
+.jetpack-instant-search__clear-filters-button {
+	margin-bottom: 1em;
+}

--- a/modules/search/instant-search/components/search-filters.scss
+++ b/modules/search/instant-search/components/search-filters.scss
@@ -1,4 +1,4 @@
-.jetpack-search-filters-widget__filter-list {
+.jetpack-instant-search__filter-list {
 	div label {
 		display: inline-block;
 		width: auto;

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -9,7 +9,6 @@ import { h, Component, Fragment } from 'preact';
 /**
  * Internal dependencies
  */
-import { getFilterQuery, setFilterQuery } from '../lib/query-string';
 import SearchResult from './search-result';
 import ScrollButton from './scroll-button';
 import SearchFilters from './search-filters';
@@ -42,10 +41,6 @@ class SearchResults extends Component {
 		}
 		return sprintf( _n( '%s result', '%s results', total, 'jetpack' ), num );
 	}
-
-	onChangeFilter = ( filterName, filterValue ) => {
-		setFilterQuery( filterName, filterValue );
-	};
 
 	renderPrimarySection() {
 		const { query } = this.props;
@@ -120,10 +115,8 @@ class SearchResults extends Component {
 			<Fragment>
 				{ this.props.widgets.map( widget => (
 					<SearchFilters
-						filters={ getFilterQuery() }
 						loading={ this.props.isLoading }
 						locale={ this.props.locale }
-						onChange={ this.onChangeFilter }
 						postTypes={ this.props.postTypes }
 						results={ this.props.response }
 						widget={ widget }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -196,13 +196,13 @@ export function getFilterQuery( filterKey ) {
 }
 
 export function hasFilter() {
-	const filter_keys = getFilterKeys();
-	for ( let i = 0; i < filter_keys.length; i++ ) {
-		if ( getFilterQueryByKey( filter_keys[ i ] ).length > 0 ) {
-			return true;
-		}
-	}
-	return false;
+	return getFilterKeys().some( key => getFilterQueryByKey( key ).length > 0 );
+}
+
+export function clearFiltersFromQuery() {
+	const query = getQuery();
+	getFilterKeys().forEach( key => delete query[ key ] );
+	pushQueryString( encode( query ) );
 }
 
 export function setFilterQuery( filterKey, filterValue ) {


### PR DESCRIPTION
Partially fixes #14181.

#### Changes proposed in this Pull Request:
* Adds a button to clear applied filters in the overlay sidebar.

<img width="1036" alt="Screen Shot 2020-01-10 at 4 00 00 PM" src="https://user-images.githubusercontent.com/4044428/72192272-4dca5880-33c2-11ea-9cfb-b7036ef1c03e.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, this adds a new feature to Jetpack Instant Search, which has not yet been launched to the public.

#### Testing instructions:
1. If you haven't already, set up Instant Search following the instructions in the [readme](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions). Ensure that you've configured filters for your Jetpack Search widget.
2. Navigate to your WordPress site and submit a query into the search widget.
3. Ensure that the search overlay appears along with the search filters on the right side. 
4. Select a search filter of choice. Ensure that your results have been filtered as expected. Ensure that a "Clear Filters" button has appeared above your filters.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None.