### PR TITLE
WP.com block editor: Allow cross-site authentication cookies.

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -6,6 +6,7 @@ module.exports = [
 	'class.jetpack-gutenberg.php',
 	'class.jetpack-plan.php',
 	'extensions/',
+	'functions.cookies.php',
 	'functions.global.php',
 	'functions.opengraph.php',
 	'_inc/lib/admin-pages/class-jetpack-about-page.php',

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -25,7 +25,7 @@ function jetpack_shim_setcookie( $name, $value, $options ) {
 		return false;
 	}
 
-	$cookie = "Set-Cookie: $name=" . rawurlencode( $value ) . '; ';
+	$cookie = 'Set-Cookie: ' . $name . '=' . rawurlencode( $value ) . '; ';
 
 	foreach ( $options as $k => $v ) {
 		if ( 'expires' === $k && ! empty( $v ) ) {

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -89,7 +89,7 @@ if (
 	 *                         Default is the value of is_ssl().
 	 * @param string $token    Optional. User's session token to use for this cookie.
 	 *
-	 * @since 8.2
+	 * @since 8.1.1
 	 */
 	function wp_set_auth_cookie( $user_id, $remember = false, $secure = '', $token = '' ) {
 		if ( $remember ) {
@@ -152,7 +152,7 @@ if (
 		 *
 		 * @param string $samesite SameSite attribute to use in auth cookies.
 		 *
-		 * @since 8.2
+		 * @since 8.1.1
 		 */
 		$samesite = apply_filters( 'jetpack_auth_cookie_samesite', 'Lax' );
 

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -27,27 +27,35 @@ function jetpack_shim_setcookie( $name, $value, $options ) {
 
 	$cookie = 'Set-Cookie: ' . $name . '=' . rawurlencode( $value ) . '; ';
 
-	foreach ( $options as $k => $v ) {
-		if ( 'expires' === $k && ! empty( $v ) ) {
-			$cookie_date = gmdate( 'D, d M Y H:i:s \G\M\T', $v );
-			$cookie     .= sprintf( 'expires=%s', $cookie_date ) . ';';
-		} elseif ( 'secure' === $k && true === $v ) {
-			$cookie .= 'secure; ';
-		} elseif ( 'httponly' === $k && true === $v ) {
-			$cookie .= 'HttpOnly; ';
-		} elseif ( 'domain' === $k && is_string( $v ) && ! empty( $v ) ) {
-			if ( strpbrk( $v, false !== $not_allowed_chars ) ) {
-				return false;
-			}
-			$cookie .= sprintf( 'domain=%s', $v . '; ' );
-		} elseif ( 'path' === $k && is_string( $v ) && ! empty( $v ) ) {
-			if ( strpbrk( $v, false !== $not_allowed_chars ) ) {
-				return false;
-			}
-			$cookie .= sprintf( 'path=%s', $v . '; ' );
-		} elseif ( 'samesite' === $k && is_string( $v ) && ! empty( $v ) ) {
-			$cookie .= sprintf( 'SameSite=%s', $v . '; ' );
+	if ( ! empty( $options['expires'] ) ) {
+		$cookie_date = gmdate( 'D, d M Y H:i:s \G\M\T', $options['expires'] );
+		$cookie     .= sprintf( 'expires=%s', $cookie_date ) . ';';
+	}
+
+	if ( ! empty( $options['secure'] ) && true === $options['secure'] ) {
+		$cookie .= 'secure; ';
+	}
+
+	if ( ! empty( $options['httponly'] ) && true === $options['httponly'] ) {
+		$cookie .= 'HttpOnly; ';
+	}
+
+	if ( ! empty( $options['domain'] ) && is_string( $options['domain'] ) ) {
+		if ( strpbrk( $options['domain'], false !== $not_allowed_chars ) ) {
+			return false;
 		}
+		$cookie .= sprintf( 'domain=%s', $options['domain'] . '; ' );
+	}
+
+	if ( ! empty( $options['path'] ) && is_string( $options['path'] ) ) {
+		if ( strpbrk( $options['path'], false !== $not_allowed_chars ) ) {
+			return false;
+		}
+		$cookie .= sprintf( 'path=%s', $options['path'] . '; ' );
+	}
+
+	if ( ! empty( $options['samesite'] ) && is_string( $options['samesite'] ) ) {
+		$cookie .= sprintf( 'SameSite=%s', $options['samesite'] . '; ' );
 	}
 
 	$cookie = trim( $cookie );

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -25,7 +25,7 @@ function jetpack_shim_setcookie( $name, $value, $options ) {
 		return false;
 	}
 
-	$cookie = 'Set-Cookie: $name=' . rawurlencode( $value ) . '; ';
+	$cookie = "Set-Cookie: $name=" . rawurlencode( $value ) . '; ';
 
 	foreach ( $options as $k => $v ) {
 		if ( 'expires' === $k && ! empty( $v ) ) {

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -9,6 +9,17 @@
  */
 
 /**
+ * Only proceed if Jetpack is connected to WordPress.com,
+ * and there is no active shortcircuit filter. Note that because this file
+ * executes on plugin load (to be able to define `wp_set_auth_cookie` before
+ * `pluggable.php`), a third party can only use the short-circuit filter in plugins
+ * loaded before Jetpack, or in an mu-plugin.
+ */
+if ( ! Jetpack::is_active() || apply_filters( 'jetpack_disable_auth_cookie_plugable', '__return_false' ) ) {
+	return;
+}
+
+/**
  * A PHP 5.X compatible version of the array argument version of PHP 7.3's setcookie().
  *
  * Useful for setting SameSite cookies in PHP 7.2 or earlier.

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This file is meant to be the home for any function handling cookies that can
+ * be accessed anywhere within Jetpack.
+ *
+ * This file is loaded whether or not Jetpack is active.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * A PHP 5.X compatible version of the array argument version of PHP 7.3's setcookie().
+ *
+ * Useful for setting SameSite cookies in PHP 7.2 or earlier.
+ *
+ * @param string $name    Name of the cookie.
+ * @param string $value   Value of the cookie.
+ * @param array  $options Options to include with the cookie.
+ * @return bool False when error happens, other wise true.
+ */
+function shim_setcookie( $name, $value, $options ) {
+	$not_allowed_chars = ",; \t\r\n\013\014";
+
+	if ( strpbrk( $name, $not_allowed_chars ) !== false ) {
+		return false;
+	}
+
+	$cookie = 'Set-Cookie: $name=' . rawurlencode( $value ) . '; ';
+
+	foreach ( $options as $k => $v ) {
+		if ( 'expires' === $k && ! empty( $v ) ) {
+			$cookie_date = gmdate( 'D, d M Y H:i:s \G\M\T', $v );
+			$cookie     .= sprintf( 'expires=%s', $cookie_date ) . ';';
+		} elseif ( 'secure' === $k && true === $v ) {
+			$cookie .= 'secure; ';
+		} elseif ( 'httponly' === $k && true === $v ) {
+			$cookie .= 'HttpOnly; ';
+		} elseif ( 'domain' === $k && is_string( $v ) && ! empty( $v ) ) {
+			if ( strpbrk( $v, false !== $not_allowed_chars ) ) {
+				return false;
+			}
+			$cookie .= sprintf( 'domain=%s', $v . '; ' );
+		} elseif ( 'path' === $k && is_string( $v ) && ! empty( $v ) ) {
+			if ( strpbrk( $v, false !== $not_allowed_chars ) ) {
+				return false;
+			}
+			$cookie .= sprintf( 'path=%s', $v . '; ' );
+		} elseif ( 'samesite' === $k && is_string( $v ) && ! empty( $v ) ) {
+			$cookie .= sprintf( 'SameSite=%s', $v . '; ' );
+		}
+	}
+
+	$cookie = trim( $cookie );
+	$cookie = trim( $cookie, ';' );
+	header( $cookie, false );
+
+	return true;
+}
+
+if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
+	/**
+	 * Sets the authentication cookies based on user ID.
+	 *
+	 * The $remember parameter increases the time that the cookie will be kept. The
+	 * default the cookie is kept without remembering is two days. When $remember is
+	 * set, the cookies will be kept for 14 days or two weeks.
+	 *
+	 * This overrides the `wp_set_auth_cookie` pluggable function in order to support `SameSite` cookies.
+	 *
+	 * @param int    $user_id  User ID.
+	 * @param bool   $remember Whether to remember the user.
+	 * @param mixed  $secure   Whether the admin cookies should only be sent over HTTPS.
+	 *                         Default is the value of is_ssl().
+	 * @param string $token    Optional. User's session token to use for this cookie.
+	 *
+	 * @since 8.2
+	 */
+	function wp_set_auth_cookie( $user_id, $remember = false, $secure = '', $token = '' ) {
+		if ( $remember ) {
+			/** This filter is documented in wp-includes/pluggable.php */
+			$expiration = time() + apply_filters( 'auth_cookie_expiration', 14 * DAY_IN_SECONDS, $user_id, $remember );
+
+			/*
+			 * Ensure the browser will continue to send the cookie after the expiration time is reached.
+			 * Needed for the login grace period in wp_validate_auth_cookie().
+			 */
+			$expire = $expiration + ( 12 * HOUR_IN_SECONDS );
+		} else {
+			/** This filter is documented in wp-includes/pluggable.php */
+			$expiration = time() + apply_filters( 'auth_cookie_expiration', 2 * DAY_IN_SECONDS, $user_id, $remember );
+			$expire     = 0;
+		}
+
+		if ( '' === $secure ) {
+			$secure = is_ssl();
+		}
+
+		// Front-end cookie is secure when the auth cookie is secure and the site's home URL is forced HTTPS.
+		$secure_logged_in_cookie = $secure && 'https' === wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		$secure = apply_filters( 'secure_auth_cookie', $secure, $user_id );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		$secure_logged_in_cookie = apply_filters( 'secure_logged_in_cookie', $secure_logged_in_cookie, $user_id, $secure );
+
+		if ( $secure ) {
+			$auth_cookie_name = SECURE_AUTH_COOKIE;
+			$scheme           = 'secure_auth';
+		} else {
+			$auth_cookie_name = AUTH_COOKIE;
+			$scheme           = 'auth';
+		}
+
+		if ( '' === $token ) {
+			$manager = WP_Session_Tokens::get_instance( $user_id );
+			$token   = $manager->create( $expiration );
+		}
+
+		$auth_cookie      = wp_generate_auth_cookie( $user_id, $expiration, $scheme, $token );
+		$logged_in_cookie = wp_generate_auth_cookie( $user_id, $expiration, 'logged_in', $token );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		do_action( 'set_auth_cookie', $auth_cookie, $expire, $expiration, $user_id, $scheme, $token );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		do_action( 'set_logged_in_cookie', $logged_in_cookie, $expire, $expiration, $user_id, 'logged_in', $token );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the SameSite attribute to use in auth cookies.
+		 *
+		 * @param string $samesite SameSite attribute to use in auth cookies.
+		 *
+		 * @since 8.2
+		 */
+		$samesite = apply_filters( 'jetpack_auth_cookie_samesite', 'Lax' );
+
+		shim_setcookie(
+			$auth_cookie_name,
+			$auth_cookie,
+			array(
+				'expires'  => $expire,
+				'path'     => PLUGINS_COOKIE_PATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => $samesite,
+			)
+		);
+
+		shim_setcookie(
+			$auth_cookie_name,
+			$auth_cookie,
+			array(
+				'expires'  => $expire,
+				'path'     => ADMIN_COOKIE_PATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => $samesite,
+			)
+		);
+
+		shim_setcookie(
+			LOGGED_IN_COOKIE,
+			$logged_in_cookie,
+			array(
+				'expires'  => $expire,
+				'path'     => COOKIEPATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure_logged_in_cookie,
+				'httponly' => true,
+				'samesite' => $samesite,
+			)
+		);
+
+		if ( COOKIEPATH !== SITECOOKIEPATH ) {
+			shim_setcookie(
+				LOGGED_IN_COOKIE,
+				$logged_in_cookie,
+				array(
+					'expires'  => $expire,
+					'path'     => SITECOOKIEPATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure_logged_in_cookie,
+					'httponly' => true,
+					'samesite' => $samesite,
+				)
+			);
+		}
+	}
+endif;

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -15,7 +15,7 @@
  * `pluggable.php`), a third party can only use the short-circuit filter in plugins
  * loaded before Jetpack, or in an mu-plugin.
  */
-if ( ! Jetpack::is_active() || apply_filters( 'jetpack_disable_auth_cookie_plugable', '__return_false' ) ) {
+if ( ! Jetpack::is_active() || apply_filters( 'jetpack_disable_auth_cookie_plugable', false ) ) {
 	return;
 }
 

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -9,17 +9,6 @@
  */
 
 /**
- * Only proceed if Jetpack is connected to WordPress.com,
- * and there is no active shortcircuit filter. Note that because this file
- * executes on plugin load (to be able to define `wp_set_auth_cookie` before
- * `pluggable.php`), a third party can only use the short-circuit filter in plugins
- * loaded before Jetpack, or in an mu-plugin.
- */
-if ( ! Jetpack::is_active() || apply_filters( 'jetpack_disable_auth_cookie_plugable', false ) ) {
-	return;
-}
-
-/**
  * A PHP 5.X compatible version of the array argument version of PHP 7.3's setcookie().
  *
  * Useful for setting SameSite cookies in PHP 7.2 or earlier.
@@ -68,7 +57,23 @@ function jetpack_shim_setcookie( $name, $value, $options ) {
 	return true;
 }
 
-if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
+// Only proceed if Jetpack is connected to WordPress.com and there is no active short-circuit filter.
+if (
+	Jetpack::is_active() &&
+	/**
+	 * Allow plugins to short-circuit the `wp_set_auth_cookie` override that adds support for SameSite cookies.
+	 *
+	 * Note that because the `wp_set_auth_cookie` override executes on plugin load (to be able to define it before
+	 * `pluggable.php`), a third party can only use the short-circuit filter in plugins loaded before Jetpack, or
+	 * in an mu-plugin.
+	 *
+	 * @since 8.1.1
+	 *
+	 * @param false bool Whether the `wp_set_auth_cookie` override should be blocked. False by default.
+	 */
+	! apply_filters( 'jetpack_disable_auth_cookie_pluggable', false ) &&
+	! function_exists( 'wp_set_auth_cookie' )
+) :
 	/**
 	 * Sets the authentication cookies based on user ID.
 	 *

--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -3,7 +3,7 @@
  * This file is meant to be the home for any function handling cookies that can
  * be accessed anywhere within Jetpack.
  *
- * This file is loaded whether or not Jetpack is active.
+ * This file is loaded whether or not Jetpack is connected to WP.com.
  *
  * @package Jetpack
  */
@@ -18,7 +18,7 @@
  * @param array  $options Options to include with the cookie.
  * @return bool False when error happens, other wise true.
  */
-function shim_setcookie( $name, $value, $options ) {
+function jetpack_shim_setcookie( $name, $value, $options ) {
 	$not_allowed_chars = ",; \t\r\n\013\014";
 
 	if ( strpbrk( $name, $not_allowed_chars ) !== false ) {
@@ -140,7 +140,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 		 */
 		$samesite = apply_filters( 'jetpack_auth_cookie_samesite', 'Lax' );
 
-		shim_setcookie(
+		jetpack_shim_setcookie(
 			$auth_cookie_name,
 			$auth_cookie,
 			array(
@@ -153,7 +153,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			)
 		);
 
-		shim_setcookie(
+		jetpack_shim_setcookie(
 			$auth_cookie_name,
 			$auth_cookie,
 			array(
@@ -166,7 +166,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			)
 		);
 
-		shim_setcookie(
+		jetpack_shim_setcookie(
 			LOGGED_IN_COOKIE,
 			$logged_in_cookie,
 			array(
@@ -180,7 +180,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 		);
 
 		if ( COOKIEPATH !== SITECOOKIEPATH ) {
-			shim_setcookie(
+			jetpack_shim_setcookie(
 				LOGGED_IN_COOKIE,
 				$logged_in_cookie,
 				array(

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -54,6 +54,7 @@ require_once JETPACK__PLUGIN_DIR . 'functions.photon.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.global.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.compat.php';
 require_once JETPACK__PLUGIN_DIR . 'functions.gallery.php';
+require_once JETPACK__PLUGIN_DIR . 'functions.cookies.php';
 require_once JETPACK__PLUGIN_DIR . 'require-lib.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-autoupdate.php';
 require_once JETPACK__PLUGIN_DIR . 'class.frame-nonce-preview.php';

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -40,6 +40,8 @@ class Jetpack_WPCOM_Block_Editor {
 			add_filter( 'admin_body_class', array( $this, 'add_iframed_body_class' ) );
 		}
 
+		add_filter( 'jetpack_auth_cookie_samesite', array( $this, 'set_samesite_auth_cookie' ) );
+
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 9 );
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_assets' ) );
@@ -390,6 +392,15 @@ class Jetpack_WPCOM_Block_Editor {
 		}
 
 		return $plugin_array;
+	}
+
+	/**
+	 * Designates cookies for cross-site access.
+	 *
+	 * @return string SameSite attribute to use on auth cookies.
+	 */
+	public function set_samesite_auth_cookie() {
+		return 'None';
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/37558

### Changes proposed in this Pull Request:
* Overrides the `wp_set_auth_cookie` pluggable function with a customized version of it that supports `SameSite` cookies.
* Makes sure the auth cookies are set with `SameSite: None` so Gutenframe still works.

### Is this a new feature or does it add/remove features to an existing part of Jetpack?
New feature, but helps fixing one incoming change in Chrome that breaks the iframed block editor in Calypso: pb6Nl-daR-p2

### Testing instructions:

**Jetpack**
* Enable `SameSite` features flags in Chrome: p1HpG7-8gO-p2. 
* Start with a JN site with the beta plugin and this branch and disconnected from WP.com, in Chrome (version between 76 and 79).
* Clear cookies and log in again.
* Verify the cookies are stored without any `SameSite` attribute.

<img width="932" alt="Screenshot 2020-01-16 at 11 39 17" src="https://user-images.githubusercontent.com/1233880/72518391-87351500-3855-11ea-8c1f-c66a12d1888d.png">

* Connect to WordPress.com.
* Clear cookies and log in again.
* Cookies should be stored now with a `SameSite=None` attribute.

<img width="930" alt="Screenshot 2020-01-16 at 11 48 33" src="https://user-images.githubusercontent.com/1233880/72518738-383baf80-3856-11ea-9859-e8d037a26889.png">

* Opt in to the block editor through the sidebar prompt in the Calypso editor.

<img width="327" alt="Screen Shot 2020-01-15 at 2 18 42 PM" src="https://user-images.githubusercontent.com/349751/72476424-0f59e280-37a2-11ea-8920-b15406717828.png">

* Verify you are forwarded to `wordpress.com/block-editor/post/:site`, and not to the Jetpack site's own WP Admin editor.

**Atomic**
* Enable `SameSite` features flags in Chrome: p1HpG7-8gO-p2. 
* Activate the Jetpack Beta plugin and switch to this branch.
* Load the block editor from Calypso.
* You should remain in `wordpress.com/block-editor/post/:site` rather than being redirect to the Atomic site's WP Admin editor.
* Cookies on the Atomic site domain should be set with a `SameSite=None` attribute.

<img width="930" alt="Screenshot 2020-01-16 at 11 48 33" src="https://user-images.githubusercontent.com/1233880/72518738-383baf80-3856-11ea-9859-e8d037a26889.png">

#### Proposed changelog entry for your changes:
WP.com block editor: Allow cross-site authentication cookies
