### PR TITLE
Instant Search: Prevent body scroll with overlay open

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -51,6 +51,7 @@ class SearchApp extends Component {
 		this.getResults.flush();
 
 		this.addEventListeners();
+		this.preventBodyScroll();
 
 		if ( this.hasActiveQuery() ) {
 			this.showResults();
@@ -59,6 +60,7 @@ class SearchApp extends Component {
 
 	componentWillUnmount() {
 		this.removeEventListeners();
+		this.restoreBodyScroll();
 	}
 
 	addEventListeners() {
@@ -87,6 +89,14 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.removeEventListener( 'change', this.handleSortChange );
 		} );
+	}
+
+	preventBodyScroll() {
+		document.body.style.overflowY = 'hidden';
+	}
+
+	restoreBodyScroll() {
+		delete document.body.style.overflowY;
 	}
 
 	hasActiveQuery() {


### PR DESCRIPTION
Fixes #14351.

#### Changes proposed in this Pull Request:
* Prevents body from scrolling when the overlay is open. This is done by setting `overlay-y: hidden` when the overlay spawns.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* None.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Set a low overlay opacity in the customizer so it's easier to see the document body. 
3. Perform a site search to spawn the search overlay.
4. Try scrolling down. Overlay contents should scroll down, but the body content should remain fixed.

#### Proposed changelog entry for your changes:
* None.
