### PR TITLE
Added a specific filter to enable iframe authorization API URL.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4654,8 +4654,8 @@ endif;
 		add_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
 		add_filter( 'jetpack_connect_processing_url', array( __CLASS__, 'filter_connect_processing_url' ) );
 
-		if ( ! $iframe ) {
-			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
+		if ( $iframe ) {
+			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 		}
 
 		$c8n = self::connection();
@@ -4665,8 +4665,8 @@ endif;
 		remove_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
 		remove_filter( 'jetpack_connect_processing_url', array( __CLASS__, 'filter_connect_processing_url' ) );
 
-		if ( ! $iframe ) {
-			remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
+		if ( $iframe ) {
+			remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 		}
 
 		return $url;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4654,8 +4654,8 @@ endif;
 		add_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
 		add_filter( 'jetpack_connect_processing_url', array( __CLASS__, 'filter_connect_processing_url' ) );
 
-		if ( $iframe ) {
-			add_filter( 'jetpack_api_url', array( __CLASS__, 'filter_connect_api_iframe_url' ), 10, 2 );
+		if ( ! $iframe ) {
+			add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
 		}
 
 		$c8n = self::connection();
@@ -4665,8 +4665,8 @@ endif;
 		remove_filter( 'jetpack_connect_redirect_url', array( __CLASS__, 'filter_connect_redirect_url' ) );
 		remove_filter( 'jetpack_connect_processing_url', array( __CLASS__, 'filter_connect_processing_url' ) );
 
-		if ( $iframe ) {
-			remove_filter( 'jetpack_api_url', array( __CLASS__, 'filter_connect_api_iframe_url' ) );
+		if ( ! $iframe ) {
+			remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
 		}
 
 		return $url;
@@ -4739,26 +4739,6 @@ endif;
 		}
 
 		return $redirect;
-	}
-
-	/**
-	 * Filters the API URL that is used for connect requests. The method
-	 * intercepts only the authorize URL and replaces it with another if needed.
-	 *
-	 * @param String $api_url the default redirect API URL used by the package.
-	 * @param String $relative_url the path of the URL that's being used.
-	 * @return String the modified URL.
-	 */
-	public static function filter_connect_api_iframe_url( $api_url, $relative_url ) {
-
-		// Short-circuit on anything that is not related to connect requests.
-		if ( 'authorize' !== $relative_url ) {
-			return $api_url;
-		}
-
-		$c8n = self::connection();
-
-		return $c8n->api_url( 'authorize_iframe' );
 	}
 
 	/**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -725,9 +725,9 @@ class Manager {
 		 *
 		 * @since 8.3.0
 		 *
-		 * @param Boolean $is_iframe_flow_used should the iframe flow be used, defaults to true.
+		 * @param Boolean $is_iframe_flow_used should the iframe flow be used, defaults to false.
 		 */
-		$iframe_flow = apply_filters( 'jetpack_use_iframe_authorization_flow', true );
+		$iframe_flow = apply_filters( 'jetpack_use_iframe_authorization_flow', false );
 
 		// Do not modify anything that is not related to authorize requests.
 		if ( 'authorize' === $relative_url && $iframe_flow ) {

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -720,6 +720,24 @@ class Manager {
 		$version  = '/' . Utils::get_jetpack_api_version() . '/';
 
 		/**
+		 * Filters whether the connection manager should use the iframe authorization
+		 * flow instead of the regular redirect-based flow.
+		 *
+		 * @since 8.3.0
+		 *
+		 * @param String $url the generated URL.
+		 * @param String $relative_url the relative URL that was passed as an argument.
+		 * @param String $api_base the API base string that is being used.
+		 * @param String $version the version string that is being used.
+		 */
+		$iframe_flow = apply_filters( 'jetpack_use_iframe_authorization_flow', true );
+
+		// Do not modify anything that is not related to authorize requests.
+		if ( 'authorize' === $relative_url && $iframe_flow ) {
+			$relative_url = 'authorize_iframe';
+		}
+
+		/**
 		 * Filters the API URL that Jetpack uses for server communication.
 		 *
 		 * @since 8.0.0

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -725,10 +725,7 @@ class Manager {
 		 *
 		 * @since 8.3.0
 		 *
-		 * @param String $url the generated URL.
-		 * @param String $relative_url the relative URL that was passed as an argument.
-		 * @param String $api_base the API base string that is being used.
-		 * @param String $version the version string that is being used.
+		 * @param Boolean $is_iframe_flow_used should the iframe flow be used, defaults to true.
 		 */
 		$iframe_flow = apply_filters( 'jetpack_use_iframe_authorization_flow', true );
 


### PR DESCRIPTION
This is a companion PR to the client-example connect-in-place PR: https://github.com/Automattic/client-example/pull/10

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes a filter method that enabled the iframe API URL.
* Adds a filter inside the API URL generation method that modifies the URL for that specific case.
* Adds a simple `__return_false` hook to that filter when the iframe flow is disabled in Jetpack.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an effort to make Jetpack Connection more easily consumable.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Both connection flows should work as before. Disconnect your site and try to reconnect.
* Add the iframe enabling constant and do the same:
```
define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N\A
