### PR TITLE
Register Action does not currently display error messages to the user

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4260,8 +4260,133 @@ p {
 		add_filter( 'jetpack_short_module_description', 'wptexturize' );
 	}
 
-	function admin_notices() {
+	/**
+     * Converts an error_code into a user friendly string for admin notices
+     *
+	 * @param $error
+	 *
+	 * @return string
+	 */
+	private function pretty_error_codes( $error ) {
 
+	    $message = '';
+		switch ( $error ) {
+			case 'cheatin':
+				$message = __( "Cheatin' uh?", 'jetpack' );
+				break;
+			case 'access_denied':
+				$message = sprintf(
+					__( 'Would you mind telling us why you did not complete the Jetpack connection in this ' .
+					    ' <a href="%s">2 question survey</a>?</br>' .
+                        'A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
+					'href="https://jetpack.com/cancelled-connection/" rel="noopener noreferrer" target="_blank"'
+				);
+		        break;
+	        case 'wrong_state':
+				$message = __(
+					'You need to stay logged in to your WordPress blog while you authorize Jetpack.', 'jetpack'
+				);
+				break;
+			case 'invalid_client':
+				$message = __(
+					'We had an issue connecting Jetpack; deactivate then reactivate the Jetpack plugin, then connect again.', 'jetpack'
+				);
+				break;
+			case 'invalid_grant':
+				$message = __(
+					'There was an issue connecting your Jetpack. Please click "Connect to WordPress.com" again.', 'jetpack'
+				);
+				break;
+			case 'site_inaccessible':
+			case 'site_requires_authorization':
+				$message = __(
+					'Your website needs to be publicly accessible to use Jetpack.', 'jetpack'
+				);
+				break;
+			case 'site_blacklisted':
+				$message = sprintf(
+				        __( 'This site can\'t be connected to WordPress.com because it violates our ' .
+                            ' <a href="%s">Terms of Service</a>.', 'jetpack' ),
+					'href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"'
+				);
+				break;
+			case 'not_public':
+				$message = __(
+					'<strong>Your Jetpack has a glitch.</strong> Connecting this site with WordPress.com is not possible. ' +
+					'This usually means your site is not publicly accessible (localhost).', 'jetpack'
+				);
+				break;
+			case 'wpcom_408':
+			case 'wpcom_5??':
+			case 'wpcom_bad_response':
+			case 'wpcom_outage':
+				$message = __(
+					'WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.', 'jetpack'
+				);
+				break;
+			case 'register_http_request_failed':
+			case 'token_http_request_failed':
+				$message = __(
+					'Jetpack could not contact WordPress.com.  This usually means something is incorrectly configured on your web host.',
+					'jetpack'
+				);
+				break;
+			case 'no_role':
+			case 'no_cap':
+			case 'no_code':
+			case 'no_state':
+			case 'invalid_state':
+			case 'invalid_request':
+			case 'invalid_scope':
+			case 'unsupported_response_type':
+			case 'invalid_token':
+			case 'no_token':
+			case 'missing_secrets':
+			case 'home_missing':
+			case 'siteurl_missing':
+			case 'gmt_offset_missing':
+			case 'site_name_missing':
+			case 'secret_1_missing':
+			case 'secret_2_missing':
+			case 'site_lang_missing':
+			case 'home_malformed':
+			case 'siteurl_malformed':
+			case 'gmt_offset_malformed':
+			case 'timezone_string_malformed':
+			case 'site_name_malformed':
+			case 'secret_1_malformed':
+			case 'secret_2_malformed':
+			case 'site_lang_malformed':
+			case 'secrets_mismatch':
+			case 'verify_secret_1_missing':
+			case 'verify_secret_1_malformed':
+			case 'verify_secrets_missing':
+			case 'verify_secrets_mismatch':
+				$message = __(
+					"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. " +
+					'Please try again later, if the issue continues please contact support with this message:',
+                    'jetpack'
+				);
+				$message .= " " . esc_html( $error );
+				break;
+			default:
+				$message =
+				$message = sprintf(
+                    __(
+                        "<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. " +
+                        'Please try again later, if the issue continues please contact support with this message: %s',
+                        'jetpack'
+                    ),
+				    esc_html( $error )
+                );
+		}
+
+		return $message;
+
+    }
+
+
+	function admin_notices() {
 		if ( $this->error ) {
 			?>
 <div id="message" class="jetpack-message jetpack-err">
@@ -4269,9 +4394,9 @@ p {
 		<h2>
 			<?php
 			echo wp_kses(
-				$this->error,
+				$this->pretty_error_codes( $this->error ),
 				array(
-					'a'      => array( 'href' => array() ),
+					'a'      => array( 'href' => array(), 'rel' => array(), 'target' => array() ),
 					'small'  => true,
 					'code'   => true,
 					'strong' => true,

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4261,8 +4261,8 @@ p {
 	}
 
 	/**
-     * Converts an error_code into a user friendly string for admin notices
-     *
+	 * Converts an error_code into a user friendly string for admin notices
+	 *
 	 * @param $error
 	 *
 	 * @return string
@@ -4278,7 +4278,7 @@ p {
 				$message = sprintf(
 					__( 'Would you mind telling us why you did not complete the Jetpack connection in this ' .
 					    ' <a href="%s">2 question survey</a>?</br>' .
-                        'A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
+					    'A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
 					'href="https://jetpack.com/cancelled-connection/" rel="noopener noreferrer" target="_blank"'
 				);
 		        break;
@@ -4305,8 +4305,8 @@ p {
 				break;
 			case 'site_blacklisted':
 				$message = sprintf(
-				        __( 'This site can\'t be connected to WordPress.com because it violates our ' .
-                            ' <a href="%s">Terms of Service</a>.', 'jetpack' ),
+					__( 'This site can\'t be connected to WordPress.com because it violates our ' .
+					    ' <a href="%s">Terms of Service</a>.', 'jetpack' ),
 					'href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"'
 				);
 				break;
@@ -4383,8 +4383,7 @@ p {
 
 		return $message;
 
-    }
-
+	}
 
 	function admin_notices() {
 		if ( $this->error ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4037,7 +4037,7 @@ p {
 					exit;
 				case 'register':
 					if ( ! current_user_can( 'jetpack_connect' ) ) {
-						$error = 'cheatin';
+						$this->error = 'cheatin';
 						break;
 					}
 					check_admin_referer( 'jetpack-register' );
@@ -4045,8 +4045,8 @@ p {
 					self::maybe_set_version_option();
 					$registered = self::try_registration();
 					if ( is_wp_error( $registered ) ) {
-						$error = $registered->get_error_code();
-						self::state( 'error', $error );
+						$this->error = $registered->get_error_code();
+						self::state( 'error', $this->error );
 						self::state( 'error', $registered->get_error_message() );
 
 						/**
@@ -4057,7 +4057,7 @@ p {
 						 * @param string|int $error The error code.
 						 * @param \WP_Error $registered The error object.
 						 */
-						do_action( 'jetpack_connection_register_fail', $error, $registered );
+						do_action( 'jetpack_connection_register_fail', $this->error, $registered );
 						break;
 					}
 
@@ -4087,7 +4087,7 @@ p {
 					exit;
 				case 'activate':
 					if ( ! current_user_can( 'jetpack_activate_modules' ) ) {
-						$error = 'cheatin';
+						$this->error = 'cheatin';
 						break;
 					}
 
@@ -4112,7 +4112,7 @@ p {
 					exit;
 				case 'disconnect':
 					if ( ! current_user_can( 'jetpack_disconnect' ) ) {
-						$error = 'cheatin';
+						$this->error = 'cheatin';
 						break;
 					}
 
@@ -4123,7 +4123,7 @@ p {
 					exit;
 				case 'reconnect':
 					if ( ! current_user_can( 'jetpack_reconnect' ) ) {
-						$error = 'cheatin';
+						$this->error = 'cheatin';
 						break;
 					}
 
@@ -4134,7 +4134,7 @@ p {
 					exit;
 				case 'deactivate':
 					if ( ! current_user_can( 'jetpack_deactivate_modules' ) ) {
-						$error = 'cheatin';
+						$this->error = 'cheatin';
 						break;
 					}
 
@@ -4192,7 +4192,7 @@ p {
 			}
 		}
 
-		if ( ! $error = $error ? $error : self::state( 'error' ) ) {
+		if ( false == $this->error && empty( self::state( 'error' ) ) ) {
 			self::activate_new_modules( true );
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4276,9 +4276,7 @@ p {
 				break;
 			case 'access_denied':
 				$message = sprintf(
-					__( 'Would you mind telling us why you did not complete the Jetpack connection in this ' .
-					    ' <a href="%s">2 question survey</a>?</br>' .
-					    'A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
+					__( 'Would you mind telling us why you did not complete the Jetpack connection in this  <a %s>2 question survey</a>?</br>A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
 					'href="https://jetpack.com/cancelled-connection/" rel="noopener noreferrer" target="_blank"'
 				);
 		        break;
@@ -4305,15 +4303,14 @@ p {
 				break;
 			case 'site_blacklisted':
 				$message = sprintf(
-					__( 'This site can\'t be connected to WordPress.com because it violates our ' .
-					    ' <a href="%s">Terms of Service</a>.', 'jetpack' ),
+					__( 'This site can\'t be connected to WordPress.com because it violates our  <a %s>Terms of Service</a>.', 'jetpack' ),
 					'href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"'
 				);
 				break;
 			case 'not_public':
 				$message = __(
-					'<strong>Your Jetpack has a glitch.</strong> Connecting this site with WordPress.com is not possible. ' +
-					'This usually means your site is not publicly accessible (localhost).', 'jetpack'
+					"<strong>Your Jetpack has a glitch.</strong> Connecting this site with WordPress.com is not possible. This usually means your site is not publicly accessible (localhost).",
+                    'jetpack'
 				);
 				break;
 			case 'wpcom_408':
@@ -4362,19 +4359,18 @@ p {
 			case 'verify_secret_1_malformed':
 			case 'verify_secrets_missing':
 			case 'verify_secrets_mismatch':
-				$message = __(
-					"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. " +
-					'Please try again later, if the issue continues please contact support with this message:',
-                    'jetpack'
-				);
-				$message .= " " . esc_html( $error );
+			    $message = sprintf(
+	                __(
+                        "<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
+                        'jetpack'
+                    ),
+				    esc_html( $error )
+			    );
 				break;
 			default:
-				$message =
 				$message = sprintf(
                     __(
-                        "<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. " +
-                        'Please try again later, if the issue continues please contact support with this message: %s',
+                        "<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
                         'jetpack'
                     ),
 				    esc_html( $error )

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4260,115 +4260,6 @@ p {
 		add_filter( 'jetpack_short_module_description', 'wptexturize' );
 	}
 
-	/**
-	 * Converts an error_code into a user friendly string for admin notices
-	 *
-	 * @param $error
-	 *
-	 * @return string
-	 */
-	private function pretty_error_codes( $error ) {
-
-	    $message = '';
-		switch ( $error ) {
-			case 'cheatin':
-				$message = __( "Cheatin' uh?", 'jetpack' );
-				break;
-            case 'wrong_state':
-				$message = __(
-					'You need to stay logged in to your WordPress blog while you authorize Jetpack.', 'jetpack'
-				);
-				break;
-			case 'invalid_client':
-				$message = __(
-					'We had an issue connecting Jetpack. Please deactivate then reactivate the Jetpack plugin and then connect again.', 'jetpack'
-				);
-				break;
-			case 'invalid_grant':
-				$message = __(
-					'There was an issue connecting your Jetpack. Please click "Connect to WordPress.com" again.', 'jetpack'
-				);
-				break;
-			case 'access_denied':
-			case 'site_inaccessible':
-			case 'site_requires_authorization':
-				$message = __(
-					'Your website needs to be publicly accessible to use Jetpack. Please update your website\'s settings and try again', 'jetpack'
-				);
-				break;
-			case 'site_blacklisted':
-				$message = sprintf(
-					__( 'This site can\'t be connected to WordPress.com because it violates our  <a %s>Terms of Service</a>.', 'jetpack' ),
-					'href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"'
-				);
-				break;
-			case 'not_public':
-				$message = __(
-					"<strong>Your Jetpack has a glitch.</strong> Connecting this site with WordPress.com is not possible. This usually means your site is not publicly accessible (localhost).",
-					'jetpack'
-				);
-				break;
-			case 'wpcom_408':
-			case 'wpcom_5??':
-			case 'wpcom_bad_response':
-			case 'wpcom_outage':
-				$message = __(
-					'WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.', 'jetpack'
-				);
-				break;
-			case 'register_http_request_failed':
-			case 'token_http_request_failed':
-				$message = __(
-					'Jetpack could not contact WordPress.com.  This usually means something is incorrectly configured on your web host.',
-					'jetpack'
-				);
-				break;
-			case 'no_role':
-			case 'no_cap':
-			case 'no_code':
-			case 'no_state':
-			case 'invalid_state':
-			case 'invalid_request':
-			case 'invalid_scope':
-			case 'unsupported_response_type':
-			case 'invalid_token':
-			case 'no_token':
-			case 'missing_secrets':
-			case 'home_missing':
-			case 'siteurl_missing':
-			case 'gmt_offset_missing':
-			case 'site_name_missing':
-			case 'secret_1_missing':
-			case 'secret_2_missing':
-			case 'site_lang_missing':
-			case 'home_malformed':
-			case 'siteurl_malformed':
-			case 'gmt_offset_malformed':
-			case 'timezone_string_malformed':
-			case 'site_name_malformed':
-			case 'secret_1_malformed':
-			case 'secret_2_malformed':
-			case 'site_lang_malformed':
-			case 'secrets_mismatch':
-			case 'verify_secret_1_missing':
-			case 'verify_secret_1_malformed':
-			case 'verify_secrets_missing':
-			case 'verify_secrets_mismatch':
-			default:
-				$message = sprintf(
-					__(
-						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please <a %s>contact support</a> with this message: %s",
-						'jetpack'
-					),
-					'href="https://jetpack.com/contact-support" rel="noopener noreferrer" target="_blank"',
-					esc_html( $error )
-				);
-		}
-
-		return $message;
-
-	}
-
 	function admin_notices() {
 		if ( $this->error ) {
 			?>
@@ -4377,7 +4268,7 @@ p {
 		<h2>
 			<?php
 			echo wp_kses(
-				$this->pretty_error_codes( $this->error ),
+				$this->connection_manager->get_error_message_from_code( $this->error ),
 				array(
 					'a'      => array( 'href' => array(), 'rel' => array(), 'target' => array() ),
 					'small'  => true,

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4274,12 +4274,6 @@ p {
 			case 'cheatin':
 				$message = __( "Cheatin' uh?", 'jetpack' );
 				break;
-			case 'access_denied':
-				$message = sprintf(
-					__( 'Would you mind telling us why you did not complete the Jetpack connection in this  <a %s>2 question survey</a>?</br>A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
-					'href="https://jetpack.com/cancelled-connection/" rel="noopener noreferrer" target="_blank"'
-				);
-                break;
             case 'wrong_state':
 				$message = __(
 					'You need to stay logged in to your WordPress blog while you authorize Jetpack.', 'jetpack'
@@ -4287,7 +4281,7 @@ p {
 				break;
 			case 'invalid_client':
 				$message = __(
-					'We had an issue connecting Jetpack; deactivate then reactivate the Jetpack plugin, then connect again.', 'jetpack'
+					'We had an issue connecting Jetpack. Please deactivate then reactivate the Jetpack plugin and then connect again.', 'jetpack'
 				);
 				break;
 			case 'invalid_grant':
@@ -4295,10 +4289,11 @@ p {
 					'There was an issue connecting your Jetpack. Please click "Connect to WordPress.com" again.', 'jetpack'
 				);
 				break;
+			case 'access_denied':
 			case 'site_inaccessible':
 			case 'site_requires_authorization':
 				$message = __(
-					'Your website needs to be publicly accessible to use Jetpack.', 'jetpack'
+					'Your website needs to be publicly accessible to use Jetpack. Please update your website\'s settings and try again', 'jetpack'
 				);
 				break;
 			case 'site_blacklisted':

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4354,20 +4354,13 @@ p {
 			case 'verify_secret_1_malformed':
 			case 'verify_secrets_missing':
 			case 'verify_secrets_mismatch':
-				$message = sprintf(
-					__(
-						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
-						'jetpack'
-					),
-					esc_html( $error )
-			    );
-				break;
 			default:
 				$message = sprintf(
 					__(
-						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
+						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please <a %s>contact support</a> with this message: %s",
 						'jetpack'
 					),
+					'href="https://jetpack.com/contact-support" rel="noopener noreferrer" target="_blank"',
 					esc_html( $error )
 				);
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4279,8 +4279,8 @@ p {
 					__( 'Would you mind telling us why you did not complete the Jetpack connection in this  <a %s>2 question survey</a>?</br>A Jetpack connection is required for our free security and traffic features to work.', 'jetpack' ),
 					'href="https://jetpack.com/cancelled-connection/" rel="noopener noreferrer" target="_blank"'
 				);
-		        break;
-	        case 'wrong_state':
+                break;
+            case 'wrong_state':
 				$message = __(
 					'You need to stay logged in to your WordPress blog while you authorize Jetpack.', 'jetpack'
 				);
@@ -4310,7 +4310,7 @@ p {
 			case 'not_public':
 				$message = __(
 					"<strong>Your Jetpack has a glitch.</strong> Connecting this site with WordPress.com is not possible. This usually means your site is not publicly accessible (localhost).",
-                    'jetpack'
+					'jetpack'
 				);
 				break;
 			case 'wpcom_408':
@@ -4359,22 +4359,22 @@ p {
 			case 'verify_secret_1_malformed':
 			case 'verify_secrets_missing':
 			case 'verify_secrets_mismatch':
-			    $message = sprintf(
-	                __(
-                        "<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
-                        'jetpack'
-                    ),
-				    esc_html( $error )
+				$message = sprintf(
+					__(
+						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
+						'jetpack'
+					),
+					esc_html( $error )
 			    );
 				break;
 			default:
 				$message = sprintf(
-                    __(
-                        "<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
-                        'jetpack'
-                    ),
-				    esc_html( $error )
-                );
+					__(
+						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
+						'jetpack'
+					),
+					esc_html( $error )
+				);
 		}
 
 		return $message;

--- a/packages/connection/src/class-connection-error-handler.php
+++ b/packages/connection/src/class-connection-error-handler.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * The Jetpack Connection Error Handler class file.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * The Jetpack Connection Error Handler class is used to handle the errors
+ * generated during the connection process.
+ */
+class Connection_Error_Handler {
+
+	/**
+	 * Returns the detailed error message for an error code.
+	 *
+	 * @param string $error_code The error code.
+	 */
+	public function get_error_message_from_code( $error_code ) {
+		$message = '';
+
+		switch ( $error_code ) {
+			case 'cheatin':
+				$message = __( "Cheatin' uh?", 'jetpack' );
+				break;
+			case 'wrong_state':
+				$message = __(
+					'You need to stay logged in to your WordPress blog while you authorize Jetpack.',
+					'jetpack'
+				);
+				break;
+			case 'invalid_client':
+				$message = __(
+					'We had an issue connecting Jetpack. Please deactivate then reactivate the Jetpack plugin and then connect again.',
+					'jetpack'
+				);
+				break;
+			case 'invalid_grant':
+				$message = __(
+					'There was an issue connecting your Jetpack. Please click "Connect to WordPress.com" again.',
+					'jetpack'
+				);
+				break;
+			case 'access_denied':
+			case 'site_inaccessible':
+			case 'site_requires_authorization':
+				$message = __(
+					'Your website needs to be publicly accessible to use Jetpack. Please update your website\'s settings and try again',
+					'jetpack'
+				);
+				break;
+			case 'site_blacklisted':
+				$message = sprintf(
+					__(
+						'This site can\'t be connected to WordPress.com because it violates our  <a %s>Terms of Service</a>.',
+						'jetpack'
+					),
+					'href="https://wordpress.com/tos" rel="noopener noreferrer" target="_blank"'
+				);
+				break;
+			case 'not_public':
+				$message = __(
+					'<strong>Your Jetpack has a glitch.</strong> Connecting this site with WordPress.com is not possible. This usually means your site is not publicly accessible (localhost).',
+					'jetpack'
+				);
+				break;
+			case 'wpcom_408':
+			case 'wpcom_5??':
+			case 'wpcom_bad_response':
+			case 'wpcom_outage':
+				$message = __(
+					'WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.',
+					'jetpack'
+				);
+				break;
+			case 'register_http_request_failed':
+			case 'token_http_request_failed':
+				$message = __(
+					'Jetpack could not contact WordPress.com.  This usually means something is incorrectly configured on your web host.',
+					'jetpack'
+				);
+				break;
+			case 'no_role':
+			case 'no_cap':
+			case 'no_code':
+			case 'no_state':
+			case 'invalid_state':
+			case 'invalid_request':
+			case 'invalid_scope':
+			case 'unsupported_response_type':
+			case 'invalid_token':
+			case 'no_token':
+			case 'missing_secrets':
+			case 'home_missing':
+			case 'siteurl_missing':
+			case 'gmt_offset_missing':
+			case 'site_name_missing':
+			case 'secret_1_missing':
+			case 'secret_2_missing':
+			case 'site_lang_missing':
+			case 'home_malformed':
+			case 'siteurl_malformed':
+			case 'gmt_offset_malformed':
+			case 'timezone_string_malformed':
+			case 'site_name_malformed':
+			case 'secret_1_malformed':
+			case 'secret_2_malformed':
+			case 'site_lang_malformed':
+			case 'secrets_mismatch':
+			case 'verify_secret_1_missing':
+			case 'verify_secret_1_malformed':
+			case 'verify_secrets_missing':
+			case 'verify_secrets_mismatch':
+			default:
+				$message = sprintf(
+					__(
+						"<strong>Your Jetpack has a glitch.</strong>  We're sorry for the inconvenience. Please try again later, if the issue continues please <a %1\$s>contact support</a> with this message: %2\$s",
+						'jetpack'
+					),
+					'href="https://jetpack.com/contact-support" rel="noopener noreferrer" target="_blank"',
+					esc_html( $error_code )
+				);
+		}
+
+		return $message;
+	}
+}

--- a/packages/connection/src/class-connection-error-handler.php
+++ b/packages/connection/src/class-connection-error-handler.php
@@ -53,6 +53,7 @@ class Connection_Error_Handler {
 				break;
 			case 'site_blacklisted':
 				$message = sprintf(
+					/* translators: URL to the WPCOM TOS page. */
 					__(
 						'This site can\'t be connected to WordPress.com because it violates our  <a %s>Terms of Service</a>.',
 						'jetpack'

--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -11,7 +11,7 @@ namespace Automattic\Jetpack\Connection;
  * The Jetpack Connection Error Handler class is used to handle the errors
  * generated during the connection process.
  */
-class Connection_Error_Handler {
+class Error_Handler {
 
 	/**
 	 * Returns the detailed error message for an error code.

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2167,4 +2167,15 @@ class Manager {
 
 		return $role . ':' . hash_hmac( 'md5', "{$role}|{$user_id}", $token->secret );
 	}
+
+	/**
+	 * Returns the detailed connection error message for the given error code.
+	 *
+	 * @param string $error_code The error code.
+	 *
+	 * @return string The error message.
+	 */
+	public function get_error_message_from_code( $error_code ) {
+		return ( new Connection_Error_Handler() )->get_error_message_from_code( $error_code );
+	}
 }


### PR DESCRIPTION
Register Action does not currently display error messages to the user. This is causing confusion as users repeatedly try to 'Set up Jetpack' and are always shown the same screen without any info on the error experienced.

We are correcting this by changing  to ->error to ensure the admin_notices are rendered.

Note that pretty error messages are needed for all error codes.

Fixes #

#### Changes proposed in this Pull Request:
* Update Register logic to display error messages to the user.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updates existing Connection Flow

#### Testing instructions:
Current Behavior is shown with
* Disable support for XML-RPC or mark the site private
* Activate Jetpack on your site
* Try "Set up Jetpack"  (/wp-admin/admin.php?page=jetpack&action=register&_wpnonce=XXXXXX&from=full-screen-prompt)
* User will be shown the same "Set up Jetpack" screen 

Apply Patch
* Try "Set up Jetpack" . 
* User will see an admin notice with the error experienced

#### Proposed changelog entry for your changes:
* No Changelog needed
