### PR TITLE
Blocks: switch new blocks to production

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -1,13 +1,16 @@
 {
 	"production": [
 		"business-hours",
+		"calendly",
 		"contact-form",
 		"contact-info",
+		"eventbrite",
 		"gif",
 		"likes",
 		"mailchimp",
 		"map",
 		"markdown",
+		"opentable",
 		"pinterest",
 		"publicize",
 		"rating-star",
@@ -23,5 +26,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "calendly", "eventbrite", "opentable", "seo" ]
+	"beta": [ "amazon", "seo" ]
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Blocks: switch new blocks to production ahead of the 8.2 release. That will make it easier to test them during the Beta period.

#### Testing instructions:

* On a new site where Beta blocks are not enabled, check that you can see the Calendly, EventBrite, and OpenTable blocks.

#### Proposed changelog entry for your changes:

* N/A
