### PR TITLE
Instant Search: Address review feedback from master merge

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -273,9 +273,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			return $cache;
 		}
 
-		$endpoint     = sprintf( '/sites/%s/search', $this->jetpack_blog_id );
-		$query_params = urldecode( http_build_query( $args ) );
-		$service_url  = 'https://public-api.wordpress.com/rest/v1.3' . $endpoint . '?' . $query_params;
+		$service_url = add_query_arg(
+			$args,
+			sprintf(
+				'https://public-api.wordpress.com/rest/v1.3/sites/%d/search',
+				$this->jetpack_blog_id
+			)
+		);
 
 		$request_args = array(
 			'timeout'    => 10,

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -264,6 +264,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @return object|WP_Error The response from the public API, or a WP_Error.
 	 */
 	public function instant_api( array $args ) {
+		global $wp_version;
 		$start_time = microtime( true );
 
 		// Cache locally to avoid remote request slowing the page.
@@ -283,7 +284,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		$request_args = array(
 			'timeout'    => 10,
-			'user-agent' => 'jetpack_search',
+			'user-agent' => "WordPress/{$wp_version} | Jetpack/" . constant( 'JETPACK__VERSION' ),
 		);
 
 		$request  = wp_remote_get( esc_url_raw( $service_url ), $request_args );

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -83,7 +83,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$widget_options = end( $widget_options );
 		}
 
-		$overlay_widget_ids = get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'];
+		$overlay_widget_ids = array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
+			get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'] : array();
 		$filters            = Jetpack_Search_Helpers::get_filters_from_widgets( $overlay_widget_ids );
 		$widgets            = array();
 		foreach ( $filters as $key => $filter ) {
@@ -124,9 +125,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'siteId'          => Jetpack::get_option( 'id' ),
 
 			// filtering.
-			'postTypeFilters' => $widget_options['post_types'],
+			'postTypeFilters' => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
 			'postTypes'       => $post_type_labels,
-			'sort'            => $widget_options['sort'],
+			'sort'            => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
 			'widgets'         => array_values( $widgets ),
 		);
 

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -9,6 +9,11 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
 
+/**
+ * Class to load Instant Search experience on the site.
+ *
+ * @since 8.3.0
+ */
 class Jetpack_Instant_Search extends Jetpack_Search {
 
 	/**
@@ -277,7 +282,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'user-agent' => 'jetpack_search',
 		);
 
-		$request  = wp_remote_get( $service_url, $request_args );
+		$request  = wp_remote_get( esc_url_raw( $service_url ), $request_args );
 		$end_time = microtime( true );
 
 		if ( is_wp_error( $request ) ) {

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -267,7 +267,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$start_time = microtime( true );
 
 		// Cache locally to avoid remote request slowing the page.
-		$transient_name = '_jetpack_instant_search_cache_' . md5( wp_json_encode( $args ) );
+		$transient_name = 'jetpack_instant_search_cache_' . md5( wp_json_encode( $args ) );
 		$cache          = get_transient( $transient_name );
 		if ( false !== $cache ) {
 			return $cache;

--- a/modules/search/instant-search/components/gridicon/index.jsx
+++ b/modules/search/instant-search/components/gridicon/index.jsx
@@ -35,32 +35,32 @@ class Gridicon extends Component {
 			default:
 				return null;
 			case 'gridicons-audio':
-				return <title>{ __( 'Has audio.' ) }</title>;
+				return <title>{ __( 'Has audio.', 'jetpack' ) }</title>;
 			case 'gridicons-calendar':
-				return <title>{ __( 'Is an event.' ) }</title>;
+				return <title>{ __( 'Is an event.', 'jetpack' ) }</title>;
 			case 'gridicons-cart':
-				return <title>{ __( 'Is a product.' ) }</title>;
+				return <title>{ __( 'Is a product.', 'jetpack' ) }</title>;
 			case 'gridicons-comment':
-				return <title>{ __( 'Matching comment.' ) }</title>;
+				return <title>{ __( 'Matching comment.', 'jetpack' ) }</title>;
 			case 'gridicons-cross':
-				return <title>{ __( 'Close search overlay' ) }</title>;
+				return <title>{ __( 'Close search overlay', 'jetpack' ) }</title>;
 			case 'gridicons-folder':
-				return <title>{ __( 'Category' ) }</title>;
+				return <title>{ __( 'Category', 'jetpack' ) }</title>;
 			case 'gridicons-image-multiple':
-				return <title>{ __( 'Has multiple images.' ) }</title>;
+				return <title>{ __( 'Has multiple images.', 'jetpack' ) }</title>;
 			case 'gridicons-image':
-				return <title>{ __( 'Has an image.' ) }</title>;
+				return <title>{ __( 'Has an image.', 'jetpack' ) }</title>;
 			case 'gridicons-page':
-				return <title>{ __( 'Page' ) }</title>;
+				return <title>{ __( 'Page', 'jetpack' ) }</title>;
 			case 'gridicons-jetpack-search':
 			case 'gridicons-search':
-				return <title>{ __( 'Search' ) }</title>;
+				return <title>{ __( 'Search', 'jetpack' ) }</title>;
 			case 'gridicons-tag':
-				return <title>{ __( 'Tag' ) }</title>;
+				return <title>{ __( 'Tag', 'jetpack' ) }</title>;
 			case 'gridicons-video':
-				return <title>{ __( 'Has a video.' ) }</title>;
+				return <title>{ __( 'Has a video.', 'jetpack' ) }</title>;
 			case 'gridicons-filter':
-				return <title>{ __( 'Toggle search filters.' ) }</title>;
+				return <title>{ __( 'Toggle search filters.', 'jetpack' ) }</title>;
 		}
 	}
 

--- a/modules/search/instant-search/components/notice.scss
+++ b/modules/search/instant-search/components/notice.scss
@@ -1,4 +1,4 @@
-@import 'modules/calypsoify/_studio-wpcom.scss';
+@import '~@automattic/color-studio/dist/color-variables.scss';
 
 .jetpack-instant-search__notice {
 	padding: 0.75em;

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -69,7 +69,9 @@ const SearchBox = props => {
 				>
 					<Gridicon icon="filter" alt="Search filter icon" aria-hidden="true" />
 					<span class="screen-reader-text">
-						{ props.showFilters ? __( 'Hide filters' ) : __( 'Show filters ' ) }
+						{ props.showFilters
+							? __( 'Hide filters', 'jetpack' )
+							: __( 'Show filters', 'jetpack' ) }
 					</span>
 				</div>
 			) }

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { h, Component } from 'preact';
+import { __ } from '@wordpress/i18n';
 // NOTE: We only import the get package here for to reduced bundle size.
 //       Do not import the entire lodash library!
 // eslint-disable-next-line lodash/import-scope
@@ -95,7 +96,7 @@ export default class SearchFilters extends Component {
 						class="jetpack-instant-search__clear-filters-button"
 						onClick={ this.onClearFilters }
 					>
-						Clear Filters
+						{ __( 'Clear Filters', 'jetpack' ) }
 					</button>
 				) }
 				{ get( this.props.widget, 'filters' )

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -331,10 +331,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		}
 
 		$title = isset( $instance['title'] ) ? $instance['title'] : '';
-
-		if ( empty( $title ) ) {
-			$title = '';
-		}
+		$title = ! empty( $title ) ? $title : '';
 
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -330,8 +330,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 			return;
 		}
 
-		$title = isset( $instance['title'] ) ? $instance['title'] : '';
-		$title = ! empty( $title ) ? $title : '';
+		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
 
 		/** This filter is documented in core/src/wp-includes/default-widgets.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );


### PR DESCRIPTION
Follow-up on feedback from #14550.

#### Changes proposed in this Pull Request:
* Addresses review feedback from @jeherve from [here](https://github.com/Automattic/jetpack/pull/14550#pullrequestreview-357464231). Specifically:
  * Adding or fixing translation calls
  * Updating transient cache name
  * Using add_query_arg
  * More explicit user agent
  * Use a8c/color-studio for color variables
  * Fix undefined index notices

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Please note that the Jetpack Search widget will need to be added to twice: once to your site sidebar/footer and once to the Jetpack Search Sidebar within the search overlay.

2. Search your site. Ensure that an overlay spawns with your search results.

3. Try a different search using the search overlay input. Ensure that it works as expected.

#### Proposed changelog entry for your changes:
* None.
