### PR TITLE
Instant Search: Restore initial href upon closing overlay

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -26,6 +26,7 @@ import {
 	setSortQuery,
 	getSortKeyFromSortOption,
 	getSortOptionFromSortKey,
+	restorePreviousHref,
 } from '../lib/query-string';
 import { bindCustomizerChanges } from '../lib/customize';
 
@@ -134,6 +135,7 @@ class SearchApp extends Component {
 	hideResults = () => {
 		this.setState( { showResults: false } );
 		this.restoreBodyScroll();
+		restorePreviousHref( this.props.initialHref );
 	};
 
 	onChangeQuery = event => setSearchQuery( event.target.value );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -100,7 +100,7 @@ class SearchApp extends Component {
 	}
 
 	restoreBodyScroll() {
-		delete document.body.style.overflowY;
+		document.body.style.overflowY = null;
 	}
 
 	hasActiveQuery() {

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -213,3 +213,10 @@ export function getResultFormatQuery() {
 
 	return RESULT_FORMAT_MINIMAL;
 }
+
+export function restorePreviousHref( initialHref ) {
+	if ( history.pushState ) {
+		window.history.pushState( null, null, initialHref );
+		window.dispatchEvent( new Event( 'queryStringChange' ) );
+	}
+}


### PR DESCRIPTION
Fixes #14517.

#### Changes proposed in this Pull Request:
* Restores initial href upon closing overlay; this clears the search and filter query string values when necessary.
* Fixes incorrect body scroll restoration logic

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* None.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Starting at `/`, perform a site search and then close the overlay. Ensure that you have been navigated back to `/`.
3. Starting at `/s=japan`, enter a new search into the overlay input and then close the overlay. Ensure that you been navigated back to `/s=japan`.

#### Proposed changelog entry for your changes:
* None.
