### PR TITLE
Update spacing on offline notice

### DIFF
--- a/modules/search/instant-search/components/notice.scss
+++ b/modules/search/instant-search/components/notice.scss
@@ -2,7 +2,7 @@
 
 .jetpack-instant-search__notice {
 	padding: 0.75em;
-	margin-bottom: 1em;
+	margin: 1em 0;
 	font-size: 14px;
 
 	&.jetpack-instant-search__notice--warning {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Minor spacing changes to the offline notice in Jetpack Search.

#### Before

<img width="711" alt="Screen Shot 2020-01-21 at 14 37 46" src="https://user-images.githubusercontent.com/390760/72814154-7cff8600-3c5c-11ea-86b8-21db790853af.png">


#### After

<img width="723" alt="Screen Shot 2020-01-21 at 14 15 40" src="https://user-images.githubusercontent.com/390760/72814166-7f61e000-3c5c-11ea-9960-387d0ce1af19.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* No.

#### Testing instructions:

1. Follow the [testing instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search.
1. Enter search term and see results on overlay.
1. Break your connection (e.g.: disable proxy) and notice the offline notice.
1. Ensure it looks good.


#### Proposed changelog entry for your changes:

* None.
