### PR TITLE
Block version gating

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -119,20 +119,33 @@ class Jetpack_Gutenberg {
 			return false;
 		}
 
-		if ( is_file( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' ) ) {
+		$current_plugin_version = self::get_plugin_version();
 
-			if ( ! function_exists( 'get_plugin_data' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			}
-
-			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
-
-			if ( isset( $plugin_data['Version'] ) ) {
-				return $plugin_data['Version'] < $plugin_version;
-			}
+		if ( ! empty( $current_plugin_version ) ) {
+			return $current_plugin_version < $plugin_version;
 		}
 
 		return version_compare( $wp_version, $core_wp_version, '<' );
+	}
+
+	/**
+	 * Get the version of gutenberg plugin if it is installed
+	 *
+	 * @since 8.4.0
+	 *
+	 * @return string Verion number of installed gutenberg plugin.
+	 */
+	public static function get_plugin_version() {
+		if ( is_file( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' ) ) {
+			if ( ! function_exists( 'get_plugin_data' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			}
+			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
+
+			if ( isset( $plugin_data['Version'] ) ) {
+				return $plugin_data['Version'];
+			}
+		}
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -115,37 +115,15 @@ class Jetpack_Gutenberg {
 	public static function is_block_version_gated( $core_wp_version, $plugin_version ) {
 		global $wp_version;
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) {
 			return false;
 		}
 
-		$current_plugin_version = self::get_plugin_version();
-
-		if ( ! empty( $current_plugin_version ) ) {
-			return $current_plugin_version < $plugin_version;
+		if ( defined( 'GUTENBERG_VERSION' ) ) {
+			return GUTENBERG_VERSION < $plugin_version;
 		}
 
 		return version_compare( $wp_version, $core_wp_version, '<' );
-	}
-
-	/**
-	 * Get the version of gutenberg plugin if it is installed
-	 *
-	 * @since 8.4.0
-	 *
-	 * @return string Verion number of installed gutenberg plugin.
-	 */
-	public static function get_plugin_version() {
-		if ( is_file( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' ) ) {
-			if ( ! function_exists( 'get_plugin_data' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			}
-			$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/gutenberg/gutenberg.php' );
-
-			if ( isset( $plugin_data['Version'] ) ) {
-				return $plugin_data['Version'];
-			}
-		}
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -115,7 +115,7 @@ class Jetpack_Gutenberg {
 	public static function is_block_version_gated( $core_wp_version, $plugin_version ) {
 		global $wp_version;
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! jetpack_is_atomic_site() ) {
 			return false;
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -96,10 +96,10 @@ class Jetpack_Gutenberg {
 
 	/**
 	 * Check to see if a minimum version of Gutenberg is available. Because a Gutenberg version is not available in
-	 * php if the Gutenberg plugin is not installed, we also need the minimum WordPress version that was released
-	 * with the required Gutenberg version.
+	 * php if the Gutenberg plugin is not installed, if we know which minimum WP release has the required version we can
+	 * optionally fall back to that.
 	 *
-	 * @param array  $version_requirements An array containing the required Gutenberg version and the WordPress version that was released with this minimum version.
+	 * @param array  $version_requirements An array containing the required Gutenberg version and, if known, the WordPress version that was released with this minimum version.
 	 * @param string $slug The slug of the block or plugin that has the gutenberg version requirement.
 	 *
 	 * @since 8.3.0
@@ -109,8 +109,8 @@ class Jetpack_Gutenberg {
 	public static function is_gutenberg_version_available( $version_requirements, $slug ) {
 		global $wp_version;
 
-		// Bail if the version requirements are not set correctly.
-		if ( empty( $version_requirements['gutenberg'] ) || empty( $version_requirements['wp'] ) ) {
+		// Bail if we don't at least have the gutenberg version requirement, the WP version is optional.
+		if ( empty( $version_requirements['gutenberg'] ) ) {
 			return false;
 		}
 
@@ -119,11 +119,13 @@ class Jetpack_Gutenberg {
 			return true;
 		}
 
-		// If running a production build of the gutenberg plugin then GUTENBERG_VERSION is set, otherwise check that
-		// we have a the minimum version of WordPress that was released with the required Gutenberg version.
+		$version_available = false;
+
+		// If running a production build of the gutenberg plugin then GUTENBERG_VERSION is set, otherwise if WP version
+		// with required version of Gutenberg is known check that.
 		if ( defined( 'GUTENBERG_VERSION' ) ) {
 			$version_available = version_compare( GUTENBERG_VERSION, $version_requirements['gutenberg'], '>=' );
-		} else {
+		} elseif ( ! empty( $version_requirements['wp'] ) ) {
 			$version_available = version_compare( $wp_version, $version_requirements['wp'], '>=' );
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -95,9 +95,11 @@ class Jetpack_Gutenberg {
 	private static $availability = array();
 
 	/**
-	 * Check to see if a minimum version of Gutenberg is available
+	 * Check to see if a minimum version of Gutenberg is available. Because a Gutenberg version is not available in
+	 * php if the Gutenberg plugin is not installed, we also need the minimum WordPress version that was released
+	 * with the required Gutenberg version
 	 *
-	 * @param array  $version_requirements An array containing WordPress and Gutenberg plugin version requirements.
+	 * @param array  $version_requirements An array containing the required Gutenberg version and the WordPress version that was released with this minimum version.
 	 * @param string $slug The slug of the block or plugin that has the gutenberg version requirement.
 	 *
 	 * @since 8.3.0
@@ -108,7 +110,7 @@ class Jetpack_Gutenberg {
 		global $wp_version;
 
 		// Bail if the version requirements are not set correctly.
-		if ( empty( $version_requirements['gutenberg_plugin'] ) || empty( $version_requirements['wp'] ) ) {
+		if ( empty( $version_requirements['gutenberg'] ) || empty( $version_requirements['wp'] ) ) {
 			return false;
 		}
 
@@ -120,7 +122,7 @@ class Jetpack_Gutenberg {
 		// If running a production build of the gutenberg plugin then GUTENBERG_VERSION is set, otherwise check that
 		// we have a the minimum version of WordPress that was released with the required Gutenberg version.
 		if ( defined( 'GUTENBERG_VERSION' ) ) {
-			$version_available = version_compare( GUTENBERG_VERSION, $version_requirements['gutenberg_plugin'], '>=' );
+			$version_available = version_compare( GUTENBERG_VERSION, $version_requirements['gutenberg'], '>=' );
 		} else {
 			$version_available = version_compare( $wp_version, $version_requirements['wp'], '>=' );
 		}
@@ -133,8 +135,8 @@ class Jetpack_Gutenberg {
 					'required_feature' => $slug,
 					'required_version' => $version_requirements,
 					'current_version'  => array(
-						'wp'                       => $wp_version,
-						'gutenberg_plugin_version' => defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : null,
+						'wp'        => $wp_version,
+						'gutenberg' => defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : null,
 					),
 				)
 			);

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -97,7 +97,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Check to see if a minimum version of Gutenberg is available. Because a Gutenberg version is not available in
 	 * php if the Gutenberg plugin is not installed, we also need the minimum WordPress version that was released
-	 * with the required Gutenberg version
+	 * with the required Gutenberg version.
 	 *
 	 * @param array  $version_requirements An array containing the required Gutenberg version and the WordPress version that was released with this minimum version.
 	 * @param string $slug The slug of the block or plugin that has the gutenberg version requirement.

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -115,7 +115,7 @@ class Jetpack_Gutenberg {
 	public static function is_block_version_gated( $core_wp_version, $plugin_version ) {
 		global $wp_version;
 
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM && ! jetpack_is_atomic_site() ) {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			return false;
 		}
 

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -149,4 +149,32 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$this->assertNotEmpty( $extensions );
 		$this->assertNotContains( 'onion', $extensions );
 	}
+
+	function test_block_not_version_gated_on_wpcom() {
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			$this->markTestSkipped( 'wpcom only test' );
+			return;
+		};
+		
+		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '999999', '999999');
+		$this->assertEquals( false, $version_gated );
+	}
+
+	function test_block_version_gated_if_core_wp_version_less_than_minimum() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->markTestSkipped( 'atomic and jetpack only test' );
+			return;
+		};
+		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '999999', '999999');
+		$this->assertEquals( true, $version_gated );
+	}
+
+	function test_block_not_version_gated_if_core_wp_version_greater_than_minimum() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->markTestSkipped( 'atomic and jetpack only test' );
+			return;
+		};
+		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '0', '999999');
+		$this->assertEquals( false, $version_gated );
+	}
 }

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -151,16 +151,16 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 	}
 
 	function test_returns_false_if_core_wp_version_less_than_minimum() {
-		$version_gated = Jetpack_Gutenberg::is_editor_version_available(
-			array( 'wp' => '999999', 'plugin' => '999999' ),
+		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
+			array( 'wp' => '999999', 'gutenberg_plugin' => '999999' ),
 			'gated_block'
 		);
 		$this->assertEquals( false, $version_gated );
 	}
 
 	function test_returns_true_if_core_wp_version_greater_or_equal_to_minimum() {
-		$version_gated = Jetpack_Gutenberg::is_editor_version_available(
-			array( 'wp' => '0', 'plugin' => '999999' ),
+		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
+			array( 'wp' => '0', 'gutenberg_plugin' => '999999' ),
 			'ungated_block'
 		);
 		$this->assertEquals( true, $version_gated );

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -152,7 +152,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	function test_returns_false_if_core_wp_version_less_than_minimum() {
 		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
-			array( 'wp' => '999999', 'gutenberg_plugin' => '999999' ),
+			array( 'wp' => '999999', 'gutenberg' => '999999' ),
 			'gated_block'
 		);
 		$this->assertEquals( false, $version_gated );
@@ -160,7 +160,7 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	function test_returns_true_if_core_wp_version_greater_or_equal_to_minimum() {
 		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
-			array( 'wp' => '0', 'gutenberg_plugin' => '999999' ),
+			array( 'wp' => '0', 'gutenberg' => '999999' ),
 			'ungated_block'
 		);
 		$this->assertEquals( true, $version_gated );

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -150,13 +150,19 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$this->assertNotContains( 'onion', $extensions );
 	}
 
-	function test_block_version_gated_if_core_wp_version_less_than_minimum() {
-		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '999999', '999999');
-		$this->assertEquals( true, $version_gated );
+	function test_returns_false_if_core_wp_version_less_than_minimum() {
+		$version_gated = Jetpack_Gutenberg::is_editor_version_available(
+			array( 'wp' => '999999', 'plugin' => '999999' ),
+			'gated_block'
+		);
+		$this->assertEquals( false, $version_gated );
 	}
 
-	function test_block_not_version_gated_if_core_wp_version_greater_than_minimum() {
-		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '0', '999999');
-		$this->assertEquals( false, $version_gated );
+	function test_returns_true_if_core_wp_version_greater_or_equal_to_minimum() {
+		$version_gated = Jetpack_Gutenberg::is_editor_version_available(
+			array( 'wp' => '0', 'plugin' => '999999' ),
+			'ungated_block'
+		);
+		$this->assertEquals( true, $version_gated );
 	}
 }

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -150,30 +150,12 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$this->assertNotContains( 'onion', $extensions );
 	}
 
-	function test_block_not_version_gated_on_wpcom() {
-		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
-			$this->markTestSkipped( 'wpcom only test' );
-			return;
-		};
-		
-		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '999999', '999999');
-		$this->assertEquals( false, $version_gated );
-	}
-
 	function test_block_version_gated_if_core_wp_version_less_than_minimum() {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->markTestSkipped( 'atomic and jetpack only test' );
-			return;
-		};
 		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '999999', '999999');
 		$this->assertEquals( true, $version_gated );
 	}
 
 	function test_block_not_version_gated_if_core_wp_version_greater_than_minimum() {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$this->markTestSkipped( 'atomic and jetpack only test' );
-			return;
-		};
 		$version_gated = Jetpack_Gutenberg::is_block_version_gated( '0', '999999');
 		$this->assertEquals( false, $version_gated );
 	}

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -152,7 +152,10 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	function test_returns_false_if_core_wp_version_less_than_minimum() {
 		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
-			array( 'wp' => '999999', 'gutenberg' => '999999' ),
+			array(
+				'wp'        => '999999',
+				'gutenberg' => '999999',
+			),
 			'gated_block'
 		);
 		$this->assertEquals( false, $version_gated );
@@ -160,7 +163,10 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 	function test_returns_true_if_core_wp_version_greater_or_equal_to_minimum() {
 		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
-			array( 'wp' => '0', 'gutenberg' => '999999' ),
+			array(
+				'wp'        => '1',
+				'gutenberg' => '999999',
+			),
 			'ungated_block'
 		);
 		$this->assertEquals( true, $version_gated );


### PR DESCRIPTION
Adds a version gating option block registration.

#### Changes proposed in this Pull Request:

* Some of the new blocks being created require specific versions of gutenberg. This PR introduces the ability to include min WP and gutenberg plugin versions in jetpack_register_block $args

* It also runs set_extension_unavailable if block is version gated in order to allow a version upgrade nudge to be added a later point.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* New feature.

#### Testing instructions:
* Check out this branch and build blocks
* Update `extensions/blocks/markdown/markdown.php` block registration to the following:
```php
jetpack_register_block( 'jetpack/markdown', array( 'version_requirements' => array( 'gutenberg' => '8', 'wp' => '7')) );
```
* Load the build in your local jetpack dev setup and check that `window.Jetpack_Editor_Initial_State.available_blocks;` shows 
```
markdown:
available: false
unavailable_reason: "incorrect_gutenberg_version"
details:
required_feature: "jetpack/markdown"
required_version: {gutenberg: "8", wp: "7"}
current_version: {wp: "5.3", gutenberg: "7.5.0"}
```
* Play around with modifying the gutenberg and wp versions, and the versions you are running and check block shows available or not.

**N.B.** Your local dev may set `GUTENBERG_DEVELOPMENT_MODE` in which case the block will always show available, in which case you can comment out the following in `class.jetpack-gutenberg.php` to test:
```php
if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE ) {
	return true;
}
```