### PR TITLE
Eventbrite block: Make widget div ID more unique

### DIFF
--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -47,7 +47,16 @@ class EventbriteEdit extends Component {
 	};
 
 	componentDidMount() {
+		const { attributes, clientId, setAttributes } = this.props;
 		const { resolvingUrl } = this.state;
+
+		// Use the block's clientId to make the widget div more unique.
+		// The `clientId` changes every load while the Eventbrite's `blockId` doesn't,
+		// but it's unique enough (generated with uuid/v4) to be reasonably sure that
+		// there won't be two widgets with the same div ID.
+		if ( ! attributes.blockId ) {
+			setAttributes( { blockId: clientId } );
+		}
 
 		// Check if we need to resolve an Eventbrite URL immediately.
 		if ( resolvingUrl ) {
@@ -299,13 +308,13 @@ class EventbriteEdit extends Component {
 
 	renderInlinePreview() {
 		const { className } = this.props;
-		const { eventId } = this.props.attributes;
+		const { blockId, eventId } = this.props.attributes;
 
 		if ( ! eventId ) {
 			return;
 		}
 
-		const widgetId = createWidgetId( eventId );
+		const widgetId = createWidgetId( blockId, eventId );
 		const html = `
 			<script src="https://www.eventbrite.com/static/widgets/eb_widgets.js"></script>
 			<style>

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -47,16 +47,14 @@ class EventbriteEdit extends Component {
 	};
 
 	componentDidMount() {
-		const { attributes, clientId, setAttributes } = this.props;
+		const { clientId, setAttributes } = this.props;
 		const { resolvingUrl } = this.state;
 
 		// Use the block's clientId to make the widget div more unique.
 		// The `clientId` changes every load while the Eventbrite's `blockId` doesn't,
 		// but it's unique enough (generated with uuid/v4) to be reasonably sure that
 		// there won't be two widgets with the same div ID.
-		if ( ! attributes.blockId ) {
-			setAttributes( { blockId: clientId } );
-		}
+		setAttributes( { blockId: clientId } );
 
 		// Check if we need to resolve an Eventbrite URL immediately.
 		if ( resolvingUrl ) {

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -51,9 +51,6 @@ class EventbriteEdit extends Component {
 		const { resolvingUrl } = this.state;
 
 		// Use the block's clientId to make the widget div more unique.
-		// The `clientId` changes every load while the Eventbrite's `blockId` doesn't,
-		// but it's unique enough (generated with uuid/v4) to be reasonably sure that
-		// there won't be two widgets with the same div ID.
 		setAttributes( { blockId: clientId } );
 
 		// Check if we need to resolve an Eventbrite URL immediately.

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -47,11 +47,11 @@ class EventbriteEdit extends Component {
 	};
 
 	componentDidMount() {
-		const { clientId, setAttributes } = this.props;
+		const { setAttributes } = this.props;
 		const { resolvingUrl } = this.state;
 
-		// Use the block's clientId to make the widget div more unique.
-		setAttributes( { blockId: clientId } );
+		// Use a random number to make the widget div more unique.
+		setAttributes( { blockId: ( new Date().getTime() * Math.random() ).toFixed() } );
 
 		// Check if we need to resolve an Eventbrite URL immediately.
 		if ( resolvingUrl ) {

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -29,7 +29,7 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 		return '';
 	}
 
-	$widget_id = JETPACK_EVENTBRITE_WIDGET_SLUG . '-' . $attr['eventId'];
+	$widget_id = JETPACK_EVENTBRITE_WIDGET_SLUG . '-' . $attr['blockId'] . '-' . $attr['eventId'];
 
 	wp_enqueue_script( 'eventbrite-widget', 'https://www.eventbrite.com/static/widgets/eb_widgets.js', array(), JETPACK__VERSION, true );
 

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -96,8 +96,8 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 		} )();"
 	);
 
-	// Replace the placeholder id saved in the post_content with a unique id for the widget.
-	$content = preg_replace( '/eventbrite-placeholder-id/', $widget_id, $content );
+	// Replace the placeholder id saved in the post_content with a unique id used by widget.js.
+	$content = preg_replace( '/eventbrite-widget-\d+/', $widget_id, $content );
 
 	return $content;
 }

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -14,8 +14,6 @@ jetpack_register_block(
 	)
 );
 
-const JETPACK_EVENTBRITE_WIDGET_SLUG = 'eventbrite-widget';
-
 /**
  * Eventbrite block registration/dependency delclaration.
  *

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -48,7 +48,7 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
 		$content .= sprintf(
-			'<div id="%s"></div>',
+			'<div id="%s" class="eventbrite__in-page-checkout"></div>',
 			esc_attr( $widget_id )
 		);
 

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -25,11 +25,11 @@ const JETPACK_EVENTBRITE_WIDGET_SLUG = 'eventbrite-widget';
  * @return string
  */
 function jetpack_render_eventbrite_block( $attr, $content ) {
-	if ( empty( $attr['eventId'] ) || empty( $attr['url'] ) ) {
+	if ( is_admin() || empty( $attr['eventId'] ) || empty( $attr['url'] ) ) {
 		return '';
 	}
 
-	$widget_id = JETPACK_EVENTBRITE_WIDGET_SLUG . '-' . $attr['blockId'] . '-' . $attr['eventId'];
+	$widget_id = wp_unique_id( 'eventbrite-widget-' );
 
 	wp_enqueue_script( 'eventbrite-widget', 'https://www.eventbrite.com/static/widgets/eb_widgets.js', array(), JETPACK__VERSION, true );
 
@@ -45,6 +45,13 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 				eventId: " . absint( $attr['eventId'] ) . ",
 				iframeContainerId: '" . esc_js( $widget_id ) . "',
 			} );"
+		);
+
+		// $content contains a fallback link to the event that's saved in the post_content.
+		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
+		$content .= sprintf(
+			'<div id="%s"></div>',
+			esc_attr( $widget_id )
 		);
 
 		return sprintf(
@@ -89,22 +96,8 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 		} )();"
 	);
 
+	// Replace the placeholder id saved in the post_content with a unique id for the widget.
+	$content = preg_replace( '/eventbrite-placeholder-id/', $widget_id, $content );
+
 	return $content;
 }
-
-/**
- * Share PHP block settings with js block code.
- *
- * @return void
- */
-function jetpack_eventbrite_block_editor_assets() {
-	wp_localize_script(
-		'jetpack-blocks-editor',
-		'Jetpack_Block_Eventbrite_Settings',
-		array(
-			'widget_slug' => JETPACK_EVENTBRITE_WIDGET_SLUG,
-		)
-	);
-}
-
-add_action( 'enqueue_block_editor_assets', 'jetpack_eventbrite_block_editor_assets' );

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -51,6 +51,9 @@ export const settings = {
 		eventId: {
 			type: 'number',
 		},
+		blockId: {
+			type: 'string',
+		},
 		useModal: {
 			type: 'boolean',
 		},

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -51,9 +51,6 @@ export const settings = {
 		eventId: {
 			type: 'number',
 		},
-		blockId: {
-			type: 'string',
-		},
 		useModal: {
 			type: 'boolean',
 		},

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -22,6 +22,7 @@ import { createWidgetId } from './utils';
 function saveButton( attributes ) {
 	const {
 		backgroundColor,
+		blockId,
 		borderRadius,
 		customBackgroundColor,
 		customTextColor,
@@ -55,7 +56,7 @@ function saveButton( attributes ) {
 			<RichText.Content
 				className={ buttonClasses }
 				href={ url }
-				id={ createWidgetId( eventId ) }
+				id={ createWidgetId( blockId, eventId ) }
 				rel="noopener noreferrer"
 				role="button"
 				style={ buttonStyle }
@@ -68,7 +69,7 @@ function saveButton( attributes ) {
 }
 
 export default function save( { attributes } ) {
-	const { eventId, useModal, url } = attributes;
+	const { blockId, eventId, useModal, url } = attributes;
 
 	if ( ! eventId ) {
 		return;
@@ -79,7 +80,7 @@ export default function save( { attributes } ) {
 	}
 
 	return (
-		<div id={ createWidgetId( eventId ) }>
+		<div id={ createWidgetId( blockId, eventId ) }>
 			{ url && (
 				<a className="eventbrite__direct-link" href={ url }>
 					{ url }

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -51,7 +51,7 @@ function saveButton( attributes ) {
 				href={ url }
 				// Placeholder id, preg replaced with a unique id generated in PHP when the block is rendered.
 				// IMPORTANT: do not remove or change unless you also update the render function in eventbrite.php.
-				id="eventbrite-placeholder-id"
+				id={ `eventbrite-widget-${ ( Date.now() * Math.random() ).toFixed() }` }
 				rel="noopener noreferrer"
 				role="button"
 				style={ buttonStyle }

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -5,11 +5,6 @@ import classnames from 'classnames';
 import { RichText, getColorClassName } from '@wordpress/block-editor';
 
 /**
- * Internal dependencies
- */
-import { createWidgetId } from './utils';
-
-/**
  * Adapted button save function from @wordpress/block-library
  * (Using Gutenberg code that shipped with WordPress 5.3)
  *
@@ -22,11 +17,9 @@ import { createWidgetId } from './utils';
 function saveButton( attributes ) {
 	const {
 		backgroundColor,
-		blockId,
 		borderRadius,
 		customBackgroundColor,
 		customTextColor,
-		eventId,
 		text,
 		textColor,
 		url,
@@ -56,7 +49,9 @@ function saveButton( attributes ) {
 			<RichText.Content
 				className={ buttonClasses }
 				href={ url }
-				id={ createWidgetId( blockId, eventId ) }
+				// Placeholder id, preg replaced with a unique id generated in PHP when the block is rendered.
+				// IMPORTANT: do not remove or change unless you also update the render function in eventbrite.php.
+				id="eventbrite-placeholder-id"
 				rel="noopener noreferrer"
 				role="button"
 				style={ buttonStyle }
@@ -69,7 +64,7 @@ function saveButton( attributes ) {
 }
 
 export default function save( { attributes } ) {
-	const { blockId, eventId, useModal, url } = attributes;
+	const { eventId, useModal, url } = attributes;
 
 	if ( ! eventId ) {
 		return;
@@ -80,12 +75,10 @@ export default function save( { attributes } ) {
 	}
 
 	return (
-		<div id={ createWidgetId( blockId, eventId ) }>
-			{ url && (
-				<a className="eventbrite__direct-link" href={ url }>
-					{ url }
-				</a>
-			) }
-		</div>
+		url && (
+			<a className="eventbrite__direct-link" href={ url }>
+				{ url }
+			</a>
+		)
 	);
 }

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -20,6 +20,7 @@ function saveButton( attributes ) {
 		borderRadius,
 		customBackgroundColor,
 		customTextColor,
+		eventId,
 		text,
 		textColor,
 		url,
@@ -51,7 +52,7 @@ function saveButton( attributes ) {
 				href={ url }
 				// Placeholder id, preg replaced with a unique id generated in PHP when the block is rendered.
 				// IMPORTANT: do not remove or change unless you also update the render function in eventbrite.php.
-				id={ `eventbrite-widget-${ ( Date.now() * Math.random() ).toFixed() }` }
+				id={ `eventbrite-widget-${ eventId }` }
 				rel="noopener noreferrer"
 				role="button"
 				style={ buttonStyle }

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -1,16 +1,14 @@
-.wp-block-jetpack-eventbrite {
-	// Make sure the widget embed container is always as tall as the
-	// default/minimum value set by Eventbrite (425px), by overriding
-	// the container's inline height (set by Eventbrite, sometimes incorrectly as 0px),
-	// and setting the default height directly to the iframe.
-	&:not( .wp-block-button ) {
-		height: auto !important;
-		iframe {
-			height: 425px;
-		}
-	}
+.eventbrite__direct-link {
+	display: none;
+}
 
-	a.eventbrite__direct-link {
-		display: none;
+// Make sure the widget embed container is always as tall as the
+// default/minimum value set by Eventbrite (425px), by overriding
+// the container's inline height (set by Eventbrite, sometimes incorrectly as 0px),
+// and setting the default height directly to the iframe.
+.eventbrite__in-page-checkout {
+	height: auto !important;
+	iframe {
+		height: 425px;
 	}
 }

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -1,6 +1,8 @@
 .wp-block-jetpack-eventbrite {
 	// Make sure the widget embed container is always as tall as the
-	// default/minimum value set by Eventbrite (425px).
+	// default/minimum value set by Eventbrite (425px), by overriding
+	// the container's inline height (set by Eventbrite, sometimes incorrectly as 0px),
+	// and setting the default height directly to the iframe.
 	&:not( .wp-block-button ) {
 		height: auto !important;
 		iframe {

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -1,4 +1,13 @@
 .wp-block-jetpack-eventbrite {
+	// Make sure the widget embed container is always as tall as the
+	// default/minimum value set by Eventbrite (425px).
+	&:not( .wp-block-button ) {
+		height: auto !important;
+		iframe {
+			height: 425px;
+		}
+	}
+
 	a.eventbrite__direct-link {
 		display: none;
 	}

--- a/extensions/blocks/eventbrite/utils.js
+++ b/extensions/blocks/eventbrite/utils.js
@@ -34,9 +34,10 @@ export function eventIdFromUrl( url ) {
 /**
  * Creates an html id used to identify an embedded Eventbrite widget.
  *
+ * @param   {string} blockId Block id.
  * @param   {string} eventId Event id.
  * @returns {string}         HTML id.
  */
-export function createWidgetId( eventId ) {
-	return `${ window.Jetpack_Block_Eventbrite_Settings.widget_slug }-${ eventId }`;
+export function createWidgetId( blockId, eventId ) {
+	return `${ window.Jetpack_Block_Eventbrite_Settings.widget_slug }-${ blockId }-${ eventId }`;
 }

--- a/extensions/blocks/eventbrite/utils.js
+++ b/extensions/blocks/eventbrite/utils.js
@@ -30,14 +30,3 @@ export function eventIdFromUrl( url ) {
 	const match = url.match( /(\d+)\/?(?:\?[^\/]*)?\s*$/ );
 	return match && match[ 1 ] ? parseInt( match[ 1 ], 10 ) : null;
 }
-
-/**
- * Creates an html id used to identify an embedded Eventbrite widget.
- *
- * @param   {string} blockId Block id.
- * @param   {string} eventId Event id.
- * @returns {string}         HTML id.
- */
-export function createWidgetId( blockId, eventId ) {
-	return `${ window.Jetpack_Block_Eventbrite_Settings.widget_slug }-${ blockId }-${ eventId }`;
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fix #14560

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Create a unique id for each block instance when the block is rendered.
* Make sure the embedded `iframe` is always as tall as the default/minimum height set by Eventbrite (425px).

Currently the Eventbrite widget uses only the event ID as unique ID, which means that if multiple widgets use the same event, they will conflict between each others.
These conflicts are the cause of several seemingly unrelated issues: block not rendering, blocks rendering inside each other, etc.

| Before | After |
| - | - |
| <img width="492" alt="Screenshot 2020-02-03 at 14 02 09" src="https://user-images.githubusercontent.com/2070010/73659458-33685f80-468e-11ea-92f9-3db5101bd0b2.png"> | <img width="756" alt="Screenshot 2020-02-03 at 17 37 13" src="https://user-images.githubusercontent.com/2070010/73676255-fad77e80-46ab-11ea-8dd3-7421dd1f12b3.png"> |
| <img width="509" alt="Screenshot 2020-02-03 at 14 02 38" src="https://user-images.githubusercontent.com/2070010/73659572-6f9bc000-468e-11ea-8eec-6c2155ac1355.png"> | <img width="752" alt="Screenshot 2020-02-03 at 17 37 40" src="https://user-images.githubusercontent.com/2070010/73676270-03c85000-46ac-11ea-90d5-d2c914eeca6a.png"> |
| <img width="768" alt="Screenshot 2020-02-03 at 14 03 48" src="https://user-images.githubusercontent.com/2070010/73659762-cc977600-468e-11ea-96bb-bdfdb8f512b3.png"> | <img width="752" alt="Screenshot 2020-02-03 at 17 36 52" src="https://user-images.githubusercontent.com/2070010/73676291-0d51b800-46ac-11ea-8146-fa2172856ef1.png"> |

---

The CSS change that forces the container `height: auto !important` and the iframe `height: 425px` is needed to fix an issue occurring when multiple blocks of Embed type use the same event.
The Eventbrite script somehow only applies the correct height (which is both default and minimum 425px) to the last embed, while typically setting the others' height to 0.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

See the screens in #14560 for more info on what can go wrong.

* Open the editor.
* Insert two Eventbrite widgets using the same event.
* Save and preview the post.
* Make sure both widgets are visible and working as expected.
* Try changing the embed type (both embeds, both buttons, one and one), and make sure the post is always rendered correctly.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A, it's a new block
