### PR TITLE
Instant Search: Properly handle numerical searches

### DIFF
--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -9,9 +9,8 @@ export function getThemeOptions( searchOptions ) {
 		searchInputSelector: [
 			'input[name="s"]',
 			'#searchform input.search-field',
-			'.search-form input.search-field',
+			'.search-form input.search-field:not(.jetpack-instant-search__box-input)',
 			'.searchform input.search-field',
-			'.jetpack-instant-search-wrapper input.search-field',
 		].join( ', ' ),
 		searchSortSelector: [ '.jetpack-search-sort' ],
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -36,7 +36,8 @@ function pushQueryString( queryString, shouldEmitEvent = true ) {
 
 export function getSearchQuery() {
 	const query = getQuery();
-	return 's' in query ? decodeURIComponent( query.s.replace( /\+/g, '%20' ) ) : '';
+	// Cast query.s as string since it can be a number
+	return 's' in query ? decodeURIComponent( String( query.s ) ) : '';
 }
 
 export function setSearchQuery( searchValue ) {


### PR DESCRIPTION
Fixes #14671.

#### Changes proposed in this Pull Request:
* Fixes a bug that prevents purely numerical search queries in Jetpack Instant Search.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No, this is a bugfix.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Please note that the Jetpack Search widget will need to be added to twice: once to your site sidebar/footer and once to the Jetpack Search Sidebar within the search overlay.

2. Search your site using only numbers, such as `123`.

#### Proposed changelog entry for your changes:
* No changelog necessary.
