### PR TITLE
Search: Revert "Correctly trigger failed_jetpack_search_query action"

### DIFF
--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -518,23 +518,6 @@ class Jetpack_Search {
 		$response_code = wp_remote_retrieve_response_code( $request );
 
 		if ( ! $response_code || $response_code < 200 || $response_code >= 300 ) {
-			/**
-			 * Fires after a search query request has failed
-			 *
-			 * @module search
-			 *
-			 * @since  5.6.0
-			 *
-			 * @param array Array containing the response code and response from the failed search query
-			 */
-			do_action(
-				'failed_jetpack_search_query',
-				array(
-					'response_code' => $response_code,
-					'json'          => $response,
-				)
-			);
-
 			return new WP_Error( 'invalid_search_api_response', 'Invalid response from API - ' . $response_code );
 		}
 
@@ -573,6 +556,27 @@ class Jetpack_Search {
 		 * @param array $query Array of information about the query performed
 		 */
 		do_action( 'did_jetpack_search_query', $query );
+
+		if ( ! $response_code || $response_code < 200 || $response_code >= 300 ) {
+			/**
+			 * Fires after a search query request has failed
+			 *
+			 * @module search
+			 *
+			 * @since  5.6.0
+			 *
+			 * @param array Array containing the response code and response from the failed search query
+			 */
+			do_action(
+				'failed_jetpack_search_query',
+				array(
+					'response_code' => $response_code,
+					'json'          => $response,
+				)
+			);
+
+			return new WP_Error( 'invalid_search_api_response', 'Invalid response from API - ' . $response_code );
+		}
 
 		return $response;
 	}


### PR DESCRIPTION
Reverts Automattic/jetpack#14594

I merged the last PR too quickly. It introduces an issue, as it calls `$response` before it is actually defined.

#### Testing instructions:

Not much to test, this is a revert.

#### Proposed changelog entry for your changes:

N/A