### PR TITLE
Map Block: add missing text domain for option labels.

### DIFF
--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -154,7 +154,7 @@ class MapEdit extends Component {
 					<Toolbar>
 						<IconButton
 							icon={ settings.markerIcon }
-							label="Add a marker"
+							label={ __( 'Add a marker', 'jetpack' ) }
 							onClick={ () => this.setState( { addPointVisibility: true } ) }
 						/>
 					</Toolbar>
@@ -179,7 +179,7 @@ class MapEdit extends Component {
 							{
 								value: markerColor,
 								onChange: value => setAttributes( { markerColor: value } ),
-								label: 'Marker Color',
+								label: __( 'Marker Color', 'jetpack' ),
 							},
 						] }
 					/>


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
Map Block: add missing text domain for option labels.

#### Testing instructions:

* Not too much to test here, the strings in the map block should remain accessible.

#### Proposed changelog entry for your changes:

* N/A
