### PR TITLE
[not verified] Sync Chunk Keys need to be unique

### DIFF
--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -567,7 +567,7 @@ class Sender {
 	 */
 	private function create_action_to_send( $action_name, $data ) {
 		return array(
-			( microtime( true ) * 10000 ) => array(
+			(string) microtime( true ) => array(
 				$action_name,
 				$data,
 				get_current_user_id(),

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -567,7 +567,7 @@ class Sender {
 	 */
 	private function create_action_to_send( $action_name, $data ) {
 		return array(
-			microtime( true ) => array(
+			( microtime( true ) * 10000 ) => array(
 				$action_name,
 				$data,
 				get_current_user_id(),


### PR DESCRIPTION
The sender uses microtime(true) to set the key for the… chunk. This can be an issue with fast performing queries as when use as an array key the decimal portion is dropped so the key is second based not microtime which leads to clashes.

This update ensure the decimal part is part of the key

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Jetpack Sync uses microtime keys for data chunks when a Full Sync is performed. When actively pulling data these can clash as the decimal part of the time is dropped. This ensures unique keys are produced.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Improves 'sync/checkout' endpoint to support pulls from Automattic infrastructure. Non end-user.

#### Testing instructions:

1. Find a test site that has more than 100 users, 1000 terms, 100 comments or 1000 term relationships

Existing Behavior
1. Clear the cache site (reset)
1. Perform a Full Sync via pull `wp jetpack-sync pull --blog-id=XXX --start`
1. Review cache site counts for the various objects. They will not match :)

Apply Patch
1. Clear the cache site (reset)
1. Perform a Full Sync via pull `wp jetpack-sync pull --blog-id=XXX --start`
1. Review cache site counts for the various objects. They will not match :)

Regression Testing

1. Perform a Full Sync (no commands) confirm it processes as expected
1. Perform some edit actions, verify they come across in the incremental sync.

#### Proposed changelog entry for your changes:
* N/A : This is to support internal functionality not impacting end users.
