### PR TITLE
Tiled gallery: gutter

### DIFF
--- a/extensions/blocks/tiled-gallery/constants.js
+++ b/extensions/blocks/tiled-gallery/constants.js
@@ -1,6 +1,7 @@
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const DEFAULT_GALLERY_WIDTH = 580;
-export const GUTTER_WIDTH = 4;
+export const DEFAULT_GUTTER = 4;
+export const MAX_GUTTER = 50;
 export const MAX_COLUMNS = 20;
 export const PHOTON_MAX_RESIZE = 2000;
 

--- a/extensions/blocks/tiled-gallery/constants.js
+++ b/extensions/blocks/tiled-gallery/constants.js
@@ -1,7 +1,13 @@
 export const ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const DEFAULT_GALLERY_WIDTH = 580;
-export const DEFAULT_GUTTER = 4;
-export const MAX_GUTTER = 50;
+export const DEFAULT_GUTTER = 'small';
+export const GUTTERS = {
+	// Fixed in CSS, see `variables.scss`
+	none: 0,
+	small: 4,
+	medium: 24,
+	large: 48,
+};
 export const MAX_COLUMNS = 20;
 export const PHOTON_MAX_RESIZE = 2000;
 

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -27,7 +27,7 @@ import {
  */
 import FilterToolbar from './filter-toolbar';
 import Layout from './layout';
-import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES, MAX_COLUMNS } from './constants';
+import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES, MAX_COLUMNS, MAX_GUTTER } from './constants';
 import { getActiveStyleName } from '../../shared/block-styles';
 import { icon } from '.';
 import EditButton from '../../shared/edit-button';
