### PR TITLE
[Coming Soon] Add support for is_coming_soon in sites API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -41,6 +41,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'logo'              => '(array) The site logo, set in the Customizer',
 		'visible'           => '(bool) If this site is visible in the user\'s site list',
 		'is_private'        => '(bool) If the site is a private site or not',
+		'is_coming_soon'    => '(bool) If the site is marked as "coming soon" or not',
 		'single_user_site'  => '(bool) Whether the site is single user. Only returned for WP.com sites and for Jetpack sites with version 3.4 or higher.',
 		'is_vip'            => '(bool) If the site is a VIP site or not.',
 		'is_following'      => '(bool) If the current user is subscribed to this site in the reader',
@@ -70,6 +71,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'logo',
 		'visible',
 		'is_private',
+		'is_coming_soon',
 		'is_following',
 		'meta',
 		'launch_status',
@@ -308,6 +310,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				$response[ $key ] = $this->site->user_can_manage();
 			case 'is_private' :
 				$response[ $key ] = $this->site->is_private();
+				break;
+			case 'is_coming_soon' :
+				// This option is stored on wp.com for both simple and atomic sites. @see mu-plugins/private-blog.php
+				$response[ $key ] = $this->site->is_private() && get_option( 'wpcom_coming_soon' );
 				break;
 			case 'visible' :
 				$response[ $key ] = $this->site->is_visible();
@@ -647,6 +653,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			unset( $response->is_vip );
 			unset( $response->single_user_site );
 			unset( $response->is_private );
+			unset( $response->is_coming_soon );
 			unset( $response->capabilities );
 			unset( $response->lang );
 			unset( $response->user_can_manage );

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -38,6 +38,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'logo'              => '(array) The site logo, set in the Customizer',
 		'visible'           => '(bool) If this site is visible in the user\'s site list',
 		'is_private'        => '(bool) If the site is a private site or not',
+		'is_coming_soon'    => '(bool) If the site is a "coming soon" site or not',
 		'single_user_site'  => '(bool) Whether the site is single user. Only returned for WP.com sites and for Jetpack sites with version 3.4 or higher.',
 		'is_vip'            => '(bool) If the site is a VIP site or not.',
 		'is_following'      => '(bool) If the current user is subscribed to this site in the reader',


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

* This diff adds `is_coming_soon` boolean flag to site endpoint.

Differential Revision: D37570-code

This commit syncs r201925-wpcom.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* More context available here: paObgF-MY-p2

#### Testing instructions:

**For simple sites:**

1. Apply https://github.com/Automattic/wp-calypso/pull/38803
1. In calypso, inspect call to `/rest/v1.2/me/sites` and confirm the response now says `is_coming_soon: false` for all your sites sites
1. Flip `wpcom_coming_soon` option for one of the sites to 1
1. Confirm that endpoint now says `is_coming_soon: true` for that site

**For Jetpack sites:**

Jetpack sites are outside of scope for this PR. Just try a few API calls mentioned above and confirm they don't error out.

#### Proposed changelog entry for your changes:

* None
