### PR TITLE
Lazy Images: Skip images with data-skip-lazy attribute

### DIFF
--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -202,6 +202,10 @@ class Jetpack_Lazy_Images {
 			return $attributes;
 		}
 
+		if ( isset( $attributes['data-skip-lazy'] ) ) {
+			return $attributes;
+		}
+
 		/**
 		 * Allow plugins and themes to conditionally skip processing an image via its attributes.
 		 *

--- a/tests/php/modules/lazy-images/test_class.lazy-images.php
+++ b/tests/php/modules/lazy-images/test_class.lazy-images.php
@@ -272,6 +272,34 @@ class WP_Test_Lazy_Images extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @dataProvider get_dont_process_images_with_skip_lazy_data_attribute_data
+	 */
+	function test_dont_process_images_with_skip_lazy_data_attribute( $input, $should_skip = true ) {
+		$instance = Jetpack_Lazy_Images::instance();
+		$output = $instance->add_image_placeholders( $input );
+
+		if ( $should_skip ) {
+			$this->assertNotContains( 'srcset="placeholder.jpg"', $output );
+		} else {
+			$this->assertContains( 'srcset="placeholder.jpg"', $output );
+		}
+	}
+
+	function get_dont_process_images_with_skip_lazy_data_attribute_data() {
+		return array(
+			'skip_lazy_attr_only' => array(
+				'<img src="image.jpg" srcset="medium.jpg 1000w, large.jpg 2000w" data-skip-lazy/>',
+			),
+			'skip-lazy-attr-true' => array(
+				'<img src="image.jpg" srcset="medium.jpg 1000w, large.jpg 2000w" data-skip-lazy="true"/>',
+			),
+			'skip-lazy-attr-1' => array(
+				'<img src="image.jpg" srcset="medium.jpg 1000w, large.jpg 2000w" data-skip-lazy="1"/>',
+			),
+		);
+	}
+
+	/**
 	 * @dataProvider get_should_skip_image_with_blacklisted_class_data
 	 */
 	function test_should_skip_image_with_blacklisted_class( $expected, $input, $empty_blacklisted_classes = false ) {


### PR DESCRIPTION
Per a request from a hosting partner and a community member, add the ability to skip lazy loading of images that have the `data-skip-lazy` attribute.

#### Changes proposed in this Pull Request:

* Do not lazy load images that have `data-skip-lazy` attribute

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This is a new feature for an existing module.

#### Testing instructions:

- Checkout branch
- Ensure Lazy Images is active
- Create a post with an image
- Modify image's HTML to include `data-skip-lazy="1"`
- Publish post then load post
- Check source of image, and ensure that it does not have the `jetpack-lazy-image--handled` class nor any other lazy attributes.

For example, there are two images in the source here. The top on was **not** lazy loaded but the bottom one was.

![Screen Shot 2020-01-31 at 11 00 59 AM](https://user-images.githubusercontent.com/1126811/73558652-3ad30300-4419-11ea-926a-b9afed0ffbc0.png)


#### Proposed changelog entry for your changes:

* Update lazy images module to skip images with the data-skip-lazy attribute