### PR TITLE
Contact Info Block: wrap the phone number link tag in a span

### DIFF
--- a/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
+++ b/extensions/blocks/contact-info/class-jetpack-contact-info-block.php
@@ -98,7 +98,8 @@ class Jetpack_Contact_Info_Block {
 	}
 
 	/**
-	 * Adds phone schema attributes.
+	 * Adds phone schema attributes. Also wraps the tel link in a span so that
+	 * it's recognized as a telephone number in Google's Structured Data.
 	 *
 	 * @param array  $attr    Array containing the phone block attributes.
 	 * @param string $content String containing the phone block content.
@@ -106,9 +107,14 @@ class Jetpack_Contact_Info_Block {
 	 * @return string
 	 */
 	public static function render_phone( $attr, $content ) {
-		$content = self::has_attributes( $attr, array( 'className' ) ) ?
-			str_replace( 'href="tel:', 'itemprop="telephone" href="tel:', $content ) :
-			'';
-		return $content;
+		if ( self::has_attributes( $attr, array( 'className' ) ) ) {
+			return str_replace(
+				array( '<a href="tel:', '</a>' ),
+				array( '<span itemprop="telephone"><a href="tel:', '</a></span>' ),
+				$content
+			);
+		}
+
+		return '';
 	}
 }


### PR DESCRIPTION
Fixes #14298

#### Changes proposed in this Pull Request:
* Google's Structured Data doesn't recognize a phone number in a link tag. To fix this, wrap the link tag in a span.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

##### Test Site
* Jetpack must be activated and connected.

##### Test Steps
1. Add a Contact Info block with a phone number to a post.
2. Verify that the phone number displays properly when viewing the post.
3. Submit the post URL to Google's Structured Data Testing tool at https://search.google.com/structured-data/testing-tool/u/0/
4. Verify that the telephone number is recognized in the Structured Data test results.


#### Proposed changelog entry for your changes:
* tbd
