### PR TITLE
Sync: ensure we run the initial sync on new connections

### DIFF
--- a/packages/sync/src/class-main.php
+++ b/packages/sync/src/class-main.php
@@ -20,13 +20,12 @@ class Main {
 	 * @action plugins_loaded
 	 */
 	public static function configure() {
-		// Exit out early if Sync isn't allowed.
-		if ( ! Actions::sync_allowed() ) {
-			return;
+		if ( Actions::sync_allowed() ) {
+			add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_early' ), 5 );
+			add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_late' ), 90 );
 		}
-
-		add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_early' ), 5 );
-		add_action( 'plugins_loaded', array( __CLASS__, 'on_plugins_loaded_late' ), 90 );
+		// Any hooks below are special cases that need to be declared even if Sync is not allowed.
+		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 	}
 
 	/**
@@ -47,7 +46,6 @@ class Main {
 
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Automattic\\Jetpack\\Sync\\Actions', 'cleanup_on_upgrade' ), 10, 2 );
-		add_action( 'jetpack_user_authorized', array( 'Automattic\\Jetpack\\Sync\\Actions', 'do_initial_sync' ), 10, 0 );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue where initial sync no longer happens during connection / reconnection.

#### Changes proposed in this Pull Request:
In #14204, we changed the way we initialize the Sync package,
which was a bit too strict and didn't allow for initial syncs
to happen.

Let's make sure we always hook to `jetpack_user_authorized` and
attempt to `do_initial_sync` during connections or reconnections.

There are safeguards in `do_initial_sync` to protect sites that
should sync from doing an initial sync.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes an issue in Sync package

#### Testing instructions:
- Get this PR running on a testing site
- Disconnect the site from WordPress.com if necessary
- (re)Connect to WordPress.com and ensure an initial sync was performed
- you verify by checking the "Full Sync" section of the debugger 
- or by observing sync data in real time

#### Proposed changelog entry for your changes:
* none
