### PR TITLE
Eventbrite Block: Add isDefault to the Embed button

### DIFF
--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -273,7 +273,7 @@ class EventbriteEdit extends Component {
 							placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
 							onChange={ event => this.setState( { editedUrl: event.target.value } ) }
 						/>
-						<Button isLarge type="submit">
+						<Button isLarge isDefault type="submit">
 							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
 						</Button>
 						{ this.cannotEmbed() && (

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -246,6 +246,8 @@ class EventbriteEdit extends Component {
 		);
 	}
 
+	// @todo Remove isDefault and isLarge from Button when the minimum WP version
+	// supported by JP uses Gutenberg > 7.2
 	renderEditEmbed() {
 		const { className } = this.props;
 		const { editedUrl } = this.state;
@@ -273,8 +275,6 @@ class EventbriteEdit extends Component {
 							placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
 							onChange={ event => this.setState( { editedUrl: event.target.value } ) }
 						/>
-						// @todo Remove isDefault and isLarge when the minimum WP // version supported by
-						Jetpack uses Gutenberg > 7.2
 						<Button isLarge isDefault isSecondary type="submit">
 							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
 						</Button>

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -273,8 +273,8 @@ class EventbriteEdit extends Component {
 							placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
 							onChange={ event => this.setState( { editedUrl: event.target.value } ) }
 						/>
-						// @todo Remove isDefault when the minimum WP version supported by Jetpack uses
-						Gutenberg > 7.2
+						// @todo Remove isDefault and isLarge when the minimum WP version supported by Jetpack
+						uses Gutenberg > 7.2
 						<Button isLarge isDefault isSecondary type="submit">
 							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
 						</Button>

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -273,8 +273,8 @@ class EventbriteEdit extends Component {
 							placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
 							onChange={ event => this.setState( { editedUrl: event.target.value } ) }
 						/>
-						// @todo Remove isDefault and isLarge when the minimum WP version supported by Jetpack
-						uses Gutenberg > 7.2
+						// @todo Remove isDefault and isLarge when the minimum WP // version supported by
+						Jetpack uses Gutenberg > 7.2
 						<Button isLarge isDefault isSecondary type="submit">
 							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
 						</Button>

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -273,7 +273,9 @@ class EventbriteEdit extends Component {
 							placeholder={ __( 'Enter an event URL to embed here…', 'jetpack' ) }
 							onChange={ event => this.setState( { editedUrl: event.target.value } ) }
 						/>
-						<Button isLarge isDefault type="submit">
+						// @todo Remove isDefault when the minimum WP version supported by Jetpack uses
+						Gutenberg > 7.2
+						<Button isLarge isDefault isSecondary type="submit">
 							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
 						</Button>
 						{ this.cannotEmbed() && (


### PR DESCRIPTION
Partially fixes #14462

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Make sure the embed button has a border by using `isDefault` so it matches all other embed blocks.

**Before:**

<img width="484" alt="Screen Shot 2020-02-05 at 3 53 50 PM" src="https://user-images.githubusercontent.com/1464705/73893912-d4425080-482f-11ea-9058-d3d36f52357d.png">


**After:**

<img width="487" alt="Screen Shot 2020-02-05 at 3 53 04 PM" src="https://user-images.githubusercontent.com/1464705/73893922-d99f9b00-482f-11ea-83bd-d5b1b367f860.png">


#### Testing instructions:
* Insert an Eventbrite block
* Confirm the Embed button has a border
