### PR TITLE
Instant Search: use taxonomy name rather than slug for filters

### DIFF
--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -37,11 +37,11 @@ function generateAggregation( filter ) {
 			};
 		}
 		case 'taxonomy': {
-			let field = `taxonomy.${ filter.taxonomy }.slug`;
+			let field = `taxonomy.${ filter.taxonomy }.name.raw`;
 			if ( filter.taxonomy === 'post_tag' ) {
-				field = 'tag.slug';
+				field = 'tag.name.raw';
 			} else if ( filter.type === 'category' ) {
-				field = 'category.slug';
+				field = 'category.name.raw';
 			}
 			return { terms: { field, size: filter.count } };
 		}

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -39,9 +39,9 @@ function generateAggregation( filter ) {
 		case 'taxonomy': {
 			let field = `taxonomy.${ filter.taxonomy }.name.raw`;
 			if ( filter.taxonomy === 'post_tag' ) {
-				field = 'tag.name.raw';
-			} else if ( filter.type === 'category' ) {
-				field = 'category.name.raw';
+				field = 'tag.slug';
+			} else if ( filter.taxonomy === 'category' ) {
+				field = 'category.slug';
 			}
 			return { terms: { field, size: filter.count } };
 		}

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -116,7 +116,7 @@ function buildFilterObject( filterQuery ) {
 					filter.bool.must.push( filterKeyToEsFilter.get( key )( item ) );
 				} else {
 					// If key is not in the standard map, assume to be a custom taxonomy
-					filter.bool.must.push( { term: { [ `taxonomy.${ key }.slug` ]: item } } );
+					filter.bool.must.push( { term: { [ `taxonomy.${ key }.name.raw` ]: item } } );
 				}
 			} );
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/13812.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Switches taxonomy filters to use `name.raw` rather than `slug`, which should solve encoding issues.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No - it's part of the Instant Search prototype.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
* To test the specific issue mentioned in #13812, add the following code to your `mu-plugins` directory:

```
function register_custom_taxonomies() {
		register_taxonomy( 'language', array( 'post' ), array(
			'label'    => __( 'Language', 'wptv' ),
			'template' => __( 'Language: %l.', 'wptv' ),
			'helps'    => __( 'Separate languages with commas.', 'wptv' ),
			'sort'     => true,
			'args'     => array( 'orderby' => 'term_order' ),
			'rewrite'  => array( 'slug' => 'language' ),
		) );
}
add_action( 'init', 'register_custom_taxonomies' );
```

...then set up a Language filter at `/wp-admin/widgets.php`. 
* Search for "japan" using the blog ID for wordpress.tv and ensure that the Japanese filter label looks correct:
<img width="312" alt="Screen Shot 2020-01-23 at 15 46 48" src="https://user-images.githubusercontent.com/17325/72954717-35186480-3dfe-11ea-95b0-d46791586ee7.png">
* Ensure that applying the Japanese filter shows only posts in that language.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not required.
