### PR TITLE
Sync amp-options by default

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -46,6 +46,9 @@ class Jetpack_AMP_Support {
 
 		// Filter photon image args for AMP Stories.
 		add_filter( 'jetpack_photon_post_image_args', array( 'Jetpack_AMP_Support', 'filter_photon_post_image_args_for_stories' ), 10, 2 );
+
+		// Sync the amp-options.
+		add_filter( 'jetpack_options_whitelist', array( 'Jetpack_AMP_Support', 'filter_jetpack_options_whitelist' ) );
 	}
 
 	/**
@@ -441,6 +444,19 @@ class Jetpack_AMP_Support {
 		}
 
 		return $args;
+	}
+
+	/**
+	 *  Adds amp-options to the list of options to sync, if AMP is available
+	 *
+	 * @param array $options_whitelist Whitelist of options to sync.
+	 * @return array Updated options whitelist
+	 */
+	public static function filter_jetpack_options_whitelist( $options_whitelist ) {
+		if ( function_exists( 'is_amp_endpoint' ) ) {
+			$options_whitelist[] = 'amp-options';
+		}
+		return $options_whitelist;
 	}
 }
 

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -158,7 +158,6 @@ class Defaults {
 		'site_user_type',
 		'site_vertical',
 		'jetpack_excluded_extensions',
-		'amp-options',
 	);
 
 	/**

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -158,6 +158,7 @@ class Defaults {
 		'site_user_type',
 		'site_vertical',
 		'jetpack_excluded_extensions',
+		'amp-options',
 	);
 
 	/**
@@ -395,7 +396,7 @@ class Defaults {
 		'snitch',
 		'vip-legacy-redirect',
 		'wp_automatic',
-		'wp-rest-api-log', // https://wordpress.org/plugins/wp-rest-api-log/
+		'wp-rest-api-log', // https://wordpress.org/plugins/wp-rest-api-log/.
 		'wpephpcompat_jobs',
 		'wprss_feed_item',
 	);

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,7 +198,6 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'site_vertical'                        => 'pineapple',
 			'jetpack_excluded_extensions'          => 'pineapple',
 			'jetpack-memberships-connected-account-id' => '340',
-			'amp-options'                              => array( 'experiences' => array( 'website' ) ) // phpcs:ignore
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -198,6 +198,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'site_vertical'                        => 'pineapple',
 			'jetpack_excluded_extensions'          => 'pineapple',
 			'jetpack-memberships-connected-account-id' => '340',
+			'amp-options'                              => array( 'experiences' => array( 'website' ) ) // phpcs:ignore
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
In order to understand AMP compatibility with Jetpack sites, it's very helpful to sync amp-options.

Alternatively, the AMP plugin could filter `jetpack_options_whitelist` and inject this themselves. That could be a better approach?

cc @westonruter 