### PR TITLE
Map Block: Tweak the scroll-to-zoom behaviour.

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -115,7 +115,7 @@ export class Map extends Component {
 		this.debouncedSizeMap.cancel();
 	}
 	componentDidUpdate( prevProps ) {
-		const { apiKey, children, points, mapStyle, mapDetails } = this.props;
+		const { apiKey, children, points, mapStyle, mapDetails, isSelected } = this.props;
 		const { map } = this.state;
 		if ( apiKey && apiKey.length > 0 && apiKey !== prevProps.apiKey ) {
 			this.loadMapLibraries();
@@ -133,6 +133,16 @@ export class Map extends Component {
 		}
 		if ( mapStyle !== prevProps.mapStyle || mapDetails !== prevProps.mapDetails ) {
 			map.setStyle( this.getMapStyle() );
+		}
+
+		// Only allow scroll zooming when the block is selected, so the block can't
+		// accidentally capture the pointer when scrolling through a post.
+		if ( isSelected !== prevProps.isSelected ) {
+			if ( isSelected ) {
+				map.scrollZoom.enable();
+			} else {
+				map.scrollZoom.disable();
+			}
 		}
 	}
 	/* Event handling */
@@ -277,7 +287,7 @@ export class Map extends Component {
 	}
 	initMap( mapCenter ) {
 		const { mapboxgl } = this.state;
-		const { zoom, onMapLoaded, onError, admin } = this.props;
+		const { zoom, onMapLoaded, onError, admin, isSelected } = this.props;
 		let map = null;
 		try {
 			map = new mapboxgl.Map( {
@@ -293,6 +303,12 @@ export class Map extends Component {
 			onError( 'mapbox_error', e.message );
 			return;
 		}
+
+		// If the map block doesn't have the focus right now, disable scroll zooming.
+		if ( ! isSelected ) {
+			map.scrollZoom.disable();
+		}
+
 		map.on( 'error', e => {
 			onError( 'mapbox_error', e.error.message );
 		} );

--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -115,7 +115,7 @@ export class Map extends Component {
 		this.debouncedSizeMap.cancel();
 	}
 	componentDidUpdate( prevProps ) {
-		const { apiKey, children, points, mapStyle, mapDetails, isSelected } = this.props;
+		const { apiKey, children, points, mapStyle, mapDetails, scrollToZoom } = this.props;
 		const { map } = this.state;
 		if ( apiKey && apiKey.length > 0 && apiKey !== prevProps.apiKey ) {
 			this.loadMapLibraries();
@@ -135,10 +135,9 @@ export class Map extends Component {
 			map.setStyle( this.getMapStyle() );
 		}
 
-		// Only allow scroll zooming when the block is selected, so the block can't
-		// accidentally capture the pointer when scrolling through a post.
-		if ( isSelected !== prevProps.isSelected ) {
-			if ( isSelected ) {
+		// Only allow scroll zooming when the `scrollToZoom` is set.
+		if ( scrollToZoom !== prevProps.scrollToZoom ) {
+			if ( scrollToZoom ) {
 				map.scrollZoom.enable();
 			} else {
 				map.scrollZoom.disable();
@@ -287,7 +286,7 @@ export class Map extends Component {
 	}
 	initMap( mapCenter ) {
 		const { mapboxgl } = this.state;
-		const { zoom, onMapLoaded, onError, admin, isSelected } = this.props;
+		const { zoom, onMapLoaded, onError, scrollToZoom, admin } = this.props;
 		let map = null;
 		try {
 			map = new mapboxgl.Map( {
@@ -304,8 +303,9 @@ export class Map extends Component {
 			return;
 		}
 
-		// If the map block doesn't have the focus right now, disable scroll zooming.
-		if ( ! isSelected ) {
+		// If the map block doesn't have the focus in the editor, or
+		// it hasn't been enabled on the front end, disable scroll zooming.
+		if ( ! scrollToZoom ) {
 			map.scrollZoom.disable();
 		}
 

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -134,6 +134,7 @@ class MapEdit extends Component {
 			markerColor,
 			align,
 			preview,
+			scrollToZoom,
 		} = attributes;
 		const {
 			addPointVisibility,
@@ -183,6 +184,14 @@ class MapEdit extends Component {
 							},
 						] }
 					/>
+					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+						<ToggleControl
+							label={ __( 'Scroll to zoom', 'jetpack' ) }
+							help={ __( 'Allow the map to capture scrolling, and zoom in or out.', 'jetpack' ) }
+							checked={ scrollToZoom }
+							onChange={ value => setAttributes( { scrollToZoom: value } ) }
+						/>
+					</PanelBody>
 					{ points.length ? (
 						<PanelBody title={ __( 'Markers', 'jetpack' ) } initialOpen={ false }>
 							<Locations
@@ -268,7 +277,7 @@ class MapEdit extends Component {
 				<div className={ className }>
 					<Map
 						ref={ this.mapRef }
-						isSelected={ isSelected }
+						scrollToZoom={ isSelected } // Only scroll to zoom when the block is selected.
 						mapStyle={ mapStyle }
 						mapDetails={ mapDetails }
 						points={ points }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -268,6 +268,7 @@ class MapEdit extends Component {
 				<div className={ className }>
 					<Map
 						ref={ this.mapRef }
+						isSelected={ isSelected }
 						mapStyle={ mapStyle }
 						mapDetails={ mapDetails }
 						points={ points }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -184,7 +184,7 @@ class MapEdit extends Component {
 							},
 						] }
 					/>
-					<PanelBody title={ __( 'Settings', 'jetpack' ) }>
+					<PanelBody title={ __( 'Map Settings', 'jetpack' ) }>
 						<ToggleControl
 							label={ __( 'Scroll to zoom', 'jetpack' ) }
 							help={ __( 'Allow the map to capture scrolling, and zoom in or out.', 'jetpack' ) }

--- a/extensions/blocks/map/save.js
+++ b/extensions/blocks/map/save.js
@@ -7,7 +7,16 @@ import { Component } from '@wordpress/element';
 class MapSave extends Component {
 	render() {
 		const { attributes } = this.props;
-		const { align, mapStyle, mapDetails, points, zoom, mapCenter, markerColor } = attributes;
+		const {
+			align,
+			mapStyle,
+			mapDetails,
+			points,
+			zoom,
+			mapCenter,
+			markerColor,
+			scrollToZoom,
+		} = attributes;
 		const pointsList = points.map( ( point, index ) => {
 			const { longitude, latitude } = point.coordinates;
 			const url = 'https://www.google.com/maps/search/?api=1&query=' + latitude + ',' + longitude;
@@ -28,6 +37,7 @@ class MapSave extends Component {
 				data-zoom={ zoom }
 				data-map-center={ JSON.stringify( mapCenter ) }
 				data-marker-color={ markerColor }
+				data-scroll-to-zoom={ scrollToZoom ? scrollToZoom : null }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/extensions/blocks/map/save.js
+++ b/extensions/blocks/map/save.js
@@ -37,7 +37,7 @@ class MapSave extends Component {
 				data-zoom={ zoom }
 				data-map-center={ JSON.stringify( mapCenter ) }
 				data-marker-color={ markerColor }
-				data-scroll-to-zoom={ scrollToZoom ? scrollToZoom : null }
+				data-scroll-to-zoom={ scrollToZoom || null }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -66,6 +66,10 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		scrollToZoom: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	supports: {
 		html: false,


### PR DESCRIPTION
This PR changes the behaviour of scroll-to-zoom on the map block.

Currently, it will capture the scroll event whenever the pointer is over the map block: this means that you can accidentally zoom when scrolling through a post.

In the block editor, it now only zooms when the block is selected: scrolling through a post won't accidentally be captured by an unselected map block.

On the front end, the there is now an option (defaulting to off) for enabling scroll to zoom.

Fixes #11904.

#### Changes proposed in this Pull Request:
* Improve the usability of scroll to zoom.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Changes the behaviour of the map block.

#### Testing instructions:

* Create a new post in the block editor, and add a map block.
* Test that zooming only happens when the map block is selected.
* Publish the post.
* Test that zooming only happens on the front end when the "Scroll to zoom" option is toggled.

#### Screenshots

<img width="1030" alt="" src="https://user-images.githubusercontent.com/352291/74487757-76d78f00-4f14-11ea-9050-8d350f465894.png">


#### Proposed changelog entry for your changes:
* Map Block: Prevent an unselected block from accidentally capturing scrolling, and add an option for toggling zoom to scroll behaviour in the published post.
