### PR TITLE
Instant search: add "powered by Jetpack" message

### DIFF
--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -37,17 +37,24 @@ const logoSize = 12;
 const JetpackColophon = () => {
 	return (
 		<div className="jetpack-instant-search__jetpack-colophon">
-			<svg
-				className="jetpack-instant-search__jetpack-colophon-logo"
-				height={ logoSize }
-				width={ logoSize }
-				viewBox={ `0 0 32 32` }
+			<a
+				href="https://jetpack.com/search"
+				rel="external noopener noreferrer"
+				target="_blank"
+				className="jetpack-instant-search__jetpack-colophon-link"
 			>
-				{ logoPath }
-			</svg>
-			<span className="jetpack-instant-search__jetpack-colophon-text">
-				{ __( 'Search powered by Jetpack', 'jetpack' ) }
-			</span>
+				<svg
+					className="jetpack-instant-search__jetpack-colophon-logo"
+					height={ logoSize }
+					width={ logoSize }
+					viewBox={ `0 0 32 32` }
+				>
+					{ logoPath }
+				</svg>
+				<span className="jetpack-instant-search__jetpack-colophon-text">
+					{ __( 'Search powered by Jetpack', 'jetpack' ) }
+				</span>
+			</a>
 		</div>
 	);
 };

--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -3,13 +3,51 @@
 /**
  * External dependencies
  */
-import { h } from 'preact';
+import { h, Fragment } from 'preact';
 import { __ } from '@wordpress/i18n';
+import { colors as PALETTE } from '@automattic/color-studio';
+
+/**
+ * Module constants
+ */
+const COLOR_JETPACK = PALETTE[ 'Jetpack Green' ];
+const COLOR_WHITE = PALETTE[ 'White' ]; // eslint-disable-line dot-notation
+
+const logoPath = (
+	<Fragment>
+		<path
+			className="jetpack-logo__icon-circle"
+			fill={ COLOR_JETPACK }
+			d="M16,0C7.2,0,0,7.2,0,16s7.2,16,16,16s16-7.2,16-16S24.8,0,16,0z"
+		/>
+		<polygon
+			className="jetpack-logo__icon-triangle"
+			fill={ COLOR_WHITE }
+			points="15,19 7,19 15,3 "
+		/>
+		<polygon
+			className="jetpack-logo__icon-triangle"
+			fill={ COLOR_WHITE }
+			points="17,29 17,13 25,13 "
+		/>
+	</Fragment>
+);
+const logoSize = 12;
 
 const JetpackColophon = () => {
 	return (
 		<div className="jetpack-instant-search__jetpack-colophon">
-			{ __( 'Search powered by Jetpack', 'jetpack' ) }
+			<svg
+				className="jetpack-instant-search__jetpack-colophon-logo"
+				height={ logoSize }
+				width={ logoSize }
+				viewBox={ `0 0 32 32` }
+			>
+				{ logoPath }
+			</svg>
+			<span className="jetpack-instant-search__jetpack-colophon-text">
+				{ __( 'Search powered by Jetpack', 'jetpack' ) }
+			</span>
 		</div>
 	);
 };

--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -4,9 +4,14 @@
  * External dependencies
  */
 import { h } from 'preact';
+import { __ } from '@wordpress/i18n';
 
 const JetpackColophon = () => {
-	return <div className="jetpack-instant-search__jetpack-colophon">Powered by Jetpack</div>;
+	return (
+		<div className="jetpack-instant-search__jetpack-colophon">
+			{ __( 'Search powered by Jetpack', 'jetpack' ) }
+		</div>
+	);
 };
 
 export default JetpackColophon;

--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -1,0 +1,12 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+const JetpackColophon = () => {
+	return <div className="jetpack-instant-search__jetpack-colophon">Powered by Jetpack</div>;
+};
+
+export default JetpackColophon;

--- a/modules/search/instant-search/components/jetpack-colophon.scss
+++ b/modules/search/instant-search/components/jetpack-colophon.scss
@@ -1,10 +1,15 @@
 .jetpack-instant-search__jetpack-colophon {
-	align-items: center;
-	display: flex;
-	justify-content: center;
 	margin-top: 2em;
 	margin-bottom: 2em;
 	text-align: center;
+}
+
+.jetpack-instant-search__jetpack-colophon-link {
+	align-items: center;
+	color: inherit;
+	display: flex;
+	justify-content: center;
+	text-decoration: none;
 }
 
 .jetpack-instant-search__jetpack-colophon-logo {

--- a/modules/search/instant-search/components/jetpack-colophon.scss
+++ b/modules/search/instant-search/components/jetpack-colophon.scss
@@ -1,0 +1,17 @@
+.jetpack-instant-search__jetpack-colophon {
+	display: flex;
+	justify-content: center;
+	margin-top: 2em;
+	margin-bottom: 2em;
+	text-align: center;
+}
+
+.jetpack-instant-search__jetpack-colophon-logo {
+	display: inline;
+}
+
+.jetpack-instant-search__jetpack-colophon-text {
+	font-size: 0.7em;
+	font-weight: 600;
+	padding-left: 4px;
+}

--- a/modules/search/instant-search/components/jetpack-colophon.scss
+++ b/modules/search/instant-search/components/jetpack-colophon.scss
@@ -1,6 +1,6 @@
 .jetpack-instant-search__jetpack-colophon {
 	margin-top: 2em;
-	margin-bottom: 2em;
+	margin-bottom: 1em;
 	text-align: center;
 }
 

--- a/modules/search/instant-search/components/jetpack-colophon.scss
+++ b/modules/search/instant-search/components/jetpack-colophon.scss
@@ -1,6 +1,6 @@
 .jetpack-instant-search__jetpack-colophon {
 	margin-top: 2em;
-	margin-bottom: 1em;
+	margin-bottom: 2em;
 	text-align: center;
 }
 

--- a/modules/search/instant-search/components/jetpack-colophon.scss
+++ b/modules/search/instant-search/components/jetpack-colophon.scss
@@ -1,4 +1,5 @@
 .jetpack-instant-search__jetpack-colophon {
+	align-items: center;
 	display: flex;
 	justify-content: center;
 	margin-top: 2em;
@@ -13,5 +14,5 @@
 .jetpack-instant-search__jetpack-colophon-text {
 	font-size: 0.7em;
 	font-weight: 600;
-	padding-left: 4px;
+	padding-left: 6px;
 }

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -225,6 +225,7 @@ class SearchApp extends Component {
 					query={ getSearchQuery() }
 					response={ this.state.response }
 					resultFormat={ getResultFormatQuery() }
+					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
 					widgets={ this.props.options.widgets }
 				/>
 			</Overlay>,

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -8,6 +8,7 @@ import { Component, h } from 'preact';
 /**
  * Internal dependencies
  */
+import JetpackColophon from './jetpack-colophon';
 import SearchBox from './search-box';
 import SearchFilters from './search-filters';
 import SearchSort from './search-sort';
@@ -73,6 +74,7 @@ class SearchForm extends Component {
 								widget={ widget }
 							/>
 						) ) }
+						<JetpackColophon />
 					</div>
 				) }
 			</form>

