### PR TITLE
get_sync_status does not properly account for unexpected states

### DIFF
--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -730,8 +730,10 @@ class Actions {
 
 		$sync_module     = Modules::get_module( 'full-sync' );
 		$queue           = self::$sender->get_sync_queue();
-		$cron_timestamps = array_keys( _get_cron_array() );
-		$next_cron       = $cron_timestamps[0] - time();
+
+		// _get_cron_array can be false
+		$cron_timestamps = ( _get_cron_array() ) ? array_keys( _get_cron_array() ) : array();
+		$next_cron       = ( ! empty( $cron_timestamps ) ) ? $cron_timestamps[0] - time() : '';
 
 		$checksums = array();
 
@@ -770,7 +772,8 @@ class Actions {
 			)
 		);
 
-		if ( false === strpos( get_class( $sync_module ), 'Full_Sync_Immediately' ) ) {
+		// Verify $sync_module is not false
+		if ( ( $sync_module ) && false === strpos( get_class( $sync_module ), 'Full_Sync_Immediately' ) ) {
 			$result['full_queue_size'] = $full_queue->size();
 			$result['full_queue_lag']  = $full_queue->lag();
 		}


### PR DESCRIPTION
Enhance get_sync_status to resolve warnings by the following use cases:
_get_cron_array returning false
full-sync module returning false

Fixes #

#### Changes proposed in this Pull Request:
* It is possible for full-sync module to be false and for _get_cron_array to return false. This PR hardens the code to account for these scenarios.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Resolves Warning and Fatal seen on a few sites.

#### Testing instructions:

Test 1
* Activate Jetpack version 8.2
* Delete the 'cron' option
* from `wp shell` run `Automattic\Jetpack\Sync\Actions::get_sync_status();`
* Verify you see the warning:
Warning: array_keys() expects parameter 1 to be array, bool given
* Apply patch
* from `wp shell` run `Automattic\Jetpack\Sync\Actions::get_sync_status();`
* Verify no warning is generated

Test 2
* Activate Jetpack version 8.2
* unset the full-sync module
* from `wp shell` run `Automattic\Jetpack\Sync\Actions::get_sync_status();`
* Verify you see the warning
Warning: get_class() expects parameter 1 to be object, bool given
* Apply patch
* from `wp shell` run `Automattic\Jetpack\Sync\Actions::get_sync_status();`
* Verify no warning is generated

#### Proposed changelog entry for your changes:
* Resolve warnings within the get_sync_status function.
