### PR TITLE
PHPUnit: fix unclear sync tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ matrix:
           # This is required to run new chrome on old trusty
           - libnss3
   - php: "7.0"
-    name: "Sync Beta"
-    env: SYNC_BETA=1 WP_BRANCH=latest
+    name: "Legacy full sync"
+    env: LEGACY_FULL_SYNC=1 WP_BRANCH=latest
 
   allow_failures:
     - name: "E2E tests"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -68,10 +68,10 @@
 		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
-			<exclude>tests/php/sync/test_class.jetpack-sync-full-immediately.php</exclude>
+			<exclude>tests/php/sync/test_class.jetpack-sync-full.php</exclude>
 		</testsuite>
-		<testsuite name="sync-beta">
-			<file>tests/php/sync/test_class.jetpack-sync-full-immediately.php</file>
+		<testsuite name="legacy-full-sync">
+			<file>tests/php/sync/test_class.jetpack-sync-full.php</file>
 		</testsuite>
 		<testsuite name="theme-tools">
 			<directory prefix="test_" suffix=".php">php/modules/theme-tools</directory>
@@ -105,7 +105,7 @@
 		<exclude>
 			<group>external-http</group>
 			<group>uninstall</group>
-			<group>sync-beta</group>
+			<group>legacy-full-sync</group>
 		</exclude>
 	</groups>
 	<filter>

--- a/tests/php.multisite.xml
+++ b/tests/php.multisite.xml
@@ -53,7 +53,7 @@
 		</testsuite>
 		<testsuite name="sync">
 			<directory prefix="test_" suffix=".php">tests/php/sync</directory>
-			<exclude>tests/php/sync/test_class.jetpack-sync-full-immediately.php</exclude>
+			<exclude>tests/php/sync/test_class.jetpack-sync-full.php</exclude>
 		</testsuite>
 		<testsuite name="theme-tools">
 			<directory prefix="test_" suffix=".php">php/modules/theme-tools</directory>

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -103,7 +103,9 @@ if ( ! ( in_running_uninstall_group() ) ) {
 }
 
 /**
- * Replace Full Sync module with Full Sync Immediately
+ * As of Jetpack 8.2, we are using Full_Sync_Immediately as the default full sync module.
+ * Some unit tests will need to revert to the now legacy Full_Sync module. The unit tests
+ * will look for a LEGACY_FULL_SYNC flag to run tests on the legacy module.
  *
  * @param array $modules Sync Modules.
  *
@@ -118,7 +120,7 @@ function jetpack_full_sync_immediately_off( $modules ) {
 	return $modules;
 }
 
-if ( false === getenv( 'SYNC_BETA' ) ) {
+if ( false !== getenv( 'LEGACY_FULL_SYNC' ) ) {
 	tests_add_filter( 'jetpack_sync_modules', 'jetpack_full_sync_immediately_off' );
 }
 

--- a/tests/php/sync/test_class.jetpack-sync-full-immediately.php
+++ b/tests/php/sync/test_class.jetpack-sync-full-immediately.php
@@ -11,11 +11,6 @@ if ( ! function_exists( 'jetpack_foo_full_sync_callable' ) ) {
 	}
 }
 
-/**
- * Sync Full Immediately
- *
- * @group sync-beta
- */
 class WP_Test_Jetpack_Sync_Full_Immediately extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync;
 

--- a/tests/php/sync/test_class.jetpack-sync-full.php
+++ b/tests/php/sync/test_class.jetpack-sync-full.php
@@ -5,6 +5,11 @@ use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Modules\Full_Sync;
 use Automattic\Jetpack\Sync\Settings;
 
+/**
+ * Testing Jetpack's full sync module prior to 8.2 release.
+ *
+ * @group legacy-full-sync
+ */
 class WP_Test_Jetpack_Sync_Full extends WP_Test_Jetpack_Sync_Base {
 	private $full_sync;
 

--- a/tests/php/sync/test_class.jetpack-sync-term-relationships.php
+++ b/tests/php/sync/test_class.jetpack-sync-term-relationships.php
@@ -4,6 +4,8 @@ use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Testing sync on Term Relationships
+ *
+ * @group legacy-full-sync
  */
 class WP_Test_Jetpack_Sync_Term_Relationships extends WP_Test_Jetpack_Sync_Base {
 	protected $post_id;
@@ -86,7 +88,7 @@ class WP_Test_Jetpack_Sync_Term_Relationships extends WP_Test_Jetpack_Sync_Base 
 		// Perform a full sync.
 		$this->full_sync->start();
 		$this->sender->do_full_sync();
-		
+
 		$post_terms_after_sync = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
 		$this->assertEquals( 1, count( $post_terms_after_sync ) );
 		$this->assertEquals( $this->taxonomy, $post_terms_after_sync[0]->taxonomy );

--- a/tests/run-travis.sh
+++ b/tests/run-travis.sh
@@ -79,8 +79,8 @@ if [ "$WP_TRAVISCI" == "phpunit" ]; then
 		export WP_TRAVISCI="phpdbg -qrr $HOME/.composer/vendor/bin/phpunit --coverage-clover $TRAVIS_BUILD_DIR/clover.xml"
 	fi
 
-  if [ "$SYNC_BETA" == "1" ]; then
-    export WP_TRAVISCI="phpunit --group=sync-beta"
+  if [ "$LEGACY_FULL_SYNC" == "1" ]; then
+    export WP_TRAVISCI="phpunit --group=legacy-full-sync"
   fi
 
 	print_build_info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes unclear unit test logic

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

We no longer need a `SYNC_BETA` flag in our unit tests because
Full_Sync_Immediately is no longer a beta feature. For clarity,
let's rename the flag to `LEGACY_FULL_SYNC` and adjust logic.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
If the travis tests are passing, and the logic makes sense to you, this is ready to go!

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog needed
