### PR TITLE
Subscriptions: Fix "deactivating module unsets Follow email option"

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -93,9 +93,8 @@ class Jetpack_Subscriptions {
 
 		add_filter( 'post_updated_messages', array( $this, 'update_published_message' ), 18, 1 );
 
-		// Set and delete "social_notifications_subscribe" option during activation / deactivation
+		// Set "social_notifications_subscribe" option during the first-time activation.
 		add_action( 'jetpack_activate_module_subscriptions',   array( $this, 'set_social_notifications_subscribe' ) );
-		add_action( 'jetpack_deactivate_module_subscriptions', array( $this, 'delete_social_notifications_subscribe' ) );
 	}
 
 	/**
@@ -865,25 +864,16 @@ class Jetpack_Subscriptions {
 	}
 
 	/**
-	 * Set the social_notifications_subscribe option to `off` when the Subscriptions module is activated.
+	 * Set the social_notifications_subscribe option to `off` when the Subscriptions module is activated in the first time.
 	 *
 	 * @since 8.1
 	 *
 	 * @return null
 	 */
 	function set_social_notifications_subscribe() {
-		update_option( 'social_notifications_subscribe', 'off' );
-	}
-
-	/**
-	 * Delete the social_notifications_subscribe option that was set to `off` on the module activation.
-	 *
-	 * @since 8.1
-	 *
-	 * @return null
-	 */
-	function delete_social_notifications_subscribe() {
-		delete_option( 'social_notifications_subscribe' );
+		if ( false === get_option( 'social_notifications_subscribe' ) ) {
+			add_option( 'social_notifications_subscribe', 'off' );
+		}
 	}
 
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14302 

#### Changes proposed in this Pull Request:

As explained here https://github.com/Automattic/jetpack/issues/14302#issuecomment-571639680, this PR does these things: 

1. When activating Subscriptions module, if `social_notifications_subscribe` option does not exist. Set it to `off`. Otherwise, does nothing. 

2. Remove the current add_action filter when deactivating Subscriptions module.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Fix an issue in a current feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Start from a brand new Jetpack site, with the Subscriptions module on.
2. Go to WP Admin > Settings > Discussion
3. Turn on "Email me whenever Someone follows my blog"
4. Go to WP Admin > Jetpack > Settings > Discussion and deactivate the Subscriptions module.
5. Once you've received confirmation, reactivate it.
6. Go to WP Admin Settings > Discussion
7.  Make sure that "Email me whenever Someone follows my blog" is STILL on.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Subscriptions: Maintain the setting `Email me whenever Someone follows my blog` when activating and deactivating this module. 