### PR TITLE
Instant Search: Fix date formatting issue for filters

### DIFF
--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -26,17 +26,8 @@ function getDateOptions( interval ) {
 }
 
 export default class SearchFilter extends Component {
-	constructor( props ) {
-		super( props );
-		this.filtersList = createRef();
-		this.idPrefix = uniqueId( 'jetpack-instant-search__filter-' );
-
-		if ( this.props.type === 'date' ) {
-			// NOTE: This assumes that the configuration never changes. It will break if we
-			// ever adjust it dynamically.
-			this.dateOptions = getDateOptions( this.props.configuration.interval );
-		}
-	}
+	filtersList = createRef();
+	idPrefix = uniqueId( 'jetpack-instant-search__filter-' );
 
 	getIdentifier() {
 		if ( this.props.type === 'postType' ) {
@@ -70,7 +61,11 @@ export default class SearchFilter extends Component {
 					type="checkbox"
 				/>
 				<label htmlFor={ `${ this.idPrefix }-dates-${ this.getIdentifier() }-${ key }` }>
-					{ new Date( key ).toLocaleString( locale, this.dateOptions ) } ({ count })
+					{ new Date( key ).toLocaleString(
+						locale,
+						getDateOptions( this.props.configuration.interval )
+					) }{' '}
+					({ count })
 				</label>
 			</div>
 		);


### PR DESCRIPTION
Fixes #13811 introduced in #13748.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes `dateOptions` instance variable from SearchFilter component.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow the [testing instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) if you haven't done so already.
2. Add multiple filters to the widget in step (1). Make sure to add at least one `Date`->`Year` filter.
3. Try searching and filtering. Ensure that the date filters are correctly formatted in all cases.

#### Proposed changelog entry for your changes:
* None.
