### PR TITLE
Eventbrite block: add link to saved HTML

### DIFF
--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -33,11 +33,11 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 
 	wp_enqueue_script( 'eventbrite-widget', 'https://www.eventbrite.com/static/widgets/eb_widgets.js', array(), JETPACK__VERSION, true );
 
+	// Add CSS to hide direct link.
+	Jetpack_Gutenberg::load_assets_as_required( 'eventbrite' );
+
 	// Show the embedded version.
 	if ( empty( $attr['useModal'] ) ) {
-		// Add CSS to hide direct link.
-		Jetpack_Gutenberg::load_assets_as_required( 'eventbrite' );
-
 		wp_add_inline_script(
 			'eventbrite-widget',
 			"window.EBWidgets.createWidget({

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -35,6 +35,9 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 
 	// Show the embedded version.
 	if ( empty( $attr['useModal'] ) ) {
+		// Add CSS to hide direct link.
+		Jetpack_Gutenberg::load_assets_as_required( 'eventbrite' );
+
 		wp_add_inline_script(
 			'eventbrite-widget',
 			"window.EBWidgets.createWidget({

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -38,6 +38,7 @@ function saveButton( eventId, attributes ) {
 		customTextColor,
 		text,
 		textColor,
+		url,
 	} = attributes;
 
 	const textClass = getColorClassName( 'color', textColor );
@@ -67,6 +68,11 @@ function saveButton( eventId, attributes ) {
 				value={ text }
 				type="button"
 			/>
+			{ url && (
+				<a className="eventbrite__direct-link" href={ url }>
+					{ url }
+				</a>
+			) }
 		</div>
 	);
 }

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -72,7 +72,7 @@ function saveButton( eventId, attributes ) {
 }
 
 export default function save( { attributes } ) {
-	const { eventId, useModal } = attributes;
+	const { eventId, useModal, url } = attributes;
 
 	if ( ! eventId ) {
 		return;
@@ -82,5 +82,13 @@ export default function save( { attributes } ) {
 		return saveButton( eventId, attributes );
 	}
 
-	return <div id={ createWidgetId( eventId ) } />;
+	return (
+		<div id={ createWidgetId( eventId ) }>
+			{ url && (
+				<a className="eventbrite__direct-link" href={ url }>
+					{ url }
+				</a>
+			) }
+		</div>
+	);
 }

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -1,0 +1,5 @@
+.wp-block-jetpack-eventbrite {
+	a.eventbrite__direct-link {
+		display: none;
+	}
+}

--- a/extensions/blocks/eventbrite/view.js
+++ b/extensions/blocks/eventbrite/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This will allow displaying useful info in RSS feeds / subscriptions emails, or when one disables the Jetpack plugin.

Related: #14435 

#### Testing instructions:

* In a new post, insert an Eventbrite block.
* Publish it; it should be displayed nicely on the frontend, with no extra link displayed. In the HTML, however, you should notice something like this:
```html
<!-- wp:jetpack/eventbrite {"url":"https://www.eventbrite.com/e/tune-into-innovation-design-terminal-demo-day-2020-tickets-88665223069","eventId":88665223069,"useModal":false,"text":"Testing something","backgroundColor":"primary"} -->
<div id="eventbrite-widget-88665223069" class="wp-block-jetpack-eventbrite"><a class="eventbrite__direct-link" href="https://www.eventbrite.com/e/tune-into-innovation-design-terminal-demo-day-2020-tickets-88665223069">https://www.eventbrite.com/e/tune-into-innovation-design-terminal-demo-day-2020-tickets-88665223069</a></div>
<!-- /wp:jetpack/eventbrite -->
```
* This should work well for both block styles.

#### Proposed changelog entry for your changes:

* N/A
