### PR TITLE
WP.com Block Editor: Allow cross-site authentication cookies.

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -34,6 +34,7 @@ module.exports = [
 	'modules/verification-tools.php',
 	'modules/widgets/contact-info.php',
 	'modules/widgets/social-icons.php',
+	'modules/wpcom-block-editor/samesite-cookies.php',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'packages',
 ];

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -46,6 +46,7 @@ $connected_tools = array(
 	'simple-payments/simple-payments.php',
 	'woocommerce-analytics/wp-woocommerce-analytics.php',
 	'wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
+	'wpcom-block-editor/samesite-cookies.php',
 );
 
 // Add connected features to our existing list if the site is currently connected.

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -40,6 +40,8 @@ class Jetpack_WPCOM_Block_Editor {
 			add_filter( 'admin_body_class', array( $this, 'add_iframed_body_class' ) );
 		}
 
+		add_filter( 'jetpack_auth_cookie_samesite', array( $this, 'set_samesite_auth_cookie' ) );
+
 		add_action( 'login_init', array( $this, 'allow_block_editor_login' ), 1 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ), 9 );
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_block_assets' ) );
@@ -390,6 +392,15 @@ class Jetpack_WPCOM_Block_Editor {
 		}
 
 		return $plugin_array;
+	}
+
+	/**
+	 * Designates cookies for cross-site access.
+	 *
+	 * @return string SameSite attribute to use on auth cookies.
+	 */
+	public function set_samesite_auth_cookie() {
+		return 'None';
 	}
 }
 

