### PR TITLE
General: Add Infinity as code owners to partnership related files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,11 @@
 /_inc/lib/jetpack-wpes-query-builder/ @gibrown
 /class.jetpack-jitm.php @withinboredom
 
-# Jetpack CLI is used heavily by our partners
-/class.jetpack-cli.php @automattic/catalyst
+# Functionality that is important to our partners
+/class.jetpack-cli.php @automattic/jetpack-infinity
+/bin/partner-provision.sh @automattic/jetpack-infinity
+/bin/partner-cancel.sh @automattic/jetpack-infinity
+
 
 # Catch-all owners, the Jetpack Crew
 # Please leave this at the bottom of the list


### PR DESCRIPTION
Now that Catalyst has become a part of Infinity, we needed to update one reference in the `CODEOWNERS` file from Catalyst to Infinity. But, it also makes sense to go ahead and add the shell scripts that partners can use to provision plans.

#### Changes proposed in this Pull Request:

* Update code owner reference from Catalyst to Infinity
* Add Infinity as owners of partnership provisioning scripts

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* Not applicable

#### Testing instructions:

* Check my spelling and ensure that the team name is `jetpack-infinity`.

#### Proposed changelog entry for your changes:

* None needed