@@ -41,6 +41,10 @@ const linkOptions = [
 // @TODO keep here or move to ./layout ?
 function layoutSupportsColumns( layout ) {
 	return [ 'columns', 'circle', 'square' ].includes( layout );
+}
+
+function layoutSupportsGutter( layout ) {
+	return [ 'columns', 'rectangular' ].includes( layout );
 }
 
 export function defaultColumnsNumber( attributes ) {
@@ -130,6 +134,8 @@ class TiledGalleryEdit extends Component {
 
 	setColumnsNumber = value => this.setAttributes( { columns: value } );
 
+	setGutter = value => this.setAttributes( { gutter: value } );
+
 	setImageAttributes = index => attributes => {
 		const {
 			attributes: { images },
@@ -163,6 +169,7 @@ class TiledGalleryEdit extends Component {
 		const {
 			align,
 			columns = defaultColumnsNumber( attributes ),
+			gutter,
 			imageFilter,
 			images,
 			linkTo,
@@ -236,6 +243,15 @@ class TiledGalleryEdit extends Component {
 								max={ Math.min( MAX_COLUMNS, images.length ) }
 							/>
 						) }
+						{ layoutSupportsGutter( layoutStyle ) && images.length > 1 && (
+							<RangeControl
+								label={ __( 'Gutter', 'jetpack' ) }
+								value={ gutter }
+								onChange={ this.setGutter }
+								min={ 0 }
+								max={ MAX_GUTTER }
+							/>
+						) }
 						<SelectControl
 							label={ __( 'Link To', 'jetpack' ) }
 							value={ linkTo }
@@ -251,6 +267,7 @@ class TiledGalleryEdit extends Component {
 					align={ align }
 					className={ className }
 					columns={ columns }
+					gutter={ gutter }
 					imageFilter={ imageFilter }
 					images={ images }
 					layoutStyle={ layoutStyle }

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -1,9 +1,9 @@
 /**
  * External Dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { filter, get, pick } from 'lodash';
+import { filter, get, map, pick } from 'lodash';
 import {
 	BlockControls,
 	BlockIcon,
@@ -13,6 +13,9 @@ import {
 } from '@wordpress/block-editor';
 import { mediaUpload } from '@wordpress/editor';
 import {
+	BaseControl,
+	Button,
+	ButtonGroup,
 	DropZone,
 	FormFileUpload,
 	PanelBody,
@@ -27,7 +30,7 @@ import {
  */
 import FilterToolbar from './filter-toolbar';
 import Layout from './layout';
-import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES, MAX_COLUMNS, MAX_GUTTER } from './constants';
+import { ALLOWED_MEDIA_TYPES, GUTTERS, LAYOUT_STYLES, MAX_COLUMNS } from './constants';
 import { getActiveStyleName } from '../../shared/block-styles';
 import { icon } from '.';
 import EditButton from '../../shared/edit-button';
@@ -38,13 +41,25 @@ const linkOptions = [
 	{ value: 'none', label: __( 'None', 'jetpack' ) },
 ];
 
+// Gutter names are translated. Avoid introducing an i18n dependency elsewhere (view)
+// by only including the labels here, the only place they're needed.
+//
+// Gutter names to labels and merge them together.
+const gutterLabels = {
+	[ 'none' ]: _x( 'None', 'Tiled gallery gutter name', 'jetpack' ),
+	[ 'small' ]: _x( 'Small', 'Tiled gallery gutter name', 'jetpack' ),
+	[ 'medium' ]: _x( 'Medium', 'Tiled gallery gutter name', 'jetpack' ),
+	[ 'large' ]: _x( 'Large', 'Tiled gallery gutter name', 'jetpack' ),
+};
+
+const gutterOptions = map( GUTTERS, ( gutterPx, gutterName ) => ( {
+	value: gutterName,
+	label: gutterLabels[ gutterName ],
+} ) );
+
 // @TODO keep here or move to ./layout ?
 function layoutSupportsColumns( layout ) {
 	return [ 'columns', 'circle', 'square' ].includes( layout );
-}
-
-function layoutSupportsGutter( layout ) {
-	return [ 'columns', 'rectangular' ].includes( layout );
 }
 
 export function defaultColumnsNumber( attributes ) {
@@ -243,15 +258,25 @@ class TiledGalleryEdit extends Component {
 								max={ Math.min( MAX_COLUMNS, images.length ) }
 							/>
 						) }
-						{ layoutSupportsGutter( layoutStyle ) && images.length > 1 && (
-							<RangeControl
-								label={ __( 'Gutter', 'jetpack' ) }
-								value={ gutter }
-								onChange={ this.setGutter }
-								min={ 0 }
-								max={ MAX_GUTTER }
-							/>
-						) }
+						<SelectControl
+							label={ __( 'Gutter', 'jetpack' ) }
+							value={ gutter }
+							onChange={ this.setGutter }
+							options={ gutterOptions }
+						/>
+						<BaseControl id="tiled-gallery-gutter" label={ __( 'Gutter', 'jetpack' ) }>
+							<ButtonGroup id="tiled-gallery-gutter">
+								{ map( GUTTERS, ( gutterPx, gutterName ) => (
+									<Button
+										isDefault={ gutter !== gutterName }
+										isPrimary={ gutter === gutterName }
+										onClick={ () => this.setGutter( gutterName ) }
+									>
+										{ gutterLabels[ gutterName ] }
+									</Button>
+								) ) }
+							</ButtonGroup>
+						</BaseControl>
 						<SelectControl
 							label={ __( 'Link To', 'jetpack' ) }
 							value={ linkTo }

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -43,6 +43,7 @@
 
 		&.is-selected {
 			outline: 4px solid $tiled-gallery-selection;
+			z-index: z-index(".block-library-gallery-item__inline-menu");
 
 			// Disable filters when selected
 			filter: none;
@@ -66,7 +67,7 @@
 	}
 
 	.tiled-gallery__add-item {
-		margin-top: $tiled-gallery-gutter;
+		margin-top: $tiled-gallery-default-gutter;
 		width: 100%;
 
 		.components-form-file-upload,
@@ -144,5 +145,20 @@
 	.components-menu-item__button.is-active {
 		color: $dark-gray-900;
 		box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
+	}
+}
+
+// To save bytes, this is re-generated via PHP for view-side.
+// See Jetpack_Tiled_Gallery_Block class' render method at tiled-gallery.php
+@for $gutter from 0 through $tiled-gallery-max-gutter {
+	.has-gutter-#{$gutter} {
+		.tiled-gallery__item + .tiled-gallery__item,
+		.tiled-gallery__row + .tiled-gallery__row {
+			margin-top: #{$gutter}px;
+		}
+
+		.tiled-gallery__col + .tiled-gallery__col {
+			margin-left: #{$gutter}px;
+		}
 	}
 }

--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -96,6 +96,12 @@
 		}
 	}
 
+	@each $gutter-size, $gutter-px in $tiled-gallery-gutters {
+		&.has-gutter-#{$gutter-size} .tiled-gallery__add-item {
+			margin-top: $gutter-px;
+		}
+	}
+
 	.tiled-gallery__item__inline-menu {
 		background-color: $tiled-gallery-selection;
 		display: inline-flex;
@@ -145,20 +151,5 @@
 	.components-menu-item__button.is-active {
 		color: $dark-gray-900;
 		box-shadow: 0 0 0 $active-item-outline-width $dark-gray-500 !important;
-	}
-}
-
-// To save bytes, this is re-generated via PHP for view-side.
-// See Jetpack_Tiled_Gallery_Block class' render method at tiled-gallery.php
-@for $gutter from 0 through $tiled-gallery-max-gutter {
-	.has-gutter-#{$gutter} {
-		.tiled-gallery__item + .tiled-gallery__item,
-		.tiled-gallery__row + .tiled-gallery__row {
-			margin-top: #{$gutter}px;
-		}
-
-		.tiled-gallery__col + .tiled-gallery__col {
-			margin-left: #{$gutter}px;
-		}
 	}
 }

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -79,7 +79,7 @@ const blockAttributes = {
 	},
 	gutter: {
 		default: DEFAULT_GUTTER,
-		type: 'integer',
+		type: 'string',
 	},
 	ids: {
 		default: [],

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -12,6 +12,7 @@ import { Path, SVG } from '@wordpress/components';
 import edit from './edit';
 import save from './save';
 import {
+	DEFAULT_GUTTER,
 	LAYOUT_CIRCLE,
 	LAYOUT_COLUMN,
 	LAYOUT_DEFAULT,
@@ -75,6 +76,10 @@ const blockAttributes = {
 	},
 	columns: {
 		type: 'number',
+	},
+	gutter: {
+		default: DEFAULT_GUTTER,
+		type: 'integer',
 	},
 	ids: {
 		default: [],

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import GalleryImageSave from '../gallery-image/save';
 import Mosaic from './mosaic';
 import Square from './square';
 import { isSquareishLayout, photonizedImgProps } from '../utils';
+import { DEFAULT_GUTTER } from '../constants';
 
 export default class Layout extends Component {
 	// This is tricky:
@@ -65,17 +67,24 @@ export default class Layout extends Component {
 	}
 
 	render() {
-		const { align, children, className, columns, images, layoutStyle } = this.props;
-
-		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
-
+		const { align, children, className, columns, gutter, images, layoutStyle } = this.props;
+		const isSquareish = isSquareishLayout( layoutStyle );
+		const LayoutRenderer = isSquareish ? Square : Mosaic;
 		const renderedImages = this.props.images.map( this.renderImage, this );
 
+		// Square & Circle layouts don't support any gutter customizations
+		const hasCustomGutter = gutter !== DEFAULT_GUTTER && ! isSquareish;
+
 		return (
-			<div className={ className }>
+			<div
+				className={ classnames( className, {
+					[ `has-gutter-${ gutter }` ]: hasCustomGutter,
+				} ) }
+			>
 				<LayoutRenderer
 					align={ align }
 					columns={ columns }
+					gutter={ gutter }
 					images={ images }
 					layoutStyle={ layoutStyle }
 					renderedImages={ renderedImages }

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { withViewportMatch } from '@wordpress/viewport';
 import classnames from 'classnames';
 
 /**
@@ -16,7 +15,7 @@ import Square from './square';
 import { isSquareishLayout, photonizedImgProps } from '../utils';
 import { DEFAULT_GUTTER, GUTTERS } from '../constants';
 
-class Layout extends Component {
+export default class Layout extends Component {
 	// This is tricky:
 	// - We need to "photonize" to resize the images at appropriate dimensions
 	// - The resize will depend on the image size and the layout in some cases
@@ -68,23 +67,9 @@ class Layout extends Component {
 	}
 
 	render() {
-		const {
-			align,
-			children,
-			className,
-			columns,
-			gutter,
-			images,
-			isSmallScreen,
-			layoutStyle,
-		} = this.props;
+		const { align, children, className, columns, gutter, images, layoutStyle } = this.props;
 		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
 		const renderedImages = this.props.images.map( this.renderImage, this );
-
-		// Get gutter width in px by keyword stored in attributes
-		// For small screens we shrink gutters half
-		const gutterWidth =
-			isSmallScreen && gutter !== 'none' ? GUTTERS[ gutter ] / 2 : GUTTERS[ gutter ];
 
 		return (
 			<div
@@ -95,7 +80,7 @@ class Layout extends Component {
 				<LayoutRenderer
 					align={ align }
 					columns={ columns }
-					gutterWidth={ gutterWidth }
+					gutterWidth={ GUTTERS[ gutter ] }
 					images={ images }
 					layoutStyle={ layoutStyle }
 					renderedImages={ renderedImages }
@@ -105,6 +90,3 @@ class Layout extends Component {
 		);
 	}
 }
-
-// If you change `small` to something else, change it also from the media-query in `view.scss`
-export default withViewportMatch( { isSmallScreen: '< small' } )( Layout );

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
+import { withViewportMatch } from '@wordpress/viewport';
 import classnames from 'classnames';
 
 /**
@@ -13,9 +14,9 @@ import GalleryImageSave from '../gallery-image/save';
 import Mosaic from './mosaic';
 import Square from './square';
 import { isSquareishLayout, photonizedImgProps } from '../utils';
-import { DEFAULT_GUTTER } from '../constants';
+import { DEFAULT_GUTTER, GUTTERS } from '../constants';
 
-export default class Layout extends Component {
+class Layout extends Component {
 	// This is tricky:
 	// - We need to "photonize" to resize the images at appropriate dimensions
 	// - The resize will depend on the image size and the layout in some cases
@@ -67,24 +68,34 @@ export default class Layout extends Component {
 	}
 
 	render() {
-		const { align, children, className, columns, gutter, images, layoutStyle } = this.props;
-		const isSquareish = isSquareishLayout( layoutStyle );
-		const LayoutRenderer = isSquareish ? Square : Mosaic;
+		const {
+			align,
+			children,
+			className,
+			columns,
+			gutter,
+			images,
+			isSmallScreen,
+			layoutStyle,
+		} = this.props;
+		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
 		const renderedImages = this.props.images.map( this.renderImage, this );
 
-		// Square & Circle layouts don't support any gutter customizations
-		const hasCustomGutter = gutter !== DEFAULT_GUTTER && ! isSquareish;
+		// Get gutter width in px by keyword stored in attributes
+		// For small screens we shrink gutters half
+		const gutterWidth =
+			isSmallScreen && gutter !== 'none' ? GUTTERS[ gutter ] / 2 : GUTTERS[ gutter ];
 
 		return (
 			<div
 				className={ classnames( className, {
-					[ `has-gutter-${ gutter }` ]: hasCustomGutter,
+					[ `has-gutter-${ gutter }` ]: gutter !== DEFAULT_GUTTER,
 				} ) }
 			>
 				<LayoutRenderer
 					align={ align }
 					columns={ columns }
-					gutter={ gutter }
+					gutterWidth={ gutterWidth }
 					images={ images }
 					layoutStyle={ layoutStyle }
 					renderedImages={ renderedImages }
@@ -94,3 +105,6 @@ export default class Layout extends Component {
 		);
 	}
 }
+
+// If you change `small` to something else, change it also from the media-query in `view.scss`
+export default withViewportMatch( { isSmallScreen: '< small' } )( Layout );

--- a/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -27,7 +27,11 @@ export default class Mosaic extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.images !== this.props.images || prevProps.align !== this.props.align ) {
+		if (
+			prevProps.images !== this.props.images ||
+			prevProps.align !== this.props.align ||
+			prevProps.gutterWidth !== this.props.gutterWidth
+		) {
 			this.triggerResize();
 		} else if ( 'columns' === this.props.layoutStyle && prevProps.columns !== this.props.columns ) {
 			this.triggerResize();
@@ -35,7 +39,7 @@ export default class Mosaic extends Component {
 	}
 
 	handleGalleryResize = entries => {
-		const { gutter } = this.props;
+		const { gutterWidth } = this.props;
 
 		if ( this.pendingRaf ) {
 			cancelAnimationFrame( this.pendingRaf );
@@ -44,7 +48,7 @@ export default class Mosaic extends Component {
 		this.pendingRaf = requestAnimationFrame( () => {
 			for ( const { contentRect, target } of entries ) {
 				const { width } = contentRect;
-				getGalleryRows( target ).forEach( row => handleRowResize( row, width, gutter ) );
+				getGalleryRows( target ).forEach( row => handleRowResize( row, width, gutterWidth ) );
 			}
 		} );
 	};

--- a/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -35,6 +35,8 @@ export default class Mosaic extends Component {
 	}
 
 	handleGalleryResize = entries => {
+		const { gutter } = this.props;
+
 		if ( this.pendingRaf ) {
 			cancelAnimationFrame( this.pendingRaf );
 			this.pendingRaf = null;
@@ -42,7 +44,7 @@ export default class Mosaic extends Component {
 		this.pendingRaf = requestAnimationFrame( () => {
 			for ( const { contentRect, target } of entries ) {
 				const { width } = contentRect;
-				getGalleryRows( target ).forEach( row => handleRowResize( row, width ) );
+				getGalleryRows( target ).forEach( row => handleRowResize( row, width, gutter ) );
 			}
 		} );
 	};

--- a/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { GUTTER_WIDTH } from '../../constants';
-
-/**
  * Distribute a difference across ns so that their sum matches the target
  *
  * @param {Array<number>}  parts  Array of numbers to fit
@@ -16,8 +11,8 @@ function adjustFit( parts, target ) {
 	return parts.map( p => p + partialDiff );
 }
 
-export function handleRowResize( row, width ) {
-	applyRowRatio( row, getRowRatio( row ), width );
+export function handleRowResize( row, width, gutter ) {
+	applyRowRatio( row, getRowRatio( row ), width, gutter );
 }
 
 function getRowRatio( row ) {
@@ -65,21 +60,22 @@ function getImageRatio( img ) {
 	return result;
 }
 
-function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
+function applyRowRatio( row, [ ratio, weightedRatio ], width, gutter ) {
 	const rawHeight =
-		( 1 / ratio ) * ( width - GUTTER_WIDTH * ( row.childElementCount - 1 ) - weightedRatio );
+		( 1 / ratio ) * ( width - gutter * ( row.childElementCount - 1 ) - weightedRatio );
 
 	applyColRatio( row, {
+		gutter,
 		rawHeight,
-		rowWidth: width - GUTTER_WIDTH * ( row.childElementCount - 1 ),
+		rowWidth: width - gutter * ( row.childElementCount - 1 ),
 	} );
 }
 
-function applyColRatio( row, { rawHeight, rowWidth } ) {
+function applyColRatio( row, { gutter, rawHeight, rowWidth } ) {
 	const cols = getRowCols( row );
 
 	const colWidths = cols.map(
-		col => ( rawHeight - GUTTER_WIDTH * ( col.childElementCount - 1 ) ) * getColumnRatio( col )[ 0 ]
+		col => ( rawHeight - gutter * ( col.childElementCount - 1 ) ) * getColumnRatio( col )[ 0 ]
 	);
 
 	const adjustedWidths = adjustFit( colWidths, rowWidth );
@@ -88,7 +84,7 @@ function applyColRatio( row, { rawHeight, rowWidth } ) {
 		const rawWidth = colWidths[ i ];
 		const width = adjustedWidths[ i ];
 		applyImgRatio( col, {
-			colHeight: rawHeight - GUTTER_WIDTH * ( col.childElementCount - 1 ),
+			colHeight: rawHeight - gutter * ( col.childElementCount - 1 ),
 			width,
 			rawWidth,
 		} );

--- a/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -11,8 +11,8 @@ function adjustFit( parts, target ) {
 	return parts.map( p => p + partialDiff );
 }
 
-export function handleRowResize( row, width, gutter ) {
-	applyRowRatio( row, getRowRatio( row ), width, gutter );
+export function handleRowResize( row, width, gutterWidth ) {
+	applyRowRatio( row, getRowRatio( row ), width, gutterWidth );
 }
 
 function getRowRatio( row ) {
@@ -60,22 +60,22 @@ function getImageRatio( img ) {
 	return result;
 }
 
-function applyRowRatio( row, [ ratio, weightedRatio ], width, gutter ) {
+function applyRowRatio( row, [ ratio, weightedRatio ], width, gutterWidth ) {
 	const rawHeight =
-		( 1 / ratio ) * ( width - gutter * ( row.childElementCount - 1 ) - weightedRatio );
+		( 1 / ratio ) * ( width - gutterWidth * ( row.childElementCount - 1 ) - weightedRatio );
 
 	applyColRatio( row, {
-		gutter,
+		gutterWidth,
 		rawHeight,
-		rowWidth: width - gutter * ( row.childElementCount - 1 ),
+		rowWidth: width - gutterWidth * ( row.childElementCount - 1 ),
 	} );
 }
 
-function applyColRatio( row, { gutter, rawHeight, rowWidth } ) {
+function applyColRatio( row, { gutterWidth, rawHeight, rowWidth } ) {
 	const cols = getRowCols( row );
 
 	const colWidths = cols.map(
-		col => ( rawHeight - gutter * ( col.childElementCount - 1 ) ) * getColumnRatio( col )[ 0 ]
+		col => ( rawHeight - gutterWidth * ( col.childElementCount - 1 ) ) * getColumnRatio( col )[ 0 ]
 	);
 
 	const adjustedWidths = adjustFit( colWidths, rowWidth );
@@ -84,7 +84,7 @@ function applyColRatio( row, { gutter, rawHeight, rowWidth } ) {
 		const rawWidth = colWidths[ i ];
 		const width = adjustedWidths[ i ];
 		applyImgRatio( col, {
-			colHeight: rawHeight - gutter * ( col.childElementCount - 1 ),
+			colHeight: rawHeight - gutterWidth * ( col.childElementCount - 1 ),
 			width,
 			rawWidth,
 		} );

--- a/extensions/blocks/tiled-gallery/save.js
+++ b/extensions/blocks/tiled-gallery/save.js
@@ -13,13 +13,20 @@ export default function TiledGallerySave( { attributes } ) {
 		return null;
 	}
 
-	const { align, className, columns = defaultColumnsNumber( attributes ), linkTo } = attributes;
+	const {
+		align,
+		className,
+		columns = defaultColumnsNumber( attributes ),
+		gutter,
+		linkTo,
+	} = attributes;
 
 	return (
 		<Layout
 			align={ align }
 			className={ className }
 			columns={ columns }
+			gutter={ gutter }
 			imageFilter={ imageFilter }
 			images={ images }
 			isSave

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -18,7 +18,6 @@ class Jetpack_Tiled_Gallery_Block {
 	const IMG_SRCSET_WIDTH_MAX  = 2000;
 	const IMG_SRCSET_WIDTH_MIN  = 600;
 	const IMG_SRCSET_WIDTH_STEP = 300;
-	const DEFAULT_GUTTER        = 4;
 	const DEFAULT_COLUMNS       = 3;
 
 	/**
@@ -50,23 +49,6 @@ class Jetpack_Tiled_Gallery_Block {
 		if ( class_exists( 'Jetpack_Plan' ) ) {
 			$jetpack_plan = Jetpack_Plan::get();
 			wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
-		}
-
-		// Generate styles for non-default gutter.
-		if ( isset( $attr['gutter'] ) && absint( $attr['gutter'] ) !== self::DEFAULT_GUTTER && ! $is_squareish_layout ) {
-			$gutter     = absint( $attr['gutter'] );
-			$css_prefix = '.wp-block-jetpack-tiled-gallery.has-gutter-' . $gutter;
-
-			$gutter_css = sprintf(
-				'
-				%1$s .tiled-gallery__item + .tiled-gallery__item,
-				%1$s .tiled-gallery__row + .tiled-gallery__row { margin-top: %2$dpx; }
-				%1$s .tiled-gallery__col + .tiled-gallery__col { margin-left: %2$dpx; }',
-				$css_prefix,
-				$gutter
-			);
-
-			wp_add_inline_style( 'jetpack-block-tiled-gallery', $gutter_css );
 		}
 
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -18,7 +18,6 @@ class Jetpack_Tiled_Gallery_Block {
 	const IMG_SRCSET_WIDTH_MAX  = 2000;
 	const IMG_SRCSET_WIDTH_MIN  = 600;
 	const IMG_SRCSET_WIDTH_STEP = 300;
-	const DEFAULT_COLUMNS       = 3;
 
 	/**
 	 * Register the block

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -18,6 +18,8 @@ class Jetpack_Tiled_Gallery_Block {
 	const IMG_SRCSET_WIDTH_MAX  = 2000;
 	const IMG_SRCSET_WIDTH_MIN  = 600;
 	const IMG_SRCSET_WIDTH_STEP = 300;
+	const DEFAULT_GUTTER        = 4;
+	const DEFAULT_COLUMNS       = 3;
 
 	/**
 	 * Register the block
@@ -48,6 +50,23 @@ class Jetpack_Tiled_Gallery_Block {
 		if ( class_exists( 'Jetpack_Plan' ) ) {
 			$jetpack_plan = Jetpack_Plan::get();
 			wp_localize_script( 'jetpack-gallery-settings', 'jetpack_plan', array( 'data' => $jetpack_plan['product_slug'] ) );
+		}
+
+		// Generate styles for non-default gutter.
+		if ( isset( $attr['gutter'] ) && absint( $attr['gutter'] ) !== self::DEFAULT_GUTTER && ! $is_squareish_layout ) {
+			$gutter     = absint( $attr['gutter'] );
+			$css_prefix = '.wp-block-jetpack-tiled-gallery.has-gutter-' . $gutter;
+
+			$gutter_css = sprintf(
+				'
+				%1$s .tiled-gallery__item + .tiled-gallery__item,
+				%1$s .tiled-gallery__row + .tiled-gallery__row { margin-top: %2$dpx; }
+				%1$s .tiled-gallery__col + .tiled-gallery__col { margin-left: %2$dpx; }',
+				$css_prefix,
+				$gutter
+			);
+
+			wp_add_inline_style( 'jetpack-block-tiled-gallery', $gutter_css );
 		}
 
 		if ( preg_match_all( '/<img [^>]+>/', $content, $images ) ) {

--- a/extensions/blocks/tiled-gallery/variables.scss
+++ b/extensions/blocks/tiled-gallery/variables.scss
@@ -1,2 +1,2 @@
-$tiled-gallery-gutter: 4px; // Fixed in JS, see `LayoutStyles` from `edit.jsx`
+$tiled-gallery-default-gutter: 4px; // Fixed in JS, see `constants.js`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)

--- a/extensions/blocks/tiled-gallery/variables.scss
+++ b/extensions/blocks/tiled-gallery/variables.scss
@@ -1,2 +1,14 @@
-$tiled-gallery-default-gutter: 4px; // Fixed in JS, see `constants.js`
 $tiled-gallery-selection: #0085ba; // Gutenberg primary theme color (https://github.com/WordPress/gutenberg/blob/6928e41c8afd7daa3a709afdda7eee48218473b7/bin/packages/post-css-config.js#L4)
+
+// Fixed in JS, see `constants.js`
+$tiled-gallery-max-column-count: 20;
+
+// Gutters - fixed in JS, see `constants.js`
+$tiled-gallery-gutters: (
+	'none': 0,
+	'small': 4px,
+	'medium': 16px,
+	'large': 48px
+);
+$tiled-gallery-default-gutter-size: 'small';
+$tiled-gallery-default-gutter: map-get($tiled-gallery-gutters, $tiled-gallery-default-gutter-size);

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -1,10 +1,11 @@
 @import '../../shared/styles/jetpack-variables.scss';
 @import './variables.scss';
 @import './css-gram.scss';
+@import '../../shared/styles/gutenberg-base-styles.scss';
 
-// Fixed in JS, see `constants.js`
-$tiled-gallery-max-column-count: 20;
-$tiled-gallery-max-gutter: 50;
+@mixin tiled-gallery-squareish-layout-col-width($gutter, $cols){
+	width: calc( ( 100% - #{ $gutter * ( $cols - 1 ) } ) / #{$cols} );
+}
 
 .wp-block-jetpack-tiled-gallery {
 	margin: 0 auto $jetpack-block-margin-bottom;
@@ -19,11 +20,38 @@ $tiled-gallery-max-gutter: 50;
 			flex-grow: 1;
 			width: 100%;
 
+			// Default gutter for square'ish layouts for each column size
 			@for $cols from 1 through $tiled-gallery-max-column-count {
 				&.columns-#{$cols} {
 					.tiled-gallery__col {
-						// Note: Square and Circle layouts don't support custom gutter size
-						width: calc( ( 100% - #{ $tiled-gallery-default-gutter * ( $cols - 1 ) } ) / #{$cols} );
+						@include tiled-gallery-squareish-layout-col-width($tiled-gallery-default-gutter, $cols);
+					}
+				}
+			}
+
+			// Generate different size gutters for square'ish layouts for each column size
+			@for $cols from 1 through $tiled-gallery-max-column-count {
+				// When gutter size is set
+				@each $gutter-size, $gutter-px in $tiled-gallery-gutters {
+					// Small is default, hence no need to define it here since it's defined above
+					@if $gutter-size != $tiled-gallery-default-gutter-size {
+						&.columns-#{$cols} {
+							.tiled-gallery__col {
+								@include tiled-gallery-squareish-layout-col-width($gutter-px, $cols);
+							}
+						}
+					}
+
+					@if $gutter-px > 0 {
+						// For small screens we shrink gutters half
+						// If you change `small` break to something else, change it also from `extensions/blocks/tiled-gallery/layout/index.js`
+						@media (max-width: #{ ($break-small) }) {
+							&.columns-#{$cols} {
+								.tiled-gallery__col {
+									@include tiled-gallery-squareish-layout-col-width($gutter-px/2, $cols);
+								}
+							}
+						}
 					}
 				}
 			}
@@ -51,13 +79,6 @@ $tiled-gallery-max-gutter: 50;
 	flex-direction: row;
 	justify-content: center;
 	margin: 0;
-
-	// See also tiled-gallery.php render method if you modify this
-	/*
-	& + & {
-		margin-top: $tiled-gallery-default-gutter;
-	}
-	*/
 }
 
 .tiled-gallery__col {
@@ -65,13 +86,6 @@ $tiled-gallery-max-gutter: 50;
 	flex-direction: column;
 	justify-content: center;
 	margin: 0;
-
-	// See also tiled-gallery.php render method if you modify this
-	/*
-	& + & {
-		margin-left: $tiled-gallery-default-gutter;
-	}
-	*/
 }
 
 .tiled-gallery__item {
@@ -101,13 +115,6 @@ $tiled-gallery-max-gutter: 50;
 		@include gingham;
 	}
 
-	// See also tiled-gallery.php render method if you modify this
-	/*
-	& + & {
-		margin-top: $tiled-gallery-default-gutter;
-	}
-	*/
-
 	> img {
 		background-color: rgba( 0, 0, 0, 0.1 );
 	}
@@ -126,7 +133,7 @@ $tiled-gallery-max-gutter: 50;
 	}
 }
 
-// See also editor.scss for more custom gutter logic
+// Default gutter when not set
 .tiled-gallery__item + .tiled-gallery__item,
 .tiled-gallery__row + .tiled-gallery__row {
 	margin-top: $tiled-gallery-default-gutter;
@@ -134,4 +141,34 @@ $tiled-gallery-max-gutter: 50;
 
 .tiled-gallery__col + .tiled-gallery__col {
 	margin-left: $tiled-gallery-default-gutter;
+}
+
+// When gutter size is set
+@each $gutter-size, $gutter-px in $tiled-gallery-gutters {
+	// Small is default, hence no need to define it here since it's defined above
+	@if $gutter-size != $tiled-gallery-default-gutter-size {
+		.has-gutter-#{$gutter-size} .tiled-gallery__item + .tiled-gallery__item,
+		.has-gutter-#{$gutter-size} .tiled-gallery__row + .tiled-gallery__row {
+			margin-top: #{$gutter-px};
+		}
+
+		.has-gutter-#{$gutter-size} .tiled-gallery__col + .tiled-gallery__col {
+			margin-left: #{$gutter-px};
+		}
+	}
+
+	@if $gutter-px > 0 {
+		// For small screens we shrink gutters half
+		// If you change `small` break to something else, change it also from `extensions/blocks/tiled-gallery/layout/index.js`
+		@media (max-width: #{ ($break-small) }) {
+			.has-gutter-#{$gutter-size} .tiled-gallery__item + .tiled-gallery__item,
+			.has-gutter-#{$gutter-size} .tiled-gallery__row + .tiled-gallery__row {
+				margin-top: #{$gutter-px/2};
+			}
+
+			.has-gutter-#{$gutter-size} .tiled-gallery__col + .tiled-gallery__col {
+				margin-left: #{$gutter-px/2};
+			}
+		}
+	}
 }

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -2,7 +2,9 @@
 @import './variables.scss';
 @import './css-gram.scss';
 
+// Fixed in JS, see `constants.js`
 $tiled-gallery-max-column-count: 20;
+$tiled-gallery-max-gutter: 50;
 
 .wp-block-jetpack-tiled-gallery {
 	margin: 0 auto $jetpack-block-margin-bottom;
@@ -20,7 +22,8 @@ $tiled-gallery-max-column-count: 20;
 			@for $cols from 1 through $tiled-gallery-max-column-count {
 				&.columns-#{$cols} {
 					.tiled-gallery__col {
-						width: calc( ( 100% - #{ $tiled-gallery-gutter * ( $cols - 1 ) } ) / #{$cols} );
+						// Note: Square and Circle layouts don't support custom gutter size
+						width: calc( ( 100% - #{ $tiled-gallery-default-gutter * ( $cols - 1 ) } ) / #{$cols} );
 					}
 				}
 			}
@@ -49,9 +52,12 @@ $tiled-gallery-max-column-count: 20;
 	justify-content: center;
 	margin: 0;
 
+	// See also tiled-gallery.php render method if you modify this
+	/*
 	& + & {
-		margin-top: $tiled-gallery-gutter;
+		margin-top: $tiled-gallery-default-gutter;
 	}
+	*/
 }
 
 .tiled-gallery__col {
@@ -60,9 +66,12 @@ $tiled-gallery-max-column-count: 20;
 	justify-content: center;
 	margin: 0;
 
+	// See also tiled-gallery.php render method if you modify this
+	/*
 	& + & {
-		margin-left: $tiled-gallery-gutter;
+		margin-left: $tiled-gallery-default-gutter;
 	}
+	*/
 }
 
 .tiled-gallery__item {
@@ -92,9 +101,12 @@ $tiled-gallery-max-column-count: 20;
 		@include gingham;
 	}
 
+	// See also tiled-gallery.php render method if you modify this
+	/*
 	& + & {
-		margin-top: $tiled-gallery-gutter;
+		margin-top: $tiled-gallery-default-gutter;
 	}
+	*/
 
 	> img {
 		background-color: rgba( 0, 0, 0, 0.1 );
@@ -112,4 +124,14 @@ $tiled-gallery-max-column-count: 20;
 		padding: 0;
 		width: 100%;
 	}
+}
+
+// See also editor.scss for more custom gutter logic
+.tiled-gallery__item + .tiled-gallery__item,
+.tiled-gallery__row + .tiled-gallery__row {
+	margin-top: $tiled-gallery-default-gutter;
+}
+
+.tiled-gallery__col + .tiled-gallery__col {
+	margin-left: $tiled-gallery-default-gutter;
 }

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -1,7 +1,6 @@
 @import '../../shared/styles/jetpack-variables.scss';
 @import './variables.scss';
 @import './css-gram.scss';
-@import '../../shared/styles/gutenberg-base-styles.scss';
 
 @mixin tiled-gallery-squareish-layout-col-width($gutter, $cols){
 	width: calc( ( 100% - #{ $gutter * ( $cols - 1 ) } ) / #{$cols} );
@@ -38,18 +37,6 @@
 						&.columns-#{$cols} {
 							.tiled-gallery__col {
 								@include tiled-gallery-squareish-layout-col-width($gutter-px, $cols);
-							}
-						}
-					}
-
-					@if $gutter-px > 0 {
-						// For small screens we shrink gutters half
-						// If you change `small` break to something else, change it also from `extensions/blocks/tiled-gallery/layout/index.js`
-						@media (max-width: #{ ($break-small) }) {
-							&.columns-#{$cols} {
-								.tiled-gallery__col {
-									@include tiled-gallery-squareish-layout-col-width($gutter-px/2, $cols);
-								}
 							}
 						}
 					}
@@ -154,21 +141,6 @@
 
 		.has-gutter-#{$gutter-size} .tiled-gallery__col + .tiled-gallery__col {
 			margin-left: #{$gutter-px};
-		}
-	}
-
-	@if $gutter-px > 0 {
-		// For small screens we shrink gutters half
-		// If you change `small` break to something else, change it also from `extensions/blocks/tiled-gallery/layout/index.js`
-		@media (max-width: #{ ($break-small) }) {
-			.has-gutter-#{$gutter-size} .tiled-gallery__item + .tiled-gallery__item,
-			.has-gutter-#{$gutter-size} .tiled-gallery__row + .tiled-gallery__row {
-				margin-top: #{$gutter-px/2};
-			}
-
-			.has-gutter-#{$gutter-size} .tiled-gallery__col + .tiled-gallery__col {
-				margin-left: #{$gutter-px/2};
-			}
 		}
 	}
 }


