### PR TITLE
Load Admin Dashboard prior to connection. Revert of 71d0a1f

### DIFF
--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -172,6 +172,10 @@ export class Footer extends React.Component {
 			? this.props.siteAdminUrl + 'admin.php?page=jetpack_about'
 			: 'https://jetpack.com';
 
+		const privacyUrl = this.props.siteConnectionStatus
+			? this.props.siteAdminUrl + 'admin.php?page=jetpack#/privacy'
+			: 'https://automattic.com/privacy/';
+
 		return (
 			<div className={ classes }>
 				<div className="jp-footer__a8c-attr-container">
@@ -230,7 +234,7 @@ export class Footer extends React.Component {
 					<li className="jp-footer__link-item">
 						<a
 							onClick={ this.trackPrivacyClick }
-							href="#/privacy"
+							href={ privacyUrl }
 							rel="noopener noreferrer"
 							title={ __( "Automattic's Privacy Policy" ) }
 							className="jp-footer__link"

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -2,17 +2,32 @@
  * External dependencies
  */
 import React from 'react';
-import ReactDom from 'react-dom';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import { translate as __ } from 'i18n-calypso';
+import analytics from 'lib/analytics';
 
 /**
  * Internal dependencies
  */
-import { isDevVersion as _isDevVersion, userCanManageOptions } from 'state/initial-state';
+import {
+	isDevVersion as _isDevVersion,
+	getCurrentVersion,
+	userCanManageOptions,
+	getSiteAdminUrl,
+} from 'state/initial-state';
+import { isInIdentityCrisis, getSiteConnectionStatus } from 'state/connection';
 import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
 import DevCard from 'components/dev-card';
 import onKeyDownCallback from 'utils/onkeydown-callback';
+
+const smoothScroll = () => {
+	const jpContentY = document.getElementById( 'jp-navigation' ).offsetTop;
+	window.scrollTo( 0, window.scrollY - jpContentY / 1.5 );
+	if ( window.scrollY > jpContentY ) {
+		window.requestAnimationFrame( smoothScroll );
+	}
+};
 
 export class Footer extends React.Component {
 	static displayName = 'Footer';
@@ -23,14 +38,58 @@ export class Footer extends React.Component {
 		}
 	};
 
+	trackVersionClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'version',
+		} );
+	};
+
+	trackTermsClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'terms',
+		} );
+	};
+
+	trackAboutClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'about',
+		} );
+	};
+
+	trackPrivacyClick = () => {
+		window.requestAnimationFrame( smoothScroll );
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'privacy',
+		} );
+	};
+
+	trackModulesClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'modules',
+		} );
+	};
+
+	trackDebugClick = () => {
+		analytics.tracks.recordJetpackClick( {
+			target: 'footer_link',
+			link: 'debug',
+		} );
+	};
+
 	render() {
-		if ( ! this.props.isDevVersion ) {
-			return null;
-		}
+		const classes = classNames( this.props.className, 'jp-footer' );
+
+		const version = this.props.currentVersion;
+
 		const maybeShowReset = () => {
-			if ( this.props.userCanManageOptions ) {
+			if ( this.props.isDevVersion && this.props.userCanManageOptions ) {
 				return (
-					<li className="jp-footer__link-item" key="reset">
+					<li className="jp-footer__link-item">
 						<a
 							role="button"
 							tabIndex="0"
@@ -43,39 +102,162 @@ export class Footer extends React.Component {
 					</li>
 				);
 			}
-			return null;
+			return '';
+		};
+
+		const maybeShowModules = () => {
+			if ( this.props.siteConnectionStatus && this.props.userCanManageOptions ) {
+				return (
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackModulesClick }
+							href={ this.props.siteAdminUrl + 'admin.php?page=jetpack_modules' }
+							title={ __( 'Access the full list of Jetpack modules available on your site.' ) }
+							className="jp-footer__link"
+						>
+							{ __( 'Modules', {
+								context: 'Navigation item. Noun. Links to a list of modules for Jetpack.',
+							} ) }
+						</a>
+					</li>
+				);
+			}
+		};
+
+		const maybeShowDebug = () => {
+			if ( this.props.userCanManageOptions ) {
+				return (
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackDebugClick }
+							href={ this.props.siteAdminUrl + 'admin.php?page=jetpack-debugger' }
+							title={ __( 'Test your site’s compatibility with Jetpack.' ) }
+							className="jp-footer__link"
+						>
+							{ __( 'Debug', {
+								context: 'Navigation item. Noun. Links to a debugger tool for Jetpack.',
+							} ) }
+						</a>
+					</li>
+				);
+			}
 		};
 
 		const maybeShowDevCardFooterLink = () => {
-			return (
-				<li className="jp-footer__link-item" key="dev-tools">
-					<a
-						role="button"
-						tabIndex="0"
-						onKeyDown={ onKeyDownCallback( this.props.enableDevCard ) }
-						onClick={ this.props.enableDevCard }
-						className="jp-footer__link"
-					>
-						{ __( 'Dev Tools', { context: 'Navigation item.' } ) }
-					</a>
-				</li>
-			);
+			if ( this.props.isDevVersion ) {
+				return (
+					<li className="jp-footer__link-item">
+						<a
+							role="button"
+							tabIndex="0"
+							onKeyDown={ onKeyDownCallback( this.props.enableDevCard ) }
+							onClick={ this.props.enableDevCard }
+							className="jp-footer__link"
+						>
+							{ __( 'Dev Tools', { context: 'Navigation item.' } ) }
+						</a>
+					</li>
+				);
+			}
+			return '';
 		};
 
 		const maybeShowDevCard = () => {
-			return this.props.displayDevCard && <DevCard key="dev-card" />;
+			if ( this.props.isDevVersion && this.props.displayDevCard ) {
+				return <DevCard />;
+			}
 		};
 
-		const children = [ maybeShowReset(), maybeShowDevCardFooterLink(), maybeShowDevCard() ];
-		return ReactDom.createPortal( children, document.getElementById( 'jp-footer__links-id' ) );
+		const aboutPageUrl = this.props.siteConnectionStatus
+			? this.props.siteAdminUrl + 'admin.php?page=jetpack_about'
+			: 'https://jetpack.com';
+
+		return (
+			<div className={ classes }>
+				<div className="jp-footer__a8c-attr-container">
+					<a href={ aboutPageUrl }>
+						<svg
+							role="img"
+							className="jp-footer__a8c-attr"
+							x="0"
+							y="0"
+							viewBox="0 0 935 38.2"
+							enableBackground="new 0 0 935 38.2"
+							aria-labelledby="a8c-svg-title"
+						>
+							<title id="a8c-svg-title">{ __( 'An Automattic Airline' ) }</title>
+							<path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z" />
+							<path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z" />
+							<path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z" />
+						</svg>
+					</a>
+				</div>
+				<ul className="jp-footer__links">
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackVersionClick }
+							href="https://jetpack.com"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="jp-footer__link"
+							title={ __( 'Jetpack version' ) }
+						>
+							{ version ? __( 'Jetpack version %(version)s', { args: { version } } ) : 'Jetpack' }
+						</a>
+					</li>
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackAboutClick }
+							href={ aboutPageUrl }
+							className="jp-footer__link"
+							title={ __( 'About Jetpack' ) }
+						>
+							{ __( 'About', { context: 'Link to learn more about Jetpack.' } ) }
+						</a>
+					</li>
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackTermsClick }
+							href="https://wordpress.com/tos/"
+							target="_blank"
+							rel="noopener noreferrer"
+							title={ __( 'WordPress.com Terms of Service' ) }
+							className="jp-footer__link"
+						>
+							{ __( 'Terms', { context: 'Shorthand for Terms of Service.' } ) }
+						</a>
+					</li>
+					<li className="jp-footer__link-item">
+						<a
+							onClick={ this.trackPrivacyClick }
+							href="#/privacy"
+							rel="noopener noreferrer"
+							title={ __( "Automattic's Privacy Policy" ) }
+							className="jp-footer__link"
+						>
+							{ __( 'Privacy', { context: 'Shorthand for Privacy Policy.' } ) }
+						</a>
+					</li>
+					{ maybeShowModules() }
+					{ maybeShowDebug() }
+					{ maybeShowReset() }
+					{ maybeShowDevCardFooterLink() }
+					{ maybeShowDevCard() }
+				</ul>
+			</div>
+		);
 	}
 }
 
 export default connect(
 	state => {
 		return {
+			currentVersion: getCurrentVersion( state ),
 			displayDevCard: canDisplayDevCard( state ),
 			isDevVersion: _isDevVersion( state ),
+			isInIdentityCrisis: isInIdentityCrisis( state ),
+			siteAdminUrl: getSiteAdminUrl( state ),
+			siteConnectionStatus: getSiteConnectionStatus( state ),
 			userCanManageOptions: userCanManageOptions( state ),
 		};
 	},

--- a/_inc/client/static-main.jsx
+++ b/_inc/client/static-main.jsx
@@ -11,6 +11,7 @@ import { bindActionCreators } from 'redux';
 import Masthead from 'components/masthead';
 import LoadingPlaceholder from 'components/loading-placeholder';
 import { setInitialState } from 'state/initial-state';
+import Footer from 'components/footer';
 
 class StaticMain extends React.Component {
 	UNSAFE_componentWillMount() {
@@ -22,7 +23,8 @@ class StaticMain extends React.Component {
 			<div id="jp-plugin-container">
 				<Masthead { ...this.props } />
 				<LoadingPlaceholder { ...this.props } />
-				<style type="text/css">{ '.vp-deactivated { display: none; }' }</style>
+				<Footer { ...this.props } />
+				<style type="text/css">{ '.vp-deactivated{ display: none; }' }</style>
 			</div>
 		);
 	}

--- a/_inc/jetpack-connection-banner.js
+++ b/_inc/jetpack-connection-banner.js
@@ -8,14 +8,7 @@
 		fullScreenDismiss = $( '.jp-connect-full__dismiss, .jp-connect-full__dismiss-paragraph' ),
 		wpWelcomeNotice = $( '#welcome-panel' ),
 		connectionBanner = $( '#message' ),
-		placeholder = $( '.jp-loading-placeholder' ),
 		connectionBannerDismiss = $( '.connection-banner-dismiss' );
-
-	if ( placeholder && placeholder.length ) {
-		fullScreenContainer.show();
-		var shell = $( '<div class="jp-lower"></div>' ).html( fullScreenContainer );
-		placeholder.hide().after( shell );
-	}
 
 	// Move the banner below the WP Welcome notice on the dashboard
 	$( window ).on( 'load', function() {

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -275,6 +275,9 @@ abstract class Jetpack_Admin_Page {
 		);
 		$args              = wp_parse_args( $args, $defaults );
 		$jetpack_admin_url = admin_url( 'admin.php?page=jetpack' );
+		$jetpack_about_url = ( Jetpack::is_active() || Jetpack::is_development_mode() )
+			? admin_url( 'admin.php?page=jetpack_about' )
+			: 'https://jetpack.com';
 
 		?>
 		<div id="jp-plugin-container" class="
@@ -298,6 +301,7 @@ abstract class Jetpack_Admin_Page {
 							<?php
 							if ( is_network_admin() ) {
 								$current_screen = get_current_screen();
+
 								$highlight_current_sites    = ( 'toplevel_page_jetpack-network' === $current_screen->id ? 'is-primary' : '' );
 								$highlight_current_settings = ( 'jetpack_page_jetpack-settings-network' === $current_screen->id ? 'is-primary' : '' );
 								?>
@@ -340,135 +344,48 @@ abstract class Jetpack_Admin_Page {
 			echo $callback_ui;
 			?>
 			<!-- END OF CALLBACK -->
-			<?php self::render_footer(); ?>
-		</div>
-		<?php
-		return;
-	}
 
-	/**
-	 * Output a list item with a link.
-	 *
-	 * @param string $url         URL.
-	 * @param string $title       Link title attribute.
-	 * @param string $text        Link text.
-	 * @param bool   $is_internal Is the link linking to an internal or external domain.
-	 */
-	public static function the_footer_link( $url, $title, $text, $is_internal = true ) {
-		printf(
-			'<li class="jp-footer__link-item"><a class="jp-footer__link" href="%1$s" title="%2$s" %4$s>%3$s</a></li>',
-			esc_url( $url ),
-			esc_attr( $title ),
-			esc_html( $text ),
-			( $is_internal ? '' : 'target="_blank" rel="noopener noreferrer"' )
-		);
-	}
-
-	/**
-	 * Render the footer of the jetpack dashboard. For admin pages.
-	 *
-	 * Note that the Jetpack Dashboard may append additional links to that list.
-	 */
-	public static function render_footer() {
-		$admin_url = admin_url( 'admin.php?page=jetpack' );
-
-		$is_dev_mode_or_connected = Jetpack::is_active() || ( new Status() )->is_development_mode();
-
-		$privacy_url = ( $is_dev_mode_or_connected )
-			? $admin_url . '#/privacy'
-			: 'https://automattic.com/privacy/';
-
-		$about_url = ( $is_dev_mode_or_connected )
-			? admin_url( 'admin.php?page=jetpack_about' )
-			: 'https://jetpack.com';
-
-		?>
-		<div class="jp-footer">
+			<div class="jp-footer">
 				<div class="jp-footer__a8c-attr-container">
-					<a href="<?php echo esc_url( $about_url ); ?>">
+					<a href="<?php echo esc_url( $jetpack_about_url ); ?>">
 						<svg role="img" class="jp-footer__a8c-attr" x="0" y="0" viewBox="0 0 935 38.2" enable-background="new 0 0 935 38.2" aria-labelledby="a8c-svg-title"><title id="a8c-svg-title">An Automattic Airline</title><path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z"></path><path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z"></path><path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z"></path></svg>
 					</a>
 				</div>
-				<ul class="jp-footer__links" id="jp-footer__links-id">
-					<?php
-					// Version number.
-					self::the_footer_link(
-						'https://jetpack.com',
-						__( 'Jetpack version', 'jetpack' ),
-						sprintf(
-							/* Translators: placeholder is a number. */
-							__( 'Jetpack version %s', 'jetpack' ),
-							JETPACK__VERSION
-						),
-						false
-					);
-
-					// About page.
-					self::the_footer_link(
-						$about_url,
-						__( 'About Jetpack', 'jetpack' ),
-						__( 'About', 'jetpack' ),
-						$is_dev_mode_or_connected
-					);
-
-					// TOS.
-					self::the_footer_link(
-						'https://wordpress.com/tos/',
-						__( 'WordPress.com Terms of Service', 'jetpack' ),
-						_x( 'Terms', 'Navigation item', 'jetpack' ),
-						false
-					);
-
-					// Privacy policy.
-					self::the_footer_link(
-						$privacy_url,
-						__( "Automattic's Privacy Policy", 'jetpack' ),
-						_x( 'Privacy', 'Navigation item', 'jetpack' ),
-						$is_dev_mode_or_connected
-					);
-
-					// Network Admin Jetpack dashboard.
-					if ( is_multisite() && current_user_can( 'jetpack_network_sites_page' ) ) {
-						self::the_footer_link(
-							network_admin_url( 'admin.php?page=jetpack' ),
-							__( "Manage your network's Jetpack Sites", 'jetpack' ),
-							_x( 'Network Sites', 'Navigation item', 'jetpack' ),
-							true
-						);
-					}
-
-					// Network Admin Jetpack settings.
-					if ( is_multisite() && current_user_can( 'jetpack_network_settings_page' ) ) {
-						self::the_footer_link(
-							network_admin_url( 'admin.php?page=jetpack-settings' ),
-							__( "Manage your network's Jetpack settings", 'jetpack' ),
-							_x( 'Network Settings', 'Navigation item', 'jetpack' ),
-							true
-						);
-					}
-
-					// Legacy Modules page.
-					if ( current_user_can( 'manage_options' ) && $is_dev_mode_or_connected ) {
-						self::the_footer_link(
-							admin_url( 'admin.php?page=jetpack_modules' ),
-							__( 'Access the full list of Jetpack modules available on your site', 'jetpack' ),
-							_x( 'Modules', 'Navigation item', 'jetpack' ),
-							true
-						);
-					}
-
-					// Debugger.
-					if ( current_user_can( 'manage_options' ) ) {
-						self::the_footer_link(
-							admin_url( 'admin.php?page=jetpack-debugger' ),
-							__( "Test your site's compatibility with Jetpack", 'jetpack' ),
-							_x( 'Debug', 'Navigation item', 'jetpack' ),
-							true
-						);
-					}
-					?>
+				<ul class="jp-footer__links">
+					<li class="jp-footer__link-item">
+						<a href="https://jetpack.com" target="_blank" rel="noopener noreferrer" class="jp-footer__link" title="<?php esc_html_e( 'Jetpack version', 'jetpack' ); ?>">Jetpack <?php echo JETPACK__VERSION; ?></a>
+					</li>
+					<li class="jp-footer__link-item">
+						<a href="<?php echo esc_url( $jetpack_about_url ); ?>" title="<?php esc_attr__( 'About Jetpack', 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html__( 'About', 'jetpack' ); ?></a>
+					</li>
+					<li class="jp-footer__link-item">
+						<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" title="<?php esc_html__( 'WordPress.com Terms of Service', 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Terms', 'Navigation item', 'jetpack' ); ?></a>
+					</li>
+					<li class="jp-footer__link-item">
+						<a href="<?php echo esc_url( $jetpack_admin_url . '#/privacy' ); ?>" rel="noopener noreferrer" title="<?php esc_html_e( "Automattic's Privacy Policy", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Privacy', 'Navigation item', 'jetpack' ); ?></a>
+					</li>
+					<?php if ( is_multisite() && current_user_can( 'jetpack_network_sites_page' ) ) { ?>
+						<li class="jp-footer__link-item">
+							<a href="<?php echo esc_url( network_admin_url( 'admin.php?page=jetpack' ) ); ?>" title="<?php esc_html_e( "Manage your network's Jetpack Sites.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Network Sites', 'Navigation item', 'jetpack' ); ?></a>
+						</li>
+					<?php } ?>
+					<?php if ( is_multisite() && current_user_can( 'jetpack_network_settings_page' ) ) { ?>
+						<li class="jp-footer__link-item">
+							<a href="<?php echo esc_url( network_admin_url( 'admin.php?page=jetpack-settings' ) ); ?>" title="<?php esc_html_e( "Manage your network's Jetpack Sites.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Network Settings', 'Navigation item', 'jetpack' ); ?></a>
+						</li>
+					<?php } ?>
+					<?php if ( current_user_can( 'manage_options' ) ) { ?>
+						<li class="jp-footer__link-item">
+							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack_modules' ) ); ?>" title="<?php esc_html_e( "Access the full list of Jetpack modules available on your site.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Modules', 'Navigation item', 'jetpack' ); ?></a>
+						</li>
+						<li class="jp-footer__link-item">
+							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack-debugger' ) ); ?>" title="<?php esc_html_e( "Test your site's compatibility with Jetpack.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Debug', 'Navigation item', 'jetpack' ); ?></a>
+						</li>
+					<?php } ?>
 				</ul>
 			</div>
+		</div>
 		<?php
+		return;
 	}
 }

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -279,6 +279,10 @@ abstract class Jetpack_Admin_Page {
 			? admin_url( 'admin.php?page=jetpack_about' )
 			: 'https://jetpack.com';
 
+		$jetpack_privacy_url = ( Jetpack::is_active() || Jetpack::is_development_mode() )
+			? $jetpack_admin_url . '#/privacy'
+			: 'https://automattic.com/privacy/';
+
 		?>
 		<div id="jp-plugin-container" class="
 		<?php
@@ -362,7 +366,7 @@ abstract class Jetpack_Admin_Page {
 						<a href="https://wordpress.com/tos/" target="_blank" rel="noopener noreferrer" title="<?php esc_html__( 'WordPress.com Terms of Service', 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Terms', 'Navigation item', 'jetpack' ); ?></a>
 					</li>
 					<li class="jp-footer__link-item">
-						<a href="<?php echo esc_url( $jetpack_admin_url . '#/privacy' ); ?>" rel="noopener noreferrer" title="<?php esc_html_e( "Automattic's Privacy Policy", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Privacy', 'Navigation item', 'jetpack' ); ?></a>
+						<a href="<?php echo esc_url( $jetpack_privacy_url ); ?>" rel="noopener noreferrer" title="<?php esc_html_e( "Automattic's Privacy Policy", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Privacy', 'Navigation item', 'jetpack' ); ?></a>
 					</li>
 					<?php if ( is_multisite() && current_user_can( 'jetpack_network_sites_page' ) ) { ?>
 						<li class="jp-footer__link-item">

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -116,8 +116,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 			// We got the static.html so let's display it
 			echo $static_html;
-			self::render_footer();
-
 		}
 	}
 
@@ -149,6 +147,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			return; // No need for scripts on a fallback page
 		}
 
