### PR TITLE
Add a track for each time a block plan upgrade nudge is shown to the user

### DIFF
--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -109,6 +109,7 @@ export default compose( [
 			} );
 
 		const planName = get( plan, [ 'product_name' ] );
+		console.log( blockName, planName );
 		return {
 			trackViewEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -105,7 +105,7 @@ export default compose( [
 
 		return {
 			trackViewEvent: blockName =>
-				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_view', {
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
 					plan,
 					block: blockName,
 				} ),

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -7,6 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { compact, get, startsWith } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,33 +20,45 @@ import './store';
 
 import './style.scss';
 
-export const UpgradeNudge = ( { planName, trackEvent, upgradeUrl } ) => (
-	<BlockNudge
-		buttonLabel={ __( 'Upgrade', 'jetpack' ) }
-		icon={
-			<GridiconStar
-				className="jetpack-upgrade-nudge__icon"
-				size={ 18 }
-				aria-hidden="true"
-				role="img"
-				focusable="false"
-			/>
-		}
-		href={ upgradeUrl }
-		onClick={ trackEvent }
-		title={
-			planName
-				? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
-						planName,
-				  } )
-				: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
-		}
-		subtitle={ __(
-			'You can try it out before upgrading, but only you will see it. It will be hidden from your visitors until you upgrade.',
-			'jetpack'
-		) }
-	/>
-);
+export const UpgradeNudge = ( {
+	planName,
+	trackViewEvent,
+	trackClickEvent,
+	upgradeUrl,
+	blockName,
+} ) => {
+	useEffect( () => {
+		trackViewEvent( blockName );
+	}, [] );
+
+	return (
+		<BlockNudge
+			buttonLabel={ __( 'Upgrade', 'jetpack' ) }
+			icon={
+				<GridiconStar
+					className="jetpack-upgrade-nudge__icon"
+					size={ 18 }
+					aria-hidden="true"
+					role="img"
+					focusable="false"
+				/>
+			}
+			href={ upgradeUrl }
+			onClick={ trackClickEvent }
+			title={
+				planName
+					? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
+							planName,
+					  } )
+					: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
+			}
+			subtitle={ __(
+				'You can try it out before upgrading, but only you will see it. It will be hidden from your visitors until you upgrade.',
+				'jetpack'
+			) }
+		/>
+	);
+};
 
 export default compose( [
 	withSelect( ( select, { plan: planSlug } ) => {
@@ -91,7 +104,12 @@ export default compose( [
 			} );
 
 		return {
-			trackEvent: blockName =>
+			trackViewEvent: blockName =>
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_view', {
+					plan,
+					block: blockName,
+				} ),
+			trackClickEvent: blockName =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 					plan,
 					block: blockName,

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -28,8 +28,10 @@ export const UpgradeNudge = ( {
 	blockName,
 } ) => {
 	useEffect( () => {
-		trackViewEvent( blockName );
-	}, [] );
+		if ( planName && blockName ) {
+			trackViewEvent();
+		}
+	}, [ planName, blockName ] );
 
 	return (
 		<BlockNudge
@@ -61,7 +63,7 @@ export const UpgradeNudge = ( {
 };
 
 export default compose( [
-	withSelect( ( select, { plan: planSlug } ) => {
+	withSelect( ( select, { plan: planSlug, blockName } ) => {
 		const plan = select( 'wordpress-com/plans' ).getPlan( planSlug );
 
 		// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
@@ -103,18 +105,19 @@ export default compose( [
 				redirect_to,
 			} );
 
+		const planName = get( plan, [ 'product_name' ] );
 		return {
-			trackViewEvent: blockName =>
+			trackViewEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
-					plan,
+					planName,
 					block: blockName,
 				} ),
-			trackClickEvent: blockName =>
+			trackClickEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
-					plan,
+					planName,
 					block: blockName,
 				} ),
-			planName: get( plan, [ 'product_name' ] ),
+			planName,
 			upgradeUrl,
 		};
 	} ),

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -106,12 +106,12 @@ export default compose( [
 		return {
 			trackViewEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
-					planName,
+					plan: planName,
 					block: blockName,
 				} ),
 			trackClickEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
-					planName,
+					plan: planName,
 					block: blockName,
 				} ),
 			planName,

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -28,10 +28,12 @@ export const UpgradeNudge = ( {
 	blockName,
 } ) => {
 	useEffect( () => {
-		if ( planName && blockName ) {
+		console.log(planName, blockName);
+		if ( planName ) {
+			console.log('fire-event');
 			trackViewEvent();
 		}
-	}, [ planName, blockName ] );
+	}, [ planName ] );
 
 	return (
 		<BlockNudge

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -49,9 +49,12 @@ export const UpgradeNudge = ( {
 			onClick={ trackClickEvent }
 			title={
 				planName
-					? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
-							planName,
-					  } )
+					? sprintf(
+							__( 'Upgrade to %(planName)s to use this block on your site bob.', 'jetpack' ),
+							{
+								planName,
+							}
+					  )
 					: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
 			}
 			subtitle={ __(

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -20,17 +20,9 @@ import './store';
 
 import './style.scss';
 
-export const UpgradeNudge = ( {
-	planName,
-	trackViewEvent,
-	trackClickEvent,
-	upgradeUrl,
-	blockName,
-} ) => {
+export const UpgradeNudge = ( { planName, trackViewEvent, trackClickEvent, upgradeUrl } ) => {
 	useEffect( () => {
-		console.log(planName, blockName);
 		if ( planName ) {
-			console.log('fire-event');
 			trackViewEvent();
 		}
 	}, [ planName ] );
@@ -111,18 +103,21 @@ export default compose( [
 			} );
 
 		const planName = get( plan, [ 'product_name' ] );
-		console.log( blockName, planName );
 		return {
-			trackViewEvent: () =>
-				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
+			trackViewEvent: () => {
+				console.log( 'firing view event for - ', blockName, planName );
+				return void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
 					planName,
 					block: blockName,
-				} ),
-			trackClickEvent: () =>
-				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+				} );
+			},
+			trackClickEvent: () => {
+				console.log( 'firing view event for - ', blockName, planName );
+				return void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 					planName,
 					block: blockName,
-				} ),
+				} );
+			},
 			planName,
 			upgradeUrl,
 		};

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -104,20 +104,16 @@ export default compose( [
 
 		const planName = get( plan, [ 'product_name' ] );
 		return {
-			trackViewEvent: () => {
-				console.log( 'firing view event for - ', blockName, planName );
-				return void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
+			trackViewEvent: () =>
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
 					planName,
 					block: blockName,
-				} );
-			},
-			trackClickEvent: () => {
-				console.log( 'firing view event for - ', blockName, planName );
-				return void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+				} ),
+			trackClickEvent: () =>
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 					planName,
 					block: blockName,
-				} );
-			},
+				} ),
 			planName,
 			upgradeUrl,
 		};

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -106,12 +106,12 @@ export default compose( [
 		return {
 			trackViewEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
-					plan: planName,
+					plan: planPathSlug,
 					block: blockName,
 				} ),
 			trackClickEvent: () =>
 				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
-					plan: planName,
+					plan: planPathSlug,
 					block: blockName,
 				} ),
 			planName,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Currently the block upgrade nudge only tracks a click on the upgrade button. This PR adds a track for each time the upgrade nudge is viewed by a user.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 34-GH-explorers-private

#### Testing instructions:
* Apply D39067-code to your sandbox
* On a free sandboxed WPcom site try adding a Calendly or OpenTable block in order to get the block upgrade nudge to display.
* Go to Tracks and check that only a single event is registered for each view (may take up to 5 minutes for event to register here)