### PR TITLE
Instant Search: update overlay styles

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -22,7 +22,6 @@ const SearchBox = props => {
 			{ /* TODO: Add support for preserving label text */ }
 			<label htmlFor={ inputId } className="screen-reader-text">
 				{ __( 'Site Search', 'jetpack' ) }
-				<span class="screen-reader-text">Search for:</span>
 			</label>
 			<input
 				id={ inputId }

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -22,6 +22,7 @@ const SearchBox = props => {
 			{ /* TODO: Add support for preserving label text */ }
 			<label htmlFor={ inputId } className="screen-reader-text">
 				{ __( 'Site Search', 'jetpack' ) }
+				<span class="screen-reader-text">Search for:</span>
 			</label>
 			<input
 				id={ inputId }

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -11,9 +11,5 @@
 
 /* apply to all the inputs to try and pick up any theme styling */
 .jetpack-instant-search__box input {
-	border-radius: 2px;
-	font-size: 14px;
-	height: 26px;
 	width: 100%;
-	line-height: 1.2em;
 }

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -1,5 +1,7 @@
 .jetpack-instant-search__box {
 	display: flex;
+	align-items: center;
+	flex: 0 0 100%;
 }
 
 .jetpack-instant-search__box-filter-icon {

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -5,7 +5,7 @@
 }
 
 .jetpack-instant-search__box-filter-icon {
-	margin-left: 4px;
+	margin-left: 8px;
 	cursor: pointer;
 }
 

--- a/modules/search/instant-search/components/search-result-minimal.jsx
+++ b/modules/search/instant-search/components/search-result-minimal.jsx
@@ -96,7 +96,6 @@ class SearchResultMinimal extends Component {
 
 		return (
 			<li className="jetpack-instant-search__search-result-minimal">
-				<SearchResultDate date={ fields.date } locale={ locale } />
 				<h3 className="jetpack-instant-search__search-result-title">
 					<PostTypeIcon postType={ fields.post_type } shortcodeTypes={ fields.shortcode_types } />
 					<a
@@ -107,6 +106,7 @@ class SearchResultMinimal extends Component {
 						dangerouslySetInnerHTML={ { __html: highlight.title } }
 					/>
 				</h3>
+				<SearchResultDate date={ fields.date } locale={ locale } />
 				{ noMatchingContent ? this.renderNoMatchingContent() : this.renderMatchingContent() }
 				<SearchResultComments comments={ highlight && highlight.comments } />
 			</li>

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -2,20 +2,20 @@
 	padding: 0.125em 0;
 	margin: 1em 0;
 	position: relative;
+}
 
-	h3 {
-		clear: none;
-		overflow: hidden;
+.jetpack-instant-search__search-result-title {
+	clear: none;
+	overflow: hidden;
 
-		.gridicon {
-			margin-right: 8px;
-		}
+	.gridicon {
+		margin-right: 8px;
 	}
+}
 
-	.jetpack-instant-search__search-result-date {
-		font-size: 0.85em;
-		margin: 0.5em 0;
-	}
+.jetpack-instant-search__search-result-date {
+	font-size: 0.85em;
+	margin: 0.5em 0;
 }
 
 .jetpack-instant-search__search-result-minimal-tag,

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -6,9 +6,6 @@
 	.jetpack-instant-search__search-result-date {
 		font-size: 0.85em;
 		margin: 0.5em 0;
-		position: absolute;
-		right: 0;
-		top: 0;
 	}
 }
 

--- a/modules/search/instant-search/components/search-result-minimal.scss
+++ b/modules/search/instant-search/components/search-result-minimal.scss
@@ -3,27 +3,19 @@
 	margin: 1em 0;
 	position: relative;
 
+	h3 {
+		clear: none;
+		overflow: hidden;
+
+		.gridicon {
+			margin-right: 8px;
+		}
+	}
+
 	.jetpack-instant-search__search-result-date {
 		font-size: 0.85em;
 		margin: 0.5em 0;
 	}
-}
-
-.jetpack-instant-search__search-result-minimal h3 {
-	clear: none;
-}
-
-.jetpack-instant-search__search-result-minimal h3 .gridicon {
-	margin-left: 5px;
-	margin-right: 5px;
-}
-
-.jetpack-instant-search__search-result-minimal .gridicon {
-	margin-right: 5px;
-}
-
-.jetpack-instant-search__search-result-minimal h3 {
-	overflow: hidden;
 }
 
 .jetpack-instant-search__search-result-minimal-tag,

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -35,11 +35,16 @@
 }
 
 .jetpack-instant-search__result-comments {
-	padding-left: 10px;
-	margin-left: 1px;
-	margin-top: 10px;
+	padding-left: 16px;
+	margin-left: 8px;
+	margin-top: 16px;
 	border-left: 2px solid #eee;
 	font-size: 0.9em;
+
+	.gridicon {
+		margin-right: 8px;
+		vertical-align: middle;
+	}
 }
 
 .jetpack-instant-search__search-results-list {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -24,7 +24,7 @@
 
 .jetpack-instant-search__search-results-real-query {
 	font-size: 1.5em;
-	text-decoration: bold;
+	font-weight: bold;
 }
 
 .jetpack-instant-search__search-results-unused-query,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/390760/72631162-c47bce80-394b-11ea-8334-e4971319c99e.png)

#### Changes proposed in this Pull Request:

* Makes main search input as wide as possible.
* Adds screen reader text for the search box.
* Changes date position.
* Update style for comments.
* Tweaks spacings.
* Cleans up a few styles.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* No

#### Testing instructions:

1. Follow the [testing instructions here](https://github.com/Automattic/jetpack/blob/add/instant-search-filter-injection/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Search.
2. Perform a site search to trigger the Jetpack Search overlay.
3. Ensure that the elements in the overlay look good.

#### Proposed changelog entry for your changes:

* None needed.
