### PR TITLE
Subscriptions: inform a clear error for pending confirmations

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -525,6 +525,7 @@ class Jetpack_Subscriptions {
 	 *	not_subscribed  : strange error.  Jetpack servers at WordPress.com could subscribe the email.
 	 *	disabled        : Site owner has disabled subscriptions.
 	 *	active          : Already subscribed.
+	 *  pending         : Tried to subscribe before but the confirmation link is never clicked. No confirmation email is sent.
 	 *	unknown         : strange error.  Jetpack servers at WordPress.com returned something malformed.
 	 *	unknown_status  : strange error.  Jetpack servers at WordPress.com returned something I didn't understand.
 	 */
@@ -587,8 +588,11 @@ class Jetpack_Subscriptions {
 			case 'active' :
 				$r[] = new Jetpack_Error( 'active' );
 				continue 2;
-			case 'pending' :
+			case 'confirming' :
 				$r[] = true;
+				continue 2;
+			case 'pending' :
+				$r[] = new Jetpack_Error( 'pending' );
 				continue 2;
 			default :
 				$r[] = new Jetpack_Error( 'unknown_status', (string) $response[0]['status'] );
@@ -656,11 +660,13 @@ class Jetpack_Subscriptions {
 				$result = 'opted_out';
 				break;
 			case 'active':
-			case 'pending':
 				$result = 'already';
 				break;
 			case 'flooded_email':
 				$result = 'many_pending_subs';
+				break;
+			case 'pending':
+				$result = 'pending';
 				break;
 			default:
 				$result = 'error';

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -579,24 +579,24 @@ class Jetpack_Subscriptions {
 			}
 
 			switch ( $response[0]['status'] ) {
-			case 'error' :
-				$r[] = new Jetpack_Error( 'not_subscribed' );
-				continue 2;
-			case 'disabled' :
-				$r[] = new Jetpack_Error( 'disabled' );
-				continue 2;
-			case 'active' :
-				$r[] = new Jetpack_Error( 'active' );
-				continue 2;
-			case 'confirming' :
-				$r[] = true;
-				continue 2;
-			case 'pending' :
-				$r[] = new Jetpack_Error( 'pending' );
-				continue 2;
-			default :
-				$r[] = new Jetpack_Error( 'unknown_status', (string) $response[0]['status'] );
-				continue 2;
+				case 'error':
+					$r[] = new Jetpack_Error( 'not_subscribed' );
+					continue 2;
+				case 'disabled':
+					$r[] = new Jetpack_Error( 'disabled' );
+					continue 2;
+				case 'active':
+					$r[] = new Jetpack_Error( 'active' );
+					continue 2;
+				case 'confirming':
+					$r[] = true;
+					continue 2;
+				case 'pending':
+					$r[] = new Jetpack_Error( 'pending' );
+					continue 2;
+				default:
+					$r[] = new Jetpack_Error( 'unknown_status', (string) $response[0]['status'] );
+					continue 2;
 			}
 		}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -525,7 +525,7 @@ class Jetpack_Subscriptions {
 	 *	not_subscribed  : strange error.  Jetpack servers at WordPress.com could subscribe the email.
 	 *	disabled        : Site owner has disabled subscriptions.
 	 *	active          : Already subscribed.
-	 *  pending         : Tried to subscribe before but the confirmation link is never clicked. No confirmation email is sent.
+	 *	pending         : Tried to subscribe before but the confirmation link is never clicked. No confirmation email is sent.
 	 *	unknown         : strange error.  Jetpack servers at WordPress.com returned something malformed.
 	 *	unknown_status  : strange error.  Jetpack servers at WordPress.com returned something I didn't understand.
 	 */

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -180,6 +180,23 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						?>
 					</p>
 					<?php break;
+				case 'pending':
+					?>
+					<p class="error">
+						<?php
+						printf(
+							wp_kses(
+								/* translators: 1: Link to Subscription Management page https://subscribe.wordpress.com/, 2: Description of this link */
+								__( 'You subscribed this site before but you have not clicked the confirmation link yet. Please check your mailbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a>.', 'jetpack' ),
+								self::$allowed_html_tags_for_message
+							),
+							'https://subscribe.wordpress.com/',
+							esc_attr__( 'Manage your email preferences.', 'jetpack' )
+						);
+						?>
+					</p>
+					<?php
+					break;
 				case 'success' : ?>
                     <div class="success"><?php echo wpautop( str_replace( '[total-subscribers]', number_format_i18n( $subscribers_total['value'] ), $success_message ) ); ?></div>
 					<?php break;

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -187,7 +187,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						printf(
 							wp_kses(
 								/* translators: 1: Link to Subscription Management page https://subscribe.wordpress.com/, 2: Description of this link */
-								__( 'You subscribed this site before but you have not clicked the confirmation link yet. Please check your mailbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank">subscribe.wordpress.com</a>.', 'jetpack' ),
+								__( 'You subscribed this site before but you have not clicked the confirmation link yet. Please check your mailbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a>.', 'jetpack' ),
 								self::$allowed_html_tags_for_message
 							),
 							'https://subscribe.wordpress.com/',

--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -187,7 +187,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						printf(
 							wp_kses(
 								/* translators: 1: Link to Subscription Management page https://subscribe.wordpress.com/, 2: Description of this link */
-								__( 'You subscribed this site before but you have not clicked the confirmation link yet. Please check your mailbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a>.', 'jetpack' ),
+								__( 'You subscribed this site before but you have not clicked the confirmation link yet. Please check your inbox. <br /> Otherwise, you can manage your preferences at <a href="%1$s" title="%2$s" target="_blank" rel="noopener noreferrer">subscribe.wordpress.com</a>.', 'jetpack' ),
 								self::$allowed_html_tags_for_message
 							),
 							'https://subscribe.wordpress.com/',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #276

**Heads-up: To test this PR, it requires to have a sandbox.** 

### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

As explained in this comment https://github.com/Automattic/jetpack/issues/276#issuecomment-568405281, what I am trying to do in this PR: 

1, Apply patch D37557-code to introduce a new status=confirming. With this change, Jetpack is able to handle 2 different cases: 

* `confirming`: an email tries to subscribe a site for the first time.
* `pending`: this email tries to subcribe the site again while the confirmation link (sent during the first try) has not been clicked. 

2, Jetpack plugin code sends respective messages for two statuses in the front-end. A notice here is that I am changing the handling of `pending` status. You can see my comment above, it was not correctly handled. 

### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Fix a bug in a current feature. 

### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before trying two test cases below, make sure you've done two actions: 

1. Apply D37557-code in your sandbox.
2. Configure JETPACK__SANDBOX_DOMAIN in your wp-config.php 

#### Case 01 - Compatibility for the previous JP versions

1. DO NOT apply this Jetpack PR in your testing site.
2. Use a test email to subscribe your testing site 
3. See a successful message `Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing.`
4. Try to use this email and subscribe again. 
5. Continue to see the successful message above. 

#### Case 02 - Fix the bug in new releases 

1. APPLY this Jetpack PR in your testing site. 
2. In jetpack.php, change constant `JETPACK__VERSION` to 8.2. https://github.com/Automattic/jetpack/blob/master/jetpack.php#L18
3. Go to JPDB of your site > `Full Sync` section > choose `options, constants, functions, updates` > Run `Schedule Sync`. Make sure the full-sync is finished.
4. Refresh JPDB, the version of JP should be 8.2 now. 
5. Use a test email to subscribe your testing site.
6. See a successful message `Success! An email was just sent to confirm your subscription. Please find the email now and click 'Confirm Follow' to start subscribing.`
7. Try to use this email and subscribe again. 
8. See an error message `You subscribed this site before but you have not clicked the confirmation link yet. Please check your mailbox. Otherwise, you can manage your preferences at subscribe.wordpress.com.`

Extra steps to restore your site version: 

- In jetpack.php, revert the previous value of `JETPACK__VERSION`.
- Follow steps 3 and 4 but verify that your site version is back to the previous value. 

### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Subscriptions: inform a clear error for pending confirmations
