### PR TITLE
Instant Search: Clear search and filter queries when necessary

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -27,7 +27,6 @@ import {
 	getSortKeyFromSortOption,
 	getSortOptionFromSortKey,
 	restorePreviousHref,
-	clearSearchAndFilterQueries,
 } from '../lib/query-string';
 import { bindCustomizerChanges } from '../lib/customize';
 
@@ -69,7 +68,7 @@ class SearchApp extends Component {
 	addEventListeners() {
 		bindCustomizerChanges( this.handleOverlayOptionsUpdate );
 
-		window.addEventListener( 'popstate', this.onChangeQueryString );
+		window.addEventListener( 'popstate', this.onPopstate );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
@@ -83,7 +82,7 @@ class SearchApp extends Component {
 	}
 
 	removeEventListeners() {
-		window.removeEventListener( 'popstate', this.onChangeQueryString );
+		window.removeEventListener( 'popstate', this.onPopstate );
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
@@ -141,6 +140,11 @@ class SearchApp extends Component {
 	};
 
 	onChangeQuery = event => setSearchQuery( event.target.value );
+
+	onPopstate = () => {
+		this.showResults();
+		this.onChangeQueryString();
+	};
 
 	onChangeQueryString = () => {
 		this.getResults();

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -134,10 +134,10 @@ class SearchApp extends Component {
 		this.preventBodyScroll();
 	};
 	hideResults = () => {
-		this.setState( { showResults: false } );
 		this.restoreBodyScroll();
-		restorePreviousHref( this.props.initialHref );
-		clearSearchAndFilterQueries();
+		restorePreviousHref( this.props.initialHref, () => {
+			this.setState( { showResults: false } );
+		} );
 	};
 
 	onChangeQuery = event => setSearchQuery( event.target.value );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -27,6 +27,7 @@ import {
 	getSortKeyFromSortOption,
 	getSortOptionFromSortKey,
 	restorePreviousHref,
+	clearSearchAndFilterQueries,
 } from '../lib/query-string';
 import { bindCustomizerChanges } from '../lib/customize';
 
@@ -136,6 +137,7 @@ class SearchApp extends Component {
 		this.setState( { showResults: false } );
 		this.restoreBodyScroll();
 		restorePreviousHref( this.props.initialHref );
+		clearSearchAndFilterQueries();
 	};
 
 	onChangeQuery = event => setSearchQuery( event.target.value );

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -220,3 +220,12 @@ export function restorePreviousHref( initialHref ) {
 		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }
+
+export function clearSearchAndFilterQueries() {
+	// TODO: Improve detection of search and filter queries
+	if ( window.location.search ) {
+		setSearchQuery( '' );
+		clearFiltersFromQuery();
+		window.location.reload();
+	}
+}

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -22,7 +22,7 @@ function getQuery() {
 	return decode( window.location.search.substring( 1 ) );
 }
 
-function pushQueryString( queryString ) {
+function pushQueryString( queryString, shouldEmitEvent = true ) {
 	if ( history.pushState ) {
 		const url = new window.URL( window.location.href );
 		if ( window[ SERVER_OBJECT_NAME ] && 'homeUrl' in window[ SERVER_OBJECT_NAME ] ) {
@@ -30,7 +30,7 @@ function pushQueryString( queryString ) {
 		}
 		url.search = queryString;
 		window.history.pushState( null, null, url.toString() );
-		window.dispatchEvent( new Event( 'queryStringChange' ) );
+		shouldEmitEvent && window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }
 
@@ -214,18 +214,22 @@ export function getResultFormatQuery() {
 	return RESULT_FORMAT_MINIMAL;
 }
 
-export function restorePreviousHref( initialHref ) {
+export function restorePreviousHref( initialHref, callback ) {
 	if ( history.pushState ) {
 		window.history.pushState( null, null, initialHref );
-		window.dispatchEvent( new Event( 'queryStringChange' ) );
-	}
-}
 
-export function clearSearchAndFilterQueries() {
-	// TODO: Improve detection of search and filter queries
-	if ( window.location.search ) {
-		setSearchQuery( '' );
-		clearFiltersFromQuery();
-		window.location.reload();
+		const query = getQuery();
+		const keys = [ ...getFilterKeys(), 's' ];
+		// If initialHref has search or filter query values, clear them and reload.
+		if ( Object.keys( query ).some( key => keys.includes( key ) ) ) {
+			keys.forEach( key => delete query[ key ] );
+			pushQueryString( encode( query ), false );
+			window.location.reload( true );
+			return;
+		}
+
+		// Otherwise, invoke the callback and emit a QS change event
+		callback();
+		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }


### PR DESCRIPTION
Fixes #14532.

#### Changes proposed in this Pull Request:
* If the initial href includes a query string, strip `s` and filter query values and reload the page.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Starting at `/`, perform a site search and then close the overlay. Ensure that you have been navigated back to `/`.
3. Starting at `/s=japan`, enter a new search into the overlay input and then close the overlay. Ensure that you been navigated back to `/`.

#### Proposed changelog entry for your changes:
* None.
