### PR TITLE
Gutenberg 7.2.0: replace legacy editor- classes with block-editor-

### DIFF
--- a/extensions/blocks/contact-info/editor.scss
+++ b/extensions/blocks/contact-info/editor.scss
@@ -1,10 +1,10 @@
 .jetpack-contact-info-block {
 	/* css class added to increase specificity */
-	.editor-plain-text.editor-plain-text:focus {
+	.block-editor-plain-text.block-editor-plain-text:focus {
 		box-shadow: none;
 	}
 
-	.editor-plain-text {
+	.block-editor-plain-text {
 		flex-grow: 1;
 		min-height: unset;
 		padding: 0;

--- a/extensions/blocks/markdown/editor.scss
+++ b/extensions/blocks/markdown/editor.scss
@@ -6,7 +6,7 @@
 }
 
 // @TODO: Remove all these specific styles when related Gutenberg core styles become more generic
-.editor-block-list__block {
+.block-editor-block-list__block {
 	.wp-block-jetpack-markdown__preview {
 		min-height: 1.8em;
 		line-height: 1.8;

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -179,8 +179,8 @@
 	}
 
 	// Hide upload buttons in style picker preview
-	.editor-block-preview__content & {
-		.editor-media-placeholder {
+	.block-editor-block-preview__content & {
+		.block-editor-media-placeholder {
 			display: none;
 		}
 	}

--- a/extensions/shared/components/block-nudge/style.scss
+++ b/extensions/shared/components/block-nudge/style.scss
@@ -3,15 +3,15 @@
 
 .jetpack-block-nudge {
 	// Necessary extra specificity
-	&.editor-warning {
+	&.block-editor-warning {
 		margin-bottom: 0;
 	}
 
-	.editor-warning__message {
+	.block-editor-warning__message {
 		margin: 13px 0;
 	}
 
-	.editor-warning__actions {
+	.block-editor-warning__actions {
 		line-height: 1;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Gutenberg 7.2.0 & 7.3.0 removed legacy `editor-` classes in WordPress/gutenberg#19050 and WordPress/gutenberg#19489. This PR updates references to legacy classes found in these PRs and the Gutenberg repo.

These were refactored in the aforementioned PRs:

```
editor-warning
editor-warning__message
editor-media-placeholder
editor-block-list__block
editor-plain-text
```

These were found in Gutenberg with the newer format (possibly updated in other revisions - need to check):

```
editor-block-preview__content
```

## Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Booted a local Jetpack environment with this PR and compared with a site on WPCOM. Some visual regressions spotted:

### Markdown

#### Before

<img width="757" alt="Screenshot 2020-01-29 at 4 40 51 PM" src="https://user-images.githubusercontent.com/1705499/73366380-88832a80-42b6-11ea-9ff6-653d66ea6c40.png">

#### After

<img width="642" alt="Screenshot 2020-01-29 at 4 40 45 PM" src="https://user-images.githubusercontent.com/1705499/73366308-6a1d2f00-42b6-11ea-97ab-923efdd46410.png">

### Recurring Payments button (block nudge)

#### Before

<img width="709" alt="Screenshot 2020-01-29 at 4 54 46 PM" src="https://user-images.githubusercontent.com/1705499/73367409-317e5500-42b8-11ea-8478-19ac54adf502.png">

#### After

<img width="621" alt="Screenshot 2020-01-29 at 4 54 35 PM" src="https://user-images.githubusercontent.com/1705499/73367427-36db9f80-42b8-11ea-8b50-1915f0ffd38e.png">

### Contact Info

#### Before (on focus)

<img width="773" alt="Screenshot 2020-01-29 at 5 08 50 PM" src="https://user-images.githubusercontent.com/1705499/73368785-40660700-42ba-11ea-958d-b40f1a3e8524.png">

#### After (on focus)

<img width="676" alt="Screenshot 2020-01-29 at 5 09 17 PM" src="https://user-images.githubusercontent.com/1705499/73368803-44922480-42ba-11ea-95e8-68424f0ca45d.png">

## Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

Not sure.
