### PR TITLE
Addition of progress field to sync/status endpoint

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -488,6 +488,7 @@ new Jetpack_JSON_API_Sync_Status_Endpoint(
 			'full_queue_next_sync'  => '(float) Time in seconds before trying to sync the full sync queue again',
 			'cron_size'             => '(int) Size of the current cron array',
 			'next_cron'             => '(int) The number of seconds till the next item in cron.',
+			'progress'              => '(array) Full Sync status by module',
 		),
 		'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status',
 	)


### PR DESCRIPTION
Immediate Full Sync introduces a progress field to return explicit status of each module under sync.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?

N/A change applies to WP.com infrastructure and is already present.

#### Changes proposed in this Pull Request:
* Adds progress to fields returned by sync/status endpoint

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* existing functionality

#### Testing instructions:

* https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status will now show progress field for a site that has the Immediate Full Sync enabled

#### Proposed changelog entry for your changes:
* N/A
