### PR TITLE
Instant Search: prevents the load more button from being cut off in some themes

### DIFF
--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -35,6 +35,7 @@
 
 .jetpack-instant-search__search-results-primary {
 	flex: 5;
+	margin-bottom: 6em;
 
 	@include break-medium() {
 		margin-right: 4em;


### PR DESCRIPTION
Addresses issue reported in https://github.com/Automattic/jetpack/issues/14610

#### Changes proposed in this Pull Request:
* Prevents the load more button from being cut off in some themes.
  * Adds margin bottom to the primary area of the overlay, which solves this problem but is also good practice to ensure search results are readable until the very last one.

![image](https://user-images.githubusercontent.com/390760/74450242-b3a07900-4e75-11ea-9584-c6e309c79b19.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Search your site to trigger the Jetpack Search overlay.
3. Uncheck “Use infinite scroll” in Jetpack Search options in the Customizer.
3. Ensure that you can see all results and the load more button below them.

#### Proposed changelog entry for your changes:
* None.
