### PR TITLE
 Modify jetpack_shim_setcookie to correct strpbrk logic

### DIFF
--- a/functions.cookies.php
+++ b/functions.cookies.php
@@ -21,7 +21,7 @@
 function jetpack_shim_setcookie( $name, $value, $options ) {
 	$not_allowed_chars = ",; \t\r\n\013\014";
 
-	if ( strpbrk( $name, $not_allowed_chars ) !== false ) {
+	if ( false !== strpbrk( $name, $not_allowed_chars ) ) {
 		return false;
 	}
 
@@ -45,14 +45,14 @@ function jetpack_shim_setcookie( $name, $value, $options ) {
 	}
 
 	if ( ! empty( $options['domain'] ) && is_string( $options['domain'] ) ) {
-		if ( strpbrk( $options['domain'], false !== $not_allowed_chars ) ) {
+		if ( false !== strpbrk( $options['domain'], $not_allowed_chars ) ) {
 			return false;
 		}
 		$cookie .= sprintf( 'domain=%s', $options['domain'] . '; ' );
 	}
 
 	if ( ! empty( $options['path'] ) && is_string( $options['path'] ) ) {
-		if ( strpbrk( $options['path'], false !== $not_allowed_chars ) ) {
+		if ( false !== strpbrk( $options['path'], $not_allowed_chars ) ) {
 			return false;
 		}
 		$cookie .= sprintf( 'path=%s', $options['path'] . '; ' );


### PR DESCRIPTION
strpbrk function usage was passing true as the charlist instead of performing a !== check on the return value. This corrects the logic and updates to use yoda statements.

Fixes #14385 

#### Changes proposed in this Pull Request:
* Updates the logic of jetpack_shim_setcookie to use the charlist as expected

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Fixes a bug with existing functionality

#### Testing instructions:
* Create a Jetpack Site with the character 1 in the path or domain
* Install 8.1.1 version of Jetpack
* Attempt to Login
* Login will fail with no cookies being set
--
* Apply patch
* Attempt to Login
* Login will be successful 

#### Proposed changelog entry for your changes:
* Corrects login issue introduced for sites with 1 in the site domain or path.
