### PR TITLE
Instant Search: Update TrainTracks properties to add session_id

### DIFF
--- a/modules/search/instant-search/components/search-result.jsx
+++ b/modules/search/instant-search/components/search-result.jsx
@@ -32,6 +32,7 @@ class SearchResult extends Component {
 			railcar: this.props.railcar.railcar,
 			rec_blog_id: this.props.railcar.rec_blog_id,
 			rec_post_id: this.props.railcar.rec_post_id,
+			session_id: this.props.railcar.session_id,
 			// TODO: Add a way to differentiate between different result formats
 			ui_algo: 'jetpack-instant-search-ui/v1',
 			ui_position: this.props.index,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Update TrainTracks render event to add `session_id` event property

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Open the network monitor and open your site. Ensure that no requests have been fired for `t.gif`.
3. Perform a search on your site. Ensure that requests for `t.gif` have been made.
4. Look for `session_id` in the request query parameters.

#### Proposed changelog entry for your changes:
* None.
