### PR TITLE
Masterbar: Add My Home submenu to all Atomic sites

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -1331,40 +1331,6 @@ class A8C_WPCOM_Masterbar {
 	}
 
 	/**
-	 * Calls the wpcom API to get the creation date of the site
-	 * and determine if it's eligible for the 'My Home' page.
-	 *
-	 * @return bool Whether the site has 'My Home' enabled.
-	 */
-	private function is_my_home_enabled() {
-		$my_home_enabled = get_transient( 'jetpack_my_home_enabled' );
-
-		if ( false === $my_home_enabled ) {
-			$site_id       = Jetpack_Options::get_option( 'id' );
-			$site_response = Client::wpcom_json_api_request_as_blog(
-				sprintf( '/sites/%d', $site_id ) . '?force=wpcom&options=created_at',
-				'1.1'
-			);
-
-			if ( is_wp_error( $site_response ) ) {
-				return false;
-			}
-
-			$site_data = json_decode( wp_remote_retrieve_body( $site_response ) );
-
-			$my_home_enabled = $site_data &&
-					isset( $site_data->options->created_at ) &&
-					( new Datetime( '2019-08-06 00:00:00.000' ) ) <= ( new Datetime( $site_data->options->created_at ) )
-				? 1
-				: 0;
-
-			set_transient( 'jetpack_my_home_enabled', $my_home_enabled );
-		}
-
-		return (bool) $my_home_enabled;
-	}
-
-	/**
 	 * Adds "My Home" submenu item to sites that are eligible.
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin Bar instance.
@@ -1375,18 +1341,16 @@ class A8C_WPCOM_Masterbar {
 			return;
 		}
 
-		if ( $this->is_my_home_enabled() ) {
-			$wp_admin_bar->add_menu(
-				array(
-					'parent' => 'blog',
-					'id'     => 'my-home',
-					'title'  => __( 'My Home', 'jetpack' ),
-					'href'   => 'https://wordpress.com/home/' . esc_attr( $this->primary_site_slug ),
-					'meta'   => array(
-						'class' => 'mb-icon',
-					),
-				)
-			);
-		}
+		$wp_admin_bar->add_menu(
+			array(
+				'parent' => 'blog',
+				'id'     => 'my-home',
+				'title'  => __( 'My Home', 'jetpack' ),
+				'href'   => 'https://wordpress.com/home/' . esc_attr( $this->primary_site_slug ),
+				'meta'   => array(
+					'class' => 'mb-icon',
+				),
+			)
+		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

We're enabling the Customer Home section to all WP.com sites created before Aug 2019 once [this A/B test finishes](https://github.com/Automattic/wp-calypso/pull/39265).

This PR removes the dates check we were performing to determine if Customer Home was enabled for a given site, so the submenu link is always added to the masterbar.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
It modifies the WP.com masterbar module so Atomic sites will always get a Customer Home link on it. Needed after https://github.com/Automattic/wp-calypso/pull/39265 lands (if the "show home in all sites" variant wins).

#### Testing instructions:
* Install the Jetpack Beta plugin on 2 Atomic sites, one created before Aug 2019 and the other one created after Aug 2019.
* Go to Jetpack > Jetpack Beta and activate the `update/customer-home-all-sites` feature branch.
* Click on My Sites.
* Make sure there is a Home item pointing to `wordpress.com/home/:site` on both sites.

#### Proposed changelog entry for your changes:
N/A
