### PR TITLE
PHPStan: add PHP Static Analysis tool to analyze codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 vendor/bin
 vendor/dealerdirect
 vendor/phpcompatibility
+vendor/phpstan
 vendor/sirbrillig
 vendor/squizlabs
 vendor/wp-coding-standards

--- a/.svnignore
+++ b/.svnignore
@@ -27,6 +27,7 @@ tools
 vendor/bin
 vendor/dealerdirect
 vendor/phpcompatibility
+vendor/phpstan
 vendor/sirbrillig
 vendor/squizlabs
 vendor/wp-coding-standards
@@ -41,6 +42,7 @@ vendor/automattic/**/assets/*.scss
 composer.lock
 package.json
 postcss.config.js
+phpstan.neon
 gulpfile.js
 gulpfile.babel.js
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,13 @@ matrix:
     after_script:
       - ./tests/process-coverage.sh
 
+  # PHPStan PHP Static Analysis Tool
+  - php: "7.3"
+    name: "PHPStan"
+    env: WP_BRANCH=latest
+    script:
+    - yarn php:phpstan
+
   - php: "7.0"
     name: "Legacy full sync"
     env: LEGACY_FULL_SYNC=1 WP_BRANCH=latest
@@ -122,6 +129,7 @@ matrix:
     - name: "Spell check Markdown files"
     - name: "Code Coverage"
     - name: "E2E tests with latest Gutenberg"
+    - name: "PHPStan"
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.0",
+		"phpstan/phpstan": "0.12.40",
 		"sirbrillig/phpcs-changed": "2.5.1",
 		"sirbrillig/phpcs-variable-analysis": "2.8.3",
 		"wp-coding-standards/wpcs": "2.3.0"
@@ -47,7 +48,8 @@
 		"php:lint": "vendor/bin/phpcs -p -s",
 		"php:changed": "vendor/sirbrillig/phpcs-changed/bin/phpcs-changed --git",
 		"php:autofix": "vendor/bin/phpcbf",
-		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
+		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
+		"php:phpstan": "vendor/bin/phpstan analyze -l 0 ."
 	},
 	"repositories": [
 		{

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
 		"phpstan/phpstan": "0.12.40",
 		"sirbrillig/phpcs-changed": "2.5.1",
 		"sirbrillig/phpcs-variable-analysis": "2.8.3",
+		"szepeviktor/phpstan-wordpress": "^0.6.3",
 		"wp-coding-standards/wpcs": "2.3.0"
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60257ed85635aee470db9bba63cad4ff",
+    "content-hash": "6594b8f8f8b79688d7b869cdca8a4eef",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -850,6 +850,46 @@
             "time": "2020-06-25T14:57:39+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "7ea14fc5e4242255f6b48295fdda0512053f0dc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/7ea14fc5e4242255f6b48295fdda0512053f0dc1",
+                "reference": "7ea14fc5e4242255f6b48295fdda0512053f0dc1",
+                "shasum": ""
+            },
+            "replace": {
+                "giacocorsiglia/wordpress-stubs": "*"
+            },
+            "require-dev": {
+                "giacocorsiglia/stubs-generator": "^0.5.0",
+                "php": "~7.1"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "time": "2020-08-18T04:31:49+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "9.3.5",
             "source": {
@@ -1217,6 +1257,142 @@
                 "standards"
             ],
             "time": "2020-08-10T04:50:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
+                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v0.6.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "d3ff2a9c0f3c336f352061524253c79ccc5ae30f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/d3ff2a9c0f3c336f352061524253c79ccc5ae30f",
+                "reference": "d3ff2a9c0f3c336f352061524253c79ccc5ae30f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
+                "phpstan/phpstan": "^0.12.26",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8.6",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.4.3"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/szepeviktor",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-08-21T09:36:29+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47b37ad7ddee294cec6da18fcee814dc",
+    "content-hash": "60257ed85635aee470db9bba63cad4ff",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -1008,6 +1008,62 @@
                 "wordpress"
             ],
             "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "dce7293ad7b59fc09a9ab9b0b5b44902c092ca17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dce7293ad7b59fc09a9ab9b0b5b44902c092ca17",
+                "reference": "dce7293ad7b59fc09a9ab9b0b5b44902c092ca17",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-26T19:06:20+00:00"
         },
         {
             "name": "sirbrillig/phpcs-changed",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"php:compatibility": "composer php:compatibility",
 		"php:lint": "composer php:lint",
 		"php:autofix": "composer php:autofix",
+		"php:phpstan": "composer php:phpstan",
 		"test-adminpage": "yarn test-client && yarn test-gui",
 		"test-client": "NODE_ENV=test NODE_PATH=tests:_inc/client tests/runner.js",
 		"test-decrypt-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./tests/e2e/config/encrypted.enc -out ./tests/e2e/config/local-test.js",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,14 @@
+parameters:
+	excludes_analyse:
+		- vendor/automattic/*/tests/*
+		- vendor/bin
+		- vendor/dealerdirect/*
+		- vendor/phpcompatibility/*
+		- vendor/phpstan/*
+		- vendor/sirbrillig/*
+		- vendor/squizlabs/*
+		- vendor/wp-coding-standards/*
+		- packages/*
+		- docker
+		- tools
+		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,7 @@ parameters:
         - class.jetpack-connection-banner.php
         - class.jetpack-data.php
     excludes_analyse:
+    	- node_modules/*
     	- vendor/automattic/*/tests/*
     	- vendor/bin
     	- vendor/dealerdirect/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,14 +1,34 @@
+# Add to composer.json:  "autoload": { "classmap": [ "_inc/lib" ] },
+#$ composer dump-autoload -o
+
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-	excludes_analyse:
-		- vendor/automattic/*/tests/*
-		- vendor/bin
-		- vendor/dealerdirect/*
-		- vendor/phpcompatibility/*
-		- vendor/phpstan/*
-		- vendor/sirbrillig/*
-		- vendor/squizlabs/*
-		- vendor/wp-coding-standards/*
-		- packages/*
-		- docker
-		- tools
-		- tests
+    level: 2
+#    level: 4
+#    level: max
+    inferPrivatePropertyTypeFromConstructor: true
+    paths:
+        - class.frame-nonce-preview.php
+        - class.jetpack-admin.php
+        - class.jetpack-affiliate.php
+        - class.jetpack-autoupdate.php
+        - class.jetpack-bbpress-json-api-compat.php
+        - class.jetpack-client-server.php
+##        - class.jetpack-cli.php
+        - class.jetpack-connection-banner.php
+        - class.jetpack-data.php
+    excludes_analyse:
+    	- vendor/automattic/*/tests/*
+    	- vendor/bin
+    	- vendor/dealerdirect/*
+    	- vendor/phpcompatibility/*
+    	- vendor/phpstan/*
+    	- vendor/sirbrillig/*
+    	- vendor/squizlabs/*
+    	- vendor/szepeviktor/*
+    	- vendor/wp-coding-standards/*
+    	- packages/*
+    	- docker
+    	- tools
+    	- tests


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Let's see if we can add a PHP Static Analysis tool to our list of tools.

* See #13466 for an example of the errors it can uncover.

This is very much a test, as our codebase is not clean from bugs right now. 

[PHPStan](https://github.com/phpstan/phpstan) includes a number of configuration options we can dig into. As a first step, I set the rule level to the minimum, `0`, to see how this all works:
https://github.com/phpstan/phpstan#rule-levels

I am currently having trouble running this locally though, I would need to look into that. It may just be memory trouble since it has to analyze so many files?

```
yarn php:phpstan
yarn run v1.21.1
$ composer php:phpstan
> vendor/bin/phpstan analyze -l 0 .
Note: Using configuration file /xx/wp-content/plugins/jetpack/phpstan.neon.
  143/1327 [▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░]  10%Script vendor/bin/phpstan analyze -l 0 . handling the php:phpstan event returned with error code 255
error Command failed with exit code 255.
```

Another option may also be to limit this to our packages as a start.

cc @szepeviktor who originally proposed the tool.

#### Testing instructions:

* What happens when you run `yarn php:phpstan` locally, after a `yarn build` to install the new dep?
* Does the new Travis test return results?

#### Proposed changelog entry for your changes:

* N/A
