### PR TITLE
OpenTable: Ensure that the block style CSS is applied on the frontend

### DIFF
--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -22,7 +22,7 @@ export const getStyleOptions = rid =>
 	compact( [
 		{ value: 'standard', label: __( 'Standard (224 x 301 pixels)', 'jetpack' ) },
 		{ value: 'tall', label: __( 'Tall (288 x 490 pixels)', 'jetpack' ) },
-		{ value: 'wide', label: __( 'Wide (840 x 350 pixels)', 'jetpack' ) },
+		{ value: 'wide', label: __( 'Wide (840 x 150 pixels)', 'jetpack' ) },
 		( ! rid || rid.length === 1 ) && {
 			value: 'button',
 			label: __( 'Button (210 x 113 pixels)', 'jetpack' ),

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -71,30 +71,6 @@
 		z-index: 10;
 	}
 
-	&-theme-standard {
-		height: 301px;
-
-		&.is-multi {
-			height: 361px;
-		}
-	}
-
-	&-theme-tall {
-		height: 490px;
-
-		&.is-multi {
-			height: 550px;
-		}
-	}
-
-	&-theme-wide {
-		height: 350px;
-	}
-
-	&-theme-button {
-		height: 113px;
-	}
-
 	&-restaurant-picker {
 		margin-bottom: 1em;
 		position: relative;

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -14,6 +14,7 @@ import icon from './icon';
  * Style dependencies
  */
 import './editor.scss';
+import './view.scss';
 
 export const name = 'opentable';
 export const title = __( 'OpenTable', 'jetpack' );

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -91,10 +91,14 @@ add_action( 'enqueue_block_assets', 'Jetpack\OpenTable_Block\add_language_settin
 function load_assets( $attributes ) {
 	\Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
+	$classes = array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) );
+	if ( count( $attributes['rid'] ) > 1 ) {
+		$classes[] = 'is-multi';
+	}
 	$classes = \Jetpack_Gutenberg::block_classes(
 		FEATURE_NAME,
 		$attributes,
-		array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) )
+		$classes
 	);
 	$content = '<div class="' . esc_attr( $classes ) . '">';
 	// The OpenTable script uses multiple `rid` paramters,

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -91,7 +91,11 @@ add_action( 'enqueue_block_assets', 'Jetpack\OpenTable_Block\add_language_settin
 function load_assets( $attributes ) {
 	\Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	$classes = \Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
+	$classes = \Jetpack_Gutenberg::block_classes(
+		FEATURE_NAME,
+		$attributes,
+		array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) )
+	);
 	$content = '<div class="' . esc_attr( $classes ) . '">';
 	// The OpenTable script uses multiple `rid` paramters,
 	// so we can't use WordPress to output it, as WordPress attempts to validate it and removes them.

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -1,4 +1,29 @@
 .wp-block-jetpack-opentable {
+
+	&-theme-standard {
+		height: 301px;
+
+		&.is-multi {
+			height: 361px;
+		}
+	}
+
+	&-theme-tall {
+		height: 490px;
+
+		&.is-multi {
+			height: 550px;
+		}
+	}
+
+	&-theme-wide {
+		height: 150px;
+	}
+
+	&-theme-button {
+		height: 113px;
+	}
+
 	.ot-dtp-picker {
 		box-sizing: content-box;
 


### PR DESCRIPTION
The CSS for the block styles was only being used in the editor, and the
height of the rendered block was sometimes incorrect in the frontend.

#### Changes proposed in this Pull Request:

This change fixes that by adding the style class to the rendered block
and ensuring the required CSS is available.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a fix to a beta block.

#### Testing instructions:
Add an OpenTable block to a post and view the post on the frontend. Ensure that the block is rendered with the correct height, especially with the 'wide' style.

#### Proposed changelog entry for your changes:
No changelog required.
