### PR TITLE
In progress - Config: Add a class that customizes the textdomain in packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,11 @@
 		"php:lint": "vendor/bin/phpcs -p -s",
 		"php:changed": "vendor/sirbrillig/phpcs-changed/bin/phpcs-changed --git",
 		"php:autofix": "vendor/bin/phpcbf",
-		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
+		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
+		"post-autoload-dump": "Automattic\\Jetpack\\Config\\Textdomain_Customizer::post_autoload_dump"
+	},
+	"extra": {
+		"textdomain": "jetpack"
 	},
 	"repositories": [
 		{

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -86,5 +86,4 @@ class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterfac
 		$generator->dump( $config, $localRepo, $package, $installationManager, 'composer', $optimize, $suffix );
 		$this->generated = true;
 	}
-
 }

--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -5,9 +5,24 @@
 	"license": "GPL-2.0-or-later",
 	"minimum-stability": "dev",
 	"require": {},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
+	},
 	"autoload": {
 		"classmap": [
 			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		]
+	},
+	"extra": {
+		"translatable": [
+			"/automattic/jetpack-config/src/example-file.php"
 		]
 	}
 }

--- a/packages/config/phpunit.xml
+++ b/packages/config/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+    <testsuites>
+        <testsuite name="general">
+            <directory prefix="test" suffix=".php">tests/php</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/packages/config/src/class-textdomain-customizer.php
+++ b/packages/config/src/class-textdomain-customizer.php
@@ -101,7 +101,7 @@ class Textdomain_Customizer {
 			$current_package_prefix = substr( $package->getName(), 0, strlen( $jetpack_package_prefix ) );
 
 			if ( $jetpack_package_prefix !== $current_package_prefix ) {
-				// Not a Jetpack package, so bail.
+				// Not a Jetpack package, so skip.
 				continue;
 			}
 
@@ -190,7 +190,7 @@ class Textdomain_Customizer {
 	}
 
 	/**
-	 * Replaces all occurrences of the placeholder textdomain 'JETPACK_CUSTOMIZE_TEXTDOMAIN'
+	 * Replaces all occurrences of the placeholder textdomain JETPACK_CUSTOMIZE_TEXTDOMAIN
 	 * in the input file with the plugin's textdomain.
 	 *
 	 * @param string $file_path The file path.
@@ -203,7 +203,7 @@ class Textdomain_Customizer {
 		$file_contents = file_get_contents( $file_path );
 
 		$file_contents = str_replace(
-			'\'JETPACK_CUSTOMIZE_TEXTDOMAIN\'',
+			'JETPACK_CUSTOMIZE_TEXTDOMAIN',
 			'\'' . $this->textdomain . '\'',
 			$file_contents
 		);

--- a/packages/config/src/class-textdomain-customizer.php
+++ b/packages/config/src/class-textdomain-customizer.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * The Textdomain_Customizer class.
+ *
+ * @package jetpack-config
+ */
+
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+
+namespace Automattic\Jetpack\Config;
+
+use Composer\Script\Event;
+
+/**
+ * This class is used to customize the textdomain of the strings in the packages.
+ */
+class Textdomain_Customizer {
+
+	/**
+	 * The Composer object.
+	 *
+	 * @var Composer
+	 */
+	private $composer;
+
+	/**
+	 * The textdomain.
+	 *
+	 * @var string
+	 */
+	private $textdomain;
+
+	/**
+	 * The vendor directory.
+	 *
+	 * @var string
+	 */
+	private $vendor_dir;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Composer $composer a Composer object.
+	 */
+	public function __construct( $composer ) {
+		$this->composer = $composer;
+	}
+
+	/**
+	 * This method is called when composer fires the post_autoload_dump event.
+	 *
+	 * @param Event $event The composer event.
+	 */
+	public static function post_autoload_dump( Event $event ) {
+		$composer = $event->getComposer();
+
+		$instance = ( new self( $composer ) );
+
+		/*
+		 * Check the version of the Config package and bail if it's a dev version.
+		 * We don't want to change files during development.
+		 */
+		$package = $instance->find_package( 'automattic/jetpack-config' );
+		if ( $package->isDev() ) {
+			return;
+		}
+
+		$instance->customize_textdomain_in_packages();
+	}
+
+	/**
+	 * Find a package in the local composer repo with the input package name. No
+	 * verison constraints are used to find the package.
+	 *
+	 * @param string $package_name The package name.
+	 *
+	 * @return Composer\Package|null The package object.
+	 */
+	private function find_package( $package_name ) {
+		$local_repo = $this->composer->getRepositoryManager()->getLocalRepository();
+		return $local_repo->findPackage( $package_name, '*' );
+	}
+
+	/**
+	 * Traverses the project's packages. Sets the textdomain in the Jetpack
+	 * packages that declare translatable files in their composer.json files.
+	 */
+	public function customize_textdomain_in_packages() {
+		$packages = $this->get_packages();
+
+		if ( ! is_array( $packages ) ) {
+			return;
+		}
+
+		$this->set_vendor_dir();
+		$this->set_textdomain();
+
+		foreach ( $packages as $package ) {
+			$jetpack_package_prefix = 'automattic/jetpack-';
+			$current_package_prefix = substr( $package->getName(), 0, strlen( $jetpack_package_prefix ) );
+
+			if ( $jetpack_package_prefix !== $current_package_prefix ) {
+				// Not a Jetpack package, so bail.
+				continue;
+			}
+
+			if ( $package->getExtra() && isset( $package->getExtra()['translatable'] ) ) {
+				$files = (array) $package->getExtra()['translatable'];
+				$this->customize_textdomain_in_files( $files );
+			}
+		}
+	}
+
+	/**
+	 * Gets the packages in the local composer repository.
+	 *
+	 * @return array of Composer\Package\PackagesInterface objects.
+	 */
+	protected function get_packages() {
+		$local_repo = $this->composer->getRepositoryManager()->getLocalRepository();
+		return $local_repo->getPackages();
+	}
+
+	/**
+	 * Sets the $vendor_dir instance variable using the vendor directory from
+	 * the composer config.
+	 */
+	protected function set_vendor_dir() {
+		$this->vendor_dir = $this->composer->getConfig()->get( 'vendor-dir' );
+	}
+
+	/**
+	 * Sets the textdomain instance variable using the textdomain provided by
+	 * the plugin. If the plugin did not provide a textdomain, uses 'default'.
+	 */
+	private function set_textdomain() {
+		$root_extra = $this->get_root_extra();
+
+		if ( isset( $root_extra['textdomain'] ) &&
+			is_string( $root_extra['textdomain'] ) ) {
+
+				$this->textdomain = $root_extra['textdomain'];
+				return;
+		}
+
+		$this->textdomain = 'default';
+	}
+
+	/**
+	 * Returns the value of the extra section in the root packages's
+	 * composer.json file.
+	 *
+	 * @return array mixed The root package's extra array.
+	 */
+	protected function get_root_extra() {
+		return $this->composer->getPackage()->getExtra();
+	}
+
+	/**
+	 * Sets the textdomain in the input files and directories.
+	 *
+	 * @param array $files The array of translatable files.
+	 */
+	private function customize_textdomain_in_files( $files ) {
+		if ( ! is_array( $files ) ) {
+			return;
+		}
+
+		foreach ( $files as $file ) {
+			$file_path = $this->vendor_dir . $file;
+
+			if ( ! file_exists( $file_path ) ) {
+				return;
+			}
+
+			if ( is_dir( $file_path ) ) {
+				$iterator = new \RecursiveDirectoryIterator(
+					$file_path,
+					\RecursiveDirectoryIterator::SKIP_DOTS
+				);
+
+				foreach ( new \RecursiveIteratorIterator( $iterator ) as $file_info ) {
+						self::customize_textdomain_in_file( $file_info->getRealPath() );
+				}
+			} elseif ( is_file( $file_path ) ) {
+				self::customize_textdomain_in_file( $file_path );
+			}
+		}
+	}
+
+	/**
+	 * Replaces all occurrences of the placeholder textdomain 'JETPACK_CUSTOMIZE_TEXTDOMAIN'
+	 * in the input file with the plugin's textdomain.
+	 *
+	 * @param string $file_path The file path.
+	 */
+	private function customize_textdomain_in_file( $file_path ) {
+		if ( ! file_exists( $file_path ) ) {
+			return;
+		}
+
+		$file_contents = file_get_contents( $file_path );
+
+		$file_contents = str_replace(
+			'\'JETPACK_CUSTOMIZE_TEXTDOMAIN\'',
+			'\'' . $this->textdomain . '\'',
+			$file_contents
+		);
+
+		file_put_contents( $file_path, $file_contents );
+	}
+}

--- a/packages/config/src/example-file.php
+++ b/packages/config/src/example-file.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * An example file to show that the textdomain customizer works.
+ */
+
+	$example_text = __( 'Text to be translated.', 'JETPACK_CUSTOMIZE_TEXTDOMAIN' );

--- a/packages/config/src/example-file.php
+++ b/packages/config/src/example-file.php
@@ -3,4 +3,4 @@
  * An example file to show that the textdomain customizer works.
  */
 
-	$example_text = __( 'Text to be translated.', 'JETPACK_CUSTOMIZE_TEXTDOMAIN' );
+	$example_text = __( 'Text to be translated.', JETPACK_CUSTOMIZE_TEXTDOMAIN );

--- a/packages/config/tests/php/bootstrap.php
+++ b/packages/config/tests/php/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/packages/config/tests/php/test_Textdomain_Customizer.php
+++ b/packages/config/tests/php/test_Textdomain_Customizer.php
@@ -59,22 +59,10 @@ class Test_Textdomain_Customizer extends TestCase {
 		);
 		$file_put_contents_spy->enable();
 
-		$test_package1 = new class() {
-
-			/**
-			 * Mocks the getName() method of the Composer\Package class.
-			 */
-			public function getName() { //phpcs:ignore WordPress.NamingConventions
-				return 'automattic/jetpack-test_package1';
-			}
-
-			/**
-			 * Mocks the getExtra() method of the Composer\Package class.
-			 */
-			public function getExtra() { //phpcs:ignore WordPress.NamingConventions
-				return array( 'translatable' => 'test1' );
-			}
-		};
+		$test_package1 = new Mock_Package(
+			'automattic/jetpack-test_package1',
+			array( 'translatable' => 'test1' )
+		);
 
 		$packages = array( $test_package1 );
 
@@ -115,4 +103,39 @@ class Test_Textdomain_Customizer extends TestCase {
 		$mock_function->enable();
 		return $mock_function;
 	}
+}
+
+//phpcs:disable Generic.Files.OneObjectStructurePerFile
+/**
+ *
+ * A class to create minimal mock Composers\Package objects for the unit tests.
+ * The class provides implementations for the getName() and getExtra() methods.
+ */
+class Mock_Package {
+	/**
+	 * The constructor.
+	 *
+	 * @param string $name The package name.
+	 * @param mixed  $extra The package extra.
+	 */
+	public function __construct( $name, $extra ) {
+		$this->name  = $name;
+		$this->extra = $extra;
+	}
+
+	//phpcs:disable WordPress.NamingConventions
+	/**
+	 * Returns the mock package's name.
+	 */
+	public function getName() {
+		return $this->name;
+	}
+
+	/**
+	 * Returns the mock package's extra value.
+	 */
+	public function getExtra() {
+		return $this->extra;
+	}
+
 }

