### PR TITLE
WP.com Block Editor: Remove function that isn't needed

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -412,7 +412,7 @@ class Jetpack_WPCOM_Block_Editor {
 		add_action( 'set_auth_cookie', array( $this, 'set_samesite_auth_cookies' ), 10, 5 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_samesite_logged_in_cookies' ), 10, 4 );
 		add_action( 'clear_auth_cookie', array( $this, 'clear_auth_cookies' ) );
-		add_filter( 'send_auth_cookies', array( $this, 'disable_core_auth_cookies' ) );
+		add_filter( 'send_auth_cookies', '__return_false' );
 	}
 
 	/**
@@ -534,15 +534,6 @@ class Jetpack_WPCOM_Block_Editor {
 				)
 			);
 		}
-	}
-
-	/**
-	 * Prevents the default core auth cookies from being generated so they don't collide with our cross-site cookies.
-	 *
-	 * @return bool Whether the default core auth cookies should be generated.
-	 */
-	public function disable_core_auth_cookies() {
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
We're creating a function to only return false. We can use `__return_false` instead.

#### Changes proposed in this Pull Request:
* Removes function that duplicates a Core function.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a. Identical code. 

#### Proposed changelog entry for your changes:
* n/a
