### PR TITLE
Instant Search: Fix taxonomy name compilation bug

### DIFF
--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -3,10 +3,6 @@
  */
 import 'url-polyfill';
 import { decode, encode } from 'qss';
-// NOTE: We only import the get package here for to reduced bundle size.
-//       Do not import the entire lodash library!
-// eslint-disable-next-line lodash/import-scope
-import get from 'lodash/get';
 
 /**
  * Internal dependencies
@@ -170,16 +166,13 @@ export function getFilterKeys() {
 	];
 
 	// Extract taxonomy names from server widget data
-	const widgetFilters = get( window[ SERVER_OBJECT_NAME ], 'widgets[0].filters' );
-	if ( widgetFilters ) {
-		return [
-			...keys,
-			...widgetFilters
-				.filter( filter => filter.type === 'taxonomy' )
-				.map( filter => filter.taxonomy ),
-		];
-	}
-	return [ ...keys, 'category', 'post_tag' ];
+	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
+		.map( w => w.filters )
+		.filter( filters => Array.isArray( filters ) )
+		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
+		.filter( filter => filter.type === 'taxonomy' )
+		.map( filter => filter.taxonomy );
+	return [ ...keys, ...taxonomies ];
 }
 
 export function getFilterQuery( filterKey ) {


### PR DESCRIPTION
Fixes #14377.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes logic in `getFilterKeys` function to account for all widget configurations instead of just the first widget when compiling an array of viable taxonomy names.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow the [newly updated testing instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) which requires adding a Jetpack Search widget into the overlay widget area (named `Jetpack Search Sidebar`). Do not configure a taxonomy filter for the widget in the overlay.
2. Add a Jetpack Search widget to either your footer or site sidebar. Configure a taxonomy filter for this widget.
3. Trigger the search overlay by clicking on a taxonomy filter selected in step 2.
4. Ensure that the search results in the overlay have been filtered as expected. 

#### Proposed changelog entry for your changes:
* None.