### PR TITLE
Map Block: Fix the map theme picker buttons

### DIFF
--- a/extensions/blocks/map/map-theme-picker/style.scss
+++ b/extensions/blocks/map/map-theme-picker/style.scss
@@ -5,7 +5,6 @@
 	// @todo: .edit-post-settings-sidebar__panel-block selector can be removed when WP 5.4 is the minimum.
 	.edit-post-settings-sidebar__panel-block & {
 		border: 1px solid $light-gray-500;
-		border-radius: 100%;
 		width: 56px;
 		height: 56px;
 		margin: 2px;
@@ -16,7 +15,7 @@
 		background-size: contain;
 		transform: scale( 1 );
 		transition: transform 0.2s ease;
-		&:first-child, &:last-child {
+		&, &:first-child, &:last-child {
 			border-radius: 100%;
 		}
 		&:hover {

--- a/extensions/blocks/map/map-theme-picker/style.scss
+++ b/extensions/blocks/map/map-theme-picker/style.scss
@@ -16,6 +16,9 @@
 		background-size: contain;
 		transform: scale( 1 );
 		transition: transform 0.2s ease;
+		&:first-child, &:last-child {
+			border-radius: 100%;
+		}
 		&:hover {
 			transform: scale( 1.1 );
 		}


### PR DESCRIPTION
Core is overriding the `border-radius` of the map theme buttons, so the first and last don't appear round, like they should.

Fixes #14701.

#### Changes proposed in this Pull Request:
* CSS fix for map block theme buttons.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix.

#### Testing instructions:

* Open the block editor.
* Insert a map block.
* Check that the map theme buttons are all round.

#### Screenshots

**Before**

<img width="377" alt="image" src="https://user-images.githubusercontent.com/87168/74589718-4a08a200-5010-11ea-8441-bf541cd5c80a.png">

**After**

<img width="325" alt="" src="https://user-images.githubusercontent.com/352291/74628113-dd74db00-51a8-11ea-9a45-9a82521c10ee.png">


#### Proposed changelog entry for your changes:
* Map Block: Fix the styling of the map theme buttons.
