### PR TITLE
Instant Search: Update search marketing link to add locale

### DIFF
--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -34,11 +34,16 @@ const logoPath = (
 );
 const logoSize = 12;
 
-const JetpackColophon = () => {
+const JetpackColophon = props => {
+	const locale_prefix = props.locale.split( '-', 1 )[ 0 ];
+	const url =
+		locale_prefix && locale_prefix !== 'en'
+			? 'https://' + locale_prefix + '.jetpack.com/search'
+			: 'https://jetpack.com/search';
 	return (
 		<div className="jetpack-instant-search__jetpack-colophon">
 			<a
-				href="https://jetpack.com/search"
+				href={ url }
 				rel="external noopener noreferrer"
 				target="_blank"
 				className="jetpack-instant-search__jetpack-colophon-link"

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -34,7 +34,7 @@ const SearchSidebar = props => {
 					document.getElementById( `${ widget.widget_id }-wrapper` )
 				);
 			} ) }
-			{ props.showPoweredBy && <JetpackColophon /> }
+			{ props.showPoweredBy && <JetpackColophon locale={ props.locale } /> }
 		</div>
 	);
 };


### PR DESCRIPTION
Add the locale prefix to the jetpack.com link (e.g. es.jetpack.com/search) based on the locale of the site.

Jetpack.com will redirect to English whenever the translated site doesn't work, so just always apply the locale prefix.
