### PR TITLE
Optimization of "if" checking to prevent errors

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -88,7 +88,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			if ( ! empty( $data ) ) {
 				foreach ( $data as $data_instance ) {
 					$product = wc_get_product( $data_instance['product_id'] );
-					if ( ! $product ) {
+					if ( ! $product instanceof WC_Product ) {
 						continue;
 					}
 					$product_details = $this->get_product_details( $product );
@@ -328,7 +328,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		$referer_postid = isset( $_SERVER['HTTP_REFERER'] ) ? url_to_postid( $_SERVER['HTTP_REFERER'] ) : 0;
 		// if the referring post is not a product OR the product being added is not the same as post
 		// (eg. related product list on single product page) then include a product view event
-		if ( ! wc_get_product( $referer_postid ) || $product_id != $referer_postid ) {
+		$product_by_referer_postid = wc_get_product( $referer_postid );
+		if ( ! $product_by_referer_postid instanceof WC_Product || (int) $product_id !== $referer_postid ) {
 			$this->capture_event_in_session_data( $product_id, $quantity, 'woocommerceanalytics_product_view' );
 		}
 		// add cart event to the session data
@@ -343,7 +344,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	public function capture_event_in_session_data( $product_id, $quantity, $event ) {
 
 		$product = wc_get_product( $product_id );
-		if ( ! $product ) {
+		if ( ! $product instanceof WC_Product ) {
 			return;
 		}
 
@@ -380,7 +381,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 */
 	public function get_product_categories_concatenated( $product ) {
 
-		if ( ! $product ) {
+		if ( ! $product instanceof WC_Product ) {
 			return '';
 		}
 


### PR DESCRIPTION
An error occurred if one was added when finalizing the order that does not have a product ID (item without product page)

Fixes #

#### Changes proposed in this Pull Request:
* Optimization of the "if" check to ensure that the variable "$product" is an object

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:

* Add an item (item without product page) to the cart and finalize an order.

#### Proposed changelog entry:

* WooCommerce Analytics - Check that the $product variable is of the correct type (WC_Product).
