### PR TITLE
Map Block: Consolidate the Mapbox API handling

### DIFF
--- a/_inc/lib/class-jetpack-mapbox-helper.php
+++ b/_inc/lib/class-jetpack-mapbox-helper.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Mapbox API helper.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Jetpack_Mapbox_Helper
+ */
+class Jetpack_Mapbox_Helper {
+	/**
+	 * Site option key for the Mapbox service.
+	 *
+	 * @var string
+	 */
+	private static $site_option_key = 'mapbox_api_key';
+
+	/**
+	 * Transient key for the WordPress.com Mapbox access token.
+	 *
+	 * @var string
+	 */
+	private static $transient_key = 'wpcom_mapbox_access_token';
+
+	/**
+	 * Get the site's own Mapbox access token if set, or the WordPress.com's one otherwise.
+	 *
+	 * @return array An array containing the key (if any) and its source ("site" or "wpcom").
+	 */
+	public static function get_access_token() {
+		// If the site provides its own Mapbox access token, return it.
+		$service_api_key = Jetpack_Options::get_option( self::$site_option_key );
+		if ( $service_api_key ) {
+			return self::format_access_token( $service_api_key );
+		}
+
+		// If on WordPress.com, try to return the access token straight away.
+		if ( self::is_wpcom() && defined( 'WPCOM_MAPBOX_ACCESS_TOKEN' ) ) {
+			return self::format_access_token( WPCOM_MAPBOX_ACCESS_TOKEN, 'wpcom' );
+		}
+
+		$site_id = self::get_wpcom_site_id();
+
+		// If not on WordPress.com, return an empty access token.
+		if ( ! $site_id || ( ! self::is_wpcom() && ! jetpack_is_atomic_site() ) ) {
+			return self::format_access_token();
+		}
+
+		// If there is a cached token, return it.
+		$cached_token = get_transient( self::$transient_key );
+		if ( $cached_token ) {
+			return self::format_access_token( $cached_token, 'wpcom' );
+		}
+
+		// Otherwise get it from the WordPress.com endpoint.
+		$request_url = 'https://public-api.wordpress.com/wpcom/v2/sites/' . $site_id . '/mapbox';
+		$response    = wp_remote_get( esc_url_raw( $request_url ) );
+		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return self::format_access_token();
+		}
+
+		$response_body             = json_decode( wp_remote_retrieve_body( $response ) );
+		$wpcom_mapbox_access_token = $response_body->wpcom_mapbox_access_token;
+
+		set_transient( self::$transient_key, $wpcom_mapbox_access_token, HOUR_IN_SECONDS );
+		return self::format_access_token( $wpcom_mapbox_access_token, 'wpcom' );
+	}
+
+	/**
+	 * Check if we're in WordPress.com.
+	 *
+	 * @return bool
+	 */
+	private static function is_wpcom() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM;
+	}
+
+	/**
+	 * Get the current site's WordPress.com ID.
+	 *
+	 * @return mixed The site's WordPress.com ID.
+	 */
+	private static function get_wpcom_site_id() {
+		if ( self::is_wpcom() ) {
+			return get_current_blog_id();
+		} elseif ( method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active() ) {
+			return Jetpack_Options::get_option( 'id' );
+		}
+		return false;
+	}
+
+	/**
+	 * Format an access token and its source into an array.
+	 *
+	 * @param string $key The API key.
+	 * @param string $source The key's source ("site" or "wpcom").
+	 * @return array
+	 */
+	private static function format_access_token( $key = '', $source = 'site' ) {
+		return array(
+			'key'    => $key,
+			'source' => $source,
+		);
+	}
+}

--- a/_inc/lib/class-jetpack-mapbox-helper.php
+++ b/_inc/lib/class-jetpack-mapbox-helper.php
@@ -45,7 +45,7 @@ class Jetpack_Mapbox_Helper {
 				: self::format_access_token( WPCOM_MAPBOX_ACCESS_TOKEN, 'wpcom' );
 		}
 
