### PR TITLE
Tiled gallery: add next-prev image order buttons

### DIFF
--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -128,6 +128,32 @@ class TiledGalleryEdit extends Component {
 		} );
 	};
 
+	onMove = ( oldIndex, newIndex ) => {
+		const images = [ ...this.props.attributes.images ];
+		images.splice( newIndex, 1, this.props.attributes.images[ oldIndex ] );
+		images.splice( oldIndex, 1, this.props.attributes.images[ newIndex ] );
+		this.setState( { selectedImage: newIndex } );
+		this.setAttributes( { images } );
+	};
+
+	onMoveForward = oldIndex => {
+		return () => {
+			if ( oldIndex === this.props.attributes.images.length - 1 ) {
+				return;
+			}
+			this.onMove( oldIndex, oldIndex + 1 );
+		};
+	};
+
+	onMoveBackward = oldIndex => {
+		return () => {
+			if ( oldIndex === 0 ) {
+				return;
+			}
+			this.onMove( oldIndex, oldIndex - 1 );
+		};
+	};
+
 	setColumnsNumber = value => this.setAttributes( { columns: value } );
 
 	setImageAttributes = index => attributes => {
@@ -255,6 +281,8 @@ class TiledGalleryEdit extends Component {
 					images={ images }
 					layoutStyle={ layoutStyle }
 					linkTo={ linkTo }
+					onMoveBackward={ this.onMoveBackward }
+					onMoveForward={ this.onMoveForward }
 					onRemoveImage={ this.onRemoveImage }
 					onSelectImage={ this.onSelectImage }
 					selectedImage={ isSelected ? selectedImage : null }

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -63,6 +63,44 @@
 				width: 100%;
 			}
 		}
+
+		&.is-selected .tiled-gallery__item__move-menu,
+		&.is-selected .tiled-gallery__item__inline-menu {
+			background: $white;
+			border: 1px solid $dark-opacity-light-800;
+			border-radius: $radius-round-rectangle;
+			transition: box-shadow 0.2s ease-out;
+			@include reduce-motion("transition");
+
+			&:hover {
+				box-shadow: $shadow-toolbar;
+			}
+
+			.components-button {
+				color: $dark-opacity-300;
+				padding: 2px;
+				height: $icon-button-size-small;
+
+				// Remove hover box shadows, since they clash with the container.
+				&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover {
+					box-shadow: none;
+				}
+
+				@include break-small() {
+					// Use smaller buttons to fit when there are many columns.
+					.columns-7 &,
+					.columns-8 & {
+						padding: 0;
+						width: inherit;
+						height: inherit;
+					}
+				}
+			}
+
+			.components-button:focus {
+				color: inherit;
+			}
+		}
 	}
 
 	.tiled-gallery__add-item {
@@ -95,23 +133,39 @@
 		}
 	}
 
