### PR TITLE
Blocks: Share attribute validation code

### DIFF
--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -1,7 +1,6 @@
 /**
  * External Dependencies
  */
-import { reduce } from 'lodash';
 import { __ } from '@wordpress/i18n';
 
 const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
@@ -67,24 +66,3 @@ export default {
 		validator: colourValidator,
 	},
 };
-
-export const getValidatedAttributes = ( attributeDetails, attributes ) =>
-	reduce(
-		attributes,
-		( ret, attribute, attributeKey ) => {
-			const { type, validator, validValues, default: defaultVal } = attributeDetails[
-				attributeKey
-			];
-			if ( 'boolean' === type ) {
-				ret[ attributeKey ] = !! attribute;
-			} else if ( validator ) {
-				ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
-			} else if ( validValues ) {
-				ret[ attributeKey ] = validValues.includes( attribute ) ? attribute : defaultVal;
-			} else {
-				ret[ attributeKey ] = attribute;
-			}
-			return ret;
-		},
-		{}
-	);

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -26,7 +26,8 @@ import { __, _x } from '@wordpress/i18n';
  */
 import './editor.scss';
 import icon from './icon';
-import attributeDetails, { getValidatedAttributes } from './attributes';
+import attributeDetails from './attributes';
+import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesPreviewAndSelector from './blockStylesPreviewAndSelector';

--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
-import { compact, reduce, isEmpty } from 'lodash';
+import { compact, isEmpty } from 'lodash';
 
 const optionValues = options => options.map( option => option.value );
 
@@ -62,24 +62,3 @@ export const defaultAttributes = {
 		type: 'boolean',
 	},
 };
-
-export const getValidatedAttributes = ( attributeDetails, attributesToValidate ) =>
-	reduce(
-		attributesToValidate,
-		( ret, attribute, attributeKey ) => {
-			const { type, validator, validValues, default: defaultVal } = attributeDetails[
-				attributeKey
-			];
-			if ( 'boolean' === type ) {
-				ret[ attributeKey ] = !! attribute;
-			} else if ( validator ) {
-				ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
-			} else if ( validValues ) {
-				ret[ attributeKey ] = validValues.includes( attribute ) ? attribute : defaultVal;
-			} else {
-				ret[ attributeKey ] = attribute;
-			}
-			return ret;
-		},
-		{}
-	);

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -40,8 +40,8 @@ import {
 	languageOptions,
 	languageValues,
 	defaultAttributes,
-	getValidatedAttributes,
 } from './attributes';
+import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 
 export default function OpenTableEdit( { attributes, setAttributes, className, clientId } ) {
 	const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );

--- a/extensions/shared/get-validated-attributes.js
+++ b/extensions/shared/get-validated-attributes.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { reduce } from 'lodash';
+
+export const getValidatedAttributes = ( attributeDetails, attributesToValidate ) =>
+	reduce(
+		attributesToValidate,
+		( ret, attribute, attributeKey ) => {
+			const { type, validator, validValues, default: defaultVal } = attributeDetails[
+				attributeKey
+			];
+			if ( 'boolean' === type ) {
+				ret[ attributeKey ] = !! attribute;
+			} else if ( validator ) {
+				ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
+			} else if ( validValues ) {
+				ret[ attributeKey ] = validValues.includes( attribute ) ? attribute : defaultVal;
+			} else {
+				ret[ attributeKey ] = attribute;
+			}
+			return ret;
+		},
+		{}
+	);

--- a/extensions/shared/get-validated-attributes.js
+++ b/extensions/shared/get-validated-attributes.js
@@ -3,6 +3,13 @@
  */
 import { reduce } from 'lodash';
 
+/**
+ * Take user set attributes and validate them against the attribute definition.
+ *
+ * @param {string} attributeDetails An object representing the attributes for a block, formatted as an object with these properties: type, default, validator.
+ * @param {string} attributesToValidate The attributes for an instance of the block, which may have been edited by a user
+ * @returns {object} Block attributes that have been validated.
+ */
 export const getValidatedAttributes = ( attributeDetails, attributesToValidate ) =>
 	reduce(
 		attributesToValidate,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The function `getValidatedAttributes` is the same in both the Calendly and OpenTable blocks, so we can just extract this to shared to remove this duplicate code.

#### Testing instructions:
* Create a new post
* Add a Calendly block
* Add an OpenTable block
* Confirm that they both work as expected

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