--- a/packages/config/tests/php/test_Textdomain_Customizer.php
+++ b/packages/config/tests/php/test_Textdomain_Customizer.php
@@ -27,9 +27,9 @@ class Test_Textdomain_Customizer extends TestCase {
 			->method( 'set_vendor_dir' )
 			->will( $this->returnValue( '' ) );
 
-		$this->mock_function( 'file_exists', true );
 		$this->mock_function( 'is_dir', false );
 		$this->mock_function( 'is_file', true );
+		$this->mock_function( 'realpath', true );
 	}
 
 	/**

--- a/packages/config/tests/php/test_Textdomain_Customizer.php
+++ b/packages/config/tests/php/test_Textdomain_Customizer.php
@@ -1,0 +1,118 @@
+<?php // phpcs:ignore WordPress.Files.FileName
+
+namespace Automattic\Jetpack\Config;
+
+use Automattic\Jetpack\Config\Textdomain_Customizer;
+use phpmock\Mock;
+use phpmock\MockBuilder;
+use phpmock\spy\Spy;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contains unit tests for the Textdomain_Customizer class.
+ */
+class Test_Textdomain_Customizer extends TestCase {
+
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+
+		$this->textdomain_customizer = $this->getMockBuilder( 'Automattic\Jetpack\Config\Textdomain_Customizer' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'get_packages', 'set_vendor_dir', 'get_root_extra' ) )
+			->getMock();
+
+		$this->textdomain_customizer->expects( $this->once() )
+			->method( 'set_vendor_dir' )
+			->will( $this->returnValue( '' ) );
+
+		$this->mock_function( 'file_exists', true );
+		$this->mock_function( 'is_dir', false );
+		$this->mock_function( 'is_file', true );
+	}
+
+	/**
+	 * Teardown function.
+	 */
+	public function tearDown() {
+		unset( $this->textdomain_customizer );
+		Mock::disableAll();
+	}
+
+	/**
+	 * Test customize_textdomain_in_packages.
+	 */
+	public function test_customizer_textdomain_in_packages() {
+
+		$input  = "__( 'text to be translated', 'JETPACK_CUSTOMIZE_TEXTDOMAIN' )";
+		$output = "__( 'text to be translated', 'test_textdomain' )";
+
+		$this->mock_function( 'file_get_contents', $input );
+
+		$file_put_contents_spy = new Spy(
+			__NAMESPACE__,
+			'file_put_contents',
+			function() {
+				return true;
+			}
+		);
+		$file_put_contents_spy->enable();
+
+		$test_package1 = new class() {
+
+			/**
+			 * Mocks the getName() method of the Composer\Package class.
+			 */
+			public function getName() { //phpcs:ignore WordPress.NamingConventions
+				return 'automattic/jetpack-test_package1';
+			}
+
+			/**
+			 * Mocks the getExtra() method of the Composer\Package class.
+			 */
+			public function getExtra() { //phpcs:ignore WordPress.NamingConventions
+				return array( 'translatable' => 'test1' );
+			}
+		};
+
+		$packages = array( $test_package1 );
+
+		$this->textdomain_customizer->expects( $this->once() )
+			->method( 'get_packages' )
+			->will( $this->returnValue( $packages ) );
+
+		$this->textdomain_customizer->expects( $this->once() )
+			->method( 'get_root_extra' )
+			->will( $this->returnValue( array( 'textdomain' => 'test_textdomain' ) ) );
+
+		$this->textdomain_customizer->customize_textdomain_in_packages();
+
+		$file_put_contents_invocs = $file_put_contents_spy->getInvocations();
+		$this->assertCount( 1, $file_put_contents_invocs );
+
+		$file_put_contents_args = $file_put_contents_invocs[0]->getArguments();
+		$this->assertEquals( $output, $file_put_contents_args[1] );
+	}
+
+	/**
+	 * Mock a global function and make it return a certain value.
+	 *
+	 * @param string $function_name Name of the function.
+	 * @param mixed  $return_value  Return value of the function.
+	 * @return phpmock\Mock The mock object.
+	 */
+	protected function mock_function( $function_name, $return_value = null ) {
+		$builder = new MockBuilder();
+		$builder->setNamespace( __NAMESPACE__ )
+			->setName( $function_name )
+			->setFunction(
+				function() use ( &$return_value ) {
+					return $return_value;
+				}
+			);
+		$mock_function = $builder->build();
+		$mock_function->enable();
+		return $mock_function;
+	}
+}