-		// If not on WordPress.com, return an empty access token.
+		// If not on WordPress.com or Atomic, return an empty access token.
 		if ( ! $site_id || ( ! self::is_wpcom() && ! jetpack_is_atomic_site() ) ) {
 			return self::format_access_token();
 		}

--- a/_inc/lib/class-jetpack-mapbox-helper.php
+++ b/_inc/lib/class-jetpack-mapbox-helper.php
@@ -35,12 +35,15 @@ class Jetpack_Mapbox_Helper {
 			return self::format_access_token( $service_api_key );
 		}
 
+		$site_id = self::get_wpcom_site_id();
+
 		// If on WordPress.com, try to return the access token straight away.
 		if ( self::is_wpcom() && defined( 'WPCOM_MAPBOX_ACCESS_TOKEN' ) ) {
-			return self::format_access_token( WPCOM_MAPBOX_ACCESS_TOKEN, 'wpcom' );
+			jetpack_require_lib( 'mapbox-blacklist' );
+			return wpcom_is_site_blacklisted_from_map_block( $site_id )
+				? self::format_access_token()
+				: self::format_access_token( WPCOM_MAPBOX_ACCESS_TOKEN, 'wpcom' );
 		}
-
-		$site_id = self::get_wpcom_site_id();
 
 		// If not on WordPress.com, return an empty access token.
 		if ( ! $site_id || ( ! self::is_wpcom() && ! jetpack_is_atomic_site() ) ) {

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -122,7 +122,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		switch ( $service ) {
 			case 'mapbox':
 				if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
-					jetpack_require_lib( 'class.jetpack-mapbox-helper' );
+					jetpack_require_lib( 'class-jetpack-mapbox-helper' );
 				}
 				$mapbox                 = Jetpack_Mapbox_Helper::get_access_token();
 				$service_api_key        = $mapbox['key'];
@@ -201,7 +201,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 			case 'mapbox':
 				// After deleting a custom Mapbox key, try to revert to the WordPress.com one if available.
 				if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
-					jetpack_require_lib( 'class.jetpack-mapbox-helper' );
+					jetpack_require_lib( 'class-jetpack-mapbox-helper' );
 				}
 				$mapbox                 = Jetpack_Mapbox_Helper::get_access_token();
 				$service_api_key        = $mapbox['key'];

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -121,7 +121,10 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 
 		switch ( $service ) {
 			case 'mapbox':
-				$mapbox                 = self::get_service_api_key_mapbox();
+				if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
+					jetpack_require_lib( 'class.jetpack-mapbox-helper' );
+				}
+				$mapbox                 = Jetpack_Mapbox_Helper::get_access_token();
 				$service_api_key        = $mapbox['key'];
 				$service_api_key_source = $mapbox['source'];
 				break;
@@ -168,10 +171,11 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		$message = esc_html__( 'API key updated successfully.', 'jetpack' );
 		Jetpack_Options::update_option( $option, $service_api_key );
 		return array(
-			'code'            => 'success',
-			'service'         => $service,
-			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
-			'message'         => $message,
+			'code'                   => 'success',
+			'service'                => $service,
+			'service_api_key'        => Jetpack_Options::get_option( $option, '' ),
+			'service_api_key_source' => 'site',
+			'message'                => $message,
 		);
 	}
 
@@ -192,11 +196,28 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 		$option = self::key_for_api_service( $service );
 		Jetpack_Options::delete_option( $option );
 		$message = esc_html__( 'API key deleted successfully.', 'jetpack' );
+
+		switch ( $service ) {
+			case 'mapbox':
+				// After deleting a custom Mapbox key, try to revert to the WordPress.com one if available.
+				if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
+					jetpack_require_lib( 'class.jetpack-mapbox-helper' );
+				}
+				$mapbox                 = Jetpack_Mapbox_Helper::get_access_token();
+				$service_api_key        = $mapbox['key'];
+				$service_api_key_source = $mapbox['source'];
+				break;
+			default:
+				$service_api_key        = Jetpack_Options::get_option( $option, '' );
+				$service_api_key_source = 'site';
+		};
+
 		return array(
-			'code'            => 'success',
-			'service'         => $service,
-			'service_api_key' => Jetpack_Options::get_option( $option, '' ),
-			'message'         => $message,
+			'code'                   => 'success',
+			'service'                => $service,
+			'service_api_key'        => $service_api_key,
+			'service_api_key_source' => $service_api_key_source,
+			'message'                => $message,
 		);
 	}
 
