### PR TITLE
Calendly: Changed the embed, to remove the inline styles

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -79,6 +79,9 @@ add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
  * @return string
  */
 function load_assets( $attr, $content ) {
+	if ( is_admin() ) {
+		return;
+	}
 	static $block_num = 0;
 	$block_num++;
 	$url = get_attribute( $attr, 'url' );

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -79,6 +79,8 @@ add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
  * @return string
  */
 function load_assets( $attr, $content ) {
+	static $block_num = 0;
+	$block_num++;
 	$url = get_attribute( $attr, 'url' );
 	if ( empty( $url ) ) {
 		return;

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -111,10 +111,7 @@ function load_assets( $attr, $content ) {
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
 	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr, array( 'calendly-style-' . $style ) );
-<<<<<<< HEAD
 	$block_id                       = wp_unique_id( 'calendly-block-' );
-=======
->>>>>>> Scoped the height setting to the inline style
 
 	$url = add_query_arg(
 		array(

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -107,7 +107,7 @@ function load_assets( $attr, $content ) {
 	$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
-	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr );
+	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr, array( 'calendly-style-' . $style ) );
 	$block_id                       = wp_unique_id( 'calendly-block-' );
 
 	$url = add_query_arg(

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -108,7 +108,10 @@ function load_assets( $attr, $content ) {
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
 	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr, array( 'calendly-style-' . $style ) );
+<<<<<<< HEAD
 	$block_id                       = wp_unique_id( 'calendly-block-' );
+=======
+>>>>>>> Scoped the height setting to the inline style
 
 	$url = add_query_arg(
 		array(

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -79,11 +79,6 @@ add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
  * @return string
  */
 function load_assets( $attr, $content ) {
-	if ( is_admin() ) {
-		return;
-	}
-	static $block_num = 0;
-	$block_num++;
 	$url = get_attribute( $attr, 'url' );
 	if ( empty( $url ) ) {
 		return;
@@ -155,18 +150,18 @@ function load_assets( $attr, $content ) {
 		);
 	} else { // Inline style.
 		$content = sprintf(
-			'<div class="%1$s" id="calendly-block-%2$d"></div>',
+			'<div class="%1$s" id="%2$s"></div>',
 			esc_attr( $classes ),
-			$block_num
+			$block_id
 		);
 		$script  = <<<JS_END
 Calendly.initInlineWidget({
 	url: '%s',
-	parentElement: document.getElementById('calendly-block-%d'),
+	parentElement: document.getElementById('%s'),
 	inlineStyles: false,
 });
 JS_END;
-		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), $block_num ) );
+		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), $block_id ) );
 	}
 
 	return $content;

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -79,6 +79,8 @@ add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
  * @return string
  */
 function load_assets( $attr, $content ) {
+	static $block_num = 0;
+	$block_num++;
 	$url = get_attribute( $attr, 'url' );
 	if ( empty( $url ) ) {
 		return;
@@ -93,7 +95,7 @@ function load_assets( $attr, $content ) {
 		'https://assets.calendly.com/assets/external/widget.js',
 		null,
 		JETPACK__VERSION,
-		false
+		true
 	);
 
 	$style                          = get_attribute( $attr, 'style' );
@@ -150,10 +152,18 @@ function load_assets( $attr, $content ) {
 		);
 	} else { // Inline style.
 		$content = sprintf(
-			'<div class="calendly-inline-widget %1$s" data-url="%2$s" style="min-width:320px;height:630px;"></div>',
+			'<div class="%1$s" id="calendly-block-%2$d"></div>',
 			esc_attr( $classes ),
-			esc_url( $url )
+			$block_num
 		);
+		$script  = <<<JS_END
+Calendly.initInlineWidget({
+	url: '%s',
+	parentElement: document.getElementById('calendly-block-%d'),
+	inlineStyles: false,
+});
+JS_END;
+		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), $block_num ) );
 	}
 
 	return $content;

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -82,8 +82,6 @@ function load_assets( $attr, $content ) {
 	if ( is_admin() ) {
 		return;
 	}
-	static $block_num = 0;
-	$block_num++;
 	$url = get_attribute( $attr, 'url' );
 	if ( empty( $url ) ) {
 		return;
@@ -157,7 +155,7 @@ function load_assets( $attr, $content ) {
 		$content = sprintf(
 			'<div class="%1$s" id="%2$s"></div>',
 			esc_attr( $classes ),
-			$block_id
+			esc_attr( $block_id )
 		);
 		$script  = <<<JS_END
 Calendly.initInlineWidget({
@@ -166,7 +164,7 @@ Calendly.initInlineWidget({
 	inlineStyles: false,
 });
 JS_END;
-		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), $block_id ) );
+		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 	}
 
 	return $content;

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -257,8 +257,10 @@ export default function CalendlyEdit( props ) {
 		</InspectorControls>
 	);
 
+	const classes = `${ className } calendly-style-${ style }`;
+
 	return (
-		<div className={ className }>
+		<div className={ classes }>
 			{ inspectorControls }
 			{ blockControls }
 			{ url ? blockPreview( style ) : blockPlaceholder }

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -26,6 +26,7 @@ import { getBlockDefaultClassName } from '@wordpress/blocks';
  * Internal dependencies
  */
 import './editor.scss';
+import './view.scss';
 import icon from './icon';
 import attributeDetails from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
@@ -147,7 +148,6 @@ export default function CalendlyEdit( props ) {
 				frameBorder="0"
 				data-origwidth="100%"
 				data-origheight="100%"
-				style={ { minWidth: '320px', height: '630px', width: '100%' } }
 				title="Calendly"
 			></iframe>
 		</>

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -2,6 +2,6 @@
 	top: 47px;
 }
 
-.wp-block-jetpack-calendly {
+.wp-block-jetpack-calendly.calendly-style-inline {
 	height: 630px;
 }

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -1,3 +1,7 @@
 .admin-bar .calendly-overlay .calendly-popup-close {
 	top: 47px;
 }
+
+.wp-block-jetpack-calendly {
+	height: 630px;
+}


### PR DESCRIPTION
The inline styles added to the parent container by the Calendly script
were interfering with the CSS used for aligning elements to the left
and right on the desktop view of Twenty Twenty (and so probably other
themes)

#### Changes proposed in this Pull Request:

An undocumented option to the init function stops these styles being
added, and so this change swaps the embed code to set that option, as
well as tweak the CSS to make the best effort at laying out the embed when
aligned to the sides.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This an improvement on a new feature

#### Testing instructions:

* Embed a Calendly block and set the alignment to left or right
* Add some lorem ipsum text to the post
* Preview the post at different screen sizes. (You'll have to reload the page sometimes as the Calendly code sets the width of the embed on load and doesn't always resize it)
* Check that the embed isn't (too) broken. Previously the embed would disappear over screens 1000px wide and be partially cut off by the side of the screen. 

There are still some known problems with the Twenty Twenty theme and alignment of blocks, but having discussed it with @kjellr (p1580823343135400-slack-themes), we've decided that it's best to leave the layout to the theme and make the block as lightweight as possible.

#### Proposed changelog entry for your changes:
* No changelog required
