### PR TITLE
OpenTable: Separate block registration from setting the availability

### DIFF
--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -68,7 +68,7 @@ function set_availability() {
 		);
 	}
 }
-add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\register_block' );
+add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\set_availability' );
 
 /**
  * Adds an inline script which updates the block editor settings to

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -46,6 +46,17 @@ function register_block() {
 			BLOCK_NAME,
 			array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
 		);
+	}
+}
+add_action( 'init', 'Jetpack\OpenTable_Block\register_block' );
+
+/**
+ * Set the availability of the block as the editor
+ * is loaded.
+ */
+function set_availability() {
+	if ( is_available() ) {
+		\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
 	} else {
 		\Jetpack_Gutenberg::set_extension_unavailable(
 			BLOCK_NAME,


### PR DESCRIPTION
As with other blocks that rely on server-side rendering, we need to make
sure that the block is registered so that it is rendered in the frontend
of the site.

#### Changes proposed in this Pull Request:

This change registers the block during the `init` hook, but keeps the
setting of the block availability to the
`jetpack_register_gutenberg_extensions` hook.

This is a stop-gap solution until a more generalised change to block registration is completed, like we're working on in #14426

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a fix to the new OpenTable block

#### Testing instructions:
* Enable beta blocks on your Jetpack site
* Check that you can still insert an OpenTable block
* Check that the block is rendered on the frontend when the post is published.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No changelog entry is required.
