### PR TITLE
Calendly: Make the block registration consistent with OpenTable

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -46,6 +46,17 @@ function register_block() {
 			BLOCK_NAME,
 			array( 'render_callback' => 'Jetpack\Calendly_Block\load_assets' )
 		);
+	}
+}
+add_action( 'init', 'Jetpack\Calendly_Block\register_block' );
+
+/**
+ * Set the availability of the block as the editor
+ * is loaded
+ */
+function set_availability() {
+	if ( is_available() ) {
+		\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
 	} else {
 		\Jetpack_Gutenberg::set_extension_unavailable(
 			BLOCK_NAME,
@@ -57,8 +68,7 @@ function register_block() {
 		);
 	}
 }
-
-add_action( 'init', 'Jetpack\Calendly_Block\register_block' );
+add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
 
 /**
  * Calendly block registration/dependency declaration.


### PR DESCRIPTION
In #14464 we're changing the approach to registering the block and
setting its availability, both to fix an issue that meant it wasn't
available in the front end of the site, and to make it consistent with
other blocks.

#### Changes proposed in this Pull Request:

This change makes the Calendly block follow the same
pattern, by splitting the block registration from the availability
setting, and using the `jetpack_register_gutenberg_extensions` hook.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This an update to a new feature

#### Testing instructions:
* Enable beta blocks on a test site
* Check that you can still add and use the Calendly block

#### Proposed changelog entry for your changes:
No changelog entry required.
