### PR TITLE
Blocks: Update the block scaffolding

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1890,7 +1890,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 		$hasKeywords = isset( $assoc_args['keywords'] );
 
 		$files = array(
-			"$path/$slug.php"   => $this->render_block_file(
+			"$path/$slug.php"     => $this->render_block_file(
 				'block-register-php',
 				array(
 					'slug'            => $slug,
@@ -1899,7 +1899,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 					'jetpackVersion'  => substr( JETPACK__VERSION, 0, strpos( JETPACK__VERSION, '.' ) ) . '.x',
 				)
 			),
-			"$path/index.js"    => $this->render_block_file(
+			"$path/index.js"      => $this->render_block_file(
 				'block-index-js',
 				array(
 					'slug'        => $slug,
@@ -1919,21 +1919,23 @@ class Jetpack_CLI extends WP_CLI_Command {
 					'hasKeywords' => $hasKeywords,
 				)
 			),
-			"$path/editor.js"   => $this->render_block_file( 'block-editor-js' ),
-			"$path/editor.scss" => $this->render_block_file(
+			"$path/editor.js"     => $this->render_block_file( 'block-editor-js' ),
+			"$path/editor.scss"   => $this->render_block_file(
 				'block-editor-scss',
 				array(
 					'slug'  => $slug,
 					'title' => $title,
 				)
 			),
-			"$path/edit.js"     => $this->render_block_file(
+			"$path/edit.js"       => $this->render_block_file(
 				'block-edit-js',
 				array(
 					'title'     => $title,
 					'className' => str_replace( ' ', '', ucwords( str_replace( '-', ' ', $slug ) ) ),
 				)
 			),
+			"$path/icon.js"       => $this->render_block_file( 'block-icon-js' ),
+			"$path/attributes.js" => $this->render_block_file( 'block-attributes-js' ),
 		);
 
 		$files_written = array();

--- a/wp-cli-templates/block-attributes-js.mustache
+++ b/wp-cli-templates/block-attributes-js.mustache
@@ -1,0 +1,3 @@
+export default {
+	// @TODO - Add block attributes here
+};

--- a/wp-cli-templates/block-edit-js.mustache
+++ b/wp-cli-templates/block-edit-js.mustache
@@ -2,26 +2,42 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { BlockIcon } from '@wordpress/block-editor';
+import { Notice, Placeholder} from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import icon from './icon';
 
-class {{ className }}Edit extends Component {
+export default function {{ className }}Edit( { attributes, className, setAttributes } ) {
 	/**
 	 * Write the block editor UI.
 	 *
 	 * @returns {object} The UI displayed when user edits this block.
 	 */
-    render() {
-        const { attributes, setAttributes } = this.props;
+	const [ notice, setNotice ] = useState();
 
-        return (
-			<p>{ __( 'Block edit goes here', 'jetpack' ) }</p>
-        );
-    }
+	const setErrorNotice = () => __( 'Put error message here.', 'jetpack' );
+
+	return (
+		<div className={ className }>
+			<Placeholder
+				label={ __( '{{ title }}', 'jetpack' ) }
+				instructions={ __( 'Instructions go here.', 'jetpack' ) }
+				icon={ <BlockIcon icon={ icon } /> }
+				notices={
+					notice && (
+						<Notice status="error" isDismissible={ false }>
+							{ notice }
+						</Notice>
+					)
+				}
+			>
+				{ __( 'User input goes here?', 'jetpack' ) }
+			</Placeholder>
+		</div>
+	);
 }
-
-export default {{ className }}Edit;

--- a/wp-cli-templates/block-edit-js.mustache
+++ b/wp-cli-templates/block-edit-js.mustache
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockIcon } from '@wordpress/block-editor';
-import { Notice, Placeholder} from '@wordpress/components';
+import { Notice, Placeholder } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 /**
@@ -20,7 +20,8 @@ export default function {{ className }}Edit( { attributes, className, setAttribu
 	 */
 	const [ notice, setNotice ] = useState();
 
-	const setErrorNotice = () => __( 'Put error message here.', 'jetpack' );
+	/* Call this function when you want to show an error in the placeholder. */
+	const setErrorNotice = () => setNotice( __( 'Put error message here.', 'jetpack' ) );
 
 	return (
 		<div className={ className }>

--- a/wp-cli-templates/block-icon-js.mustache
+++ b/wp-cli-templates/block-icon-js.mustache
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	</SVG>
+);

--- a/wp-cli-templates/block-icon-js.mustache
+++ b/wp-cli-templates/block-icon-js.mustache
@@ -4,6 +4,7 @@
 import { SVG, Path } from '@wordpress/components';
 
 export default (
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
 	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
 	</SVG>

--- a/wp-cli-templates/block-index-js.mustache
+++ b/wp-cli-templates/block-index-js.mustache
@@ -8,8 +8,9 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import renderMaterialIcon from '../../shared/render-material-icon';
+import attributes from './attributes';
 import edit from './edit';
+import icon from './icon';
 
 /**
  * Style dependencies
@@ -20,23 +21,16 @@ export const name = '{{ slug }}';
 export const title = __( '{{ title }}', 'jetpack' );
 export const settings = {
 	title,
-
 	description: (
 		<Fragment>
 			<p>{ __( '{{ description }}', 'jetpack' ) }</p>
 			<ExternalLink href="#">{ __( 'Learn more about {{ title }}', 'jetpack' ) }</ExternalLink>
 		</Fragment>
 	),
-
 	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
-	icon: renderMaterialIcon(
-		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
-	),
-
+	icon,
 	category: 'jetpack',
-
 	keywords: [{{#keywords}}_x( '{{ keyword }}', 'block search term', 'jetpack' ), {{/keywords}}],
-
 	supports: {
 		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
 		align: false, /* if set to true, the 'align' option below can be used*/
@@ -59,12 +53,10 @@ export const settings = {
 		// When false, the block won't be available to be converted into a reusable block.
 		reusable: true,
 	},
-
 	edit,
-
 	/* @TODO Write the block editor output */
 	save: () => null,
-
+	attributes,
 	example: {
 		attributes: {
 			// @TODO: Add default values for block attributes, for generating the block preview.

--- a/wp-cli-templates/block-index-js.mustache
+++ b/wp-cli-templates/block-index-js.mustache
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __{{#hasKeywords}}, _x{{/hasKeywords}} } from '@wordpress/i18n';
-import { ExternalLink, Path } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -27,7 +27,6 @@ export const settings = {
 			<ExternalLink href="#">{ __( 'Learn more about {{ title }}', 'jetpack' ) }</ExternalLink>
 		</Fragment>
 	),
-	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
 	icon,
 	category: 'jetpack',
 	keywords: [{{#keywords}}_x( '{{ keyword }}', 'block search term', 'jetpack' ), {{/keywords}}],


### PR DESCRIPTION
This updates the block scaffolding to be more aligned with the most recent blocks we have created.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use functional components rather than a class
* Put the icon in a separate file
* Put the attributes in a separate file
* Use a block placeholder

There are more things we could do, but I thought this was a good first step.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Change to an existing feature.

#### Testing instructions:
* Run `yarn docker:wp jetpack scaffold block "Cool block"`
* Open the editor
* Try adding a "Cool block" to the editor.
* Check that the block loads correctly

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Change the block scaffolding to use functional components
