### PR TITLE
Connection: add a filter for setting Jetpack api constants

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -23,6 +23,13 @@ class Client {
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function remote_request( $args, $body = null ) {
+		add_filter(
+			'jetpack_constant_default_value',
+			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
+			10,
+			2
+		);
+
 		$defaults = array(
 			'url'           => '',
 			'user_id'       => 0,
@@ -67,12 +74,7 @@ class Client {
 			return new \WP_Error( 'malformed_token' );
 		}
 
-		$api_version_hook = 'jetpack_constant_JETPACK__API_VERSION';
-		$api_filter_name  = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
-
-		add_filter( $api_version_hook, $api_filter_name, 10, 2 );
 		$jetpack_api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
-		remove_filter( $api_version_hook, $api_filter_name, 10 );
 
 		$token_key = sprintf(
 			'%s:%d:%d',

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -67,10 +67,17 @@ class Client {
 			return new \WP_Error( 'malformed_token' );
 		}
 
+		$api_version_hook = 'jetpack_constant_JETPACK__API_VERSION';
+		$api_filter_name  = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
+
+		add_filter( $api_version_hook, $api_filter_name, 10, 2 );
+		$jetpack_api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
+		remove_filter( $api_version_hook, $api_filter_name, 10 );
+
 		$token_key = sprintf(
 			'%s:%d:%d',
 			$token_key,
-			Utils::get_jetpack_api_version(),
+			$jetpack_api_version,
 			$token->external_user_id
 		);
 

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -74,12 +74,10 @@ class Client {
 			return new \WP_Error( 'malformed_token' );
 		}
 
-		$jetpack_api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
-
 		$token_key = sprintf(
 			'%s:%d:%d',
 			$token_key,
-			$jetpack_api_version,
+			Constants::get_constant( 'JETPACK__API_VERSION' ),
 			$token->external_user_id
 		);
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -69,6 +69,13 @@ class Manager {
 		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		}
+
+		add_filter(
+			'jetpack_constant_default_value',
+			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
+			10,
+			2
+		);
 	}
 
 	/**
@@ -334,12 +341,7 @@ class Manager {
 		@list( $token_key, $version, $user_id ) = explode( ':', wp_unslash( $_GET['token'] ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		$api_version_hook = 'jetpack_constant_JETPACK__API_VERSION';
-		$api_filter_name  = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
-
-		add_filter( $api_version_hook, $api_filter_name, 10, 2 );
 		$jetpack_api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
-		remove_filter( $api_version_hook, $api_filter_name, 10 );
 
 		if (
 			empty( $token_key )
@@ -721,18 +723,8 @@ class Manager {
 	 * @return String API URL.
 	 */
 	public function api_url( $relative_url ) {
-		$api_base_hook   = 'jetpack_constant_JETPACK__API_BASE';
-		$api_filter_name = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
-
-		add_filter( $api_base_hook, $api_filter_name, 10, 2 );
 		$api_base = Constants::get_constant( 'JETPACK__API_BASE' );
-		remove_filter( $api_base_hook, $api_filter_name, 10 );
-
-		$api_version_hook = 'jetpack_constant_JETPACK__API_VERSION';
-
-		add_filter( $api_version_hook, $api_filter_name, 10, 2 );
 		$api_version = '/' . Constants::get_constant( 'JETPACK__API_VERSION' ) . '/';
-		remove_filter( $api_version_hook, $api_filter_name, 10 );
 
 		/**
 		 * Filters whether the connection manager should use the iframe authorization
@@ -774,12 +766,7 @@ class Manager {
 	 * @return String XMLRPC API URL.
 	 */
 	public function xmlrpc_api_url() {
-		$api_base_hook   = 'jetpack_constant_JETPACK__API_BASE';
-		$api_filter_name = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
-
-		add_filter( $api_base_hook, $api_filter_name, 10, 2 );
 		$api_base = Constants::get_constant( 'JETPACK__API_BASE' );
-		remove_filter( $api_base_hook, $api_filter_name, 10 );
 
 		$base = preg_replace(
 			'#(https?://[^?/]+)(/?.*)?$#',

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -334,11 +334,17 @@ class Manager {
 		@list( $token_key, $version, $user_id ) = explode( ':', wp_unslash( $_GET['token'] ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
+		$api_version_hook = 'jetpack_constant_JETPACK__API_VERSION';
+		$api_filter_name  = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
+
+		add_filter( $api_version_hook, $api_filter_name, 10, 2 );
+		$jetpack_api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
+		remove_filter( $api_version_hook, $api_filter_name, 10 );
+
 		if (
 			empty( $token_key )
 		||
-			empty( $version ) || strval( Utils::get_jetpack_api_version() ) !== $version
-		) {
+			empty( $version ) || strval( $jetpack_api_version ) !== $version ) {
 			return new \WP_Error( 'malformed_token', 'Malformed token in request', compact( 'signature_details' ) );
 		}
 
@@ -715,9 +721,18 @@ class Manager {
 	 * @return String API URL.
 	 */
 	public function api_url( $relative_url ) {
+		$api_base_hook   = 'jetpack_constant_JETPACK__API_BASE';
+		$api_filter_name = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
+
+		add_filter( $api_base_hook, $api_filter_name, 10, 2 );
 		$api_base = Constants::get_constant( 'JETPACK__API_BASE' );
-		$api_base = $api_base ? $api_base : 'https://jetpack.wordpress.com/jetpack.';
-		$version  = '/' . Utils::get_jetpack_api_version() . '/';
+		remove_filter( $api_base_hook, $api_filter_name, 10 );
+
+		$api_version_hook = 'jetpack_constant_JETPACK__API_VERSION';
+
+		add_filter( $api_version_hook, $api_filter_name, 10, 2 );
+		$api_version = '/' . Constants::get_constant( 'JETPACK__API_VERSION' ) . '/';
+		remove_filter( $api_version_hook, $api_filter_name, 10 );
 
 		/**
 		 * Filters whether the connection manager should use the iframe authorization
@@ -742,14 +757,14 @@ class Manager {
 		 * @param String $url the generated URL.
 		 * @param String $relative_url the relative URL that was passed as an argument.
 		 * @param String $api_base the API base string that is being used.
-		 * @param String $version the version string that is being used.
+		 * @param String $api_version the API version string that is being used.
 		 */
 		return apply_filters(
 			'jetpack_api_url',
-			rtrim( $api_base . $relative_url, '/\\' ) . $version,
+			rtrim( $api_base . $relative_url, '/\\' ) . $api_version,
 			$relative_url,
 			$api_base,
-			$version
+			$api_version
 		);
 	}
 
@@ -759,10 +774,17 @@ class Manager {
 	 * @return String XMLRPC API URL.
 	 */
 	public function xmlrpc_api_url() {
+		$api_base_hook   = 'jetpack_constant_JETPACK__API_BASE';
+		$api_filter_name = __NAMESPACE__ . '\Utils::jetpack_api_constant_filter';
+
+		add_filter( $api_base_hook, $api_filter_name, 10, 2 );
+		$api_base = Constants::get_constant( 'JETPACK__API_BASE' );
+		remove_filter( $api_base_hook, $api_filter_name, 10 );
+
 		$base = preg_replace(
 			'#(https?://[^?/]+)(/?.*)?$#',
 			'\\1',
-			Constants::get_constant( 'JETPACK__API_BASE' )
+			$api_base
 		);
 		return untrailingslashit( $base ) . '/xmlrpc.php';
 	}

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -766,12 +766,10 @@ class Manager {
 	 * @return String XMLRPC API URL.
 	 */
 	public function xmlrpc_api_url() {
-		$api_base = Constants::get_constant( 'JETPACK__API_BASE' );
-
 		$base = preg_replace(
 			'#(https?://[^?/]+)(/?.*)?$#',
 			'\\1',
-			$api_base
+			Constants::get_constant( 'JETPACK__API_BASE' )
 		);
 		return untrailingslashit( $base ) . '/xmlrpc.php';
 	}

--- a/packages/connection/src/class-utils.php
+++ b/packages/connection/src/class-utils.php
@@ -14,7 +14,8 @@ use Automattic\Jetpack\Constants;
  */
 class Utils {
 
-	const DEFAULT_JETPACK_API_VERSION = 1;
+	const DEFAULT_JETPACK__API_VERSION = 1;
+	const DEFAULT_JETPACK__API_BASE    = 'https://jetpack.wordpress.com/jetpack.';
 
 	/**
 	 * Some hosts disable the OpenSSL extension and so cannot make outgoing HTTPS requests.
@@ -63,14 +64,22 @@ class Utils {
 	}
 
 	/**
-	 * Returns the Jetpack__API_VERSION constant if it exists, else returns a
-	 * default value of 1.
+	 * Filters the value of the api constant.
 	 *
-	 * @return integer
+	 * @param String $constant_value The constant value.
+	 * @param String $constant_name The constant name.
+	 * @return mixed | null
 	 */
-	public static function get_jetpack_api_version() {
-		$api_version = Constants::get_constant( 'JETPACK__API_VERSION' );
-		$api_version = $api_version ? $api_version : self::DEFAULT_JETPACK_API_VERSION;
-		return $api_version;
+	public static function jetpack_api_constant_filter( $constant_value, $constant_name ) {
+		if ( ! is_null( $constant_value ) ) {
+			// If the constant value was already set elsewhere, use that value.
+			return $constant_value;
+		}
+
+		if ( defined( "self::DEFAULT_$constant_name" ) ) {
+			return constant( "self::DEFAULT_$constant_name" );
+		}
+
+		return null;
 	}
 }

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -40,6 +40,17 @@ class ManagerTest extends TestCase {
 				);
 
 		$this->wp_redirect = $builder->build();
+
+		// Mock the apply_filters() call in Constants::get_constant().
+		$builder = new MockBuilder();
+		$builder->setNamespace( 'Automattic\Jetpack' )
+				->setName( 'apply_filters' )
+				->setFunction(
+					function( $filter_name, $value, $name ) {
+						return constant( __NAMESPACE__ . "\Utils::DEFAULT_$name" );
+					}
+				);
+		$this->constants_apply_filters = $builder->build();
 	}
 
 	public function tearDown() {
@@ -76,7 +87,7 @@ class ManagerTest extends TestCase {
 
 	public function test_api_url_defaults() {
 		$this->apply_filters->enable();
-		$this->set_up_api_constant_filter_mocks();
+		$this->constants_apply_filters->enable();
 
 		$this->assertEquals(
 			'https://jetpack.wordpress.com/jetpack.something/1/',
@@ -95,7 +106,7 @@ class ManagerTest extends TestCase {
 	 */
 	public function test_api_url_uses_constants_and_filters() {
 		$this->apply_filters->enable();
-		$this->set_up_api_constant_filter_mocks();
+		$this->constants_apply_filters->enable();
 
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://example.com/api/base.' );
 		$this->assertEquals(
@@ -222,38 +233,5 @@ class ManagerTest extends TestCase {
 				return $return_value;
 			} );
 		return $builder->build()->enable();
-	}
-
-	protected function set_up_api_constant_filter_mocks() {
-		$add_filter_builder = new MockBuilder();
-		$add_filter_builder->setNamespace( 'Automattic\Jetpack\Connection' )
-			->setName( 'add_filter' )
-			->setFunction(
-				function() {
-					return null;
-				}
-			);
-		$add_filter_builder->build()->enable();
-
-		$remove_filter_builder = new MockBuilder();
-		$remove_filter_builder->setNamespace( 'Automattic\Jetpack\Connection' )
-			->setName( 'remove_filter' )
-			->setFunction(
-				function() {
-					return null;
-				}
-			);
-		$remove_filter_builder->build()->enable();
-
-		// Mock the apply_filters() call in Constants::get_constant().
-		$apply_filters_builder = new MockBuilder();
-		$apply_filters_builder->setNamespace( 'Automattic\Jetpack' )
-				->setName( 'apply_filters' )
-				->setFunction(
-					function( $filter_name, $value, $name ) {
-						return constant( "Automattic\Jetpack\Connection\Utils::DEFAULT_{$name}" );
-					}
-				);
-		$apply_filters_builder->build()->enable();
 	}
 }

--- a/packages/connection/tests/php/test_Utils.php
+++ b/packages/connection/tests/php/test_Utils.php
@@ -22,23 +22,61 @@ class UtilsTest extends TestCase {
 		Constants::clear_constants();
 	}
 
+
 	/**
-	 * Utils::get_jetpack_api_version should return the JETPACK__API_VERSION
-	 * constant when the constant is defined.
+	 * Tests the Utils::jetpack_api_constant_filter() method.
 	 *
-	 *  @covers Automattic\Jetpack\Connection\Utils::get_jetpack_api_version
+	 * @covers Automattic\Jetpack\Connection\Utils::jetpack_api_constant_filter
+	 * @dataProvider jetpack_api_constant_filter_data_provider
+	 *
+	 * @param mixed  $constant_value The constant value.
+	 * @param string $constant_name The constant name.
+	 * @param mixed  $expected_output The expected output of Utils::get_jetpack_api_constant.
 	 */
-	public function test_get_jetpack_api_version_with_constant() {
-		$test_constant_value = 3;
-		Constants::set_constant( 'JETPACK__API_VERSION', $test_constant_value );
-		$this->assertEquals( $test_constant_value, Utils::get_jetpack_api_version() );
+	public function test_jetpack_api_constant_filter( $constant_value, $constant_name, $expected_output ) {
+		$this->assertEquals( $expected_output, Utils::jetpack_api_constant_filter( $constant_value, $constant_name ) );
 	}
 
 	/**
-	 * Utils::get_jetpack_api_version should return the default Jetpack API version
-	 * value when the JETPACK__API_VERSION constant is not defined.
+	 * Data provider for test_jetpack_api_constant_filter.
+	 *
+	 * The test data arrays have the format:
+	 *    'constant_value'  => The value that the constant will be set to. Null if the constant will not be set.
+	 *    'constant_name'   => The name of the constant.
+	 *    'expected_output' => The expected output of Utils::jetpack_api_constant_filter().
 	 */
-	public function test_get_jetpack_api_version_without_constant() {
-		$this->assertEquals( Utils::DEFAULT_JETPACK_API_VERSION, Utils::get_jetpack_api_version() );
+	public function jetpack_api_constant_filter_data_provider() {
+		return array(
+			'jetpack__api_base_without_constant'     =>
+				array(
+					'constant_value'  => null,
+					'constant_name'   => 'JETPACK__API_BASE',
+					'expected_output' => Utils::DEFAULT_JETPACK__API_BASE,
+				),
+			'jetpack__api_version_without_constant'  =>
+				array(
+					'constant_value'  => null,
+					'constant_name'   => 'JETPACK__API_VERSION',
+					'expected_output' => Utils::DEFAULT_JETPACK__API_VERSION,
+				),
+			'no_default_value_in_utils'              =>
+				array(
+					'constant_value'  => null,
+					'constant_name'   => 'JETPACK__TEST',
+					'expected_output' => null,
+				),
+			'jetpack__api_base_with_constant_set'    =>
+				array(
+					'constant_value'  => 'https://example.com/api/base.',
+					'constant_name'   => 'JETPACK__API_BASE',
+					'expected_output' => 'https://example.com/api/base.',
+				),
+			'jetpack__api_version_with_constant_set' =>
+				array(
+					'constant_value'  => 20,
+					'constant_name'   => 'JETPACK__API_VERSION',
+					'expected_output' => 20,
+				),
+		);
 	}
 }

--- a/packages/constants/composer.json
+++ b/packages/constants/composer.json
@@ -5,7 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1"
 	},
 	"autoload": {
 		"classmap": [

--- a/packages/constants/src/class-constants.php
+++ b/packages/constants/src/class-constants.php
@@ -72,7 +72,11 @@ class Constants {
 			return self::$set_constants[ $name ];
 		}
 
-		return defined( $name ) ? constant( $name ) : null;
+		if ( defined( $name ) ) {
+			return constant( $name );
+		}
+
+		return apply_filters( "jetpack_constant_$name", null, $name );
 	}
 
 	/**

--- a/packages/constants/src/class-constants.php
+++ b/packages/constants/src/class-constants.php
@@ -61,7 +61,8 @@ class Constants {
 
 	/**
 	 * Attempts to retrieve the "constant" from constants Manager, and if it hasn't been set,
-	 * then attempts to get the constant with the constant() function.
+	 * then attempts to get the constant with the constant() function. If that also hasn't
+	 * been set, attempts to get a value from filters.
 	 *
 	 * @param string $name The name of the constant.
 	 *
@@ -76,7 +77,15 @@ class Constants {
 			return constant( $name );
 		}
 
-		return apply_filters( "jetpack_constant_$name", null, $name );
+		/**
+		 * Filters the value of the constant.
+		 *
+		 * @since 8.5.0
+		 *
+		 * @param null The constant value to be filtered. The default is null.
+		 * @param String $name The constant name.
+		 */
+		return apply_filters( 'jetpack_constant_default_value', null, $name );
 	}
 
 	/**

--- a/packages/constants/tests/php/test_Constants.php
+++ b/packages/constants/tests/php/test_Constants.php
@@ -73,15 +73,14 @@ class Test_Constants extends TestCase {
 	 */
 	function test_jetpack_constants_get_constant_null_when_not_set() {
 		$this->apply_filters_spy->enable();
-		$test_constant_name   = 'UNDEFINED';
-		$expected_filter_name = "jetpack_constant_{$test_constant_name}";
+		$test_constant_name = 'UNDEFINED';
 
 		$actual_output = Constants::get_constant( $test_constant_name );
 
 		list($filter_name, $filter_constant_value, $filter_constant_name )
 			= $this->apply_filters_spy->getInvocations()[0]->getArguments();
 
-		$this->assertEquals( $expected_filter_name, $filter_name );
+		$this->assertEquals( 'jetpack_constant_default_value', $filter_name );
 		$this->assertNull( $filter_constant_value );
 		$this->assertEquals( $test_constant_name, $filter_constant_name );
 
@@ -119,10 +118,9 @@ class Test_Constants extends TestCase {
 	 */
 	function test_jetpack_constants_get_constant_use_filter_value() {
 		$test_constant_name  = 'TEST_CONSTANT';
-		$test_filter_name    = "jetpack_constant_{$test_constant_name}";
 		$test_constant_value = 'test value';
 
-		// Special apply_filters spy for this test.
+		// Create a new apply_filters spy for this test.
 		$apply_filters_spy = new Spy(
 			'Automattic\Jetpack',
 			'apply_filters',
@@ -137,7 +135,7 @@ class Test_Constants extends TestCase {
 		list($filter_name, $filter_constant_value, $filter_constant_name )
 			= $apply_filters_spy->getInvocations()[0]->getArguments();
 
-		$this->assertEquals( $test_filter_name, $filter_name );
+		$this->assertEquals( 'jetpack_constant_default_value', $filter_name );
 		$this->assertNull( $filter_constant_value );
 		$this->assertEquals( $test_constant_name, $filter_constant_name );
 

--- a/packages/constants/tests/php/test_Constants.php
+++ b/packages/constants/tests/php/test_Constants.php
@@ -1,6 +1,8 @@
 <?php
 
 use Automattic\Jetpack\Constants;
+use phpmock\Mock;
+use phpmock\spy\Spy;
 use PHPUnit\Framework\TestCase;
 
 class Test_Constants extends TestCase {
@@ -8,11 +10,20 @@ class Test_Constants extends TestCase {
 		if ( ! defined( 'JETPACK__VERSION' ) ) {
 			define( 'JETPACK__VERSION', '7.5' );
 		}
+
+		$this->apply_filters_spy = new Spy(
+			'Automattic\Jetpack',
+			'apply_filters',
+			function ( $filter_name, $value, $name ) {
+				return $value;
+			}
+		);
 	}
 
 	public function tearDown() {
 		parent::tearDown();
 		Constants::$set_constants = array();
+		Mock::disableAll();
 	}
 
 	/**
@@ -49,22 +60,44 @@ class Test_Constants extends TestCase {
 	 * @covers Automattic\Jetpack\Constants::get_constant
 	 */
 	function test_jetpack_constants_default_to_constant() {
-		$this->assertEquals( Constants::get_constant( 'JETPACK__VERSION' ), JETPACK__VERSION );
+		$this->apply_filters_spy->enable();
+		$actual_output = Constants::get_constant( 'JETPACK__VERSION' );
+
+		// apply_filters() should not have been called.
+		$this->assertEquals( array(), $this->apply_filters_spy->getInvocations() );
+		$this->assertEquals( JETPACK__VERSION, $actual_output );
 	}
 
 	/**
 	 * @covers Automattic\Jetpack\Constants::get_constant
 	 */
 	function test_jetpack_constants_get_constant_null_when_not_set() {
-		$this->assertNull( Constants::get_constant( 'UNDEFINED' ) );
+		$this->apply_filters_spy->enable();
+		$test_constant_name   = 'UNDEFINED';
+		$expected_filter_name = "jetpack_constant_{$test_constant_name}";
+
+		$actual_output = Constants::get_constant( $test_constant_name );
+
+		list($filter_name, $filter_constant_value, $filter_constant_name )
+			= $this->apply_filters_spy->getInvocations()[0]->getArguments();
+
+		$this->assertEquals( $expected_filter_name, $filter_name );
+		$this->assertNull( $filter_constant_value );
+		$this->assertEquals( $test_constant_name, $filter_constant_name );
+
+		$this->assertNull( $actual_output );
 	}
 
 	/**
 	 * @covers Automattic\Jetpack\Constants::get_constant
 	 */
 	function test_jetpack_constants_can_override_previously_defined_constant() {
+		$this->apply_filters_spy->enable();
 		$test_version = '1.0.0';
 		Constants::set_constant( 'JETPACK__VERSION', $test_version );
+
+		// apply_filters() should not have been called.
+		$this->assertEquals( array(), $this->apply_filters_spy->getInvocations() );
 		$this->assertEquals( Constants::get_constant( 'JETPACK__VERSION' ), $test_version );
 	}
 
@@ -72,8 +105,43 @@ class Test_Constants extends TestCase {
 	 * @covers Automattic\Jetpack\Constants::get_constant
 	 */
 	function test_jetpack_constants_override_to_null_gets_null() {
+		$this->apply_filters_spy->enable();
 		Constants::set_constant( 'JETPACK__VERSION', null );
+
+		// apply_filters() should not have been called.
+		$this->assertEquals( array(), $this->apply_filters_spy->getInvocations() );
 		$this->assertNull( Constants::get_constant( 'JETPACK__VERSION' ) );
+	}
+
+
+	/**
+	 * @covers Automattic\Jetpack\Constants::get_constant
+	 */
+	function test_jetpack_constants_get_constant_use_filter_value() {
+		$test_constant_name  = 'TEST_CONSTANT';
+		$test_filter_name    = "jetpack_constant_{$test_constant_name}";
+		$test_constant_value = 'test value';
+
+		// Special apply_filters spy for this test.
+		$apply_filters_spy = new Spy(
+			'Automattic\Jetpack',
+			'apply_filters',
+			function ( $filter_name, $value, $name ) use ( $test_constant_value ) {
+				return $test_constant_value;
+			}
+		);
+		$apply_filters_spy->enable();
+
+		$actual_output = Constants::get_constant( $test_constant_name );
+
+		list($filter_name, $filter_constant_value, $filter_constant_name )
+			= $apply_filters_spy->getInvocations()[0]->getArguments();
+
+		$this->assertEquals( $test_filter_name, $filter_name );
+		$this->assertNull( $filter_constant_value );
+		$this->assertEquals( $test_constant_name, $filter_constant_name );
+
+		$this->assertEquals( $test_constant_value, $actual_output );
 	}
 
 	/**


### PR DESCRIPTION
The connection package needs the JETPACK__API_VERSION and JETPACK_API_BASE constants.

Disconnecting the site with the connection package alone (Jetpack is not installed) causes a PHP Warning to be generated:  `PHP Warning: Use of undefined constant JETPACK__API_BASE`. This change will fix that warning.

#### Changes proposed in this Pull Request:
* Add a method, `Utils::jetpack_api_constant_filter()`, that is used to filter the api constants.
* In `Constants::get_constant()`, call `apply_filters()` when the constant is not set in the Constants manager or defined.
* Update the uses of these constants in the connection package Client and Manager classes.
* Update the unit tests.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

##### Test site
* This branch of Jetpack must be installed.
* The client-example plugin must be installed.
* Debug logging must be enabled.

##### Test steps
###### Jetpack
Test that the Jetpack connection works.
1. Start with a disconnected site (deactivate Jetpack if the site is already connected).
2. Connect Jetpack (both site registration and user authorization).
3. Disconnect Jetpack.
4. Verify that no errors/warnings/notices were generated in the debug.log.


###### Client-example
Test that the connection works without Jetpack.
1. Deactivate Jetpack.
2. Connect using the connection flow in the client-example plugin (both site registration and user authorization).
3. Disconnect the site.
4. Verify that no errors/warnings/notices were generated in the debug.log.

#### Proposed changelog entry for your changes:
* n/a