+	.tiled-gallery__item__move-menu,
 	.tiled-gallery__item__inline-menu {
-		background-color: $tiled-gallery-selection;
+		margin: $grid-size;
 		display: inline-flex;
-		padding: 0 0 2px 2px;
-		position: absolute;
-		right: 0;
-		top: 0;
+		z-index: z-index(".block-library-gallery-item__inline-menu");
 
 		.components-button {
-			color: $white;
-			&:hover,
-			&:focus {
-				color: $white;
+			color: transparent;
+		}
+
+		@include break-small() {
+			// Use smaller buttons to fit when there are many columns.
+			.columns-7 &,
+			.columns-8 & {
+				padding: $grid-size-small / 2;
 			}
 		}
 	}
 
+	.tiled-gallery__item__inline-menu {
+		position: absolute;
+		top: -2px;
+		right: -2px;
+	}
+
+	.tiled-gallery__item__move-menu {
+		position: absolute;
+		top: -2px;
+		left: -2px;
+	}
+
+	.tiled-gallery__item__move-backward,
+	.tiled-gallery__item__move-forward,
 	.tiled-gallery__item__remove {
 		padding: 0;
 	}

--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -12,7 +12,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { close, leftArrow, rightArrow } from '../icons';
+import { close, downChevron, leftChevron, rightChevron, upChevron } from '../icons';
 
 class GalleryImageEdit extends Component {
 	img = createRef();
@@ -65,6 +65,7 @@ class GalleryImageEdit extends Component {
 		const {
 			'aria-label': ariaLabel,
 			alt,
+			columns,
 			height,
 			id,
 			imageFilter,
@@ -132,7 +133,7 @@ class GalleryImageEdit extends Component {
 			>
 				<div className="tiled-gallery__item__move-menu">
 					<IconButton
-						icon={ leftArrow }
+						icon={ columns === 1 ? upChevron : leftChevron }
 						onClick={ isFirstItem ? undefined : onMoveBackward }
 						className="tiled-gallery__item__move-backward"
 						label={ __( 'Move image backward', 'jetpack' ) }
@@ -140,7 +141,7 @@ class GalleryImageEdit extends Component {
 						disabled={ ! isSelected }
 					/>
 					<IconButton
-						icon={ rightArrow }
+						icon={ columns === 1 ? downChevron : rightChevron }
 						onClick={ isLastItem ? undefined : onMoveForward }
 						className="tiled-gallery__item__move-forward"
 						label={ __( 'Move image forward', 'jetpack' ) }

--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -5,9 +5,14 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { Component, createRef, Fragment } from '@wordpress/element';
-import { IconButton, Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 import { withSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { close, leftArrow, rightArrow } from '../icons';
 
 class GalleryImageEdit extends Component {
 	img = createRef();
@@ -63,9 +68,13 @@ class GalleryImageEdit extends Component {
 			height,
 			id,
 			imageFilter,
+			isFirstItem,
+			isLastItem,
 			isSelected,
 			link,
 			linkTo,
+			onMoveBackward,
+			onMoveForward,
 			onRemove,
 			origUrl,
 			srcSet,
@@ -121,16 +130,33 @@ class GalleryImageEdit extends Component {
 					[ `filter__${ imageFilter }` ]: !! imageFilter,
 				} ) }
 			>
-				{ isSelected && (
-					<div className="tiled-gallery__item__inline-menu">
-						<IconButton
-							icon="no-alt"
-							onClick={ onRemove }
-							className="tiled-gallery__item__remove"
-							label={ __( 'Remove Image', 'jetpack' ) }
-						/>
-					</div>
-				) }
+				<div className="tiled-gallery__item__move-menu">
+					<Button
+						icon={ leftArrow }
+						onClick={ isFirstItem ? undefined : onMoveBackward }
+						className="tiled-gallery__item__move-backward"
+						label={ __( 'Move image backward', 'jetpack' ) }
+						aria-disabled={ isFirstItem }
+						disabled={ ! isSelected }
+					/>
+					<Button
+						icon={ rightArrow }
+						onClick={ isLastItem ? undefined : onMoveForward }
+						className="tiled-gallery__item__move-forward"
+						label={ __( 'Move image forward', 'jetpack' ) }
+						aria-disabled={ isLastItem }
+						disabled={ ! isSelected }
+					/>
+				</div>
+				<div className="tiled-gallery__item__inline-menu">
+					<Button
+						icon={ close }
+						onClick={ onRemove }
+						className="tiled-gallery__item__remove"
+						label={ __( 'Remove image', 'jetpack' ) }
+						disabled={ ! isSelected }
+					/>
+				</div>
 				{ /* Keep the <a> HTML structure, but ensure there is no navigation from edit */
 				/* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
 				{ href ? <a>{ img }</a> : img }

--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { Component, createRef, Fragment } from '@wordpress/element';
-import { Button, Spinner } from '@wordpress/components';
+import { IconButton, Spinner } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 import { withSelect } from '@wordpress/data';
 
@@ -131,7 +131,7 @@ class GalleryImageEdit extends Component {
 				} ) }
 			>
 				<div className="tiled-gallery__item__move-menu">
-					<Button
+					<IconButton
 						icon={ leftArrow }
 						onClick={ isFirstItem ? undefined : onMoveBackward }
 						className="tiled-gallery__item__move-backward"
@@ -139,7 +139,7 @@ class GalleryImageEdit extends Component {
 						aria-disabled={ isFirstItem }
 						disabled={ ! isSelected }
 					/>
-					<Button
+					<IconButton
 						icon={ rightArrow }
 						onClick={ isLastItem ? undefined : onMoveForward }
 						className="tiled-gallery__item__move-forward"
@@ -149,7 +149,7 @@ class GalleryImageEdit extends Component {
 					/>
 				</div>
 				<div className="tiled-gallery__item__inline-menu">
-					<Button
+					<IconButton
 						icon={ close }
 						onClick={ onRemove }
 						className="tiled-gallery__item__remove"

--- a/extensions/blocks/tiled-gallery/icons.js
+++ b/extensions/blocks/tiled-gallery/icons.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+/**
+ * @todo: Replace with `@wordpress/icons` when available
+ */
+export const leftArrow = (
+	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M5 8.70002L10.6 14.4L12 12.9L7.8 8.70002L12 4.50002L10.6 3.00002L5 8.70002Z" />
+	</SVG>
+);
+
+/**
+ * @todo: Replace with `@wordpress/icons` when available
+ */
+export const rightArrow = (
+	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M13 8.7L7.4 3L6 4.5L10.2 8.7L6 12.9L7.4 14.4L13 8.7Z" />
+	</SVG>
+);
+
+/**
+ * @todo: Replace with `@wordpress/icons` when available
+ */
+export const close = (
+	<SVG width="18" height="18" viewBox="-2 -2 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M14.95 6.46L11.41 10l3.54 3.54-1.41 1.41L10 11.42l-3.53 3.53-1.42-1.42L8.58 10 5.05 6.47l1.42-1.42L10 8.58l3.54-3.53z" />
+	</SVG>
+);

--- a/extensions/blocks/tiled-gallery/icons.js
+++ b/extensions/blocks/tiled-gallery/icons.js
@@ -6,7 +6,7 @@ import { Path, SVG } from '@wordpress/components';
 /**
  * @todo: Replace with `@wordpress/icons` when available
  */
-export const leftArrow = (
+export const leftChevron = (
 	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M5 8.70002L10.6 14.4L12 12.9L7.8 8.70002L12 4.50002L10.6 3.00002L5 8.70002Z" />
 	</SVG>
@@ -15,9 +15,27 @@ export const leftArrow = (
 /**
  * @todo: Replace with `@wordpress/icons` when available
  */
-export const rightArrow = (
+export const rightChevron = (
 	<SVG width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M13 8.7L7.4 3L6 4.5L10.2 8.7L6 12.9L7.4 14.4L13 8.7Z" />
+	</SVG>
+);
+
+/**
+ * @todo: Replace with `@wordpress/icons` when available
+ */
+export const downChevron = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M7.41,8.59L12,13.17l4.59-4.58L18,10l-6,6l-6-6L7.41,8.59z" />
+	</SVG>
+);
+
+/**
+ * @todo: Replace with `@wordpress/icons` when available
+ */
+export const upChevron = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M12,8l-6,6l1.41,1.41L12,10.83l4.59,4.58L18,14L12,8z" />
 	</SVG>
 );
 

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -26,6 +26,8 @@ export default class Layout extends Component {
 			isSave,
 			linkTo,
 			layoutStyle,
+			onMoveBackward,
+			onMoveForward,
 			onRemoveImage,
 			onSelectImage,
 			selectedImage,
@@ -49,10 +51,14 @@ export default class Layout extends Component {
 				height={ img.height }
 				id={ img.id }
 				imageFilter={ imageFilter }
+				isFirstItem={ i === 0 }
+				isLastItem={ i + 1 === images.length }
 				isSelected={ selectedImage === i }
 				key={ i }
 				link={ img.link }
 				linkTo={ linkTo }
+				onMoveBackward={ isSave ? undefined : onMoveBackward( i ) }
+				onMoveForward={ isSave ? undefined : onMoveForward( i ) }
 				onRemove={ isSave ? undefined : onRemoveImage( i ) }
 				onSelect={ isSave ? undefined : onSelectImage( i ) }
 				origUrl={ img.url }

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -21,6 +21,7 @@ export default class Layout extends Component {
 	//   This is because the images are stored in an array in the block attributes.
 	renderImage( img, i ) {
 		const {
+			columns,
 			imageFilter,
 			images,
 			isSave,
@@ -48,6 +49,7 @@ export default class Layout extends Component {
 			<Image
 				alt={ img.alt }
 				aria-label={ ariaLabel }
+				columns={ columns }
 				height={ img.height }
 				id={ img.id }
 				imageFilter={ imageFilter }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack/issues/14546

This was a pretty quick one by mostly copying from the core. Not entirely sure how to give credit back.

#### Changes proposed in this Pull Request:
* Add next/prev buttons
* Adjust close-button style to match core gallery:

**Before**
<img width="159" alt="Screenshot 2020-02-16 at 23 00 08" src="https://user-images.githubusercontent.com/87168/74612695-773c7980-5110-11ea-8d9b-abea952ecaff.png">

**After**
<img width="127" alt="image" src="https://user-images.githubusercontent.com/87168/74612702-88858600-5110-11ea-8ac0-bc51b9a729b4.png">


Mostly just copied code from [core gallery](https://github.com/WordPress/gutenberg/tree/78de49ede8fac2cf76600e9048d653d56ab30c11/packages/block-library/src/gallery) to align. This could be re-usable somehow from the core but I think using inner blocks for the UI would be a better approach than sharing components for this (see example "buttons" block).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Improve! 💪 

#### Testing instructions:
- Add tiled gallery and add some images to it
- Ensure you can still re-arrange it via regular media modal: 
    <img width="400" alt="Screenshot 2020-02-15 at 18 42 40" src="https://user-images.githubusercontent.com/87168/74612488-89b5b380-510e-11ea-8fe1-0bf694a3f995.png">
- Ensure you can re-arrange images via arrow buttons — test all layouts:
    <img width="400" alt="Screenshot 2020-02-15 at 18 41 21" src="https://user-images.githubusercontent.com/87168/74612509-a5b95500-510e-11ea-88d5-953472b02906.png">
- Ensure first and last image have disabled next/prev buttons:
    <img width="130" alt="Screenshot 2020-02-15 at 18 41 52" src="https://user-images.githubusercontent.com/87168/74612493-8f12fe00-510e-11ea-8fd1-0d440cf1fa05.png">
- Ensure very small images work
    <img width="150" alt="Screenshot 2020-02-15 at 18 41 34" src="https://user-images.githubusercontent.com/87168/74612521-bb2e7f00-510e-11ea-9d9a-a5cc722a4230.png">
- Ensure arrows switch to up/down arrows when using only one column layout
    <img width="400" alt="Screenshot 2020-02-16 at 22 58 38" src="https://user-images.githubusercontent.com/87168/74612656-08f7b700-5110-11ea-9a73-7fb6149a421f.png">




#### Proposed changelog entry for your changes:
* Easily re-arrange images in Tiled gallery
