### PR TITLE
Instant Search: Improve search form detection

### DIFF
--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -7,6 +7,7 @@ export function getCheckedInputNames( parentDom ) {
 export function getThemeOptions( searchOptions ) {
 	const options = {
 		searchInputSelector: [
+			'input[name="s"]',
 			'#searchform input.search-field',
 			'.search-form input.search-field',
 			'.searchform input.search-field',


### PR DESCRIPTION
Fixes #14452.

#### Changes proposed in this Pull Request:
* Checks for all inputs with `name="s"` when looking for search forms to hook the overlay into.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Change your site theme to any of the themes mentioned in #14452 (e.g. `Shapely`, `2010`, `2011`, or `2012`).
2. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
3. Perform a site search to spawn the search overlay.
4. Ensure that the search overlay renders as expected.

#### Proposed changelog entry for your changes:
* None