### PR TITLE
Instant Search: Fix broken dates in iOS Chrome

### DIFF
--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -25,6 +25,15 @@ function getDateOptions( interval ) {
 	return { year: 'numeric', month: 'long' };
 }
 
+// TODO: Fix this in the API
+// TODO: Remove once format is fixed in the API
+function fixDateFormat( dateString ) {
+	if ( dateString[ dateString.length - 1 ] !== 'Z' ) {
+		dateString += 'Z';
+	}
+	return dateString.split( ' ' ).join( 'T' );
+}
+
 export default class SearchFilter extends Component {
 	filtersList = createRef();
 	idPrefix = uniqueId( 'jetpack-instant-search__filter-' );
@@ -65,7 +74,7 @@ export default class SearchFilter extends Component {
 					htmlFor={ `${ this.idPrefix }-dates-${ this.getIdentifier() }-${ key }` }
 					className="jetpack-instant-search__filter-list-label"
 				>
-					{ new Date( key ).toLocaleString(
+					{ new Date( fixDateFormat( key ) ).toLocaleString(
 						locale,
 						getDateOptions( this.props.configuration.interval )
 					) }{' '}


### PR DESCRIPTION
Temporarily fixes #14534 with a client-side solution. This should be fixed in the API in the future.

#### Changes proposed in this Pull Request:
* Sanitizes date filters' `key_as_string` values to be ISO8601 compliant date and time.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Ensure that you've enabled a year filter in the search overlay sidebar.
2. Perform a search on your site using Chrome iOS. Click on the filter toggle adjacent to the overlay input.
3. Ensure that your search filters appear as expected. Also ensure that your year filters render as expected. 

#### Proposed changelog entry for your changes:
* None.