### PR TITLE
Add save functions for the OpenTable and Calendly blocks

### DIFF
--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -33,7 +33,7 @@ export const settings = {
 		html: false,
 	},
 	edit,
-	save: () => null,
+	save: ( { attributes: { url } } ) => url,
 	attributes,
 	example: {
 		attributes: {

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -33,7 +33,7 @@ export const settings = {
 		html: false,
 	},
 	edit,
-	save: ( { attributes: { url } } ) => url,
+	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
 	attributes,
 	example: {
 		attributes: {

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -35,9 +35,11 @@ export const settings = {
 	edit,
 	save: ( { attributes: { rid } } ) => (
 		<>
-			{ rid.map(
-				restaurantId => 'https://www.opentable.com/restref/client/?rid=' + restaurantId + ' '
-			) }
+			{ rid.map( restaurantId => (
+				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
+					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
+				</a>
+			) ) }
 		</>
 	),
 	attributes: defaultAttributes,

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -33,11 +33,17 @@ export const settings = {
 		html: false,
 	},
 	edit,
-	save: () => null,
+	save: ( { attributes: { rid } } ) => (
+		<>
+			{ rid.map(
+				restaurantId => 'https://www.opentable.com/restref/client/?rid=' + restaurantId + ' '
+			) }
+		</>
+	),
 	attributes: defaultAttributes,
 	example: {
 		attributes: {
-			rid: '1',
+			rid: [ '1' ],
 			style: 'standard',
 			iframe: true,
 			domain: 'com',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds save functions to both the OpenTable and Calendly blocks. This means that when these blocks are rendered outside of a post there will be fall back content (URLs)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p58i-8tn#comment-44442-p2

#### Testing instructions:
* Add a Calendly block and enter a valid URL
* Look in the code editor and check you see the URL between the comments, something like:
<img width="603" alt="Screenshot 2020-01-22 at 17 11 23" src="https://user-images.githubusercontent.com/275961/72916619-4009c100-3d3a-11ea-8cdf-04d40afa0563.png">

* Add an OpenTable block and enter a valid restaurant(s)
* Look in the code editor and check you see the URL between the comments, something like:
<img width="599" alt="Screenshot 2020-01-22 at 17 11 27" src="https://user-images.githubusercontent.com/275961/72916621-41d38480-3d3a-11ea-9d0e-da515353bb29.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog