### PR TITLE
Instant search: move focus for overlay

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-import { h } from 'preact';
-import { useState } from 'preact/hooks';
+import { h, createRef } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import uniqueId from 'lodash/uniqueId';
@@ -16,6 +16,16 @@ import Gridicon from './gridicon';
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
+	const inputRef = createRef();
+
+	useEffect( () => {
+		inputRef.current.focus();
+		//console.log( inputRef.current );
+		return () => {
+			// Cleanup after event
+			// @todo Focus back on the activeElement before the overlay was opened
+		};
+	}, [] );
 
 	return (
 		<div className="jetpack-instant-search__box">
@@ -27,9 +37,7 @@ const SearchBox = props => {
 				id={ inputId }
 				className="search-field jetpack-instant-search__box-input"
 				onInput={ props.onChangeQuery }
-				onFocus={ props.onFocus }
-				onBlur={ props.onBlur }
-				ref={ props.appRef }
+				ref={ inputRef }
 				placeholder={ __( 'Search…', 'jetpack' ) }
 				type="search"
 				value={ props.query }

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -43,8 +43,6 @@ class SearchForm extends Component {
 					<SearchBox
 						enableFilters
 						onChangeQuery={ this.onChangeQuery }
-						onFocus={ this.props.onSearchFocus }
-						onBlur={ this.props.onSearchBlur }
 						query={ getSearchQuery() }
 						widget={ this.props.widget }
 						toggleFilters={ this.toggleFilters }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move focus to the overlay search input when the overlay is opened.
* Move focus back to the previously focused element (`document.activeElement`) when the overlay is closed.

Reference: https://davidwalsh.name/focused-element

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No - it's part of the Instant Search prototype.

#### Testing instructions:
To be added.
