### PR TITLE
Eventbrite block: Add missing "jetpack" text domains

### DIFF
--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -31,8 +31,8 @@ import EventbriteModalExample from './eventbrite-modal-example.png';
 import './editor.scss';
 
 const MODAL_BUTTON_STYLES = [
-	{ name: 'fill', label: __( 'Fill' ), isDefault: true },
-	{ name: 'outline', label: __( 'Outline' ) },
+	{ name: 'fill', label: __( 'Fill', 'jetpack' ), isDefault: true },
+	{ name: 'outline', label: __( 'Outline', 'jetpack' ) },
 ];
 
 class EventbriteEdit extends Component {
@@ -147,7 +147,7 @@ class EventbriteEdit extends Component {
 		return (
 			<div className="wp-block-embed is-loading">
 				<Spinner />
-				<p>{ __( 'Embedding…' ) }</p>
+				<p>{ __( 'Embedding…', 'jetpack' ) }</p>
 			</div>
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14458

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add missing "jetpack" text domains in the Eventbrite block.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
