### PR TITLE
Search: always mark VIP Go sites as supported

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -290,6 +290,9 @@ class Jetpack_Search {
 	 * Loads scripts for Tracks analytics library
 	 */
 	public function is_search_supported() {
+		if ( defined( 'VIP_GO_ENV' ) && false !== VIP_GO_ENV ) {
+			return true;
+		}
 		if ( method_exists( 'Jetpack_Plan', 'supports' ) ) {
 			return Jetpack_Plan::supports( 'search' );
 		}


### PR DESCRIPTION
Add a check for `VIP_GO_ENV` so that `is_search_supported`  always returns true regardless of what plan data the site has.

#### Changes proposed in this Pull Request:
* `is_search_supported` returns true for `VIP_GO_ENV`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Discussion: https://wp.me/p9GBOq-1yd

#### Testing instructions:
* Spin up a VIP Go test site
* Remove the `jetpack_active_plan` option, see if search is still operating


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add check for `VIP_GO_ENV` inside `is_search_supported`.
