### PR TITLE
Instant Search: add dark theme styles

### DIFF
--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -6,7 +6,6 @@
 	opacity: 0.975;
 	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
 	position: fixed;
-	background: white;
 	padding: 3em 1em;
 	overflow-y: auto;
 	overflow-x: hidden;
@@ -14,6 +13,14 @@
 
 	&.is-hidden {
 		transform: translateX( 100vw );
+	}
+
+	&.jetpack-instant-search__overlay--light {
+		background: #fff;
+	}
+
+	&.jetpack-instant-search__overlay--dark {
+		background: #131313;
 	}
 }
 

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -7,10 +7,25 @@
 	display: flex;
 
 	mark {
-		background-color: #ffc;
 		font-weight: bold;
 		color: inherit;
 		padding: 0;
+	}
+
+	.jetpack-instant-search__overlay--light & {
+		color: inherit;
+
+		mark {
+			background-color: #ffc;
+		}
+	}
+
+	.jetpack-instant-search__overlay--dark & {
+		color: #fff;
+
+		mark {
+			background-color: #324E85;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds base styles for dark theme in the Jetpack Search overlay.
* **Note**: requires `colorTheme` integration from https://github.com/Automattic/jetpack/pull/14427

![image](https://user-images.githubusercontent.com/390760/72892436-644fa880-3d0e-11ea-95c5-b5a1b6a0abd8.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* No

#### Testing instructions:

1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
1. Follow instructions to change to the dark theme on https://github.com/Automattic/jetpack/pull/14427
1. Alternatively you can add `.jetpack-instant-search__overlay--light` or `.jetpack-instant-search__overlay--dark` to the element `.jetpack-instant-search__search-results`.
1. Ensure light/dark themes work properly, that all elements are styled and legible.

#### Proposed changelog entry for your changes:

* None needed.
