### PR TITLE
Connection\Manager: Use jetpack_master_user class constant

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -528,7 +528,7 @@ class Manager {
 	 * @return string|int Returns the ID of the connection owner or False if no connection owner found.
 	 */
 	public function get_connection_owner_id() {
-		$user_token       = $this->get_access_token( JETPACK_MASTER_USER );
+		$user_token       = $this->get_access_token( self::JETPACK_MASTER_USER );
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
 			$connection_owner = $user_token->external_user_id;
@@ -603,7 +603,7 @@ class Manager {
 	 * @return object|false False if no connection owner found.
 	 */
 	public function get_connection_owner() {
-		$user_token = $this->get_access_token( JETPACK_MASTER_USER );
+		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER );
 
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
@@ -625,7 +625,7 @@ class Manager {
 			$user_id = get_current_user_id();
 		}
 
-		$user_token = $this->get_access_token( JETPACK_MASTER_USER );
+		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER );
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* There are few cases in the Manager class where the global `JETPACK_MASTER_USER` constant is used. Convert those to the class constant. The global constant is set in Jetpack, so this change helps to separate the connection package from Jetpack.
* This does not change any behavior. Jetpack defines the global `JETPACK_MASTER_USER` constant as `true` [here](https://github.com/Automattic/jetpack/blob/master/jetpack.php#L19). The Connection\Manager class sets its `JETPACK_MASTER_USER` constant to `true` [here](https://github.com/Automattic/jetpack/blob/master/packages/connection/src/class-manager.php#L24).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
* No testing is required.

#### Proposed changelog entry for your changes:
* n/a
