### PR TITLE
Instant Search: Refine TrainTracks integration

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -249,6 +249,7 @@ class SearchApp extends Component {
 					hasNextPage={ this.hasNextPage() }
 					highlightColor={ this.props.options.highlightColor }
 					isLoading={ this.state.isLoading }
+					isVisible={ this.state.showResults }
 					locale={ this.props.options.locale }
 					onLoadNextPage={ this.loadNextPage }
 					postTypes={ this.props.options.postTypes }

--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -15,17 +15,23 @@ import { RESULT_FORMAT_PRODUCT } from '../lib/constants';
 
 class SearchResult extends Component {
 	componentDidMount() {
-		recordTrainTracksRender( this.getCommonTrainTracksProps() );
+		!! this.props.railcar && recordTrainTracksRender( this.getCommonTrainTracksProps() );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( this.props.railcar !== prevProps.railcar ) {
+			!! this.props.railcar && recordTrainTracksRender( this.getCommonTrainTracksProps() );
+		}
 	}
 
 	getCommonTrainTracksProps() {
 		return {
-			fetch_algo: this.props.result.railcar.fetch_algo,
-			fetch_position: this.props.result.railcar.fetch_position,
-			fetch_query: this.props.result.railcar.fetch_query,
-			railcar: this.props.result.railcar.railcar,
-			rec_blog_id: this.props.result.railcar.rec_blog_id,
-			rec_post_id: this.props.result.railcar.rec_post_id,
+			fetch_algo: this.props.railcar.fetch_algo,
+			fetch_position: this.props.railcar.fetch_position,
+			fetch_query: this.props.railcar.fetch_query,
+			railcar: this.props.railcar.railcar,
+			rec_blog_id: this.props.railcar.rec_blog_id,
+			rec_post_id: this.props.railcar.rec_post_id,
 			// TODO: Add a way to differentiate between different result formats
 			ui_algo: 'jetpack-instant-search-ui/v1',
 			ui_position: this.props.index,
@@ -34,7 +40,8 @@ class SearchResult extends Component {
 
 	onClick = () => {
 		// Send out analytics call
-		recordTrainTracksInteract( { ...this.getCommonTrainTracksProps(), action: 'click' } );
+		!! this.props.railcar &&
+			recordTrainTracksInteract( { ...this.getCommonTrainTracksProps(), action: 'click' } );
 	};
 
 	render() {

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -107,6 +107,7 @@ class SearchResults extends Component {
 								index={ index }
 								locale={ this.props.locale }
 								query={ this.props.query }
+								railcar={ this.props.isVisible ? result.railcar : null }
 								result={ result }
 								resultFormat={ this.props.resultFormat }
 							/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Correctly fire TrainTracks render events when the search query or filters change.
* Prevent TrainTracks render events from firing while the overlay is hidden.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Open the network monitor and open your site. Ensure that no requests have been fired for `t.gif`.
3. Perform a search on your site. Ensure that requests for `t.gif` have been made.
4. Change the search query. Ensure that additional requests for `t.gif` have been made.

#### Proposed changelog entry for your changes:
* None.
