### PR TITLE
Site migration: change `migration_status` in sites endpoint to `site_migration`

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -52,7 +52,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
-		'migration_status'  => '(string) A string describing the migration status of the site.',
+		'site_migration'    => '(array) Data about any migration into the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
 	);
@@ -75,7 +75,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_following',
 		'meta',
 		'launch_status',
-		'migration_status',
+		'site_migration',
 		'is_fse_active',
 		'is_fse_eligible',
 	);
@@ -144,7 +144,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 	protected static $jetpack_response_field_additions = array(
 		'subscribers_count',
-		'migration_status',
+		'site_migration',
 	);
 
 	protected static $jetpack_response_field_member_additions = array(
@@ -391,8 +391,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'launch_status' :
 				$response[ $key ] = $this->site->get_launch_status();
 				break;
-			case 'migration_status' :
-				$response[ $key ] = $this->site->get_migration_status();
+			case 'site_migration' :
+				$response[ $key ] = $this->site->get_migration_meta();
 				break;
 			case 'is_fse_active':
 				$response[ $key ] = $this->site->is_fse_active();

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -49,7 +49,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'meta'              => '(object) Meta data',
 		'quota'             => '(array) An array describing how much space a user has left for uploads',
 		'launch_status'     => '(string) A string describing the launch status of a site',
-		'migration_status'  => '(string) A string describing the migration status of the site.',
+		'site_migration'    => '(array) Data about any migration into the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
 	);

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -651,8 +651,8 @@ abstract class SAL_Site {
 		return false;
 	}
 
-	function get_migration_status() {
-		return false;
+	function get_migration_meta() {
+		return null;
 	}
 
 	function get_site_segment() {

--- a/tests/e2e/lib/plan-helper.js
+++ b/tests/e2e/lib/plan-helper.js
@@ -236,7 +236,7 @@ function getPlanData(
 			space_available: 2100373225472,
 		},
 		launch_status: false,
-		migration_status: 'inactive',
+		site_migration: null,
 		is_fse_active: false,
 		is_fse_eligible: false,
 	};


### PR DESCRIPTION
Differential Revision: D38929-code

This commit syncs r203001-wpcom.

#### Changes proposed in this Pull Request:

* This PR reflects a change to the name and data type of the `migration_status` element of the response from the sites endpoint from a string to an array called `site_migration`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This supports the changes in D38929-code, which allow us to retrieve some metadata about a migration if one has been done into a site. See pbkcP4-8-p2.

#### Testing instructions:

* Verify that with the PR applied, the endpoint returns an empty string

#### Proposed changelog entry for your changes:

* No changelog entry required.
