### PR TITLE
API: bring in Mailchimp / AMP changes to bring files in sync

### DIFF
--- a/class.json-api-endpoints.php
+++ b/class.json-api-endpoints.php
@@ -2070,21 +2070,14 @@ abstract class WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
-	 * Determine if endpoint has been called from amp-form
+	 * Get an array of all valid AMP origins for a blog's siteurl.
 	 *
-	 * @return bool
-	 */
-	public function is_amp_request() {
-		return ( isset( $_GET, $_GET['__amp_source_origin'] ) );
-	}
-
-	/**
-	 * Get an array of all valid AMP origins for a blog's siteurl 
-	 *
+	 * @param string $siteurl Origin url of the API request.
 	 * @return array
 	 */
 	public function get_amp_cache_origins( $siteurl ) {
 		$host = parse_url( $siteurl, PHP_URL_HOST );
+
 		/*
 		 * From AMP docs:
 		 * "When possible, the Google AMP Cache will create a subdomain for each AMP document's domain by first converting it
@@ -2096,9 +2089,9 @@ abstract class WPCOM_JSON_API_Endpoint {
 			// phpcs:ignore PHPCompatibility.Constants.RemovedConstants.intl_idna_variant_2003Deprecated
 			$host = idn_to_utf8( $host, IDNA_DEFAULT, defined( 'INTL_IDNA_VARIANT_UTS46' ) ? INTL_IDNA_VARIANT_UTS46 : INTL_IDNA_VARIANT_2003 );
 		}
-		$subdomain = str_replace( [ '-', '.' ], [ '--', '-' ], $host );
-		return [
-			$siteurl, 
+		$subdomain = str_replace( array( '-', '.' ), array( '--', '-' ), $host );
+		return array(
+			$siteurl,
 			// Google AMP Cache (legacy).
 			'https://cdn.ampproject.org',
 			// Google AMP Cache subdomain.
@@ -2107,45 +2100,20 @@ abstract class WPCOM_JSON_API_Endpoint {
 			sprintf( 'https://%s.amp.cloudflare.com', $subdomain ),
 			// Bing AMP Cache.
 			sprintf( 'https://%s.bing-amp.com', $subdomain ),
-		];
-	}
-
-	/**
-	 * Return the source origin for use in API response headers, or false if invalid.
-	 *
-	 * @return string|bool
-	 */
-	public function get_amp_source_origin( $siteurl ) {
-		if ( ! isset( $_GET['__amp_source_origin'], $_SERVER['HTTP_ORIGIN'] ) ) {
-			return false;
-		}
-
-		$source_origin = esc_url_raw( $_GET['__amp_source_origin'] );
-		$http_origin = esc_url_raw( $_SERVER['HTTP_ORIGIN'] );
-		
-		if ( $source_origin !== esc_url_raw( $siteurl ) ) {
-			return false;
-		}
-
-		$amp_urls = $this->get_amp_cache_origins( $siteurl );
-		if ( ! in_array( $http_origin, $amp_urls, true ) ) {
-			return false;
-		}
-
-		return wp_unslash( $source_origin );
+		);
 	}
 
 	/**
 	 * Return endpoint response
 	 *
-	 * @param ... determined by ->$path
+	 * @param string $path ... determined by ->$path.
 	 *
-	 * @return
+	 * @return array|WP_Error
 	 *  falsy: HTTP 500, no response body
 	 *  WP_Error( $error_code, $error_message, $http_status_code ): HTTP $status_code, json_encode( array( 'error' => $error_code, 'message' => $error_message ) ) response body
 	 *  $data: HTTP 200, json_encode( $data ) response body
 	 */
