### PR TITLE
Block List HOC: Ensure className is preserved

### DIFF
--- a/extensions/shared/with-has-warning-is-interactive-class-names/index.jsx
+++ b/extensions/shared/with-has-warning-is-interactive-class-names/index.jsx
@@ -14,7 +14,7 @@ export default name =>
 		BlockListBlock => props => (
 			<BlockListBlock
 				{ ...props }
-				className={ props.name === name ? 'has-warning is-interactive' : '' }
+				className={ props.name === name ? 'has-warning is-interactive' : props.className }
 			/>
 		),
 		'withHasWarningIsInteractiveClassNames'


### PR DESCRIPTION
As the HOC was used as part of a filter, the className was getting set
by the last filter that was run. This was a lucky accident for OpenTable
as it meant that it wasn't affected by the bug being fixed in #14732 


#### Changes proposed in this Pull Request:
This change passes through the className prop when the block names don't
match, which means that if it's been set by a previous filter, it is
preserved.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix

#### Testing instructions:
* Use this branch on a free plan simple site.
* Add a Calendly and OpenTable block. 
* Verify that the containing `block-editor-block-list__block` div has the `has-warning` and `is-interactive` classes for the blocks
* Check that other blocks that don't require a plan also don't have those classes

This is dependent on #14732, which should be merged first or OpenTable will break for free WPCOM sites.

#### Proposed changelog entry for your changes:
This only affects WPCOM sites, so I don't think it requires a changelog.
