### PR TITLE
CI: Disable markdown spell checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,13 @@ matrix:
     name: "Build dashboard & extensions"
     language: node_js
     env: WP_TRAVISCI="yarn build"
-  - if: branch !~ /(^branch-.*-built)/
-    name: "Spell check Markdown files"
-    language: node_js
-    env: WP_TRAVISCI="yarn test-spelling"
+
+  # Disable for now until we fix all the spelling issues
+  # - name: "Spell check Markdown files"
+  #   if: branch !~ /(^branch-.*-built)/
+  #   language: node_js
+  #   env: WP_TRAVISCI="yarn test-spelling"
+
   - php: "nightly"
     name: "PHP Nightly"
   - php: "7.4snapshot"


### PR DESCRIPTION
Spell checking job that is running in CI is kinda useless since it's timing out all the time due to interactive interface waiting for user input.

To make it actually useful, we should walk through all the spelling violations and fix them. Also, it might be better to find a tool that will fail the build right away without waiting for user input.

example of such job: https://travis-ci.org/Automattic/jetpack/jobs/642838290

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure that spell checking job is not running anymore.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
