### PR TITLE
SSO: do not display JITM when not in wp-admin

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1100,7 +1100,7 @@ class Jetpack_SSO {
 		 */
 		if (
 			'wp:dashboard:admin_notices' !== $message_path
-			|| true != Jetpack_Options::get_option( 'sso_first_login' ) // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+			|| true !== Jetpack_Options::get_option( 'sso_first_login' )
 		) {
 			return $envelopes;
 		}

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -1092,7 +1092,7 @@ class Jetpack_SSO {
 	 *
 	 * @return array $envelopes New array of JITM messages. May now contain only one message, about SSO.
 	 */
-	public function inject_sso_jitm( $envelopes, $message_path ) {
+	public function inject_sso_jitm( $envelopes, $message_path = null) {
 		/*
 		 * Bail early if:
 		 * - the request does not originate from wp-admin main dashboard.

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -37,7 +37,7 @@ class Jetpack_SSO {
 		add_action( 'login_form_logout',               array( $this, 'store_wpcom_profile_cookies_on_logout' ) );
 		add_action( 'jetpack_unlinked_user',           array( $this, 'delete_connection_for_user') );
 		add_action( 'wp_login',                        array( 'Jetpack_SSO', 'clear_cookies_after_login' ) );
-		add_action( 'jetpack_jitm_received_envelopes', array( $this, 'inject_sso_jitm' ) );
+		add_action( 'jetpack_jitm_received_envelopes', array( $this, 'inject_sso_jitm' ), 10, 2 );
 
 		// Adding this action so that on login_init, the action won't be sanitized out of the $action global.
 		add_action( 'login_form_jetpack-sso', '__return_true' );
@@ -1087,13 +1087,21 @@ class Jetpack_SSO {
 	 *
 	 * @since 6.9.0
 	 *
-	 * @param array $envelopes Array of JITM messages received after API call.
+	 * @param array  $envelopes    Array of JITM messages received after API call.
+	 * @param string $message_path The message path to ask for.
 	 *
 	 * @return array $envelopes New array of JITM messages. May now contain only one message, about SSO.
 	 */
-	public function inject_sso_jitm( $envelopes ) {
-		// Bail early if that's not the first time the user uses SSO.
-		if ( true != Jetpack_Options::get_option( 'sso_first_login' ) ) {
+	public function inject_sso_jitm( $envelopes, $message_path ) {
+		/*
+		 * Bail early if:
+		 * - the request does not originate from wp-admin main dashboard.
+		 * - that's not the first time the user uses SSO.
+		 */
+		if (
+			'wp:dashboard:admin_notices' !== $message_path
+			|| true != Jetpack_Options::get_option( 'sso_first_login' ) // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+		) {
 			return $envelopes;
 		}
 

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -543,10 +543,12 @@ class JITM {
 		 * Allow adding your own custom JITMs after a set of JITMs has been received.
 		 *
 		 * @since 6.9.0
+		 * @since 8.3.0 - Added Message path.
 		 *
-		 * @param array $envelopes array of existing JITMs.
+		 * @param array  $envelopes    array of existing JITMs.
+		 * @param string $message_path The message path to ask for.
 		 */
-		$envelopes = apply_filters( 'jetpack_jitm_received_envelopes', $envelopes );
+		$envelopes = apply_filters( 'jetpack_jitm_received_envelopes', $envelopes, $message_path );
 
 		foreach ( $envelopes as $idx => &$envelope ) {
 


### PR DESCRIPTION

Fixes #14547

#### Changes proposed in this Pull Request:

This PR introduces a change to the filter that can be used to customize the list of JITMs returned by a site for a specific query. We now pass the message path to that filter, so folks customizing the list of messages can choose to only do so on specific pages, for example.

We then use that new parameter to ensure that the custom JITM currently displayed the first time you log in to your site using SSO only appears when you access the main dashboard, where the message should be displayed.

#### Testing instructions:

- Create a test site using this branch.
- Setup Jetpack and Connect to WordPress.com
- Turn on the following setting in Jetpack Settings:
<img width="1025" alt="Screen Shot 2020-01-31 at 1 43 35 PM" src="https://user-images.githubusercontent.com/1270189/73578814-754a9900-4435-11ea-8855-e6ba7e9990d7.png">
- Visit WordPress.com/stats/day/siteslug
- You should not see a JITM telling you more about the SSO feature.
- Go back to wp-admin and log out.
- Log back in using SSO.
- You should see the JITM then.

#### Proposed changelog entry for your changes:

* Secure Sign On: do not display feature message when logging in to WordPress.com's central dashboard.
