### PR TITLE
OpenTable: Fix error when pasting embed codes

### DIFF
--- a/extensions/blocks/opentable/restaurant-picker.js
+++ b/extensions/blocks/opentable/restaurant-picker.js
@@ -13,7 +13,7 @@ import { __, _n } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useRestaurantSearch from './use-restaurant-search';
+import useRestaurantSearch, { possibleEmbed } from './use-restaurant-search';
 
 const MAX_SUGGESTIONS = 20;
 const embedRegex = /<script type=\'text\/javascript\' src=\'\/\/www.opentable\.(\w{2,3}\.)?\w+\/widget\/reservation\/loader\?[^']+\'><\/script>/;
@@ -51,6 +51,7 @@ export default function RestaurantPicker( props ) {
 		<FormTokenField
 			value={ selectedRestaurants }
 			suggestions={ restaurantNames }
+			saveTransform={ token => ( possibleEmbed.test( token ) ? '' : token.trim() ) }
 			onInputChange={ setInput }
 			maxSuggestions={ MAX_SUGGESTIONS }
 			label={ _n( 'Restaurant', 'Restaurants', selectedRestaurants.length, 'jetpack' ) }

--- a/extensions/blocks/opentable/use-restaurant-search.js
+++ b/extensions/blocks/opentable/use-restaurant-search.js
@@ -8,6 +8,8 @@ import { unionBy, throttle, isEmpty } from 'lodash';
  */
 import { useState, useEffect, useCallback } from '@wordpress/element';
 
+export const possibleEmbed = /^\s*(http[s]?:\/\/|\<script)/;
+
 export default function useRestaurantSearch( searchTerm, maxResults ) {
 	const [ restaurants, setRestaurants ] = useState( [] );
 
@@ -29,7 +31,7 @@ export default function useRestaurantSearch( searchTerm, maxResults ) {
 	] );
 
 	useEffect( () => {
-		if ( ! isEmpty( searchTerm ) && ! searchTerm.startsWith( '<script' ) ) {
+		if ( ! isEmpty( searchTerm ) && ! possibleEmbed.test( searchTerm ) ) {
 			throttledSearchRestaurants( searchTerm );
 		}
 	}, [ searchTerm ] );


### PR DESCRIPTION
We were accidentally relying on an error being thrown during the
onChange handler, when an embed code was pasted into the input. The
error meant that the event bubbled up and the onSubmit event handled the
input correctly.

#### Changes proposed in this Pull Request:
This change sets the saveTransform function to check if the current
input looks like an embed. If it does, then it prevents it from being
treated like a token, and the onChange handler is never called.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix to an existing feature

#### Testing instructions:
Without this branch, and with the browser developer console open paste in an embed code into an OpenTable block - for example:

```
<script type='text/javascript' src='//www.opentable.com/widget/reservation/loader?rid=412810&type=standard&theme=standard&iframe=true&domain=com&lang=en-US&newtab=false&ot_source=Restaurant%20website'></script>
```
Hit Enter or click the Embed button.
Notice that you see an error along the lines of `parsed is null`

Do the same thing with this branch and you should not see the error. 
#### Proposed changelog entry for your changes:
I'm not sure this requires a changelog entry, but if it does:

Bug fixed that caused an unhandled error when inserting an OpenTable embed code
