### PR TITLE
Gif block: Update placeholder

### DIFF
--- a/extensions/blocks/gif/edit.js
+++ b/extensions/blocks/gif/edit.js
@@ -4,7 +4,7 @@
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Component, createRef } from '@wordpress/element';
-import { Button, PanelBody, Path, Placeholder, SVG, TextControl } from '@wordpress/components';
+import { Button, PanelBody, Path, Placeholder, SVG } from '@wordpress/components';
 import { InspectorControls, RichText } from '@wordpress/block-editor';
 
 /**
@@ -136,11 +136,11 @@ class GifEdit extends Component {
 				onSubmit={ this.onFormSubmit }
 				ref={ this.textControlRef }
 			>
-				<TextControl
-					className="wp-block-jetpack-gif_input"
-					label={ INPUT_PROMPT }
-					placeholder={ INPUT_PROMPT }
-					onChange={ value => setAttributes( { searchText: value } ) }
+				<input
+					type="text"
+					className="wp-block-jetpack-gif_input components-placeholder__input"
+					placeholder={ __( 'Enter search terms, e.g. cat…', 'jetpack' ) }
+					onChange={ event => setAttributes( { searchText: event.target.value } ) }
 					value={ searchText }
 				/>
 				<Button isDefault onClick={ this.onSubmit }>
@@ -159,7 +159,12 @@ class GifEdit extends Component {
 					</PanelBody>
 				</InspectorControls>
 				{ ! giphyUrl ? (
-					<Placeholder className="wp-block-jetpack-gif_placeholder" icon={ icon } label={ title }>
+					<Placeholder
+						className="wp-block-jetpack-gif_placeholder"
+						icon={ icon }
+						label={ title }
+						instructions={ INPUT_PROMPT }
+					>
 						{ inputFields }
 					</Placeholder>
 				) : (

--- a/extensions/blocks/gif/editor.scss
+++ b/extensions/blocks/gif/editor.scss
@@ -30,20 +30,10 @@
 		flex-direction: row;
 		flex-wrap: wrap;
 		justify-content: center;
+		margin-bottom: 10px;
 		max-width: 400px;
 		width: 100%;
 		z-index: 1;
-		.components-text-control__input {
-			height: 36px;
-		}
-		.components-base-control__label {
-			position: absolute;
-			top: -1000em;
-		}
-	}
-	.wp-block-jetpack-gif_input {
-		flex-grow: 1;
-		margin-right: 0.5em;
 	}
 	.wp-block-jetpack-gif_thumbnails-container {
 		display: flex;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Makes some changes the the placeholder for the Gif block to make it more aligned with other embed blocks

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a post
* Add a Gif block
* Check that the placeholder looks like this:
<img width="627" alt="Screenshot 2020-02-04 at 11 49 16" src="https://user-images.githubusercontent.com/275961/73781019-6a00b180-4744-11ea-91f7-bcfc837b543d.png">
* Check that the block preview looks like this:
<img width="643" alt="Screenshot 2020-02-04 at 11 49 25" src="https://user-images.githubusercontent.com/275961/73781022-6bca7500-4744-11ea-9536-97ee8cacea7a.png">



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
