### PR TITLE
Instant Search : Update mobile structure

### DIFF
--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -42,6 +42,8 @@ class Gridicon extends Component {
 				return <title>{ __( 'Is a product.' ) }</title>;
 			case 'gridicons-comment':
 				return <title>{ __( 'Matching comment.' ) }</title>;
+			case 'gridicons-cross':
+				return <title>{ __( 'Close search overlay' ) }</title>;
 			case 'gridicons-folder':
 				return <title>{ __( 'Category' ) }</title>;
 			case 'gridicons-image-multiple':
@@ -88,6 +90,12 @@ class Gridicon extends Component {
 				return (
 					<g>
 						<path d="M3 6v9c0 1.105.895 2 2 2h9v5l5.325-3.804c1.05-.75 1.675-1.963 1.675-3.254V6c0-1.105-.895-2-2-2H5c-1.105 0-2 .895-2 2z" />
+					</g>
+				);
+			case 'gridicons-cross':
+				return (
+					<g>
+						<path d="M18.36 19.78L12 13.41l-6.36 6.37-1.42-1.42L10.59 12 4.22 5.64l1.42-1.42L12 10.59l6.36-6.36 1.41 1.41L13.41 12l6.36 6.36z" />
 					</g>
 				);
 			case 'gridicons-folder':

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -5,7 +5,11 @@
  */
 import { h } from 'preact';
 import { useEffect } from 'preact/hooks';
-import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from './gridicon';
 
 const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
@@ -28,7 +32,7 @@ const Overlay = ( { isVisible, closeOverlay, children } ) => {
 	return (
 		<div className={ classNames.join( ' ' ) }>
 			<button className="jetpack-instant-search__overlay-close" onClick={ closeOverlay }>
-				{ __( 'Close', 'jetpack' ) }
+				<Gridicon icon="cross" size="24" />
 			</button>
 			{ children }
 		</div>

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -1,16 +1,16 @@
 .jetpack-instant-search__overlay {
+	position: fixed;
 	top: 0;
 	left: 0;
+	z-index: 9999999999999;
 	width: 100vw;
 	height: 100vh;
-	opacity: 0.975;
-	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
-	position: fixed;
-	background: white;
 	padding: 3em 1em;
+	opacity: 0.975;
+	background: white;
 	overflow-y: auto;
 	overflow-x: hidden;
-	z-index: 9999999999999;
+	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
 
 	&.is-hidden {
 		transform: translateX( 100vw );

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -29,4 +29,13 @@
 	top: 0;
 	right: 0;
 	z-index: 20;
+	width: 44px;
+	height: 44px;
+	padding: 0;
+	line-height: 1;
+
+	@include break-medium() {
+		width: 64px;
+		height: 64px;
+	}
 }

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -6,8 +6,7 @@
 	width: 100vw;
 	height: 100vh;
 	padding: 3em 1em;
-	opacity: 0.975;
-	background: white;
+	background: rgba(255, 255, 255, 0.975);
 	overflow-y: auto;
 	overflow-x: hidden;
 	transition: opacity 0.5s linear, 0.25s transform ease-in-out;

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -21,4 +21,5 @@
 	position: fixed;
 	top: 0;
 	right: 0;
+	z-index: 20;
 }

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -18,6 +18,7 @@
 }
 
 .jetpack-instant-search__overlay-close {
-	position: absolute;
-	right: 2em;
+	position: fixed;
+	top: 0;
+	right: 0;
 }

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -8,8 +8,7 @@
 	margin-left: 8px;
 	cursor: pointer;
 
-	// TODO: To be updated to break-medium
-	@include break-small() {
+	@include break-medium() {
 		display: none;
 	}
 }

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -5,7 +5,7 @@
 }
 
 .jetpack-instant-search__box-filter-icon {
-	margin-left: 8px;
+	margin: 0 16px;
 	cursor: pointer;
 
 	@include break-medium() {

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -62,6 +62,7 @@ class SearchForm extends Component {
 				</div>
 				{ this.state.showFilters && (
 					<div className="jetpack-instant-search__search-form-filters">
+						<div className="jetpack-instant-search__search-form-filters-arrow" />
 						<SearchSort onChange={ this.onChangeSort } value={ getSortQuery() } />
 						{ this.props.widgets.map( widget => (
 							<SearchFilters

--- a/modules/search/instant-search/components/search-form.scss
+++ b/modules/search/instant-search/components/search-form.scss
@@ -1,6 +1,78 @@
+$arrow-height: 10px;
+
 .jetpack-instant-search__search-form-filters {
-	// TODO: To be updated to break-medium
+	position: absolute;
+	top: 52px;
+	right: 0;
+	z-index: 10;
+	width: 100%;
+	margin: 12px 0 32px;
+	padding: 16px 24px;
+	border-radius: 6px;
+
+	.jetpack-instant-search__overlay--light & {
+		background: #fff;
+		border: 1px solid rgba(0, 0, 0, 0.1);
+		box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1);
+	}
+
+	.jetpack-instant-search__overlay--dark & {
+		background: #222;
+		border: 1px solid rgba(140, 140, 140, 0.1);
+		box-shadow: 0 2px 3px rgba(140, 140, 140, 0.1);
+	}
+
 	@include break-small() {
+		width: auto;
+		min-width: 360px;
+	}
+
+	@include break-medium() {
+		display: none;
+	}
+}
+
+.jetpack-instant-search__search-form-filters-arrow {
+	position: absolute;
+	top: ( $arrow-height + 1px ) * -1;
+	right: 16px;
+	width: $arrow-height * 2;
+	height: $arrow-height;
+
+	&:before,
+	&:after {
+		content: '';
+		position: absolute;
+		border-color: transparent;
+		border-style: solid;
+		border-width: 0 $arrow-height $arrow-height $arrow-height;
+	}
+
+	&:before {
+		top: 0;
+
+		.jetpack-instant-search__overlay--light & {
+			border-bottom-color: rgba(0, 0, 0, 0.1 );
+		}
+
+		.jetpack-instant-search__overlay--dark & {
+			border-bottom-color: rgba(140, 140, 140, 0.1 );
+		}
+	}
+
+	&:after {
+		top: 1px;
+
+		.jetpack-instant-search__overlay--light & {
+			border-bottom-color: #fff;
+		}
+
+		.jetpack-instant-search__overlay--dark & {
+			border-bottom-color: #222;
+		}
+	}
+	
+	@include break-medium() {
 		display: none;
 	}
 }

--- a/modules/search/instant-search/components/search-form.scss
+++ b/modules/search/instant-search/components/search-form.scss
@@ -56,7 +56,7 @@ $arrow-height: 10px;
 		}
 
 		.jetpack-instant-search__overlay--dark & {
-			border-bottom-color: rgba(140, 140, 140, 0.1 );
+			border-bottom-color: rgba(140, 140, 140, 0.25 );
 		}
 	}
 

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -20,7 +20,27 @@
 	margin-right: 4em;
 }
 .jetpack-instant-search__search-results-secondary {
-	flex: 2;
+	display: none; // TODO: toggle visibility via JS?
+	position: absolute;
+	top: 0;
+	width: 80%;
+	padding: 1em 2em;	
+	background: #fff;
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 6px;
+	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
+
+	@include break-medium() {
+		flex: 2;
+		position: static;
+		width: auto;
+		padding: 0;
+		background: none;
+		border: 0;
+		border-radius: 0;
+		box-shadow: none;
+
+	}
 }
 
 .jetpack-instant-search__search-results-real-query {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -1,17 +1,17 @@
 .jetpack-instant-search__search-results {
-	padding: 0.125em 2em;
-	margin: 0 auto;
 	position: relative;
-	max-width: 1080px;
-	text-align: left;
 	display: flex;
 	z-index: 10;
+	max-width: 1080px;
+	margin: 0 auto;
+	padding: 0.125em 2em;
+	text-align: left;
 
 	mark {
+		padding: 0;
 		background-color: #ffc;
 		font-weight: bold;
 		color: inherit;
-		padding: 0;
 	}
 }
 
@@ -36,11 +36,11 @@
 }
 
 .jetpack-instant-search__result-comments {
-	padding-left: 16px;
 	margin-left: 8px;
 	margin-top: 16px;
-	border-left: 2px solid #eee;
+	padding-left: 16px;
 	font-size: 0.9em;
+	border-left: 2px solid #eee;
 
 	.gridicon {
 		margin-right: 8px;
@@ -57,8 +57,8 @@
 	// https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type#Accessibility_concerns
 	li:before {
 		content: '\200B';
-		height: 1px;
 		position: absolute;
+		height: 1px;
 		width: 1px;
 	}
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -5,6 +5,7 @@
 	max-width: 1080px;
 	text-align: left;
 	display: flex;
+	z-index: 10;
 
 	mark {
 		background-color: #ffc;

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -4,7 +4,7 @@
 	z-index: 10;
 	max-width: 1080px;
 	margin: 0 auto;
-	padding: 0.125em 2em;
+	padding: 0.125em 1em;
 	text-align: left;
 
 	mark {
@@ -26,6 +26,10 @@
 		mark {
 			background-color: #324E85;
 		}
+	}
+
+	@include break-small() {
+		padding: 0.125em 2em;
 	}
 }
 

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -34,15 +34,7 @@
 	margin-right: 4em;
 }
 .jetpack-instant-search__search-results-secondary {
-	display: none; // TODO: toggle visibility via JS?
-	position: absolute;
-	top: 0;
-	width: 80%;
-	padding: 1em 2em;	
-	background: #fff;
-	border: 1px solid rgba(0, 0, 0, 0.1);
-	border-radius: 6px;
-	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1);
+	display: none;
 
 	@include break-medium() {
 		flex: 2;

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -31,14 +31,18 @@
 
 .jetpack-instant-search__search-results-primary {
 	flex: 5;
-	margin-right: 4em;
+
+	@include break-medium() {
+		margin-right: 4em;
+	}
 }
 .jetpack-instant-search__search-results-secondary {
 	display: none;
 
 	@include break-medium() {
-		flex: 2;
 		position: static;
+		display: block;
+		flex: 2;
 		width: auto;
 		padding: 0;
 		background: none;
@@ -90,9 +94,9 @@
 }
 
 .jetpack-instant-search__search-results-search-form {
-	// Only display the search form in the main column at the smallest breakpoint
-	font-size: 0.8em;
+	position: relative;
 	margin-bottom: 1em;
+	font-size: 0.8em;
 
 	.jetpack-instant-search__sort-select {
 		font-size: 0.9em;

--- a/modules/search/instant-search/components/search-sidebar.scss
+++ b/modules/search/instant-search/components/search-sidebar.scss
@@ -1,7 +1,7 @@
 .jetpack-instant-search__sidebar {
 	.jetpack-filters.widget_search,
 	.jetpack-instant-search-wrapper {
-		@media ( max-width: #{ ( $break-medium ) } ) {
+		@media ( max-width: #{ ( $break-medium - 1 ) } ) {
 			display: none;
 		}
 	}

--- a/modules/search/instant-search/components/search-sidebar.scss
+++ b/modules/search/instant-search/components/search-sidebar.scss
@@ -1,8 +1,7 @@
 .jetpack-instant-search__sidebar {
 	.jetpack-filters.widget_search,
 	.jetpack-instant-search-wrapper {
-		// TODO: To be updated to break-medium
-		@media ( max-width: #{ ( $break-small ) } ) {
+		@media ( max-width: #{ ( $break-medium ) } ) {
 			display: none;
 		}
 	}

--- a/modules/search/instant-search/components/search-sort.jsx
+++ b/modules/search/instant-search/components/search-sort.jsx
@@ -25,7 +25,7 @@ export default class SearchSort extends Component {
 		return (
 			<div className="jetpack-instant-search__sort">
 				<label>
-					{ __( 'Sort by', 'jetpack' ) }
+					<span>{ __( 'Sort by', 'jetpack' ) }</span>
 					<select
 						className="jetpack-instant-search__sort-select"
 						onBlur={ this.handleChange }

--- a/modules/search/instant-search/components/search-sort.scss
+++ b/modules/search/instant-search/components/search-sort.scss
@@ -1,10 +1,13 @@
 .jetpack-instant-search__sort {
-	text-align: left;
 	margin-top: 1em;
 	margin-bottom: 1em;
+	text-align: left;
+
+	span {
+		margin-right: 4px;
+	}
 }
 
 .jetpack-instant-search__sort-select {
-	margin-left: 4px;
 	text-align: left;
 }

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -1,8 +1,15 @@
 $break-small: 600px;
+$break-medium: 768px;
 $grid-size-large: 16px;
 
 @mixin break-small() {
 	@media ( min-width: #{ ( $break-small ) } ) {
+		@content;
+	}
+}
+
+@mixin break-medium() {
+	@media ( min-width: #{ ( $break-medium ) } ) {
 		@content;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Use cross instead of label in the button to close overlay (reported in https://github.com/Automattic/jetpack/pull/14379#pullrequestreview-344742333 ).
* Changes position of close overlay button to the corner.
* Fixes z-index stack order so close button is always usable.
* Adds mobile styles for the popover.
* Adds medium break point at `768px`.

![instant-search-mobile-light](https://user-images.githubusercontent.com/390760/73192885-a408fc80-4121-11ea-8b15-f023d0472aea.png)

![instant-search-mobile-dark](https://user-images.githubusercontent.com/390760/73192888-a5d2c000-4121-11ea-962a-8362fc428071.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:

1. Follow the [testing instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search.
1. Enter search term and see results on overlay.
1. Ensure all elements work.

**Note for devs**: ~I will need some help to toggle visibility of the filters pane / widget area when using a mobile device. Saw some related code, but couldn't get it working. This could mean all popover styles I've added here are misplaced and need relocating to a different class.~ This was added by @jsnmoon in https://github.com/Automattic/jetpack/pull/14451

#### Proposed changelog entry for your changes:

* None needed.
