### PR TITLE
Connection: move some post auth work to package

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7023,11 +7023,6 @@ endif;
 
 		// Since this is a fresh connection, be sure to clear out IDC options
 		Jetpack_IDC::clear_all_idc_options();
-		Jetpack_Options::delete_raw_option( 'jetpack_last_connect_url_check' );
-
-		// Start nonce cleaner
-		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
-		wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 
 		if ( $send_state_messages ) {
 			self::state( 'message', 'authorized' );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1807,6 +1807,12 @@ class Manager {
 		 */
 		do_action( 'jetpack_authorize_ending_authorized', $data );
 
+		\Jetpack_Options::delete_raw_option( 'jetpack_last_connect_url_check' );
+
+		// Start nonce cleaner.
+		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
+		wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
+
 		return 'authorized';
 	}
 


### PR DESCRIPTION
A few things in `Jetpack::handle_post_authorization_actions()` should be
moved to the Connection package so that they're used with all connections.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Move these method calls from Jetpack to the connection package:
 * `Jetpack_Options::delete_raw_option( 'jetpack_last_connect_url_check' )`;
 *  `wp_clear_scheduled_hook( 'jetpack_clean_nonces' );`
 *   `wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing feature of Jetpack.

#### Testing instructions:

These changes affect user authorization, so test authorization.

##### Test site
* Jetpack must be installed and not connected.
* Debug logging must be enabled.

##### Test steps
1. Connect Jetpack and authorize the user using the original authorization flow.
2. Disconnect Jetpack.
3. Connect Jetpack and authorize the user using the iframe authorization flow, which can be enabled with `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );`
4. Add a secondary administrator to the site.
5. Log in as the secondary administrator and authorize the user.
6. Verify that no errors were generated in the debug.log.


#### Proposed changelog entry for your changes:
* n/a
