### PR TITLE
Stop REST API Log entries from being synced

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -395,6 +395,7 @@ class Defaults {
 		'snitch',
 		'vip-legacy-redirect',
 		'wp_automatic',
+		'wp-rest-api-log', // https://wordpress.org/plugins/wp-rest-api-log/
 		'wpephpcompat_jobs',
 		'wprss_feed_item',
 	);


### PR DESCRIPTION
REST API Log (https://wordpress.org/plugins/wp-rest-api-log/) saves api requests/responses to the Post Table using a custom post-type. This data is not for front end consumption or to power activity. When used on a site it can lead to 100s/1000s of sync actions in a short time that can delay editorial user actions from being processed.

This blacklists the custom post-type so these logs are not sent to WP.com for processing.

#### Changes proposed in this Pull Request:
* Blacklist the 'wp-rest-api-log' post_type so they do not get into the sync queue.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Removes 'wp-rest-api-log' content from syncing to WP.com

#### Testing instructions:
* Before Patch
* Install the REST API Log Plugin
* Perform various REST API calls to the site
* Verify 'wp-rest-api-log' posts are being synced to WP.com
* Apply Patch
* Perform various REST API calls to the site
* Verify 'wp-rest-api-log' posts are not being synced to WP.com

#### Proposed changelog entry for your changes:
* Increase reliability of internal sync by not sending `wp-rest-api-log` posts