--- a/modules/search/instant-search/components/search-form.scss
+++ b/modules/search/instant-search/components/search-form.scss
@@ -10,6 +10,14 @@ $arrow-height: 10px;
 	padding: 16px 24px;
 	border-radius: 6px;
 
+	.jetpack-instant-search__jetpack-colophon {
+		margin-bottom: 1em;
+	}
+
+	.jetpack-instant-search__jetpack-colophon-text {
+		font-size: 0.8em;
+	}
+
 	.jetpack-instant-search__overlay--light & {
 		background: #fff;
 		border: 1px solid rgba(0, 0, 0, 0.1);

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -133,6 +133,7 @@ class SearchResults extends Component {
 				locale={ this.props.locale }
 				postTypes={ this.props.postTypes }
 				response={ this.props.response }
+				showPoweredBy={ this.props.showPoweredBy }
 				widgets={ this.props.widgets }
 			/>
 		);

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -8,7 +8,12 @@ import { createPortal, useState, useEffect } from 'preact/compat';
 import SearchFilters from './search-filters';
 import WidgetAreaContainer from './widget-area-container';
 
-const SearchBox = props => {
+/**
+ * Internal dependencies
+ */
+import JetpackColophon from './jetpack-colophon';
+
+const SearchSidebar = props => {
 	// TODO: Change JetpackInstantSearchOptions.widgets to only include info from widgets inside Overlay sidebar
 	const [ widgetIds, setWidgetIds ] = useState( [] );
 
@@ -48,7 +53,8 @@ const SearchBox = props => {
 						document.getElementById( `${ widget.widget_id }-wrapper` )
 					);
 				} ) }
+			{ props.showPoweredBy && <JetpackColophon /> }
 		</div>
 	);
 };
-export default SearchBox;
+export default SearchSidebar;

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -15,6 +15,7 @@ $grid-size-large: 16px;
 }
 
 @import './components/gridicon/style.scss';
+@import './components/jetpack-colophon.scss';
 @import './components/notice.scss';
 @import './components/overlay.scss';
 @import './components/search-results.scss';

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
 		"react-dom": "16.8.6"
 	},
 	"devDependencies": {
+		"@automattic/color-studio": "2.2.1",
 		"@slack/web-api": "5.3.0",
 		"@testing-library/jest-dom": "4.2.3",
 		"@testing-library/preact": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,11 @@
   resolved "https://registry.yarnpkg.com/@automattic/calypso-color-schemes/-/calypso-color-schemes-1.0.0.tgz#17a14e3257bd90b40e960d624cca4353d4d20c34"
   integrity sha512-W7r4pgcBauLx65oTLbHKV84ScnfEKmW7T/sXkPfByHhuIE7+OpubmiiBsizWatk1I/puUTmj+SDqEOJMOyRdzA==
 
+"@automattic/color-studio@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.2.1.tgz#e920af382a4db624ebca1591adace289912bf37b"
+  integrity sha512-doMeOR5ly+qviYgWhWStByZHnnv3AFBC4Tj6aZLTrw8voulIu9AUv3Z9eit8a68uzCI77VkN7fUFadOiYIYBWg==
+
 "@automattic/custom-colors-loader@automattic/custom-colors-loader":
   version "1.0.0"
   resolved "https://codeload.github.com/automattic/custom-colors-loader/tar.gz/e102d3ae049662e77ba9ba9e9f9cf0627313b38c"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes part of #12540.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a "powered by Jetpack" message (aka Jetpack colophon) to the bottom of the overlay search sidebar.

<img width="318" alt="73035536-a4de1d80-3e05-11ea-8c6d-c1890eebe8da" src="https://user-images.githubusercontent.com/17325/73406190-aefaa180-435a-11ea-91dc-8037b48ac057.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No - it's part of the Instant Search development branch.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Customizer in your site's wp-admin.
* Under Jetpack Search, try toggling the 'Display "Powered by Jetpack"' option on and off.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not required.
