### PR TITLE
OpenTable: Allow the various block styles to be centre aligned

### DIFF
--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -247,6 +247,7 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 	const editClasses = classnames( className, {
 		[ `${ className }-theme-${ style }` ]: ! isEmpty( rid ) && styleValues.includes( style ),
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
+		[ `align${ align }` ]: align,
 	} );
 
 	return (

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -1,10 +1,18 @@
 .wp-block-jetpack-opentable {
 
+	&.aligncenter iframe {
+		margin: 0 auto;
+	}
+
 	&-theme-standard {
 		height: 301px;
 
 		&.is-multi {
 			height: 361px;
+		}
+
+		&.aligncenter iframe {
+			width: 224px !important;
 		}
 	}
 
@@ -14,14 +22,24 @@
 		&.is-multi {
 			height: 550px;
 		}
+
+		&.aligncenter iframe {
+			width: 288px !important;
+		}
 	}
 
 	&-theme-wide {
 		height: 150px;
+		&.aligncenter iframe {
+			width: 840px !important;
+		}
 	}
 
 	&-theme-button {
 		height: 113px;
+		&.aligncenter iframe {
+			width: 210px !important;
+		}
 	}
 
 	.ot-dtp-picker {


### PR DESCRIPTION
The centre alignment wasn't working as the iframe is set to 100% and its
content was left-aligned. 

#### Changes proposed in this Pull Request:

This change adds CSS to fix the width of the iframe when the embed is centre aligned. The width of the iframe is getting set by the OpenTable embed JS code, so in order to override it, we need to use `!important`. That's not ideal, but I think as it's isolated, it should be ok.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix to a new feature

#### Testing instructions:
* Add on OpenTable block
* Set the alignment to centre
* Check that the block is centred in the various styles. N.B. the wide style is larger than the main content column of TwentyTwenty, and so can't be centred.

#### Proposed changelog entry for your changes:
~~No changelog entry necessary.~~
As this has moved milestone it probably does need a changelog entry now. How about:

Centre alignment fixed for the OpenTable block
