### PR TITLE
E2E: test with latest Gutenberg

### DIFF
--- a/tests/e2e/bin/setup-e2e-travis.sh
+++ b/tests/e2e/bin/setup-e2e-travis.sh
@@ -150,6 +150,10 @@ PHP
 
 	# create a debug.log file
 	touch $WP_CORE_DIR/wp-content/debug.log
+
+	# Install plugins
+	wp plugin install gutenberg --activate
+	wp plugin list
 }
 
 prepare_jetpack() {
@@ -173,8 +177,9 @@ if [ "${1}" == "reset_wp" ]; then
 	wp --path=$WP_CORE_DIR db reset --yes
 	wp --path=$WP_CORE_DIR core install --url="$WP_SITE_URL" --title="E2E Gutenpack blocks" --admin_user=wordpress --admin_password=wordpress --admin_email=wordpress@example.com
 	wp --path=$WP_CORE_DIR plugin activate jetpack
+	wp --path=$WP_CORE_DIR plugin activate gutenberg
 	wp --path=$WP_CORE_DIR plugin activate e2e-plan-data-interceptor.php
-
+	wp plugin list
 
 	# create a debug.log file
 	touch $WP_CORE_DIR/wp-content/debug.log

--- a/tests/e2e/bin/setup-e2e-travis.sh
+++ b/tests/e2e/bin/setup-e2e-travis.sh
@@ -153,7 +153,6 @@ PHP
 
 	# Install plugins
 	wp plugin install gutenberg --activate
-	wp plugin list
 }
 
 prepare_jetpack() {
@@ -164,6 +163,7 @@ prepare_jetpack() {
 	# Symlink functionality plugin
 	ln -s $WORKING_DIR/tests/e2e/plugins/e2e-plan-data-interceptor.php $WP_CORE_DIR/wp-content/plugins/e2e-plan-data-interceptor.php
 
+	wp plugin activate gutenberg
 	wp plugin activate jetpack
 	wp plugin activate e2e-plan-data-interceptor.php
 }
@@ -176,10 +176,9 @@ if [ "${1}" == "reset_wp" ]; then
 
 	wp --path=$WP_CORE_DIR db reset --yes
 	wp --path=$WP_CORE_DIR core install --url="$WP_SITE_URL" --title="E2E Gutenpack blocks" --admin_user=wordpress --admin_password=wordpress --admin_email=wordpress@example.com
-	wp --path=$WP_CORE_DIR plugin activate jetpack
 	wp --path=$WP_CORE_DIR plugin activate gutenberg
+	wp --path=$WP_CORE_DIR plugin activate jetpack
 	wp --path=$WP_CORE_DIR plugin activate e2e-plan-data-interceptor.php
-	wp plugin list
 
 	# create a debug.log file
 	touch $WP_CORE_DIR/wp-content/debug.log


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Run E2E setup with latest Gutenberg plugin active

##### TODO
Update some legacy CSS selectors in tests.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Update E2E setup

#### Testing instructions:
- CI E2E task

#### Proposed changelog entry for your changes:
- N/A
