### PR TITLE
OpenTable: Accept more embed options

### DIFF
--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -43,6 +43,7 @@ import {
 	defaultAttributes,
 } from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
+import { getAttributesFromEmbedCode } from './utils';
 
 export default function OpenTableEdit( { attributes, setAttributes, className, clientId } ) {
 	const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
@@ -64,43 +65,10 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 		);
 
 	const parseEmbedCode = embedCode => {
-		if ( ! embedCode ) {
+		const newAttributes = getAttributesFromEmbedCode( embedCode );
+		if ( ! newAttributes ) {
 			setErrorNotice();
-			return;
 		}
-
-		const scriptTagAttributes = embedCode.match( /< *script[^>]*src *= *["']?([^"']*)/i );
-		if ( ! scriptTagAttributes || ! scriptTagAttributes[ 1 ] ) {
-			setErrorNotice();
-			return;
-		}
-
-		let src = '';
-		if ( scriptTagAttributes[ 1 ].indexOf( 'http' ) === 0 ) {
-			src = new URL( scriptTagAttributes[ 1 ] );
-		} else {
-			src = new URL( 'http:' + scriptTagAttributes[ 1 ] );
-		}
-
-		if ( ! src.search ) {
-			setErrorNotice();
-			return;
-		}
-
-		const searchParams = new URLSearchParams( src.search );
-		let styleSetting = searchParams.get( 'theme' );
-		if ( searchParams.get( 'type' ) === 'button' ) {
-			styleSetting = searchParams.get( 'type' );
-		}
-
-		const newAttributes = {
-			rid: searchParams.getAll( 'rid' ),
-			iframe: Boolean( searchParams.get( 'iframe' ) ),
-			domain: searchParams.get( 'domain' ),
-			lang: searchParams.get( 'lang' ),
-			newtab: Boolean( searchParams.get( 'newtab' ) ),
-			style: styleSetting,
-		};
 
 		const validatedNewAttributes = getValidatedAttributes( defaultAttributes, newAttributes );
 		setAttributes( validatedNewAttributes );

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import './view.scss';
 
 export const name = 'opentable';
 export const title = __( 'OpenTable', 'jetpack' );
+import { getAttributesFromEmbedCode, restRefRegex, ridRegex } from './utils';
 
 export const settings = {
 	title,
@@ -53,5 +55,20 @@ export const settings = {
 			lang: 'en-US',
 			newtab: false,
 		},
+	},
+	transforms: {
+		from: [
+			{
+				type: 'raw',
+				isMatch: node =>
+					node.nodeName === 'P' &&
+					node.textContent.indexOf( 'http' ) === 0 &&
+					( ridRegex.test( node.textContent ) || restRefRegex.test( node.textContent ) ),
+				transform: node => {
+					const newAttributes = getAttributesFromEmbedCode( node.textContent );
+					return createBlock( 'jetpack/opentable', newAttributes );
+				},
+			},
+		],
 	},
 };

--- a/extensions/blocks/opentable/restaurant-picker.js
+++ b/extensions/blocks/opentable/restaurant-picker.js
@@ -16,8 +16,6 @@ import { __, _n } from '@wordpress/i18n';
 import useRestaurantSearch from './use-restaurant-search';
 
 const MAX_SUGGESTIONS = 20;
-const embedRegex = /<script type=\'text\/javascript\' src=\'\/\/www.opentable\.(\w{2,3}\.)?\w+\/widget\/reservation\/loader\?[^']+\'><\/script>/;
-const linkRegex = /restref=([0-9]+)&/;
 
 export default function RestaurantPicker( props ) {
 	const [ input, setInput ] = useState( '' );
@@ -41,26 +39,9 @@ export default function RestaurantPicker( props ) {
 		.filter( restaurant => selectedRestaurants.indexOf( restaurant.rid.toString() ) )
 		.map( restaurant => restaurant.name + ` (#${ restaurant.rid })` );
 
-	const getRestaurantsToEmbed = () => {
-		if ( ! isEmpty( selectedRestaurants ) ) {
-			return selectedRestaurants;
-		}
-
-		if ( embedRegex.test( input ) ) {
-			return input;
-		}
-
-		const linkRegexMatches = input.match( linkRegex );
-		if ( linkRegexMatches ) {
-			return [ linkRegexMatches[ 1 ] ];
-		}
-
-		return input;
-	};
-
 	const onSubmit = event => {
 		event.preventDefault();
-		props.onSubmit( getRestaurantsToEmbed() );
+		props.onSubmit( isEmpty( selectedRestaurants ) ? input : selectedRestaurants );
 	};
 
 	const formInput = (

--- a/extensions/blocks/opentable/restaurant-picker.js
+++ b/extensions/blocks/opentable/restaurant-picker.js
@@ -17,6 +17,7 @@ import useRestaurantSearch from './use-restaurant-search';
 
 const MAX_SUGGESTIONS = 20;
 const embedRegex = /<script type=\'text\/javascript\' src=\'\/\/www.opentable\.(\w{2,3}\.)?\w+\/widget\/reservation\/loader\?[^']+\'><\/script>/;
+const linkRegex = /restref=([0-9]+)&/;
 
 export default function RestaurantPicker( props ) {
 	const [ input, setInput ] = useState( '' );
@@ -40,11 +41,26 @@ export default function RestaurantPicker( props ) {
 		.filter( restaurant => selectedRestaurants.indexOf( restaurant.rid.toString() ) )
 		.map( restaurant => restaurant.name + ` (#${ restaurant.rid })` );
 
+	const getRestaurantsToEmbed = () => {
+		if ( ! isEmpty( selectedRestaurants ) ) {
+			return selectedRestaurants;
+		}
+
+		if ( embedRegex.test( input ) ) {
+			return input;
+		}
+
+		const linkRegexMatches = input.match( linkRegex );
+		if ( linkRegexMatches ) {
+			return [ linkRegexMatches[ 1 ] ];
+		}
+
+		return input;
+	};
+
 	const onSubmit = event => {
 		event.preventDefault();
-		props.onSubmit(
-			isEmpty( selectedRestaurants ) && embedRegex.test( input ) ? input : selectedRestaurants
-		);
+		props.onSubmit( getRestaurantsToEmbed() );
 	};
 
 	const formInput = (

--- a/extensions/blocks/opentable/test/utils.js
+++ b/extensions/blocks/opentable/test/utils.js
@@ -9,6 +9,8 @@ import { getAttributesFromEmbedCode } from '../utils';
 
 const widgetEmbedCode = "<script type='text/javascript' src='//www.opentable.com/widget/reservation/loader?rid=1&type=standard&theme=standard&iframe=true&domain=com&lang=en-US&newtab=false&ot_source=Restaurant%20website'></script>";
 
+const invalidEmbedCode = "<script type='text/javascript' src='https://www.widgets-r-us.com/widget/widgetygoddness?rid=1&type=standard&theme=standard&iframe=true&domain=com&lang=en-US&newtab=false&ot_source=Restaurant%20website'></script>";
+
 const marketingUrl = "https://www.opentable.com/vongs-thai-kitchen-reservations-chicago?restref=1&lang=en-US&ot_source=Restaurant%20website";
 
 const customUrl1 = "https://www.opentable.com/restref/client/?restref=412810&lang=en-US&ot_source=Restaurant%20website&corrid=e413926b-0352-46d6-a8d8-d1d525932310";
@@ -16,6 +18,8 @@ const customUrl1 = "https://www.opentable.com/restref/client/?restref=412810&lan
 const customUrl2 = "https://www.opentable.com/restref/client/?restref=1&lang=es-MX&ot_source=Restaurant%20website&corrid=09f44cc6-f0cb-4e98-9298-f4ba8cc20183";
 
 const customUrl3 = "https://www.opentable.com/restref/client/?rid=1&corrid=010a3136-569e-42a5-a381-e111887b4cf5";
+
+const invalidUrl = "https://www.widgets-r-us.com/widget/widgetygoddness?rid=1&type=standard&theme=standard&iframe=true&domain=com&lang=en-US&newtab=false&ot_source=Restaurant%20website";
 
 describe( 'getAttributesFromEmbedCode', () => {
 	test( 'Widget embed code', () => {
@@ -74,5 +78,17 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"rid": [ "1" ],
 			}
 		);
+	} );
+
+	test( 'Invaild Embed Code', () => {
+		expect( 
+			getAttributesFromEmbedCode( invalidEmbedCode )
+		).toBeUndefined();
+	} );
+
+	test( 'Invaild URL', () => {
+		expect( 
+			getAttributesFromEmbedCode( invalidUrl )
+		).toBeUndefined();
 	} );
 } );

--- a/extensions/blocks/opentable/test/utils.js
+++ b/extensions/blocks/opentable/test/utils.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getAttributesFromEmbedCode } from '../utils';
+
+const widgetEmbedCode = "<script type='text/javascript' src='//www.opentable.com/widget/reservation/loader?rid=1&type=standard&theme=standard&iframe=true&domain=com&lang=en-US&newtab=false&ot_source=Restaurant%20website'></script>";
+
+const marketingUrl = "https://www.opentable.com/vongs-thai-kitchen-reservations-chicago?restref=1&lang=en-US&ot_source=Restaurant%20website";
+
+const customUrl1 = "https://www.opentable.com/restref/client/?restref=412810&lang=en-US&ot_source=Restaurant%20website&corrid=e413926b-0352-46d6-a8d8-d1d525932310";
+
+const customUrl2 = "https://www.opentable.com/restref/client/?restref=1&lang=es-MX&ot_source=Restaurant%20website&corrid=09f44cc6-f0cb-4e98-9298-f4ba8cc20183";
+
+const customUrl3 = "https://www.opentable.com/restref/client/?rid=1&corrid=010a3136-569e-42a5-a381-e111887b4cf5";
+
+describe( 'getAttributesFromEmbedCode', () => {
+	test( 'Widget embed code', () => {
+		expect(
+			getAttributesFromEmbedCode( widgetEmbedCode )
+		).toEqual(
+			{
+				"domain": "com",
+				"iframe": 'true',
+				"lang": "en-US",
+				"newtab": 'false',
+				"rid": [ "1" ],
+				"style": "standard",
+			}
+		);
+	} );
+
+	test( 'Marketing URL', () => {
+		expect(
+			getAttributesFromEmbedCode( marketingUrl )
+		).toEqual(
+			{
+				"lang": "en-US",
+				"rid": [ "1" ],
+			}
+		);
+	} );
+
+	test( 'Custom URL 1', () => {
+		expect(
+			getAttributesFromEmbedCode( customUrl1 )
+		).toEqual(
+			{
+				"lang": "en-US",
+				"rid": [ "412810" ],
+			}
+		);
+	} );
+
+	test( 'Custom URL 2', () => {
+		expect(
+			getAttributesFromEmbedCode( customUrl2 )
+		).toEqual(
+			{
+				"lang": "es-MX",
+				"rid": [ "1" ],
+			}
+		);
+	} );
+
+	test( 'Custom URL 3', () => {
+		expect(
+			getAttributesFromEmbedCode( customUrl3 )
+		).toEqual(
+			{
+				"rid": [ "1" ],
+			}
+		);
+	} );
+} );

--- a/extensions/blocks/opentable/utils.js
+++ b/extensions/blocks/opentable/utils.js
@@ -10,7 +10,7 @@ const getAttributesFromUrl = url => {
 		src = new URL( 'http:' + url );
 	}
 
-	if ( ! src.search ) {
+	if ( ! src.host || src.host.indexOf( 'opentable' ) === -1 || ! src.search ) {
 		return;
 	}
 

--- a/extensions/blocks/opentable/utils.js
+++ b/extensions/blocks/opentable/utils.js
@@ -1,4 +1,4 @@
-export const embedRegex = /< *script[^>]*src *= *["']?([^"']*)/i;
+export const embedRegex = /<\s*script[^>]*src\s*=\s*["']?([^"']*)/i;
 export const restRefRegex = /restref=([0-9]+)&/;
 export const ridRegex = /rid=([0-9]+)&/;
 

--- a/extensions/blocks/opentable/utils.js
+++ b/extensions/blocks/opentable/utils.js
@@ -1,0 +1,80 @@
+export const embedRegex = /< *script[^>]*src *= *["']?([^"']*)/i;
+export const restRefRegex = /restref=([0-9]+)&/;
+export const ridRegex = /rid=([0-9]+)&/;
+
+const getAttributesFromUrl = url => {
+	let src = '';
+	if ( url.indexOf( 'http' ) === 0 ) {
+		src = new URL( url );
+	} else {
+		src = new URL( 'http:' + url );
+	}
+
+	if ( ! src.search ) {
+		return;
+	}
+
+	const searchParams = new URLSearchParams( src.search );
+	let styleSetting = searchParams.get( 'theme' );
+	if ( searchParams.get( 'type' ) === 'button' ) {
+		styleSetting = searchParams.get( 'type' );
+	}
+
+	let restaurantId = searchParams.getAll( 'rid' );
+	if ( ! restaurantId || restaurantId.length === 0 ) {
+		restaurantId = searchParams.getAll( 'restref' );
+	}
+	if ( ! restaurantId || restaurantId.length === 0 ) {
+		return;
+	}
+
+	const newAttributes = {};
+	if ( restaurantId ) {
+		newAttributes.rid = restaurantId;
+	}
+
+	const domain = searchParams.get( 'domain' );
+	if ( domain ) {
+		newAttributes.domain = domain;
+	}
+
+	const iframe = searchParams.get( 'iframe' );
+	if ( iframe ) {
+		newAttributes.iframe = iframe;
+	}
+
+	const lang = searchParams.get( 'lang' );
+	if ( lang ) {
+		newAttributes.lang = lang;
+	}
+
+	const newtab = searchParams.get( 'newtab' );
+	if ( newtab ) {
+		newAttributes.newtab = newtab;
+	}
+
+	if ( styleSetting ) {
+		newAttributes.style = styleSetting;
+	}
+
+	return newAttributes;
+};
+
+const getUrlFromEmbedCode = embedCode => {
+	const scriptTagAttributes = embedCode.match( embedRegex );
+	if ( scriptTagAttributes && scriptTagAttributes[ 1 ] ) {
+		return scriptTagAttributes[ 1 ];
+	}
+
+	if ( restRefRegex.test( embedCode ) || ridRegex.test( embedCode ) ) {
+		return embedCode;
+	}
+};
+
+export const getAttributesFromEmbedCode = embedCode => {
+	if ( ! embedCode ) {
+		return;
+	}
+
+	return getAttributesFromUrl( getUrlFromEmbedCode( embedCode ) );
+};

--- a/extensions/shared/get-validated-attributes.js
+++ b/extensions/shared/get-validated-attributes.js
@@ -18,7 +18,7 @@ export const getValidatedAttributes = ( attributeDetails, attributesToValidate )
 				attributeKey
 			];
 			if ( 'boolean' === type ) {
-				ret[ attributeKey ] = !! attribute;
+				ret[ attributeKey ] = attribute === 'false' ? false : !! attribute;
 			} else if ( validator ) {
 				ret[ attributeKey ] = validator( attribute ) ? attribute : defaultVal;
 			} else if ( validValues ) {

--- a/extensions/shared/test/get-validated-attributes.js
+++ b/extensions/shared/test/get-validated-attributes.js
@@ -10,28 +10,28 @@ const colourValidator = value => hexRegex.test( value );
 const urlValidator = url => ! url || url.startsWith( 'http' );
 
 const defaultAttributes = {
-    boolean: {
-        default: true,
-        type: 'boolean',
-    },
-    color: {
-        default: 'ffffff',
-        type: 'string',
-        validator: colourValidator,
-    },
-    language: {
-        default: 'en',
-        type: 'string',
-        validValues: [ 'en', 'fr', 'de', 'es', 'he', 'jp' ],
-    },
-    url: {
-        type: 'string',
-        validator: urlValidator,
-    },
-    freeform: {
-        default: 'one',
-        type: 'string',
-    },
+	boolean: {
+		default: true,
+		type: 'boolean',
+	},
+	color: {
+		default: 'ffffff',
+		type: 'string',
+		validator: colourValidator,
+	},
+	language: {
+		default: 'en',
+		type: 'string',
+		validValues: [ 'en', 'fr', 'de', 'es', 'he', 'jp' ],
+	},
+	url: {
+		type: 'string',
+		validator: urlValidator,
+	},
+	freeform: {
+		default: 'one',
+		type: 'string',
+	},
 };
 
 describe( 'getValidatedAttributes', () => {

--- a/extensions/shared/test/get-validated-attributes.js
+++ b/extensions/shared/test/get-validated-attributes.js
@@ -1,0 +1,151 @@
+/**
+ * Internal dependencies
+ */
+import { getValidatedAttributes } from '../get-validated-attributes';
+
+const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
+
+const colourValidator = value => hexRegex.test( value );
+
+const urlValidator = url => ! url || url.startsWith( 'http' );
+
+const defaultAttributes = {
+    boolean: {
+        default: true,
+        type: 'boolean',
+    },
+    color: {
+        default: 'ffffff',
+        type: 'string',
+        validator: colourValidator,
+    },
+    language: {
+        default: 'en',
+        type: 'string',
+        validValues: [ 'en', 'fr', 'de', 'es', 'he', 'jp' ],
+    },
+    url: {
+        type: 'string',
+        validator: urlValidator,
+    },
+    freeform: {
+        default: 'one',
+        type: 'string',
+    },
+};
+
+describe( 'getValidatedAttributes', () => {
+	test( 'boolean attributes', () => {
+		expect(
+			getValidatedAttributes( defaultAttributes, { boolean: true } )
+		).toStrictEqual(
+			{ boolean: true }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { boolean: 'true' } )
+		).toStrictEqual(
+			{ boolean: true }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { boolean: false } )
+		).toStrictEqual(
+			{ boolean: false }
+		);
+
+        expect(
+			getValidatedAttributes( defaultAttributes, { boolean: 'false' } )
+		).toStrictEqual(
+			{ boolean: false }
+		);
+
+	} );
+
+	test( 'attributes with a validator function', () => {
+		expect(
+			getValidatedAttributes( defaultAttributes, { color: 'ffffff' } )
+		).toStrictEqual(
+			{ color: 'ffffff' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { color: 'white' } )
+		).toStrictEqual(
+			{ color: 'ffffff' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { color: '000000' } )
+		).toStrictEqual(
+			{ color: '000000' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { color: 'black' } )
+		).toStrictEqual(
+			{ color: 'ffffff' }
+        );
+    } );
+
+	test( 'attributes with valid values', () => {
+		expect(
+			getValidatedAttributes( defaultAttributes, { language: 'en' } )
+		).toStrictEqual(
+			{ language: 'en' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { language: 'fr' } )
+		).toStrictEqual(
+			{ language: 'fr' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { language: 'pt' } )
+		).toStrictEqual(
+			{ language: 'en' }
+        );
+    } );
+
+	test( 'attributes without a default values', () => {
+		expect(
+			getValidatedAttributes( defaultAttributes, { url: 'http://jetpack.com' } )
+		).toStrictEqual(
+			{ url: 'http://jetpack.com' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { url: 'https://jetpack.com' } )
+		).toStrictEqual(
+			{ url: 'https://jetpack.com' }
+        );
+
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { url: 'jetpack.com' } )
+		).toStrictEqual(
+			{ url: undefined }
+        );
+	} );
+
+	test( 'attributes without validation', () => {
+		expect(
+			getValidatedAttributes( defaultAttributes, { freeform: 'one' } )
+		).toStrictEqual(
+			{ freeform: 'one' }
+        );
+
+		expect(
+			getValidatedAttributes( defaultAttributes, { freeform: 'two' } )
+		).toStrictEqual(
+			{ freeform: 'two' }
+        );
+
+        expect(
+			getValidatedAttributes( defaultAttributes, { freeform: undefined } )
+		).toStrictEqual(
+			{ freeform: undefined }
+        );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This broadens the scope of what kinds of embed the OpenTable block will accept
* It will now take an embed code, a URL, or a list of selected restaurants.

#### Testing instructions:
* Add an OpenTable block
* Check that you can still search for restaurants and embed a widget based on the results
* Check that you can copy/paste the embed code from this page into the embed code form: 
https://www.opentable.com/widget/reservation/preview?rid=1&lang=en-US
* Check that you can copy/paste the URL from this page into the embed code form: https://www.opentable.com/widget/reservation/preview?rid=1&lang=en-US
* Also test other forms of URL, for example:
- https://www.opentable.com/restref/client/?restref=412810&lang=en-US&ot_source=Restaurant%20website&corrid=e413926b-0352-46d6-a8d8-d1d525932310
- https://www.opentable.com/restref/client/?restref=1&lang=es-MX&ot_source=Restaurant%20website&corrid=09f44cc6-f0cb-4e98-9298-f4ba8cc20183 (uses a different language)
- https://www.opentable.com/restref/client/?rid=1&corrid=010a3136-569e-42a5-a381-e111887b4cf5
* Also test that these URLs work when pasted directly into the editor
* Make sure that other types of embed still work.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Accept URLs when embedding an OpenTable block
