### PR TITLE
Added dynamic plugins_loaded hook priority.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -578,13 +578,13 @@ class Jetpack {
 
 		$first_priority = array_shift( $taken_priorities );
 
-		if ( defined( 'PHP_INT_MAX' ) && $first_priority <= PHP_INT_MAX ) {
+		if ( defined( 'PHP_INT_MAX' ) && $first_priority <= - PHP_INT_MAX ) {
 			trigger_error( // phpcs:ignore
 				/* translators: plugins_loaded is a filter name in WordPress, no need to translate. */
 				__( 'A plugin on your site is using the plugins_loaded filter with a priority that is too high. Jetpack does not support this, you may experience problems.', 'jetpack' ), // phpcs:ignore
 				E_USER_NOTICE
 			);
-			$new_priority = PHP_INT_MAX;
+			$new_priority = - PHP_INT_MAX;
 		} else {
 			$new_priority = $first_priority - 1;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -578,7 +578,18 @@ class Jetpack {
 
 		$first_priority = array_shift( $taken_priorities );
 
-		add_action( 'plugins_loaded', array( $this, 'configure' ), $first_priority - 1 );
+		if ( defined( 'PHP_INT_MAX' ) && $first_priority <= PHP_INT_MAX ) {
+			trigger_error( // phpcs:ignore
+				/* translators: plugins_loaded is a filter name in WordPress, no need to translate. */
+				__( 'A plugin on your site is using the plugins_loaded filter with a priority that is too high. Jetpack does not support this, you may experience problems.', 'jetpack' ), // phpcs:ignore
+				E_USER_NOTICE
+			);
+			$new_priority = PHP_INT_MAX;
+		} else {
+			$new_priority = $first_priority - 1;
+		}
+
+		add_action( 'plugins_loaded', array( $this, 'configure' ), $new_priority );
 	}
 
 	/**


### PR DESCRIPTION
Before we were using priority 1 always, but some plugins want to use the hook even earlier than that, so we are watching the filters being added on each plugin load and reassigning our own configure call to an earlier priority.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes a bug with authenticated REST API calls with plugins like Give or WPMU enabled.

#### Changes proposed in this Pull Request:
* Added dynamic `plugins_loaded` hook priority determining mechanism.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a bug fix.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
* Use a snippet like this to trigger the problem:
```
function break_jetpack(){
	wp_get_current_user();
}
add_action( 'plugins_loaded', 'break_jetpack', 0 );
```
* Make an authenticated REST API call to your site using a mobile application or CLI.
* Observe the fatal error.
* Use this PR, observe no fatal errors.

#### Proposed changelog entry for your changes:
* Fixed a compatibility issue with several plugins on REST API calls.

