### PR TITLE
OpenTable Block: Make the registration happen via an action

### DIFF
--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -46,16 +46,6 @@ function register_block() {
 			BLOCK_NAME,
 			array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
 		);
-	}
-}
-add_action( 'init', 'Jetpack\OpenTable_Block\register_block' );
-
-/**
- * Set block's availability.
- */
-function set_availability() {
-	if ( is_available() ) {
-		\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
 	} else {
 		\Jetpack_Gutenberg::set_extension_unavailable(
 			BLOCK_NAME,
@@ -67,7 +57,7 @@ function set_availability() {
 		);
 	}
 }
-add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\set_availability' );
+add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\register_block' );
 
 /**
  * Adds an inline script which updates the block editor settings to

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -13,10 +13,18 @@ const FEATURE_NAME = 'opentable';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
 
-jetpack_register_block(
-	BLOCK_NAME,
-	array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
-);
+/**
+ * Registers the block for use in Gutenberg
+ * This is down via an action so that we can disable
+ * registration if we need to
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
+	);
+}
+add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\register_block' );
 
 /**
  * Adds an inline script which updates the block editor settings to

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -37,8 +37,8 @@ function is_available() {
 
 /**
  * Registers the block for use in Gutenberg
- * This is down via an action so that we can disable
- * registration if we need to
+ * This is done via an action so that we can disable
+ * registration if we need to.
  */
 function register_block() {
 	if ( is_available() ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In certain circumstances, we need to prevent the block from being registered. This change puts the call to `jetpack_register_block` into a function run by an action hook so that it can be removed if necessary.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
It changes the approach to an existing feature, so a small refactor really.

#### Testing instructions:
Check that you can still insert an OpenTable block. It's a beta block so you will need to have a site with those enabled

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
I don't believe this requires a changelog entry
