### PR TITLE
Map block: Record a Tracks event on Map load on WordPress.com

### DIFF
--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -43,16 +43,14 @@ function jetpack_get_mapbox_api_key() {
 /**
  * Record a Tracks event every time the Map block is loaded on WordPress.com and Atomic.
  */
-function jetpack_record_mapbox_load_event() {
-	$event_name = 'jetpack_map_block_mapbox_load';
-	$user       = wp_get_current_user();
+function jetpack_record_mapbox_wpcom_load_event() {
+	$event_name = 'wpcom_map_block_mapbox_load';
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		require_lib( 'tracks/client' );
-		tracks_record_event( $user, $event_name, array( 'site_id' => get_current_blog_id() ) );
-		return;
-	} elseif ( jetpack_is_atomic_site() ) {
+		tracks_record_event( wp_get_current_user(), $event_name, array( 'site_id' => get_current_blog_id() ) );
+	} elseif ( jetpack_is_atomic_site() && Jetpack::is_active() ) {
 		$tracking = new Automattic\Jetpack\Tracking();
-		$tracking->tracks_record_event( $user, $event_name, array( 'site_id' => Jetpack_Options::get_option( 'id' ) ) );
+		$tracking->record_user_event( $event_name, array( 'site_id' => Jetpack_Options::get_option( 'id' ) ) );
 	}
 }
 
@@ -95,7 +93,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		);
 	}
 
-	jetpack_record_mapbox_load_event();
+	jetpack_record_mapbox_wpcom_load_event();
 
 	Jetpack_Gutenberg::load_assets_as_required( 'map' );
 
@@ -144,7 +142,7 @@ function jetpack_map_block_render_single_block_page() {
 
 	add_filter( 'jetpack_is_amp_request', '__return_false' );
 
-	jetpack_record_mapbox_load_event();
+	jetpack_record_mapbox_wpcom_load_event();
 
 	Jetpack_Gutenberg::load_assets_as_required( 'map' );
 	wp_scripts()->do_items();

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -47,10 +47,10 @@ function jetpack_record_mapbox_wpcom_load_event() {
 	$event_name = 'wpcom_map_block_mapbox_load';
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		require_lib( 'tracks/client' );
-		tracks_record_event( wp_get_current_user(), $event_name, array( 'site_id' => get_current_blog_id() ) );
+		tracks_record_event( wp_get_current_user(), $event_name );
 	} elseif ( jetpack_is_atomic_site() && Jetpack::is_active() ) {
 		$tracking = new Automattic\Jetpack\Tracking();
-		$tracking->record_user_event( $event_name, array( 'site_id' => Jetpack_Options::get_option( 'id' ) ) );
+		$tracking->record_user_event( $event_name );
 	}
 }
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -63,6 +63,8 @@ function jetpack_record_mapbox_wpcom_load_event() {
  * @return string
  */
 function jetpack_map_block_load_assets( $attr, $content ) {
+	jetpack_record_mapbox_wpcom_load_event();
+
 	$api_key = jetpack_get_mapbox_api_key();
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
@@ -92,8 +94,6 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 			$placeholder
 		);
 	}
-
-	jetpack_record_mapbox_wpcom_load_event();
 
 	Jetpack_Gutenberg::load_assets_as_required( 'map' );
 
@@ -141,8 +141,6 @@ function jetpack_map_block_render_single_block_page() {
 	ob_start();
 
 	add_filter( 'jetpack_is_amp_request', '__return_false' );
-
-	jetpack_record_mapbox_wpcom_load_event();
 
 	Jetpack_Gutenberg::load_assets_as_required( 'map' );
 	wp_scripts()->do_items();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Record a Tracks event every time the Map block is loaded on WordPress.com and Atomic.
The only event property is the site ID.

The reason is to be able to monitor the usage of the Mapbox API in case of abuses or excesses, and to identify and blacklist any possible problematic sites.

No events are tracked on Jetpack (non-Simple, non-Atomic) sites.

#### Re: GDPR review

This event is recorded both on the editor and on the front end.
We have no interest in knowing the user, but only the site ID.
I would have liked to use `tracks_record_event` without providing a user, but as far as I can see it's not possible to, say, pass `null`, as the tracking system [requires a `WP_User` object](https://github.com/Automattic/jetpack/blob/be32f2677a02b4f4e4e84146aa8dcf3bbf97c08b/packages/tracking/src/class-tracking.php#L132).
For this reason, I've decided to pass `wp_get_current_user()`, and let the system decide what to do with it.

I wonder if it makes sense to simply pass a `new WP_User()` instead.

Either way, I'd love to make sure I'm not messing up with GDPR in any ways whatsoever.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhancement

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

To test this in a timely manner, please add an `error_log` to both event recordings. On record success, it should just log `true`.
E.g.
```php
$t = tracks_record_event( $user, $event_name, array( 'site_id' => get_current_blog_id() ) );
error_log( json_encode( $t ) );
```

Jetpack Site

* Open the editor, add a Map block, and insert a personal Mapbox access token.
* Save the post, and view it on the front end.
* Check the error log and make sure there are no logs caused by the event tracking.

Simple Site

* Checkout the twin diff and manually add the `error_log`s.
* Open the editor, add a Map block.
* Save the post, and view it on the front end.
* Check the error log and make sure there are 2 logs: 1 for the editor and 1 for the front end.
* Now add another Map blocks to the post.
* Save and open on the front end.
* Check the error log: make sure there are 4 new logs: 1 for each Map blocks in the editor and in the front end.

Atomic Site

* Install and activate the [Jetpack Beta](https://github.com/Automattic/jetpack-beta/releases/latest) plugin.
* In wp-admin, navigate to Jetpack -> Jetpack Beta; search for the `update/map-block-tracks` feature branch, and activate it.
* I'm not sure how to check the error log on Atomic, so head to the wp-admin plugin editor and add some `var_dump`s instead. Make sure you're modifying the correct Jetpack (one is the normal version, the other contains this very branch).
* Open the editor, add a Map block.
* Save the post, and view it on the front end.
* Make sure there are 2 var dumps: 1 for the editor and 1 for the front end.
* Now add another Map blocks to the post.
* Save and open on the front end.
* Make sure there are 4 var dumps: 1 for each Map blocks in the editor and in the front end.

Automatticians

After a while (10+ minutes), search for `jetpack_map_block_mapbox_load` and check if the results are consistent with your tests.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
