### PR TITLE
OpenTable: Clarify wording in embed prompt

### DIFF
--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -231,7 +231,7 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 			label={ __( 'OpenTable Reservation', 'jetpack' ) }
 			icon={ <BlockIcon icon={ icon } /> }
 			instructions={ __(
-				'Enter your restaurant names, OpenTable Restaurant IDs, or embed code',
+				'Enter your restaurant name, or paste an OpenTable Reservation Widget embed code.',
 				'jetpack'
 			) }
 			notices={


### PR DESCRIPTION
Fixes #14346

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
If someone enters their ID and it's a subset of another, like 432 and 4321. You nearly always get back restaurants with 432 in the name, street address, or with IDs starting and ending in 432, but never the restaurant with ID 432.

This wording is simpler and more transparent.

#### Testing instructions:
* Add an OpenTable block to a post
* Check that you see this wording "Enter your restaurant name, or paste an OpenTable Reservation Widget embed code":
<img width="459" alt="Screenshot 2020-01-16 at 11 58 46" src="https://user-images.githubusercontent.com/275961/72523552-fa3f8b00-3857-11ea-8387-dc80b0bdc34b.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
