### PR TITLE
Instant Search: change visual on close button

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -1,14 +1,14 @@
 <?php
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Constants;
+
 /**
  * Jetpack Search: Instant Front-End Search and Filtering
  *
  * @since 8.3.0
  * @package jetpack
  */
-
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Constants;
-
 class Jetpack_Instant_Search extends Jetpack_Search {
 
 	/**
@@ -103,7 +103,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$prefix  = Jetpack_Search_Options::OPTION_PREFIX;
 		$options = array(
 			'overlayOptions'  => array(
-				'closeColor'      => get_option( $prefix . 'close_color', '#BD3854' ),
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
 				'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', false ),
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -1,14 +1,14 @@
 <?php
-
-use Automattic\Jetpack\Connection\Client;
-use Automattic\Jetpack\Constants;
-
 /**
  * Jetpack Search: Instant Front-End Search and Filtering
  *
  * @since 8.3.0
  * @package jetpack
  */
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Constants;
+
 class Jetpack_Instant_Search extends Jetpack_Search {
 
 	/**

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -96,27 +96,6 @@ class Jetpack_Search_Customize {
 			)
 		);
 
-		$id = $setting_prefix . 'close_color';
-		$wp_customize->add_setting(
-			$id,
-			array(
-				'default'   => '#BD3854',
-				'transport' => 'postMessage',
-				'type'      => 'option',
-			)
-		);
-		$wp_customize->add_control(
-			new WP_Customize_Color_Control(
-				$wp_customize,
-				$id,
-				array(
-					'label'       => __( 'Close Button', 'jetpack' ),
-					'description' => __( 'Select a color and position for the close button.', 'jetpack' ),
-					'section'     => $section_id,
-				)
-			)
-		);
-
 		$id = $setting_prefix . 'highlight_color';
 		$wp_customize->add_setting(
 			$id,

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -15,7 +15,11 @@ const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
 };
 
-const Overlay = ( { children, closeColor, closeOverlay, colorTheme, isVisible, opacity } ) => {
+const onKeyPressHandler = event => {
+	event.preventDefault();
+};
+
+const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) => {
 	useEffect( () => {
 		window.addEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
 		return () => {
@@ -33,13 +37,15 @@ const Overlay = ( { children, closeColor, closeOverlay, colorTheme, isVisible, o
 			].join( ' ' ) }
 			style={ { opacity: opacity / 100 } }
 		>
-			<button
+			<div
 				className="jetpack-instant-search__overlay-close"
 				onClick={ closeOverlay }
-				style={ { background: closeColor } }
+				onKeyPress={ onKeyPressHandler }
+				role="button"
+				tabIndex="0"
 			>
 				<Gridicon icon="cross" size="24" />
-			</button>
+			</div>
 			{ children }
 		</div>
 	);

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -9,14 +9,9 @@ import { useEffect } from 'preact/hooks';
 /**
  * Internal dependencies
  */
-import Gridicon from './gridicon';
 
 const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
-};
-
-const onKeyPressHandler = event => {
-	event.preventDefault();
 };
 
 const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) => {
@@ -37,15 +32,6 @@ const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) =
 			].join( ' ' ) }
 			style={ { opacity: opacity / 100 } }
 		>
-			<div
-				className="jetpack-instant-search__overlay-close"
-				onClick={ closeOverlay }
-				onKeyPress={ onKeyPressHandler }
-				role="button"
-				tabIndex="0"
-			>
-				<Gridicon icon="cross" size="24" />
-			</div>
 			{ children }
 		</div>
 	);

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -26,18 +26,21 @@
 
 .jetpack-instant-search__overlay-close {
 	position: fixed;
-	top: 0;
-	right: 0;
+	top: 4px;
+	right: 4px;
 	z-index: 20;
 	width: 44px;
 	height: 44px;
 	margin: 0;
-	padding: 20px;
-	background-color: transparent;
+	padding: 10px;
 	line-height: 1;
+	cursor: pointer;
 
 	@include break-medium() {
+		position: absolute;
+		top: -32px;
 		width: 64px;
 		height: 64px;
+		padding: 20px;
 	}
 }

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -31,7 +31,9 @@
 	z-index: 20;
 	width: 44px;
 	height: 44px;
