### PR TITLE
Map Block: Map Controls UI Fixes

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -116,6 +116,7 @@ export class Map extends Component {
 	}
 	componentDidUpdate( prevProps ) {
 		const {
+			admin,
 			apiKey,
 			children,
 			points,
@@ -123,7 +124,6 @@ export class Map extends Component {
 			mapDetails,
 			scrollToZoom,
 			showFullscreenButton,
-			admin,
 		} = this.props;
 		const { map, fullscreenControl } = this.state;
 		if ( apiKey && apiKey.length > 0 && apiKey !== prevProps.apiKey ) {

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -319,7 +319,7 @@ class MapEdit extends Component {
 						/>
 						<ToggleControl
 							label={ __( 'Show Fullscreen Button', 'jetpack' ) }
-							help={ __( 'Allow the user to display the map in fullscreen.', 'jetpack' ) }
+							help={ __( 'Allow your visitors to display the map in fullscreen.', 'jetpack' ) }
 							checked={ showFullscreenButton }
 							onChange={ value => setAttributes( { showFullscreenButton: value } ) }
 						/>

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -220,6 +220,7 @@ class MapEdit extends Component {
 			preview,
 			scrollToZoom,
 			mapHeight,
+			showFullscreenButton,
 		} = attributes;
 		const {
 			addPointVisibility,
@@ -315,6 +316,12 @@ class MapEdit extends Component {
 							help={ __( 'Allow the map to capture scrolling, and zoom in or out.', 'jetpack' ) }
 							checked={ scrollToZoom }
 							onChange={ value => setAttributes( { scrollToZoom: value } ) }
+						/>
+						<ToggleControl
+							label={ __( 'Show Fullscreen Button', 'jetpack' ) }
+							help={ __( 'Allow the user to display the map in fullscreen.', 'jetpack' ) }
+							checked={ showFullscreenButton }
+							onChange={ value => setAttributes( { showFullscreenButton: value } ) }
 						/>
 					</PanelBody>
 					{ points.length ? (
@@ -423,6 +430,7 @@ class MapEdit extends Component {
 							<Map
 								ref={ this.mapRef }
 								scrollToZoom={ allowScrollToZoom }
+								showFullscreenButton={ showFullscreenButton }
 								mapStyle={ mapStyle }
 								mapDetails={ mapDetails }
 								mapHeight={ mapHeight }

--- a/extensions/blocks/map/index.js
+++ b/extensions/blocks/map/index.js
@@ -1,6 +1,11 @@
 /**
  * Internal dependencies
  */
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import { settings as mapSettings } from './settings.js';
 import edit from './edit';
 import save from './save';
@@ -26,4 +31,11 @@ export const settings = {
 	edit,
 	save,
 	example: mapSettings.example,
+	deprecated: [
+		{
+			attributes: omit( mapSettings.attributes, 'showFullscreenButton' ),
+			migrate: attributes => ( { ...attributes, showFullscreenButton: true } ),
+			save,
+		},
+	],
 };

--- a/extensions/blocks/map/save.js
+++ b/extensions/blocks/map/save.js
@@ -17,6 +17,7 @@ class MapSave extends Component {
 			markerColor,
 			scrollToZoom,
 			mapHeight,
+			showFullscreenButton,
 		} = attributes;
 		const pointsList = points.map( ( point, index ) => {
 			const { longitude, latitude } = point.coordinates;
@@ -40,6 +41,7 @@ class MapSave extends Component {
 				data-marker-color={ markerColor }
 				data-scroll-to-zoom={ scrollToZoom || null }
 				data-map-height={ mapHeight || null }
+				data-show-fullscreen-button={ showFullscreenButton || null }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -74,6 +74,10 @@ export const settings = {
 		mapHeight: {
 			type: 'integer',
 		},
+		showFullscreenButton: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 	supports: {
 		html: false,

--- a/extensions/blocks/map/style.scss
+++ b/extensions/blocks/map/style.scss
@@ -19,4 +19,8 @@
 		}
 		max-width: 300px;
 	}
+	.mapboxgl-ctrl-group button {
+		// Prevents theme styles adding a border radius to all buttons affecting the Map block controls too.
+		border-radius: 0;
+	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #11892

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevent theme styles adding a border radius to all buttons affecting the Map block controls too.

| Before | After |
| - | - |
| <img width="130" alt="image" src="https://user-images.githubusercontent.com/87168/48888954-f2937a80-ee3c-11e8-9885-85ebd259adc2.png"> | <img width="100" alt="Screenshot 2020-02-14 at 17 11 07" src="https://user-images.githubusercontent.com/2070010/74552408-144eb500-4f4d-11ea-8b36-4f16bc84e6cb.png"> |

* Add the fullscreen control as a block attribute.

<img width="1020" alt="Screenshot 2020-02-19 at 15 00 05" src="https://user-images.githubusercontent.com/2070010/74846603-a4fc0b00-5328-11ea-99b1-414548673e08.png">

In the editor, the fullscreen button will always be disabled.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ⚠️ **Before applying the PR** add a Map block to a post in order to test if the block attributes are migrated correctly.
* Test the PR with a theme that adds border radius to buttons (e.g. Twenty Nineteen).
* Open the editor and make sure the pre-existing Map block show up without issues. Check in the code editor that has the new `showFullscreenButton` attribute. 
* Preview on the front end and make sure the horizontal separator in the zoom controls is straight (compare to before/after screens).
* Enable and disable the "Show fullscreen button" setting, and check that it works as expected in both editor and front end, and that the fullscreen control is always disabled in the editor.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add a "show fullscreen button" setting to the Map block.
