### PR TITLE
Yarn: run with `--frozen-lockfile`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"clean-client": "rm -rf _inc/build/ css/",
 		"clean-composer": "rm -rf vendor/",
 		"clean-extensions": "rm -rf _inc/blocks/ ",
-		"install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files --production=false",
+		"install-if-deps-outdated": "yarn check 2> /dev/null || yarn install --check-files --production=false --frozen-lockfile",
 		"distclean": "rm -rf node_modules && yarn clean",
 		"build": "yarn install-if-deps-outdated && yarn clean && yarn build-client && yarn build-php && yarn build-extensions && yarn build-search",
 		"build-client": "gulp",


### PR DESCRIPTION
I haven't dug very much into this but I realized there was no `--frozen-lockfile` in `package.json` or in [Travis CI config](https://github.com/Automattic/jetpack/blob/5b94682c7c85f56e57278490bb38aa5213d141d6/.travis.yml). 🤔 

That's like running `npm ci` vs `npm install`. I haven't checked but it might also be faster.

That would ensure that `package.json` and `yarn.lock` are never out of date with each other. It's not like it happens often, but [it has happened](https://github.com/Automattic/jetpack/pull/14094).

Note that if later on project updates to Yarn v2, this will need to be changed to `--immutable`:

> If the --immutable option is set, Yarn will abort with an error exit code if anything in the install artifacts (yarn.lock, .pnp.js, ...) was to be modified. For backward compatibility we offer an **alias under the name of --frozen-lockfile, but it will be removed in a later release.**

([via](https://yarnpkg.com/cli/install#details))

## Testing instructions

I haven't actually tested this yet since I basically wanted to hear your thoughts first. I think it would go something along the lines of:

- Run `yarn build`, confirm it pass
- Update a dependency version in `package.json` and then run `yarn build` - it should stall