### PR TITLE
Correctly trigger failed_jetpack_search_query action

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -518,6 +518,23 @@ class Jetpack_Search {
 		$response_code = wp_remote_retrieve_response_code( $request );
 
 		if ( ! $response_code || $response_code < 200 || $response_code >= 300 ) {
+			/**
+			 * Fires after a search query request has failed
+			 *
+			 * @module search
+			 *
+			 * @since  5.6.0
+			 *
+			 * @param array Array containing the response code and response from the failed search query
+			 */
+			do_action(
+				'failed_jetpack_search_query',
+				array(
+					'response_code' => $response_code,
+					'json'          => $response,
+				)
+			);
+
 			return new WP_Error( 'invalid_search_api_response', 'Invalid response from API - ' . $response_code );
 		}
 
@@ -556,27 +573,6 @@ class Jetpack_Search {
 		 * @param array $query Array of information about the query performed
 		 */
 		do_action( 'did_jetpack_search_query', $query );
-
-		if ( ! $response_code || $response_code < 200 || $response_code >= 300 ) {
-			/**
-			 * Fires after a search query request has failed
-			 *
-			 * @module search
-			 *
-			 * @since  5.6.0
-			 *
-			 * @param array Array containing the response code and response from the failed search query
-			 */
-			do_action(
-				'failed_jetpack_search_query',
-				array(
-					'response_code' => $response_code,
-					'json'          => $response,
-				)
-			);
-
-			return new WP_Error( 'invalid_search_api_response', 'Invalid response from API - ' . $response_code );
-		}
 
 		return $response;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Where it's currently located, we never actually hit, since non-success response codes return early.

This moves the `do_action` to the spot of the early return so we actually trigger this action.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Fixes a feature in the Search module.

#### Testing instructions:

It's a bit tricky to force a failure but we can clever about it :)

- Make sure search module is enabled on the site
- In your `/etc/hosts` (or related DNS file), point `public-api.wordpress.com` to `127.0.0.1`.
- Go to a search page.
- At the bottom of the source of the page, you'll see debug information about the error. Without this patch, the action never fires and our callback to print the debug info is never called.

#### Proposed changelog entry for your changes:

> Correctly trigger failed_jetpack_search_query when a Search request fails
