### PR TITLE
Add an amazon block

### DIFF
--- a/extensions/blocks/amazon/amazon.php
+++ b/extensions/blocks/amazon/amazon.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Amazon Block.
+ *
+ * @since 8.x
+ *
+ * @package Jetpack
+ */
+
+jetpack_register_block(
+	'jetpack/amazon',
+	array( 'render_callback' => 'jetpack_amazon_block_load_assets' )
+);
+
+/**
+ * Amazon block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Amazon block attributes.
+ * @param string $content String containing the Amazon block content.
+ *
+ * @return string
+ */
+function jetpack_amazon_block_load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( 'amazon' );
+	return $content;
+}

--- a/extensions/blocks/amazon/edit.js
+++ b/extensions/blocks/amazon/edit.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+class AmazonEdit extends Component {
+	/**
+	 * Write the block editor UI.
+	 *
+	 * @returns {object} The UI displayed when user edits this block.
+	 */
+	render() {
+		return <p>{ __( 'Coming soon', 'jetpack' ) }</p>;
+	}
+}
+
+export default AmazonEdit;

--- a/extensions/blocks/amazon/editor.js
+++ b/extensions/blocks/amazon/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/extensions/blocks/amazon/editor.scss
+++ b/extensions/blocks/amazon/editor.scss
@@ -1,0 +1,5 @@
+/**
+ * Editor styles for Amazon
+ */
+
+.wp-block-jetpack-amazon { }

--- a/extensions/blocks/amazon/index.js
+++ b/extensions/blocks/amazon/index.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, Path } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import renderMaterialIcon from '../../shared/render-material-icon';
+import edit from './edit';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'amazon';
+export const title = __( 'Amazon', 'jetpack' );
+export const settings = {
+	title,
+	description: (
+		<Fragment>
+			<p>{ __( 'Amazon', 'jetpack' ) }</p>
+			<ExternalLink href="#">{ __( 'Learn more about Amazon', 'jetpack' ) }</ExternalLink>
+		</Fragment>
+	),
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
+	icon: renderMaterialIcon(
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	),
+	category: 'jetpack',
+	keywords: [],
+	supports: {
+		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
+		align: false /* if set to true, the 'align' option below can be used*/,
+		// Pick which alignment options to display.
+		/*align: [ 'left', 'right', 'full' ],*/
+		// Support for wide alignment, that requires additional support in themes.
+		alignWide: true,
+		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		anchor: false,
+		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		customClassName: true,
+		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		className: true,
+		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		html: false,
+		// Passing false hides this block in Gutenberg's visual inserter.
+		/*inserter: true,*/
+		// When false, user will only be able to insert the block once per post.
+		multiple: true,
+		// When false, the block won't be available to be converted into a reusable block.
+		reusable: true,
+	},
+	edit,
+	/* @TODO Write the block editor output */
+	save: () => null,
+	example: {
+		attributes: {
+			// @TODO: Add default values for block attributes, for generating the block preview.
+		},
+	},
+};

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -23,5 +23,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "calendly", "eventbrite", "opentable", "seo" ]
+	"beta": [ "amazon", "calendly", "eventbrite", "opentable", "seo" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds initial scaffolding for an Amazon block, so that we can iterate on the block in different PRs and keep our changes smaller and easier to review

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* pb5gDS-h1-p2

#### Testing instructions:
* Create a new post
* Add an Amazon block
* Check that you can see the "coming soon" message.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
