### PR TITLE
Blocks: add paid label next to block title when it requires a plan

### DIFF
--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -68,7 +68,7 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 	}
 
 	if ( blockTags.length ) {
-		blockTitle = blockTitle + ` (${ blockTags.join( ', ' ) })`;
+		blockTitle = `${ blockTitle } (${ blockTags.join( ', ' ) })`;
 	}
 
 	const result = registerBlockType( `jetpack/${ name }`, {

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -12,6 +12,11 @@ import extensionList from '../index.json';
 import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 import withHasWarningIsInteractiveClassNames from './with-has-warning-is-interactive-class-names';
 import wrapPaidBlock from './wrap-paid-block';
+
+const availableBlockTags = {
+	paid: __( 'paid', 'jetpack' ),
+	beta: __( 'beta', 'jetpack' ),
+};
 
 const betaExtensions = extensionList.beta || [];
 
@@ -53,11 +58,17 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 	}
 
 	let blockTitle = settings.title;
+	const blockTags = [];
+
 	if ( requiredPlan ) {
-		blockTitle = sprintf( __( '%s (paid)', 'jetpack' ), blockTitle );
+		blockTags.push( availableBlockTags.plan );
 	}
 	if ( betaExtensions.includes( name ) ) {
-		blockTitle = `${ blockTitle } (beta)`;
+		blockTags.push( availableBlockTags.beta );
+	}
+
+	if ( blockTags.length ) {
+		blockTitle = blockTitle + ` (${ blockTags.join( ', ' ) })`;
 	}
 
 	const result = registerBlockType( `jetpack/${ name }`, {

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -15,7 +15,14 @@ import wrapPaidBlock from './wrap-paid-block';
 
 const betaExtensions = extensionList.beta || [];
 
-function requiresPlan( unavailableReason, details ) {
+/**
+ * Checks whether the block requires a paid plan or not.
+ *
+ * @param {string} unavailableReason The reason why block is unavailable
+ * @param {Object} details The block details
+ * @returns {string|boolean} Either false if the block doesn't require a paid plan, or the actual plan name it requires.
+ */
+function requiresPaidPlan( unavailableReason, details ) {
 	if ( unavailableReason === 'missing_plan' ) {
 		return details.required_plan;
 	}
@@ -33,7 +40,7 @@ function requiresPlan( unavailableReason, details ) {
 export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
 	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );
 
-	const requiredPlan = requiresPlan( unavailableReason, details );
+	const requiredPlan = requiresPaidPlan( unavailableReason, details );
 
 	if ( ! available && ! requiredPlan ) {
 		if ( 'production' !== process.env.NODE_ENV ) {

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -35,6 +35,41 @@ function requiresPaidPlan( unavailableReason, details ) {
 }
 
 /**
+ * Builds an array of tags associated with this block, such as ["paid", "beta"].
+ *
+ * @param {string} name The block's name.
+ * @param {string|boolean} requiredPlan  Does this block require a paid plan?
+ * @returns {array} Array of tags associated with this block
+ */
+function buildBlockTags( name, requiredPlan ) {
+	const blockTags = [];
+
+	if ( requiredPlan ) {
+		blockTags.push( availableBlockTags.paid );
+	}
+	if ( betaExtensions.includes( name ) ) {
+		blockTags.push( availableBlockTags.beta );
+	}
+
+	return blockTags;
+}
+
+/**
+ * Takes a block title string and optionally appends comma separated block tags in parentheses.
+ *
+ * @param {string} blockTitle The block's title
+ * @param {array} blockTags The tags you want appended in parentheses (tags, show, here)
+ * @returns {string} Block title
+ */
+function buildBlockTitle( blockTitle, blockTags = [] ) {
+	if ( blockTags.length ) {
+		blockTitle = `${ blockTitle } (${ blockTags.join( ', ' ) })`;
+	}
+
+	return blockTitle;
+}
+
+/**
  * Registers a gutenberg block if the availability requirements are met.
  *
  * @param {string} name The block's name.
@@ -57,23 +92,9 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 		return false;
 	}
 
-	let blockTitle = settings.title;
-	const blockTags = [];
-
-	if ( requiredPlan ) {
-		blockTags.push( availableBlockTags.paid );
-	}
-	if ( betaExtensions.includes( name ) ) {
-		blockTags.push( availableBlockTags.beta );
-	}
-
-	if ( blockTags.length ) {
-		blockTitle = `${ blockTitle } (${ blockTags.join( ', ' ) })`;
-	}
-
 	const result = registerBlockType( `jetpack/${ name }`, {
 		...settings,
-		title: blockTitle,
+		title: buildBlockTitle( settings.title, buildBlockTags( name, requiredPlan ) ),
 		edit: requiredPlan ? wrapPaidBlock( { requiredPlan } )( settings.edit ) : settings.edit,
 		example: requiredPlan ? undefined : settings.example,
 	} );

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -61,7 +61,7 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 	const blockTags = [];
 
 	if ( requiredPlan ) {
-		blockTags.push( availableBlockTags.plan );
+		blockTags.push( availableBlockTags.paid );
 	}
 	if ( betaExtensions.includes( name ) ) {
 		blockTags.push( availableBlockTags.beta );

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -44,9 +45,17 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 		return false;
 	}
 
+	let blockTitle = settings.title;
+	if ( requiredPlan ) {
+		blockTitle = sprintf( __( '%s (paid)', 'jetpack' ), blockTitle );
+	}
+	if ( betaExtensions.includes( name ) ) {
+		blockTitle = `${ blockTitle } (beta)`;
+	}
+
 	const result = registerBlockType( `jetpack/${ name }`, {
 		...settings,
-		title: betaExtensions.includes( name ) ? `${ settings.title } (beta)` : settings.title,
+		title: blockTitle,
 		edit: requiredPlan ? wrapPaidBlock( { requiredPlan } )( settings.edit ) : settings.edit,
 		example: requiredPlan ? undefined : settings.example,
 	} );

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -14,7 +14,7 @@ import withHasWarningIsInteractiveClassNames from './with-has-warning-is-interac
 import wrapPaidBlock from './wrap-paid-block';
 
 const availableBlockTags = {
-	paid: __( 'paid', 'jetpack' ),
+	paid: _x( 'paid', 'Short label appearing near a block requiring a paid plan', 'jetpack' ),
 	beta: __( 'beta', 'jetpack' ),
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Related: #11875, #13490 

* This adds a ` (paid)` label next to block titles whenever a block requires a plan.

<img width="439" alt="screenshot 2020-02-19 at 22 38 15" src="https://user-images.githubusercontent.com/426388/74879122-cb419b00-5368-11ea-9314-c4925c1e2843.png">

A few notes:

- I have chosen to have `(beta)` take priority whenever a block is both paid and in Beta. I am not sure that's the best approach.
- (beta) is not translatable. I don't know if it should be.

@jeryj Do you think you could take a look and take over?

Thank you!

#### Testing instructions:

* Start from a site using the free version of Jetpack, and connected to WordPress.com.
* Add the following filter to enable paid blocks on your site: `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );`
* Open the block picker.

#### Proposed changelog entry for your changes:

* Blocks: better differentiate paid blocks from free ones.
