### PR TITLE
Moved JITM initialization to plugins_loaded.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -713,6 +713,10 @@ class Jetpack {
 			$config->ensure( $feature );
 		}
 
+		if ( is_admin() ) {
+			$config->ensure( 'jitm' );
+		}
+
 		$this->connection_manager = new Connection_Manager();
 
 		/*

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -65,8 +65,6 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
-	$jitm = new Automattic\Jetpack\JITM();
-	add_action( 'plugins_loaded', array( $jitm, 'register' ) );
 	jetpack_require_lib( 'debugger' );
 }
 

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -70,7 +70,6 @@ class Config {
 		}
 
 		if ( $this->config['tracking'] ) {
-
 			$this->ensure_class( 'Automattic\Jetpack\Terms_Of_Service' )
 				&& $this->ensure_class( 'Automattic\Jetpack\Tracking' )
 				&& $this->ensure_feature( 'tracking' );
@@ -83,7 +82,7 @@ class Config {
 
 		if ( $this->config['jitm'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\JITM' )
-				&& $this->ensure_feature( 'sync' );
+				&& $this->ensure_feature( 'jitm' );
 		}
 	}
 

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -81,7 +81,7 @@ class Config {
 				&& $this->ensure_feature( 'sync' );
 		}
 
-		if ( is_admin() && $this->config['jitm'] ) {
+		if ( $this->config['jitm'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\JITM' )
 				&& $this->ensure_feature( 'sync' );
 		}

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\JITM;
 use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
 use Automattic\Jetpack\Sync\Main as Sync_Main;
 use Automattic\Jetpack\Terms_Of_Service;
@@ -27,6 +28,7 @@ class Config {
 	 * @var Array
 	 */
 	protected $config = array(
+		'jitm'       => false,
 		'connection' => false,
 		'sync'       => false,
 		'tracking'   => false,
@@ -76,6 +78,11 @@ class Config {
 
 		if ( $this->config['sync'] ) {
 			$this->ensure_class( 'Automattic\Jetpack\Sync\Main' )
+				&& $this->ensure_feature( 'sync' );
+		}
+
+		if ( is_admin() && $this->config['jitm'] ) {
+			$this->ensure_class( 'Automattic\Jetpack\JITM' )
 				&& $this->ensure_feature( 'sync' );
 		}
 	}
@@ -160,6 +167,15 @@ class Config {
 			 */
 			add_action( 'jetpack_agreed_to_terms_of_service', array( $tracking, 'init' ) );
 		}
+
+		return true;
+	}
+
+	/**
+	 * Enables the JITM feature.
+	 */
+	protected function enable_jitm() {
+		JITM::configure();
 
 		return true;
 	}

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -34,6 +34,14 @@ class JITM {
 	private $tracking;
 
 	/**
+	 * The configuration method that is called from the jetpack-config package.
+	 */
+	public static function configure() {
+		$jitm = new self();
+		$jitm->register();
+	}
+
+	/**
 	 * JITM constructor.
 	 */
 	public function __construct() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
The JITM package should be initialized just as every other package - using the Config class. This PR makes it do that.

#### Changes proposed in this Pull Request:
* Added a configure method in the JITM class, moved the register call there.
* Added a configure call to the Config class for the JITM package.
* Removed the load-jetpack.php JITM object creation.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an ongoing effort to remove package usage before `plugins_loaded`: 1146297891914257-as-1151187353457655

#### Testing instructions:
* Log into your Jetpack site in wp-admin.
* Make sure you're still able to see JIT messages.

#### Proposed changelog entry for your changes:
* N/A
