### PR TITLE
Jetpack_Media: Delete revision history items before updating metadata

### DIFF
--- a/_inc/lib/class.media.php
+++ b/_inc/lib/class.media.php
@@ -397,22 +397,24 @@ class Jetpack_Media {
 	 * - preserve original media file
 	 * - trace revision history
 	 *
-	 * @param  number $media_id - media post ID
-	 * @param  array $file_array - temporal file
+	 * @param  number $media_id - media post ID.
+	 * @param  array  $file_array - temporal file.
 	 * @return {Post|WP_Error} Updated media item or a WP_Error is something went wrong.
 	 */
 	public static function edit_media_file( $media_id, $file_array ) {
-		$media_item = get_post( $media_id );
+		$media_item         = get_post( $media_id );
 		$has_original_media = self::get_original_media( $media_id );
 
 		if ( ! $has_original_media ) {
+
 			// The first time that the media is updated
-			// the original media is stored into the revision_history
+			// the original media is stored into the revision_history.
 			$snapshot = self::get_snapshot( $media_item );
+			//phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			add_post_meta( $media_id, self::$WP_ORIGINAL_MEDIA, $snapshot, true );
 		}
 
-		// save temporary file in the correct location
+		// Save temporary file in the correct location.
 		$uploaded_file = self::save_temporary_file( $file_array, $media_id );
 
 		if ( is_wp_error( $uploaded_file ) ) {
@@ -420,27 +422,30 @@ class Jetpack_Media {
 			return $uploaded_file;
 		}
 
-		// revision_history control
+		// Revision_history control.
 		self::register_revision( $media_item, $uploaded_file, $has_original_media );
 
-		$uploaded_path = $uploaded_file['file'];
+		$uploaded_path     = $uploaded_file['file'];
 		$udpated_mime_type = $uploaded_file['type'];
-		$was_updated = update_attached_file( $media_id, $uploaded_path );
+		$was_updated       = update_attached_file( $media_id, $uploaded_path );
 
 		if ( ! $was_updated ) {
 			return WP_Error( 'update_error', 'Media update error' );
 		}
 
+		// Check maximum amount of revision_history before updating the attachment metadata.
+		self::limit_revision_history( $media_id );
+
 		$new_metadata = wp_generate_attachment_metadata( $media_id, $uploaded_path );
 		wp_update_attachment_metadata( $media_id, $new_metadata );
 
-		// check maximum amount of revision_history
-		self::limit_revision_history( $media_id );
-
-		$edited_action = wp_update_post( (object) array(
-			'ID'              => $media_id,
-			'post_mime_type'  => $udpated_mime_type
-		), true );
+		$edited_action = wp_update_post(
+			(object) array(
+				'ID'             => $media_id,
+				'post_mime_type' => $udpated_mime_type,
+			),
+			true
+		);
 
 		if ( is_wp_error( $edited_action ) ) {
 			return $edited_action;
@@ -456,4 +461,3 @@ function clean_revision_history( $media_id ) {
 };
 
 add_action( 'delete_attachment', 'clean_revision_history' );
-


### PR DESCRIPTION
When a media file is remotely edited, the `Jetpack_Media::edit_media_file()` method is called. Within this method, the `wp_generate_attachment_metadata()` function is called, which updates the metadata for the updated file. Then `Jetpack_Media::limit_revision_history()` is called, which determines if the revision history limit has been reached.

If the revision history limit has been reached, the `Jetpack_Media::delete_media_history_file()`
method is called. This method calls `wp_generated_attachment_metadata()` on the file that is being deleted, which updates the attachment metadata. However, we already updated the attachment metadata, and this overwrites that updated metadata with the metadata for the file that's being deleted. This causes broken image URLs in the wp-admin media library.

Fixes #14315

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Call `Jetpack_Media::limit_revision_history()` before calling `wp_generate_attachment_metadata()` in the `Jetpack_Media::edit_media_file()` method. This will prevent the updated attachment metadata from being overwritten.
* Fix some PHPCS warnings for comments and whitespace.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes an existing part of Jetpack.

#### Testing instructions

##### Test site
* Jetpack must be active and connected.

##### Test instructions

1. Add an image to the site's media library.
2. Navigate to Calypso admin -> Media.
3. Edit the image.
4. Navigate to wp-admin -> Media Library. The edited image should display correctly.
5. Navigate to Calypso admin -> Media.
6. Edit the image a second time.
7. Navigate to wp-admin -> Media Library. The edited image should display correctly.

#### Proposed changelog entry for your changes:
* Fix a bug that broke image urls if they were remotely updated multiple times.
