### PR TITLE
Eventbrite and OpenTable Blocks: Increase specificity of the Inserter preview CSS to avoid conflicts

### DIFF
--- a/extensions/blocks/eventbrite/editor.scss
+++ b/extensions/blocks/eventbrite/editor.scss
@@ -12,7 +12,7 @@
 	}
 }
 
-.block-editor-block-preview__content div[data-block] {
+.block-editor-block-preview__content [data-type='jetpack/eventbrite'] div[data-block] {
 	display: table;
 }
 

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -7,7 +7,6 @@
 .wp-block-jetpack-opentable {
 	position: relative;
 
-
 	.components-base-control {
 		width: 100%;
 	}
@@ -20,7 +19,7 @@
 
 		form {
 			flex-direction: row;
-			@media screen and (max-width: 479px) {
+			@media screen and ( max-width: 479px ) {
 				display: block;
 			}
 
@@ -34,7 +33,7 @@
 
 			.components-form-token-field__input-container {
 				width: 100%;
-				@media screen and (min-width: 480px) {
+				@media screen and ( min-width: 480px ) {
 					width: 327px;
 				}
 			}
@@ -51,7 +50,7 @@
 				line-height: normal;
 				// End copied styles
 
-				@media screen and (min-width: 480px) {
+				@media screen and ( min-width: 480px ) {
 					margin: 1px 0 0 4px;
 					position: relative;
 				}
@@ -104,7 +103,7 @@
 	&-placeholder-links {
 		display: flex;
 		flex-direction: column;
-		@media screen and (min-width: 480px) {
+		@media screen and ( min-width: 480px ) {
 			display: block;
 		}
 
@@ -123,7 +122,6 @@
 		padding: 0;
 		margin: 0;
 	}
-
 }
 
 .components-toggle-control.is-opentable {
@@ -134,4 +132,8 @@
 	button.is-active {
 		font-weight: bold;
 	}
+}
+
+.block-editor-block-preview__content [data-type='jetpack/opentable'] div[data-block] {
+	display: table;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Increase the CSS specificity of the workaround that improve the Eventbrite and OpenTable block previews in the Inserter.

<img width="712" alt="Screenshot 2020-01-31 at 16 27 09" src="https://user-images.githubusercontent.com/2070010/73556047-91a30180-4446-11ea-96b7-0db823d976e0.png">

We added this workaround in https://github.com/Automattic/jetpack/pull/14075, but it's too generic and affects other block previews, such as the WordPress.com Page Layout Selector.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the editor and click on the top bar's block insterter.
* Hover on various blocks, especially Jetpack ones, and make sure that they look good enough.

Notes:
- Some blocks (e.g. Image, Slideshow, Map) might not be positioned correctly at first hover. Try again!
- Pinterest is incorrectly positioned, period. `display: table` doesn't help.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A

#### Related

https://github.com/Automattic/wp-calypso/issues/39198
