### PR TITLE
Connection\Utils: Add a new function which provides the Jetpack API version

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -70,7 +70,7 @@ class Client {
 		$token_key = sprintf(
 			'%s:%d:%d',
 			$token_key,
-			Constants::get_constant( 'JETPACK__API_VERSION' ),
+			Utils::get_jetpack_api_version(),
 			$token->external_user_id
 		);
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -337,7 +337,7 @@ class Manager {
 		if (
 			empty( $token_key )
 		||
-			empty( $version ) || strval( JETPACK__API_VERSION ) !== $version
+			empty( $version ) || strval( Utils::get_jetpack_api_version() ) !== $version
 		) {
 			return new \WP_Error( 'malformed_token', 'Malformed token in request', compact( 'signature_details' ) );
 		}
@@ -716,10 +716,8 @@ class Manager {
 	 */
 	public function api_url( $relative_url ) {
 		$api_base = Constants::get_constant( 'JETPACK__API_BASE' );
-		$version  = Constants::get_constant( 'JETPACK__API_VERSION' );
-
 		$api_base = $api_base ? $api_base : 'https://jetpack.wordpress.com/jetpack.';
-		$version  = $version ? '/' . $version . '/' : '/1/';
+		$version  = '/' . Utils::get_jetpack_api_version() . '/';
 
 		/**
 		 * Filters the API URL that Jetpack uses for server communication.

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -14,6 +14,8 @@ use Automattic\Jetpack\Constants;
  */
 class Utils {
 
+	const DEFAULT_JETPACK_API_VERSION = 1;
+
 	/**
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requests.
 	 * This method sets the URL scheme to HTTP when HTTPS requests can't be made.
@@ -58,5 +60,17 @@ class Utils {
 			$options = compact( 'user_tokens' );
 		}
 		return \Jetpack_Options::update_options( $options );
+	}
+
+	/**
+	 * Returns the Jetpack__API_VERSION constant if it exists, else returns a
+	 * default value of 1.
+	 *
+	 * @return integer
+	 */
+	public static function get_jetpack_api_version() {
+		$api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
+		$api_version = $api_version ? $api_version : self::DEFAULT_JETPACK_API_VERSION;
+		return $api_version;
 	}
 }

--- a/packages/connection/tests/php/test_Utils.php
+++ b/packages/connection/tests/php/test_Utils.php
@@ -1,0 +1,44 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * The UtilsTest class file.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provides unit tests for the methods in the Utils class.
+ */
+class UtilsTest extends TestCase {
+
+	/**
+	 * This method is called after each test.
+	 */
+	public function tearDown() {
+		Constants::clear_constants();
+	}
+
+	/**
+	 * Utils::get_jetpack_api_version should return the JETPACK__API_VERSION
+	 * constant when the constant is defined.
+	 *
+	 *  @covers Automattic\Jetpack\Connection\Utils::get_jetpack_api_version
+	 */
+	public function test_get_jetpack_api_version_with_constant() {
+		$test_constant_value = 3;
+		Constants::set_constant( 'JETPACK__API_VERSION', $test_constant_value );
+		$this->assertEquals( $test_constant_value, Utils::get_jetpack_api_version() );
+	}
+
+	/**
+	 * Utils::get_jetpack_api_version should return the default Jetpack API version
+	 * value when the JETPACK__API_VERSION constant is not defined.
+	 */
+	public function test_get_jetpack_api_version_without_constant() {
+		$this->assertEquals( Utils::DEFAULT_JETPACK_API_VERSION, Utils::get_jetpack_api_version() );
+	}
+}


### PR DESCRIPTION
This change helps to separate the Connection package from Jetpack. The JETPACK__API_VERSION constant is provided by Jetpack. If the connection package is used without Jetpack, the JETPACK_API_VERSION constant is undefined and a PHP warning is generated.

#### Changes proposed in this Pull Request:
* Add a new function to the Util class which provides the Jetpack API version. It will return the JETPACK__API_VERSION constant if it's available. Otherwise, it will return a default value of 1.
* Use this new function to obtain the Jetpack API version in the Manager and Client classes.
* Add Automattic\Jetpack\Connection\Utils to the autoloader ignore list. This is just temporary to keep PHP notices from being generated; it should be removed when Automattic\Jetpack\Connection\Manager is removed from the ignore list

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
* tbd

#### Proposed changelog entry for your changes:
* tbd
