### PR TITLE
Blocks: Add support for Collections

### DIFF
--- a/extensions/blocks/amazon/index.js
+++ b/extensions/blocks/amazon/index.js
@@ -14,6 +14,7 @@ import edit from './edit';
  * Style dependencies
  */
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'amazon';
 export const title = __( 'Amazon', 'jetpack' );
@@ -22,7 +23,7 @@ export const settings = {
 	title,
 	description: __( 'Promote Amazon products and earn a commission from sales.', 'jetpack' ),
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'earn' : 'jetpack',
 	keywords: [ __( 'amazon', 'jetpack' ), __( 'affiliate', 'jetpack' ) ],
 	supports: {
 		align: true,

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { Path } from '@wordpress/components';
+import { registerBlockCollection } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -82,7 +83,7 @@ export const settings = {
 	title: __( 'Business Hours', 'jetpack' ),
 	description: __( 'Display opening hours for your business.', 'jetpack' ),
 	icon,
-	category: 'jetpack',
+	category: typeof registerBlockCollection === 'function' ? 'widgets' : 'jetpack',
 	supports: {
 		html: true,
 	},

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -83,7 +83,7 @@ export const settings = {
 	title: __( 'Business Hours', 'jetpack' ),
 	description: __( 'Display opening hours for your business.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	supports: {
 		html: true,
 	},

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -3,7 +3,6 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import { Path } from '@wordpress/components';
-import { registerBlockCollection } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -12,6 +11,7 @@ import './editor.scss';
 import './style.scss';
 import BusinessHours from './edit';
 import renderMaterialIcon from '../../shared/render-material-icon';
+import { supportsCollections } from '../../shared/block-category';
 
 /**
  * Block Registrations:
@@ -83,7 +83,7 @@ export const settings = {
 	title: __( 'Business Hours', 'jetpack' ),
 	description: __( 'Display opening hours for your business.', 'jetpack' ),
 	icon,
-	category: typeof registerBlockCollection === 'function' ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	supports: {
 		html: true,
 	},

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -83,7 +83,7 @@ export const settings = {
 	title: __( 'Business Hours', 'jetpack' ),
 	description: __( 'Display opening hours for your business.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	supports: {
 		html: true,
 	},

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	title,
 	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	keywords: [
 		_x( 'calendar', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	title,
 	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	keywords: [
 		_x( 'calendar', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -16,6 +16,7 @@ import { getAttributesFromEmbedCode, REGEX } from './utils';
  * Style dependencies
  */
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const CALENDLY_EXAMPLE_URL = 'https://calendly.com/wordpresscom/jetpack-block-example';
 
@@ -25,7 +26,7 @@ export const settings = {
 	title,
 	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	keywords: [
 		_x( 'calendar', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -175,7 +175,7 @@ export const settings = {
 };
 
 const FieldDefaults = {
-	category: 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	parent: [ 'jetpack/contact-form' ],
 	supports: {
 		reusable: false,

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -18,6 +18,7 @@ import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import renderMaterialIcon from '../../shared/render-material-icon';
 import colorValidator from '../../shared/colorValidator';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'contact-form';
 
@@ -32,7 +33,7 @@ export const settings = {
 		_x( 'feedback', 'block search term', 'jetpack' ),
 		_x( 'contact form', 'block search term', 'jetpack' ),
 	],
-	category: 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	supports: {
 		html: false,
 	},

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -33,7 +33,7 @@ export const settings = {
 		_x( 'feedback', 'block search term', 'jetpack' ),
 		_x( 'contact form', 'block search term', 'jetpack' ),
 	],
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	supports: {
 		html: false,
 	},
@@ -175,7 +175,7 @@ export const settings = {
 };
 
 const FieldDefaults = {
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	parent: [ 'jetpack/contact-form' ],
 	supports: {
 		reusable: false,

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -33,7 +33,7 @@ export const settings = {
 		_x( 'feedback', 'block search term', 'jetpack' ),
 		_x( 'contact form', 'block search term', 'jetpack' ),
 	],
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	supports: {
 		html: false,
 	},

--- a/extensions/blocks/contact-info/address/index.js
+++ b/extensions/blocks/contact-info/address/index.js
@@ -64,7 +64,7 @@ export const settings = {
 			<Circle cx="12" cy="9" r="2.5" />
 		</Fragment>
 	),
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	attributes,
 	parent: [ 'jetpack/contact-info' ],
 	edit,

--- a/extensions/blocks/contact-info/address/index.js
+++ b/extensions/blocks/contact-info/address/index.js
@@ -11,6 +11,7 @@ import { Path, Circle } from '@wordpress/components';
 import edit from './edit';
 import save from './save';
 import renderMaterialIcon from '../../../shared/render-material-icon';
+import { supportsCollections } from '../../../shared/block-category';
 
 const attributes = {
 	address: {
@@ -63,7 +64,7 @@ export const settings = {
 			<Circle cx="12" cy="9" r="2.5" />
 		</Fragment>
 	),
-	category: 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	attributes,
 	parent: [ 'jetpack/contact-info' ],
 	edit,

--- a/extensions/blocks/contact-info/email/index.js
+++ b/extensions/blocks/contact-info/email/index.js
@@ -10,6 +10,7 @@ import { Path } from '@wordpress/components';
 import edit from './edit';
 import renderMaterialIcon from '../../../shared/render-material-icon';
 import save from './save';
+import { supportsCollections } from '../../../shared/block-category';
 
 const attributes = {
 	email: {
@@ -34,7 +35,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 	),
-	category: 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	attributes,
 	edit,
 	save,

--- a/extensions/blocks/contact-info/email/index.js
+++ b/extensions/blocks/contact-info/email/index.js
@@ -35,7 +35,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 	),
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	attributes,
 	edit,
 	save,

--- a/extensions/blocks/contact-info/index.js
+++ b/extensions/blocks/contact-info/index.js
@@ -15,6 +15,7 @@ import './style.scss';
 import { name as addressName, settings as addressSettings } from './address/';
 import { name as emailName, settings as emailSettings } from './email/';
 import { name as phoneName, settings as phoneSettings } from './phone/';
+import { supportsCollections } from '../../shared/block-category';
 
 const attributes = {};
 
@@ -40,7 +41,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M19 5v14H5V5h14m0-2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 9c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zm6 10H6v-1.53c0-2.5 3.97-3.58 6-3.58s6 1.08 6 3.58V18zm-9.69-2h7.38c-.69-.56-2.38-1.12-3.69-1.12s-3.01.56-3.69 1.12z" />
 	),
-	category: 'jetpack',
+	category: supportsCollections() ? 'formatting' : 'jetpack',
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/extensions/blocks/contact-info/index.js
+++ b/extensions/blocks/contact-info/index.js
@@ -41,7 +41,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M19 5v14H5V5h14m0-2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 9c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zm6 10H6v-1.53c0-2.5 3.97-3.58 6-3.58s6 1.08 6 3.58V18zm-9.69-2h7.38c-.69-.56-2.38-1.12-3.69-1.12s-3.01.56-3.69 1.12z" />
 	),
-	category: supportsCollections() ? 'formatting' : 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/extensions/blocks/contact-info/index.js
+++ b/extensions/blocks/contact-info/index.js
@@ -41,7 +41,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M19 5v14H5V5h14m0-2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 9c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zm6 10H6v-1.53c0-2.5 3.97-3.58 6-3.58s6 1.08 6 3.58V18zm-9.69-2h7.38c-.69-.56-2.38-1.12-3.69-1.12s-3.01.56-3.69 1.12z" />
 	),
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/extensions/blocks/contact-info/phone/index.js
+++ b/extensions/blocks/contact-info/phone/index.js
@@ -10,6 +10,7 @@ import { Path } from '@wordpress/components';
 import edit from './edit';
 import renderMaterialIcon from '../../../shared/render-material-icon';
 import save from './save';
+import { supportsCollections } from '../../../shared/block-category';
 
 const attributes = {
 	phone: {
@@ -34,7 +35,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 	),
-	category: 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	attributes,
 	parent: [ 'jetpack/contact-info' ],
 	edit,

--- a/extensions/blocks/contact-info/phone/index.js
+++ b/extensions/blocks/contact-info/phone/index.js
@@ -35,7 +35,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 	),
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	attributes,
 	parent: [ 'jetpack/contact-info' ],
 	edit,

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -12,6 +12,7 @@ import attributes from './attributes';
 import deprecated from './deprecated/v1';
 import edit from './edit';
 import save from './save';
+import { supportsCollections } from '../../shared/block-category';
 
 // Example URLs
 // https://www.eventbrite.com/e/test-event-tickets-123456789
@@ -41,7 +42,7 @@ export const settings = {
 	title,
 	description: __( 'Embed Eventbrite event details and ticket checkout.', 'jetpack' ),
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	keywords: [
 		_x( 'events', 'block search term', 'jetpack' ),
 		_x( 'tickets', 'block search term', 'jetpack' ),

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -42,7 +42,7 @@ export const settings = {
 	title,
 	description: __( 'Embed Eventbrite event details and ticket checkout.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 	keywords: [
 		_x( 'events', 'block search term', 'jetpack' ),
 		_x( 'tickets', 'block search term', 'jetpack' ),

--- a/extensions/blocks/gif/index.js
+++ b/extensions/blocks/gif/index.js
@@ -27,7 +27,7 @@ export const icon = (
 export const settings = {
 	title,
 	icon,
-	category: supportsCollections() ? 'formatting' : 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 	keywords: [
 		_x( 'animated', 'block search term', 'jetpack' ),
 		_x( 'giphy', 'block search term', 'jetpack' ),

--- a/extensions/blocks/gif/index.js
+++ b/extensions/blocks/gif/index.js
@@ -12,6 +12,7 @@ import edit from './edit';
 // Ordering is important! Editor overrides style!
 import './style.scss';
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'gif';
 export const title = __( 'GIF', 'jetpack' );
@@ -26,7 +27,7 @@ export const icon = (
 export const settings = {
 	title,
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'formatting' : 'jetpack',
 	keywords: [
 		_x( 'animated', 'block search term', 'jetpack' ),
 		_x( 'giphy', 'block search term', 'jetpack' ),

--- a/extensions/blocks/google-calendar/index.js
+++ b/extensions/blocks/google-calendar/index.js
@@ -11,6 +11,7 @@ import edit from './edit';
 import { extractAttributesFromIframe, URL_REGEX, IFRAME_REGEX } from './utils';
 import './editor.scss';
 import icon from './icon';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'google-calendar';
 export const title = __( 'Google Calendar', 'jetpack' );
@@ -25,7 +26,7 @@ export const settings = {
 		_x( 'appointments', 'block search term', 'jetpack' ),
 	],
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'embeds' : 'jetpack',
 	supports: {
 		align: true,
 		alignWide: true,

--- a/extensions/blocks/google-calendar/index.js
+++ b/extensions/blocks/google-calendar/index.js
@@ -26,7 +26,7 @@ export const settings = {
 		_x( 'appointments', 'block search term', 'jetpack' ),
 	],
 	icon,
-	category: supportsCollections() ? 'embeds' : 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 	supports: {
 		align: true,
 		alignWide: true,

--- a/extensions/blocks/instagram-gallery/index.js
+++ b/extensions/blocks/instagram-gallery/index.js
@@ -8,6 +8,7 @@ import { __, _x } from '@wordpress/i18n';
  */
 import attributes from './attributes';
 import edit from './edit';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'instagram-gallery';
 
@@ -15,7 +16,7 @@ export const settings = {
 	title: __( 'Instagram Gallery', 'jetpack' ),
 	description: __( 'Embed posts from your Instagram account', 'jetpack' ),
 	icon: 'instagram',
-	category: 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 	keywords: [
 		_x( 'images', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -24,7 +24,7 @@ export const settings = {
 	title: __( 'Mailchimp', 'jetpack' ),
 	icon,
 	description: __( 'A form enabling readers to join a Mailchimp list.', 'jetpack' ),
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -9,6 +9,7 @@ import { Path, SVG } from '@wordpress/components';
  */
 import edit from './edit';
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'mailchimp';
 
@@ -23,7 +24,7 @@ export const settings = {
 	title: __( 'Mailchimp', 'jetpack' ),
 	icon,
 	description: __( 'A form enabling readers to join a Mailchimp list.', 'jetpack' ),
-	category: 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -34,7 +34,7 @@ export const settings = {
 			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
 		</svg>
 	),
-	category: supportsCollections() ? 'common' : 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 	keywords: [
 		_x( 'maps', 'block search term', 'jetpack' ),
 		_x( 'location', 'block search term', 'jetpack' ),

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -13,6 +13,7 @@ import defaultTheme from './map-theme_default.jpg';
 import blackAndWhiteTheme from './map-theme_black_and_white.jpg';
 import satelliteTheme from './map-theme_satellite.jpg';
 import terrainTheme from './map-theme_terrain.jpg';
+import { supportsCollections } from '../../shared/block-category';
 
 export const settings = {
 	name: 'map',
@@ -33,7 +34,7 @@ export const settings = {
 			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
 		</svg>
 	),
-	category: 'jetpack',
+	category: supportsCollections() ? 'common' : 'jetpack',
 	keywords: [
 		_x( 'maps', 'block search term', 'jetpack' ),
 		_x( 'location', 'block search term', 'jetpack' ),

--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -12,6 +12,7 @@ import './editor.scss';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import edit from './edit';
 import save from './save';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'markdown';
 
@@ -57,7 +58,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: 'jetpack',
+	category: supportsCollections() ? 'formatting' : 'jetpack',
 
 	keywords: [
 		_x( 'formatting', 'block search term', 'jetpack' ),

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -20,12 +20,13 @@ import './view.scss';
 export const name = 'opentable';
 export const title = __( 'OpenTable', 'jetpack' );
 import { getAttributesFromEmbedCode, restRefRegex, ridRegex } from './utils';
+import { supportsCollections } from '../../shared/block-category';
 
 export const settings = {
 	title,
 	description: __( 'Allow visitors to book a reservation with OpenTable', 'jetpack' ),
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	keywords: [
 		_x( 'booking', 'block search term', 'jetpack' ),
 		_x( 'reservation', 'block search term', 'jetpack' ),

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -26,7 +26,7 @@ export const settings = {
 	title,
 	description: __( 'Allow visitors to book a reservation with OpenTable', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'earn' : 'jetpack',
 	keywords: [
 		_x( 'booking', 'block search term', 'jetpack' ),
 		_x( 'reservation', 'block search term', 'jetpack' ),

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -33,7 +33,7 @@ export const settings = {
 
 	icon,
 
-	category: supportsCollections() ? 'embeds' : 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 
 	keywords: [
 		_x( 'social', 'block search term', 'jetpack' ),

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -10,6 +10,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import { pinType } from './utils';
+import { supportsCollections } from '../../shared/block-category';
 
 export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^/]+)(\/[^/]+)?/i;
 
@@ -32,7 +33,7 @@ export const settings = {
 
 	icon,
 
-	category: 'jetpack',
+	category: supportsCollections() ? 'embeds' : 'jetpack',
 
 	keywords: [
 		_x( 'social', 'block search term', 'jetpack' ),

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -19,6 +19,7 @@ import { queueMusic } from './icons/';
  */
 import './style.scss';
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'podcast-player';
 export const namespaceName = `jetpack/${ name }`;
@@ -27,7 +28,7 @@ export const settings = {
 	title,
 	description: __( 'Select and play episodes from a single podcast.', 'jetpack' ),
 	icon: queueMusic,
-	category: 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 	keywords: [
 		_x( 'audio', 'block search term', 'jetpack' ),
 		_x( 'embed', 'block search term', 'jetpack' ),

--- a/extensions/blocks/rating-star/index.js
+++ b/extensions/blocks/rating-star/index.js
@@ -11,6 +11,7 @@ import save from './save';
 import { StarIcon, StarBlockIcon } from './icon';
 import './editor.scss';
 import './style.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'rating-star';
 
@@ -26,7 +27,7 @@ export const settings = {
 		_x( 'rating', 'block search term', 'jetpack' ),
 		_x( 'review', 'block search term', 'jetpack' ),
 	],
-	category: 'jetpack',
+	category: supportsCollections() ? 'formatting' : 'jetpack',
 	example: {},
 	styles: [
 		{

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -11,6 +11,7 @@ import { trimEnd } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import edit from './edit';
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'recurring-payments';
 
@@ -27,7 +28,7 @@ export const settings = {
 	title: __( 'Recurring Payments', 'jetpack' ),
 	icon,
 	description: __( 'Button allowing you to sell subscription products.', 'jetpack' ),
-	category: 'jetpack',
+	category: supportsCollections() ? 'earn' : 'jetpack',
 	keywords: [
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'subscriptions', 'block search term', 'jetpack' ),

--- a/extensions/blocks/related-posts/index.js
+++ b/extensions/blocks/related-posts/index.js
@@ -9,6 +9,7 @@ import { G, Path, SVG } from '@wordpress/components';
  */
 import edit from './edit';
 import './style.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'related-posts';
 
@@ -23,7 +24,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: 'jetpack',
+	category: supportsCollections() ? 'embed' : 'jetpack',
 
 	keywords: [
 		_x( 'similar content', 'block search term', 'jetpack' ),

--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -12,6 +12,7 @@ import edit from './components/edit';
 import save from './components/save';
 import { CRITERIA_AFTER, DEFAULT_THRESHOLD } from './constants';
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'repeat-visitor';
 export const icon = renderMaterialIcon(
@@ -28,7 +29,7 @@ export const settings = {
 			default: DEFAULT_THRESHOLD,
 		},
 	},
-	category: 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	description: __(
 		'Control block visibility based on how often a visitor has viewed the page.',
 		'jetpack'

--- a/extensions/blocks/revue/index.js
+++ b/extensions/blocks/revue/index.js
@@ -9,6 +9,7 @@ import { __, _x } from '@wordpress/i18n';
 import attributes from './attributes';
 import edit from './edit';
 import icon from './icon';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'revue';
 
@@ -16,7 +17,7 @@ export const settings = {
 	title: __( 'Revue', 'jetpack' ),
 	description: __( 'Add a subscription form for your Revue newsletter.', 'jetpack' ),
 	icon,
-	category: 'jetpack',
+	category: supportsCollections() ? 'widgets' : 'jetpack',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/revue/index.js
+++ b/extensions/blocks/revue/index.js
@@ -17,7 +17,7 @@ export const settings = {
 	title: __( 'Revue', 'jetpack' ),
 	description: __( 'Add a subscription form for your Revue newsletter.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/revue/index.js
+++ b/extensions/blocks/revue/index.js
@@ -17,7 +17,7 @@ export const settings = {
 	title: __( 'Revue', 'jetpack' ),
 	description: __( 'Add a subscription form for your Revue newsletter.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -22,6 +22,7 @@ import simplePaymentsExample1 from './simple-payments_example-1.jpg';
  * Styles
  */
 import './editor.scss';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'simple-payments';
 
@@ -55,7 +56,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: 'jetpack',
+	category: supportsCollections() ? 'earn' : 'jetpack',
 
 	keywords: [
 		_x( 'buy', 'block search term', 'jetpack' ),

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -112,7 +112,7 @@ export const name = 'slideshow';
 
 export const settings = {
 	title: __( 'Slideshow', 'jetpack' ),
-	category: supportsCollections() ? 'common' : 'jetpack',
+	category: supportsCollections() ? 'layout' : 'jetpack',
 	keywords: [
 		_x( 'image', 'block search term', 'jetpack' ),
 		_x( 'gallery', 'block search term', 'jetpack' ),

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -10,6 +10,7 @@ import { Path, SVG } from '@wordpress/components';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
+import { supportsCollections } from '../../shared/block-category';
 
 /**
  * Example Images
@@ -111,7 +112,7 @@ export const name = 'slideshow';
 
 export const settings = {
 	title: __( 'Slideshow', 'jetpack' ),
-	category: 'jetpack',
+	category: supportsCollections() ? 'common' : 'jetpack',
 	keywords: [
 		_x( 'image', 'block search term', 'jetpack' ),
 		_x( 'gallery', 'block search term', 'jetpack' ),

--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -12,6 +12,7 @@ import { RawHTML } from '@wordpress/element';
 import edit from './edit';
 import save from './save';
 import renderMaterialIcon from '../../shared/render-material-icon';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'subscriptions';
 export const settings = {
@@ -28,7 +29,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
 	),
-	category: 'jetpack',
+	category: supportsCollections() ? 'marketing' : 'jetpack',
 
 	keywords: [
 		_x( 'subscribe', 'block search term', 'jetpack' ),

--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -29,7 +29,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M23 16v2h-3v3h-2v-3h-3v-2h3v-3h2v3h3zM20 2v9h-4v3h-3v4H4c-1.1 0-2-.9-2-2V2h18zM8 13v-1H4v1h4zm3-3H4v1h7v-1zm0-2H4v1h7V8zm7-4H4v2h14V4z" />
 	),
-	category: supportsCollections() ? 'marketing' : 'jetpack',
+	category: supportsCollections() ? 'grow' : 'jetpack',
 
 	keywords: [
 		_x( 'subscribe', 'block search term', 'jetpack' ),

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -36,6 +36,7 @@ import tiledGalleryExample3 from './tiled-gallery_example-3.jpg';
 import tiledGalleryExample4 from './tiled-gallery_example-4.jpg';
 import tiledGalleryExample5 from './tiled-gallery_example-5.jpg';
 import tiledGalleryExample6 from './tiled-gallery_example-6.jpg';
+import { supportsCollections } from '../../shared/block-category';
 
 // Style names are translated. Avoid introducing an i18n dependency elsewhere (view)
 // by only including the labels here, the only place they're needed.
@@ -197,7 +198,7 @@ export const icon = (
 
 export const settings = {
 	attributes: blockAttributes,
-	category: 'jetpack',
+	category: supportsCollections() ? 'common' : 'jetpack',
 	description:
 		__( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ) +
 		( ! isSimpleSite()

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -198,7 +198,7 @@ export const icon = (
 
 export const settings = {
 	attributes: blockAttributes,
-	category: supportsCollections() ? 'common' : 'jetpack',
+	category: supportsCollections() ? 'layout' : 'jetpack',
 	description:
 		__( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ) +
 		( ! isSimpleSite()

--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -10,6 +10,7 @@ import { Fragment } from '@wordpress/element';
  */
 import edit from './edit';
 import { DEFAULT_FORMAT } from './constants';
+import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'wordads';
 export const title = __( 'Ad', 'jetpack' );
@@ -56,7 +57,7 @@ export const settings = {
 		attributes: {},
 	},
 
-	category: 'jetpack',
+	category: supportsCollections() ? 'earn' : 'jetpack',
 
 	keywords: [
 		_x( 'ads', 'block search term', 'jetpack' ),

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -1,19 +1,27 @@
 /**
  * External dependencies
  */
-import { getCategories, setCategories } from '@wordpress/blocks';
+import { getCategories, setCategories, registerBlockCollection } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import JetpackLogo from '../shared/jetpack-logo';
 
-setCategories( [
-	...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
-	// Add a Jetpack block category
-	{
-		slug: 'jetpack',
+if ( typeof registerBlockCollection === 'function' ) {
+	registerBlockCollection( 'jetpack', {
 		title: 'Jetpack',
 		icon: <JetpackLogo />,
-	},
-] );
+	} );
+} else {
+	// This can be removed once G 7.3 is shipped in the Core version that is JP's minimum.
+	setCategories( [
+		...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
+		// Add a Jetpack block category
+		{
+			slug: 'jetpack',
+			title: 'Jetpack',
+			icon: <JetpackLogo />,
+		},
+	] );
+}

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -8,7 +8,19 @@ import { getCategories, setCategories, registerBlockCollection } from '@wordpres
  */
 import JetpackLogo from '../shared/jetpack-logo';
 
-if ( typeof registerBlockCollection === 'function' ) {
+/**
+ * Return bool depending on registerBlockCollection compatibility.
+ *
+ * @return {boolean} Value to indicate function support.
+ */
+export const supportsCollections = () => {
+	if ( typeof registerBlockCollection === 'function' ) {
+		return true;
+	}
+	return false;
+};
+
+if ( supportsCollections() ) {
 	registerBlockCollection( 'jetpack', {
 		title: 'Jetpack',
 		icon: <JetpackLogo />,

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -43,7 +43,7 @@ setCategories( [
 	// Add a Earn block category
 	{
 		slug: 'earn',
-		title: __( 'Earn' ),
+		title: __( 'Earn', 'jetpack' ),
 		icon: <JetpackLogo />,
 	},
 ] );
@@ -53,7 +53,7 @@ setCategories( [
 	// Add a Grow block category
 	{
 		slug: 'grow',
-		title: __( 'Grow' ),
+		title: __( 'Grow', 'jetpack' ),
 		icon: <JetpackLogo />,
 	},
 ] );

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -11,13 +11,12 @@ import JetpackLogo from '../shared/jetpack-logo';
 /**
  * Return bool depending on registerBlockCollection compatibility.
  *
+ * @todo When Jetpack's minimum is WP 5.4. Remove this function and update all block categories.
+ *
  * @return {boolean} Value to indicate function support.
  */
 export const supportsCollections = () => {
-	if ( typeof registerBlockCollection === 'function' ) {
-		return true;
-	}
-	return false;
+	return typeof registerBlockCollection === 'function';
 };
 
 if ( supportsCollections() ) {
@@ -26,7 +25,7 @@ if ( supportsCollections() ) {
 		icon: <JetpackLogo />,
 	} );
 } else {
-	// This can be removed once G 7.3 is shipped in the Core version that is JP's minimum.
+	// This can be removed once Jetpack's minimum is Core 5.4.
 	setCategories( [
 		...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
 		// Add a Jetpack block category
@@ -40,7 +39,7 @@ if ( supportsCollections() ) {
 
 setCategories( [
 	...getCategories().filter( ( { slug } ) => slug !== 'earn' ),
-	// Add a Jetpack block category
+	// Add a Earn block category
 	{
 		slug: 'earn',
 		title: 'Earn',
@@ -50,7 +49,7 @@ setCategories( [
 
 setCategories( [
 	...getCategories().filter( ( { slug } ) => slug !== 'marketing' ),
-	// Add a Jetpack block category
+	// Add a Marketing block category
 	{
 		slug: 'marketing',
 		title: 'Marketing',

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -37,3 +37,23 @@ if ( supportsCollections() ) {
 		},
 	] );
 }
+
+setCategories( [
+	...getCategories().filter( ( { slug } ) => slug !== 'earn' ),
+	// Add a Jetpack block category
+	{
+		slug: 'earn',
+		title: 'Earn',
+		icon: <JetpackLogo />,
+	},
+] );
+
+setCategories( [
+	...getCategories().filter( ( { slug } ) => slug !== 'marketing' ),
+	// Add a Jetpack block category
+	{
+		slug: 'marketing',
+		title: 'Marketing',
+		icon: <JetpackLogo />,
+	},
+] );

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getCategories, setCategories, registerBlockCollection } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -42,7 +43,7 @@ setCategories( [
 	// Add a Earn block category
 	{
 		slug: 'earn',
-		title: 'Earn',
+		title: __( 'Earn' ),
 		icon: <JetpackLogo />,
 	},
 ] );
@@ -52,7 +53,7 @@ setCategories( [
 	// Add a Marketing block category
 	{
 		slug: 'marketing',
-		title: 'Marketing',
+		title: __( 'Marketing' ),
 		icon: <JetpackLogo />,
 	},
 ] );

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -49,11 +49,11 @@ setCategories( [
 ] );
 
 setCategories( [
-	...getCategories().filter( ( { slug } ) => slug !== 'marketing' ),
-	// Add a Marketing block category
+	...getCategories().filter( ( { slug } ) => slug !== 'grow' ),
+	// Add a Grow block category
 	{
-		slug: 'marketing',
-		title: __( 'Marketing' ),
+		slug: 'grow',
+		title: __( 'Grow' ),
 		icon: <JetpackLogo />,
 	},
 ] );


### PR DESCRIPTION
Supports #14598
Replaces and closes #14721

In Gutenberg 7.3, the block editor now supports "Collections". In the block picker, a Collection looks like a category, except blocks can also have a category.

The use case here is when do people think "I need a business hours block. I bet that's in the Jetpack category!"... probably not. They probably think of the function -- an embed, a widget, etc.

The problem is a block can only be in one category so devs have generally grouped them by the block provider.

Collections allow the block provider (Jetpack in our case) present all of our blocks together—like we have done with a custom category—while also listing it in a context-appropriate category.

For those running Gutenberg 7.3 or WordPress 5.4:
![2020-01-23 at 9 14 PM](https://user-images.githubusercontent.com/88897/73042071-6d7f6900-3e25-11ea-89b6-7c24ba947a79.png)

For those not running Gutenberg 7.3 or on WordPress 5.3, it retains the original behavior:
![2020-01-23 at 9 15 PM](https://user-images.githubusercontent.com/88897/73042109-8daf2800-3e25-11ea-8ef5-f83145b92aad.png)


#### Changes proposed in this Pull Request:
* Adds a 'Jetpack' block collection.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* On a connected Jetpack site WITHOUT Gutenberg, add a new post. Verify all the blocks are in a Jetpack category when viewing the block inserter.
* On a connected Jetpack site WITH Gutenberg, add a new post. With this patch, the Business Hours block will be in a Jetpack collection (looks just like a category) AND the widgets category.

AS OF NOW, when running G 7.3, the rest of Jetpack's blocks will fail since we're not adding them to a `Jetpack` category. We'll need to update the other blocks before landing it, but opening the PR now to get opinions on the implementation.

I opted to need to update blocks since if we allow those blocks with other categories to be added to a collection and those with the 'legacy' Jetpack category, the inserter will have two "Jetpack" entries -- the category and the collection -- so that's not really an option. 

#### Proposed changelog entry for your changes:
* Block Editor: Blocks are now listed both as part of a Jetpack Collection and in their proper category. (Requires Gutenberg 7.3)
