### PR TITLE
Instant Search: Apply customizer changes without page reload

### DIFF
--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -53,8 +53,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => 'light',
-				'type'    => 'option',
+				'default'   => 'light',
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -75,8 +76,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => 97,
-				'type'    => 'option',
+				'default'   => 97,
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -98,8 +100,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => '#BD3854',
-				'type'    => 'option',
+				'default'   => '#BD3854',
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -118,8 +121,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => '#FFC',
-				'type'    => 'option',
+				'default'   => '#FFC',
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -138,8 +142,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => true,
-				'type'    => 'option',
+				'default'   => true,
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -155,8 +160,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => true,
-				'type'    => 'option',
+				'default'   => true,
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 
@@ -173,8 +179,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default' => true,
-				'type'    => 'option',
+				'default'   => true,
+				'transport' => 'postMessage',
+				'type'      => 'option',
 			)
 		);
 		$wp_customize->add_control(

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -27,6 +27,7 @@ import {
 	getSortKeyFromSortOption,
 	getSortOptionFromSortKey,
 } from '../lib/query-string';
+import { bindCustomizerChanges } from '../lib/customize';
 
 class SearchApp extends Component {
 	static defaultProps = {
@@ -39,6 +40,7 @@ class SearchApp extends Component {
 		this.state = {
 			hasError: false,
 			isLoading: false,
+			overlayOptions: { ...this.props.initialOverlayOptions },
 			requestId: 0,
 			response: {},
 			showResults: false,
@@ -63,6 +65,8 @@ class SearchApp extends Component {
 	}
 
 	addEventListeners() {
+		bindCustomizerChanges( this.handleOverlayOptionsUpdate );
+
 		window.addEventListener( 'popstate', this.onChangeQueryString );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
@@ -117,6 +121,10 @@ class SearchApp extends Component {
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
+	};
+
+	handleOverlayOptionsUpdate = ( { key, value } ) => {
+		this.setState( { overlayOptions: { ...this.state.overlayOptions, [ key ]: value } } );
 	};
 
 	showResults = () => {
@@ -199,14 +207,14 @@ class SearchApp extends Component {
 	render() {
 		return createPortal(
 			<Overlay
-				closeColor={ this.props.overlayOptions.closeColor }
+				closeColor={ this.state.overlayOptions.closeColor }
 				closeOverlay={ this.hideResults }
-				colorTheme={ this.props.overlayOptions.colorTheme }
+				colorTheme={ this.state.overlayOptions.colorTheme }
 				isVisible={ this.state.showResults }
-				opacity={ this.props.overlayOptions.opacity }
+				opacity={ this.state.overlayOptions.opacity }
 			>
 				<SearchResults
-					enableLoadOnScroll={ this.props.overlayOptions.enableInfScroll }
+					enableLoadOnScroll={ this.state.overlayOptions.enableInfScroll }
 					hasError={ this.state.hasError }
 					hasNextPage={ this.hasNextPage() }
 					highlightColor={ this.props.options.highlightColor }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -20,10 +20,10 @@ const injectSearchApp = () => {
 		<SearchApp
 			aggregations={ buildFilterAggregations( window[ SERVER_OBJECT_NAME ].widgets ) }
 			initialHref={ window.location.href }
+			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }
 			isSearchPage={ getSearchQuery() !== '' }
 			options={ window[ SERVER_OBJECT_NAME ] }
-			overlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			themeOptions={ getThemeOptions( window[ SERVER_OBJECT_NAME ] ) }
 		/>,
 		document.body

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -1,0 +1,46 @@
+const CUSTOMIZE_SETTINGS = [
+	'jetpack_search_close_color',
+	'jetpack_search_color_theme',
+	'jetpack_search_inf_scroll',
+	'jetpack_search_highlight_color',
+	'jetpack_search_opacity',
+	'jetpack_search_show_logo',
+	'jetpack_search_show_powered_by',
+];
+
+const SETTINGS_TO_STATE_MAP = new Map( [
+	[ 'jetpack_search_close_color', 'closeColor' ],
+	[ 'jetpack_search_color_theme', 'colorTheme' ],
+	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
+	[ 'jetpack_search_highlight_color', 'highlightColor' ],
+	[ 'jetpack_search_opacity', 'opacity' ],
+	[ 'jetpack_search_show_logo', 'showLogo' ],
+	[ 'jetpack_search_show_powered_by', 'showPoweredBy' ],
+] );
+
+export function isInCustomizer() {
+	return Boolean(
+		'undefined' !== typeof window.wp &&
+			window.wp.customize &&
+			window.wp.customize.settings &&
+			window.wp.customize.settings.url &&
+			window.wp.customize.settings.url.self
+	);
+}
+
+export function bindCustomizerChanges( callback ) {
+	if ( ! isInCustomizer() ) {
+		return;
+	}
+
+	CUSTOMIZE_SETTINGS.forEach( setting => {
+		window.wp.customize( setting, value => {
+			value.bind( function( newValue ) {
+				callback( {
+					key: SETTINGS_TO_STATE_MAP.get( setting ),
+					value: newValue,
+				} );
+			} );
+		} );
+	} );
+}


### PR DESCRIPTION
Fixes #14296.

#### Changes proposed in this Pull Request:
* Affixes the body behavior on overlay toggle instead of component mount. This bug was introduced in #14478.
* Changes all Jetpack Search settings to use the `postMessage` transport.
* Adds `lib/customize.js` for binding customizer change events.
* Binds customizer change events to the SearchApp component.


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* None.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Open your site's customizer at `/wp-admin/customize.php`.
3. Try changing the settings inside the Jetpack Search section. Ensure that your changes take effect instantly without a page reload.

#### Proposed changelog entry for your changes:
* None