### PR TITLE
[WIP]: Blocks - Add new phone number block

### DIFF
--- a/extensions/blocks/phone-number/edit.js
+++ b/extensions/blocks/phone-number/edit.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+class PhoneNumberEdit extends Component {
+	/**
+	 * Write the block editor UI.
+	 *
+	 * @returns {object} The UI displayed when user edits this block.
+	 */
+	parseNumber = event => {
+		// if ( ! event ) {
+		// 	setErrorNotice();
+		// 	return;
+		// }
+
+		event.preventDefault();
+
+		// const newAttributes = getAttributesFromEmbedCode( embedCode );
+		// if ( ! newAttributes ) {
+		// 	setErrorNotice();
+		// 	return;
+		// }
+
+		// const newValidatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
+
+		this.props.setAttributes( 12345 );
+	};
+	render() {
+		return (
+			<>
+				<form onSubmit={ this.parseNumber }>
+					<input
+						type="text"
+						id="phoneNumber"
+						// onChange={ event => setEmbedCode( event.target.value ) }
+						placeholder={ __( 'Enter phone number', 'jetpack' ) }
+						value=""
+						className="components-placeholder__input"
+					/>
+					<div>
+						<Button isSecondary isLarge type="submit">
+							{ _x( 'Embed', 'button label', 'jetpack' ) }
+						</Button>
+					</div>
+				</form>
+			</>
+		);
+	}
+}
+
+export default PhoneNumberEdit;

