### PR TITLE
SubmitButton: Make it use the theme palette

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -102,6 +102,7 @@ function load_assets( $attr, $content ) {
 	$text_color                     = get_attribute( $attr, 'textColor' );
 	$primary_color                  = get_attribute( $attr, 'primaryColor' );
 	$submit_button_text             = get_attribute( $attr, 'submitButtonText' );
+	$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
 	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr );
@@ -140,9 +141,10 @@ function load_assets( $attr, $content ) {
 		}
 
 		$content = sprintf(
-			'<div class="%1$s" id="%2$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%3$s\'});return false;">%4$s</a></div>',
+			'<div class="wp-block-button %1$s" id="%2$s"><a class="%3$s" role="button" onclick="Calendly.initPopupWidget({url:\'%4$s\'});return false;">%5$s</a></div>',
 			esc_attr( $classes ),
 			esc_attr( $block_id ),
+			! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
 			esc_js( $url ),
 			wp_kses_post( $submit_button_text )
 		);

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -2,7 +2,7 @@
  * External Dependencies
  */
 import 'url-polyfill';
-import { isEqual } from 'lodash';
+import { isEqual, pick } from 'lodash';
 import queryString from 'query-string';
 
 /**
@@ -33,7 +33,8 @@ import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
 
-export default function CalendlyEdit( { attributes, name, className, clientId, setAttributes } ) {
+export default function CalendlyEdit( props ) {
+	const { attributes, name, className, clientId, setAttributes } = props;
 	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( attributeDetails, attributes );
 
@@ -152,13 +153,17 @@ export default function CalendlyEdit( { attributes, name, className, clientId, s
 		</>
 	);
 
-	const submitButtonPreview = (
-		<SubmitButton
-			submitButtonText={ submitButtonText }
-			attributes={ attributes }
-			setAttributes={ setAttributes }
-		/>
-	);
+	const submitButtonProps = {
+		attributes: pick( validatedAttributes, [
+			'submitButtonText',
+			'backgroundButtonColor',
+			'textButtonColor',
+			'customBackgroundButtonColor',
+			'customBackgroundButtonColor',
+		] ),
+		setAttributes,
+	};
+	const submitButtonPreview = <SubmitButton { ...submitButtonProps } />;
 
 	const linkPreview = (
 		<>

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -38,6 +38,15 @@ export const settings = {
 			type: 'string',
 			default: __( 'Join my email list', 'jetpack' ),
 		},
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
+		submitButtonClasses: {
+			type: 'string',
+		},
 		customBackgroundButtonColor: {
 			type: 'string',
 		},

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -76,6 +76,11 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 	$amp_form_action = sprintf( 'https://public-api.wordpress.com/rest/v1.1/sites/%s/email_follow/amp/subscribe/', $blog_id );
 	$is_amp_request  = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
 
+	$button_classes = 'components-button is-button is-primary ';
+	if ( ! empty( $attr['submitButtonClasses'] ) ) {
+		$button_classes .= $attr['submitButtonClasses'];
+	}
+
 	ob_start();
 	?>
 
@@ -125,7 +130,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 					/>
 				<?php endif; ?>
 				<p>
-					<button type="submit" class="components-button is-button is-primary" style="<?php echo esc_attr( $button_styles ); ?>">
+					<button type="submit" class="<?php echo esc_attr( $button_classes ); ?>" style="<?php echo esc_attr( $button_styles ); ?>">
 						<?php echo wp_kses_post( $values['submitButtonText'] ); ?>
 					</button>
 				</p>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import SubmitButton from '../../shared/submit-button';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
-import { trimEnd } from 'lodash';
+import { trimEnd, pick } from 'lodash';
 import formatCurrency, { getCurrencyDefaults } from '@automattic/format-currency';
 import { addQueryArgs, getQueryArg, isURL } from '@wordpress/url';
 import { compose } from '@wordpress/compose';
@@ -350,9 +350,8 @@ class MembershipsButtonEdit extends Component {
 	}
 
 	render = () => {
-		const { attributes, className, notices } = this.props;
+		const { notices } = this.props;
 		const { connected, products } = this.state;
-		const { align } = attributes;
 
 		const stripeConnectUrl = this.getConnectUrl();
 
@@ -377,21 +376,7 @@ class MembershipsButtonEdit extends Component {
 				</PanelBody>
 			</InspectorControls>
 		);
-		const blockClasses = classnames( className, [
-			'wp-block-button__link',
-			'components-button',
-			'is-primary',
-			'is-button',
-			`align${ align }`,
-		] );
-		const blockContent = (
-			<SubmitButton
-				className={ blockClasses }
-				submitButtonText={ this.props.attributes.submitButtonText }
-				attributes={ this.props.attributes }
-				setAttributes={ this.props.setAttributes }
-			/>
-		);
+
 		return (
 			<Fragment>
 				{ this.props.noticeUI }
@@ -474,8 +459,20 @@ class MembershipsButtonEdit extends Component {
 				{ this.state.products && inspectorControls }
 				{ ( ( ( this.hasUpgradeNudge || ! this.state.shouldUpgrade ) &&
 					connected !== API_STATE_LOADING ) ||
-					this.props.attributes.planId ) &&
-					blockContent }
+					this.props.attributes.planId ) && (
+					<SubmitButton
+						{ ...{
+							attributes: pick( this.props.attributes, [
+								'submitButtonText',
+								'backgroundButtonColor',
+								'textButtonColor',
+								'customBackgroundButtonColor',
+								'customBackgroundButtonColor',
+							] ),
+							setAttributes: this.props.setAttributes,
+						} }
+					/>
+				) }
 				{ this.hasUpgradeNudge && connected === API_STATE_NOTCONNECTED && (
 					<div className="wp-block-jetpack-recurring-payments disclaimer-only">
 						{ this.renderDisclaimer() }

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -38,6 +38,15 @@ export const settings = {
 		submitButtonText: {
 			type: 'string',
 		},
+		submitButtonClasses: {
+			type: 'string',
+		},
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
 		customBackgroundButtonColor: {
 			type: 'string',
 		},

--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -44,6 +44,12 @@ export const settings = {
 			type: 'string',
 			default: __( 'Subscribe', 'jetpack' ),
 		},
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
 		customBackgroundButtonColor: { type: 'string' },
 		customTextButtonColor: { type: 'string' },
 		submitButtonClasses: { type: 'string' },

--- a/extensions/shared/submit-button.js
+++ b/extensions/shared/submit-button.js
@@ -68,15 +68,17 @@ class SubmitButton extends Component {
 		const textClass = get( textButtonColor, 'class' );
 		const backgroundClass = get( backgroundButtonColor, 'class' );
 		return classnames( 'wp-block-button__link', {
-			'has-text-color': textButtonColor,
+			'has-text-color': textButtonColor.color,
 			[ textClass ]: textClass,
-			'has-background': backgroundButtonColor,
+			'has-background': backgroundButtonColor.color,
 			[ backgroundClass ]: backgroundClass,
 		} );
 	}
 	render() {
 		const {
 			attributes,
+			backgroundButtonColor,
+			textButtonColor,
 			fallbackBackgroundColor,
 			fallbackTextColor,
 			setAttributes,
@@ -84,8 +86,8 @@ class SubmitButton extends Component {
 			setTextButtonColor,
 		} = this.props;
 
-		const backgroundColor = attributes.customBackgroundButtonColor || fallbackBackgroundColor;
-		const color = attributes.customTextButtonColor || fallbackTextColor;
+		const backgroundColor = backgroundButtonColor.color || fallbackBackgroundColor;
+		const color = textButtonColor.color || fallbackTextColor;
 		const buttonStyle = { border: 'none', backgroundColor, color };
 		const buttonClasses = this.getButtonClasses();
 
@@ -108,23 +110,22 @@ class SubmitButton extends Component {
 						colorSettings={ [
 							{
 								value: backgroundColor,
-								onChange: nextColour => {
-									setBackgroundButtonColor( nextColour );
-									setAttributes( { customBackgroundButtonColor: nextColour } );
-								},
+								onChange: setBackgroundButtonColor,
 								label: __( 'Background Color', 'jetpack' ),
 							},
 							{
 								value: color,
-								onChange: nextColour => {
-									setTextButtonColor( nextColour );
-									setAttributes( { customTextButtonColor: nextColour } );
-								},
+								onChange: setTextButtonColor,
 								label: __( 'Text Color', 'jetpack' ),
 							},
 						] }
 					/>
-					<ContrastChecker textColor={ color } backgroundColor={ backgroundColor } />
+					<ContrastChecker
+						textColor={ color }
+						backgroundColor={ backgroundColor }
+						fallbackBackgroundColor
+						fallbackTextColor
+					/>
 				</InspectorControls>
 			</Fragment>
 		);
@@ -132,6 +133,6 @@ class SubmitButton extends Component {
 }
 
 export default compose( [
-	withColors( 'backgroundButtonColor', { textButtonColor: 'color' } ),
+	withColors( { backgroundButtonColor: 'background-color' }, { textButtonColor: 'color' } ),
 	applyFallbackStyles,
 ] )( SubmitButton );

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -226,18 +226,6 @@ class Jetpack_Memberships {
 			'powered_text' => __( 'Powered by WordPress.com', 'jetpack' ),
 		);
 
-		$classes = Jetpack_Gutenberg::block_classes(
-			self::$button_block_name,
-			$attrs,
-			array(
-				'wp-block-button__link',
-				'components-button',
-				'is-primary',
-				'is-button',
-				self::$css_classname_prefix . '-' . $data['id'],
-			)
-		);
-
 		if ( isset( $attrs['submitButtonText'] ) ) {
 			$data['button_label'] = $attrs['submitButtonText'];
 		}
@@ -263,12 +251,13 @@ class Jetpack_Memberships {
 		$button_styles = implode( ';', $button_styles );
 		add_thickbox();
 		return sprintf(
-			'<button data-blog-id="%d" data-powered-text="%s" data-plan-id="%d" data-lang="%s" class="%s" style="%s">%s</button>',
+			'<div class="wp-block-button %1$s"><a role="button" data-blog-id="%2$d" data-powered-text="%3$s" data-plan-id="%4$d" data-lang="%5$s" class="%6$s" style="%7$s">%8$s</a></div>',
+			esc_attr( Jetpack_Gutenberg::block_classes( self::$button_block_name, $attrs ) ),
 			esc_attr( $data['blog_id'] ),
 			esc_attr( $data['powered_text'] ),
 			esc_attr( $data['id'] ),
 			esc_attr( get_locale() ),
-			esc_attr( $classes ),
+			isset( $attrs['submitButtonClasses'] ) ? esc_attr( $attrs['submitButtonClasses'] ) : 'wp-block-button__link',
 			esc_attr( $button_styles ),
 			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button )
 		);


### PR DESCRIPTION
The `SubmitButton` component was setting the `customButtonTextColor`
(or the `customButtonBackgroundColor`) attribute whenever a colour was
set. This would override any colour classes set to use the theme
palette, like `has-primary-color`. As a result the colours wouldn't
update as the theme was changed.

This also meant that a few components were only rendering the button
using the custom colour attributes, and so would suffer from the same
problem.

Additionally, the Calendly attribute validation was not allowing colour
names like `primary`. For now, I've removed the validation as everything
is properly escaped, but in future, we should probably create a better
regex to check for hex values or hyphenated lowercase words.

#### Changes proposed in this Pull Request:
This change updates the SubmitButton to respect the theme palette and set the `submitButtonClasses` attribute on the component where it is being used. As a result, I have also had to update various places where it has been used, so the classes are used when the button is rendered.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a minor bug fix although the validation change is critical for Calendly, so if we're not happy with this change as a whole, I'll separate that into another PR.

#### Testing instructions:
* On a test site create a post with any (or all) of the Subscription, Calendly, Recurring Payments, and MailChimp blocks.
* Set their colours using colours from the theme palette. 
* Preview the post and check that the correct colours are rendered.
* Change the theme, and check that the colours change accordingly
* Set a custom colour.
* Check that this renders correctly.
* Change the theme again.
* Check that the same custom colour is used.

#### Proposed changelog entry for your changes:
* SubmitButton now uses the theme's colour palette where possible

(The problem with this is that already saved blocks will have custom colour attributes, and won't benefit from this change)
