### PR TITLE
Map Block: Fix missing Mapbox access token on WPCOM

### DIFF
--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -20,11 +20,17 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_get_mapbox_api_key() {
-	if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys' ) || ! Jetpack::is_active() ) {
-		return Jetpack_Options::get_option( 'mapbox_api_key' );
+	$site_id = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+
+	$request_url = 'https://public-api.wordpress.com/wpcom/v2/sites/' . $site_id . '/service-api-keys/mapbox';
+	$response    = wp_remote_get( esc_url_raw( $request_url ) );
+
+	if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+		$response_body = json_decode( wp_remote_retrieve_body( $response ) );
+		return $response_body->service_api_key;
 	}
-	$response = WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key( array( 'service' => 'mapbox' ) );
-	return $response['service_api_key'];
+
+	return Jetpack_Options::get_option( 'mapbox_api_key' );
 }
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

In #14307, we let WPCOM users use the Map block without providing a Mapbox access token.
For some reasons, the `WPCOM_REST_API_V2_Endpoint_Service_API_Keys` class is not instantiated on WPCOM when called directly, from the front end.

This PR changes how we access that endpoint: instead of calling it directly, we call it remotely as intended, leaving to the endpoint all the needed checks. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
Basically repeat the #14307 tests:

Prerequisites

- Have a Simple, Atomic, and Jetpack test sites ready.
- Make sure none of them has a Mapbox token saved. In that case, _before applying this PR_, please remove it in the Mapbox Access Token field in the Map block sidebar.

Jetpack

- Open the editor and insert a Map block.
- Make sure the Map block loads in the placeholder state, and asks for a token.
- Provide a token, and make sure the map loads correctly.
- Make sure it's possible to change and remove the token in the Mapbox Access Token field in the block sidebar.
- Save the post and check the front end.
- Make sure the Map block is rendered correctly.
- Update the token in the Mapbox Access Token field in the block sidebar with a random incorrect string.
- Wait a bit for the API call to complete and then make sure the block reverted to the placeholder state, with an "incorrect token" error notice.

Simple

- Apply D38065-code and sandbox the API.
- Open the editor and insert a Map block.
- Make sure the Map block loads without asking for an access token.
- Make sure there is no Mapbox Access Token field in the block sidebar.
- Save the post and check the front end.
- Make sure the Map block is rendered correctly.

Atomic

- Install and activate the [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases/latest) plugin.
- In wp-admin, navigate to Jetpack -> Jetpack Beta; search for the `fix/map-block-missing-api-key-wpcom` feature branch, and activate it.
- Repeat the same testing steps for a Simple site (skip the first step).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No changelog entry needed: this is a hotfix for a still unreleased feature.