### PR TITLE
Map Block: On select, only show the Add Marker UI if there are no markers

### DIFF
--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -281,7 +281,7 @@ class MapEdit extends Component {
 						apiKey={ apiKey }
 						onSetPoints={ value => setAttributes( { points: value } ) }
 						onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
-						onMapLoaded={ () => this.setState( { addPointVisibility: true } ) }
+						onMapLoaded={ () => this.setState( { addPointVisibility: ! points.length } ) }
 						onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
 						onError={ this.onError }
 					>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #11870

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When selecting a Map block, only show the Add Marker UI if there are no existing markers.

Props @jeffersonrabb for the solution!

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the editor and add two Map blocks.
* Select the first map: make sure you are prompted to add a marker.
* Add a marker.
* Leave the second map without markers.
* Save and reload the editor.
* Select the map with a marker: make sure you are **not** prompted to add a new marker. You should still be able to add them via the Add Marker toolbar button.
* Select the map without markers: make sure you are prompted to add a marker.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Map Block: On select, only show the Add Marker UI if there are no markers.
