### PR TITLE
Calendly: Allow theme color names to be saved in the submit button

### DIFF
--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -21,11 +21,9 @@ export default {
 	},
 	submitButtonTextColor: {
 		type: 'string',
-		validator: colourValidator,
 	},
 	submitButtonBackgroundColor: {
 		type: 'string',
-		validator: colourValidator,
 	},
 	submitButtonClasses: { type: 'string' },
 	hideEventTypeDetails: {


### PR DESCRIPTION
Broken out from https://github.com/Automattic/jetpack/pull/14599
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When setting colors from the theme pallette, we should save them with names like `primary` and `accent`, rather than their color. This PR removes the validation which insists these colors are a valid hex code, so that this works. 

#### Testing instructions:
* Add a Calendly block to a page
* Select the Link style
* Change the button color to a theme color
* Go to the code view
* Check that the `backgroundButtonColor` attribute is set to a string not a hex value.
* Save the page and reload, and check that the attribute is still there!

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
