### PR TITLE
Private Sites: Make /sites return is_private based on blog_public site option

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -309,11 +309,11 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'user_can_manage' :
 				$response[ $key ] = $this->site->user_can_manage();
 			case 'is_private' :
-				$response[ $key ] = $this->site->is_private();
+				$response[ $key ] = wpcom_is_coming_soon() ? is_private_blog() : $this->site->is_private();
 				break;
 			case 'is_coming_soon' :
 				// This option is stored on wp.com for both simple and atomic sites. @see mu-plugins/private-blog.php
-				$response[ $key ] = $this->site->is_private() && get_option( 'wpcom_coming_soon' );
+				$response[ $key ] = wpcom_is_coming_soon();
 				break;
 			case 'visible' :
 				$response[ $key ] = $this->site->is_visible();


### PR DESCRIPTION
#### Changes proposed in this Pull Request: 

Differential Revision: D38388-code

This commit syncs r202410-wpcom.

At the moment, `/sites` endpoint will always return false for atomic sites. That's because privacy was never supported on atomic sites. Since this support is coming, we want to base that on blog_public setting. The ultimate fix would be updating SAL, and that's what we're going to do in longer term. A short term fix is to directly consult site_options.

#### Testing instructions:

* See D38388-code

#### Proposed changelog entry for your changes:

* N/A
