### PR TITLE
Instant Search: Update filter toggle to work with widget area

### DIFF
--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -7,9 +7,15 @@
 .jetpack-instant-search__box-filter-icon {
 	margin-left: 8px;
 	cursor: pointer;
+
+	// TODO: To be updated to break-medium
+	@include break-small() {
+		display: none;
+	}
 }
 
 /* apply to all the inputs to try and pick up any theme styling */
-.jetpack-instant-search__box input {
+.jetpack-instant-search__box input,
+.jetpack-instant-search__box input[type='search'].jetpack-instant-search__box-input {
 	width: 100%;
 }

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { Component, Fragment, h } from 'preact';
+import { Component, h } from 'preact';
 
 /**
  * Internal dependencies
@@ -32,14 +32,23 @@ class SearchForm extends Component {
 	onChangeQuery = event => setSearchQuery( event.target.value );
 	onChangeSort = sort => setSortQuery( sort );
 
-	toggleFilters = () => {
-		this.setState( state => ( { showFilters: ! state.showFilters } ) );
+	toggleFilters = event => {
+		if (
+			event.type === 'click' ||
+			( event.type === 'keydown' && ( event.key === 'Enter' || event.key === ' ' ) )
+		) {
+			// Prevent page scroll from pressing spacebar
+			if ( event.key === ' ' ) {
+				event.preventDefault();
+			}
+			this.setState( state => ( { showFilters: ! state.showFilters } ) );
+		}
 	};
 
 	render() {
 		return (
 			<form onSubmit={ noop } role="search" className={ this.props.className }>
-				<div className="search-form">
+				<div className="search-form jetpack-instant-search__search-form">
 					<SearchBox
 						enableFilters
 						onChangeQuery={ this.onChangeQuery }
@@ -52,18 +61,20 @@ class SearchForm extends Component {
 					/>
 				</div>
 				{ this.state.showFilters && (
-					<Fragment>
+					<div className="jetpack-instant-search__search-form-filters">
 						<SearchSort onChange={ this.onChangeSort } value={ getSortQuery() } />
-						<SearchFilters
-							filters={ getFilterQuery() }
-							loading={ this.props.isLoading }
-							locale={ this.props.locale }
-							onChange={ this.onChangeFilter }
-							postTypes={ this.props.postTypes }
-							results={ this.props.response }
-							widget={ this.props.widget }
-						/>
-					</Fragment>
+						{ this.props.widgets.map( widget => (
+							<SearchFilters
+								filters={ getFilterQuery() }
+								loading={ this.props.isLoading }
+								locale={ this.props.locale }
+								onChange={ this.onChangeFilter }
+								postTypes={ this.props.postTypes }
+								results={ this.props.response }
+								widget={ widget }
+							/>
+						) ) }
+					</div>
 				) }
 			</form>
 		);

--- a/modules/search/instant-search/components/search-form.scss
+++ b/modules/search/instant-search/components/search-form.scss
@@ -1,3 +1,6 @@
-.jetpack-instant-search__search-results-search-form {
-	margin-bottom: 1em;
+.jetpack-instant-search__search-form-filters {
+	// TODO: To be updated to break-medium
+	@include break-small() {
+		display: none;
+	}
 }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -59,7 +59,14 @@ class SearchResults extends Component {
 						`,
 					} }
 				/>
-				<SearchForm className="jetpack-instant-search__search-results-search-form" />
+				<SearchForm
+					className="jetpack-instant-search__search-results-search-form"
+					isLoading={ this.props.isLoading }
+					locale={ this.props.locale }
+					postTypes={ this.props.postTypes }
+					response={ this.props.response }
+					widgets={ this.props.widgets }
+				/>
 
 				<div
 					className={

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -65,6 +65,7 @@
 .jetpack-instant-search__search-results-search-form {
 	// Only display the search form in the main column at the smallest breakpoint
 	font-size: 0.8em;
+	margin-bottom: 1em;
 
 	.jetpack-instant-search__sort-select {
 		font-size: 0.9em;

--- a/modules/search/instant-search/components/search-sidebar.scss
+++ b/modules/search/instant-search/components/search-sidebar.scss
@@ -1,0 +1,9 @@
+.jetpack-instant-search__sidebar {
+	.jetpack-filters.widget_search,
+	.jetpack-instant-search-wrapper {
+		// TODO: To be updated to break-medium
+		@media ( max-width: #{ ( $break-small ) } ) {
+			display: none;
+		}
+	}
+}

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -17,6 +17,7 @@ $grid-size-large: 16px;
 @import './components/search-form.scss';
 @import './components/search-result-minimal.scss';
 @import './components/search-result-product.scss';
+@import './components/search-sidebar.scss';
 
 .jetpack-instant-search__is-loading {
 	opacity: 0.2;


### PR DESCRIPTION
Fixes #14450. Visuals are not final.

<img width="447" alt="Screen Shot 2020-01-23 at 4 56 25 PM" src="https://user-images.githubusercontent.com/4044428/73034137-5a5aa200-3e01-11ea-91c3-e0ac6633333e.png">

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hides the filter toggle for bigger viewports.
* Hides the filter popover for bigger viewports.
* Hides the filters in the sidebar for smaller viewports.
* Updates the filter toggle event handler to only react to `Enter` and `Space`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Perform a site search to spawn the search overlay.
3. Resize your viewport below `600px`.
4. Ensure that a filter toggle appears next to the overlay search input.
5. Ensure that clicking the filter toggle spawns the search filters directly below the search input.
6. Ensure that the search filters in the widget sidebar have been hidden.
7. While the search filter toggle is enabled, resize the window above `600px`; ensure that the filters in the search results column have been hidden.

#### Proposed changelog entry for your changes:
* No.