--- a/packages/config/tests/php/test_Textdomain_Customizer.php
+++ b/packages/config/tests/php/test_Textdomain_Customizer.php
@@ -45,7 +45,7 @@ class Test_Textdomain_Customizer extends TestCase {
 	 */
 	public function test_customizer_textdomain_in_packages() {
 
-		$input  = "__( 'text to be translated', 'JETPACK_CUSTOMIZE_TEXTDOMAIN' )";
+		$input  = "__( 'text to be translated', JETPACK_CUSTOMIZE_TEXTDOMAIN )";
 		$output = "__( 'text to be translated', 'test_textdomain' )";
 
 		$this->mock_function( 'file_get_contents', $input );


### PR DESCRIPTION
This is a POC to explore a possible solution for using textdomains in the packages. All of the implementation details are up for debate, but I think the general idea works.

#### The Consuming Plugin

The consuming plugin must set two items in its composer.json file:

- the post-autoload-dump script in the scripts section.

- the textdomain in the extra section.

For example, the scripts and extra sections of Jetpack’s composer.json file would look like:
```
"scripts": {
		"php:compatibility": "vendor/bin/phpcs -p -s --runtime-set testVersion '5.6-' --standard=PHPCompatibilityWP --ignore=docker,tools,tests,node_modules,vendor --extensions=php",
		"php:lint": "vendor/bin/phpcs -p -s",
		"php:changed": "vendor/sirbrillig/phpcs-changed/bin/phpcs-changed --git",
		"php:autofix": "vendor/bin/phpcbf",
		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1"
		"php:lint:errors": "vendor/bin/phpcs -p -s --runtime-set ignore_warnings_on_exit 1",
		"post-autoload-dump": "Automattic\\Jetpack\\Config\\Textdomain_Customizer::post_autoload_dump"
	},
"extra": {
	"textdomain": "jetpack"
},
```
#### The Jetpack Packages

The Jetpack packages must provide a list of their translatable files in the extra section of their composer.json files. This PR includes a temporary example file in the Config package. The Config package composer.json includes this extra section listing the example file:

```
"extra": {
		"translatable": [
			"/automattic/jetpack-config/src/example-file.php"
		]
	}
```


#### How it works

1. When `composer dump-autoload` is run (it's run after both install and update), the `Textdomain_Customizer::post_autoload_dump()` method is called at the end of the dump-autoload process.
2. The version of the Config package is checked. If it’s a development version, the `post_autoload_dump()` method just returns. This prevents the files from being changed and causing headaches during development.
3. The plugin's composer.json file is checked for a `textdomain` entry in the extra section. If it exists, that textdomain will be used in the package files. If it does not exist, 'default' will be used.
3. The textdomain_customizer traverses through the installed composer packages, looking for Jetpack packages and the `translatable` entry in each Jetpack package's composer.json file. If a Jetpack package has a `translatable` entry, the listed files are processed.
4. The files are processed by replacing every occurrence of the placeholder `JETPACK_CUSTOMIZE_TEXTDOMAIN` with either the plugin's textdomain or 'default'. 

#### Changes proposed in this Pull Request:

* Add a new class and method, `Textdomain_Customizer`, that customizes the textdomain of strings in the packages. I put this in the Config class because it might be useful for multiple packages.
* Update Jetpack's composer.json file with the post_autoload_dump method and Jetpack's textdomain.
* Added a unit test. I need to write more tests. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature.

#### Testing instructions
1. Checkout this branch.
2. Run `composer install` and check the example file included in this PR, `packages/config/src/example-file.php`. The textdomain in this file should still be the placeholder `JETPACK_CUSTOMIZE_TEXTDOMAIN` because you're using a development version of the Config package.
3. To test that the method works, comment out [this line](https://github.com/Automattic/jetpack/pull/14650/files#diff-b4edeb9fd63a2c0186980efd39b2d8fcR66) to skip the early return for development versions.
4. Run `composer install` and check file `packages/config/src/example-file.php`. The textdomain should be 'jetpack'. 



#### Proposed changelog entry for your changes:
* tbd

## To do
A couple of things need to be done:
- [ ] Refactoring to make CodeClimate happy.
- [ ] More unit tests.
- [ ] Display error messages when expected files don't exist.
