### PR TITLE
Update JP block style consistency after core update

### DIFF
--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -277,7 +277,7 @@ class JetpackContactForm extends Component {
 									) }
 								</div>
 								<div className="jetpack-contact-form__create">
-									<Button isPrimary type="submit" disabled={ this.hasEmailError() }>
+									<Button isDefault type="submit" disabled={ this.hasEmailError() }>
 										{ __( 'Add form', 'jetpack' ) }
 									</Button>
 								</div>

--- a/extensions/blocks/contact-form/components/jetpack-contact-form.js
+++ b/extensions/blocks/contact-form/components/jetpack-contact-form.js
@@ -71,13 +71,6 @@ class JetpackContactForm extends Component {
 		};
 	}
 
-	getIntroMessage() {
-		return __(
-			'You’ll receive an email notification each time someone fills out the form. Where should it go, and what should the subject line be?',
-			'jetpack'
-		);
-	}
-
 	getEmailHelpMessage() {
 		return __( 'You can enter multiple email addresses separated by commas.', 'jetpack' );
 	}
@@ -270,16 +263,19 @@ class JetpackContactForm extends Component {
 							icon={ renderMaterialIcon(
 								<Path d="M13 7.5h5v2h-5zm0 7h5v2h-5zM19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14zM11 6H6v5h5V6zm-1 4H7V7h3v3zm1 3H6v5h5v-5zm-1 4H7v-3h3v3z" />
 							) }
+							instructions={ __(
+								'You’ll receive an email notification each time someone fills out the form. Where should it go, and what should the subject line be?',
+								'jetpack'
+							) }
 						>
 							<form onSubmit={ this.onFormSettingsSet }>
-								<p className="jetpack-contact-form__intro-message">{ this.getIntroMessage() }</p>
 								{ this.renderToAndSubjectFields() }
-								<p className="jetpack-contact-form__intro-message">
+								<div class="components-placeholder__instructions">
 									{ __(
 										'(If you leave these blank, notifications will go to the author with the post or page title as the subject line.)',
 										'jetpack'
 									) }
-								</p>
+								</div>
 								<div className="jetpack-contact-form__create">
 									<Button isPrimary type="submit" disabled={ this.hasEmailError() }>
 										{ __( 'Add form', 'jetpack' ) }

--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -28,10 +28,6 @@
 	.components-base-control {
 		width: 100%;
 	}
-
-	.components-button {
-		margin: 6px 0 0;
-	}
 }
 
 .jetpack-contact-form__intro-message {

--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -20,13 +20,17 @@
 	}
 
 	.help-message {
+		color: $dark-gray-150;
 		width: 100%;
-		margin: -18px 0 28px;
+		margin: 0 0 1em;
 	}
 
 	.components-base-control {
-		margin-bottom: 16px;
 		width: 100%;
+	}
+
+	.components-button {
+		margin: 6px 0 0;
 	}
 }
 

