### PR TITLE
Calendly: Prevent notices for undefined attributes

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -110,7 +110,6 @@ function jetpack_calendly_block_get_attribute( $attributes, $attribute_name ) {
 	}
 
 	$default_attributes = array(
-		'url'                  => 'url',
 		'style'                => 'inline',
 		'submitButtonText'     => esc_html__( 'Schedule time with me', 'jetpack' ),
 		'backgroundColor'      => 'ffffff',
@@ -119,5 +118,7 @@ function jetpack_calendly_block_get_attribute( $attributes, $attribute_name ) {
 		'hideEventTypeDetails' => false,
 	);
 
-	return $default_attributes[ $attribute_name ];
+	if ( isset( $default_attributes[ $attribute_name ] ) ) {
+		return $default_attributes[ $attribute_name ];
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14368

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* If there is no default attribute don't return it. This prevents us throwing notices for blocks without default attributes defined on them.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Calendly block to a post
* Embed a calendar
* Open the post in the front end of the site
* Check that you don't see any notices in the error log

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
