### PR TITLE
Calendly: Change buttons to a standard link for AMP requests

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -112,6 +112,7 @@ function load_assets( $attr, $content ) {
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
 	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr, array( 'calendly-style-' . $style ) );
+	$is_amp_request                 = class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
 	$block_id                       = wp_unique_id( 'calendly-block-' );
 
 	$url = add_query_arg(
@@ -146,8 +147,11 @@ function load_assets( $attr, $content ) {
 			wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
 		}
 
+		$markup  = $is_amp_request
+			? '<div class="%1$s" id="%2$s"><a class="%3$s" role="button" href="%3$s">%4$s</a></div>'
+			: '<div class="%1$s" id="%2$s"><a class="%3$s" role="button" onclick="Calendly.initPopupWidget({url:\'%3$s\'});return false;">%4$s</a></div>';
 		$content = sprintf(
-			'<div class="wp-block-button %1$s" id="%2$s"><a class="%3$s" role="button" onclick="Calendly.initPopupWidget({url:\'%4$s\'});return false;">%5$s</a></div>',
+			$markup,
 			esc_attr( $classes ),
 			esc_attr( $block_id ),
 			! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -71,6 +71,39 @@ function set_availability() {
 add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
 
 /**
+ * Enqueues the Calendly JS library, and adds an inline
+ * function to attach event handlers to the button
+ */
+function enqueue_calendly_js() {
+	wp_enqueue_script(
+		'jetpack-calendly-external-js',
+		'https://assets.calendly.com/assets/external/widget.js',
+		null,
+		JETPACK__VERSION,
+		false
+	);
+	wp_add_inline_script(
+		'jetpack-calendly-external-js',
+		"function calendly_attach_link_events( elementId ) {
+			var widget = document.getElementById( elementId );
+			if ( widget ) {
+				widget.addEventListener( 'click', function( event ) {
+					event.preventDefault();
+					Calendly.initPopupWidget({url:event.target.href});
+				} );
+
+				widget.addEventListener( 'keydown', function( event ) {
+					// Enter and space keys.
+					if ( event.keyCode === 13 || event.keyCode === 32 ) {
+						event.preventDefault();
+						event.target && event.target.click();
+					}
+				} );
+			}
+		}"
+	);
+}
+/**
  * Calendly block registration/dependency declaration.
  *
  * @param array  $attr    Array containing the Calendly block attributes.
@@ -90,30 +123,22 @@ function load_assets( $attr, $content ) {
 		return;
 	}
 
+	$style                   = get_attribute( $attr, 'style' );
+	$hide_event_type_details = get_attribute( $attr, 'hideEventTypeDetails' );
+	$background_color        = get_attribute( $attr, 'backgroundColor' );
+	$text_color              = get_attribute( $attr, 'textColor' );
+	$primary_color           = get_attribute( $attr, 'primaryColor' );
+	$classes                 = \Jetpack_Gutenberg::block_classes( 'calendly', $attr );
+	$is_amp_request          = class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
+	$block_id                = wp_unique_id( 'calendly-block-' );
+
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
 	\Jetpack_Gutenberg::load_assets_as_required( 'calendly' );
-	wp_enqueue_script(
-		'jetpack-calendly-external-js',
-		'https://assets.calendly.com/assets/external/widget.js',
-		null,
-		JETPACK__VERSION,
-		true
-	);
-
-	$style                          = get_attribute( $attr, 'style' );
-	$hide_event_type_details        = get_attribute( $attr, 'hideEventTypeDetails' );
-	$background_color               = get_attribute( $attr, 'backgroundColor' );
-	$text_color                     = get_attribute( $attr, 'textColor' );
-	$primary_color                  = get_attribute( $attr, 'primaryColor' );
-	$submit_button_text             = get_attribute( $attr, 'submitButtonText' );
-	$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
-	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
-	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
-	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr, array( 'calendly-style-' . $style ) );
-	$is_amp_request                 = class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
-	$block_id                       = wp_unique_id( 'calendly-block-' );
+	if ( ! wp_script_is( 'jetpack-calendly-external-js' ) && ! $is_amp_request ) {
+		enqueue_calendly_js();
+	}
 
 	$url = add_query_arg(
 		array(
@@ -126,38 +151,15 @@ function load_assets( $attr, $content ) {
 	);
 
 	if ( 'link' === $style ) {
-		wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
-
-		/*
-		 * If we have some additional styles from the editor
-		 * (a custom text color, custom bg color, or both )
-		 * Let's add that CSS inline.
-		 */
-		if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
-			$inline_styles = sprintf(
-				'#%1$s .wp-block-button__link{%2$s%3$s}',
-				esc_attr( $block_id ),
-				! empty( $submit_button_text_color )
-					? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
-					: '',
-				! empty( $submit_button_background_color )
-					? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
-					: ''
-			);
-			wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+		if ( ! wp_style_is( 'jetpack-calendly-external-css' ) ) {
+			wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
 		}
 
-		$markup  = $is_amp_request
-			? '<div class="%1$s" id="%2$s"><a class="%3$s" role="button" href="%3$s">%4$s</a></div>'
-			: '<div class="%1$s" id="%2$s"><a class="%3$s" role="button" onclick="Calendly.initPopupWidget({url:\'%3$s\'});return false;">%4$s</a></div>';
-		$content = sprintf(
-			$markup,
-			esc_attr( $classes ),
-			esc_attr( $block_id ),
-			! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
-			esc_js( $url ),
-			wp_kses_post( $submit_button_text )
-		);
+		$content = preg_replace( '/data-id-attr="placeholder"/', 'id="' . esc_attr( $block_id ) . '"', $content );
+
+		if ( ! $is_amp_request ) {
+			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( "calendly_attach_link_events( '%s' )", esc_js( $block_id ) ) );
+		}
 	} else { // Inline style.
 		$content = sprintf(
 			'<div class="%1$s" id="%2$s"></div>',

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -156,40 +156,7 @@ function load_assets( $attr, $content ) {
 			wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
 		}
 		if ( strstr( $content, sprintf( '>%s</a>', $orig_url ) ) ) {
-			// This is the lecacy version, so create the full link content.
-			$submit_button_text             = get_attribute( $attr, 'submitButtonText' );
-			$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
-			$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
-			$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
-
-			/*
-			 * If we have some additional styles from the editor
-			 * (a custom text color, custom bg color, or both )
-			 * Let's add that CSS inline.
-			 */
-			if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
-				$inline_styles = sprintf(
-					'#%1$s .wp-block-button__link{%2$s%3$s}',
-					esc_attr( $block_id ),
-					! empty( $submit_button_text_color )
-						? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
-						: '',
-					! empty( $submit_button_background_color )
-						? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
-						: ''
-				);
-				wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
-			}
-
-			$content = sprintf(
-				'<div class="%1$s" id="%2$s"><a class="%3$s" href="%4$s" role="button">%5$s</a></div>',
-				esc_attr( $classes ),
-				esc_attr( $block_id ),
-				! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
-				esc_js( $url ),
-				wp_kses_post( $submit_button_text )
-			);
-
+			$content = deprecated_render_button( $attr, $block_id, $classes, $url );
 		} else {
 			// It's the new version so simply substitute the ID.
 			$content = preg_replace( '/data-id-attr="placeholder"/', 'id="' . esc_attr( $block_id ) . '"', $content );
@@ -216,6 +183,51 @@ JS_END;
 
 	return $content;
 }
+
+/**
+ * The renders the legacy version of the button HTML.
+ *
+ * @param array  $attr      Array containing the Calendly block attributes.
+ * @param string $block_id  The value for the ID attribute of the link.
+ * @param string $classes   The CSS classes for the wrapper div.
+ * @param string $url       Calendly URL for the link HREF.
+ */
+function deprecated_render_button( $attr, $block_id, $classes, $url ) {
+	// This is the lecacy version, so create the full link content.
+	$submit_button_text             = get_attribute( $attr, 'submitButtonText' );
+	$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
+	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
+	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
+
+	/*
+	 * If we have some additional styles from the editor
+	 * (a custom text color, custom bg color, or both )
+	 * Let's add that CSS inline.
+	 */
+	if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
+		$inline_styles = sprintf(
+			'#%1$s .wp-block-button__link{%2$s%3$s}',
+			esc_attr( $block_id ),
+			! empty( $submit_button_text_color )
+				? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
+				: '',
+			! empty( $submit_button_background_color )
+				? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
+				: ''
+		);
+		wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+	}
+
+	return sprintf(
+		'<div class="%1$s" id="%2$s"><a class="%3$s" href="%4$s" role="button">%5$s</a></div>',
+		esc_attr( $classes ),
+		esc_attr( $block_id ),
+		! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
+		esc_js( $url ),
+		wp_kses_post( $submit_button_text )
+	);
+}
+
 
 /**
  * Get filtered attributes.

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -140,7 +140,8 @@ function load_assets( $attr, $content ) {
 		enqueue_calendly_js();
 	}
 
-	$url = add_query_arg(
+	$orig_url = $url;
+	$url      = add_query_arg(
 		array(
 			'hide_event_type_details' => (int) $hide_event_type_details,
 			'background_color'        => sanitize_hex_color_no_hash( $background_color ),
@@ -154,8 +155,45 @@ function load_assets( $attr, $content ) {
 		if ( ! wp_style_is( 'jetpack-calendly-external-css' ) ) {
 			wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
 		}
+		if ( strstr( $content, sprintf( '>%s</a>', $orig_url ) ) ) {
+			// This is the lecacy version, so create the full link content.
+			$submit_button_text             = get_attribute( $attr, 'submitButtonText' );
+			$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
+			$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
+			$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
 
-		$content = preg_replace( '/data-id-attr="placeholder"/', 'id="' . esc_attr( $block_id ) . '"', $content );
+			/*
+			 * If we have some additional styles from the editor
+			 * (a custom text color, custom bg color, or both )
+			 * Let's add that CSS inline.
+			 */
+			if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
+				$inline_styles = sprintf(
+					'#%1$s .wp-block-button__link{%2$s%3$s}',
+					esc_attr( $block_id ),
+					! empty( $submit_button_text_color )
+						? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
+						: '',
+					! empty( $submit_button_background_color )
+						? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
+						: ''
+				);
+				wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+			}
+
+			$content = sprintf(
+				'<div class="%1$s" id="%2$s"><a class="%3$s" href="%4$s" role="button">%5$s</a></div>',
+				esc_attr( $classes ),
+				esc_attr( $block_id ),
+				! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
+				esc_js( $url ),
+				wp_kses_post( $submit_button_text )
+			);
+
+		} else {
+			// It's the new version so simply substitute the ID.
+			$content = preg_replace( '/data-id-attr="placeholder"/', 'id="' . esc_attr( $block_id ) . '"', $content );
+		}
 
 		if ( ! $is_amp_request ) {
 			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( "calendly_attach_link_events( '%s' )", esc_js( $block_id ) ) );

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -159,7 +159,7 @@ export default function CalendlyEdit( props ) {
 			'backgroundButtonColor',
 			'textButtonColor',
 			'customBackgroundButtonColor',
-			'customBackgroundButtonColor',
+			'customTextButtonColor',
 		] ),
 		setAttributes,
 	};

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -9,6 +9,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import attributes from './attributes';
 import edit from './edit';
