### PR TITLE
Empty Helper function for checkin handler

### DIFF
--- a/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/packages/sync/src/modules/class-full-sync-immediately.php
@@ -394,7 +394,9 @@ class Full_Sync_Immediately extends Module {
 	}
 
 	/**
-	 * Empty Function as we don't close buffers on Immediate Full Sync
+	 * Empty Function as we don't close buffers on Immediate Full Sync.
+	 *
+	 * @param Array $actions an array of actions, ignored for queueless sync.
 	 */
 	public function update_sent_progress_action( $actions ) {
 		return;

--- a/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/packages/sync/src/modules/class-full-sync-immediately.php
@@ -392,4 +392,11 @@ class Full_Sync_Immediately extends Module {
 		// Setting autoload to true means that it's faster to check whether we should continue enqueuing.
 		$this->update_status( array( 'finished' => time() ) );
 	}
+
+	/**
+	 * Empty Function as we don't close buffers on Immediate Full Sync
+	 */
+	public function update_sent_progress_action($actions) {
+		return;
+	}
 }

--- a/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/packages/sync/src/modules/class-full-sync-immediately.php
@@ -396,7 +396,7 @@ class Full_Sync_Immediately extends Module {
 	/**
 	 * Empty Function as we don't close buffers on Immediate Full Sync
 	 */
-	public function update_sent_progress_action($actions) {
+	public function update_sent_progress_action( $actions ) {
 		return;
 	}
 }


### PR DESCRIPTION
Address missing update_sent_progress_action with new Immediate Full Sync class. 

The sync/close endpoint is not queue aware instead it tries to checkin for both Sync and Full Sync. With the new non-queue approach the update_sent_progress_action was not implemented as it has no functionality. However as the endpoint does not distinguish if it is a Full Sync it still tries to call it. Adding the missing function resolves a Fatal in the endpoint.

#### Changes proposed in this Pull Request:
*  checkin process tries to call above missing function

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

#### Proposed changelog entry for your changes:
* Address missing function within Full Sync needed for sync/close endpoint
