### PR TITLE
Eventbrite: implement getValidatedAttributes

### DIFF
--- a/extensions/blocks/eventbrite/attributes.js
+++ b/extensions/blocks/eventbrite/attributes.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+const urlValidator = url => ! url || url.startsWith( 'http' );
+
+export default {
+	url: {
+		type: 'string',
+		validator: urlValidator,
+	},
+	eventId: {
+		type: 'number',
+	},
+	useModal: {
+		type: 'boolean',
+	},
+	// Modal button attributes, used for Button & Modal embed type.
+	text: {
+		type: 'string',
+		default: _x( 'Register', 'verb: e.g. register for an event.', 'jetpack' ),
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+	borderRadius: {
+		type: 'number',
+	},
+};

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -23,7 +23,9 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
+import attributeDetails from './attributes';
 import { convertToLink, eventIdFromUrl } from './utils';
+import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { icon, URL_REGEX } from '.';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import ModalButtonPreview from './modal-button-preview';
@@ -116,10 +118,13 @@ class EventbriteEdit extends Component {
 			return;
 		}
 
-		this.props.setAttributes( {
+		const newAttributes = {
 			eventId: eventIdFromUrl( url ),
 			url,
-		} );
+		};
+		const validatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
+
+		this.props.setAttributes( validatedAttributes );
 
 		// Setting the `resolvingUrl` state here, then waiting for `componentDidUpdate()` to
 		// be called before actually resolving it ensures that the `editedUrl` state has also been

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { G, Path, Rect, SVG } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
+import attributes from './attributes';
 import edit from './edit';
 import save from './save';
 
@@ -44,37 +45,7 @@ export const settings = {
 	supports: {
 		html: false,
 	},
-	attributes: {
-		url: {
-			type: 'string',
-		},
-		eventId: {
-			type: 'number',
-		},
-		useModal: {
-			type: 'boolean',
-		},
-		// Modal button attributes, used for Button & Modal embed type.
-		text: {
-			type: 'string',
-			default: _x( 'Register', 'verb: e.g. register for an event.', 'jetpack' ),
-		},
-		backgroundColor: {
-			type: 'string',
-		},
-		textColor: {
-			type: 'string',
-		},
-		customBackgroundColor: {
-			type: 'string',
-		},
-		customTextColor: {
-			type: 'string',
-		},
-		borderRadius: {
-			type: 'number',
-		},
-	},
+	attributes,
 	edit,
 	save,
 	transforms: {


### PR DESCRIPTION
This implements getValidatedAttributes in the Eventbrite block, so it matches OpenTable and Calendly.

#### Changes proposed in this Pull Request:
* Validate the block attributes using getValidatedAttributes.
* There should be no functional changes, but this brings the blocks more into line with each other which should make it easier to share code between all blocks in the future.
* We'll also be able to validate style values once this PR merges: https://github.com/Automattic/jetpack/pull/14528

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Refactors an existing block

#### Testing instructions:
* Add a new Eventbrite block
* Check that things continue to work as before.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog