### PR TITLE
Core REST API: Add permission callback to delete_jitm_message endpoint

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -116,6 +116,9 @@ jQuery( document ).ready( function ( $ ) {
 				$.ajax( {
 					url: window.jitm_config.api_root + 'jetpack/v4/jitm',
 					method: 'POST', // using DELETE without permalinks is broken in default nginx configuration
+					beforeSend: function( xhr ) {
+						xhr.setRequestHeader( 'X-WP-Nonce', window.jitm_config.nonce );
+					},
 					data: {
 						id: response.id,
 						feature_class: response.feature_class,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -102,7 +102,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', '/jitm', array(
 			'methods'             => WP_REST_Server::CREATABLE,
 			'callback'            => __CLASS__ . '::delete_jitm_message',
-			'permission_callback' => '__return_true',
+			'permission_callback' => __CLASS__ . '::delete_jitm_message_permission_callback',
 		) );
 
 		// Test current connection status of Jetpack
@@ -702,8 +702,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
-	 * Dismisses a jitm
-	 * @param $request WP_REST_Request The request
+	 * Dismisses a jitm.
+	 *
+	 * @param WP_REST_Request $request The request.
 	 *
 	 * @return bool Always True
 	 */
@@ -882,6 +883,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		return new WP_Error( 'invalid_user_permission_jetpack_disconnect', self::$user_permissions_error_msg, array( 'status' => rest_authorization_required_code() ) );
 
+	}
+
+	/**
+	 * Verify that the user can dismiss JITM messages.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return bool|WP_Error True if user is able to dismiss JITM messages.
+	 */
+	public static function delete_jitm_message_permission_callback() {
+		if ( current_user_can( 'read' ) ) {
+			return true;
+		}
+
+		return new WP_Error( 'invalid_user_permission_jetpack_delete_jitm_message', self::$user_permissions_error_msg, array( 'status' => self::rest_authorization_required_code() ) );
 	}
 
 	/**

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -130,6 +130,7 @@ class JITM {
 				'activate_module_text'   => esc_html__( 'Activate', 'jetpack' ),
 				'activated_module_text'  => esc_html__( 'Activated', 'jetpack' ),
 				'activating_module_text' => esc_html__( 'Activating', 'jetpack' ),
+				'nonce'                  => wp_create_nonce( 'wp_rest' ),
 			)
 		);
 	}

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -21,7 +21,7 @@ use Automattic\Jetpack\Status;
  */
 class JITM {
 
-	const PACKAGE_VERSION = '1.0'; // TODO: Keep in sync with version specified in composer.json.
+	const PACKAGE_VERSION = '1.7.3'; // TODO: Keep in sync with version specified in composer.json.
 
 	/**
 	 * The configuration method that is called from the jetpack-config package.

--- a/packages/jitm/tests/php/test_JITM.php
+++ b/packages/jitm/tests/php/test_JITM.php
@@ -25,6 +25,7 @@ class Test_Jetpack_JITM extends TestCase {
 		$this->mock_empty_function( 'esc_url_raw' );
 		$this->mock_empty_function( 'rest_url' );
 		$this->mock_empty_function( 'esc_html__' );
+		$this->mock_empty_function( 'wp_create_nonce' );
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
See #16539 

#### Changes proposed in this Pull Request:
* Only users with the 'read' capability should be able to dismiss JITMs. Add a new permission callback to the `delete_jitm_message` endpoint that restricts dismissals to users that have the 'read' capability.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

##### Test Site
* Must have Jetpack active and connected.
* Must display JITMs (that is, they haven't been dismissed.)

##### Test Steps
1. Confirm that JITMs can be successfully dismissed in wp-admin:
   a. Navigate to the Jetpack dashboard. Dismiss the JITM.
   b. Reload the page and confirm that the JITM is not displayed.
   c. Confirm that the `hide_jitm` option was updated using the command shown below. The dismissed JITM should be in the `hide_jitm` array.
          
       wp jetpack options get hide_jitm

2. Confirm that JITMs can be successfully dismissed in Calypso:
   a. Navigate to a Calypso page that displays a JITM, on the themes upload page.
   b. Dismiss the JITM.
   c. Reload the page and confirm that the JITM not displayed.

(NOTE: I haven't been able to see a JITM in Calypso, so I haven't been able to test this.)

3. Attempt to make a post request to the JITM endpoint: 

      `wp-json/jetpack/v4/jitm`

    a. The post request body should be a JSON request with the keys 'id' and 'feature_class'. For example:
         ``` { "id": "some_id", "feature_class": "some_feature_class" }```

    b. The POST request should be rejected with a 401 error. 

#### Proposed changelog entry for your changes:
* tbd
