### PR TITLE
Fix the Calendly placeholder

### DIFF
--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -81,20 +81,22 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 	};
 
 	const embedCodeForm = (
-		<form onSubmit={ parseEmbedCode }>
-			<input
-				type="text"
-				id="embedCode"
-				onChange={ event => setEmbedCode( event.target.value ) }
-				placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
-				value={ embedCode }
-				className="components-placeholder__input"
-			/>
-			<div>
-				<Button isSecondary isLarge type="submit">
-					{ _x( 'Embed', 'button label', 'jetpack' ) }
-				</Button>
-			</div>
+		<>
+			<form onSubmit={ parseEmbedCode }>
+				<input
+					type="text"
+					id="embedCode"
+					onChange={ event => setEmbedCode( event.target.value ) }
+					placeholder={ __( 'Calendly web address or embed code…', 'jetpack' ) }
+					value={ embedCode }
+					className="components-placeholder__input"
+				/>
+				<div>
+					<Button isSecondary isLarge type="submit">
+						{ _x( 'Embed', 'button label', 'jetpack' ) }
+					</Button>
+				</div>
+			</form>
 			<div className={ `${ className }-learn-more` }>
 				<ExternalLink
 					href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview"
@@ -103,7 +105,7 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 					{ __( 'Need help finding your embed code?', 'jetpack' ) }
 				</ExternalLink>
 			</div>
-		</form>
+		</>
 	);
 
 	const blockPlaceholder = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This fixes a small layout issue in the Calendly block placeholder

Before:
<img width="545" alt="Screenshot 2020-01-22 at 13 45 44" src="https://user-images.githubusercontent.com/275961/72899259-84d32f00-3d1d-11ea-9037-fb91e796e7ba.png">

After:
<img width="540" alt="Screenshot 2020-01-22 at 13 45 16" src="https://user-images.githubusercontent.com/275961/72899262-87358900-3d1d-11ea-8a22-17f21de5e6a2.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the Gutenberg plugin
* Add a Calendly block to a post
* Resize your brower's window to less than 600px
* Check that the placeholder looks like the screenshot

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
