### PR TITLE
Use Jetpack_RelatedPosts::get_options() to get options for server-rendered Related Posts

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -194,7 +194,7 @@ class Jetpack_RelatedPosts {
 	 * @return string Rendered related posts HTML.
 	 */
 	public function get_server_rendered_html() {
-		$rp_settings       = Jetpack_Options::get_option( 'relatedposts', array() );
+		$rp_settings       = $this->get_options();
 		$block_rp_settings = array(
 			'displayThumbnails' => $rp_settings['show_thumbnails'],
 			'showHeadline'      => $rp_settings['show_headline'],


### PR DESCRIPTION
It was discovered by @jamesozzie that filtering options for rendering Related Posts does not work on AMP pages. For example, in response to a [support forum topic](https://wordpress.org/support/topic/increase-related-post-limit-on-amp-pages/) he was looking to reduce the number of posts displayed from 3 to 2 with code like so:

```php
function jetpackme_more_related_posts( $options ) {
    if ( function_exists('is_amp_endpoint') && is_amp_endpoint()) {
        $options['size'] = 2; //change the number for the amount required
    }
    return $options;
 }
add_filter( 'jetpack_relatedposts_filter_options', 'jetpackme_more_related_posts' );
```

This turned out not to work because AMP pages render the Related Posts using `Jetpack_RelatedPosts::get_server_rendered_html()` and this method was calling `Jetpack_Options::get_option( 'relatedposts', array() )` rather than `Jetpack_RelatedPosts::get_options()`, and only the later method applies the `jetpack_relatedposts_filter_options` filter (as well as apply other normalizations).

This PR updates `\Jetpack_RelatedPosts::get_server_rendered_html()` to use `Jetpack_RelatedPosts::get_options()` rather than the lower-level `Jetpack_Options::get_option( 'relatedposts', array() )`.

Issue introduced in Jetpack 7.6 via #13028 for #9556.

#### Changes proposed in this Pull Request:

* Ensure options for rendering Related Posts are filterable when rendering on AMP pages.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a `jetpackme_more_related_posts` filter to change the `size` (see above).
* Verify the size change is applied to AMP and non-AMP pages alike.

#### Proposed changelog entry for your changes:

* Ensure options for rendering Related Posts are filterable when rendering on AMP pages. Use `Jetpack_RelatedPosts::get_options()` to get options for server-rendered Related Posts