### PR TITLE
Instant Search: Integrate customizer options

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -101,14 +101,15 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		$prefix  = Jetpack_Search_Options::OPTION_PREFIX;
 		$options = array(
-			// overlay options.
-			'closeColor'      => (bool) get_option( $prefix . 'close_color', '#BD3854' ),
-			'colorTheme'      => (bool) get_option( $prefix . 'color_theme', 'light' ),
-			'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', true ),
-			'highlightColor'  => (bool) get_option( $prefix . 'highlight_color', '#FFC' ),
-			'opacity'         => (bool) get_option( $prefix . 'opacity', 97 ),
-			'showLogo'        => (bool) get_option( $prefix . 'show_logo', true ),
-			'showPoweredBy'   => (bool) get_option( $prefix . 'show_powered_by', true ),
+			'overlayOptions'  => array(
+				'closeColor'      => get_option( $prefix . 'close_color', '#BD3854' ),
+				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
+				'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', false ),
+				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
+				'opacity'         => (int) get_option( $prefix . 'opacity', 97 ),
+				'showLogo'        => (bool) get_option( $prefix . 'show_logo', true ),
+				'showPoweredBy'   => (bool) get_option( $prefix . 'show_powered_by', true ),
+			),
 
 			// core config.
 			'homeUrl'         => home_url(),
@@ -134,11 +135,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		 */
 		$options = apply_filters( 'jetpack_instant_search_options', $options );
 
-		wp_localize_script(
-			'jetpack-instant-search',
-			'JetpackInstantSearchOptions',
-			$options
-		);
+		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
+		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=' . wp_json_encode( $options ) );
 	}
 
 	/**

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -65,8 +65,8 @@ class Jetpack_Search_Customize {
 				'section'     => $section_id,
 				'type'        => 'radio',
 				'choices'     => array(
-					'light' => 'Light',
-					'dark'  => 'Dark',
+					'light' => __( 'Light', 'jetpack' ),
+					'dark'  => __( 'Dark', 'jetpack' ),
 				),
 			)
 		);

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -87,9 +87,9 @@ class Jetpack_Search_Customize {
 				'label'       => __( 'Background Opacity', 'jetpack' ),
 				'description' => __( 'Select and opacity for the search overlay.', 'jetpack' ),
 				'input_attrs' => array(
-					'min'  => 0,
+					'min'  => 85,
 					'max'  => 100,
-					'step' => 1,
+					'step' => 0.5,
 				),
 			)
 		);

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -11,7 +11,7 @@ const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
 };
 
-const Overlay = ( { isVisible, closeOverlay, children } ) => {
+const Overlay = ( { children, closeColor, closeOverlay, colorTheme, isVisible, opacity } ) => {
 	useEffect( () => {
 		window.addEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
 		return () => {
@@ -20,14 +20,20 @@ const Overlay = ( { isVisible, closeOverlay, children } ) => {
 		};
 	}, [] );
 
-	const classNames = [ 'jetpack-instant-search__overlay' ];
-	if ( ! isVisible ) {
-		classNames.push( 'is-hidden' );
-	}
-
 	return (
-		<div className={ classNames.join( ' ' ) }>
-			<button className="jetpack-instant-search__overlay-close" onClick={ closeOverlay }>
+		<div
+			className={ [
+				'jetpack-instant-search__overlay',
+				`jetpack-instant-search__overlay--${ colorTheme }`,
+				isVisible ? '' : 'is-hidden',
+			].join( ' ' ) }
+			style={ { opacity: opacity / 100 } }
+		>
+			<button
+				className="jetpack-instant-search__overlay-close"
+				onClick={ closeOverlay }
+				style={ { background: closeColor } }
+			>
 				{ __( 'Close', 'jetpack' ) }
 			</button>
 			{ children }

--- a/modules/search/instant-search/components/scroll-button.jsx
+++ b/modules/search/instant-search/components/scroll-button.jsx
@@ -11,17 +11,18 @@ import { __ } from '@wordpress/i18n';
 import debounce from 'lodash/debounce';
 
 class ScrollButton extends Component {
+	overlayElement = document.getElementsByClassName( 'jetpack-instant-search__overlay' )[ 0 ];
 	componentDidMount() {
-		this.props.enableLoadOnScroll && document.addEventListener( 'scroll', this.checkScroll );
+		this.overlayElement.addEventListener( 'scroll', this.checkScroll );
 	}
 	componentDidUnmount() {
-		document.removeEventListener( 'scroll', this.checkScroll );
+		this.overlayElement.removeEventListener( 'scroll', this.checkScroll );
 	}
 
 	checkScroll = debounce( () => {
 		if (
 			this.props.enableLoadOnScroll &&
-			window.innerHeight + window.scrollY === document.body.offsetHeight
+			window.innerHeight + this.overlayElement.scrollTop === this.overlayElement.scrollHeight
 		) {
 			this.props.onLoadNextPage();
 		}

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -183,11 +183,18 @@ class SearchApp extends Component {
 
 	render() {
 		return createPortal(
-			<Overlay isVisible={ this.state.showResults } closeOverlay={ this.hideResults }>
+			<Overlay
+				closeColor={ this.props.overlayOptions.closeColor }
+				closeOverlay={ this.hideResults }
+				colorTheme={ this.props.overlayOptions.colorTheme }
+				isVisible={ this.state.showResults }
+				opacity={ this.props.overlayOptions.opacity }
+			>
 				<SearchResults
-					enableLoadOnScroll={ this.props.options.enableLoadOnScroll }
+					enableLoadOnScroll={ this.props.overlayOptions.enableInfScroll }
 					hasError={ this.state.hasError }
 					hasNextPage={ this.hasNextPage() }
+					highlightColor={ this.props.options.highlightColor }
 					isLoading={ this.state.isLoading }
 					locale={ this.props.options.locale }
 					onLoadNextPage={ this.loadNextPage }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -49,6 +49,16 @@ class SearchResults extends Component {
 
 		return (
 			<Fragment>
+				<style
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ {
+						__html: `
+							.jetpack-instant-search__search-results mark { 
+								background-color: ${ this.props.highlightColor };
+							}
+						`,
+					} }
+				/>
 				<SearchForm className="jetpack-instant-search__search-results-search-form" />
 
 				<div

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -23,6 +23,7 @@ const injectSearchApp = () => {
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }
 			isSearchPage={ getSearchQuery() !== '' }
 			options={ window[ SERVER_OBJECT_NAME ] }
+			overlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			themeOptions={ getThemeOptions( window[ SERVER_OBJECT_NAME ] ) }
 		/>,
 		document.body


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Injects server-side values into JavaScript via `wp_add_inline_script` instead of `wp_localize_script` ([reason](https://core.trac.wordpress.org/ticket/25280))
* Fixes value casting for overlay options in PHP
* Fixes infinite scroll functionality with overlay
* Integrates applicable customizer values into the instant search application. (`showLogo`, `showPoweredBy` have not yet been integrated. `colorTheme` has been partially integrated.)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Not applicable.

#### Testing instructions
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Go to the Customizer (`/wp-admin/customize.php`) and navigate to `Jetpack Search`.
3. Try changing various values present in this section (e.g. Background Opacity, Close Button Color, Infinite Scroll, etc.). 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
