### PR TITLE
EventBrite: add missing textdomain to new strings

### DIFF
--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -31,8 +31,8 @@ import EventbriteModalExample from './eventbrite-modal-example.png';
 import './editor.scss';
 
 const MODAL_BUTTON_STYLES = [
-	{ name: 'fill', label: __( 'Fill' ), isDefault: true },
-	{ name: 'outline', label: __( 'Outline' ) },
+	{ name: 'fill', label: __( 'Fill', 'jetpack' ), isDefault: true },
+	{ name: 'outline', label: __( 'Outline', 'jetpack' ) },
 ];
 
 class EventbriteEdit extends Component {
@@ -147,7 +147,7 @@ class EventbriteEdit extends Component {
 		return (
 			<div className="wp-block-embed is-loading">
 				<Spinner />
-				<p>{ __( 'Embedding…' ) }</p>
+				<p>{ __( 'Embedding…', 'jetpack' ) }</p>
 			</div>
 		);
 	}


### PR DESCRIPTION
Fixes #14458

#### Changes proposed in this Pull Request:

* EventBrite: add missing textdomain to new strings

#### Testing instructions:

* Not much to test here, the strings should still appear nicely in your dashboard.

#### Proposed changelog entry for your changes:

* N/A