--- a/extensions/blocks/gif/edit.js
+++ b/extensions/blocks/gif/edit.js
@@ -143,7 +143,7 @@ class GifEdit extends Component {
 					onChange={ value => setAttributes( { searchText: value } ) }
 					value={ searchText }
 				/>
-				<Button isSecondary onClick={ this.onSubmit }>
+				<Button isDefault onClick={ this.onSubmit }>
 					{ __( 'Search', 'jetpack' ) }
 				</Button>
 			</form>

--- a/extensions/blocks/gif/edit.js
+++ b/extensions/blocks/gif/edit.js
@@ -143,7 +143,7 @@ class GifEdit extends Component {
 					onChange={ value => setAttributes( { searchText: value } ) }
 					value={ searchText }
 				/>
-				<Button isLarge onClick={ this.onSubmit }>
+				<Button isSecondary onClick={ this.onSubmit }>
 					{ __( 'Search', 'jetpack' ) }
 				</Button>
 			</form>

--- a/extensions/blocks/gif/editor.scss
+++ b/extensions/blocks/gif/editor.scss
@@ -27,16 +27,15 @@
 		flex-direction: row;
 		flex-wrap: wrap;
 		justify-content: center;
-		margin: 0 auto;
 		max-width: 400px;
 		width: 100%;
 		z-index: 1;
+		.components-text-control__input {
+			height: 36px;
+		}
 		.components-base-control__label {
 			position: absolute;
 			top: -1000em;
-		}
-		.components-button {
-			margin-top: 1px;
 		}
 	}
 	.wp-block-jetpack-gif_input {

--- a/extensions/blocks/gif/editor.scss
+++ b/extensions/blocks/gif/editor.scss
@@ -7,6 +7,9 @@
 	.components-base-control__field {
 		text-align: center;
 	}
+	.components-placeholder__label svg {
+		margin-right: 1ch;
+	}
 	.wp-block-jetpack-gif_cover {
 		background: none;
 		border: none;

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -149,24 +149,23 @@ class MailchimpSubscribeEdit extends Component {
 			</Placeholder>
 		);
 		const placeholder = (
-			<div className="wp-block-jetpack-mailchimp">
-				<Placeholder
-					icon={ icon }
-					label={ __( 'Mailchimp', 'jetpack' ) }
-					notices={ notices }
-					instructions={ __(
-						'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.',
-						'jetpack'
-					) }
-				>
-					<Button isDefault isLarge href={ connectURL } target="_blank">
-						{ __( 'Set up Mailchimp form', 'jetpack' ) }
-					</Button>
-					<Button isLink onClick={ this.apiCall }>
-						{ __( 'Re-check Connection', 'jetpack' ) }
-					</Button>
-				</Placeholder>
-			</div>
+			<Placeholder
+				className="wp-block-jetpack-mailchimp"
+				icon={ icon }
+				label={ __( 'Mailchimp', 'jetpack' ) }
+				notices={ notices }
+				instructions={ __(
+					'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.',
+					'jetpack'
+				) }
+			>
+				<Button isDefault isLarge href={ connectURL } target="_blank">
+					{ __( 'Set up Mailchimp form', 'jetpack' ) }
+				</Button>
+				<Button isLink onClick={ this.apiCall }>
+					{ __( 'Re-check Connection', 'jetpack' ) }
+				</Button>
+			</Placeholder>
 		);
 		const inspectorControls = (
 			<InspectorControls>

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -149,23 +149,21 @@ class MailchimpSubscribeEdit extends Component {
 			</Placeholder>
 		);
 		const placeholder = (
-			<Placeholder icon={ icon } label={ __( 'Mailchimp', 'jetpack' ) } notices={ notices }>
-				<div className="components-placeholder__instructions">
-					{ __(
-						'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.',
-						'jetpack'
-					) }
-					<br />
-					<br />
-					<Button isDefault isLarge href={ connectURL } target="_blank">
-						{ __( 'Set up Mailchimp form', 'jetpack' ) }
-					</Button>
-					<br />
-					<br />
-					<Button isLink onClick={ this.apiCall }>
-						{ __( 'Re-check Connection', 'jetpack' ) }
-					</Button>
-				</div>
+			<Placeholder
+				icon={ icon }
+				label={ __( 'Mailchimp', 'jetpack' ) }
+				notices={ notices }
+				instructions={ __(
+					'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.',
+					'jetpack'
+				) }
+			>
+				<Button isDefault isLarge href={ connectURL } target="_blank">
+					{ __( 'Set up Mailchimp form', 'jetpack' ) }
+				</Button>
+				<Button isLink onClick={ this.apiCall }>
+					{ __( 'Re-check Connection', 'jetpack' ) }
+				</Button>
 			</Placeholder>
 		);
 		const inspectorControls = (

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -149,22 +149,24 @@ class MailchimpSubscribeEdit extends Component {
 			</Placeholder>
 		);
 		const placeholder = (
-			<Placeholder
-				icon={ icon }
-				label={ __( 'Mailchimp', 'jetpack' ) }
-				notices={ notices }
-				instructions={ __(
-					'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.',
-					'jetpack'
-				) }
-			>
-				<Button isDefault isLarge href={ connectURL } target="_blank">
-					{ __( 'Set up Mailchimp form', 'jetpack' ) }
-				</Button>
-				<Button isLink onClick={ this.apiCall }>
-					{ __( 'Re-check Connection', 'jetpack' ) }
-				</Button>
-			</Placeholder>
+			<div className="wp-block-jetpack-mailchimp">
+				<Placeholder
+					icon={ icon }
+					label={ __( 'Mailchimp', 'jetpack' ) }
+					notices={ notices }
+					instructions={ __(
+						'You need to connect your Mailchimp account and choose a list in order to start collecting Email subscribers.',
+						'jetpack'
+					) }
+				>
+					<Button isDefault isLarge href={ connectURL } target="_blank">
+						{ __( 'Set up Mailchimp form', 'jetpack' ) }
+					</Button>
+					<Button isLink onClick={ this.apiCall }>
+						{ __( 'Re-check Connection', 'jetpack' ) }
+					</Button>
+				</Placeholder>
+			</div>
 		);
 		const inspectorControls = (
 			<InspectorControls>

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -159,9 +159,11 @@ class MailchimpSubscribeEdit extends Component {
 					'jetpack'
 				) }
 			>
-				<Button isDefault isLarge href={ connectURL } target="_blank">
-					{ __( 'Set up Mailchimp form', 'jetpack' ) }
-				</Button>
+				<div>
+					<Button isDefault isLarge href={ connectURL } target="_blank">
+						{ __( 'Set up Mailchimp form', 'jetpack' ) }
+					</Button>
+				</div>
 				<Button isLink onClick={ this.apiCall }>
 					{ __( 'Re-check Connection', 'jetpack' ) }
 				</Button>

--- a/extensions/blocks/mailchimp/editor.scss
+++ b/extensions/blocks/mailchimp/editor.scss
@@ -30,4 +30,22 @@
 		margin-top: 0;
 	}
 
+	.components-placeholder__fieldset .components-button {
+		margin-right: 0;
+	}
+
+	.components-placeholder__fieldset .components-button.is-link {
+		display: inline-block;
+		flex-basis: 100%;
+    text-align: center;
+	}
+
+	.components-placeholder__fieldset .components-button:not(.is-link)~.components-button.is-link {
+		margin-left: 0;
+	}
+
+	.components-placeholder__instructions {
+		max-width: 80%;
+	}
+
 }

--- a/extensions/blocks/mailchimp/editor.scss
+++ b/extensions/blocks/mailchimp/editor.scss
@@ -30,18 +30,10 @@
 		margin-top: 0;
 	}
 
-	.components-placeholder__fieldset .components-button {
-		margin-right: 0;
-	}
-
-	.components-placeholder__fieldset .components-button.is-link {
-		display: inline-block;
-		flex-basis: 100%;
-    text-align: center;
-	}
-
-	.components-placeholder__fieldset .components-button:not(.is-link)~.components-button.is-link {
-		margin-left: 0;
+	.components-placeholder__fieldset {
+		display: block;
+		flex-direction: unset;
+		flex-wrap: unset;
 	}
 
 }

--- a/extensions/blocks/mailchimp/editor.scss
+++ b/extensions/blocks/mailchimp/editor.scss
@@ -2,6 +2,10 @@
 
 .wp-block-jetpack-mailchimp {
 
+	.components-placeholder__label svg {
+		margin-right: 1ch;
+	}
+
 	.wp-block-jetpack-mailchimp_notification {
 		display: block;
 	}

--- a/extensions/blocks/mailchimp/editor.scss
+++ b/extensions/blocks/mailchimp/editor.scss
@@ -44,8 +44,4 @@
 		margin-left: 0;
 	}
 
-	.components-placeholder__instructions {
-		max-width: 80%;
-	}
-
 }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -211,25 +211,29 @@ class MapEdit extends Component {
 				<Spinner />
 			</Placeholder>
 		);
+
+		const instructions = (
+			<Fragment>
+				{ __( 'To use the map block, you need an Access Token.', 'jetpack' ) }
+				<br />
+				<ExternalLink href="https://www.mapbox.com">
+					{ __( 'Create an account or log in to Mapbox.', 'jetpack' ) }
+				</ExternalLink>
+				<br />
+				{ __(
+					'Locate and copy the default access token. Then, paste it into the field below.',
+					'jetpack'
+				) }
+			</Fragment>
+		);
 		const placeholderAPIStateFailure = (
 			<Placeholder
 				icon={ settings.icon }
 				label={ __( 'Map', 'jetpack' ) }
 				notices={ notices }
-				instructions={ __( 'To use the map block, you need an Access Token.', 'jetpack' ) }
+				instructions={ instructions }
 			>
 				<Fragment>
-					<div className="components-placeholder__instructions">
-						<ExternalLink href="https://www.mapbox.com">
-							{ __( 'Create an account or log in to Mapbox.', 'jetpack' ) }
-						</ExternalLink>
-					</div>
-					<div className="components-placeholder__instructions">
-						{ __(
-							'Locate and copy the default access token. Then, paste it into the field below.',
-							'jetpack'
-						) }
-					</div>
 					<form>
 						<TextControl
 							className="wp-block-jetpack-map-components-text-control-api-key"

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -69,9 +69,9 @@ class MapEdit extends Component {
 		// Allow one cycle for alignment change to take effect
 		setTimeout( this.mapRef.current.sizeMap, 0 );
 	};
-	updateAPIKeyControl = value => {
+	updateAPIKeyControl = event => {
 		this.setState( {
-			apiKeyControl: value,
+			apiKeyControl: event.target.value,
 		} );
 	};
 	updateAPIKey = () => {
@@ -235,15 +235,15 @@ class MapEdit extends Component {
 			>
 				<Fragment>
 					<form>
-						<TextControl
-							className="wp-block-jetpack-map-components-text-control-api-key"
+						<input
+							type="text"
+							className="components-placeholder__input"
 							disabled={ apiRequestOutstanding }
 							placeholder={ __( 'Paste Token Here', 'jetpack' ) }
 							value={ apiKeyControl }
 							onChange={ this.updateAPIKeyControl }
 						/>
 						<Button
-							className="wp-block-jetpack-map-components-text-control-api-key-submit"
 							isLarge
 							isSecondary
 							disabled={ apiRequestOutstanding || ! apiKeyControl || apiKeyControl.length < 1 }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -212,35 +212,42 @@ class MapEdit extends Component {
 			</Placeholder>
 		);
 		const placeholderAPIStateFailure = (
-			<Placeholder icon={ settings.icon } label={ __( 'Map', 'jetpack' ) } notices={ notices }>
+			<Placeholder
+				icon={ settings.icon }
+				label={ __( 'Map', 'jetpack' ) }
+				notices={ notices }
+				instructions={ __( 'To use the map block, you need an Access Token.', 'jetpack' ) }
+			>
 				<Fragment>
 					<div className="components-placeholder__instructions">
-						{ __( 'To use the map block, you need an Access Token.', 'jetpack' ) }
-						<br />
 						<ExternalLink href="https://www.mapbox.com">
 							{ __( 'Create an account or log in to Mapbox.', 'jetpack' ) }
 						</ExternalLink>
-						<br />
+					</div>
+					<div className="components-placeholder__instructions">
 						{ __(
 							'Locate and copy the default access token. Then, paste it into the field below.',
 							'jetpack'
 						) }
 					</div>
-					<TextControl
-						className="wp-block-jetpack-map-components-text-control-api-key"
-						disabled={ apiRequestOutstanding }
-						placeholder={ __( 'Paste Token Here', 'jetpack' ) }
-						value={ apiKeyControl }
-						onChange={ this.updateAPIKeyControl }
-					/>
-					<Button
-						className="wp-block-jetpack-map-components-text-control-api-key-submit"
-						isLarge
-						disabled={ apiRequestOutstanding || ! apiKeyControl || apiKeyControl.length < 1 }
-						onClick={ this.updateAPIKey }
-					>
-						{ __( 'Set Token', 'jetpack' ) }
-					</Button>
+					<form>
+						<TextControl
+							className="wp-block-jetpack-map-components-text-control-api-key"
+							disabled={ apiRequestOutstanding }
+							placeholder={ __( 'Paste Token Here', 'jetpack' ) }
+							value={ apiKeyControl }
+							onChange={ this.updateAPIKeyControl }
+						/>
+						<Button
+							className="wp-block-jetpack-map-components-text-control-api-key-submit"
+							isLarge
+							isSecondary
+							disabled={ apiRequestOutstanding || ! apiKeyControl || apiKeyControl.length < 1 }
+							onClick={ this.updateAPIKey }
+						>
+							{ __( 'Set Token', 'jetpack' ) }
+						</Button>
+					</form>
 				</Fragment>
 			</Placeholder>
 		);

--- a/extensions/blocks/map/editor.scss
+++ b/extensions/blocks/map/editor.scss
@@ -5,18 +5,6 @@
 		margin-right: 0.4em;
 	}
 }
-.wp-block-jetpack-map-components-text-control-api-key {
-	margin-right: 4px;
-	&.components-base-control .components-base-control__field {
-		margin-bottom: 0;
-	}
-}
-.wp-block-jetpack-map-components-text-control-api-key-submit.is-large {
-	height: 31px;
-}
-.wp-block-jetpack-map-components-text-control-api-key-submit:disabled {
-	opacity: 1;
-}
 .wp-block[data-type='jetpack/map'] {
 	.components-placeholder__label {
 		svg {

--- a/extensions/blocks/pinterest/edit.js
+++ b/extensions/blocks/pinterest/edit.js
@@ -171,7 +171,7 @@ class PinterestEdit extends Component {
 								placeholder={ __( 'Enter URL to embed here…', 'jetpack' ) }
 								onChange={ event => this.setState( { editedUrl: event.target.value } ) }
 							/>
-							<Button isLarge type="submit">
+							<Button isLarge isSecondary type="submit">
 								{ _x( 'Embed', 'button label', 'jetpack' ) }
 							</Button>
 							{ cannotEmbed && (

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -406,19 +406,15 @@ class MembershipsButtonEdit extends Component {
 							icon={ <BlockIcon icon={ icon } /> }
 							label={ __( 'Recurring Payments', 'jetpack' ) }
 							notices={ notices }
+							instructions={ __(
+								"You'll need to upgrade your plan to use the Recurring Payments button.",
+								'jetpack'
+							) }
 						>
-							<div className="components-placeholder__instructions">
-								<p>
-									{ __(
-										"You'll need to upgrade your plan to use the Recurring Payments button.",
-										'jetpack'
-									) }
-								</p>
-								<Button isDefault isLarge href={ this.state.upgradeURL } target="_blank">
-									{ __( 'Upgrade Your Plan', 'jetpack' ) }
-								</Button>
-								{ this.renderDisclaimer() }
-							</div>
+							<Button isSecondary isLarge href={ this.state.upgradeURL } target="_blank">
+								{ __( 'Upgrade Your Plan', 'jetpack' ) }
+							</Button>
+							{ this.renderDisclaimer() }
 						</Placeholder>
 					</div>
 				) }

--- a/extensions/blocks/recurring-payments/editor.scss
+++ b/extensions/blocks/recurring-payments/editor.scss
@@ -9,11 +9,6 @@
 		text-align: left;
 	}
 
-	.components-button {
-		display: inline-block;
-		margin-bottom: 20px;
-	}
-
 	.components-placeholder {
 		min-height: 150px;
 		padding: 24px;
@@ -24,10 +19,6 @@
 				font-size: 13px;
 				margin: 0 0 20px;
 			}
-		}
-
-		&__instructions {
-			margin-bottom: 0;
 		}
 	}
 
@@ -45,10 +36,12 @@
 
 		&__disclaimer {
 			color: var( --color-gray-200 );
+			flex-basis: 100%;
 			margin: 0;
 			font-style: italic;
 			a {
 				color: var( --color-gray-400 );
+				line-height: 36px;
 			}
 		}
 

--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -49,8 +49,12 @@
 	margin-right: 20px;
 
 	.components-text-control__input {
-		width: 5em;
+		margin-left: 12px;
 		text-align: center;
+		width: 5em;
+	}
+	.components-base-control+.components-base-control {
+		margin-bottom: 0;
 	}
 }
 

--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -32,6 +32,7 @@
 		flex-wrap: nowrap;
 		.components-base-control {
 			flex-basis: 100%;
+			margin-bottom: 0;
 		}
 	}
 
@@ -53,9 +54,7 @@
 		text-align: center;
 		width: 5em;
 	}
-	.components-base-control+.components-base-control {
-		margin-bottom: 0;
-	}
+
 }
 
 // Overrides to make the preview look good

--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -1,6 +1,9 @@
 .wp-block-jetpack-repeat-visitor {
 	.components-notice {
 		margin: 1em 0 0;
+		&__content {
+			color: var( --color-black );
+		}
 	}
 	.components-radio-control__option {
 		text-align: left;


### PR DESCRIPTION
## Description

One of the effects of the merge of [this core PR](https://github.com/WordPress/gutenberg/pull/18745) is that blank slate screens go from being center aligned to being left aligned.

@huguesvincent raised a flag when he noticed that many of the JP blocks now look off visually.

The goal of this PR is to reign in the blank slate screen design across all JP blocks.

## Testing Instructions

- Set up a local JP dev environment
- Make sure Gutenberg plugin is also installed
- Test each block listed in the change log below

## Change Log

Here's a detailed list of changes I'm made including before/after screenshots for each update:

### Contact Form

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/jkunAvl0/Image+2020-01-15+at+2.33.45+PM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/Z4uwnDx1/Image+2020-01-15+at+3.14.59+PM.png)

Changes:

- Replaced top `<p>` tag with `placeholder__instructions` to reduce amount of padding between elements.
- Reduced bottom margin of `help-message`.
- Lightened up the `help-message` text to give everything a touch more visual hierarchy
- Adjusted margin around extra line of text and button


### Gif

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/nOumKbWR/Image+2020-01-15+at+3.17.12+PM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/d5uegyvP/Image+2020-01-15+at+3.40.43+PM.png)

Changes:

- Removed `margin:0 auto;` which was forcing the input to be centered
- Removed isLarge CSS property to button
- Added isSecondary CSS property to button
- Adjusted height of input to match button height

Note:

I left a not on [this core issue](https://github.com/WordPress/gutenberg/issues/19662#issuecomment-575149675) to see if we can get the input and button height issue addressed in core. If that happens, I'll circle back and remove my extra input height CSS here.

### MailChimp

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/d5ueD8yd/Image+2020-01-16+at+9.54.42+AM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/rRuLzXG9/Image+2020-01-16+at+10.14.17+AM.png)

Changes:

- Moved instructions to instructions prop
- Removed <br> tags

### Map

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/NQuvpqlW/Image+2020-01-16+at+10.17.45+AM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/p9u5ZxAv/Image+2020-01-16+at+10.36.14+AM.png)

Changes:

- Moved instructions to instructions prop
- Removed <br> tags
- Added a bit more structure
- Added isSecondary to button

### Pinterest

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/WnuE6KZr/Image+2020-01-16+at+10.38.57+AM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/v1umWR9b/Image+2020-01-16+at+10.40.53+AM.png)

Changes:

- Added isSecondary to button

### Recurring Payments

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/9ZuNy2pP/Image+2020-01-16+at+10.42.43+AM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/mXumGE5X/Image+2020-01-16+at+11.14.52+AM.png)

Changes:

- Moved instructions to instructions prop
- Removed some unnecessary CSS

### Repeat Visitor

Before:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/Z4uwGZGz/Image+2020-01-16+at+11.20.11+AM.png)

After:

![](https://p111.p2.n0.cdn.getcloudapp.com/items/YEud48nQ/Image+2020-01-16+at+11.25.26+AM.png)

Changes:

- Added margin between label and input
- Removed some unnecessary margin-bottom
