### PR TITLE
Map Block: Persist Center Point

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -181,10 +181,16 @@ export class Map extends Component {
 		this.setBoundsByMarkers();
 	};
 	setBoundsByMarkers = () => {
-		const { zoom, points, onSetZoom } = this.props;
+		const { admin, onSetMapCenter, onSetZoom, points, zoom } = this.props;
 		const { map, activeMarker, mapboxgl, zoomControl, boundsSetProgrammatically } = this.state;
 		if ( ! map ) {
 			return;
+		}
+		// Do not allow map dragging in the editor if there are markers, because the positioning will be programmatically overridden.
+		if ( points.length && admin ) {
+			map.dragPan.disable();
+		} else {
+			map.dragPan.enable();
 		}
 		// If there are no points at all, there is no data to set bounds to. Abort the function.
 		if ( ! points.length ) {
@@ -198,6 +204,7 @@ export class Map extends Component {
 		points.forEach( point => {
 			bounds.extend( [ point.coordinates.longitude, point.coordinates.latitude ] );
 		} );
+		onSetMapCenter( bounds.getCenter() );
 
 		// If there are multiple points, zoom is determined by the area they cover, and zoom control is removed.
 		if ( points.length > 1 ) {
@@ -296,7 +303,13 @@ export class Map extends Component {
 		map.on( 'zoomend', () => {
 			this.props.onSetZoom( map.getZoom() );
 		} );
-
+		map.on( 'moveend', () => {
+			const { onSetMapCenter, points } = this.props;
+			// If there are no markers, user repositioning controls map center. If there are markers, set programmatically.
+			if ( points.length < 1 ) {
+				onSetMapCenter( map.getCenter() );
+			}
+		} );
 		/* Listen for clicks on the Map background, which hides the current popup. */
 		map.getCanvas().addEventListener( 'click', this.onMapClick );
 		this.setState( { map, zoomControl }, () => {
@@ -312,13 +325,14 @@ export class Map extends Component {
 			window.addEventListener( 'resize', this.debouncedSizeMap );
 		} );
 	}
-	googlePoint2Mapbox( google_point ) {
-		const mapCenter = [
-			google_point.longitude ? google_point.longitude : 0,
-			google_point.latitude ? google_point.latitude : 0,
-		];
-		return mapCenter;
-	}
+	googlePoint2Mapbox = google_point =>
+		google_point.hasOwnProperty( 'lat' ) && google_point.hasOwnProperty( 'lng' )
+			? google_point // Already a valid Mapbox point.
+			: {
+					// Legacy point, supported here to avoid block deprecation.
+					lng: google_point.longitude ? google_point.longitude : 0,
+					lat: google_point.latitude ? google_point.latitude : 0,
+			  };
 }
 
 Map.defaultProps = {
@@ -326,6 +340,7 @@ Map.defaultProps = {
 	mapStyle: 'default',
 	zoom: 13,
 	onSetZoom: () => {},
+	onSetMapCenter: () => {},
 	onMapLoaded: () => {},
 	onMarkerClick: () => {},
 	onError: () => {},

--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -330,8 +330,8 @@ export class Map extends Component {
 			? google_point // Already a valid Mapbox point.
 			: {
 					// Legacy point, supported here to avoid block deprecation.
-					lng: google_point.longitude ? google_point.longitude : 0,
-					lat: google_point.latitude ? google_point.latitude : 0,
+					lat: google_point.latitude || 0,
+					lng: google_point.longitude || 0,
 			  };
 }
 

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -262,6 +262,7 @@ class MapEdit extends Component {
 						admin={ true }
 						apiKey={ apiKey }
 						onSetPoints={ value => setAttributes( { points: value } ) }
+						onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
 						onMapLoaded={ () => this.setState( { addPointVisibility: true } ) }
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
 						onError={ this.onError }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR makes a few changes to the calculation and persistence of the Map block center point. The block determines the center point based on the map points that have been set. When the block initializes, the map "travels" to correct position and zoom, which causes a dramatic and unnecessary animation. This PR persists the true center point of the map, allowing the map to initialize in that position, avoiding the animation. 

This PR also adds a bonus feature: in a map with no points  defined, the editor can determine the center point by dragging, and this position will be respected when the map renders. 

If any points have been chosen, dragging is disabled. This is done to avoid the false expectation that the new position will be respected, since the block will replace it with the calculated center point based on the available points. 

Based on https://github.com/Automattic/wp-calypso/pull/28811.

#### Testing instructions:

* On `master`, add three Map blocks to a page with 0 points, 1 point, and 2 points.
* Switch to `fix/map-block-center-point`, verify that the blocks remain valid and work as expected.
* Create a new post and add Map blocks to it: 1) no points defined, left in original position (SF, CA) 2) no points defined, dragged somewhere else 3) one point defined 4) multiple points defined
* Verify the positions of all four remain intact after saving and reloading the editor, and that there is no initial animation. 
* Verify the position of all four are identical in the front end, and that there is no initial animation.
* Verify the first two can be dragged, and the second two cannot.
