### PR TITLE
GitHub Actions: Re-enable actions.

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -1,0 +1,19 @@
+name: Build production to master-built
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_master_job:
+    runs-on: ubuntu-latest
+    name: Build production version of master to master-built branch!
+    steps:
+      - name: Checkout Jetpack
+        uses: actions/checkout@master
+      - name: Build production version
+        uses: automattic/action-jetpack-build-to-branch@master
+        with:
+          branch_pull: 'master'
+          branch_push: 'master-built'
+          commit_message: 'Automated production build from master'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This reverts commit 911fc5f4c0dcd8f874f97c35e1c916aec7676577.

GitHub Actions are now possible again in the Jetpack repo. Let's bring back what we have.

See #14033

#### Changes proposed in this Pull Request:
* Re-add previous GitHub actions.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Post-merge, open a PR that touches files in a package.
* Ensure label is added.

#### Proposed changelog entry for your changes:
* n/a, internal repo tool.
