### PR TITLE
Mapbox: query for an API key differently depending on platform

### DIFF
--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -20,11 +20,27 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_get_mapbox_api_key() {
-	if ( ! class_exists( 'WPCOM_REST_API_V2_Endpoint_Service_API_Keys' ) || ! Jetpack::is_active() ) {
-		return Jetpack_Options::get_option( 'mapbox_api_key' );
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		$endpoint = sprintf(
+			'https://public-api.wordpress.com/wpcom/v2/sites/%d/service-api-keys/mapbox',
+			get_current_blog_id()
+		);
+	} else {
+		$endpoint = sprintf(
+			'%swpcom/v2/service-api-keys/mapbox',
+			rest_url()
+		);
 	}
-	$response = WPCOM_REST_API_V2_Endpoint_Service_API_Keys::get_service_api_key( array( 'service' => 'mapbox' ) );
-	return $response['service_api_key'];
+
+	$response      = wp_remote_get( esc_url_raw( $endpoint ) );
+	$response_code = wp_remote_retrieve_response_code( $response );
+
+	if ( 200 === $response_code ) {
+		$response_body = json_decode( wp_remote_retrieve_body( $response ) );
+		return $response_body->service_api_key;
+	}
+
+	return Jetpack_Options::get_option( 'mapbox_api_key' );
 }
 
 /**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

An alternative to #14440

#### Testing instructions:

Basically repeat the #14307 tests:

Prerequisites

- Have a Simple, Atomic, and Jetpack test sites ready.
- Make sure none of them has a Mapbox token saved. In that case, _before applying this PR_, please remove it in the Mapbox Access Token field in the Map block sidebar.

Jetpack

- Open the editor and insert a Map block.
- Make sure the Map block loads in the placeholder state, and asks for a token.
- Provide a token, and make sure the map loads correctly.
- Make sure it's possible to change and remove the token in the Mapbox Access Token field in the block sidebar.
- Save the post and check the front end.
- Make sure the Map block is rendered correctly.
- Update the token in the Mapbox Access Token field in the block sidebar with a random incorrect string.
- Wait a bit for the API call to complete and then make sure the block reverted to the placeholder state, with an "incorrect token" error notice.

Simple

- Apply D38065-code and sandbox the API.
- Open the editor and insert a Map block.
- Make sure the Map block loads without asking for an access token.
- Make sure there is no Mapbox Access Token field in the block sidebar.
- Save the post and check the front end.
- Make sure the Map block is rendered correctly.

Atomic

- Install and activate the [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases/latest) plugin.
- In wp-admin, navigate to Jetpack -> Jetpack Beta; search for the `fix/map-block-missing-api-key-wpcom` feature branch, and activate it.
- Repeat the same testing steps for a Simple site (skip the first step).

#### Proposed changelog entry for your changes:

* N/A
