### PR TITLE
Search: Front end search filters open overlay

### DIFF
--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -77,7 +77,7 @@ class Jetpack_Search_Template_Tags {
 	 * @since 8.3.0
 	 *
 	 * @param array $filters    The available filters for the current query.
-	 * @param array $post_types An array of post types (ignored)
+	 * @param array $post_types An array of post types (ignored).
 	 */
 	public static function render_instant_filters( $filters = null, $post_types = null ) {
 		if ( is_null( $filters ) ) {
@@ -165,17 +165,27 @@ class Jetpack_Search_Template_Tags {
 			return;
 		}
 
-		$data_base = 'data-filter-type="' . $filter['buckets'][0]['type'] . '" ';
-		$qv = $filter['buckets'][0]['query_vars'];
-		switch( $filter['buckets'][0]['type'] ) {
+		$data_base = '';
+		$qv        = $filter['buckets'][0]['query_vars'];
+		$tax_key   = '';
+		switch ( $filter['buckets'][0]['type'] ) {
 			case 'taxonomy':
-
+				$data_base = 'data-filter-type="' . $filter['buckets'][0]['type'] . '" ';
+				foreach ( $qv as $k => $v ) {
+					$tax_key = $k;
+				}
+				if ( 'category_name' === $tax_key ) {
+					$data_base .= 'data-taxonomy="category"';
+				} else {
+					$data_base .= 'data-taxonomy="' . $tax_key . '"';
+				}
 				break;
 			case 'post_type':
-				$data_base .= 'data-val="' . $qv['post_type'] . '"';
+				$data_base = 'data-filter-type="post_types" ';
 				break;
 			case 'date_histogram':
-
+				$date_slug = $filter['buckets'][0]['interval'] . '_date';
+				$data_base = 'data-filter-type="' . $date_slug . '" ';
 				break;
 		}
 
@@ -186,11 +196,22 @@ class Jetpack_Search_Template_Tags {
 		<ul class="jetpack-search-filters-widget__filter-list">
 			<?php
 			foreach ( $filter['buckets'] as $item ) :
-				$data_str = ' ';
-				foreach( $item['query_vars'] as $k => $v ) {
-					$data_str .= 'data-' . $k . '="' . $v . '" ';
+				$data_str = $data_base . ' ';
+				switch ( $filter['buckets'][0]['type'] ) {
+					case 'taxonomy':
+						$data_str .= 'data-val="' . $item['query_vars'][ $tax_key ] . '"';
+						break;
+					case 'post_type':
+						$data_str .= 'data-val="' . $item['query_vars']['post_type'] . '"';
+						break;
+					case 'date_histogram':
+						if ( 'month' === $item['interval'] ) {
+							$data_str .= 'data-val="' . $item['query_vars']['year'] . '-' . $item['query_vars']['month'] . '"';
+						} else {
+							$data_str .= 'data-val="' . $item['query_vars']['year'] . '" ';
+						}
+						break;
 				}
-				$url = ( empty( $item['active'] ) ) ?  $item['url'] : $item['remove_url'];
 				?>
 				<li>
 				<a href="#" class="jetpack-search-filter__link" <?php echo $data_str; ?>>

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -176,12 +176,19 @@ class Jetpack_Search_Template_Tags {
 
 		// Temporarily add some dummy filters to demonstrate filter behaviour.
 		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
-				'<h3>Filters</h3>' .
+				'<h3>Post type</h3>' .
 				'<div><input type="checkbox" id="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Test filter 1</label></div>' .
+				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Post</label></div>' .
 				'<div><input type="checkbox" id="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Test filter 2</label></div>' .
+				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Page</label></div>' .
 				'</div>';
+
+		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
+				'<h3>Year</h3>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-3" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-3" class="jetpack-search-form__test-filter-label">2020</label></div>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-4" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-4" class="jetpack-search-form__test-filter-label">2019</label></div></div>';
 
 		echo '<div class="jetpack-search-form">';
 		echo $form;

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -72,6 +72,24 @@ class Jetpack_Search_Template_Tags {
 	}
 
 	/**
+	 * Renders filters for instant search.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $filters    The available filters for the current query.
+	 * @param array $post_types An array of post types (ignored)
+	 */
+	public static function render_instant_filters( $filters = null, $post_types = null ) {
+		if ( is_null( $filters ) ) {
+			$filters = Jetpack_Search::instance()->get_filters();
+		}
+
+		foreach ( (array) $filters as $filter ) {
+			self::render_instant_filter( $filter );
+		}
+	}
+
+	/**
 	 * Renders a single filter that can be applied to the current search.
 	 *
 	 * @since 5.8.0
@@ -136,6 +154,62 @@ class Jetpack_Search_Template_Tags {
 	}
 
 	/**
+	 * Renders a single filter for instant search.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $filter             The filter to render.
+	 */
+	public static function render_instant_filter( $filter ) {
+		if ( empty( $filter ) || empty( $filter['buckets'] ) ) {
+			return;
+		}
+
+		$data_base = 'data-filter-type="' . $filter['buckets'][0]['type'] . '" ';
+		$qv = $filter['buckets'][0]['query_vars'];
+		switch( $filter['buckets'][0]['type'] ) {
+			case 'taxonomy':
+
+				break;
+			case 'post_type':
+				$data_base .= 'data-val="' . $qv['post_type'] . '"';
+				break;
+			case 'date_histogram':
+
+				break;
+		}
+
+		?>
+		<h4 class="jetpack-search-filters-widget__sub-heading">
+			<?php echo esc_html( $filter['name'] ); ?>
+		</h4>
+		<ul class="jetpack-search-filters-widget__filter-list">
+			<?php
+			foreach ( $filter['buckets'] as $item ) :
+				$data_str = ' ';
+				foreach( $item['query_vars'] as $k => $v ) {
+					$data_str .= 'data-' . $k . '="' . $v . '" ';
+				}
+				$url = ( empty( $item['active'] ) ) ?  $item['url'] : $item['remove_url'];
+				?>
+				<li>
+				<a href="#" class="jetpack-search-filter__link" <?php echo $data_str; ?>>
+						<?php
+							echo esc_html( $item['name'] );
+							echo '&nbsp;';
+							echo esc_html( sprintf(
+								'(%s)',
+								number_format_i18n( absint( $item['count'] ) )
+							) );
+						?>
+					</a>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+		<?php
+	}
+
+	/**
 	 * Outputs the search widget's title.
 	 *
 	 * @since 5.8.0
@@ -173,22 +247,6 @@ class Jetpack_Search_Template_Tags {
 		}
 
 		$form = self::inject_hidden_form_fields( $form, $fields_to_inject );
-
-		// Temporarily add some dummy filters to demonstrate filter behaviour.
-		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
-				'<h3>Post type</h3>' .
-				'<div><input type="checkbox" id="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Post</label></div>' .
-				'<div><input type="checkbox" id="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Page</label></div>' .
-				'</div>';
-
-		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
-				'<h3>Year</h3>' .
-				'<div><input type="checkbox" id="jetpack-search-form__test-filter-3" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-3" class="jetpack-search-form__test-filter-label">2020</label></div>' .
-				'<div><input type="checkbox" id="jetpack-search-form__test-filter-4" class="jetpack-search-form__test-filter-checkbox">' .
-				'<label for="jetpack-search-form__test-filter-4" class="jetpack-search-form__test-filter-label">2019</label></div></div>';
 
 		echo '<div class="jetpack-search-form">';
 		echo $form;

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -176,6 +176,8 @@ class Jetpack_Search_Template_Tags {
 				}
 				if ( 'category_name' === $tax_key ) {
 					$data_base .= 'data-taxonomy="category"';
+				} elseif ( 'tag' === $tax_key ) {
+					$data_base .= 'data-taxonomy="post_tag"';
 				} else {
 					$data_base .= 'data-taxonomy="' . $tax_key . '"';
 				}
@@ -184,8 +186,11 @@ class Jetpack_Search_Template_Tags {
 				$data_base = 'data-filter-type="post_types" ';
 				break;
 			case 'date_histogram':
-				$date_slug = $filter['buckets'][0]['interval'] . '_date';
-				$data_base = 'data-filter-type="' . $date_slug . '" ';
+				if ( $filter['buckets'][0]['query_vars']['monthnum'] ) {
+					$data_base = 'data-filter-type="month_post_date" ';
+				} else {
+					$data_base = 'data-filter-type="year_post_date" ';
+				}
 				break;
 		}
 
@@ -205,11 +210,12 @@ class Jetpack_Search_Template_Tags {
 						$data_str .= 'data-val="' . $item['query_vars']['post_type'] . '"';
 						break;
 					case 'date_histogram':
-						if ( 'month' === $item['interval'] ) {
-							$data_str .= 'data-val="' . $item['query_vars']['year'] . '-' . $item['query_vars']['month'] . '"';
+						if ( $item['query_vars']['monthnum'] ) {
+							$d = sprintf( '%d-%02d-01 00:00:00', $item['query_vars']['year'], $item['query_vars']['monthnum'] );
 						} else {
-							$data_str .= 'data-val="' . $item['query_vars']['year'] . '" ';
+							$d = sprintf( '%d-01-01 00:00:00', $item['query_vars']['year'] );
 						}
+						$data_str .= 'data-val="' . $d . '" ';
 						break;
 				}
 				?>

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -174,6 +174,15 @@ class Jetpack_Search_Template_Tags {
 
 		$form = self::inject_hidden_form_fields( $form, $fields_to_inject );
 
+		// Temporarily add some dummy filters to demonstrate filter behaviour.
+		$form .= '<div class="jetpack-search-form__test-filters" style="margin-top: 20px">' .
+				'<h3>Filters</h3>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-1" class="jetpack-search-form__test-filter-label">Test filter 1</label></div>' .
+				'<div><input type="checkbox" id="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-checkbox">' .
+				'<label for="jetpack-search-form__test-filter-2" class="jetpack-search-form__test-filter-label">Test filter 2</label></div>' .
+				'</div>';
+
 		echo '<div class="jetpack-search-form">';
 		echo $form;
 		echo '</div>';

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -4,7 +4,7 @@
 	width: 100vw;
 	height: 100vh;
 	opacity: 0.975;
-	transition: opacity 0.5s linear, 0.5s transform ease-in-out;
+	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
 	position: fixed;
 	background: white;
 	padding: 3em 1em;
@@ -14,7 +14,7 @@
 	animation-fill-mode: forwards;
 
 	&.is-hidden {
-		transform: translateX( 200vw );
+		transform: translateX( 100vw );
 	}
 }
 

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -4,16 +4,17 @@
 	width: 100vw;
 	height: 100vh;
 	opacity: 0.975;
-	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
+	transition: opacity 0.5s linear, 0.5s transform ease-in-out;
 	position: fixed;
 	background: white;
 	padding: 3em 1em;
 	overflow-y: auto;
 	overflow-x: hidden;
 	z-index: 9999999999999;
+	animation-fill-mode: forwards;
 
 	&.is-hidden {
-		transform: translateY( -100vh );
+		transform: translateX( 200vw );
 	}
 }
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -73,6 +73,10 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.addEventListener( 'change', this.handleSortChange );
 		} );
+
+		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
+			element.addEventListener( 'click', this.handleFilterInputClick );
+		} );
 	}
 
 	removeEventListeners() {
@@ -86,6 +90,10 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.removeEventListener( 'change', this.handleSortChange );
+		} );
+
+		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
+			element.removeEventListener( 'click', this.handleFilterInputClick );
 		} );
 	}
 
@@ -108,6 +116,10 @@ class SearchApp extends Component {
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
+	};
+
+	handleFilterInputClick = () => {
+		this.showResults();
 	};
 
 	showResults = () => this.setState( { showResults: true } );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -26,6 +26,7 @@ import {
 	setSortQuery,
 	getSortKeyFromSortOption,
 	getSortOptionFromSortKey,
+	setFilterQuery,
 } from '../lib/query-string';
 
 class SearchApp extends Component {
@@ -118,7 +119,24 @@ class SearchApp extends Component {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
 	};
 
-	handleFilterInputClick = () => {
+	handleFilterInputClick = event => {
+		event.preventDefault();
+
+		switch ( event.target.dataset.filterType ) {
+			case 'post_type':
+				setFilterQuery( 'post_types', event.target.dataset.postType );
+				break;
+			case 'date':
+				if ( event.target.dataset.month ) {
+					setFilterQuery( 'month_post_date', event.target.dataset.dateVal );
+				} else {
+					setFilterQuery( 'year_post_date', event.target.dataset.dateVal );
+				}
+				break;
+			case 'taxonomy':
+				setFilterQuery( event.target.dataset.taxonomy, event.target.dataset.val );
+				break;
+		}
 		this.showResults();
 	};
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -135,10 +135,12 @@ class SearchApp extends Component {
 	handleFilterInputClick = event => {
 		event.preventDefault();
 
-		if ( event.target.dataset.filterType === 'taxonomy' ) {
-			setFilterQuery( event.target.dataset.taxonomy, event.target.dataset.val );
-		} else {
-			setFilterQuery( event.target.dataset.filterType, event.target.dataset.val );
+		if ( event.target.dataset.filterType ) {
+			if ( event.target.dataset.filterType === 'taxonomy' ) {
+				setFilterQuery( event.target.dataset.taxonomy, event.target.dataset.val );
+			} else {
+				setFilterQuery( event.target.dataset.filterType, event.target.dataset.val );
+			}
 		}
 		this.showResults();
 	};

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -122,20 +122,10 @@ class SearchApp extends Component {
 	handleFilterInputClick = event => {
 		event.preventDefault();
 
-		switch ( event.target.dataset.filterType ) {
-			case 'post_type':
-				setFilterQuery( 'post_types', event.target.dataset.postType );
-				break;
-			case 'date':
-				if ( event.target.dataset.month ) {
-					setFilterQuery( 'month_post_date', event.target.dataset.dateVal );
-				} else {
-					setFilterQuery( 'year_post_date', event.target.dataset.dateVal );
-				}
-				break;
-			case 'taxonomy':
-				setFilterQuery( event.target.dataset.taxonomy, event.target.dataset.val );
-				break;
+		if ( event.target.dataset.filterType === 'taxonomy' ) {
+			setFilterQuery( event.target.dataset.taxonomy, event.target.dataset.val );
+		} else {
+			setFilterQuery( event.target.dataset.filterType, event.target.dataset.val );
 		}
 		this.showResults();
 	};

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -23,12 +23,6 @@ $grid-size-large: 16px;
 	opacity: 0.2;
 }
 
-// Temporary test styles
-.jetpack-search-form__test-filter-checkbox {
-	display: none;
-}
-
-.jetpack-search-form__test-filter-label:hover {
-	text-decoration: underline;
-	cursor: pointer;
+.jetpack-search-filters-widget__filter-list {
+	list-style-type: none;
 }

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -21,3 +21,12 @@ $grid-size-large: 16px;
 .jetpack-instant-search__is-loading {
 	opacity: 0.2;
 }
+
+.jetpack-search-form__test-filter-checkbox {
+	display: none;
+}
+
+.jetpack-search-form__test-filter-label:hover {
+	text-decoration: underline;
+	cursor: pointer;
+}

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -22,6 +22,7 @@ $grid-size-large: 16px;
 	opacity: 0.2;
 }
 
+// Temporary test styles
 .jetpack-search-form__test-filter-checkbox {
 	display: none;
 }

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -13,6 +13,10 @@ export function getThemeOptions( searchOptions ) {
 			'.jetpack-instant-search-wrapper input.search-field',
 		].join( ', ' ),
 		searchSortSelector: [ '.jetpack-search-sort' ],
+		filterInputSelector: [
+			'.jetpack-search-form__test-filter-checkbox',
+			'.jetpack-search-form__test-filter-label',
+		],
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;
 }

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -14,10 +14,7 @@ export function getThemeOptions( searchOptions ) {
 			'.jetpack-instant-search-wrapper input.search-field',
 		].join( ', ' ),
 		searchSortSelector: [ '.jetpack-search-sort' ],
-		filterInputSelector: [
-			'.jetpack-search-form__test-filter-checkbox',
-			'.jetpack-search-form__test-filter-label',
-		],
+		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;
 }

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -92,7 +92,11 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		add_action( 'jetpack_search_render_filters_widget_title', array( 'Jetpack_Search_Template_Tags', 'render_widget_title' ), 10, 3 );
-		add_action( 'jetpack_search_render_filters', array( 'Jetpack_Search_Template_Tags', 'render_available_filters' ), 10, 2 );
+		if ( Jetpack_Search_Options::is_instant_enabled() ) {
+			add_action( 'jetpack_search_render_filters', array( 'Jetpack_Search_Template_Tags', 'render_instant_filters' ), 10, 2 );
+		} else {
+			add_action( 'jetpack_search_render_filters', array( 'Jetpack_Search_Template_Tags', 'render_available_filters' ), 10, 2 );
+		}
 	}
 
 	/**

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -500,10 +500,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @param array $instance The current widget instance.
 	 */
 	public function widget_empty_instant( $args, $instance ) {
-		if ( Jetpack_Search_Helpers::should_rerun_search_in_customizer_preview() ) {
-			Jetpack_Search::instance()->update_search_results_aggregations();
-		}
-
 		$title = isset( $instance['title'] ) ? $instance['title'] : '';
 
 		if ( empty( $title ) ) {

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -289,7 +289,11 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		if ( Jetpack_Search_Options::is_instant_enabled() ) {
-			$this->widget_instant( $args, $instance );
+			if ( 'jetpack-instant-search-sidebar' === $args['id'] ) {
+				$this->widget_empty_instant( $args, $instance );
+			} else {
+				$this->widget_instant( $args, $instance );
+			}
 		} else {
 			$this->widget_non_instant( $args, $instance );
 		}
@@ -486,6 +490,53 @@ class Jetpack_Search_Widget extends WP_Widget {
 		echo '</div>';
 		echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
+
+	/**
+	 * Render the instant widget for the overlay.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param array $args     Widgets args supplied by the theme.
+	 * @param array $instance The current widget instance.
+	 */
+	public function widget_empty_instant( $args, $instance ) {
+		if ( Jetpack_Search_Helpers::should_rerun_search_in_customizer_preview() ) {
+			Jetpack_Search::instance()->update_search_results_aggregations();
+		}
+
+		$title = isset( $instance['title'] ) ? $instance['title'] : '';
+
+		if ( empty( $title ) ) {
+			$title = '';
+		}
+
+		/** This filter is documented in core/src/wp-includes/default-widgets.php */
+		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
+
+		echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		?>
+			<div id="<?php echo esc_attr( $this->id ); ?>-wrapper" class="jetpack-instant-search-wrapper">
+		<?php
+
+		if ( ! empty( $title ) ) {
+			/**
+			 * Responsible for displaying the title of the Jetpack Search filters widget.
+			 *
+			 * @module search
+			 *
+			 * @since  5.7.0
+			 *
+			 * @param string $title                The widget's title
+			 * @param string $args['before_title'] The HTML tag to display before the title
+			 * @param string $args['after_title']  The HTML tag to display after the title
+			 */
+			do_action( 'jetpack_search_render_filters_widget_title', $title, $args['before_title'], $args['after_title'] );
+		}
+
+		echo '</div>';
+		echo $args['after_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
 
 	/**
 	 * Renders JavaScript for the sorting controls on the frontend.


### PR DESCRIPTION
Render filters on the front end outside of the overlay and open the overlay when they are clicked on.

Two open bugs:
- currently the filters always use post_date for dates
- the filters that get added to the url don't get cleared when the user exits the overlay (same for the search param)

Testing:
- configure a bunch of front end filters in the sidebar: tags, categories, post types, dates
- also configure them in the overlay
- load the front end and click around

Note: the trick of passing a blog_id into the url won't work for the php rendered filters.

Based off of #14320 