### PR TITLE
Mobile Apps: completely remove the edit post link when in app

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -641,7 +641,7 @@ class Jetpack {
 
 		// Hide edit post link if mobile app.
 		if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
-			add_filter( 'edit_post_link', '__return_empty_string' );
+			add_filter( 'get_edit_post_link', '__return_empty_string' );
 		}
 
 		// Update the Jetpack plan from API on heartbeats


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13314

#### Changes proposed in this Pull Request:

This issue was introduced in #12867.

The original goal of this change was to to hide the Edit Post link
whenever you would access your site via the mobile app's in-app browser.

To hide the Edit Post link, we originally opted to hook into the edit_post_link filter.
While this works, it only changes the string returned for the Edit Post link itself.
It does not account for any "before" or "after" parameters that may be passed
when calling the edit_post_link function; those are not part of the filter:
https://github.com/WordPress/WordPress/blob/001ffe81fbec4438a9f594f330e18103d21fbcd7/wp-includes/link-template.php#L1439

Instead, let's shortcircuit that link earlier, by hooking into the get_edit_post_link filter.
If that filter is set to return an empty string, the edit_post_link function will return early:
https://github.com/WordPress/WordPress/blob/001ffe81fbec4438a9f594f330e18103d21fbcd7/wp-includes/link-template.php#L1420

Matching WordPress.com reference: D38302-code

#### Testing instructions:

* Start from a Jetpack site using the Twenty Nineteen theme.
* Connect your site to WordPress.com.
* Open your site's frontend in your browser.
* In your browser tools, change your user agent to `wordpress/3.1`:
![image](https://user-images.githubusercontent.com/426388/73382458-d9e7e580-42c7-11ea-8fea-020b6a0e46be.png)
* Reload the page.
* You should see a little pencil icon at the bottom of your posts, but no "Edit" text or link.
* Now apply this branch. 
* The pencil icon should be completely gone.

#### Proposed changelog entry for your changes:

* Mobile Apps: completely remove the edit post link when in app
