### PR TITLE
Eventbrite and OpenTable Blocks: Fix block preview sizing with Gutenberg

### DIFF
--- a/extensions/blocks/eventbrite/editor.scss
+++ b/extensions/blocks/eventbrite/editor.scss
@@ -12,7 +12,8 @@
 	}
 }
 
-.block-editor-block-preview__content [data-type='jetpack/eventbrite'] div[data-block] {
+.block-editor-block-preview__content [data-type='jetpack/eventbrite'] div[data-block],
+.block-editor-block-preview__content [data-type='jetpack/eventbrite'][data-block] {
 	display: table;
 }
 

--- a/extensions/blocks/eventbrite/editor.scss
+++ b/extensions/blocks/eventbrite/editor.scss
@@ -12,7 +12,10 @@
 	}
 }
 
-.block-editor-block-preview__content [data-type='jetpack/eventbrite'] div[data-block],
+// Display "table" is used because the button container should only wrap the content and not take the full width.
+// Both selector rules needed because the block wrapper used in Gutenberg was removed in v7.3
+// @link https://github.com/WordPress/gutenberg/pull/19593
+.block-editor-block-preview__content [data-type='jetpack/eventbrite'] [data-block],
 .block-editor-block-preview__content [data-type='jetpack/eventbrite'][data-block] {
 	display: table;
 }

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -134,7 +134,10 @@
 	}
 }
 
-.block-editor-block-preview__content [data-type='jetpack/opentable'] div[data-block],
+// Display "table" is used because the preview container should only wrap the content and not take the full width.
+// Both selector rules needed because the block wrapper used in Gutenberg was removed in v7.3
+// @link https://github.com/WordPress/gutenberg/pull/19593
+.block-editor-block-preview__content [data-type='jetpack/opentable'] [data-block],
 .block-editor-block-preview__content [data-type='jetpack/opentable'][data-block] {
 	display: table;
 }

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -134,6 +134,7 @@
 	}
 }
 
-.block-editor-block-preview__content [data-type='jetpack/opentable'] div[data-block] {
+.block-editor-block-preview__content [data-type='jetpack/opentable'] div[data-block],
+.block-editor-block-preview__content [data-type='jetpack/opentable'][data-block] {
 	display: table;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Gutenberg 7.3 [removes a wrapper div](https://github.com/WordPress/gutenberg/pull/19593) around blocks that changes the display of the block previews for the Eventbrite and OpenTable blocks.

This change adds additional style rules that restore the block previews.

**Before**

<img width="698" alt="Screen Shot 2020-01-31 at 21 49 32" src="https://user-images.githubusercontent.com/1699996/73586744-4523ea00-4477-11ea-85e4-bb983aac1c42.png">

**After**

<img width="695" alt="Screen Shot 2020-01-31 at 22 15 29" src="https://user-images.githubusercontent.com/1699996/73586747-4d7c2500-4477-11ea-9614-6f45e6332c69.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Follow-up to #14540

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install and activate the latest version of the Gutenberg plugin (7.3)
* Use the block picker to see previews of the Eventbrite and OpenTable blocks
* Without this PR, the block previews look very small
* With this PR, the block preview should look correctly sized

Note that there is an extra margin at the top of the block preview--this appears to be a bug in Gutenberg 7.3 since it also appears in the Core block previews.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A since these are new blocks in the 8.2 release.
