### PR TITLE
Added better defaults for the connection package.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -561,15 +561,6 @@ class Jetpack {
 		add_action( 'plugins_loaded', array( $this, 'configure' ), 1 );
 		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
-		add_filter(
-			'jetpack_connection_secret_generator',
-			function( $callable ) {
-				return function() {
-					return wp_generate_password( 32, false );
-				};
-			}
-		);
-
 		add_action( 'jetpack_verify_signature_error', array( $this, 'track_xmlrpc_error' ) );
 
 		add_filter(

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1169,7 +1169,7 @@ class Manager {
 			 *
 			 * @param Callable a function or method that returns a secret string.
 			 */
-			$this->secret_callable = apply_filters( 'jetpack_connection_secret_generator', array( $this, 'secret_callable' ) );
+			$this->secret_callable = apply_filters( 'jetpack_connection_secret_generator', array( $this, 'secret_callable_method' ) );
 		}
 
 		return $this->secret_callable;
@@ -1182,7 +1182,7 @@ class Manager {
 	 *
 	 * @return String $secret value.
 	 */
-	private function secret_callable() {
+	private function secret_callable_method() {
 		return wp_generate_password( 32, false );
 	}
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1169,10 +1169,21 @@ class Manager {
 			 *
 			 * @param Callable a function or method that returns a secret string.
 			 */
-			$this->secret_callable = apply_filters( 'jetpack_connection_secret_generator', 'wp_generate_password' );
+			$this->secret_callable = apply_filters( 'jetpack_connection_secret_generator', array( $this, 'secret_callable' ) );
 		}
 
 		return $this->secret_callable;
+	}
+
+	/**
+	 * Runs the wp_generate_password function with the required parameters. This is the
+	 * default implementation of the secret callable, can be overridden using the
+	 * jetpack_connection_secret_generator filter.
+	 *
+	 * @return String $secret value.
+	 */
+	private function secret_callable() {
+		return wp_generate_password( 32, false );
 	}
 
 	/**


### PR DESCRIPTION
Before we had to enable a special filter to generate connection secrets. With the addition of the new filter method, the connection package will take care of it automatically. There will be no need to define that filter in the consumer packages.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
* Adds a new filter defining the callable that generates secret strings.
* Removes the filter that is defined in the main class file because it's not needed anymore.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the Jetpack DNA Project.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* This alters the registration step of the connection, so first make sure your site is disconnected and not registered, i.e. the connection button has the registration URL.
* Try to register and connect, bonus points for additionally trying the in-place flow using the constant:
```
define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );
```
#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
