### PR TITLE
Instant Search: fix missing props on mobile colophon

### DIFF
--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -75,7 +75,7 @@ class SearchForm extends Component {
 								widget={ widget }
 							/>
 						) ) }
-						<JetpackColophon />
+						<JetpackColophon locale={ this.props.locale } />
 					</div>
 				) }
 			</form>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/14708

#### Changes proposed in this Pull Request:

* Adds missing props on mobile colophon.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:

1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Ensure that you've added a Jetpack Search widget with search filters into the Jetpack Sidebar.
2. Perform a search on your site and resize your viewport to be narrower than 768 pixels.
3. Click on the filter toggle button adjacent to the overlay search input. Ensure that the mobile filter popover appears.

#### Proposed changelog entry for your changes:
* None.
