### PR TITLE
Keyring: Bring the Google Drive implementation into line with the upstream version

### DIFF
--- a/modules/publicize/publicize.php
+++ b/modules/publicize/publicize.php
@@ -208,6 +208,10 @@ abstract class Publicize_Base {
 			case 'linkedin':
 				return 'LinkedIn';
 				break;
+			case 'google_drive': // google-drive used to be called google_drive.
+			case 'google-drive':
+				return 'Google Drive';
+				break;
 			case 'twitter':
 			case 'facebook':
 			case 'tumblr':


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

Differential Revision: D38384-code

This commit syncs r202413-wpcom.

- Rename the service from `google_drive` to `google-drive`, including updating everywhere that assumed it would be named with an underscore.
- Remove the `wpcom_get_keyring_connection_item` filter to fix the name, it's handled in `Publicize_Base::get_service_label()`, instead.

Note: The redirect URI that's configured with Google for the OAuth client will need to be updated to be `service=google-drive`.

#### Testing instructions:

Test Plan: Confirm that the Google Drive entry in `/me/keyring-connections` has the correct label.

#### Proposed changelog entry for your changes:

* N/A
