### PR TITLE
Eventbrite block: Fix block transform not properly creating the block

### DIFF
--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -8,6 +8,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { eventIdFromUrl } from './utils';
 import edit from './edit';
 import save from './save';
 
@@ -84,8 +85,10 @@ export const settings = {
 					node.nodeName === 'P' &&
 					( URL_REGEX.test( node.textContent ) || CUSTOM_URL_REGEX.test( node.textContent ) ),
 				transform: node => {
+					const url = node.textContent.trim();
 					return createBlock( 'jetpack/eventbrite', {
-						url: node.textContent.trim(),
+						eventId: eventIdFromUrl( url ),
+						url: url,
 					} );
 				},
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14460 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the Eventbrite block transform not creating the block when pasting an Eventbrite raw URL in the editor.

The Eventbrite block needs to be created with an explicit `eventId` which is normally inferred from the event URL.
Since the `eventId` change was introduced only lately, the block transform function was creating the block with just the URL.

**Note**: the two currently used regexes do not match Eventbrite URLs with query params.
I'm bad with regexes, so I'd happily leave this to anyone else here or in a follow up.
This PR is intended to take care of the actual bug occurring, where pasting an Eventbrite URL is transformed into a broken block.
After this update, pasting an Eventbrite URL with query params is not transformed at all, which is not a great behaviour, but definitely better than a blocker bug.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Editor and paste an Eventbrite URL without query args (e.g. `https://www.eventbrite.com/e/foobar-event-tickets-123456789`).
* Make sure the URL is automatically transformed into an Eventbrite block with the correct event.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A