### PR TITLE
Instant Search: fix filter display in Zerif Lite theme

### DIFF
--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -59,8 +59,12 @@ export default class SearchFilter extends Component {
 					name={ key }
 					onChange={ this.toggleFilter }
 					type="checkbox"
+					className="jetpack-instant-search__filter-list-input"
 				/>
-				<label htmlFor={ `${ this.idPrefix }-dates-${ this.getIdentifier() }-${ key }` }>
+				<label
+					htmlFor={ `${ this.idPrefix }-dates-${ this.getIdentifier() }-${ key }` }
+					className="jetpack-instant-search__filter-list-label"
+				>
 					{ new Date( key ).toLocaleString(
 						locale,
 						getDateOptions( this.props.configuration.interval )
@@ -81,8 +85,12 @@ export default class SearchFilter extends Component {
 					name={ key }
 					onChange={ this.toggleFilter }
 					type="checkbox"
+					className="jetpack-instant-search__filter-list-input"
 				/>
-				<label htmlFor={ `${ this.idPrefix }-post-types-${ key }` }>
+				<label
+					htmlFor={ `${ this.idPrefix }-post-types-${ key }` }
+					className="jetpack-instant-search__filter-list-label"
+				>
 					{ strip( name ) } ({ count })
 				</label>
 			</div>
@@ -98,8 +106,12 @@ export default class SearchFilter extends Component {
 					name={ key }
 					onChange={ this.toggleFilter }
 					type="checkbox"
+					className="jetpack-instant-search__filter-list-input"
 				/>
-				<label htmlFor={ `${ this.idPrefix }-taxonomies-${ key }` }>
+				<label
+					htmlFor={ `${ this.idPrefix }-taxonomies-${ key }` }
+					className="jetpack-instant-search__filter-list-label"
+				>
 					{ strip( key ) } ({ count })
 				</label>
 			</div>

--- a/modules/search/instant-search/components/search-filters.scss
+++ b/modules/search/instant-search/components/search-filters.scss
@@ -1,11 +1,22 @@
 .jetpack-instant-search__filter-list {
-	div label {
-		display: inline-block;
-		width: auto;
-		margin-left: 5px;
-	}
 	margin-bottom: 10px;
 	text-align: left;
+}
+
+.jetpack-instant-search__filter-list-input,
+// Extra specific to override width in some themes, e.g. Zerif Lite
+.widget_search .jetpack-instant-search__filter-list-input {
+	width: inherit;
+	cursor: pointer;
+}
+
+.jetpack-instant-search__filter-list-label,
+// Extra specific to override width in some themes, e.g. Zerif Lite
+.widget_search .jetpack-instant-search__filter-list-label {
+	display: inline-block;
+	width: auto;
+	margin-left: 5px;
+	cursor: pointer;
 }
 
 .jetpack-instant-search__clear-filters-button {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes display bug raised in https://github.com/Automattic/jetpack/issues/14453.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix display of filters in overlay for Zerif Lite theme.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No - this is part of the Instant Search development branch.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the Zerif Lite theme on your test site: https://wordpress.org/themes/zerif-lite/
* Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
* Set up some filters in the Search (Jetpack) widget and try and search on the front end of your site.

Before:

<img width="231" alt="Screen Shot 2020-01-28 at 14 42 23" src="https://user-images.githubusercontent.com/17325/73229001-24d8fe80-41dd-11ea-9766-b6c1497c6a71.png">

After:

<img width="219" alt="Screen Shot 2020-01-28 at 14 41 28" src="https://user-images.githubusercontent.com/17325/73229091-75505c00-41dd-11ea-8057-a70c2e17d88f.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not required.
