### PR TITLE
Block registration availability for paid features: take 2

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -5,6 +5,7 @@ module.exports = [
 	'3rd-party/woocommerce-services.php',
 	'class.jetpack-gutenberg.php',
 	'class.jetpack-plan.php',
+	'class.wpcom-plan.php',
 	'extensions/',
 	'functions.cookies.php',
 	'functions.global.php',

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -36,6 +36,19 @@ function jetpack_register_block( $slug, $args = array() ) {
 }
 
 /**
+ * Registers a gutenberg block for WPCOM users with a
+ * pard pland and all Jetpack users
+ *
+ * @param string $slug Slug of the block.
+ * @param array  $args Arguments that are passed into register_block_type.
+ */
+function jetpack_register_premium_wpcom_block( $slug, $args = array() ) {
+	if ( Jetpack_Gutenberg::is_premium_wpcom_available() ) {
+		jetpack_register_block( $slug, $args );
+	}
+}
+
+/**
  * Helper function to register a Jetpack Gutenberg plugin
  *
  * @deprecated 7.1.0 Use Jetpack_Gutenberg::set_extension_available() instead
@@ -800,5 +813,50 @@ class Jetpack_Gutenberg {
 		}
 
 		return $preset_extensions;
+	}
+
+
+	/**
+	 * Check if the block should be available on the site.
+	 *
+	 * @return bool
+	 */
+	public static function is_premium_wpcom_available() {
+		if (
+			defined( 'IS_WPCOM' )
+			&& IS_WPCOM
+			&& function_exists( 'has_any_blog_stickers' )
+		) {
+			if ( has_any_blog_stickers(
+				array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
+				get_current_blog_id()
+			) ) {
+				return true;
+			}
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Set the availability of a WPCOM premium block
+	 * based on the context we're running in
+	 *
+	 * @param string $slug Slug of the block.
+	 */
+	public static function set_premium_wpcom_availability( $slug ) {
+		if ( self::is_premium_wpcom_available() ) {
+			self::set_extension_available( $slug );
+		} else {
+			self::set_extension_unavailable(
+				$slug,
+				'missing_plan',
+				array(
+					'required_feature' => 'opentable',
+					'required_plan'    => 'value_bundle',
+				)
+			);
+		}
 	}
 }

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -815,48 +815,28 @@ class Jetpack_Gutenberg {
 		return $preset_extensions;
 	}
 
-
 	/**
-	 * Check if the block should be available on the site.
+	 * Check if a block is supported by your plan,
+	 * whether it's a Jetpack plan or a WordPress.com plan.
+	 *
+	 * This can be used to decide a block should be registered or not.
+	 *
+	 * @since 8.2.0
+	 *
+	 * @param string $slug Block slug.
+	 * @param string $env  Current environment. Can be wpcom (wpcom simple sites) or jetpack.
 	 *
 	 * @return bool
 	 */
-	public static function is_premium_wpcom_available() {
-		if (
-			defined( 'IS_WPCOM' )
-			&& IS_WPCOM
-			&& function_exists( 'has_any_blog_stickers' )
-		) {
-			if ( has_any_blog_stickers(
-				array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
-				get_current_blog_id()
-			) ) {
-				return true;
-			}
-			return false;
+	public static function is_supported_by_plan( $slug, $env ) {
+		$slug = self::remove_extension_prefix( $slug );
+
+		if ( 'wpcom' === $env ) {
+			return Wpcom_Plan::supports( $slug );
+		} elseif ( 'jetpack' === $env ) {
+			return Jetpack::is_active() && Jetpack_Plan::supports( $slug );
 		}
 
-		return true;
-	}
-
-	/**
-	 * Set the availability of a WPCOM premium block
-	 * based on the context we're running in
-	 *
-	 * @param string $slug Slug of the block.
-	 */
-	public static function set_premium_wpcom_availability( $slug ) {
-		if ( self::is_premium_wpcom_available() ) {
-			self::set_extension_available( $slug );
-		} else {
-			self::set_extension_unavailable(
-				$slug,
-				'missing_plan',
-				array(
-					'required_feature' => 'opentable',
-					'required_plan'    => 'value_bundle',
-				)
-			);
-		}
+		return false;
 	}
 }

--- a/class.wpcom-plan.php
+++ b/class.wpcom-plan.php
@@ -22,7 +22,7 @@ class Wpcom_Plan {
 	}
 
 	/**
-	 * Return an array of features supported by current plan.
+	 * Return an array of features supported by current plan or sticker.
 	 *
 	 * @access public
 	 * @static
@@ -33,30 +33,39 @@ class Wpcom_Plan {
 	 */
 	public static function features( $plan ) {
 		$plan_features = array(
-			'blogger-plan'    => array(),
-			'personal-plan'   => array(
+			'blogger-plan'             => array(),
+			'personal-plan'            => array(
 				'recurring-payments',
 			),
-			'personal-bundle' => array(
+			'personal-bundle'          => array(
 				'recurring-payments',
 			),
-			'premium-plan'    => array(
+			'premium-plan'             => array(
 				'calendly',
 				'opentable',
 				'recurring-payments',
 				'simple-payments',
 			),
-			'business-plan'   => array(
+			'business-plan'            => array(
 				'calendly',
 				'opentable',
 				'recurring-payments',
 				'simple-payments',
 			),
-			'ecommerce-plan'  => array(
+			'ecommerce-plan'           => array(
 				'calendly',
 				'opentable',
 				'recurring-payments',
 				'simple-payments',
+			),
+			'wordads'                  => array(
+				'wordads',
+			),
+			'wordads-approved'         => array(
+				'wordads',
+			),
+			'wordads-approved-misfits' => array(
+				'wordads',
 			),
 		);
 
@@ -88,7 +97,17 @@ class Wpcom_Plan {
 		// Get all the site's plan stickers.
 		$plan_stickers = array_intersect(
 			get_blog_stickers( get_current_blog_id() ),
-			array( 'blogger-plan', 'personal-plan', 'premium-plan', 'business-plan', 'ecommerce-plan' )
+			array(
+				'blogger-plan',
+				'personal-plan',
+				'personal-bundle',
+				'premium-plan',
+				'business-plan',
+				'ecommerce-plan',
+				'wordads',
+				'wordads-approved',
+				'wordads-approved-misfits',
+			)
 		);
 
 		foreach ( $plan_stickers as $plan_sticker ) {

--- a/class.wpcom-plan.php
+++ b/class.wpcom-plan.php
@@ -1,0 +1,102 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Get a WordPress.com site's plan, and see if it supports a given feature.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Provides methods methods for fetching the plan from WordPress.com.
+ */
+class Wpcom_Plan {
+	/**
+	 * Check if a site is a WordPress.com site.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return bool True if the site is a WordPress.com Simple Site.
+	 */
+	public static function is_wpcom() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'get_blog_stickers' );
+	}
+
+	/**
+	 * Return an array of features supported by current plan.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $plan Current wpcom plan.
+	 *
+	 * @return array $features Array of supported features.
+	 */
+	public static function features( $plan ) {
+		$plan_features = array(
+			'blogger-plan'    => array(),
+			'personal-plan'   => array(
+				'recurring-payments',
+			),
+			'personal-bundle' => array(
+				'recurring-payments',
+			),
+			'premium-plan'    => array(
+				'calendly',
+				'opentable',
+				'recurring-payments',
+				'simple-payments',
+			),
+			'business-plan'   => array(
+				'calendly',
+				'opentable',
+				'recurring-payments',
+				'simple-payments',
+			),
+			'ecommerce-plan'  => array(
+				'calendly',
+				'opentable',
+				'recurring-payments',
+				'simple-payments',
+			),
+		);
+
+		if ( ! isset( $plan_features[ $plan ] ) ) {
+			return array();
+		}
+
+		return $plan_features[ $plan ];
+	}
+
+	/**
+	 * Check if a WordPress.com site supports a specific feature.
+	 *
+	 * @uses get_option()
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @param string $feature      The module or feature to check.
+	 *
+	 * @return bool True if plan supports feature, false if not.
+	 */
+	public static function supports( $feature ) {
+		// If the site is not a WordPress.com site, bail.
+		if ( ! self::is_wpcom() ) {
+			return false;
+		}
+
+		// Get all the site's plan stickers.
+		$plan_stickers = array_intersect(
+			get_blog_stickers( get_current_blog_id() ),
+			array( 'blogger-plan', 'personal-plan', 'premium-plan', 'business-plan', 'ecommerce-plan' )
+		);
+
+		foreach ( $plan_stickers as $plan_sticker ) {
+			if ( in_array( $feature, self::features( $plan_sticker ), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -12,28 +12,6 @@ namespace Jetpack\Calendly_Block;
 const FEATURE_NAME = 'calendly';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
-/**
- * Check if the block should be available on the site.
- *
- * @return bool
- */
-function is_available() {
-	if (
-		defined( 'IS_WPCOM' )
-		&& IS_WPCOM
-		&& function_exists( 'has_any_blog_stickers' )
-	) {
-		if ( has_any_blog_stickers(
-			array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
-			get_current_blog_id()
-		) ) {
-			return true;
-		}
-		return false;
-	}
-
-	return true;
-}
 
 /**
  * Registers the block for use in Gutenberg
@@ -41,21 +19,13 @@ function is_available() {
  * registration if we need to.
  */
 function register_block() {
-	if ( is_available() ) {
-		jetpack_register_block(
-			BLOCK_NAME,
-			array( 'render_callback' => 'Jetpack\Calendly_Block\load_assets' )
-		);
-	} else {
-		\Jetpack_Gutenberg::set_extension_unavailable(
-			BLOCK_NAME,
-			'missing_plan',
-			array(
-				'required_feature' => 'calendly',
-				'required_plan'    => 'premium-plan',
-			)
-		);
-	}
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => 'Jetpack\Calendly_Block\load_assets' ),
+		array(
+			'wpcom' => 'premium-plan',
+		)
+	);
 }
 
 add_action( 'init', 'Jetpack\Calendly_Block\register_block' );

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -19,21 +19,15 @@ const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
  * registration if we need to.
  */
 function register_block() {
-	jetpack_register_premium_wpcom_block(
+	jetpack_register_block(
 		BLOCK_NAME,
-		array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
+		array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' ),
+		array(
+			'wpcom' => 'premium-plan',
+		)
 	);
 }
 add_action( 'init', 'Jetpack\OpenTable_Block\register_block' );
-
-/**
- * Sets the availability of the block based on it
- * requiring a paid plan on WPCOM
- */
-function set_availability() {
-	\Jetpack_Gutenberg::set_premium_wpcom_availability( BLOCK_NAME );
-}
-add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\set_availability' );
 
 /**
  * Adds an inline script which updates the block editor settings to

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -12,28 +12,6 @@ namespace Jetpack\OpenTable_Block;
 const FEATURE_NAME = 'opentable';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
-/**
- * Check if the block should be available on the site.
- *
- * @return bool
- */
-function is_available() {
-	if (
-		defined( 'IS_WPCOM' )
-		&& IS_WPCOM
-		&& function_exists( 'has_any_blog_stickers' )
-	) {
-		if ( has_any_blog_stickers(
-			array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
-			get_current_blog_id()
-		) ) {
-			return true;
-		}
-		return false;
-	}
-
-	return true;
-}
 
 /**
  * Registers the block for use in Gutenberg
@@ -41,23 +19,21 @@ function is_available() {
  * registration if we need to.
  */
 function register_block() {
-	if ( is_available() ) {
-		jetpack_register_block(
-			BLOCK_NAME,
-			array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
-		);
-	} else {
-		\Jetpack_Gutenberg::set_extension_unavailable(
-			BLOCK_NAME,
-			'missing_plan',
-			array(
-				'required_feature' => 'opentable',
-				'required_plan'    => 'premium-plan',
-			)
-		);
-	}
+	jetpack_register_premium_wpcom_block(
+		BLOCK_NAME,
+		array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
+	);
 }
-add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\register_block' );
+add_action( 'init', 'Jetpack\OpenTable_Block\register_block' );
+
+/**
+ * Sets the availability of the block based on it
+ * requiring a paid plan on WPCOM
+ */
+function set_availability() {
+	\Jetpack_Gutenberg::set_premium_wpcom_availability( BLOCK_NAME );
+}
+add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\set_availability' );
 
 /**
  * Adds an inline script which updates the block editor settings to

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -27,42 +27,22 @@ class Jetpack_WordAds_Gutenblock {
 	}
 
 	/**
-	 * Check if the site is approved for ads for WP.com Simple sites.
-	 *
-	 * @return bool
-	 */
-	private static function is_available() {
-		if ( self::is_wpcom() ) {
-			return has_any_blog_stickers( array( 'wordads', 'wordads-approved', 'wordads-approved-misfits' ), get_current_blog_id() );
-		}
-
-		return self::is_jetpack_module_active();
-	}
-
-	/**
 	 * Register the WordAds block.
 	 */
 	public static function register() {
-		if ( self::is_available() ) {
+		// On WordPress.com the WordAds module is always active.
+		if ( self::is_jetpack_module_active() ) {
 			jetpack_register_block(
 				self::BLOCK_NAME,
 				array(
 					'render_callback' => array( 'Jetpack_WordAds_Gutenblock', 'gutenblock_render' ),
+				),
+				array(
+					'wpcom'   => 'wordads',
+					'jetpack' => 'wordads-jetpack',
 				)
 			);
 		}
-	}
-
-	/**
-	 * Set if the WordAds block is available.
-	 */
-	public static function set_availability() {
-		if ( ! self::is_available() ) {
-			Jetpack_Gutenberg::set_extension_unavailable( self::BLOCK_NAME, 'WordAds unavailable' );
-			return;
-		}
-		// Make the block available. Just in case it wasn't registed before.
-		Jetpack_Gutenberg::set_extension_available( self::BLOCK_NAME );
 	}
 
 	/**
@@ -118,9 +98,4 @@ class Jetpack_WordAds_Gutenblock {
 add_action(
 	'init',
 	array( 'Jetpack_WordAds_Gutenblock', 'register' )
-);
-
-add_action(
-	'jetpack_register_gutenberg_extensions',
-	array( 'Jetpack_WordAds_Gutenblock', 'set_availability' )
 );

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -59,6 +59,7 @@ require_once JETPACK__PLUGIN_DIR . 'modules/module-headings.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
+require_once JETPACK__PLUGIN_DIR . 'class.wpcom-plan.php';
 
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -13,8 +13,6 @@ class Jetpack_Simple_Payments {
 
 	static $css_classname_prefix = 'jetpack-simple-payments';
 
-	static $required_plan;
-
 	// Increase this number each time there's a change in CSS or JS to bust cache.
 	static $version = '0.25';
 
@@ -25,7 +23,6 @@ class Jetpack_Simple_Payments {
 		if ( ! self::$instance ) {
 			self::$instance = new self();
 			self::$instance->register_init_hooks();
-			self::$required_plan = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'value_bundle' : 'jetpack_premium';
 		}
 		return self::$instance;
 	}
@@ -43,7 +40,6 @@ class Jetpack_Simple_Payments {
 
 	private function register_init_hooks() {
 		add_action( 'init', array( $this, 'init_hook_action' ) );
-		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_gutenberg_block' ) );
 		add_action( 'rest_api_init', array( $this, 'register_meta_fields_in_rest_api' ) );
 	}
 
@@ -61,21 +57,16 @@ class Jetpack_Simple_Payments {
 		$this->setup_cpts();
 
 		add_filter( 'the_content', array( $this, 'remove_auto_paragraph_from_product_description' ), 0 );
-	}
 
-	function register_gutenberg_block() {
-		if ( $this->is_enabled_jetpack_simple_payments() ) {
-			jetpack_register_block( 'jetpack/simple-payments' );
-		} else {
-			Jetpack_Gutenberg::set_extension_unavailable(
-				'jetpack/simple-payments',
-				'missing_plan',
-				array(
-					'required_feature' => 'simple-payments',
-					'required_plan'    => self::$required_plan,
-				)
-			);
-		}
+		// Register block.
+		jetpack_register_block(
+			'jetpack/simple-payments',
+			array(),
+			array(
+				'wpcom'   => 'value_bundle',
+				'jetpack' => 'jetpack_premium',
+			)
+		);
 	}
 
 	function remove_auto_paragraph_from_product_description( $content ) {
@@ -184,7 +175,7 @@ class Jetpack_Simple_Payments {
 
 		jetpack_require_lib( 'components' );
 		return Jetpack_Components::render_upgrade_nudge( array(
-			'plan' => self::$required_plan
+			'plan' => ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? 'value_bundle' : 'jetpack_premium',
 		) );
 	}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This is an alternative to #14426.

I liked @simison's idea here:
https://github.com/Automattic/jetpack/pull/14426#discussion_r369485685

I thought I'd see how this could look like, so here is my take:
https://github.com/Automattic/jetpack/tree/update/wpcom-premium-block-registration-take2

I have not tested it on WordPress.com yet.

There are also some things I have not figured out:

- VideoPress seems to rely on something other than blog stickers to indicate whether VideoPress is available on a site:
https://github.com/Automattic/jetpack/blob/a211b9e939ae99f8e8efc0f84d7802419fa0d101/modules/videopress/class.videopress-gutenberg.php#L55
My approach consequently would not work there.
- I am not sure how my approach would handle things like WordPress.com sites with only the `wordads-approved` sticker.

#### Testing instructions:

* This impacts the following blocks so far:
    - OpenTable
    - Calendly
    - Recurring Payments
    - Simple Payments
    - WordAds

#### Proposed changelog entry for your changes:

* N/A
