### PR TITLE
Map block: Let WordPress.com sites set their own Mapbox access token

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -168,10 +168,11 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		$message = esc_html__( 'API key updated successfully.', 'jetpack' );
 		Jetpack_Options::update_option( $option, $service_api_key );
 		return array(
-			'code'            => 'success',
-			'service'         => $service,
-			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
-			'message'         => $message,
+			'code'                   => 'success',
+			'service'                => $service,
+			'service_api_key'        => Jetpack_Options::get_option( $option, '' ),
+			'service_api_key_source' => 'site',
+			'message'                => $message,
 		);
 	}
 
@@ -192,11 +193,25 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		$option = self::key_for_api_service( $service );
 		Jetpack_Options::delete_option( $option );
 		$message = esc_html__( 'API key deleted successfully.', 'jetpack' );
+
+		switch ( $service ) {
+			case 'mapbox':
+				// After deleting a custom Mapbox key, try to revert to the WordPress.com one if available.
+				$mapbox                 = self::get_service_api_key_mapbox();
+				$service_api_key        = $mapbox['key'];
+				$service_api_key_source = $mapbox['source'];
+				break;
+			default:
+				$service_api_key        = Jetpack_Options::get_option( $option, '' );
+				$service_api_key_source = 'site';
+		};
+
 		return array(
-			'code'            => 'success',
-			'service'         => $service,
-			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
-			'message'         => $message,
+			'code'                   => 'success',
+			'service'                => $service,
+			'service_api_key'        => $service_api_key,
+			'service_api_key_source' => $service_api_key_source,
+			'message'                => $message,
 		);
 	}
 

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -139,6 +139,7 @@ class MapEdit extends Component {
 			addPointVisibility,
 			apiKey,
 			apiKeyControl,
+			apiKeySource,
 			apiState,
 			apiRequestOutstanding,
 		} = this.state;
@@ -210,7 +211,7 @@ class MapEdit extends Component {
 							<Button
 								type="button"
 								onClick={ this.removeAPIKey }
-								disabled={ ! apiKeyControl }
+								disabled={ 'wpcom' !== apiKeySource }
 								isDefault
 							>
 								{ __( 'Remove Token', 'jetpack' ) }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -139,7 +139,6 @@ class MapEdit extends Component {
 			addPointVisibility,
 			apiKey,
 			apiKeyControl,
-			apiKeySource,
 			apiState,
 			apiRequestOutstanding,
 		} = this.state;
@@ -193,23 +192,21 @@ class MapEdit extends Component {
 							/>
 						</PanelBody>
 					) : null }
-					{ 'wpcom' !== apiKeySource && (
-						<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
-							<TextControl
-								label={ __( 'Mapbox Access Token', 'jetpack' ) }
-								value={ apiKeyControl }
-								onChange={ value => this.setState( { apiKeyControl: value } ) }
-							/>
-							<ButtonGroup>
-								<Button type="button" onClick={ this.updateAPIKey } isDefault>
-									{ __( 'Update Token', 'jetpack' ) }
-								</Button>
-								<Button type="button" onClick={ this.removeAPIKey } isDefault>
-									{ __( 'Remove Token', 'jetpack' ) }
-								</Button>
-							</ButtonGroup>
-						</PanelBody>
-					) }
+					<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
+						<TextControl
+							label={ __( 'Mapbox Access Token', 'jetpack' ) }
+							value={ apiKeyControl }
+							onChange={ value => this.setState( { apiKeyControl: value } ) }
+						/>
+						<ButtonGroup>
+							<Button type="button" onClick={ this.updateAPIKey } isDefault>
+								{ __( 'Update Token', 'jetpack' ) }
+							</Button>
+							<Button type="button" onClick={ this.removeAPIKey } isDefault>
+								{ __( 'Remove Token', 'jetpack' ) }
+							</Button>
+						</ButtonGroup>
+					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -199,10 +199,20 @@ class MapEdit extends Component {
 							onChange={ value => this.setState( { apiKeyControl: value } ) }
 						/>
 						<ButtonGroup>
-							<Button type="button" onClick={ this.updateAPIKey } isDefault>
+							<Button
+								type="button"
+								onClick={ this.updateAPIKey }
+								disabled={ ! apiKeyControl }
+								isDefault
+							>
 								{ __( 'Update Token', 'jetpack' ) }
 							</Button>
-							<Button type="button" onClick={ this.removeAPIKey } isDefault>
+							<Button
+								type="button"
+								onClick={ this.removeAPIKey }
+								disabled={ ! apiKeyControl }
+								isDefault
+							>
 								{ __( 'Remove Token', 'jetpack' ) }
 							</Button>
 						</ButtonGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14473

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Stop hiding the Mapbox access token field when the current token's source is `wpcom`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* WIP

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (WordPress.com-only change)
