### PR TITLE
Removing duplicate load_modules call.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -769,7 +769,7 @@ class Jetpack {
 	 */
 	public function late_initialization() {
 		self::plugin_textdomain();
-		self::load_modules();
+		add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 
 		Partner::init();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -768,7 +768,7 @@ class Jetpack {
 	 * @action plugins_loaded
 	 */
 	public function late_initialization() {
-		self::plugin_textdomain();
+		add_action( 'plugins_loaded', array( 'Jetpack', 'plugin_textdomain' ), 99 );
 		add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 
 		Partner::init();

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -74,8 +74,6 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.core-rest-api-endpoints.php';
 
 add_action( 'updating_jetpack_version', array( 'Jetpack', 'do_version_bump' ), 10, 2 );
 add_action( 'init', array( 'Jetpack', 'init' ) );
-add_action( 'plugins_loaded', array( 'Jetpack', 'plugin_textdomain' ), 99 );
-add_action( 'plugins_loaded', array( 'Jetpack', 'load_modules' ), 100 );
 add_filter( 'jetpack_static_url', array( 'Jetpack', 'staticize_subdomain' ) );
 add_filter( 'is_jetpack_site', '__return_true' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14499 

Fixes a problem where `jetpack_modules_loaded` action is called twice and breaks sites with certain configuration.

#### Changes proposed in this Pull Request:
* Removes one of the two calls to `load_modules` that exists in the same code path.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a bug fix for Jetpack 8.2.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Add this snippet to your code:
```
add_action('jetpack_modules_loaded','special_one_time');
function special_one_time() {
	// If tiled galleries are disabled, this class is undefined.
	if ( ! class_exists('Jetpack_Tiled_Gallery') ) return;
	class extra_Jetpack_Tiled_Gallery extends Jetpack_Tiled_Gallery { }
}
```
* Observe a fatal error.
* Use this PR.
* Observe no fatals.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A - this problem was introduced in this release cycle.
