### PR TITLE
Calendly: Add a notice to explain how to use colors

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -133,7 +133,7 @@ function load_assets( $attr, $content ) {
 			esc_js( $url ),
 			wp_kses_post( $submit_button_text )
 		);
-	} else { // Button style.
+	} else { // Inline style.
 		$content = sprintf(
 			'<div class="calendly-inline-widget %1$s" data-url="%2$s" style="min-width:320px;height:630px;"></div>',
 			esc_attr( $classes ),

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -202,17 +202,15 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 	const inspectorControls = (
 		<InspectorControls>
 			{ url && (
-				<>
-					<PanelBody title={ __( 'Styles', 'jetpack' ) }>
-						<BlockStylesPreviewAndSelector
-							clientId={ clientId }
-							styleOptions={ styleOptions }
-							onSelectStyle={ setAttributes }
-							activeStyle={ style }
-							attributes={ attributes }
-						/>
-					</PanelBody>
-				</>
+				<PanelBody title={ __( 'Styles', 'jetpack' ) }>
+					<BlockStylesPreviewAndSelector
+						clientId={ clientId }
+						styleOptions={ styleOptions }
+						onSelectStyle={ setAttributes }
+						activeStyle={ style }
+						attributes={ attributes }
+					/>
+				</PanelBody>
 			) }
 			<PanelBody title={ __( 'Calendar Settings', 'jetpack' ) } initialOpen={ false }>
 				<form onSubmit={ parseEmbedCode } className={ `${ className }-embed-form-sidebar` }>
@@ -237,11 +235,13 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 					onChange={ () => setAttributes( { hideEventTypeDetails: ! hideEventTypeDetails } ) }
 				/>
 			</PanelBody>
-			<Notice className={ `${ className }-color-notice` } isDismissible={ false }>
-				<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
-					{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
-				</ExternalLink>
-			</Notice>
+			{ url && (
+				<Notice className={ `${ className }-color-notice` } isDismissible={ false }>
+					<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
+						{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
+					</ExternalLink>
+				</Notice>
+			) }
 		</InspectorControls>
 	);
 

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -96,10 +96,7 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 				</Button>
 			</div>
 			<div className={ `${ className }-learn-more` }>
-				<ExternalLink
-					href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview"
-					target="_blank"
-				>
+				<ExternalLink href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview">
 					{ __( 'Need help finding your embed code?', 'jetpack' ) }
 				</ExternalLink>
 			</div>
@@ -217,7 +214,6 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 					</PanelBody>
 				</>
 			) }
-
 			<PanelBody title={ __( 'Calendar Settings', 'jetpack' ) } initialOpen={ false }>
 				<form onSubmit={ parseEmbedCode } className={ `${ className }-embed-form-sidebar` }>
 					<input
@@ -241,6 +237,11 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 					onChange={ () => setAttributes( { hideEventTypeDetails: ! hideEventTypeDetails } ) }
 				/>
 			</PanelBody>
+			<Notice className={ `${ className }-color-notice` } isDismissible={ false }>
+				<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
+					{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
+				</ExternalLink>
+			</Notice>
 		</InspectorControls>
 	);
 

--- a/extensions/blocks/calendly/editor.scss
+++ b/extensions/blocks/calendly/editor.scss
@@ -22,6 +22,10 @@
 	&-learn-more {
 		margin-top: 1em;
 	}
+
+	&-color-notice {
+		margin: 0;
+	}
 }
 
 .is-calendly {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a notice to the sidebar to explain how to use the Calendly color settings.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p58i-8tn#comment-44505-p2

#### Testing instructions:
* Add a Calendly block to a post
* Confirm you see this notice in the sidebar:
<img width="297" alt="Screenshot 2020-01-22 at 15 31 44" src="https://user-images.githubusercontent.com/275961/72907732-51e46780-3d2c-11ea-872c-a53d98e58b23.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog

This was suggested by @davipontesblog.
cc @lessbloat 
