### PR TITLE
Instant Search: Hide mobile filters after applying filters

### DIFF
--- a/modules/search/instant-search/components/jetpack-colophon.jsx
+++ b/modules/search/instant-search/components/jetpack-colophon.jsx
@@ -35,7 +35,7 @@ const logoPath = (
 const logoSize = 12;
 
 const JetpackColophon = props => {
-	const locale_prefix = props.locale.split( '-', 1 )[ 0 ];
+	const locale_prefix = typeof props.locale === 'string' ? props.locale.split( '-', 1 )[ 0 ] : null;
 	const url =
 		locale_prefix && locale_prefix !== 'en'
 			? 'https://' + locale_prefix + '.jetpack.com/search'

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -24,6 +24,7 @@ export default class SearchFilters extends Component {
 
 	onClearFilters = () => {
 		clearFiltersFromQuery();
+		this.props.onChange && this.props.onChange();
 	};
 
 	hasActiveFilters() {

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -19,6 +19,7 @@ import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/qu
 export default class SearchFilters extends Component {
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
+		this.props.onChange && this.props.onChange();
 	};
 
 	onClearFilters = () => {

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -29,7 +29,10 @@ class SearchForm extends Component {
 	};
 
 	onChangeQuery = event => setSearchQuery( event.target.value );
-	onChangeSort = sort => setSortQuery( sort );
+	onChangeSort = sort => {
+		setSortQuery( sort );
+		this.hideFilters();
+	};
 
 	hideFilters = () => this.setState( () => ( { showFilters: false } ) );
 	toggleFilters = event => {

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -17,7 +17,6 @@ import {
 	getFilterQuery,
 	getSearchQuery,
 	getSortQuery,
-	setFilterQuery,
 	setSearchQuery,
 	setSortQuery,
 } from '../lib/query-string';
@@ -29,10 +28,10 @@ class SearchForm extends Component {
 		showFilters: !! this.props.widget,
 	};
 
-	onChangeFilter = ( filterName, filterValue ) => setFilterQuery( filterName, filterValue );
 	onChangeQuery = event => setSearchQuery( event.target.value );
 	onChangeSort = sort => setSortQuery( sort );
 
+	hideFilters = () => this.setState( () => ( { showFilters: false } ) );
 	toggleFilters = event => {
 		if (
 			event.type === 'click' ||
@@ -69,7 +68,7 @@ class SearchForm extends Component {
 								filters={ getFilterQuery() }
 								loading={ this.props.isLoading }
 								locale={ this.props.locale }
-								onChange={ this.onChangeFilter }
+								onChange={ this.hideFilters }
 								postTypes={ this.props.postTypes }
 								results={ this.props.response }
 								widget={ widget }


### PR DESCRIPTION
Fixes #14606.

#### Changes proposed in this Pull Request:
* Hides the mobile filter popover after a filter has been selected.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Ensure that you've added a Jetpack Search widget with search filters into the Jetpack Sidebar.
2. Perform a search on your site and resize your viewport to be narrower than 768 pixels.
3. Click on the filter toggle button adjacent to the overlay search input. Ensure that the mobile filter popover appears.
4. Click on any search filter toggle. Ensure that the filter is applied and the popover is automatically closed.

#### Proposed changelog entry for your changes:
* None.