+import { SubmitButtonSave } from '../../shared/submit-button';
 import icon from './icon';
 import { getAttributesFromEmbedCode, REGEX } from './utils';
 
@@ -35,7 +36,11 @@ export const settings = {
 		html: false,
 	},
 	edit,
-	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
+	save: function( { attributes: buttonAttributes } ) {
+		return (
+			<SubmitButtonSave className="wp-block-jetpack-calendly" attributes={ buttonAttributes } />
+		);
+	},
 	attributes,
 	example: {
 		attributes: {
@@ -57,4 +62,10 @@ export const settings = {
 			},
 		],
 	},
+	deprecated: [
+		{
+			attributes,
+			save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
+		},
+	],
 };

--- a/extensions/shared/submit-button.js
+++ b/extensions/shared/submit-button.js
@@ -116,8 +116,6 @@ class SubmitButton extends Component {
 	render() {
 		const {
 			attributes,
-			backgroundButtonColor,
-			textButtonColor,
 			fallbackBackgroundColor,
 			fallbackTextColor,
 			setAttributes,

--- a/extensions/shared/submit-button.js
+++ b/extensions/shared/submit-button.js
@@ -116,6 +116,8 @@ class SubmitButton extends Component {
 	render() {
 		const {
 			attributes,
+			backgroundButtonColor,
+			textButtonColor,
 			fallbackBackgroundColor,
 			fallbackTextColor,
 			setAttributes,
@@ -123,8 +125,8 @@ class SubmitButton extends Component {
 			setTextButtonColor,
 		} = this.props;
 
-		const backgroundColor = attributes.customBackgroundButtonColor || fallbackBackgroundColor;
-		const color = attributes.customTextButtonColor || fallbackTextColor;
+		const backgroundColor = backgroundButtonColor.color || fallbackBackgroundColor;
+		const color = textButtonColor.color || fallbackTextColor;
 		const buttonStyle = { border: 'none', backgroundColor, color };
 		const buttonClasses = getButtonClasses(
 			pick( this.attributes, [ 'backgroundButtonColor', 'textButtonColor' ] )
@@ -160,6 +162,7 @@ class SubmitButton extends Component {
 						] }
 					/>
 					<ContrastChecker
+						isLargeText={ false }
 						textColor={ color }
 						backgroundColor={ backgroundColor }
 						fallbackBackgroundColor


### PR DESCRIPTION
AMP strips out `onClick` handlers, so when the button version of
the block is rendered we should change it to a standard link to the Calendly
appointment page.

We could probably get around this by attaching the click handler in
another way, but it would still be good to treat an AMP request
differently.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This a bug fix to a new feature

#### Testing instructions:
* Install the AMP for WordPress plugin.
* Create a Calendly block with the button style
* Publish the page and view it with /amp on the end of the URL
* Check that the link works.

#### Proposed changelog entry for your changes:
No changelog is necessary.
