### PR TITLE
Map block: Use the Mapbox access token directly if possible

### DIFF
--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -20,15 +20,16 @@ jetpack_register_block(
  * @return string
  */
 function jetpack_get_mapbox_api_key() {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		$endpoint = sprintf(
-			'https://public-api.wordpress.com/wpcom/v2/sites/%d/service-api-keys/mapbox',
-			get_current_blog_id()
-		);
-	} else {
-		$endpoint = rest_url( 'wpcom/v2/service-api-keys/mapbox' );
+	$service_api_key = Jetpack_Options::get_option( 'mapbox_api_key' );
+	if ( $service_api_key ) {
+		return $service_api_key;
 	}
 
+	if ( defined( 'IS_WPCOM' ) && IS_WPCOM && defined( 'WPCOM_MAPBOX_ACCESS_TOKEN' ) ) {
+		return WPCOM_MAPBOX_ACCESS_TOKEN;
+	}
+
+	$endpoint      = rest_url( 'wpcom/v2/service-api-keys/mapbox' );
 	$response      = wp_remote_get( esc_url_raw( $endpoint ) );
 	$response_code = wp_remote_retrieve_response_code( $response );
 

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -29,16 +29,14 @@ function jetpack_get_mapbox_api_key() {
 		return WPCOM_MAPBOX_ACCESS_TOKEN;
 	}
 
-	$endpoint      = rest_url( 'wpcom/v2/service-api-keys/mapbox' );
-	$response      = wp_remote_get( esc_url_raw( $endpoint ) );
-	$response_code = wp_remote_retrieve_response_code( $response );
-
-	if ( 200 === $response_code ) {
-		$response_body = json_decode( wp_remote_retrieve_body( $response ) );
-		return $response_body->service_api_key;
+	$request_url = rest_url( 'wpcom/v2/service-api-keys/mapbox' );
+	$response    = wp_remote_get( esc_url_raw( $request_url ) );
+	if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+		return '';
 	}
 
-	return Jetpack_Options::get_option( 'mapbox_api_key' );
+	$response_body = json_decode( wp_remote_retrieve_body( $response ) );
+	return $response_body->service_api_key;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14475 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On WordPress.com, use the Mapbox access token directly (if it exists) instead of calling an endpoint.

As a direct effect, this saves WordPress.com Simple sites one unnecessary API call.
As a side effect, this allows _private_ WordPress.com Simple sites to bypass the unnecessary permissions checks and use the Mapbox access token as intended.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a WordPress.com-only change, so on Jetpack just smoke test for regressions.

* Apply D38503  and D38506.
* Use a _private_ WordPress.com site that doesn't have a custom Mapbox access token saved (you can remove it from the Map block sidebar _before_ applying this PR).
* Insert a Map block, and make sure it doesn't ask for the access token anymore.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (WordPress.com-only change)
