### PR TITLE
JITMs: Allow JITMs to not have a dismiss button.

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -81,10 +81,12 @@ jQuery( document ).ready( function( $ ) {
 					'</a>';
 				html += '</div>';
 			}
-			html +=
-				'<a href="#" data-module="' +
-				envelope.feature_class +
-				'" class="jitm-banner__dismiss"></a>';
+			if ( envelope.is_dismissible ) {
+				html +=
+					'<a href="#" data-module="' +
+					envelope.feature_class +
+					'" class="jitm-banner__dismiss"></a>';
+			}
 			html += '</div>';
 			html += '</div>';
 


### PR DESCRIPTION
Only display the dismiss button in a JITM if `is_dismissible` is truthy. This will be the default setting for messages in the engine.

This will allow JITMs to be defined without a dismiss button, meaning users will continue to see the JITM until clicking on a CTA. The use-case is notices such as accepting new Terms of Service: we want the user to explicitly click the "Accept" CTA, or continue to see the JITM until new terms come into effect.

<img width="979" alt="Screen Shot 2020-01-29 at 1 56 06 PM" src="https://user-images.githubusercontent.com/349751/73401010-29fe8200-429f-11ea-89b3-2ad6c864aa23.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
See: p58i-8v7-p2

#### Testing instructions:

* On a WP.com sandbox, create a new test JITM in `jitm-engine.php` with a `->is_dismissible( false )` property and high priority.
* Sandbox the API, apply D38330-code, and load your JP site's valid JITM target page.
* Verify the JITM displays without a dismiss `X` on the right side.
* Remove the `->is_dismissible` property, reload, and verify the JITM displays the dismiss button by default.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Allow hiding the dismiss button in JITMs.
