### PR TITLE
Eventbrite block: Restore previous working user agent

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
@@ -56,15 +56,12 @@ class WPCOM_REST_API_V2_Endpoint_Resolve_Redirect extends WP_REST_Controller {
 	 * @return WP_REST_Response The REST API response.
 	 */
 	public function follow_redirect( $request ) {
-		global $wp_version;
-
 		// Add a User-Agent header since the request is sometimes blocked without it.
 		$response = wp_safe_remote_get(
 			$request['url'],
 			array(
 				'headers' => array(
-					// @see https://github.com/Automattic/jetpack/blob/fe51754410f97e0f20908ebb7fdbfbc62e703987/modules/protect.php#L534
-					'User-Agent' => "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ),
+					'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:71.0) Gecko/20100101 Firefox/71.0',
 				),
 			)
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the Eventbrite block not resolving custom event URLs because using the JP/WPCOM user agent returns 403.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Editor, insert an Eventbrite block, and paste a custom Eventbrite URL (e.g. `https://grantmk-test-event.eventbrite.com/`).
* Make sure the Eventbrite event is embedded correctly.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A