### PR TITLE
Import mediaUpload from @wordpress/editor

### DIFF
--- a/extensions/blocks/slideshow/edit.js
+++ b/extensions/blocks/slideshow/edit.js
@@ -7,7 +7,8 @@ import { compose } from '@wordpress/compose';
 import { filter, get, map, pick } from 'lodash';
 import { isBlobURL } from '@wordpress/blob';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { BlockIcon, MediaPlaceholder, mediaUpload } from '@wordpress/block-editor';
+import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
+import { mediaUpload } from '@wordpress/editor';
 import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
 
 /**

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -10,8 +10,8 @@ import {
 	InspectorControls,
 	MediaPlaceholder,
 	MediaUpload,
-	mediaUpload,
 } from '@wordpress/block-editor';
+import { mediaUpload } from '@wordpress/editor';
 import {
 	DropZone,
 	FormFileUpload,

--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -3,7 +3,7 @@
  */
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
-import { mediaUpload } from '@wordpress/block-editor';
+import { mediaUpload } from '@wordpress/editor';
 import { addFilter } from '@wordpress/hooks';
 import { every } from 'lodash';
 


### PR DESCRIPTION
With the components moving from the @wordpress/editor package to
@wordpress/block-editor the import statements were updated 47bd913169. However, the
`mediaUpload` function didn't move packages and this broke part of some of
the media blocks' upload mechanisms.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14457

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This change swaps back to importing `mediaUpload` from @wordpress/editor

At some point, we should probably move to getting `mediaUpload` from the editor settings, but currently, nothing is deprecated and that has only fairly recently become a stable API WordPress/Gutenberg#18156

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix

#### Testing instructions:
Follow the testing instructions in #14457 and check that you can now upload media to a Slideshow, VideoPress and Tiled Gallery block

#### Proposed changelog entry for your changes:
Bug fixed that prevented media being uploaded in the Slideshow, Tiled Gallery, and VideoPress blocks