### PR TITLE
Gutenberg Blocks: Fix Jetpack sidebar button

### DIFF
--- a/extensions/shared/jetpack-plugin-sidebar.scss
+++ b/extensions/shared/jetpack-plugin-sidebar.scss
@@ -19,7 +19,9 @@
 }
 
 .edit-post-pinned-plugins {
-	.components-icon-button {
+	.components-icon-button,    // Gutenberg < 7.2.0. @TODO: Remove once we drop support
+	.components-button.has-icon // Gutenberg >= 7.2.0
+	 {
 		&:not( .is-toggled ),
 		&:hover,
 		&.is-toggled,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

https://github.com/WordPress/gutenberg/pull/19241 broke the styling of our Jetpack sidebar button  (again :sweat_smile:) This is currently a problem on WP.com, where we just updated Gutenberg to 7.2.0.

This PR updates the class selectors accordingly.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Nothin' new.

#### Testing instructions:

To repro the issue on `master`, install Gutenberg 7.2.0, and activate it:

![image](https://user-images.githubusercontent.com/96308/72268494-34274c00-3622-11ea-9e08-eca9f59e2587.png)

Then, verify that the issue is fixed by this branch.

#### Proposed changelog entry for your changes:

Gutenberg Blocks: Update Jetpack sidebar button class selectors