### PR TITLE
Eventbrite Block: Add a default modal button label

### DIFF
--- a/extensions/blocks/eventbrite/editor.scss
+++ b/extensions/blocks/eventbrite/editor.scss
@@ -7,8 +7,15 @@
 
 .wp-block-jetpack-eventbrite.is-modal-button {
 	display: inline-block;
+
 	.wp-block-button__link {
 		display: block;
+	}
+
+	.wp-block-button__link:focus {
+		span[data-rich-text-placeholder]:after {
+			opacity: 0.3;
+		}
 	}
 }
 

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -35,6 +35,12 @@ export const icon = {
 	foreground: '#555d66',
 };
 
+export const defaultModalButtonText = _x(
+	'Register',
+	'verb: e.g. register for an event.',
+	'jetpack'
+);
+
 export const settings = {
 	title,
 	description: __( 'Embed Eventbrite event details and ticket checkout.', 'jetpack' ),
@@ -97,7 +103,7 @@ export const settings = {
 			url: 'https://www.eventbrite.com/e/test-event-tickets-123456789',
 			eventId: 123456789,
 			useModal: true,
-			text: _x( 'Register', 'verb: e.g. register for an event.', 'jetpack' ),
+			text: defaultModalButtonText,
 		},
 	},
 };

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -63,6 +63,7 @@ export const settings = {
 		// Modal button attributes, used for Button & Modal embed type.
 		text: {
 			type: 'string',
+			default: defaultModalButtonText,
 		},
 		backgroundColor: {
 			type: 'string',

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -35,12 +35,6 @@ export const icon = {
 	foreground: '#555d66',
 };
 
-export const defaultModalButtonText = _x(
-	'Register',
-	'verb: e.g. register for an event.',
-	'jetpack'
-);
-
 export const settings = {
 	title,
 	description: __( 'Embed Eventbrite event details and ticket checkout.', 'jetpack' ),
@@ -63,7 +57,7 @@ export const settings = {
 		// Modal button attributes, used for Button & Modal embed type.
 		text: {
 			type: 'string',
-			default: defaultModalButtonText,
+			default: _x( 'Register', 'verb: e.g. register for an event.', 'jetpack' ),
 		},
 		backgroundColor: {
 			type: 'string',
@@ -104,7 +98,6 @@ export const settings = {
 			url: 'https://www.eventbrite.com/e/test-event-tickets-123456789',
 			eventId: 123456789,
 			useModal: true,
-			text: defaultModalButtonText,
 		},
 	},
 };

--- a/extensions/blocks/eventbrite/modal-button-preview.js
+++ b/extensions/blocks/eventbrite/modal-button-preview.js
@@ -20,7 +20,6 @@ import { __ } from '@wordpress/i18n';
 import { Component, useCallback } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { PanelBody, RangeControl, withFallbackStyles } from '@wordpress/components';
-import { defaultModalButtonText } from '.';
 import {
 	RichText,
 	ContrastChecker,
@@ -85,16 +84,6 @@ class ButtonEdit extends Component {
 		}
 		this.nodeRef = node;
 	}
-
-	componentDidMount = () => {
-		const { setAttributes, attributes } = this.props;
-		const { text } = attributes;
-
-		// If there is no text value set for the button, set a default value.
-		if ( ! text ) {
-			setAttributes( { text: defaultModalButtonText } );
-		}
-	};
 
 	render() {
 		const {

--- a/extensions/blocks/eventbrite/modal-button-preview.js
+++ b/extensions/blocks/eventbrite/modal-button-preview.js
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, useCallback } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { PanelBody, RangeControl, withFallbackStyles } from '@wordpress/components';
+import { defaultModalButtonText } from '.';
 import {
 	RichText,
 	ContrastChecker,
@@ -85,6 +86,16 @@ class ButtonEdit extends Component {
 		this.nodeRef = node;
 	}
 
+	componentDidMount = () => {
+		const { setAttributes, attributes } = this.props;
+		const { text } = attributes;
+
+		// If there is no text value set for the button, set a default value.
+		if ( ! text ) {
+			setAttributes( { text: defaultModalButtonText } );
+		}
+	};
+
 	render() {
 		const {
 			attributes,
@@ -109,6 +120,7 @@ class ButtonEdit extends Component {
 				<RichText
 					placeholder={ placeholder || __( 'Add text…', 'jetpack' ) }
 					value={ text }
+					keepPlaceholderOnFocus={ true }
 					onChange={ value => setAttributes( { text: value } ) }
 					withoutInteractiveFormatting
 					className={ classnames( 'wp-block-button__link', {

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -8,6 +8,7 @@ import { RichText, getColorClassName } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { createWidgetId } from './utils';
+import { defaultModalButtonText } from '.';
 
 /**
  * Adapted button save function from @wordpress/block-library
@@ -48,6 +49,14 @@ function saveButton( attributes ) {
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 	};
 
+	const buttonText = () => {
+		if ( ! text ) {
+			return defaultModalButtonText;
+		}
+
+		return text;
+	};
+
 	// Saves link markup, but event handlers are added with inline javascript to prevent
 	// default link behavior (see the `jetpack_render_eventbrite_block` php function).
 	return (
@@ -61,7 +70,7 @@ function saveButton( attributes ) {
 				style={ buttonStyle }
 				tagName="a"
 				target="_blank"
-				value={ text }
+				value={ buttonText() }
 			/>
 		</div>
 	);

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -8,7 +8,6 @@ import { RichText, getColorClassName } from '@wordpress/block-editor';
  * Internal dependencies
  */
 import { createWidgetId } from './utils';
-import { defaultModalButtonText } from '.';
 
 /**
  * Adapted button save function from @wordpress/block-library
@@ -49,14 +48,6 @@ function saveButton( attributes ) {
 		borderRadius: borderRadius ? borderRadius + 'px' : undefined,
 	};
 
-	const buttonText = () => {
-		if ( ! text ) {
-			return defaultModalButtonText;
-		}
-
-		return text;
-	};
-
 	// Saves link markup, but event handlers are added with inline javascript to prevent
 	// default link behavior (see the `jetpack_render_eventbrite_block` php function).
 	return (
@@ -70,7 +61,7 @@ function saveButton( attributes ) {
 				style={ buttonStyle }
 				tagName="a"
 				target="_blank"
-				value={ buttonText() }
+				value={ text }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Partially fixes #14462

#### Changes proposed in this Pull Request:

When selecting the "Button & Modal" embed type, the button does not get a default value. The style preview shows "Register", so this PR matches that as the default label both in the editor and on the front end if the user does not edit and add their own label.

**Before:**

User selects "Button and Modal", there is no default button label, just the "Add Text..." placeholder. On the front end the button label is empty:

![2020-02-05 13 34 11](https://user-images.githubusercontent.com/1464705/73885245-4872f900-481c-11ea-83fd-619bb44c9f48.gif)

**After:**

User selects "Button and Modal", there is a default "Register" label that the user can edit. On the front end the button label says "Register" unless this is changed by the user:

![2020-02-05 13 31 06](https://user-images.githubusercontent.com/1464705/73885045-ea461600-481b-11ea-8219-bee6147f135c.gif)

#### Testing instructions:

* Add an eventbrite block and provide an event URL
* Change the embed type to "Button & Modal"
* Confirm that you see a default "Register" label for the button
* Save the post and confirm the label is present in the button on the front end
* Remove the label from the button and save the post, confirm the label is still present on the front end
* Refresh the editor and confirm the default "Register" label is re-added to the button.
* Edit and provide your own label, save the post and confirm your custom label appears on the front end.
* Refresh the editor and confirm your custom label remains on the button.
