### PR TITLE
Call plugin_upgrade() during the plugins_loaded action

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -395,8 +395,7 @@ class Jetpack {
 	public static function init() {
 		if ( ! self::$instance ) {
 			self::$instance = new Jetpack();
-
-			self::$instance->plugin_upgrade();
+			add_action( 'plugins_loaded', array( self::$instance, 'plugin_upgrade' ) );
 		}
 
 		return self::$instance;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Package classes must not be used before all of the plugins have been loaded.
The `Jetpack::plugin_upgrade()` method uses package classes, so hook it to the
`plugins_loaded` action.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
* Review the `plugin_upgrade()` method and ensure that nothing needs to be run before the `plugins_loaded` action fires.
* Since the `plugin_upgrade()` method is used when the plugin is updated to a new version, use the Jetpack Beta plugin to update Jetpack to this branch from a previous version:

##### Test Site
* Jetpack must be activated.
* The Jetpack Beta plugin must be activated.

##### Test instructions:
1. Navigate to wp-admin -> Jetpack -> Jetpack Beta and activate the Release Candidate version. 
2. Once the Release Candidate is active, verify that the currently running version is **8.1…**
3. Search for this branch (_update / move / plugin / upgrade / plugins / loaded_) and activate it.
4. Navigate to wp_admin -> Jetpack and verify that the version is **8.2-alpha**. You should see a **Welcome to Jetpack 8.2-alpha** notice.
5. Verify that no errors were generated in the debug.log and that everything seems to be working properly after the update.



#### Proposed changelog entry for your changes:
* n/a
