### PR TITLE
Change the selector to target blocks that have a warning class

### DIFF
--- a/extensions/shared/with-has-warning-is-interactive-class-names/style.scss
+++ b/extensions/shared/with-has-warning-is-interactive-class-names/style.scss
@@ -1,8 +1,7 @@
 .block-editor-block-list__layout
 	// Override core styles inherited from `.has-warning`:
 	// we do want blocks with upgrade nudge warning to be interactive
-	.block-editor-block-list__block.has-warning.is-interactive
-	.block-editor-block-list__block-edit {
+	.block-editor-block-list__block.has-warning.is-interactive {
 	> * {
 		pointer-events: auto;
 		user-select: auto;


### PR DESCRIPTION
Dependent on https://github.com/Automattic/jetpack/pull/14730

#### Changes proposed in this Pull Request:
* This updates the CSS selectors used by the `with-has-warning-is-interactive-class-names` component, so that they still target the block in edit mode.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
* Apply this patch D39099-code on your sandbox
* Add a Calendly block on a free site
* Check that you can interact with the block, and add a URL
* Deselect the block
* Check that you can reselect the block

#### Proposed changelog entry for your changes:
* No changelog