### PR TITLE
Ensure default block classname is used as the root of other classes

### DIFF
--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { getBlockDefaultClassName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -32,7 +33,8 @@ import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
 
-export default function CalendlyEdit( { attributes, className, clientId, setAttributes } ) {
+export default function CalendlyEdit( { attributes, name, className, clientId, setAttributes } ) {
+	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( attributeDetails, attributes );
 
 	if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -97,7 +99,7 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 					</Button>
 				</div>
 			</form>
-			<div className={ `${ className }-learn-more` }>
+			<div className={ `${ defaultClassName }-learn-more` }>
 				<ExternalLink href="https://help.calendly.com/hc/en-us/articles/223147027-Embed-options-overview">
 					{ __( 'Need help finding your embed code?', 'jetpack' ) }
 				</ExternalLink>
@@ -136,7 +138,7 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 
 	const inlinePreview = (
 		<>
-			<div className={ `${ className }-overlay` }></div>
+			<div className={ `${ defaultClassName }-overlay` }></div>
 			<iframe
 				src={ iframeSrc() }
 				width="100%"
@@ -218,7 +220,7 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 				</>
 			) }
 			<PanelBody title={ __( 'Calendar Settings', 'jetpack' ) } initialOpen={ false }>
-				<form onSubmit={ parseEmbedCode } className={ `${ className }-embed-form-sidebar` }>
+				<form onSubmit={ parseEmbedCode } className={ `${ defaultClassName }-embed-form-sidebar` }>
 					<input
 						type="text"
 						id="embedCode"
@@ -241,7 +243,7 @@ export default function CalendlyEdit( { attributes, className, clientId, setAttr
 				/>
 			</PanelBody>
 			{ url && (
-				<Notice className={ `${ className }-color-notice` } isDismissible={ false }>
+				<Notice className={ `${ defaultClassName }-color-notice` } isDismissible={ false }>
 					<ExternalLink href="https://help.calendly.com/hc/en-us/community/posts/360033166114-Embed-Widget-Color-Customization-Available-Now-">
 						{ __( 'Follow these instructions to change the colors in this block.', 'jetpack' ) }
 					</ExternalLink>

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -25,6 +25,7 @@ import {
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { getBlockDefaultClassName } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -44,7 +45,8 @@ import {
 } from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 
-export default function OpenTableEdit( { attributes, setAttributes, className, clientId } ) {
+export default function OpenTableEdit( { attributes, setAttributes, name, className, clientId } ) {
+	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
 
 	if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -134,7 +136,7 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 		const [ type, theme ] = getTypeAndTheme( styleOveride ? styleOveride : style );
 		return (
 			<>
-				<div className={ `${ className }-overlay` }></div>
+				<div className={ `${ defaultClassName }-overlay` }></div>
 				<iframe
 					title={ sprintf( __( 'Open Table Preview %s', 'jetpack' ), clientId ) }
 					scrolling="no"
@@ -239,7 +241,7 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 			}
 		>
 			<RestaurantPicker rids={ rid } onSubmit={ onPickerSubmit } />
-			<div className={ `${ className }-placeholder-links` }>
+			<div className={ `${ defaultClassName }-placeholder-links` }>
 				<ExternalLink href="https://restaurant.opentable.com/get-started/">
 					{ __( 'Sign up for OpenTable', 'jetpack' ) }
 				</ExternalLink>
@@ -249,7 +251,7 @@ export default function OpenTableEdit( { attributes, setAttributes, className, c
 	);
 
 	const editClasses = classnames( className, {
-		[ `${ className }-theme-${ style }` ]: ! isEmpty( rid ) && styleValues.includes( style ),
+		[ `${ defaultClassName }-theme-${ style }` ]: ! isEmpty( rid ) && styleValues.includes( style ),
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
 		[ `align${ align }` ]: align,
 	} );


### PR DESCRIPTION
We've been using the `className` prop to compose other class names for
the layout of the block edit component. e.g. `${ className }-overlay`.

As pointed out by @jeherve in #14623, this breaks if additional CSS
classes are added to the block in the advanced settings.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14623

#### Changes proposed in this Pull Request:
This change, uses `getBlockDefaultClassName` to get the default class
name to use instead.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This is a bug fix for the Calendly and OpenTable blocks

#### Testing instructions:

As per the bug report in #14623, create a Calendly and/or an OpenTable block, and check that you can add additional CSS classes, without it affecting the class names of the blocks internal markup. 

#### Proposed changelog entry for your changes:
* Fixed a bug with the Calendly and OpenTable blocks that meant additional CSS classes would break the classes applied to the block in the editor.
