### PR TITLE
Instant Search: Restore focus to activeElement

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -14,20 +14,26 @@ import uniqueId from 'lodash/uniqueId';
  */
 import Gridicon from './gridicon';
 
+let initiallyFocusedElement = null;
+
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	const inputRef = useRef( null );
 
-	const cb = overlayElement => () =>
-		! overlayElement.classList.contains( 'is-hidden' ) && inputRef.current.focus();
+	const cb = overlayElement => () => {
+		if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
+			initiallyFocusedElement = document.activeElement;
+			inputRef.current.focus();
+			return;
+		}
+		initiallyFocusedElement && initiallyFocusedElement.focus();
+	};
 
 	useEffect( () => {
 		const overlayElement = document.querySelector( '.jetpack-instant-search__overlay' );
 		overlayElement.addEventListener( 'transitionend', cb( overlayElement ), true );
 		cb( overlayElement )(); // invoke focus if page loads with overlay already present
 		return () => {
-			// Cleanup after event
-			// @todo Focus back on the activeElement before the overlay was opened
 			overlayElement.removeEventListener( 'transitionend', cb );
 		};
 	}, [] );


### PR DESCRIPTION
Fixes #14482.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Restores focus on the appropriate element when closing the overlay.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Starting at `/`, select your site search input and perform a search. 
3. Ensure that the search overlay appears with the overlay input in focus.
4. Close the search overlay. 
5. Ensure that the site search input from (2) is in focus.

#### Proposed changelog entry for your changes:
* None
