### PR TITLE
Calendly: Transform calendly urls to Calendly blocks

### DIFF
--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import icon from './icon';
  */
 import './editor.scss';
 
+export const REGEX = /(^|\/\/)(calendly\.com[^"']*)/i
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
 export const settings = {
@@ -42,5 +44,18 @@ export const settings = {
 			style: 'inline',
 			url: 'https://calendly.com/wordpresscom/jetpack-block-example',
 		},
+	},
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: node => node.nodeName === 'P' && REGEX.test( node.textContent ),
+				transform: node => {
+					return createBlock( 'jetpack/calendly', {
+						url: node.textContent.trim(),
+					} );
+				},
+			},
+		],
 	},
 };

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -10,13 +10,13 @@ import { createBlock } from '@wordpress/blocks';
 import attributes from './attributes';
 import edit from './edit';
 import icon from './icon';
+import { getAttributesFromEmbedCode, REGEX } from './utils';
 
 /**
  * Style dependencies
  */
 import './editor.scss';
 
-export const REGEX = /(^|\/\/)(calendly\.com[^"']*)/i;
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
 export const settings = {
@@ -51,9 +51,8 @@ export const settings = {
 				type: 'raw',
 				isMatch: node => node.nodeName === 'P' && REGEX.test( node.textContent ),
 				transform: node => {
-					return createBlock( 'jetpack/calendly', {
-						url: node.textContent.trim(),
-					} );
+					const newAttributes = getAttributesFromEmbedCode( node.textContent );
+					return createBlock( 'jetpack/calendly', newAttributes );
 				},
 			},
 		],

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -16,7 +16,7 @@ import icon from './icon';
  */
 import './editor.scss';
 
-export const REGEX = /(^|\/\/)(calendly\.com[^"']*)/i
+export const REGEX = /(^|\/\/)(calendly\.com[^"']*)/i;
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
 export const settings = {

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { REGEX } from './index';
+export const REGEX = /(^|\/\/)(calendly\.com[^"']*)/i;
 
 export const getURLFromEmbedCode = embedCode => {
 	const url = embedCode.match( REGEX );

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -1,5 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { REGEX } from './index';
+
 export const getURLFromEmbedCode = embedCode => {
-	const url = embedCode.match( /(^|\/\/)(calendly\.com[^"']*)/i );
+	const url = embedCode.match( REGEX );
 	if ( url ) {
 		return 'https://' + url[ 2 ];
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When users paste a Calendly URL we should convert it to a block

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p58i-8tn#comment-44394

#### Testing instructions:
* Create a new post
* Paste a calendly URL
* Check that it tranforms into a Calendly block

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
