### PR TITLE
Calendly: Updated the rendering of the styles to use the 'style' attribute

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -128,7 +128,7 @@ function load_assets( $attr, $content ) {
 		if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
 			$inline_styles = sprintf(
 				'#%1$s .wp-block-button__link{%2$s%3$s}',
-				$block_id,
+				esc_attr( $block_id ),
 				! empty( $submit_button_text_color )
 					? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
 					: '',
@@ -142,7 +142,7 @@ function load_assets( $attr, $content ) {
 		$content = sprintf(
 			'<div class="%1$s" id="%2$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%3$s\'});return false;">%4$s</a></div>',
 			esc_attr( $classes ),
-			$block_id,
+			esc_attr( $block_id ),
 			esc_js( $url ),
 			wp_kses_post( $submit_button_text )
 		);

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -126,7 +126,7 @@ function load_assets( $attr, $content ) {
 		 */
 		if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
 			$inline_styles = sprintf(
-				'.wp-block-jetpack-calendly .button{%1$s%2$s}',
+				'style="%1$s%2$s"',
 				! empty( $submit_button_text_color )
 					? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
 					: '',
@@ -134,13 +134,15 @@ function load_assets( $attr, $content ) {
 					? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
 					: ''
 			);
-			wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+		} else {
+			$inline_styles = '';
 		}
 
 		$content = sprintf(
-			'<div class="%1$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;">%3$s</a></div>',
+			'<div class="%1$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;"%3$s>%4$s</a></div>',
 			esc_attr( $classes ),
 			esc_js( $url ),
+			$inline_styles,
 			wp_kses_post( $submit_button_text )
 		);
 	} else { // Inline style.

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -105,6 +105,7 @@ function load_assets( $attr, $content ) {
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
 	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr );
+	$block_id                       = wp_unique_id( 'calendly-block-' );
 
 	$url = add_query_arg(
 		array(
@@ -126,7 +127,8 @@ function load_assets( $attr, $content ) {
 		 */
 		if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
 			$inline_styles = sprintf(
-				'style="%1$s%2$s"',
+				'#%1$s .wp-block-button__link{%2$s%3$s}',
+				$block_id,
 				! empty( $submit_button_text_color )
 					? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
 					: '',
@@ -134,15 +136,14 @@ function load_assets( $attr, $content ) {
 					? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
 					: ''
 			);
-		} else {
-			$inline_styles = '';
+			wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
 		}
 
 		$content = sprintf(
-			'<div class="%1$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%2$s\'});return false;"%3$s>%4$s</a></div>',
+			'<div class="%1$s" id="%2$s"><a class="wp-block-button__link" role="button" onclick="Calendly.initPopupWidget({url:\'%3$s\'});return false;">%4$s</a></div>',
 			esc_attr( $classes ),
+			$block_id,
 			esc_js( $url ),
-			$inline_styles,
 			wp_kses_post( $submit_button_text )
 		);
 	} else { // Inline style.


### PR DESCRIPTION
When rendering the block colours on the server, we were using an
`inline_style` that rendered as a style tag. This meant that each style
tag would override the last, and we were also using the wrong selector,
so the colours weren't being applied on the front end.

#### Changes proposed in this Pull Request:
This change adds the styles to each button as an inline style attribute,
so they're unique to each instance.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a fix to a new feature

#### Testing instructions:
* Create a post with two calendly blocks
* Set them to the button style
* Make them have different colours
* Publish/Preview the post and check that the buttons are displayed with the correct colours

#### Proposed changelog entry for your changes:
Not required