@@ -284,82 +305,6 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 			'status'        => $status,
 			'error_message' => $msg,
 		);
-	}
-
-	/**
-	 * Get the site's own Mapbox API key if set, or the WordPress.com's one otherwise.
-	 *
-	 * @return array An array containing the key (if any) and its source ("site" or "wpcom").
-	 */
-	public static function get_service_api_key_mapbox() {
-		// If the site provides its own Mapbox API key, return it.
-		$service_api_key = Jetpack_Options::get_option( self::key_for_api_service( 'mapbox' ) );
-		if ( $service_api_key ) {
-			return self::format_api_key( $service_api_key );
-		}
-
-		// If the site is not WordPress.com, return an empty API key.
-		$site_id = self::get_wpcom_site_id();
-		if ( ( ! self::is_wpcom() && ! jetpack_is_atomic_site() ) || ! $site_id ) {
-			return self::format_api_key();
-		}
-
-		// If there is a cached token, return it.
-		$transient_key = 'wpcom_mapbox_access_token';
-		$cached_token  = get_transient( $transient_key );
-		if ( $cached_token ) {
-			return self::format_api_key( $cached_token, 'wpcom' );
-		}
-
-		// Otherwise retrieve a WordPress.com token.
-		$request_url = 'https://public-api.wordpress.com/wpcom/v2/sites/' . $site_id . '/mapbox';
-		$response    = wp_remote_get( esc_url_raw( $request_url ) );
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return self::format_api_key();
-		}
-
-		$response_body             = json_decode( wp_remote_retrieve_body( $response ) );
-		$wpcom_mapbox_access_token = $response_body->wpcom_mapbox_access_token;
-
-		set_transient( $transient_key, $wpcom_mapbox_access_token, HOUR_IN_SECONDS );
-		return self::format_api_key( $wpcom_mapbox_access_token, 'wpcom' );
-	}
-
-	/**
-	 * Format an API key and its source into an array.
-	 *
-	 * @param string $key The API key.
-	 * @param string $source The key's source ("site" or "wpcom").
-	 * @return array
-	 */
-	private static function format_api_key( $key = '', $source = 'site' ) {
-		return array(
-			'key'    => $key,
-			'source' => $source,
-		);
-	}
-
-	/**
-	 * Check if we're in WordPress.com.
-	 *
-	 * @return bool
-	 */
-	private static function is_wpcom() {
-		return defined( 'IS_WPCOM' ) && IS_WPCOM;
-	}
-
-	/**
-	 * Get the current site's WordPress.com ID.
-	 *
-	 * @return mixed The site's WordPress.com ID or an empty string.
-	 */
-	private static function get_wpcom_site_id() {
-		if ( self::is_wpcom() ) {
-			return get_current_blog_id();
-		} elseif ( method_exists( 'Jetpack', 'is_active' ) && Jetpack::is_active() ) {
-			return Jetpack_Options::get_option( 'id' );
-		}
-		return false;
 	}
 
 	/**

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -11,6 +11,7 @@ module.exports = [
 	'functions.global.php',
 	'functions.opengraph.php',
 	'_inc/lib/admin-pages/class-jetpack-about-page.php',
+	'_inc/lib/class-jetpack-mapbox-helper.php',
 	'_inc/lib/class.jetpack-password-checker.php',
 	'_inc/lib/components.php',
 	'_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php',

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -203,7 +203,7 @@ class MapEdit extends Component {
 							<Button
 								type="button"
 								onClick={ this.updateAPIKey }
-								disabled={ ! apiKeyControl }
+								disabled={ ! apiKeyControl || apiKeyControl === apiKey }
 								isDefault
 							>
 								{ __( 'Update Token', 'jetpack' ) }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -211,7 +211,7 @@ class MapEdit extends Component {
 							<Button
 								type="button"
 								onClick={ this.removeAPIKey }
-								disabled={ 'wpcom' !== apiKeySource }
+								disabled={ 'wpcom' === apiKeySource }
 								isDefault
 							>
 								{ __( 'Remove Token', 'jetpack' ) }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -193,23 +193,31 @@ class MapEdit extends Component {
 							/>
 						</PanelBody>
 					) : null }
-					{ 'wpcom' !== apiKeySource && (
-						<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
-							<TextControl
-								label={ __( 'Mapbox Access Token', 'jetpack' ) }
-								value={ apiKeyControl }
-								onChange={ value => this.setState( { apiKeyControl: value } ) }
-							/>
-							<ButtonGroup>
-								<Button type="button" onClick={ this.updateAPIKey } isDefault>
-									{ __( 'Update Token', 'jetpack' ) }
-								</Button>
-								<Button type="button" onClick={ this.removeAPIKey } isDefault>
-									{ __( 'Remove Token', 'jetpack' ) }
-								</Button>
-							</ButtonGroup>
-						</PanelBody>
-					) }
+					<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
+						<TextControl
+							label={ __( 'Mapbox Access Token', 'jetpack' ) }
+							value={ apiKeyControl }
+							onChange={ value => this.setState( { apiKeyControl: value } ) }
+						/>
+						<ButtonGroup>
+							<Button
+								type="button"
+								onClick={ this.updateAPIKey }
+								disabled={ ! apiKeyControl }
+								isDefault
+							>
+								{ __( 'Update Token', 'jetpack' ) }
+							</Button>
+							<Button
+								type="button"
+								onClick={ this.removeAPIKey }
+								disabled={ 'wpcom' !== apiKeySource }
+								isDefault
+							>
+								{ __( 'Remove Token', 'jetpack' ) }
+							</Button>
+						</ButtonGroup>
+					</PanelBody>
 				</InspectorControls>
 			</Fragment>
 		);

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -195,6 +195,16 @@ class MapEdit extends Component {
 					) : null }
 					<PanelBody title={ __( 'Mapbox Access Token', 'jetpack' ) } initialOpen={ false }>
 						<TextControl
+							help={
+								'wpcom' === apiKeySource && (
+									<>
+										{ __( 'You can optionally enter your own access token.', 'jetpack' ) }{' '}
+										<ExternalLink href="https://account.mapbox.com/access-tokens/">
+											{ __( 'Find it on Mapbox', 'jetpack' ) }
+										</ExternalLink>
+									</>
+								)
+							}
 							label={ __( 'Mapbox Access Token', 'jetpack' ) }
 							value={ apiKeyControl }
 							onChange={ value => this.setState( { apiKeyControl: value } ) }

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -8,7 +8,7 @@
  */
 
 if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
-	jetpack_require_lib( 'class.jetpack-mapbox-helper' );
+	jetpack_require_lib( 'class-jetpack-mapbox-helper' );
 }
 
 jetpack_register_block(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14473
Fixes #14475

Replaces #14568 and #14591

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Consolidate the Mapbox access token handling into a shared helper.
* Stop hiding the Mapbox access token field when the current token's source is `wpcom`.
* On WordPress.com, use the Mapbox access token directly (if it exists) instead of calling an endpoint.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This is a WordPress.com-only change, so on Jetpack just smoke test for regressions.

* Apply D38617 and D38618.
Sandbox the API and a _private_ site that doesn't have a custom Mapbox access token saved (you can remove it from the Map block sidebar before applying this PR).
* Insert a Map block, and make sure it doesn't ask for the access token.
* Check the sidebar and make sure you see the Mapbox Access Token field.
* Try setting a personal Mapbox access token.
* Make sure the block keeps working as expected.
* Now try to remove the token.
* Make sure the block reverts to using the WPCOM token, and keeps working as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (WordPress.com-only change)