### PR TITLE
Stats: hide smiley on post embeds as well

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -41,6 +41,7 @@ function stats_load() {
 	add_action( 'wp_head', 'stats_admin_bar_head', 100 );
 
 	add_action( 'wp_head', 'stats_hide_smile_css' );
+	add_action( 'embed_head', 'stats_hide_smile_css' );
 
 	add_action( 'jetpack_admin_menu', 'stats_admin_menu' );
 


### PR DESCRIPTION
Fixes #14483

#### Changes proposed in this Pull Request:

* Jetpack uses a smiley image as tracking pixel when Stats are enabled. We use CSS to hide that image so it is not displayed in the footer of every site, and we hook that CSS in `wp_head`. That is unfortunately not enough when a post is displayed on a site via an embed post template:
https://github.com/WordPress/WordPress/blob/56c162fbc9867f923862f64f1b4570d885f1ff03/wp-includes/theme-compat/header-embed.php

In this case, we want to hook the CSS into the embed post template as well.

#### Testing instructions:

* Start from a site using Stats. Verify that when logged out, you can see the tracking pixel in your browser dev tools at the bottom of the page.
* Create a new post where you'll paste a link to another one of your posts inside a separate block; that post will be transformed into an embed.
* Publish your post and access it in an incognito window.
* Make sure no smiley face appears below the post embed.

#### Proposed changelog entry for your changes:

* Stats: hide Stats smiley in post embeds
