### PR TITLE
Resolve Redirect: Explicitly pass the parameter to be validated

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php
@@ -36,7 +36,9 @@ class WPCOM_REST_API_V2_Endpoint_Resolve_Redirect extends WP_REST_Controller {
 						'description'       => __( 'The URL to check for redirects.', 'jetpack' ),
 						'type'              => 'string',
 						'required'          => 'true',
-						'validate_callback' => 'wp_http_validate_url',
+						'validate_callback' => function ( $param ) {
+							return wp_http_validate_url( $param );
+						},
 					),
 				),
 				array(


### PR DESCRIPTION
In certain situations, a second parameter was being passed to the
`validate_callback` of the resolve-redirect endpoint. This was causing
an exception depending on its value.

#### Changes proposed in this Pull Request:

This change wraps the callback to ensure that only one parameter is
passed.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix

#### Testing instructions:
* Sandbox the API
* Insert a Pinterest block
* Try embedding a Pinterest URL e.g. https://pin.it/yspzdcdhqf5imw
* Check that it embeds correctly.

Without this patch, the block will hang with a spinner, as it receives an error form the API

#### Proposed changelog entry for your changes:
I don't believe one is needed.
