### PR TITLE
OpenTable: Remove country codes from open table language selector

### DIFF
--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -8,13 +8,13 @@ import { compact, reduce, isEmpty } from 'lodash';
 const optionValues = options => options.map( option => option.value );
 
 export const languageOptions = [
-	{ value: 'en-US', label: 'English-US' },
-	{ value: 'fr-CA', label: 'Français-CA' },
-	{ value: 'de-DE', label: 'Deutsch-DE' },
-	{ value: 'es-MX', label: 'Español-MX' },
-	{ value: 'ja-JP', label: '日本語-JP' },
-	{ value: 'nl-NL', label: 'Nederlands-NL' },
-	{ value: 'it-IT', label: 'Italiano-IT' },
+	{ value: 'en-US', label: 'English' },
+	{ value: 'fr-CA', label: 'Français' },
+	{ value: 'de-DE', label: 'Deutsch' },
+	{ value: 'es-MX', label: 'Español' },
+	{ value: 'ja-JP', label: '日本語' },
+	{ value: 'nl-NL', label: 'Nederlands' },
+	{ value: 'it-IT', label: 'Italiano' },
 ];
 export const languageValues = optionValues( languageOptions );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14345

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This removes the country codes from the languages in the language selector, since they don't add any value.

#### Testing instructions:
* Add an OpenTable block
* Look at the list of languages in the block sidebar
* Check that there are not language codes in the list

