### PR TITLE
Instant Search: respect posts per page setting

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -150,6 +150,7 @@ class SearchApp extends Component {
 				resultFormat,
 				siteId: this.props.options.siteId,
 				sort,
+				postsPerPage: this.props.options.postsPerPage,
 			} )
 				.then( newResponse => {
 					if ( this.state.requestId === requestId ) {

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -123,7 +123,16 @@ function buildFilterObject( filterQuery ) {
 	return filter;
 }
 
-export function search( { aggregations, filter, pageHandle, query, resultFormat, siteId, sort } ) {
+export function search( {
+	aggregations,
+	filter,
+	pageHandle,
+	query,
+	resultFormat,
+	siteId,
+	sort,
+	postsPerPage = 10,
+} ) {
 	const key = stringify( Array.from( arguments ) );
 
 	// Use cached value from the last 30 minutes if browser is offline
@@ -165,6 +174,7 @@ export function search( { aggregations, filter, pageHandle, query, resultFormat,
 			query: encodeURIComponent( query ),
 			sort,
 			page_handle: pageHandle,
+			size: postsPerPage,
 		} )
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13932, which requests:

> We should be using `get_option('posts_per_page'); to get the number of posts to display with each search.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No - this is part of the Instant Search prototype.

#### Testing instructions:

Follow the setup instructions in https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md.

On your test site site, go to Reading Settings (`/wp-admin/options-reading.php`) in WP Admin. Set the 'posts per page' to a number other than 10.

Perform a search on the front end of the site which usually has lots of results. Ensure that the 'posts per page' setting reflects the number of posts returned. Verify that the 'Load more...' button always returns this number of posts.

(If you need a site with lots of posts to try this out and you have your test site set up to allow other blog_ids , you can try `?blog_id=20115252&s=page`.)

#### Proposed changelog entry for your changes:

Not required.