### PR TITLE
Show LaTeX images inline

### DIFF
--- a/modules/latex.php
+++ b/modules/latex.php
@@ -87,9 +87,8 @@ function latex_render( $latex, $fg, $bg, $s = 0 ) {
 	$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
 	$url = esc_url( $url );
 	$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
-	$style = 'display: inline;';
 
-	return '<img src="' . $url . '" style="' . $style . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
+	return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
 }
 
 /**

--- a/modules/latex.php
+++ b/modules/latex.php
@@ -87,8 +87,9 @@ function latex_render( $latex, $fg, $bg, $s = 0 ) {
 	$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
 	$url = esc_url( $url );
 	$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
+  $style = 'display: inline;';
 
-	return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
+  return '<img src="' . $url . '" style="' . $style . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
 }
 
 /**

--- a/modules/latex.php
+++ b/modules/latex.php
@@ -87,9 +87,9 @@ function latex_render( $latex, $fg, $bg, $s = 0 ) {
 	$url = "//s0.wp.com/latex.php?latex=" . urlencode( $latex ) . "&bg=" . $bg . "&fg=" . $fg . "&s=" . $s;
 	$url = esc_url( $url );
 	$alt = str_replace( '\\', '&#92;', esc_attr( $latex ) );
-  $style = 'display: inline;';
+	$style = 'display: inline;';
 
-  return '<img src="' . $url . '" style="' . $style . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
+	return '<img src="' . $url . '" style="' . $style . '" alt="' . $alt . '" title="' . $alt . '" class="latex" />';
 }
 
 /**

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -249,3 +249,12 @@
 	/* !important because the gif block styles are loaded in the footer after this file */
 	margin: 1em auto !important;
 }
+
+/**
+ * Images
+ */
+
+/* Beautiful Math */
+.entry-content img.latex {
+	display: inline;
+}


### PR DESCRIPTION
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14726

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds `display: inline;` to LaTeX images.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is not a new feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Change the theme to Twenty Twenty (the default theme)
* Create a new post with the following paragraph:
  * This $latex \LaTeX$ snippet should appear inline.

The rendered LaTeX image should render inline with the surrounding text.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Show LaTeX images inline.