--- a/modules/wpcom-block-editor/samesite-cookies.php
+++ b/modules/wpcom-block-editor/samesite-cookies.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * This file handles updating authentication cookies to be compatible with the `SameSite=None` attribute.
+ * https://web.dev/samesite-cookies-explained/
+ *
+ * This file is loaded only if connected to WP.com.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * A PHP 5.X compatible version of the array argument version of PHP 7.3's setcookie().
+ *
+ * Useful for setting SameSite cookies in PHP 7.2 or earlier.
+ *
+ * @param string $name    Name of the cookie.
+ * @param string $value   Value of the cookie.
+ * @param array  $options Options to include with the cookie.
+ * @return bool False when error happens, other wise true.
+ */
+function jetpack_shim_setcookie( $name, $value, $options ) {
+	$not_allowed_chars = ",; \t\r\n\013\014";
+
+	if ( strpbrk( $name, $not_allowed_chars ) !== false ) {
+		return false;
+	}
+
+	$cookie = 'Set-Cookie: ' . $name . '=' . rawurlencode( $value ) . '; ';
+
+	foreach ( $options as $k => $v ) {
+		if ( 'expires' === $k && ! empty( $v ) ) {
+			$cookie_date = gmdate( 'D, d M Y H:i:s \G\M\T', $v );
+			$cookie     .= sprintf( 'expires=%s', $cookie_date ) . ';';
+		} elseif ( 'secure' === $k && true === $v ) {
+			$cookie .= 'secure; ';
+		} elseif ( 'httponly' === $k && true === $v ) {
+			$cookie .= 'HttpOnly; ';
+		} elseif ( 'domain' === $k && is_string( $v ) && ! empty( $v ) ) {
+			if ( strpbrk( $v, false !== $not_allowed_chars ) ) {
+				return false;
+			}
+			$cookie .= sprintf( 'domain=%s', $v . '; ' );
+		} elseif ( 'path' === $k && is_string( $v ) && ! empty( $v ) ) {
+			if ( strpbrk( $v, false !== $not_allowed_chars ) ) {
+				return false;
+			}
+			$cookie .= sprintf( 'path=%s', $v . '; ' );
+		} elseif ( 'samesite' === $k && is_string( $v ) && ! empty( $v ) ) {
+			$cookie .= sprintf( 'SameSite=%s', $v . '; ' );
+		}
+	}
+
+	$cookie = trim( $cookie );
+	$cookie = trim( $cookie, ';' );
+	header( $cookie, false );
+
+	return true;
+}
+
+if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
+	/**
+	 * Sets the authentication cookies based on user ID.
+	 *
+	 * The $remember parameter increases the time that the cookie will be kept. The
+	 * default the cookie is kept without remembering is two days. When $remember is
+	 * set, the cookies will be kept for 14 days or two weeks.
+	 *
+	 * This overrides the `wp_set_auth_cookie` pluggable function in order to support `SameSite` cookies.
+	 *
+	 * @param int    $user_id  User ID.
+	 * @param bool   $remember Whether to remember the user.
+	 * @param mixed  $secure   Whether the admin cookies should only be sent over HTTPS.
+	 *                         Default is the value of is_ssl().
+	 * @param string $token    Optional. User's session token to use for this cookie.
+	 *
+	 * @since 8.2
+	 */
+	function wp_set_auth_cookie( $user_id, $remember = false, $secure = '', $token = '' ) {
+		if ( $remember ) {
+			/** This filter is documented in wp-includes/pluggable.php */
+			$expiration = time() + apply_filters( 'auth_cookie_expiration', 14 * DAY_IN_SECONDS, $user_id, $remember );
+
+			/*
+			 * Ensure the browser will continue to send the cookie after the expiration time is reached.
+			 * Needed for the login grace period in wp_validate_auth_cookie().
+			 */
+			$expire = $expiration + ( 12 * HOUR_IN_SECONDS );
+		} else {
+			/** This filter is documented in wp-includes/pluggable.php */
+			$expiration = time() + apply_filters( 'auth_cookie_expiration', 2 * DAY_IN_SECONDS, $user_id, $remember );
+			$expire     = 0;
+		}
+
+		if ( '' === $secure ) {
+			$secure = is_ssl();
+		}
+
+		// Front-end cookie is secure when the auth cookie is secure and the site's home URL is forced HTTPS.
+		$secure_logged_in_cookie = $secure && 'https' === wp_parse_url( get_option( 'home' ), PHP_URL_SCHEME );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		$secure = apply_filters( 'secure_auth_cookie', $secure, $user_id );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		$secure_logged_in_cookie = apply_filters( 'secure_logged_in_cookie', $secure_logged_in_cookie, $user_id, $secure );
+
+		if ( $secure ) {
+			$auth_cookie_name = SECURE_AUTH_COOKIE;
+			$scheme           = 'secure_auth';
+		} else {
+			$auth_cookie_name = AUTH_COOKIE;
+			$scheme           = 'auth';
+		}
+
+		if ( '' === $token ) {
+			$manager = WP_Session_Tokens::get_instance( $user_id );
+			$token   = $manager->create( $expiration );
+		}
+
+		$auth_cookie      = wp_generate_auth_cookie( $user_id, $expiration, $scheme, $token );
+		$logged_in_cookie = wp_generate_auth_cookie( $user_id, $expiration, 'logged_in', $token );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		do_action( 'set_auth_cookie', $auth_cookie, $expire, $expiration, $user_id, $scheme, $token );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		do_action( 'set_logged_in_cookie', $logged_in_cookie, $expire, $expiration, $user_id, 'logged_in', $token );
+
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
+		/**
+		 * Filters the SameSite attribute to use in auth cookies.
+		 *
+		 * @param string $samesite SameSite attribute to use in auth cookies.
+		 *
+		 * @since 8.2
+		 */
+		$samesite = apply_filters( 'jetpack_auth_cookie_samesite', 'Lax' );
+
+		jetpack_shim_setcookie(
+			$auth_cookie_name,
+			$auth_cookie,
+			array(
+				'expires'  => $expire,
+				'path'     => PLUGINS_COOKIE_PATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => $samesite,
+			)
+		);
+
+		jetpack_shim_setcookie(
+			$auth_cookie_name,
+			$auth_cookie,
+			array(
+				'expires'  => $expire,
+				'path'     => ADMIN_COOKIE_PATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure,
+				'httponly' => true,
+				'samesite' => $samesite,
+			)
+		);
+
+		jetpack_shim_setcookie(
+			LOGGED_IN_COOKIE,
+			$logged_in_cookie,
+			array(
+				'expires'  => $expire,
+				'path'     => COOKIEPATH,
+				'domain'   => COOKIE_DOMAIN,
+				'secure'   => $secure_logged_in_cookie,
+				'httponly' => true,
+				'samesite' => $samesite,
+			)
+		);
+
+		if ( COOKIEPATH !== SITECOOKIEPATH ) {
+			jetpack_shim_setcookie(
+				LOGGED_IN_COOKIE,
+				$logged_in_cookie,
+				array(
+					'expires'  => $expire,
+					'path'     => SITECOOKIEPATH,
+					'domain'   => COOKIE_DOMAIN,
+					'secure'   => $secure_logged_in_cookie,
+					'httponly' => true,
+					'samesite' => $samesite,
+				)
+			);
+		}
+	}
+endif;


### PR DESCRIPTION
Alternative to #14349 .

Update the core WordPress authentication cookies to be compatible with the upcoming `SameSite=None` attribute, coming in Chrome 80 (and likely other browsers to follow). Use of this attribute will mean that the authentication cookies can be used by a third-party, namely `wordpress.com` for the purpose of the iframed Gutenberg editor (Gutenframe).

Fixes Automattic/wp-calypso#37558

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Override the `wp_set_auth_cookie` pluggable function with a customized version of it that supports `SameSite` cookies. Only do this if the site has a working connection to WordPress.com.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This will allow Jetpack users to continue to use WordPress.com as their editor, which is the Jetpack site's own Gutenberg editor, iframed. pb6Nl-daR-p2

#### Testing instructions:

* Follow instructions in #14349 for testing. However, no cookies should get the `SameSite=Lax` attribute until the site is connected to WP.com.

#### Proposed changelog entry for your changes:

* TBD
