### PR TITLE
Map Block: avoid using sprintf to get the local API URL.

### DIFF
--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -26,10 +26,7 @@ function jetpack_get_mapbox_api_key() {
 			get_current_blog_id()
 		);
 	} else {
-		$endpoint = sprintf(
-			'%swpcom/v2/service-api-keys/mapbox',
-			rest_url()
-		);
+		$endpoint = rest_url( 'wpcom/v2/service-api-keys/mapbox' );
 	}
 
 	$response      = wp_remote_get( esc_url_raw( $endpoint ) );


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Following up from #14442, this makes things a bit shorter and prettier, while making sure we always get the right API URL.


#### Testing instructions:

* See ##14442 
#### Proposed changelog entry for your changes:

* N/A