-	abstract function callback( $path = '' );
+	abstract public function callback( $path = '' );
 
 
 }

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -32,6 +32,8 @@ class WPCOM_JSON_API {
 
 	public $extra_headers = array();
 
+	public $amp_source_origin = null;
+
 	/**
 	 * @return WPCOM_JSON_API instance
 	 */
@@ -378,6 +380,14 @@ class WPCOM_JSON_API {
 		if ( 404 == $status_code || 400 == $status_code ) {
 			header( 'Access-Control-Allow-Origin: *' );
 		}
+
+		/* Add headers for form submission from <amp-form/> */
+		if ( $this->amp_source_origin ) {
+			$amp_source_origin = wp_unslash( $_GET['__amp_source_origin'] );
+			header( "Access-Control-Allow-Origin: " . $amp_source_origin );
+			header( 'Access-Control-Allow-Credentials: true' );
+		}
+
 
 		if ( is_null( $response ) ) {
 			$response = new stdClass();

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -383,7 +383,7 @@ class WPCOM_JSON_API {
 
 		/* Add headers for form submission from <amp-form/> */
 		if ( $this->amp_source_origin ) {
-			header( "Access-Control-Allow-Origin: " . wp_unslash( $this->amp_source_origin ) );
+			header( 'Access-Control-Allow-Origin: ' . wp_unslash( $this->amp_source_origin ) );
 			header( 'Access-Control-Allow-Credentials: true' );
 		}
 

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -39,7 +39,7 @@ class WPCOM_JSON_API {
 	 */
 	static function init( $method = null, $url = null, $post_body = null ) {
 		if ( ! self::$self ) {
-			$class      = function_exists( 'get_called_class' ) ? get_called_class() : __CLASS__; // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.get_called_classFound
+			$class      = function_exists( 'get_called_class' ) ? get_called_class() : __CLASS__; // phpcs:ignore PHPCompatibility.PHP.NewFunctions.get_called_classFound
 			self::$self = new $class( $method, $url, $post_body );
 		}
 		return self::$self;

--- a/class.json-api.php
+++ b/class.json-api.php
@@ -383,8 +383,7 @@ class WPCOM_JSON_API {
 
 		/* Add headers for form submission from <amp-form/> */
 		if ( $this->amp_source_origin ) {
-			$amp_source_origin = wp_unslash( $_GET['__amp_source_origin'] );
-			header( "Access-Control-Allow-Origin: " . $amp_source_origin );
+			header( "Access-Control-Allow-Origin: " . wp_unslash( $this->amp_source_origin ) );
 			header( 'Access-Control-Allow-Credentials: true' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR brings in 4 changes from WordPress.com to bring files back in sync:
- r202919-wpcom
- r197819-wpcom
- r196688-wpcom
- r203171-wpcom

**However, we can't merge it as is just yet, as the changes add a number of PHPCS errors that trigger our pre-commit hook.**

```
FILE: ...ev/jpdev/wp-content/plugins/jetpack/class.json-api-endpoints.php
----------------------------------------------------------------------
 2078 | WARNING | [ ] Processing form data without nonce
      |         |     verification.
      |         |     (WordPress.Security.NonceVerification.Recommended)
 2078 | WARNING | [ ] Processing form data without nonce
      |         |     verification.
      |         |     (WordPress.Security.NonceVerification.Recommended)
 2081 | ERROR   | [ ] Doc comment for parameter "$siteurl"
      |         |     missing
      |         |     (Squiz.Commenting.FunctionComment.MissingParamTag)
 2082 | ERROR   | [x] Whitespace found at end of line
      |         |     (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 2087 | WARNING | [ ] parse_url() is discouraged because of
      |         |     inconsistency in the output across PHP
      |         |     versions; use wp_parse_url() instead.
      |         |     (WordPress.WP.AlternativeFunctions.parse_url_parse_url)
 2088 | ERROR   | [ ] Empty line required before block comment
      |         |     (Squiz.Commenting.BlockComment.NoEmptyLineBefore)
 2099 | ERROR   | [x] Short array syntax is not allowed
      |         |     (Generic.Arrays.DisallowShortArraySyntax.Found)
 2099 | ERROR   | [x] Short array syntax is not allowed
      |         |     (Generic.Arrays.DisallowShortArraySyntax.Found)
 2100 | ERROR   | [x] Short array syntax is not allowed
      |         |     (Generic.Arrays.DisallowShortArraySyntax.Found)
 2101 | ERROR   | [x] Whitespace found at end of line
      |         |     (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 2113 | ERROR   | [ ] Doc comment for parameter "$siteurl"
      |         |     missing
      |         |     (Squiz.Commenting.FunctionComment.MissingParamTag)
 2119 | WARNING | [ ] Processing form data without nonce
      |         |     verification.
      |         |     (WordPress.Security.NonceVerification.Recommended)
 2123 | WARNING | [ ] Processing form data without nonce
      |         |     verification.
      |         |     (WordPress.Security.NonceVerification.Recommended)
 2124 | WARNING | [x] Equals sign not aligned with surrounding
      |         |     assignments; expected 3 spaces but found 1
      |         |     space
      |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 2125 | ERROR   | [x] Whitespace found at end of line
      |         |     (Squiz.WhiteSpace.SuperfluousWhitespace.EndLine)
 2126 | ERROR   | [ ] Use Yoda Condition checks, you must.
      |         |     (WordPress.PHP.YodaConditions.NotYoda)
 2141 | ERROR   | [ ] Missing parameter comment
      |         |     (Squiz.Commenting.FunctionComment.MissingParamComment)
 2143 | ERROR   | [ ] Return type missing for @return tag in function
      |         |     comment
      |         |     (Squiz.Commenting.FunctionComment.MissingReturnType)
 2148 | ERROR   | [ ] Visibility must be declared on method
      |         |     "callback"
      |         |     (Squiz.Scope.MethodScope.Missing)
----------------------------------------------------------------------

FILE: ...ve/Sites/dev/jpdev/wp-content/plugins/jetpack/class.json-api.php
----------------------------------------------------------------------
 386 | ERROR   | [x] String "Access-Control-Allow-Origin: " does not
     |         |     require double quotes; use single quotes
     |         |     instead
     |         |     (Squiz.Strings.DoubleQuoteUsage.NotRequired)
----------------------------------------------------------------------
```

@jeffersonrabb Could you work on fixing those errors in a new WordPress.com diff, commit your changes there, and then bring those changes back to this PR in an additional commit, so we can solve those issues?

Thank you!

#### Testing instructions:

* TBD (see D33928-code and D38795-code)

#### Proposed changelog entry for your changes:

* N/A