--- a/extensions/blocks/phone-number/edit.js
+++ b/extensions/blocks/phone-number/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,7 +12,6 @@ export default function PhoneNumber( { attributes, setAttributes, className, isS
 	if ( isSelected ) {
 		return (
 			<>
-				{ inspectorControls }
 				<div className={ className }>
 					<PlainText
 						className={ `${ className }-label-input` }
@@ -31,13 +30,12 @@ export default function PhoneNumber( { attributes, setAttributes, className, isS
 				</div>
 			</>
 		);
-	} else {
-		const href = `tel:${ attributes.phoneNumber }`;
-		return (
-			<div className={ className }>
-				<span>{ attributes.label }</span>
-				<a href={ href }>{ attributes.phoneNumber }</a>
-			</div>
-		);
 	}
+
+	const href = `tel:${ attributes.phoneNumber }`;
+	return (
+		<div className={ className }>
+			<span>{ attributes.label }</span> <a href={ href }>{ attributes.phoneNumber }</a>
+		</div>
+	);
 }

--- a/extensions/blocks/phone-number/edit.js
+++ b/extensions/blocks/phone-number/edit.js
@@ -2,9 +2,6 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
-import { InspectorControls } from '@wordpress/block-editor';
-import { Button, PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -12,48 +9,20 @@ import { Button, PanelBody } from '@wordpress/components';
 import { PlainText } from '@wordpress/block-editor';
 
 export default function PhoneNumber( { attributes, setAttributes, className, isSelected } ) {
-	const [ label, setLabel ] = useState( attributes.label );
-
-	const saveLabel = event => {
-		if ( ! event ) {
-			// setErrorNotice();
-			return;
-		}
-
-		event.preventDefault();
-
-		setAttributes( { label } );
-	};
-
-	const inspectorControls = (
-		<InspectorControls>
-			<PanelBody title={ __( 'Phone number Settings', 'jetpack' ) } initialOpen={ false }>
-				<form onSubmit={ saveLabel } className={ `${ className }-embed-form-sidebar` }>
-					<input
-						type="text"
-						id="label"
-						onChange={ event => setLabel( event.target.value ) }
-						placeholder={ __( 'Modify label', 'jetpack' ) }
-						value={ label }
-						className="components-placeholder__input"
-					/>
-					<div>
-						<Button isSecondary isLarge type="submit">
-							{ _x( 'Save', 'button label', 'jetpack' ) }
-						</Button>
-					</div>
-				</form>
-			</PanelBody>
-		</InspectorControls>
-	);
-
 	if ( isSelected ) {
 		return (
 			<>
 				{ inspectorControls }
 				<div className={ className }>
-					<span> { label }: </span>
 					<PlainText
+						className={ `${ className }-label-input` }
+						value={ attributes.label }
+						onChange={ label => setAttributes( { label } ) }
+						placeholder={ __( 'Phone' ) }
+						aria-label={ __( 'Phone Number Label' ) }
+					/>
+					<PlainText
+						className={ `${ className }-number-input` }
 						value={ attributes.phoneNumber }
 						onChange={ phoneNumber => setAttributes( { phoneNumber } ) }
 						placeholder={ __( 'Enter phone number' ) }
@@ -66,7 +35,7 @@ export default function PhoneNumber( { attributes, setAttributes, className, isS
 		const href = `tel:${ attributes.phoneNumber }`;
 		return (
 			<div className={ className }>
-				<span>{ attributes.label }: </span>
+				<span>{ attributes.label }</span>
 				<a href={ href }>{ attributes.phoneNumber }</a>
 			</div>
 		);

--- a/extensions/blocks/phone-number/edit.js
+++ b/extensions/blocks/phone-number/edit.js
@@ -1,59 +1,74 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Button, PanelBody } from '@wordpress/components';
+
 /**
  * Internal dependencies
  */
-import './editor.scss';
+import { PlainText } from '@wordpress/block-editor';
 
-class PhoneNumberEdit extends Component {
-	/**
-	 * Write the block editor UI.
-	 *
-	 * @returns {object} The UI displayed when user edits this block.
-	 */
-	parseNumber = event => {
-		// if ( ! event ) {
-		// 	setErrorNotice();
-		// 	return;
-		// }
+export default function PhoneNumber( { attributes, setAttributes, className, isSelected } ) {
+	const [ label, setLabel ] = useState( attributes.label );
+
+	const saveLabel = event => {
+		if ( ! event ) {
+			// setErrorNotice();
+			return;
+		}
 
 		event.preventDefault();
 
-		// const newAttributes = getAttributesFromEmbedCode( embedCode );
-		// if ( ! newAttributes ) {
-		// 	setErrorNotice();
-		// 	return;
-		// }
-
-		// const newValidatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
-
-		this.props.setAttributes( 12345 );
+		setAttributes( { label } );
 	};
-	render() {
-		return (
-			<>
-				<form onSubmit={ this.parseNumber }>
+
+	const inspectorControls = (
+		<InspectorControls>
+			<PanelBody title={ __( 'Phone number Settings', 'jetpack' ) } initialOpen={ false }>
+				<form onSubmit={ saveLabel } className={ `${ className }-embed-form-sidebar` }>
 					<input
 						type="text"
-						id="phoneNumber"
-						// onChange={ event => setEmbedCode( event.target.value ) }
-						placeholder={ __( 'Enter phone number', 'jetpack' ) }
-						value=""
+						id="label"
+						onChange={ event => setLabel( event.target.value ) }
+						placeholder={ __( 'Modify label', 'jetpack' ) }
+						value={ label }
 						className="components-placeholder__input"
 					/>
 					<div>
 						<Button isSecondary isLarge type="submit">
-							{ _x( 'Embed', 'button label', 'jetpack' ) }
+							{ _x( 'Save', 'button label', 'jetpack' ) }
 						</Button>
 					</div>
 				</form>
+			</PanelBody>
+		</InspectorControls>
+	);
+
+	if ( isSelected ) {
+		return (
+			<>
+				{ inspectorControls }
+				<div className={ className }>
+					<span> { label }: </span>
+					<PlainText
+						value={ attributes.phoneNumber }
+						onChange={ phoneNumber => setAttributes( { phoneNumber } ) }
+						placeholder={ __( 'Enter phone number' ) }
+						aria-label={ __( 'Phone Number' ) }
+					/>
+				</div>
 			</>
+		);
+	} else {
+		const href = `tel:${ attributes.phoneNumber }`;
+		return (
+			<div className={ className }>
+				<span>{ attributes.label }: </span>
+				<a href={ href }>{ attributes.phoneNumber }</a>
+			</div>
 		);
 	}
 }
-
-export default PhoneNumberEdit;

--- a/extensions/blocks/phone-number/editor.js
+++ b/extensions/blocks/phone-number/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/extensions/blocks/phone-number/editor.scss
+++ b/extensions/blocks/phone-number/editor.scss
@@ -1,0 +1,5 @@
+/**
+ * Editor styles for Amazon
+ */
+
+.wp-block-jetpack-amazon { }

--- a/extensions/blocks/phone-number/editor.scss
+++ b/extensions/blocks/phone-number/editor.scss
@@ -1,5 +1,18 @@
 /**
- * Editor styles for Amazon
+ * Editor styles for Phone Number
  */
 
-.wp-block-jetpack-amazon { }
+.wp-block-jetpack-phone-number { 
+    display: flex;
+
+    &-label-input.block-editor-plain-text {
+        margin-right: 10px;
+        text-align: right;
+        padding-right: 10px;
+        width: 120px;
+    }
+
+    &-number-input.block-editor-plain-text {
+        padding-left: 10px;
+    }
+}

--- a/extensions/blocks/phone-number/editor.scss
+++ b/extensions/blocks/phone-number/editor.scss
@@ -6,13 +6,15 @@
     display: flex;
 
     &-label-input.block-editor-plain-text {
-        margin-right: 10px;
+        margin-right: 8px;
         text-align: right;
-        padding-right: 10px;
+        padding-right: 8px;
         width: 120px;
     }
-
+    a {
+        margin-left: 8px;
+    }
     &-number-input.block-editor-plain-text {
-        padding-left: 10px;
+        padding-left: 8px;
     }
 }

--- a/extensions/blocks/phone-number/index.js
+++ b/extensions/blocks/phone-number/index.js
@@ -10,6 +10,7 @@ import { Fragment } from '@wordpress/element';
  */
 import renderMaterialIcon from '../../shared/render-material-icon';
 import edit from './edit';
+import save from './save';
 
 /**
  * Style dependencies
@@ -20,49 +21,41 @@ export const name = 'phone-number';
 export const title = __( 'Phone number', 'jetpack' );
 export const settings = {
 	title,
-	description: (
-		<Fragment>
-			<p>{ __( 'Phone Number', 'jetpack' ) }</p>
-			<ExternalLink href="#">{ __( 'Learn more about Phone numbers', 'jetpack' ) }</ExternalLink>
-		</Fragment>
+	description: __(
+		'Add a hyperlinked phone number that will dial when clicked on mobile',
+		'jetpack'
 	),
-	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
 	icon: renderMaterialIcon(
-		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+		<Path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z" />
 	),
 	category: 'jetpack',
 	keywords: [],
+	attributes: {
+		phoneNumber: {
+			type: 'string',
+			source: 'text',
+			selector: 'a',
+		},
+		label: {
+			type: 'string',
+			default: __( 'Phone', 'jetpack' ),
+		},
+	},
 	supports: {
-		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
-		align: false /* if set to true, the 'align' option below can be used*/,
-		// Pick which alignment options to display.
-		/*align: [ 'left', 'right', 'full' ],*/
-		// Support for wide alignment, that requires additional support in themes.
-		alignWide: true,
-		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		align: true,
+		alignWide: false,
 		anchor: false,
-		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
 		customClassName: true,
-		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
 		className: true,
-		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
 		html: false,
-		// Passing false hides this block in Gutenberg's visual inserter.
-		/*inserter: true,*/
-		// When false, user will only be able to insert the block once per post.
 		multiple: true,
-		// When false, the block won't be available to be converted into a reusable block.
 		reusable: true,
 	},
 	edit,
-	/* @TODO Write the block editor output */
-	save: () => null,
+	save,
 	example: {
 		attributes: {
-			phoneNumber: {
-				default: 12345,
-				type: 'number',
-			},
+			phoneNumber: '+0014568980',
 		},
 	},
 };

--- a/extensions/blocks/phone-number/index.js
+++ b/extensions/blocks/phone-number/index.js
@@ -38,7 +38,7 @@ export const settings = {
 		},
 		label: {
 			type: 'string',
-			default: __( 'Phone', 'jetpack' ),
+			default: __( 'Phone:', 'jetpack' ),
 		},
 	},
 	supports: {
@@ -55,7 +55,7 @@ export const settings = {
 	save,
 	example: {
 		attributes: {
-			phoneNumber: '+0014568980',
+			phoneNumber: '+001-456-8980',
 		},
 	},
 };

--- a/extensions/blocks/phone-number/index.js
+++ b/extensions/blocks/phone-number/index.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, Path } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import renderMaterialIcon from '../../shared/render-material-icon';
+import edit from './edit';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'phone-number';
+export const title = __( 'Phone number', 'jetpack' );
+export const settings = {
+	title,
+	description: (
+		<Fragment>
+			<p>{ __( 'Phone Number', 'jetpack' ) }</p>
+			<ExternalLink href="#">{ __( 'Learn more about Phone numbers', 'jetpack' ) }</ExternalLink>
+		</Fragment>
+	),
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
+	icon: renderMaterialIcon(
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	),
+	category: 'jetpack',
+	keywords: [],
+	supports: {
+		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
+		align: false /* if set to true, the 'align' option below can be used*/,
+		// Pick which alignment options to display.
+		/*align: [ 'left', 'right', 'full' ],*/
+		// Support for wide alignment, that requires additional support in themes.
+		alignWide: true,
+		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		anchor: false,
+		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		customClassName: true,
+		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		className: true,
+		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		html: false,
+		// Passing false hides this block in Gutenberg's visual inserter.
+		/*inserter: true,*/
+		// When false, user will only be able to insert the block once per post.
+		multiple: true,
+		// When false, the block won't be available to be converted into a reusable block.
+		reusable: true,
+	},
+	edit,
+	/* @TODO Write the block editor output */
+	save: () => null,
+	example: {
+		attributes: {
+			phoneNumber: {
+				default: 12345,
+				type: 'number',
+			},
+		},
+	},
+};

--- a/extensions/blocks/phone-number/phone-number.php
+++ b/extensions/blocks/phone-number/phone-number.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Phone Number Block.
+ *
+ * @since 8.x
+ *
+ * @package Jetpack
+ */
+
+jetpack_register_block(
+	'jetpack/phone-number',
+	array( 'render_callback' => 'jetpack_phone_number_block_load_assets' )
+);
+
+/**
+ * Phone Number block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Phone Number block attributes.
+ * @param string $content String containing the Phone Number block content.
+ *
+ * @return string
+ */
+function jetpack_phone_number_block_load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( 'phone-number' );
+	return $content;
+}

--- a/extensions/blocks/phone-number/save.js
+++ b/extensions/blocks/phone-number/save.js
@@ -6,7 +6,7 @@ export default function save( { attributes } ) {
 	const linkUrl = `tel:${ attributes.phoneNumber }`;
 	return (
 		<div>
-			<span>{ attributes.label }: </span>
+			<span>{ attributes.label }</span>
 			<a href={ linkUrl }>{ attributes.phoneNumber }</a>
 		</div>
 	);

--- a/extensions/blocks/phone-number/save.js
+++ b/extensions/blocks/phone-number/save.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+
+export default function save( { attributes } ) {
+	const linkUrl = `tel:${ attributes.phoneNumber }`;
+	return (
+		<div>
+			<span>{ attributes.label }: </span>
+			<a href={ linkUrl }>{ attributes.phoneNumber }</a>
+		</div>
+	);
+}

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -26,5 +26,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "seo" ]
+	"beta": [ "amazon", "seo", "phone-number" ]
 }


### PR DESCRIPTION
Just a draft initial PR for discussion at this stage

#### Changes proposed in this Pull Request:
* Adds a new phone number block as a simple way for users to add a number that will dial when clicked on mobile

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* New feature

#### Testing instructions:

* Checkout this branch to local dev environment that has experimental blocks enables and try adding and editing the Phone number block

![phone-number](https://user-images.githubusercontent.com/3629020/74135166-ace4ec80-4c50-11ea-94ad-7582485827ed.gif)

#### Proposed changelog entry for your changes:

* ... coming soon
