### PR TITLE
Block Style Previews: Fix block style previews with an upgrade nudge

### DIFF
--- a/extensions/shared/components/block-styles-selector/index.js
+++ b/extensions/shared/components/block-styles-selector/index.js
@@ -18,7 +18,7 @@ const addPreviewAttribute = block => {
 		...block,
 		attributes: {
 			...block.attributes,
-			isBlockPreview: true,
+			__isBlockPreview: true,
 		},
 	};
 };

--- a/extensions/shared/components/block-styles-selector/index.js
+++ b/extensions/shared/components/block-styles-selector/index.js
@@ -13,6 +13,16 @@ import { BlockPreview } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
+const addPreviewAttribute = block => {
+	return {
+		...block,
+		attributes: {
+			...block.attributes,
+			isBlockPreview: true,
+		},
+	};
+};
+
 const StylePreview = ( { attributes, styleOption, viewportWidth, blockName } ) => {
 	const type = getBlockType( blockName );
 
@@ -20,14 +30,14 @@ const StylePreview = ( { attributes, styleOption, viewportWidth, blockName } ) =
 		<div className="block-editor-block-styles__item-preview">
 			<BlockPreview
 				viewportWidth={ viewportWidth }
-				blocks={
+				blocks={ addPreviewAttribute(
 					type.example
 						? getBlockFromExample( blockName, {
 								attributes: { ...type.example.attributes, style: styleOption.value },
 								innerBlocks: type.example.innerBlocks,
 						  } )
-						: createBlock( type, attributes )
-				}
+						: createBlock( blockName, attributes )
+				) }
 			/>
 		</div>
 	);

--- a/extensions/shared/get-validated-attributes.js
+++ b/extensions/shared/get-validated-attributes.js
@@ -14,6 +14,9 @@ export const getValidatedAttributes = ( attributeDetails, attributesToValidate )
 	reduce(
 		attributesToValidate,
 		( ret, attribute, attributeKey ) => {
+			if ( undefined === attributeDetails[ attributeKey ] ) {
+				return ret;
+			}
 			const { type, validator, validValues, default: defaultVal } = attributeDetails[
 				attributeKey
 			];

--- a/extensions/shared/wrap-paid-block.jsx
+++ b/extensions/shared/wrap-paid-block.jsx
@@ -3,6 +3,7 @@
  */
 import { Fragment } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,7 +15,9 @@ export default ( { requiredPlan } ) =>
 		WrappedComponent => props => (
 			// Wraps the input component in a container, without mutating it. Good!
 			<Fragment>
-				<UpgradeNudge plan={ requiredPlan } blockName={ props.name } />
+				{ ! get( props, 'attributes.isBlockPreview', false ) && (
+					<UpgradeNudge plan={ requiredPlan } blockName={ props.name } />
+				) }
 				<WrappedComponent { ...props } />
 			</Fragment>
 		),

--- a/extensions/shared/wrap-paid-block.jsx
+++ b/extensions/shared/wrap-paid-block.jsx
@@ -3,7 +3,6 @@
  */
 import { Fragment } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +14,7 @@ export default ( { requiredPlan } ) =>
 		WrappedComponent => props => (
 			// Wraps the input component in a container, without mutating it. Good!
 			<Fragment>
-				{ ! get( props, 'attributes.isBlockPreview', false ) && (
+				{ ( ! props?.attributes?.__isBlockPreview ?? false ) && (
 					<UpgradeNudge plan={ requiredPlan } blockName={ props.name } />
 				) }
 				<WrappedComponent { ...props } />


### PR DESCRIPTION
When an upgrade nudge is to be displayed, the block `example` setting is
removed and this threw up a bug where we were calling `createBlock` with the
incorrect arguments.

With that fixed, it still meant that the block previews had the nudge
rendered.

#### Changes proposed in this Pull Request:

This change fixes the `createBlock` bug and prevents the nudge from rendering in the preview by defining an additional attribute on the created block. 

The nudge then isn't displayed if that attribute is found to be `true`. I realise that this is somewhat hacky, but I'm not sure of a better way of passing that information down to the `wrapPaidBlock` component. We could store something in the state somewhere instead?

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix

#### Testing instructions:
Running this branch on a sandboxed site (probably easiest using the Fusion diff) create an OpenTable or Calendly block on a site with a free plan. Check that the nudge is displayed and when the block is selected, that you can see the previews of the various styles.

#### Proposed changelog entry for your changes:
Bug fixed where incorrect parameters were passed to `createBlock` when generating a block style preview
