### PR TITLE
Instant Search: ensures widgets included in the overlay are full width

### DIFF
--- a/modules/search/instant-search/components/search-sidebar.scss
+++ b/modules/search/instant-search/components/search-sidebar.scss
@@ -5,4 +5,9 @@
 			display: none;
 		}
 	}
+
+	.jetpack-instant-search__widget-area .widget {
+		padding-left: 0;
+		padding-right: 0;
+	}
 }


### PR DESCRIPTION
Addresses issue reported in https://github.com/Automattic/jetpack/issues/14610

#### Changes proposed in this Pull Request:
* Ensures widgets included in the overlay are full width.
  * This affects Twenty Fifteen theme but probably many others.


#### Before:

![image](https://user-images.githubusercontent.com/390760/74452493-10e9f980-4e79-11ea-87d1-820774ad75ab.png)


#### After:

![image](https://user-images.githubusercontent.com/390760/74452520-1b0bf800-4e79-11ea-8869-85078fd919cf.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
1. Activate the Twenty Fifteen theme.
1. Search your site to trigger the Jetpack Search overlay.
1. Ensure that the the filters on the right side are taking as much horizontal space as possible on desktop.

#### Proposed changelog entry for your changes:
* None.