### PR TITLE
Eventbrite Block: Support transforms for links with query strings

### DIFF
--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -24,7 +24,7 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { createWidgetId, convertToLink, eventIdFromUrl } from './utils';
-import { CUSTOM_URL_REGEX, icon, URL_REGEX } from '.';
+import { icon, URL_REGEX } from '.';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import ModalButtonPreview from './modal-button-preview';
 import EventbriteInPageExample from './eventbrite-in-page-example.png';
@@ -40,8 +40,9 @@ class EventbriteEdit extends Component {
 	state = {
 		editedUrl: this.props.attributes.url || '',
 		editingUrl: false,
-		// If this is a customized URL, we're going to need to find where it redirects to.
-		resolvingUrl: CUSTOM_URL_REGEX.test( this.props.attributes.url ),
+		// Resolve the url on mount if we haven't already set an eventId,
+		// Such as when transforming from an Eventbrite link.
+		resolvingUrl: this.props.attributes.url && ! this.props.attributes.eventId,
 		resolvedStatusCode: null,
 	};
 

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -8,17 +8,16 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { eventIdFromUrl } from './utils';
 import edit from './edit';
 import save from './save';
 
 // Example URLs
 // https://www.eventbrite.com/e/test-event-tickets-123456789
 // https://www.eventbrite.co.uk/e/test-event-tickets-123456789
-export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:eventbrite\.[a-z.]+)\/e\/[^\/]*?(\d+)\/?\s*$/i;
+export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:eventbrite\.[a-z.]+)\/e\/[^\/]*?(\d+)\/?(?:\?[^\/]*)?\s*$/i;
 
 // Custom eventbrite urls use a subdomain of eventbrite.com
-export const CUSTOM_URL_REGEX = /^\s*https?:\/\/(?:.+\.)?(?:eventbrite\.[a-z.]+)\/?\s*$/i;
+export const CUSTOM_URL_REGEX = /^\s*https?:\/\/(?:.+\.)?(?:eventbrite\.[a-z.]+)\/?(?:\?[^\/]*)?\s*$/i;
 
 export const name = 'eventbrite';
 
@@ -84,13 +83,10 @@ export const settings = {
 				isMatch: node =>
 					node.nodeName === 'P' &&
 					( URL_REGEX.test( node.textContent ) || CUSTOM_URL_REGEX.test( node.textContent ) ),
-				transform: node => {
-					const url = node.textContent.trim();
-					return createBlock( 'jetpack/eventbrite', {
-						eventId: eventIdFromUrl( url ),
-						url: url,
-					} );
-				},
+				transform: node =>
+					createBlock( 'jetpack/eventbrite', {
+						url: node.textContent.trim(),
+					} ),
 			},
 		],
 	},

--- a/extensions/blocks/eventbrite/utils.js
+++ b/extensions/blocks/eventbrite/utils.js
@@ -27,7 +27,7 @@ export function eventIdFromUrl( url ) {
 		return null;
 	}
 
-	const match = url.match( /(\d+)\/?\s*$/ );
+	const match = url.match( /(\d+)\/?(?:\?[^\/]*)?\s*$/ );
 	return match && match[ 1 ] ? parseInt( match[ 1 ], 10 ) : null;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14488

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Support transforming to an Eventbrite block if an Eventbrite url has query parameters, such as `https://www.eventbrite.com/e/test-event-tickets-81376285661?ref=estw`
* Adds `(?:\?[^\/]*)?` to the Eventbrite url regexs to account for query strings

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the block editor for a page or post
* Paste in an Eventbrite link with a referral code query parameter, such as `https://www.eventbrite.com/e/test-event-tickets-81376285661?ref=estw`
* The link should transform into an Eventbrite block and display an embed for the event
* Custom eventbrite urls should work as well, such as `https://grantmk-test-event.eventbrite.com/?ref=estw`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A since this is a new block
