### PR TITLE
Instant Search: Move focus into overlay input

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-import { h, createRef } from 'preact';
-import { useState, useEffect } from 'preact/hooks';
+import { h } from 'preact';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import uniqueId from 'lodash/uniqueId';
@@ -16,14 +16,19 @@ import Gridicon from './gridicon';
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
-	const inputRef = createRef();
+	const inputRef = useRef( null );
+
+	const cb = overlayElement => () =>
+		! overlayElement.classList.contains( 'is-hidden' ) && inputRef.current.focus();
 
 	useEffect( () => {
-		inputRef.current.focus();
-		//console.log( inputRef.current );
+		const overlayElement = document.querySelector( '.jetpack-instant-search__overlay' );
+		overlayElement.addEventListener( 'transitionend', cb( overlayElement ), true );
+		cb( overlayElement )(); // invoke focus if page loads with overlay already present
 		return () => {
 			// Cleanup after event
 			// @todo Focus back on the activeElement before the overlay was opened
+			overlayElement.removeEventListener( 'transitionend', cb );
 		};
 	}, [] );
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-import { h } from 'preact';
-import { useState } from 'preact/hooks';
+import { h, createRef } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
 import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line lodash/import-scope
 import uniqueId from 'lodash/uniqueId';
@@ -16,6 +16,16 @@ import Gridicon from './gridicon';
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
+	const inputRef = createRef();
+
+	useEffect( () => {
+		inputRef.current.focus();
+		//console.log( inputRef.current );
+		return () => {
+			// Cleanup after event
+			// @todo Focus back on the activeElement before the overlay was opened
+		};
+	}, [] );
 
 	return (
 		<div className="jetpack-instant-search__box">
@@ -27,9 +37,7 @@ const SearchBox = props => {
 				id={ inputId }
 				className="search-field jetpack-instant-search__box-input"
 				onInput={ props.onChangeQuery }
-				onFocus={ props.onFocus }
-				onBlur={ props.onBlur }
-				ref={ props.appRef }
+				ref={ inputRef }
 				placeholder={ __( 'Search…', 'jetpack' ) }
 				type="search"
 				value={ props.query }

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -43,8 +43,6 @@ class SearchForm extends Component {
 					<SearchBox
 						enableFilters
 						onChangeQuery={ this.onChangeQuery }
-						onFocus={ this.props.onSearchFocus }
-						onBlur={ this.props.onSearchBlur }
 						query={ getSearchQuery() }
 						widget={ this.props.widget }
 						toggleFilters={ this.toggleFilters }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Move focus to the overlay search input when the overlay is opened.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Perform a site search to spawn the search overlay.
3. Ensure that the input inside the overlay is in focus.
4. Directly open the search page by navigating to `/?s=hello`.
5. Ensure that the page renders with the overlay input in focus.

#### Proposed changelog entry for your changes:
* None.
