### PR TITLE
Instant Search: Use widgets inside overlay for filtering

### DIFF
--- a/modules/search/instant-search/README.md
+++ b/modules/search/instant-search/README.md
@@ -24,7 +24,8 @@ This also works on WP.com
 ```
 > npm install yarn@1.7
 > npm install node@10.17.0
-> npx yarn build-search [--watch]
+> yarn build
+> yarn build-search [--watch]
 > ls _inc/build/instant-search/
 ```
 
@@ -36,7 +37,9 @@ This also works on WP.com
 
 3. Select a theme of your choice and add a Jetpack Search widget to the site via the customizer. If using a theme with a sidebar widget area, please add the Jetpack Search widget there.
 
-4. If using a theme with a sidebar widget, you can navigate to / to start the search experience. Otherwise, navigate to your search page (e.g. `/?s=hello`).
+4. Add a Jetpack Search Widget to the Jetpack Search Sidebar and configure the filters you'd like to show in the search overlay.
+
+5. Navigate to your site's search page (e.g. `/?s=hello`) via the widget you added in (3).
 
 ## Architectural Choices
 

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -11,7 +11,6 @@ import { h, Component, Fragment } from 'preact';
  */
 import SearchResult from './search-result';
 import ScrollButton from './scroll-button';
-import SearchFilters from './search-filters';
 import SearchForm from './search-form';
 import SearchSidebar from './search-sidebar';
 import Notice from './notice';
@@ -112,18 +111,13 @@ class SearchResults extends Component {
 
 	renderSecondarySection() {
 		return (
-			<Fragment>
-				{ this.props.widgets.map( widget => (
-					<SearchFilters
-						loading={ this.props.isLoading }
-						locale={ this.props.locale }
-						postTypes={ this.props.postTypes }
-						results={ this.props.response }
-						widget={ widget }
-					/>
-				) ) }
-				<SearchSidebar />
-			</Fragment>
+			<SearchSidebar
+				isLoading={ this.props.isLoading }
+				locale={ this.props.locale }
+				postTypes={ this.props.postTypes }
+				response={ this.props.response }
+				widgets={ this.props.widgets }
+			/>
 		);
 	}
 

--- a/modules/search/instant-search/components/widget-area-container.jsx
+++ b/modules/search/instant-search/components/widget-area-container.jsx
@@ -1,0 +1,40 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h, Component, createRef } from 'preact';
+
+// NOTE:
+//
+// We use Preact.Component instead of a Hooks based component because
+// we need to set shouldComponentUpdate to always return false.
+//
+// We could implement such in a Hooks based component using React.memo,
+// but doing so would require importing (and bloating the bundle with)
+// preact/compat.
+
+export default class WidgetAreaContainer extends Component {
+	container = createRef();
+
+	componentDidMount() {
+		const widgetArea = document.getElementsByClassName(
+			'jetpack-instant-search__widget-area'
+		)[ 0 ];
+
+		if ( widgetArea ) {
+			widgetArea.style.removeProperty( 'display' );
+			this.container.current.appendChild( widgetArea );
+		}
+	}
+
+	shouldComponentUpdate() {
+		return false;
+	}
+
+	render() {
+		return (
+			<div className="jetpack-instant-search__widget-area-container" ref={ this.container }></div>
+		);
+	}
+}


### PR DESCRIPTION
Following up on #14319.

<img width="1675" alt="Screen Shot 2020-01-16 at 12 06 58 PM" src="https://user-images.githubusercontent.com/4044428/72566624-6975a900-3871-11ea-8124-d95936872579.png">

#### Changes proposed in this Pull Request:
* Removes rendering filters from all Jetpack Search widgets above the overlay widget area.
* Adds filter component injection for Jetpack Search widgets inside the overlay widget area. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow the [newly updated testing instructions](https://github.com/Automattic/jetpack/blob/add/instant-search-filter-injection/modules/search/instant-search/README.md#testing-instructions) which requires adding a Jetpack Search widget into the overlay widget area (named `Jetpack Search Sidebar`). Please make sure to configure some search filters for this widget.
2. Perform a site search to trigger the Jetpack Search overlay.
3. Ensure that the search filters render inside the overlay sidebar. 
4. Ensure that the search filters inside the overlay sidebar work as expected.

#### Proposed changelog entry for your changes:
* None
