### PR TITLE
Settings: Hide backups update nudge for multisite

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -26,7 +26,12 @@ import {
 	getPlanClass,
 } from 'lib/plans/constants';
 
-import { getSiteAdminUrl, userCanManageModules, getUpgradeUrl } from 'state/initial-state';
+import {
+	isMultisite,
+	getSiteAdminUrl,
+	userCanManageModules,
+	getUpgradeUrl,
+} from 'state/initial-state';
 import { isAkismetKeyValid, isCheckingAkismetKey, getVaultPressData } from 'state/at-a-glance';
 import { getSitePlan, isFetchingSiteData, getActiveFeatures } from 'state/site';
 import SectionHeader from 'components/section-header';
@@ -113,7 +118,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SECURITY_SCANNING_JETPACK:
-				if ( backupsEnabled || 'is-business-plan' === planClass ) {
+				if ( backupsEnabled || 'is-business-plan' === planClass || this.props.multisite ) {
 					return '';
 				}
 
@@ -364,5 +369,6 @@ export default connect( state => {
 		seoUpgradeUrl: getUpgradeUrl( state, 'settings-seo' ),
 		searchUpgradeUrl: getUpgradeUrl( state, 'settings-search' ),
 		spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
+		multisite: isMultisite( state ),
 	};
 } )( SettingsCard );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -118,7 +118,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SECURITY_SCANNING_JETPACK:
-				if ( backupsEnabled || 'is-business-plan' === planClass || this.props.multisite ) {
+				if ( backupsEnabled || 'is-business-plan' === planClass || props.multisite ) {
 					return '';
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Partial fix for #14656

Related: #14657

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide Backups upgrade nudge in security settings page

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with multisite (JN can help)
* connect Jetpack and select the free plan
* go to `/wp-admin/admin.php?page=jetpack#/security` and make sure that Backups update nudge is not there.
* Repeat the above steps for singlesite where backups available.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Settings: Hide Backups update nudge for multisite sites