-	padding: 0;
+	margin: 0;
+	padding: 20px;
+	background-color: transparent;
 	line-height: 1;
 
 	@include break-medium() {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -244,6 +244,7 @@ class SearchApp extends Component {
 				opacity={ this.state.overlayOptions.opacity }
 			>
 				<SearchResults
+					closeOverlay={ this.hideResults }
 					enableLoadOnScroll={ this.state.overlayOptions.enableInfScroll }
 					hasError={ this.state.hasError }
 					hasNextPage={ this.hasNextPage() }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -9,11 +9,12 @@ import { h, Component, Fragment } from 'preact';
 /**
  * Internal dependencies
  */
-import SearchResult from './search-result';
+import Gridicon from './gridicon';
+import Notice from './notice';
 import ScrollButton from './scroll-button';
 import SearchForm from './search-form';
+import SearchResult from './search-result';
 import SearchSidebar from './search-sidebar';
-import Notice from './notice';
 
 class SearchResults extends Component {
 	getSearchTitle() {
@@ -141,6 +142,14 @@ class SearchResults extends Component {
 		);
 	}
 
+	closeOverlay = event => {
+		event.preventDefault();
+	};
+
+	onKeyPressHandler = event => {
+		event.preventDefault();
+	};
+
 	render() {
 		return (
 			<main
@@ -150,6 +159,15 @@ class SearchResults extends Component {
 					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
 				}` }
 			>
+				<div
+					className="jetpack-instant-search__overlay-close"
+					onClick={ this.closeOverlay }
+					onKeyPress={ this.onKeyPressHandler }
+					role="button"
+					tabIndex="0"
+				>
+					<Gridicon icon="cross" size="24" />
+				</div>
 				<div className="jetpack-instant-search__search-results-primary">
 					{ this.renderPrimarySection() }
 				</div>

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -163,7 +163,7 @@ class SearchResults extends Component {
 					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
 				}` }
 			>
-				<div
+				<a
 					className="jetpack-instant-search__overlay-close"
 					onClick={ this.closeOverlay }
 					onKeyPress={ this.onKeyPressHandler }
@@ -171,7 +171,7 @@ class SearchResults extends Component {
 					tabIndex="0"
 				>
 					<Gridicon icon="cross" size="24" />
-				</div>
+				</a>
 				<div className="jetpack-instant-search__search-results-primary">
 					{ this.renderPrimarySection() }
 				</div>

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -144,10 +144,14 @@ class SearchResults extends Component {
 
 	closeOverlay = event => {
 		event.preventDefault();
+		this.props.closeOverlay();
 	};
 
 	onKeyPressHandler = event => {
-		event.preventDefault();
+		if ( event.key === 'Enter' ) {
+			event.preventDefault();
+			this.props.closeOverlay();
+		}
 	};
 
 	render() {

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -28,7 +28,7 @@
 		color: #fff;
 
 		mark {
-			background-color: #324E85;
+			background-color: #324e85;
 		}
 
 		.jetpack-instant-search__overlay-close svg {
@@ -62,7 +62,6 @@
 		border: 0;
 		border-radius: 0;
 		box-shadow: none;
-
 	}
 }
 

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -18,6 +18,10 @@
 		mark {
 			background-color: #ffc;
 		}
+
+		.jetpack-instant-search__overlay-close svg {
+			fill: #000;
+		}
 	}
 
 	.jetpack-instant-search__overlay--dark & {
@@ -25,6 +29,10 @@
 
 		mark {
 			background-color: #324E85;
+		}
+
+		.jetpack-instant-search__overlay-close svg {
+			fill: #fff;
 		}
 	}
 

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -1,5 +1,4 @@
 const CUSTOMIZE_SETTINGS = [
-	'jetpack_search_close_color',
 	'jetpack_search_color_theme',
 	'jetpack_search_inf_scroll',
 	'jetpack_search_highlight_color',
@@ -9,7 +8,6 @@ const CUSTOMIZE_SETTINGS = [
 ];
 
 const SETTINGS_TO_STATE_MAP = new Map( [
-	[ 'jetpack_search_close_color', 'closeColor' ],
 	[ 'jetpack_search_color_theme', 'colorTheme' ],
 	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
 	[ 'jetpack_search_highlight_color', 'highlightColor' ],


### PR DESCRIPTION
Addresses issue reported in https://github.com/Automattic/jetpack/issues/14616

#### Changes proposed in this Pull Request:

This PR originated from an issue reported in https://github.com/Automattic/jetpack/issues/14616 that mentioned the close button was placed behind the system scrollbar. This happens because we're applying `overflow-y: hidden` on the `body` and adding overflow on the overlay itself.

The design team weighed in and the solution here is to get rid of the `background-color` on the close button, and to simply have a floating `×`. As a nice side-effect, this should give more focus to the content itself since the close button, depending on the color applied, could demand too much attention in some cases.

Here's the breakdown of all changes:

* Transforms close button into a selectable `a`.
* Moves the close button closer to the content on larger screens.
* Updates styling.
* Removes all “close button” options from the customizer.

Light theme:
![image](https://user-images.githubusercontent.com/390760/74649989-a38be080-5178-11ea-9074-444acd2125a6.png)

![image](https://user-images.githubusercontent.com/390760/74650152-fcf40f80-5178-11ea-8f57-a38b53d59035.png)


Dark theme:
![image](https://user-images.githubusercontent.com/390760/74650019-b0103900-5178-11ea-83f0-6bb100c2808f.png)

![image](https://user-images.githubusercontent.com/390760/74650133-f1a0e400-5178-11ea-8443-9a602041697d.png)


Placement reference on desktop:
![image](https://user-images.githubusercontent.com/390760/74650097-d9c96000-5178-11ea-9ad2-74e77d2ff64a.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:

1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Search your site to trigger the Jetpack Search overlay.
3. Ensure that the Jetpack Search close button works as expected, can be selected by tabbing to it, and that it's accessible.

#### Proposed changelog entry for your changes:

* None.
