### PR TITLE
Move connection manager related logic to after plugins_loaded.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -572,21 +572,6 @@ class Jetpack {
 
 		add_action( 'jetpack_verify_signature_error', array( $this, 'track_xmlrpc_error' ) );
 
-		$this->connection_manager = new Connection_Manager();
-		$this->connection_manager->init();
-
-		/*
-		 * Load things that should only be in Network Admin.
-		 *
-		 * For now blow away everything else until a more full
-		 * understanding of what is needed at the network level is
-		 * available
-		 */
-		if ( is_multisite() ) {
-			$network = Jetpack_Network::init();
-			$network->set_connection( $this->connection_manager );
-		}
-
 		add_filter(
 			'jetpack_signature_check_token',
 			array( __CLASS__, 'verify_onboarding_token' ),
@@ -729,6 +714,7 @@ class Jetpack {
 
 		foreach (
 			array(
+				'connection',
 				'sync',
 				'tracking',
 				'tos',
@@ -736,6 +722,20 @@ class Jetpack {
 			as $feature
 		) {
 			$config->ensure( $feature );
+		}
+
+		$this->connection_manager = new Connection_Manager();
+
+		/*
+		 * Load things that should only be in Network Admin.
+		 *
+		 * For now blow away everything else until a more full
+		 * understanding of what is needed at the network level is
+		 * available
+		 */
+		if ( is_multisite() ) {
+			$network = Jetpack_Network::init();
+			$network->set_connection( $this->connection_manager );
 		}
 
 		// Initialize remote file upload request handlers.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -593,16 +593,6 @@ class Jetpack {
 		add_action( 'deleted_user', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 		add_action( 'remove_user_from_blog', array( 'Automattic\\Jetpack\\Connection\\Manager', 'disconnect_user' ), 10, 1 );
 
-		if ( self::is_active() ) {
-			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );
-
-			Jetpack_Heartbeat::init();
-			if ( self::is_module_active( 'stats' ) && self::is_module_active( 'search' ) ) {
-				require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.jetpack-search-performance-logger.php';
-				Jetpack_Search_Performance_Logger::init();
-			}
-		}
-
 		add_action( 'jetpack_event_log', array( 'Jetpack', 'log' ), 10, 2 );
 
 		add_filter( 'determine_current_user', array( $this, 'wp_rest_authenticate' ) );
@@ -736,6 +726,16 @@ class Jetpack {
 		if ( is_multisite() ) {
 			$network = Jetpack_Network::init();
 			$network->set_connection( $this->connection_manager );
+		}
+
+		if ( $this->connection_manager->is_active() ) {
+			add_action( 'login_form_jetpack_json_api_authorization', array( $this, 'login_form_json_api_authorization' ) );
+
+			Jetpack_Heartbeat::init();
+			if ( self::is_module_active( 'stats' ) && self::is_module_active( 'search' ) ) {
+				require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.jetpack-search-performance-logger.php';
+				Jetpack_Search_Performance_Logger::init();
+			}
 		}
 
 		// Initialize remote file upload request handlers.

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -7,8 +7,9 @@
 
 namespace Automattic\Jetpack;
 
-use Automattic\Jetpack\Sync\Main as Sync_Main;
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
+use Automattic\Jetpack\Sync\Main as Sync_Main;
 use Automattic\Jetpack\Terms_Of_Service;
 
 /**
@@ -26,9 +27,10 @@ class Config {
 	 * @var Array
 	 */
 	protected $config = array(
-		'sync'     => false,
-		'tracking' => false,
-		'tos'      => false,
+		'connection' => false,
+		'sync'       => false,
+		'tracking'   => false,
+		'tos'        => false,
 	);
 
 	/**
@@ -60,6 +62,11 @@ class Config {
 	 * @action plugins_loaded
 	 */
 	public function on_plugins_loaded() {
+		if ( $this->config['connection'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\Connection\Manager' )
+				&& $this->ensure_feature( 'connection' );
+		}
+
 		if ( $this->config['tracking'] ) {
 
 			$this->ensure_class( 'Automattic\Jetpack\Terms_Of_Service' )
@@ -162,6 +169,15 @@ class Config {
 	 */
 	protected function enable_sync() {
 		Sync_Main::configure();
+
+		return true;
+	}
+
+	/**
+	 * Enables the Connection feature.
+	 */
+	protected function enable_connection() {
+		Manager::configure();
 
 		return true;
 	}

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -50,20 +50,22 @@ class Manager {
 	 *
 	 * @todo Implement a proper nonce verification.
 	 */
-	public function init() {
-		$this->setup_xmlrpc_handlers(
+	public static function configure() {
+		$manager = new self();
+
+		$manager->setup_xmlrpc_handlers(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$this->is_active(),
-			$this->verify_xml_rpc_signature()
+			$manager->is_active(),
+			$manager->verify_xml_rpc_signature()
 		);
 
-		if ( $this->is_active() ) {
-			add_filter( 'xmlrpc_methods', array( $this, 'public_xmlrpc_methods' ) );
+		if ( $manager->is_active() ) {
+			add_filter( 'xmlrpc_methods', array( $manager, 'public_xmlrpc_methods' ) );
 		} else {
-			add_action( 'rest_api_init', array( $this, 'initialize_rest_api_registration_connector' ) );
+			add_action( 'rest_api_init', array( $manager, 'initialize_rest_api_registration_connector' ) );
 		}
 
-		add_action( 'jetpack_clean_nonces', array( $this, 'clean_nonces' ) );
+		add_action( 'jetpack_clean_nonces', array( $manager, 'clean_nonces' ) );
 		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Moves several parts of the code where we use the Connection Manager to events happening on `plugins_loaded`.

#### Changes proposed in this Pull Request:
* Added a configure (actually renamed the `init` method and made it static) method to the Manager class.
* Added the config call to Jetpack to initialize the connection instead of manually calling `init`. This makes our pattern of always creating a new instance of the Manager "more valid".
* Moved Manager-related code (`is_active` calls) to the `plugins_loaded` hook.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a Jetpack Packages effort that reorganizes code, does change any logic.

#### Testing instructions:
Mostly smoke testing the features affected:
* Jetpack Multisite wp-admin features.
* Heartbeat: is it still working as expected?
* Search performance logger?
* Plus the usual things that depend on the XMLRPC: connection, API calls, etc.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
