### PR TITLE
Sync Package: use Full_Sync_Immediately by default

### DIFF
--- a/packages/sync/src/class-modules.php
+++ b/packages/sync/src/class-modules.php
@@ -40,7 +40,7 @@ class Modules {
 		'Automattic\\Jetpack\\Sync\\Modules\\Meta',
 		'Automattic\\Jetpack\\Sync\\Modules\\Plugins',
 		'Automattic\\Jetpack\\Sync\\Modules\\Stats',
-		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync',
+		'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately',
 		'Automattic\\Jetpack\\Sync\\Modules\\Term_Relationships',
 	);
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -109,17 +109,17 @@ if ( ! ( in_running_uninstall_group() ) ) {
  *
  * @return array
  */
-function jetpack_full_sync_immediately_on( $modules ) {
+function jetpack_full_sync_immediately_off( $modules ) {
 	foreach ( $modules as $key => $module ) {
-		if ( in_array( $module, array( 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync', 'Jetpack_Sync_Modules_Full_Sync' ), true ) ) {
-			$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately';
+		if ( in_array( $module, array( 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately' ), true ) ) {
+			$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync';
 		}
 	}
 	return $modules;
 }
 
-if ( false !== getenv( 'SYNC_BETA' ) ) {
-	tests_add_filter( 'jetpack_sync_modules', 'jetpack_full_sync_immediately_on' );
+if ( false === getenv( 'SYNC_BETA' ) ) {
+	tests_add_filter( 'jetpack_sync_modules', 'jetpack_full_sync_immediately_off' );
 }
 
 require $test_root . '/includes/bootstrap.php';


### PR DESCRIPTION
Fixes n/a

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The new full sync pattern introduced in #13963 should now be the default way to perform a full sync. We will still support the original full sync by allow sites to use a filter.
* We want to get this into master early in the release cycle so we can test it as much as possible. 
* If sites need to use the now legacy full sync, they can do so with a filter:

```
function jetpack_full_sync_immediately_off( $modules )
	foreach ( $modules as $key => $module ) {
		if ( in_array( $module, [ 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync_Immediately', ] ) ) {
			$modules[ $key ] = 'Automattic\\Jetpack\\Sync\\Modules\\Full_Sync';
		}
	}
	return $modules;
}

add_filter( 'jetpack_sync_modules', 'jetpack_full_sync_immediately_off' );
```


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This optimizes the Sync package. 

#### Testing instructions:

Heavy testing of this PR is not required to merge because we plan to test and optimize the new full sync pattern during the course of the release cycle. We do need to ensure that this PR causes no large fatals during a Full Sync.

* Apply this patch to a Jetpack testing site
* Disconnect the site if it's already connected
* Re-connect the site, which should trigger a full sync
* Ensure there are no fatal errors
* Bonus: Set your Jetpack site's API base to wordpress.com sandbox and trigger a full sync. Watch as data flows on your sandbox, and ensure there are no fatals.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Updates the Sync package with an optimized full sync.
