### PR TITLE
PHPCS: Remove exclusions

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -35,7 +35,6 @@
 
 	<arg name="colors"/>
 
-	<exclude-pattern>/docker/*</exclude-pattern>
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -37,6 +37,5 @@
 
 	<exclude-pattern>/docker/*</exclude-pattern>
 	<exclude-pattern>/node_modules/*</exclude-pattern>
-	<exclude-pattern>/tests/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 </ruleset>

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -5,6 +5,7 @@ module.exports = [
 	'3rd-party/woocommerce-services.php',
 	'class.jetpack-gutenberg.php',
 	'class.jetpack-plan.php',
+	'docker',
 	'extensions/',
 	'functions.cookies.php',
 	'functions.global.php',

--- a/docker/config/wp-tests-config.php
+++ b/docker/config/wp-tests-config.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * A wp-config for testing.
+ *
+ * @package Jetpack.
+ */
 
 /* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
 define( 'ABSPATH', '/var/www/html/' );
@@ -13,22 +18,24 @@ define( 'WP_DEFAULT_THEME', 'default' );
 
 // Test with multisite enabled.
 // Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 // define( 'WP_TESTS_MULTISITE', true );
 
 // Force known bugs to be run.
 // Tests with an associated Trac ticket that is still open are normally skipped.
+// phpcs:ignore Squiz.Commenting.InlineComment.InvalidEndChar
 // define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
 
 // Test with WordPress debug mode (default).
 define( 'WP_DEBUG', true );
 
-// Enable error logging for tests
+// Enable error logging for tests.
 define( 'WP_DEBUG_LOG', true );
 
-// Additional constants for better error log
-@error_reporting( E_ALL );
-@ini_set( 'log_errors', true );
-@ini_set( 'log_errors_max_len', '0' );
+// Additional constants for better error log.
+@error_reporting( E_ALL ); // phpcs:ignore
+@ini_set( 'log_errors', true ); // phpcs:ignore
+@ini_set( 'log_errors_max_len', '0' ); // phpcs:ignore
 
 define( 'WP_DEBUG_DISPLAY', false );
 define( 'CONCATENATE_SCRIPTS', false );
@@ -57,15 +64,16 @@ define( 'DB_COLLATE', '' );
  * Change these to different unique phrases!
  * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
  */
-define( 'AUTH_KEY',         'put your unique phrase here' );
-define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
-define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
-define( 'NONCE_KEY',        'put your unique phrase here' );
-define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'AUTH_KEY', 'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY', 'put your unique phrase here' );
+define( 'LOGGED_IN_KEY', 'put your unique phrase here' );
+define( 'NONCE_KEY', 'put your unique phrase here' );
+define( 'AUTH_SALT', 'put your unique phrase here' );
 define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
-define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
-define( 'NONCE_SALT',       'put your unique phrase here' );
+define( 'LOGGED_IN_SALT', 'put your unique phrase here' );
+define( 'NONCE_SALT', 'put your unique phrase here' );
 
+// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 $table_prefix = 'wptests_';   // Only numbers, letters, and underscores please!
 
 define( 'WP_TESTS_DOMAIN', 'example.org' );


### PR DESCRIPTION
Fixes #14328

The exclusions were helpful for files where meeting PHPCS doesn't really matter, but with #14328, it ends up causing headaches. With phpcs-changed, we'll have some minor annoyances with needing to bring code inline or add exclusions. We could exclude any file we touch if it is too annoying, but this can help reduce friction when committing files.

#### Changes proposed in this Pull Request:
* No longer exclude /tests/ and /docker/ from the exclusion list.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* n/a
