### PR TITLE
Map Block: Add zoom and height settings controls

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -177,17 +177,29 @@ export class Map extends Component {
 	};
 	// Various map functions
 	sizeMap = () => {
+		const { mapHeight } = this.props;
 		const { map } = this.state;
 		const mapEl = this.mapRef.current;
-		const blockWidth = mapEl.offsetWidth;
-		const maxHeight =
-			window.location.search.indexOf( 'map-block-counter' ) > -1
-				? window.innerHeight
-				: window.innerHeight * 0.8;
-		const blockHeight = Math.min( blockWidth * ( 3 / 4 ), maxHeight );
-		mapEl.style.height = blockHeight + 'px';
+		if ( mapHeight ) {
+			mapEl.style.height = mapHeight + 'px';
+		} else {
+			const blockWidth = mapEl.offsetWidth;
+			const maxHeight =
+				window.location.search.indexOf( 'map-block-counter' ) > -1
+					? window.innerHeight
+					: window.innerHeight * 0.8;
+			const blockHeight = Math.min( blockWidth * ( 3 / 4 ), maxHeight );
+			mapEl.style.height = blockHeight + 'px';
+		}
 		map.resize();
 		this.setBoundsByMarkers();
+	};
+	updateZoom = () => {
+		const { zoom } = this.props;
+		const { map } = this.state;
+
+		map.setZoom( zoom );
+		map.updateZoom( zoom );
 	};
 	setBoundsByMarkers = () => {
 		const { admin, onSetMapCenter, onSetZoom, points, zoom } = this.props;

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -278,7 +278,15 @@ class MapEdit extends Component {
 								type="number"
 								id={ `block-jetpack-map-height-input-${ instanceId }` }
 								className="wp-block-jetpack-map__height_input"
-								onChange={ this.onHeightChange }
+								onChange={ event => {
+									setAttributes( { mapHeight: event.target.value } );
+									// If this input isn't focussed, the onBlur handler won't be triggered
+									// to commit the map size, so we need to check for that.
+									if ( event.target !== document.activeElement ) {
+										setTimeout( this.mapRef.current.sizeMap, 0 );
+									}
+								} }
+								onBlur={ this.onHeightChange }
 								value={ mapHeight || '' }
 								min={ MIN_HEIGHT }
 								step="10"

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -248,12 +248,11 @@ class MapEdit extends Component {
 						<RangeControl
 							label={ __( 'Zoom level', 'jetpack' ) }
 							help={
-								points.length > 1
-									? __(
-											'The default zoom level cannot be changed when there are two or more markers on the map.',
-											'jetpack'
-									  )
-									: ''
+								points.length > 1 &&
+								__(
+									'The default zoom level cannot be changed when there are two or more markers on the map.',
+									'jetpack'
+								)
 							}
 							disabled={ points.length > 1 }
 							value={ zoom }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -26,6 +26,7 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -356,6 +357,11 @@ class MapEdit extends Component {
 				{ inspectorControls }
 				<div className={ className }>
 					<ResizableBox
+						className={
+							// @TODO: This can be removed when WP 5.4 is the minimum version, it's a fallback
+							// for prior to when the `showHandle` property was added.
+							classnames( { 'is-selected': isSelected } )
+						}
 						size={ {
 							height: mapHeight || 'auto',
 							width: '100%',

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -144,6 +144,13 @@ class MapEdit extends Component {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
 	};
+
+	/**
+	 * Change event handler for the map height sidebar control. Ensures the height is valid,
+	 * and updates both the height attribute, and the map component's height in the DOM.
+	 *
+	 * @param {Event} event The change event object.
+	 */
 	onHeightChange = event => {
 		const { attributes, setAttributes } = this.props;
 		const { mapHeight } = attributes;
@@ -167,6 +174,16 @@ class MapEdit extends Component {
 
 		setTimeout( this.mapRef.current.sizeMap, 0 );
 	};
+
+	/**
+	 * Event handler for the ResizableBox component. Updates both the height attribute,
+	 * and the map component's height in the DOM.
+	 *
+	 * @param {Event} event The event object.
+	 * @param {ResizeDirection} direction A string representing which resize handler was used.
+	 * @param {HtmlDivElement} elt A ref to the ResizeableBox's container element.
+	 * @param {NumberSize} delta Information about how far the element was resized.
+	 */
 	onMapResize = ( event, direction, elt, delta ) => {
 		const { onResizeStop, setAttributes } = this.props;
 
@@ -180,6 +197,7 @@ class MapEdit extends Component {
 
 		setTimeout( this.mapRef.current.sizeMap, 0 );
 	};
+
 	render() {
 		const {
 			className,

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -228,6 +228,9 @@ class MapEdit extends Component {
 									if ( isNaN( height ) ) {
 										// Set map height to default size and input box to empty string
 										height = null;
+									} else if ( null == mapHeight ) {
+										// There was previously no height defined, so set the default.
+										height = this.mapRef.current.mapRef.current.offsetHeight;
 									} else if ( height < MIN_HEIGHT ) {
 										// Set map height to minimum size
 										height = MIN_HEIGHT;

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -271,7 +271,7 @@ class MapEdit extends Component {
 					/>
 					<PanelBody title={ __( 'Map Settings', 'jetpack' ) }>
 						<BaseControl
-							label={ __( 'Height in pixels' ) }
+							label={ __( 'Height in pixels', 'jetpack' ) }
 							id={ `block-jetpack-map-height-input-${ instanceId }` }
 						>
 							<input

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -410,37 +410,39 @@ class MapEdit extends Component {
 						onResizeStart={ onResizeStart }
 						onResizeStop={ this.onMapResize }
 					>
-						<Map
-							ref={ this.mapRef }
-							scrollToZoom={ allowScrollToZoom }
-							mapStyle={ mapStyle }
-							mapDetails={ mapDetails }
-							mapHeight={ mapHeight }
-							points={ points }
-							zoom={ zoom }
-							mapCenter={ mapCenter }
-							markerColor={ markerColor }
-							onSetZoom={ value => {
-								setAttributes( { zoom: value } );
-							} }
-							admin={ true }
-							apiKey={ apiKey }
-							onSetPoints={ value => setAttributes( { points: value } ) }
-							onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
-							onMapLoaded={ () => this.setState( { addPointVisibility: ! points.length } ) }
-							onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
-							onError={ this.onError }
-						>
-							{ isSelected && addPointVisibility && (
-								<AddPoint
-									onAddPoint={ this.addPoint }
-									onClose={ () => this.setState( { addPointVisibility: false } ) }
-									apiKey={ apiKey }
-									onError={ this.onError }
-									tagName="AddPoint"
-								/>
-							) }
-						</Map>
+						<div className="wp-block-jetpack-map__map_wrapper">
+							<Map
+								ref={ this.mapRef }
+								scrollToZoom={ allowScrollToZoom }
+								mapStyle={ mapStyle }
+								mapDetails={ mapDetails }
+								mapHeight={ mapHeight }
+								points={ points }
+								zoom={ zoom }
+								mapCenter={ mapCenter }
+								markerColor={ markerColor }
+								onSetZoom={ value => {
+									setAttributes( { zoom: value } );
+								} }
+								admin={ true }
+								apiKey={ apiKey }
+								onSetPoints={ value => setAttributes( { points: value } ) }
+								onSetMapCenter={ value => setAttributes( { mapCenter: value } ) }
+								onMapLoaded={ () => this.setState( { addPointVisibility: ! points.length } ) }
+								onMarkerClick={ () => this.setState( { addPointVisibility: false } ) }
+								onError={ this.onError }
+							>
+								{ isSelected && addPointVisibility && (
+									<AddPoint
+										onAddPoint={ this.addPoint }
+										onClose={ () => this.setState( { addPointVisibility: false } ) }
+										apiKey={ apiKey }
+										onError={ this.onError }
+										tagName="AddPoint"
+									/>
+								) }
+							</Map>
+						</div>
 					</ResizableBox>
 				</div>
 			</Fragment>

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -144,6 +144,42 @@ class MapEdit extends Component {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
 	};
+	onHeightChange = event => {
+		const { attributes, setAttributes } = this.props;
+		const { mapHeight } = attributes;
+
+		let height = parseInt( event.target.value, 10 );
+
+		if ( isNaN( height ) ) {
+			// Set map height to default size and input box to empty string
+			height = null;
+		} else if ( null == mapHeight ) {
+			// There was previously no height defined, so set the default.
+			height = this.mapRef.current.mapRef.current.offsetHeight;
+		} else if ( height < MIN_HEIGHT ) {
+			// Set map height to minimum size
+			height = MIN_HEIGHT;
+		}
+
+		setAttributes( {
+			mapHeight: height,
+		} );
+
+		setTimeout( this.mapRef.current.sizeMap, 0 );
+	};
+	onMapResize = ( event, direction, elt, delta ) => {
+		const { onResizeStop, setAttributes } = this.props;
+
+		onResizeStop();
+
+		const height = parseInt( this.mapRef.current.mapRef.current.offsetHeight + delta.height, 10 );
+
+		setAttributes( {
+			mapHeight: height,
+		} );
+
+		setTimeout( this.mapRef.current.sizeMap, 0 );
+	};
 	render() {
 		const {
 			className,
@@ -154,7 +190,6 @@ class MapEdit extends Component {
 			isSelected,
 			instanceId,
 			onResizeStart,
-			onResizeStop,
 		} = this.props;
 		const {
 			mapStyle,
@@ -224,23 +259,7 @@ class MapEdit extends Component {
 							<input
 								type="number"
 								id={ `block-jetpack-map-height-input-${ instanceId }` }
-								onChange={ event => {
-									let height = parseInt( event.target.value, 10 );
-									if ( isNaN( height ) ) {
-										// Set map height to default size and input box to empty string
-										height = null;
-									} else if ( null == mapHeight ) {
-										// There was previously no height defined, so set the default.
-										height = this.mapRef.current.mapRef.current.offsetHeight;
-									} else if ( height < MIN_HEIGHT ) {
-										// Set map height to minimum size
-										height = MIN_HEIGHT;
-									}
-									setAttributes( {
-										mapHeight: height,
-									} );
-									setTimeout( this.mapRef.current.sizeMap, 0 );
-								} }
+								onChange={ this.onHeightChange }
 								value={ mapHeight || '' }
 								min={ MIN_HEIGHT }
 								step="10"
@@ -366,21 +385,12 @@ class MapEdit extends Component {
 							height: mapHeight || 'auto',
 							width: '100%',
 						} }
+						grid={ [ 10, 10 ] }
 						showHandle={ isSelected }
 						minHeight={ MIN_HEIGHT }
 						enable={ RESIZABLE_BOX_ENABLE_OPTION }
 						onResizeStart={ onResizeStart }
-						onResizeStop={ ( event, direction, elt, delta ) => {
-							onResizeStop();
-							const height = parseInt(
-								this.mapRef.current.mapRef.current.offsetHeight + delta.height,
-								10
-							);
-							setAttributes( {
-								mapHeight: height,
-							} );
-							setTimeout( this.mapRef.current.sizeMap, 0 );
-						} }
+						onResizeStop={ this.onMapResize }
 					>
 						<Map
 							ref={ this.mapRef }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -277,6 +277,7 @@ class MapEdit extends Component {
 							<input
 								type="number"
 								id={ `block-jetpack-map-height-input-${ instanceId }` }
+								className="wp-block-jetpack-map__height_input"
 								onChange={ this.onHeightChange }
 								value={ mapHeight || '' }
 								min={ MIN_HEIGHT }

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -43,6 +43,10 @@ const API_STATE_LOADING = 0;
 const API_STATE_FAILURE = 1;
 const API_STATE_SUCCESS = 2;
 
+// The minimum height that the map can be set to.
+const MIN_HEIGHT = 400;
+
+// Options for the map <ResizableBox> wrapper.
 const RESIZABLE_BOX_ENABLE_OPTION = {
 	top: false,
 	right: false,
@@ -224,9 +228,9 @@ class MapEdit extends Component {
 									if ( isNaN( height ) ) {
 										// Set map height to default size and input box to empty string
 										height = null;
-									} else if ( height < 400 ) {
+									} else if ( height < MIN_HEIGHT ) {
 										// Set map height to minimum size
-										height = 400;
+										height = MIN_HEIGHT;
 									}
 									setAttributes( {
 										mapHeight: height,
@@ -234,7 +238,7 @@ class MapEdit extends Component {
 									setTimeout( this.mapRef.current.sizeMap, 0 );
 								} }
 								value={ mapHeight || '' }
-								min="400"
+								min={ MIN_HEIGHT }
 								step="10"
 							/>
 						</BaseControl>
@@ -355,7 +359,7 @@ class MapEdit extends Component {
 							width: '100%',
 						} }
 						showHandle={ isSelected }
-						minHeight="400"
+						minHeight={ MIN_HEIGHT }
 						enable={ RESIZABLE_BOX_ENABLE_OPTION }
 						onResizeStart={ onResizeStart }
 						onResizeStop={ ( event, direction, elt, delta ) => {

--- a/extensions/blocks/map/editor.scss
+++ b/extensions/blocks/map/editor.scss
@@ -32,3 +32,7 @@
 		background-color: #e4e2de;
 	}
 }
+
+.wp-block-jetpack-map__height_input {
+	display: block;
+}

--- a/extensions/blocks/map/editor.scss
+++ b/extensions/blocks/map/editor.scss
@@ -24,4 +24,9 @@
 		font-size: 21px;
 		padding: 0px 10px 5px 9px;
 	}
+
+	.wp-block-jetpack-map__map_wrapper {
+		height: 100%;
+		overflow: hidden;
+	}
 }

--- a/extensions/blocks/map/editor.scss
+++ b/extensions/blocks/map/editor.scss
@@ -28,5 +28,7 @@
 	.wp-block-jetpack-map__map_wrapper {
 		height: 100%;
 		overflow: hidden;
+		// This matches the color that MapBox uses as a placeholder before map tiles have loaded.
+		background-color: #e4e2de;
 	}
 }

--- a/extensions/blocks/map/save.js
+++ b/extensions/blocks/map/save.js
@@ -16,6 +16,7 @@ class MapSave extends Component {
 			mapCenter,
 			markerColor,
 			scrollToZoom,
+			mapHeight,
 		} = attributes;
 		const pointsList = points.map( ( point, index ) => {
 			const { longitude, latitude } = point.coordinates;
@@ -38,6 +39,7 @@ class MapSave extends Component {
 				data-map-center={ JSON.stringify( mapCenter ) }
 				data-marker-color={ markerColor }
 				data-scroll-to-zoom={ scrollToZoom || null }
+				data-map-height={ mapHeight || null }
 			>
 				{ points.length > 0 && <ul>{ pointsList }</ul> }
 			</div>

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -71,6 +71,9 @@ export const settings = {
 			type: 'boolean',
 			default: false,
 		},
+		mapHeight: {
+			type: 'integer',
+		},
 	},
 	supports: {
 		html: false,


### PR DESCRIPTION
(Note: This PR is currently based off the branch for #14673, since that includes some changes that this one needs.)

This PR introduces sidebar settings for map zoom and height control.

The zoom control is a reflection of existing ability to set the zoom by scrolling over the map.

The height control is new, and also uses `<ResizableBox>`, which adds a clickable handle to the bottom of the map, allowing it to be dragged and resized.

Finally, this PR tweaks the zoom behaviour when points are added: when there are 2 or more points on the map, zoom customisations are already ignored, so the zoom UI is now disabled to match.

Fixes #14557.

#### Changes proposed in this Pull Request:
* Map Block: Add zoom and height controls.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhancement to the Map Block.

#### Testing instructions:

* Open the block editor.
* Add a new map block.
* Try setting the height/zoom with the sidebar control, and check that the block updates.
* Try setting the height with the resize handle, and check that everything updates.
* Try setting the zoom by scrolling on the map, and check that the sidebar control updates.

#### Proposed changelog entry for your changes:
* Map Block: Add the ability to set the size of the map.
* Map Block: Add a zoom control to the block sidebar.
