### PR TITLE
Instant search: introduce overlay from right

### DIFF
--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -13,7 +13,7 @@
 	z-index: 9999999999999;
 
 	&.is-hidden {
-		transform: translateX( 200vh );
+		transform: translateX( 100vw );
 	}
 }
 

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -13,7 +13,7 @@
 	z-index: 9999999999999;
 
 	&.is-hidden {
-		transform: translateY( -100vh );
+		transform: translateX( 200vh );
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR changes the Instant Search overlay to appear from the right, rather than from above. 

In #14230 @gibrown commented:

> For some reason I want it to slide up or from the side that the filters are on. More like turning a page...

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No - this is part of the Instant Search prototype.

#### Testing instructions:

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

#### Proposed changelog entry for your changes:

Not required.