### PR TITLE
Make the Calendly button accessible

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -80,9 +80,9 @@ function jetpack_calendly_block_load_assets( $attr, $content ) {
 		}
 
 		$content = sprintf(
-			'<div class="%1$s"><a class="button" href="" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;">%3$s</a></div>',
+			'<div class="%1$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;">%3$s</a></div>',
 			esc_attr( $classes ),
-			esc_url( $url ),
+			esc_js( $url ),
 			wp_kses_post( $submit_button_text )
 		);
 	} else { // Button style.


### PR DESCRIPTION
* Adds `role="button"`
* Use `esc_js` on the output for security reasons
* Change the button class to the same one that gutenberg uses for buttons

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p1579617455008100

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Calendly block
* Select the "link" style
* Preview the block in the front end and check it works as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog