### PR TITLE
WP.com block editor: auth cookie varies depending on site protocol

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -397,10 +397,12 @@ class Jetpack_WPCOM_Block_Editor {
 	/**
 	 * Designates cookies for cross-site access.
 	 *
+	 * @param string $samesite SameSite attribute to use in auth cookies.
+	 *
 	 * @return string SameSite attribute to use on auth cookies.
 	 */
-	public function set_samesite_auth_cookie() {
-		return 'None';
+	public function set_samesite_auth_cookie( $samesite ) {
+		return is_ssl() ? 'None' : $samesite;
 	}
 }
 


### PR DESCRIPTION
Fixes #14385

#### Changes proposed in this Pull Request:

* Ensure one can log in to their site regardless of the site protocol

#### Testing instructions:

* To test on both a HTTP and HTTPS site:
* See testing instructions in #14349 

#### Proposed changelog entry for your changes:

* N/A
