### PR TITLE
Calendly Block: Add alignment options

### DIFF
--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -11,6 +11,9 @@ const colourValidator = value => hexRegex.test( value );
 const urlValidator = url => ! url || url.startsWith( 'https://calendly.com/' );
 
 export default {
+	align: {
+		type: 'string',
+	},
 	backgroundColor: {
 		type: 'string',
 		default: 'ffffff',

--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -11,9 +11,6 @@ const colourValidator = value => hexRegex.test( value );
 const urlValidator = url => ! url || url.startsWith( 'https://calendly.com/' );
 
 export default {
-	align: {
-		type: 'string',
-	},
 	backgroundColor: {
 		type: 'string',
 		default: 'ffffff',

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -244,10 +244,10 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 	);
 
 	return (
-		<>
+		<div className={ className }>
 			{ inspectorControls }
 			{ blockControls }
 			{ url ? blockPreview( style ) : blockPlaceholder }
-		</>
+		</div>
 	);
 }

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -28,6 +28,8 @@ export const settings = {
 		__( 'appointments', 'jetpack' ),
 	],
 	supports: {
+		align: true,
+		alignWide: false,
 		html: false,
 	},
 	edit,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14367

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds alignment options

#### Testing instructions:
* Add a calendly block and set the style to "link".
* Try each of the alignment options
* Check that they behave as expected in the editor and the front end:
<img width="1005" alt="Screenshot 2020-01-21 at 15 30 58" src="https://user-images.githubusercontent.com/275961/72818330-36615a00-3c63-11ea-822f-37eb595c0aa1.png">
<img width="477" alt="Screenshot 2020-01-21 at 15 30 54" src="https://user-images.githubusercontent.com/275961/72818331-36615a00-3c63-11ea-9d47-9c55aff3dabc.png">

* Do the same for the inline version of the block.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
