### PR TITLE
Sync Health: fix excessive data loss reports

### DIFF
--- a/packages/sync/src/class-health.php
+++ b/packages/sync/src/class-health.php
@@ -135,8 +135,13 @@ class Health {
 	 * Updates sync health status with either a valid status, or an unknown status.
 	 *
 	 * @param string $status Sync Status.
+	 *
+	 * @return bool True if an update occoured, or false if the status didn't change.
 	 */
 	public static function update_status( $status ) {
+		if ( self::get_status() === $status ) {
+			return false;
+		}
 		// Default Status Option.
 		$new_status = array(
 			self::OPTION_STATUS_KEY    => self::STATUS_UNKNOWN,
@@ -152,6 +157,7 @@ class Health {
 		}
 
 		\Jetpack_Options::update_option( self::STATUS_OPTION, $new_status );
+		return true;
 	}
 
 	/**

--- a/packages/sync/src/class-listener.php
+++ b/packages/sync/src/class-listener.php
@@ -366,7 +366,11 @@ class Listener {
 		if ( ! Settings::is_sync_enabled() ) {
 			return;
 		}
-		Health::update_status( Health::STATUS_OUT_OF_SYNC );
+		$updated = Health::update_status( Health::STATUS_OUT_OF_SYNC );
+
+		if ( ! $updated ) {
+			return;
+		}
 
 		$data = array(
 			'timestamp'  => microtime( true ),

--- a/tests/php/sync/test_class.jetpack-sync-health.php
+++ b/tests/php/sync/test_class.jetpack-sync-health.php
@@ -56,5 +56,10 @@ class WP_Test_Jetpack_Sync_Health extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Health::get_status(), Health::STATUS_UNKNOWN );
 	}
 
-
+	function test_update_returns_false_if_status_not_changed() {
+		$updated = Health::update_status( Health::STATUS_IN_SYNC );
+		$this->assertTrue( $updated );
+		$updated = Health::update_status( Health::STATUS_IN_SYNC );
+		$this->assertFalse( $updated );
+	}
 }

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -213,6 +213,16 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( Health::get_status(), Health::STATUS_OUT_OF_SYNC );
 	}
 
+	function test_data_loss_action_ignored_if_already_out_of_sync() {
+		Health::update_status( Health::STATUS_OUT_OF_SYNC );
+
+		$this->listener->sync_data_loss( $this->listener->get_sync_queue() );
+		$event = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_data_loss' );
+
+		$this->assertFalse( $event );
+		$this->assertEquals( Health::get_status(), Health::STATUS_OUT_OF_SYNC );
+	}
+
 	function get_page_url() {
 		return 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . "{$_SERVER['HTTP_HOST']}{$_SERVER['REQUEST_URI']}";
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue where we could potentially be over-reporting data loss:
https://github.com/Automattic/jetpack/pull/14570#discussion_r378478880

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a guard against reporting dataloss if the site is already known to be out of sync.
* Adds unit tests covering the new logic

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It fixes an issue in the Sync Health class

#### Testing instructions:
- If the unit tests are passing, this should be good to go.
- This is part of a larger sprint, and we plan to have extensive QA in the coming weeks

#### Proposed changelog entry for your changes:
* None
