### PR TITLE
Block scaffolding: switch to namespaces for block registration

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1893,10 +1893,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 			"$path/$slug.php"     => $this->render_block_file(
 				'block-register-php',
 				array(
-					'slug'            => $slug,
-					'title'           => $title,
-					'underscoredSlug' => str_replace( '-', '_', $slug ),
-					'jetpackVersion'  => substr( JETPACK__VERSION, 0, strpos( JETPACK__VERSION, '.' ) ) . '.x',
+					'slug'             => $slug,
+					'title'            => $title,
+					'underscoredSlug'  => str_replace( '-', '_', $slug ),
+					'underscoredTitle' => str_replace( ' ', '_', $title ),
+					'jetpackVersion'   => substr( JETPACK__VERSION, 0, strpos( JETPACK__VERSION, '.' ) ) . '.x',
 				)
 			),
 			"$path/index.js"      => $this->render_block_file(

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -7,10 +7,23 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/{{ slug }}',
-	array( 'render_callback' => 'jetpack_{{ underscoredSlug }}_block_load_assets' )
-);
+namespace Jetpack\{{ title }}_Block;
+
+const FEATURE_NAME = '{{ slug }}';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * {{ title }} block registration/dependency declaration.
@@ -20,7 +33,11 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_{{ underscoredSlug }}_block_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( '{{ slug }}' );
+function load_assets( $attr, $content ) {
+	/*
+	 * Enqueue necessary scripts and styles.
+	 */
+	\Jetpack_Gutenberg::load_assets_as_required( '{{ slug }}' );
+
 	return $content;
 }

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Jetpack\{{ title }}_Block;
+namespace Jetpack\{{ underscoredTitle }}_Block;
 
 const FEATURE_NAME = '{{ slug }}';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This should make things clearer for future blocks, with less repetitions and more opportunities when folks extend that basic php file where the block is registered. It also provides the basic tools for block gating as it's done for some of our blocks already.

#### Testing instructions:

* Run `yarn docker:wp jetpack scaffold block "Cool block"`
* Open the editor
* Try adding a "Cool block" to the editor.
* Check that the block loads correctly

#### Proposed changelog entry for your changes:

* N/A