### PR DESCRIPTION
Add a gutter option to the Tiled gallery block.

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/87168/74616549-21c49480-5131-11ea-85d2-6439415a358b.png">

_Still little buggy and work in progress. Feel free to take PR over if you wanna help work on this!_

Resolves https://github.com/Automattic/jetpack/issues/9548

Allows gutter options only as steps. The previous flexible solution I tried [kinda would've exploded CSS bundle size](https://github.com/Automattic/jetpack/pull/14705/commits/52a902d16155d2762d365a35a67cebe40ccaccc4).

Needs deciding styles for the gutter picker, two options I'm testing are select input and button group:

<img width="267" alt="image" src="https://user-images.githubusercontent.com/87168/74616456-816e7000-5130-11ea-9aea-4173575891b6.png">

Latter gets little tricky with words translated sometimes longer in other languages:

<img width="251" alt="image" src="https://user-images.githubusercontent.com/87168/74616495-bf6b9400-5130-11ea-8eac-489d8c9464b1.png">

Something compact like this could be an alternative but maybe less clear what those values are:

<img width="157" alt="image" src="https://user-images.githubusercontent.com/87168/74640490-4b54de80-5178-11ea-8a68-ad710c2cbb83.png">



#### Changes proposed in this Pull Request:
* Adds gutter option to Tiled gallery block's sidebar

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhancement

#### Testing instructions:
- Add tiled gallery block and some images
- Change gutter in the sidebar for all different layouts
- Test rescaling the page
- Test different numbers of columns
- Test with a different number of images
- Test also the frontend of the  site
