### PR TITLE
Calendly: Changed the required plan slug, so the upgrade button is shown

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -63,7 +63,7 @@ function set_availability() {
 			'missing_plan',
 			array(
 				'required_feature' => 'calendly',
-				'required_plan'    => 'premium-plan',
+				'required_plan'    => 'value_bundle',
 			)
 		);
 	}


### PR DESCRIPTION
The premium plan is actually called `value_bundle`. If the slug is
invalid, then the nudge on WPCOM doesn't show the upgrade button CTA.

#### Changes proposed in this Pull Request:

This is a simple change to update the slug name.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a fix to a new feature

#### Testing instructions:
Insert a Calendly block on a WordPress.com free site and check that there is an upgrade button, which takes you to the Premium plan checkout, in the nudge above the block.

#### Proposed changelog entry for your changes:
No changelog entry required as the feature isn't yet released.
