### PR TITLE
Add Complete Open Graph to $open_graph_conflicting_plugins

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -268,6 +268,7 @@ class Jetpack {
 		// 2 Click Social Media Buttons
 		'add-link-to-facebook/add-link-to-facebook.php',         // Add Link to Facebook
 		'add-meta-tags/add-meta-tags.php',                       // Add Meta Tags
+		'complete-open-graph/complete-open-graph.php',           // Complete Open Graph
 		'easy-facebook-share-thumbnails/esft.php',               // Easy Facebook Share Thumbnail
 		'heateor-open-graph-meta-tags/heateor-open-graph-meta-tags.php',
 		// Open Graph Meta Tags by Heateor


### PR DESCRIPTION
Came up in 2653195-zen.

#### Changes proposed in this Pull Request:

* Jetpack will no longer output Open Graph tags when the Complete Open Graph plugin is present.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Simply adds another plugin to our existing list of conflicting Open Graph plugins.

#### Testing instructions:

* Start by running this branch. 
* Install and activate the Complete Open Graph plugin: https://wordpress.org/plugins/complete-open-graph/
* Check to be sure that Complete Open Graph is outputting OG tags, not Jetpack.

#### Proposed changelog entry for your changes:
* Don't output Open Graph tags if the Complete Open Graph plugin is present.
