### PR TITLE
Add alignment options to the OpenTable block

### DIFF
--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -50,7 +50,7 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 		setAttributes( validatedAttributes );
 	}
 
-	const { rid, style, iframe, domain, lang, newtab } = attributes;
+	const { align, rid, style, iframe, domain, lang, newtab } = attributes;
 	const [ notice, setNotice ] = useState();
 
 	const setErrorNotice = () =>
@@ -110,6 +110,15 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 
 	const updateStyle = newStyle => {
 		setAttributes( { style: newStyle } );
+		if ( style === 'wide' && align === 'wide' ) {
+			// If the old style was wide
+			setAttributes( { align: '' } ); // then reset the alignment
+		}
+
+		if ( newStyle === 'wide' ) {
+			// If the new style is wide
+			setAttributes( { align: 'wide' } ); // then set the alignment to wide as it works much better like that
+		}
 	};
 
 	const getTypeAndTheme = fromStyle =>

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -29,6 +29,7 @@ export const settings = {
 		__( 'restaurant', 'jetpack' ),
 	],
 	supports: {
+		align: true,
 		html: false,
 	},
 	edit,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14335

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds alignment options to the OpenTable block
* I also added some code to switch to a "wide" alignment when the "wide" style is chosen, as the block works best in these conditions (and then to reset when you select another style).

#### Testing instructions:
* Add an OpenTable block 
* Try setting the "right" and "left" alignments and verify that the block is aligned accordingly in the preview
* Switch the block to a "wide" style
* Verify that the block alignment also switches to "wide", and preview this
* Switch back to any other style
* Verify that the alignment setting is turned off.

<img width="905" alt="Screenshot 2020-01-21 at 16 39 56" src="https://user-images.githubusercontent.com/275961/72824124-ade7b700-3c6c-11ea-8355-5b9f6a9168d0.png">

#### Notes
* The center alignment option doesn't work. Should we try to remove it?
* To test you might need to change the hook to init (opentable.php line 60)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
