### PR TITLE
Composer: Add jetpack-status to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-partner": "@dev",
 		"automattic/jetpack-roles": "@dev",
+		"automattic/jetpack-status": "@dev",
 		"automattic/jetpack-sync": "@dev",
 		"automattic/jetpack-terms-of-service": "@dev",
 		"automattic/jetpack-tracking": "@dev"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Jetpack uses the Status package, so add it to the require list in Jetpack's `composer.json` file. This change doesn't affect behavior. The Status package is currently installed because it's required by a few other packages (Sync and Terms of Service). Adding it to Jetpack's `composer.json` file makes Jetpack's dependency on the Status package explicit.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
No testing should be needed. 

#### Proposed changelog entry for your changes:
* n/a
