### PR TITLE
Autoloader: Remove the ignored classes

### DIFF
--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -73,22 +73,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 
 		if ( isset( $jetpack_packages_classes[ $class_name ] ) ) {
 			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// TODO ideally we shouldn't skip any of these, see: https://github.com/Automattic/jetpack/pull/12646.
-				$ignore = in_array(
-					$class_name,
-					array(
-						'Automattic\Jetpack\JITM',
-						'Automattic\Jetpack\Connection\Manager',
-						'Automattic\Jetpack\Connection\XMLRPC_Connector',
-						'Jetpack_Options',
-						'Jetpack_Signature',
-						'Jetpack_XMLRPC_Server',
-						'Automattic\Jetpack\Constants',
-						'Automattic\Jetpack\Tracking',
-					),
-					true
-				);
-				if ( ! $ignore && function_exists( 'did_action' ) && ! did_action( 'plugins_loaded' ) ) {
+				if ( function_exists( 'did_action' ) && ! did_action( 'plugins_loaded' ) ) {
 					_doing_it_wrong(
 						esc_html( $class_name ),
 						sprintf(


### PR DESCRIPTION
If a package class is loaded before the `plugins_loaded` action has fired, a PHP notice is generated by the autoloader. Some classes were known to be loaded before `plugins_loaded` was fired. To avoid creating PHP notices for those classes, the autoloader contains a list of ignored classes. If a class in this list is loaded before `plugins_loaded` has fired, a PHP notice is not generated. The intention was to eventually fix the load order of these classes and remove the list of ignored classes.

#### Changes proposed in this Pull Request:
* We have fixed the load order of the ignored classes, so remove the ignored classes list.
PHP notices will be generated for any package class that is loaded before `plugins_loaded`
has fired.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

##### Test Site
* Jetpack must be installed.
* Plugins that use the Jetpack autoloader must be not be activated (for example, VaultPress and WooCommerce).
* Debug logging must be enabled.
* Run `composer dump-autoload` to generate a new `vendor/autoload_packages.php` file using the updated `autoloader/src/autoload.php` file.

##### Test Instructions
* The classes in the ignored class list are used in many parts of Jetpack. Test by performing many different activities, and verify that no PHP notices are generated in the debug.log.

#### Proposed changelog entry for your changes:
* n/a
