### PR TITLE
Moved the logic to gate WPCOM blocks to a shared file

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -37,8 +37,8 @@ function jetpack_register_block( $slug, $args = array() ) {
 		return false;
 	}
 
-	// If the block is dynamic, wrap the render_callback to check availability.
-	if ( isset( $args['render_callback'] ) ) {
+	// If the block is dynamic, and a Jetpack block, wrap the render_callback to check availability.
+	if ( 0 === strpos( $slug, 'jetpack/' ) && isset( $args['render_callback'] ) ) {
 		$render_callback         = $args['render_callback'];
 		$args['render_callback'] = function ( $prepared_attributes, $block_content ) use ( $render_callback, $slug ) {
 			$availability = Jetpack_Gutenberg::get_availability();

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -175,7 +175,7 @@ class Jetpack_Gutenberg {
 	 * @return string The unprefixed extension name.
 	 */
 	public static function remove_extension_prefix( $extension_name ) {
-		if ( wp_startswith( $extension_name, 'jetpack/' ) || wp_startswith( $extension_name, 'jetpack-' ) ) {
+		if ( 0 === strpos( $extension_name, 'jetpack/' ) || 0 === strpos( $extension_name, 'jetpack-' ) ) {
 			return substr( $extension_name, strlen( 'jetpack/' ) );
 		}
 		return $extension_name;

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1027,7 +1027,7 @@ class Jetpack_Gutenberg {
 			}
 			$features_data = Store_Product_List::get_site_specific_features_data();
 			$is_available  = in_array( $slug, $features_data['active'], true );
-			if ( isset( $features_data['available'][ $slug ] ) && ! empty( $features_data['available'][ $slug ] ) ) {
+			if ( ! empty( $features_data['available'][ $slug ] ) ) {
 				$plan = $features_data['available'][ $slug ][0];
 			}
 		} elseif ( ! jetpack_is_atomic_site() ) {

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1016,8 +1016,11 @@ class Jetpack_Gutenberg {
 		$plan         = '';
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			// TODO check against wpcom product.
-			$is_available = true;
+			if ( ! class_exists( 'Store_Product_List' ) ) {
+				require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
+			}
+			$features     = Store_Product_List::get_site_specific_features_data()['active'];
+			$is_available = in_array( $slug, $features, true );
 		} elseif ( ! jetpack_is_atomic_site() ) {
 			/*
 			 * If it's Atomic then assume all features are available

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1019,8 +1019,11 @@ class Jetpack_Gutenberg {
 			if ( ! class_exists( 'Store_Product_List' ) ) {
 				require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
 			}
-			$features     = Store_Product_List::get_site_specific_features_data()['active'];
-			$is_available = in_array( $slug, $features, true );
+			$features_data = Store_Product_List::get_site_specific_features_data();
+			$is_available  = in_array( $slug, $features_data['active'], true );
+			if ( isset( $features_data['available'][ $slug ] ) && ! empty( $features_data['available'][ $slug ] ) ) {
+				$plan = $features_data['available'][ $slug ][0];
+			}
 		} elseif ( ! jetpack_is_atomic_site() ) {
 			/*
 			 * If it's Atomic then assume all features are available

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1006,8 +1006,8 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Set the availability of a WPCOM premium block
-	 * based on the context we're running in
+	 * Set the availability of the block as the editor
+	 * is loaded.
 	 *
 	 * @param string $slug Slug of the block.
 	 */

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -993,7 +993,7 @@ class Jetpack_Gutenberg {
 	public static function upgrade_nudge( $plan ) {
 		if (
 			! current_user_can( 'manage_options' )
-		/** This filter is documented in class.jetpack-gutenberg.php */
+			/** This filter is documented in class.jetpack-gutenberg.php */
 			|| ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
 			/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 			|| ! apply_filters( 'jetpack_show_promotions', true )

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -39,7 +39,10 @@ function jetpack_register_block( $slug, $args = array() ) {
 
 	$feature_name = Jetpack_Gutenberg::remove_extension_prefix( $slug );
 	// If the block is dynamic, and a Jetpack block, wrap the render_callback to check availability.
-	if ( isset( $args['plan_check'] ) && true === $args['plan_check'] && 0 === strpos( $slug, 'jetpack/' ) && isset( $args['render_callback'] ) ) {
+	if (
+		isset( $args['plan_check'], $args['render_callback'] )
+		&& true === $args['plan_check']
+	) {
 		$args['render_callback'] = Jetpack_Gutenberg::get_render_callback_with_availability_check( $feature_name, $args['render_callback'] );
 		$method_name             = 'set_availability_for_plan';
 	} else {

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -23,6 +23,58 @@ class Jetpack_Plan {
 
 	const PLAN_OPTION = 'jetpack_active_plan';
 
+	const PLAN_DATA = array(
+		'free'     => array(
+			'plans'    => array(
+				'jetpack_free',
+			),
+			'supports' => array(
+				'opentable',
+			),
+		),
+		'personal' => array(
+			'plans'    => array(
+				'jetpack_personal',
+				'jetpack_personal_monthly',
+				'personal-bundle',
+				'personal-bundle-monthly',
+				'personal-bundle-2y',
+			),
+			'supports' => array(
+				'akismet',
+				'recurring-payments',
+			),
+		),
+		'premium'  => array(
+			'plans'    => array(
+				'jetpack_premium',
+				'jetpack_premium_monthly',
+				'value_bundle',
+				'value_bundle-monthly',
+				'value_bundle-2y',
+			),
+			'supports' => array(
+				'simple-payments',
+				'vaultpress',
+				'videopress',
+			),
+		),
+		'business' => array(
+			'plans'    => array(
+				'jetpack_business',
+				'jetpack_business_monthly',
+				'business-bundle',
+				'business-bundle-monthly',
+				'business-bundle-2y',
+				'ecommerce-bundle',
+				'ecommerce-bundle-monthly',
+				'ecommerce-bundle-2y',
+				'vip',
+			),
+			'supports' => array(),
+		),
+	);
+
 	/**
 	 * Given a response to the `/sites/%d` endpoint, will parse the response and attempt to set the
 	 * plan from the response.
@@ -116,63 +168,7 @@ class Jetpack_Plan {
 			)
 		);
 
-		$supports = array();
-
-		// Define what paid modules are supported by personal plans.
-		$personal_plans = array(
-			'jetpack_personal',
-			'jetpack_personal_monthly',
-			'personal-bundle',
-			'personal-bundle-monthly',
-			'personal-bundle-2y',
-		);
-
-		if ( in_array( $plan['product_slug'], $personal_plans, true ) ) {
-			// special support value, not a module but a separate plugin.
-			$supports[]    = 'akismet';
-			$supports[]    = 'recurring-payments';
-			$plan['class'] = 'personal';
-		}
-
-		// Define what paid modules are supported by premium plans.
-		$premium_plans = array(
-			'jetpack_premium',
-			'jetpack_premium_monthly',
-			'value_bundle',
-			'value_bundle-monthly',
-			'value_bundle-2y',
-		);
-
-		if ( in_array( $plan['product_slug'], $premium_plans, true ) ) {
-			$supports[]    = 'akismet';
-			$supports[]    = 'recurring-payments';
-			$supports[]    = 'simple-payments';
-			$supports[]    = 'vaultpress';
-			$supports[]    = 'videopress';
-			$plan['class'] = 'premium';
-		}
-
-		// Define what paid modules are supported by professional plans.
-		$business_plans = array(
-			'jetpack_business',
-			'jetpack_business_monthly',
-			'business-bundle',
-			'business-bundle-monthly',
-			'business-bundle-2y',
-			'ecommerce-bundle',
-			'ecommerce-bundle-monthly',
-			'ecommerce-bundle-2y',
-			'vip',
-		);
-
-		if ( in_array( $plan['product_slug'], $business_plans, true ) ) {
-			$supports[]    = 'akismet';
-			$supports[]    = 'recurring-payments';
-			$supports[]    = 'simple-payments';
-			$supports[]    = 'vaultpress';
-			$supports[]    = 'videopress';
-			$plan['class'] = 'business';
-		}
+		list( $plan['class'], $supports ) = self::get_class_and_features( $plan['product_slug'] );
 
 		// get available features.
 		foreach ( Jetpack::get_available_modules() as $module_slug ) {
@@ -190,6 +186,39 @@ class Jetpack_Plan {
 		self::$active_plan_cache = $plan;
 
 		return $plan;
+	}
+
+	/**
+	 * Get the class of plan and a list of features it supports
+	 *
+	 * @param string $plan_slug The plan that we're interested in.
+	 * @return array Two item array, the plan class and the an array of features.
+	 */
+	private static function get_class_and_features( $plan_slug ) {
+		$features = array();
+		foreach ( self::PLAN_DATA as $class => $details ) {
+			$features = array_merge( $features, $details['supports'] );
+			if ( in_array( $plan_slug, $details['plans'], true ) ) {
+				return array( $class, $features );
+			}
+		}
+		return array( 'free', self::PLAN_DATA['free']['supports'] );
+	}
+
+	/**
+	 * Gets the minimum plan slug that supports the given feature
+	 *
+	 * @param string $feature The name of the feature.
+	 * @return string|bool The slug for the minimum plan that supports.
+	 *  the feature or false if not found
+	 */
+	public static function get_minimum_plan_for_feature( $feature ) {
+		foreach ( self::PLAN_DATA as $class => $details ) {
+			if ( in_array( $feature, $details['supports'], true ) ) {
+				return $details['plans'][0];
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -30,6 +30,7 @@ class Jetpack_Plan {
 			),
 			'supports' => array(
 				'opentable',
+				'calendly',
 			),
 		),
 		'personal' => array(

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -185,6 +185,8 @@ Sometimes blocks are paid for WordPress.com users but free for Jetpack users. In
 		),
 ```
 
+The plan data is found in `class.jetpack-plan.php` for Jetpack and an example of adding the features to WordPress.com plans is in D43206-code.
+
 ### Upgrades
 Paid blocks that aren't supported by a user's plan will still be registered for use in the block editor, but won't render on the frontend of the site. An `UpgradeNudge` component will display above the block in the editor and one the front end of the site to inform users that this is a paid block.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -154,6 +154,45 @@ rsync -az --delete _inc/blocks/ \
 
 To test extensions for a Simple site in Calypso, sandbox the simple site URL (`example.wordpress.com`). Calypso loads Gutenberg from simple sites’ wp-admin in an iframe.
 
+## Paid blocks
+
+Blocks can be restricted to specific paid plans in both WordPress.com and Jetpack. When registering a block using `jetpack_register_block`, pass `plan_check => true` as a key in the second argument. When the block is registerd we check the plan data to see if the user's plan supports this block. For example:
+
+```
+function register_block() {
+	jetpack_register_block(		jetpack_register_block(
+		BLOCK_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\load_assets',
+			'plan_check'      => true,
+		)
+	);
+}
+```
+
+Sometimes blocks are paid for WordPress.com users but free for Jetpack users. In these cases it is still necessary to add the block to the plan data for both environments, for example:
+
+```
+	const PLAN_DATA = array(
+		'free'     => array(
+			'plans'    => array(
+				'jetpack_free',
+			),
+			'supports' => array(
+				'opentable',
+				'calendly',
+			),
+		),
+```
+
+### Upgrades
+Paid blocks that aren't supported by a user's plan will still be registered for use in the block editor, but won't render on the frontend of the site. An `UpgradeNudge` component will display above the block in the editor and one the front end of the site to inform users that this is a paid block.
+
+### Terminology
+Blocks can be registered but not available:
+- Registered: The block appears in the block inserter
+- Available: The block is included in the user's current plan and renders in the front end of the site
+
 ## Good to know when developing Gutenberg extensions
 
 ### The Build

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -158,9 +158,9 @@ To test extensions for a Simple site in Calypso, sandbox the simple site URL (`e
 
 Blocks can be restricted to specific paid plans in both WordPress.com and Jetpack. When registering a block using `jetpack_register_block`, pass `plan_check => true` as a key in the second argument. When the block is registerd we check the plan data to see if the user's plan supports this block. For example:
 
-```
+```php
 function register_block() {
-	jetpack_register_block(		jetpack_register_block(
+	jetpack_register_block(
 		BLOCK_NAME,
 		array(
 			'render_callback' => __NAMESPACE__ . '\load_assets',
@@ -172,23 +172,31 @@ function register_block() {
 
 Sometimes blocks are paid for WordPress.com users but free for Jetpack users. In these cases it is still necessary to add the block to the plan data for both environments, for example:
 
-```
-	const PLAN_DATA = array(
-		'free'     => array(
-			'plans'    => array(
-				'jetpack_free',
-			),
-			'supports' => array(
-				'opentable',
-				'calendly',
-			),
+```php
+const PLAN_DATA = array(
+	'free'     => array(
+		'plans'    => array(
+			'jetpack_free',
 		),
+		'supports' => array(
+			'opentable',
+			'calendly',
+		),
+	),
 ```
 
 The plan data is found in `class.jetpack-plan.php` for Jetpack and an example of adding the features to WordPress.com plans is in D43206-code.
 
 ### Upgrades
-Paid blocks that aren't supported by a user's plan will still be registered for use in the block editor, but won't render on the frontend of the site. An `UpgradeNudge` component will display above the block in the editor and one the front end of the site to inform users that this is a paid block.
+Paid blocks that aren't supported by a user's plan will still be registered for use in the block editor, but will not be displayed by default.
+
+You can, however, use the following filter:
+
+```php
+add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );
+```
+
+This will allow you to take advantage of those registered blocks. They will not be rendered to logged out visitors on the frontend of the site, but the block will be available in the block picker in the editor. When you add a paid block to a post, an `UpgradeNudge` component will display above the block in the editor and on the front end of the site to inform users that this is a paid block.
 
 ### Terminology
 Blocks can be registered but not available:

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -11,32 +11,8 @@ namespace Automattic\Jetpack\Extensions\Calendly;
 
 use Jetpack_Gutenberg;
 
-const FEATURE_NAME  = 'calendly';
-const BLOCK_NAME    = 'jetpack/' . FEATURE_NAME;
-const REQUIRED_PLAN = 'value_bundle';
-
-/**
- * Check if the block should be available on the site.
- *
- * @return bool
- */
-function is_available() {
-	if (
-		defined( 'IS_WPCOM' )
-		&& IS_WPCOM
-		&& function_exists( 'has_any_blog_stickers' )
-	) {
-		if ( has_any_blog_stickers(
-			array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
-			get_current_blog_id()
-		) ) {
-			return true;
-		}
-		return false;
-	}
-
-	return true;
-}
+const FEATURE_NAME = 'calendly';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
 /**
  * Registers the block for use in Gutenberg
@@ -46,30 +22,13 @@ function is_available() {
 function register_block() {
 	jetpack_register_block(
 		BLOCK_NAME,
-		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+		array(
+			'render_callback' => __NAMESPACE__ . '\load_assets',
+			'plan_check'      => true,
+		)
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
-
-/**
- * Set the availability of the block as the editor
- * is loaded
- */
-function set_availability() {
-	if ( is_available() ) {
-		Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
-	} else {
-		Jetpack_Gutenberg::set_extension_unavailable(
-			BLOCK_NAME,
-			'missing_plan',
-			array(
-				'required_feature' => FEATURE_NAME,
-				'required_plan'    => REQUIRED_PLAN,
-			)
-		);
-	}
-}
-add_action( 'init', __NAMESPACE__ . '\set_availability' );
 
 /**
  * Calendly block registration/dependency declaration.
@@ -80,9 +39,6 @@ add_action( 'init', __NAMESPACE__ . '\set_availability' );
  * @return string
  */
 function load_assets( $attr, $content ) {
-	if ( ! is_available() ) {
-		return \Jetpack_Gutenberg::upgrade_nudge( REQUIRED_PLAN );
-	}
 
 	if ( is_admin() ) {
 		return;

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -11,8 +11,8 @@ namespace Automattic\Jetpack\Extensions\OpenTable;
 
 use Jetpack_Gutenberg;
 
-const FEATURE_NAME  = 'opentable';
-const BLOCK_NAME    = 'jetpack/' . FEATURE_NAME;
+const FEATURE_NAME = 'opentable';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
 /**
  * Registers the block for use in Gutenberg
@@ -22,19 +22,13 @@ const BLOCK_NAME    = 'jetpack/' . FEATURE_NAME;
 function register_block() {
 	jetpack_register_block(
 		BLOCK_NAME,
-		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+		array(
+			'render_callback' => __NAMESPACE__ . '\load_assets',
+			'plan_check'      => true,
+		)
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
-
-/**
- * Set the availability of the block as the editor
- * is loaded.
- */
-function set_availability() {
-	\Jetpack_Gutenberg::set_availability_for_plan( FEATURE_NAME );
-}
-add_action( 'init', __NAMESPACE__ . '\set_availability' );
 
 /**
  * Adds an inline script which updates the block editor settings to

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -28,8 +28,8 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
- * Sets the availability of the block based on it
- * requiring a paid plan on WPCOM
+ * Set the availability of the block as the editor
+ * is loaded.
  */
 function set_availability() {
 	\Jetpack_Gutenberg::set_availability_for_plan( FEATURE_NAME );

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -13,30 +13,6 @@ use Jetpack_Gutenberg;
 
 const FEATURE_NAME  = 'opentable';
 const BLOCK_NAME    = 'jetpack/' . FEATURE_NAME;
-const REQUIRED_PLAN = 'value_bundle';
-
-/**
- * Check if the block should be available on the site.
- *
- * @return bool
- */
-function is_available() {
-	if (
-		defined( 'IS_WPCOM' )
-		&& IS_WPCOM
-		&& function_exists( 'has_any_blog_stickers' )
-	) {
-		if ( has_any_blog_stickers(
-			array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
-			get_current_blog_id()
-		) ) {
-			return true;
-		}
-		return false;
-	}
-
-	return true;
-}
 
 /**
  * Registers the block for use in Gutenberg
@@ -52,22 +28,11 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
- * Set the availability of the block as the editor
- * is loaded.
+ * Sets the availability of the block based on it
+ * requiring a paid plan on WPCOM
  */
 function set_availability() {
-	if ( is_available() ) {
-		Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
-	} else {
-		Jetpack_Gutenberg::set_extension_unavailable(
-			BLOCK_NAME,
-			'missing_plan',
-			array(
-				'required_feature' => FEATURE_NAME,
-				'required_plan'    => REQUIRED_PLAN,
-			)
-		);
-	}
+	\Jetpack_Gutenberg::set_availability_for_plan( FEATURE_NAME );
 }
 add_action( 'init', __NAMESPACE__ . '\set_availability' );
 
@@ -90,9 +55,6 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_language_setting' );
  * @return string
  */
 function load_assets( $attributes ) {
-	if ( ! is_available() ) {
-		return Jetpack_Gutenberg::upgrade_nudge( REQUIRED_PLAN );
-	}
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The logic to gate the blocks to paid plans on WPCOM is repeated for the
OpenTable and Calendly blocks. It is likely to be needed in future too,
so this change moves the repeated to logic to the `Jetpack_Gutenberg`
library.

This may not be the best place for this code to live, so opinions are welcome!

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a refactor, so changes an existing feature.

#### Testing instructions:
* Enable beta blocks on a test site
* Check that you can still add and use the OpenTable block

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No entry needed
