### PR TITLE
Eventbrite: Make sure the event ID is a number

### DIFF
--- a/extensions/blocks/eventbrite/utils.js
+++ b/extensions/blocks/eventbrite/utils.js
@@ -28,7 +28,7 @@ export function eventIdFromUrl( url ) {
 	}
 
 	const match = url.match( /(\d+)\/?\s*$/ );
-	return match && match[ 1 ] ? match[ 1 ] : null;
+	return match && match[ 1 ] ? parseInt( match[ 1 ], 10 ) : null;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14461

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Eventbrite block `eventId` is declared as a `number` attribute, but retrieved via regex from an URL.
Receiving a string is fine for the current editor load (and for the front end) but, when reloading, the type checks would fail, and the `save` function would return `undefined`, causing the block to break.

https://github.com/Automattic/jetpack/blob/5fcf11693c5b59c8124cbea96f4a74593e1cccba/extensions/blocks/eventbrite/save.js#L77-L79

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add the Eventbrite block in the editor, and provide an Eventbrite event link.
* Save the post, and reload the page.
* Make sure the block works as expected.
* Smoke test for regressions on the block on the front end.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