+
 		$is_development_mode = ( new Status() )->is_development_mode();
 		$script_deps_path    = JETPACK__PLUGIN_DIR . '_inc/build/admin.asset.php';
 		$script_dependencies = array( 'wp-polyfill' );
@@ -157,16 +156,13 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			$script_dependencies = $asset_manifest['dependencies'];
 		}
 
-		if ( Jetpack::is_active() || $is_development_mode ) {
-			wp_enqueue_script(
-				'react-plugin',
-				plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ),
-				$script_dependencies,
-				JETPACK__VERSION,
-				true
-			);
-		}
-
+		wp_enqueue_script(
+			'react-plugin',
+			plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ),
+			$script_dependencies,
+			JETPACK__VERSION,
+			true
+		);
 
 		if ( ! $is_development_mode && Jetpack::is_active() ) {
 			// Required for Analytics.


### PR DESCRIPTION
With the release of 7.9 users no longer see connection errors when trying to "Set up Jetpack". This commit reverts https://github.com/Automattic/jetpack/commit/71d0a1f637eaf5a0d71e78e6e84f18a8b3b61a8b so that the Admin Dashboard is loaded and allows for displaying error messages.

#### Changes proposed in this Pull Request:
* Revert of https://github.com/Automattic/jetpack/commit/71d0a1f637eaf5a0d71e78e6e84f18a8b3b61a8b

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* User Experience update

#### Testing instructions:

**Current Behavior is shown with**

1. Disable support for XML-RPC or mark the site private
1. Activate Jetpack on your site
1. Try "Set up Jetpack" (/wp-admin/admin.php?page=jetpack&action=register&_wpnonce=XXXXXX&from=full-screen-prompt)
1. User will be shown the same "Set up Jetpack" screen

**Apply Patch**

1. Ensure site is local, marked private, xml-rpc is disabled, or etc
1. Try "Set up Jetpack" .
1. User will see an admin notice with the error experienced

#### Proposed changelog entry for your changes:
* Resolves regression where connection errors were not being displayed to users.
