### PR TITLE
Instant Search: switch to use .slug_slash_name for displaying custom taxonomies, tags and categories

### DIFF
--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -98,25 +98,25 @@ export default class SearchFilter extends Component {
 	};
 
 	renderTaxonomy = ( { key, doc_count: count } ) => {
-		// Taxonomy keys contain slug and title separated by a slash
+		// Taxonomy keys contain slug and name separated by a slash
 		const [ slug, name ] = key && key.split( /\/(.+)/ );
 
 		return (
 			<div>
 				<input
-					checked={ this.isChecked( key ) }
-					id={ `${ this.idPrefix }-taxonomies-${ key }` }
-					name={ key }
+					checked={ this.isChecked( slug ) }
+					id={ `${ this.idPrefix }-taxonomies-${ slug }` }
+					name={ slug }
 					onChange={ this.toggleFilter }
 					type="checkbox"
 					className="jetpack-instant-search__filter-list-input"
 				/>
 
 				<label
-					htmlFor={ `${ this.idPrefix }-taxonomies-${ key }` }
+					htmlFor={ `${ this.idPrefix }-taxonomies-${ slug }` }
 					className="jetpack-instant-search__filter-list-label"
 				>
-					{ strip( name ) + ' - ' + slug } ({ count })
+					{ strip( name ) } ({ count })
 				</label>
 			</div>
 		);

--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -68,7 +68,7 @@ export default class SearchFilter extends Component {
 					{ new Date( key ).toLocaleString(
 						locale,
 						getDateOptions( this.props.configuration.interval )
-					) }{' '}
+					) }{ ' ' }
 					({ count })
 				</label>
 			</div>
@@ -98,6 +98,9 @@ export default class SearchFilter extends Component {
 	};
 
 	renderTaxonomy = ( { key, doc_count: count } ) => {
+		// Taxonomy keys contain slug and title separated by a slash
+		const [ slug, name ] = key && key.split( /\/(.+)/ );
+
 		return (
 			<div>
 				<input
@@ -108,11 +111,12 @@ export default class SearchFilter extends Component {
 					type="checkbox"
 					className="jetpack-instant-search__filter-list-input"
 				/>
+
 				<label
 					htmlFor={ `${ this.idPrefix }-taxonomies-${ key }` }
 					className="jetpack-instant-search__filter-list-label"
 				>
-					{ strip( key ) } ({ count })
+					{ strip( name ) + ' - ' + slug } ({ count })
 				</label>
 			</div>
 		);

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -37,12 +37,13 @@ function generateAggregation( filter ) {
 			};
 		}
 		case 'taxonomy': {
-			let field = `taxonomy.${ filter.taxonomy }.name.raw`;
+			let field = `taxonomy.${ filter.taxonomy }.slug_slash_name`;
 			if ( filter.taxonomy === 'post_tag' ) {
-				field = 'tag.slug';
+				field = 'tag.slug_slash_name';
 			} else if ( filter.taxonomy === 'category' ) {
-				field = 'category.slug';
+				field = 'category.slug_slash_name';
 			}
+
 			return { terms: { field, size: filter.count } };
 		}
 		case 'post_type': {
@@ -79,8 +80,8 @@ const filterKeyToEsFilter = new Map( [
 	[ 'post_types', postType => ( { term: { post_type: postType } } ) ],
 
 	// Built-in taxonomies
-	[ 'category', category => ( { term: { 'category.slug': category } } ) ],
-	[ 'post_tag', tag => ( { term: { 'tag.slug': tag } } ) ],
+	[ 'category', category => ( { term: { 'category.slug_slash_name': category } } ) ],
+	[ 'post_tag', tag => ( { term: { 'tag.slug_slash_name': tag } } ) ],
 
 	// Dates
 	[ 'month_post_date', datestring => generateDateRangeFilter( 'date', datestring, 'month' ) ],
@@ -116,7 +117,7 @@ function buildFilterObject( filterQuery ) {
 					filter.bool.must.push( filterKeyToEsFilter.get( key )( item ) );
 				} else {
 					// If key is not in the standard map, assume to be a custom taxonomy
-					filter.bool.must.push( { term: { [ `taxonomy.${ key }.name.raw` ]: item } } );
+					filter.bool.must.push( { term: { [ `taxonomy.${ key }.slug_slash_name` ]: item } } );
 				}
 			} );
 		} );

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -80,8 +80,8 @@ const filterKeyToEsFilter = new Map( [
 	[ 'post_types', postType => ( { term: { post_type: postType } } ) ],
 
 	// Built-in taxonomies
-	[ 'category', category => ( { term: { 'category.slug_slash_name': category } } ) ],
-	[ 'post_tag', tag => ( { term: { 'tag.slug_slash_name': tag } } ) ],
+	[ 'category', category => ( { term: { 'category.slug': category } } ) ],
+	[ 'post_tag', tag => ( { term: { 'tag.slug': tag } } ) ],
 
 	// Dates
 	[ 'month_post_date', datestring => generateDateRangeFilter( 'date', datestring, 'month' ) ],
@@ -117,7 +117,7 @@ function buildFilterObject( filterQuery ) {
 					filter.bool.must.push( filterKeyToEsFilter.get( key )( item ) );
 				} else {
 					// If key is not in the standard map, assume to be a custom taxonomy
-					filter.bool.must.push( { term: { [ `taxonomy.${ key }.slug_slash_name` ]: item } } );
+					filter.bool.must.push( { term: { [ `taxonomy.${ key }.slug` ]: item } } );
 				}
 			} );
 		} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Following on from https://github.com/Automattic/jetpack/pull/14437, this PR switches tags, categories and taxonomies to use the new `.slug_slash_name` field, as suggested by @gibrown in https://github.com/Automattic/jetpack/pull/14437#issuecomment-578909443.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No - it's part of the Instant Search prototype.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
* The new fields are only available on jetpack.com right now, so use the appropriate blog_id.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not required.
