### PR TITLE
Calendly: Removed look behinds in regexes

### DIFF
--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -1,33 +1,33 @@
 export const getURLFromEmbedCode = embedCode => {
-	const url = embedCode.match( /(?<!\.)calendly\.com.+?([^"']*)/i );
+	const url = embedCode.match( /\/\/calendly\.com.+?([^"']*)/i );
 	if ( url ) {
-		return 'https://' + url[ 0 ];
+		return 'https:' + url[ 0 ];
 	}
 };
 
 export const getSubmitButtonTextFromEmbedCode = embedCode => {
-	let submitButtonText = embedCode.match( /(?<=false;"\>).+(?=<\/)/ );
+	let submitButtonText = embedCode.match( /false;"\>([^<]+)\<\// );
 	if ( submitButtonText ) {
-		return submitButtonText[ 0 ];
+		return submitButtonText[ 1 ];
 	}
 
-	submitButtonText = embedCode.match( /(?<=text: ').*?(?=')/ );
+	submitButtonText = embedCode.match( /text: '([^']*?)'/ );
 	if ( submitButtonText ) {
-		return submitButtonText[ 0 ];
+		return submitButtonText[ 1 ];
 	}
 };
 
 const getSubmitButtonTextColorFromEmbedCode = embedCode => {
-	const submitButtonTextColor = embedCode.match( /(?<= textColor: ').*?(?=')/ );
+	const submitButtonTextColor = embedCode.match( /textColor: '([^']*?)'/ );
 	if ( submitButtonTextColor ) {
-		return submitButtonTextColor[ 0 ];
+		return submitButtonTextColor[ 1 ];
 	}
 };
 
 const getSubmitButtonBackgroundColorFromEmbedCode = embedCode => {
-	const submitButtonBackgroundColor = embedCode.match( /(?<= color: ').*?(?=')/ );
+	const submitButtonBackgroundColor = embedCode.match( /color: '([^']*?)'/ );
 	if ( submitButtonBackgroundColor ) {
-		return submitButtonBackgroundColor[ 0 ];
+		return submitButtonBackgroundColor[ 1 ];
 	}
 };
 

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -1,7 +1,7 @@
 export const getURLFromEmbedCode = embedCode => {
-	const url = embedCode.match( /\/\/calendly\.com.+?([^"']*)/i );
+	const url = embedCode.match( /(^|\/\/)(calendly\.com[^"']*)/i );
 	if ( url ) {
-		return 'https:' + url[ 0 ];
+		return 'https://' + url[ 2 ];
 	}
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Look behinds aren't supported by [Firefox, IE and some other browsers](https://caniuse.com/#feat=js-regexp-lookbehind), which prevented the Calendly block from registering correctly. 

This change replaces those regular expressions with ones that use groups to grab what is needed from the string.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This fixes a bug with the soon to be launched Calendly block

#### Testing instructions:
With a Jetpack site, activate the beta blocks and test that the different types of embed code can still be used with the Calendly block.

Optionally test it in another browser that doesn't support look behinds e.g. Firefox.

#### Proposed changelog entry for your changes:
* N/A
