### PR TITLE
Calendly: Don't encode line breaks in the submit button

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -83,7 +83,7 @@ function jetpack_calendly_block_load_assets( $attr, $content ) {
 			'<div class="%1$s"><a class="button" href="" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;">%3$s</a></div>',
 			esc_attr( $classes ),
 			esc_url( $url ),
-			esc_html( $submit_button_text )
+			wp_kses_post( $submit_button_text )
 		);
 	} else { // Button style.
 		$content = sprintf(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14366

#### Changes proposed in this Pull Request:
* Use `wp_kses_post` for the submit button text, to allow line breaks in submit buttons

#### Testing instructions:
* Add a new Calendly block to a post
* Select the "link" option
* Add a line break to the submit button
* Open the post in the frontend of the site
* Ensure that the line break shows without any <br>'s in the button

Before:
<img width="422" alt="Screenshot 2020-01-16 at 16 00 07" src="https://user-images.githubusercontent.com/275961/72540782-4d760580-3879-11ea-99d6-a446c8165f81.png">

After:
<img width="331" alt="Screenshot 2020-01-16 at 15 59 37" src="https://user-images.githubusercontent.com/275961/72540789-4f3fc900-3879-11ea-89e6-41d11c1816e7.png">

#### Proposed changelog entry for your changes:
* no changelog
