### PR TITLE
OpenTable: Reset the CSS on the suggestions list

### DIFF
--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -120,7 +120,8 @@
 	.editor-styles-wrapper & .components-form-token-field__suggestions-list {
 		font-family: $default-font;
 		text-align: left;
-		margin-bottom: 0;
+		padding: 0;
+		margin: 0;
 	}
 
 }


### PR DESCRIPTION
This PR fixes one of the problems in issue #14344. The suggestion list on the restaurant picker is affected by some of the main editor CSS rules for lists. This is a simple change that resets those rules.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

It's a bug fix for an existing feature

#### Testing instructions:

Insert an OpenTable block, search for a restaurant and check the formatting of the list of suggestions.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
