### PR TITLE
OpenTable: Move the CSS to make the block take only the space it needs

### DIFF
--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -5,6 +5,8 @@
  */
 
 .wp-block-jetpack-opentable {
+	// needed so that the block preview doesn't have empty space
+	display: inline-block;
 	position: relative;
 
 	.components-base-control {
@@ -108,12 +110,4 @@
 	button.is-active {
 		font-weight: bold;
 	}
-}
-
-// Display "table" is used because the preview container should only wrap the content and not take the full width.
-// Both selector rules needed because the block wrapper used in Gutenberg was removed in v7.3
-// @link https://github.com/WordPress/gutenberg/pull/19593
-.block-editor-block-preview__content [data-type='jetpack/opentable'] [data-block],
-.block-editor-block-preview__content [data-type='jetpack/opentable'][data-block] {
-	display: table;
 }


### PR DESCRIPTION
This is a different approach to https://github.com/Automattic/jetpack/pull/14553

#### Changes proposed in this Pull Request:
* This takes a different approach to https://github.com/Automattic/jetpack/pull/14553. We might as well always apply the CSS to make the block only take the space it needs. I'll follow up with a fix for Eventbrite in a different PR, but it's more involved.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the Block inserter at the top left of the editor
* Check that the block looks big in the block preview
<img width="722" alt="Screenshot 2020-02-13 at 17 59 18" src="https://user-images.githubusercontent.com/275961/74463941-932ee980-4e8a-11ea-8325-d679efa96bde.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
