### PR TITLE
Debugger: Pass the object to filter to allow easier addition of tests.

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -33,8 +33,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		 * Fires after loading default Jetpack Connection tests.
 		 *
 		 * @since 7.1.0
+		 * @since 8.3.0 Passes the Jetpack_Cxn_Tests instance.
 		 */
-		do_action( 'jetpack_connection_tests_loaded' );
+		do_action( 'jetpack_connection_tests_loaded', $this );
 
 		/**
 		 * Determines if the WP.com testing suite should be included.


### PR DESCRIPTION
Enables an easier time to add tests by doing 

```
add_action( 'jetpack_connection_tests_loaded', 'example', 10, 2);

function example( $obj ) {
$obj->add_test(...);
}
```

#### Changes proposed in this Pull Request:
* Passes $this to filters.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* @dereksmart tested this live.


#### Proposed changelog entry for your changes:
* Debugger: Improve ability to add additional tests.
