### PR TITLE
Instant Search: Update list of widgets passed to JS client

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -78,8 +78,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$widget_options = end( $widget_options );
 		}
 
-		$filters = Jetpack_Search_Helpers::get_filters_from_widgets();
-		$widgets = array();
+		$overlay_widget_ids = get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'];
+		$filters            = Jetpack_Search_Helpers::get_filters_from_widgets( $overlay_widget_ids );
+		$widgets            = array();
 		foreach ( $filters as $key => $filter ) {
 			if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
 				$widgets[ $filter['widget_id'] ]['filters']   = array();

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -158,9 +158,13 @@ class Jetpack_Search_Helpers {
 			return $filters;
 		}
 
+		$overlay_widgets = get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'];
 		foreach ( (array) $widget_options as $number => $settings ) {
 			$widget_id = self::build_widget_id( $number );
 			if ( ! self::is_active_widget( $widget_id ) || empty( $settings['filters'] ) ) {
+				continue;
+			}
+			if ( $overlay_widgets && ! in_array( $widget_id, $overlay_widgets, true ) ) {
 				continue;
 			}
 

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -148,9 +148,11 @@ class Jetpack_Search_Helpers {
 	 *
 	 * @since 5.8.0
 	 *
+	 * @param array|null $whitelisted_widget_ids array of whitelisted widget IDs.
+	 *
 	 * @return array Active filters.
 	 */
-	static function get_filters_from_widgets() {
+	public static function get_filters_from_widgets( $whitelisted_widget_ids = null ) {
 		$filters = array();
 
 		$widget_options = self::get_widgets_from_option();
@@ -158,13 +160,12 @@ class Jetpack_Search_Helpers {
 			return $filters;
 		}
 
-		$overlay_widgets = get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'];
 		foreach ( (array) $widget_options as $number => $settings ) {
 			$widget_id = self::build_widget_id( $number );
 			if ( ! self::is_active_widget( $widget_id ) || empty( $settings['filters'] ) ) {
 				continue;
 			}
-			if ( $overlay_widgets && ! in_array( $widget_id, $overlay_widgets, true ) ) {
+			if ( isset( $whitelisted_widget_ids ) && ! in_array( $widget_id, $whitelisted_widget_ids, true ) ) {
 				continue;
 			}
 

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import { h } from 'preact';
-import { createPortal, useState, useEffect } from 'preact/compat';
+import { createPortal } from 'preact/compat';
 import SearchFilters from './search-filters';
 import WidgetAreaContainer from './widget-area-container';
 
@@ -14,45 +14,26 @@ import WidgetAreaContainer from './widget-area-container';
 import JetpackColophon from './jetpack-colophon';
 
 const SearchSidebar = props => {
-	// TODO: Change JetpackInstantSearchOptions.widgets to only include info from widgets inside Overlay sidebar
-	const [ widgetIds, setWidgetIds ] = useState( [] );
-
-	useEffect( () => {
-		const widgetArea = document.getElementsByClassName(
-			'jetpack-instant-search__widget-area'
-		)[ 0 ];
-		const widgets = Array.from( widgetArea.querySelectorAll( '.jetpack-instant-search-wrapper' ) );
-
-		widgets.forEach( widget => {
-			const form = widget.querySelector( '.jetpack-search-form' );
-			form && widget.removeChild( form );
-		} );
-
-		setWidgetIds( widgets.map( element => element.id ) );
-	}, [] );
-
 	return (
 		<div className="jetpack-instant-search__sidebar">
 			<WidgetAreaContainer />
-			{ props.widgets
-				.filter( widget => widgetIds.includes( `${ widget.widget_id }-wrapper` ) )
-				.map( widget => {
-					return createPortal(
-						<div
-							id={ `${ widget.widget_id }-portaled-wrapper` }
-							className="jetpack-instant-search__portaled-wrapper"
-						>
-							<SearchFilters
-								loading={ props.isLoading }
-								locale={ props.locale }
-								postTypes={ props.postTypes }
-								results={ props.response }
-								widget={ widget }
-							/>
-						</div>,
-						document.getElementById( `${ widget.widget_id }-wrapper` )
-					);
-				} ) }
+			{ props.widgets.map( widget => {
+				return createPortal(
+					<div
+						id={ `${ widget.widget_id }-portaled-wrapper` }
+						className="jetpack-instant-search__portaled-wrapper"
+					>
+						<SearchFilters
+							loading={ props.isLoading }
+							locale={ props.locale }
+							postTypes={ props.postTypes }
+							results={ props.response }
+							widget={ widget }
+						/>
+					</div>,
+					document.getElementById( `${ widget.widget_id }-wrapper` )
+				);
+			} ) }
 			{ props.showPoweredBy && <JetpackColophon /> }
 		</div>
 	);


### PR DESCRIPTION
Fixes #14535.

#### Changes proposed in this Pull Request:
* Changes the injected value of `JetpackInstantSearchOptions.widgets` to only include Jetpack Search widgets from the overlay sidebar.
* Removes overlay sidebar membership check done in JavaScript.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* None.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Perform a search on your site. Ensure that the search overlay appears as expected.
3. Resize your viewport to be less than 768 pixels. Ensure that a filter toggle button appears next to the overlay search input.
4. Click the filter toggle button. Ensure that the filters shown inside the mobile filter popover are from Jetpack Search widgets inside the overlay sidebar. Filters from Jetpack Search widgets defined outside the overlay sidebar should not appear here.

#### Proposed changelog entry for your changes:
* None.
