### PR TITLE
Debug Tests: Improve connection test, and allow overrides

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -246,22 +246,24 @@ class Jetpack_Cxn_Test_Base {
 	 * Helper function to return consistent responses for a passing test.
 	 *
 	 * @param string      $name Test name.
-	 * @param string|bool $message Message to show when test passed.
+	 * @param string|bool $message Plain text message to show when test passed.
 	 * @param string|bool $label Label to be used on Site Health card.
+	 * @param string|bool $description HTML description to be used in Site Health card.
 	 *
 	 * @return array Test results.
 	 */
-	public static function passing_test( $name = 'Unnamed', $message = false, $label = false ) {
+	public static function passing_test( $name = 'Unnamed', $message = false, $label = false, $description = false ) {
 		if ( ! $message ) {
 			$message = __( 'Test Passed!', 'jetpack' );
 		}
 		return array(
-			'name'       => $name,
-			'pass'       => true,
-			'message'    => $message,
-			'resolution' => false,
-			'severity'   => false,
-			'label'      => $label,
+			'name'        => $name,
+			'pass'        => true,
+			'message'     => $message,
+			'description' => $description,
+			'resolution'  => false,
+			'severity'    => false,
+			'label'       => $label,
 		);
 	}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -294,12 +294,17 @@ class Jetpack_Cxn_Test_Base {
 	 * @param string $resolution Optional. Steps to resolve.
 	 * @param string $action Optional. URL to direct users to self-resolve.
 	 * @param string $severity Optional. "critical" or "recommended" for failure stats. "good" for passing.
+	 * @param string $label Optional. The label to use instead of the test name.
+	 * @param string $action_label Optional. The label for the action url instead of default 'Resolve'.
 	 *
 	 * @return array Test results.
 	 */
-	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical' ) {
+	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical', $label = false, $action_label = 'Resolve' ) {
 		// Provide standard resolutions steps, but allow pass-through of non-standard ones.
 		switch ( $resolution ) {
+			case 'connect_jetpack':
+				$resolution = false;
+				break;
 			case 'cycle_connection':
 				$resolution = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
 				break;
@@ -313,12 +318,14 @@ class Jetpack_Cxn_Test_Base {
 		}
 
 		return array(
-			'name'       => $name,
-			'pass'       => false,
-			'message'    => $message,
-			'resolution' => $resolution,
-			'action'     => $action,
-			'severity'   => $severity,
+			'name'         => $name,
+			'pass'         => false,
+			'message'      => $message,
+			'resolution'   => $resolution,
+			'action'       => $action,
+			'severity'     => $severity,
+			'label'        => $label,
+			'action_label' => $action_label,
 		);
 	}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -291,22 +291,20 @@ class Jetpack_Cxn_Test_Base {
 	 * @since 7.1.0
 	 * @since 7.3.0 Added $action for resolution action link, $severity for issue severity.
 	 *
-	 * @param string $name Test name.
-	 * @param string $message Message detailing the failure.
-	 * @param string $resolution Optional. Steps to resolve.
-	 * @param string $action Optional. URL to direct users to self-resolve.
-	 * @param string $severity Optional. "critical" or "recommended" for failure stats. "good" for passing.
-	 * @param string $label Optional. The label to use instead of the test name.
-	 * @param string $action_label Optional. The label for the action url instead of default 'Resolve'.
+	 * @param string      $name Test name.
+	 * @param string      $message Message detailing the failure.
+	 * @param string      $resolution Optional. Steps to resolve.
+	 * @param string      $action Optional. URL to direct users to self-resolve.
+	 * @param string      $severity Optional. "critical" or "recommended" for failure stats. "good" for passing.
+	 * @param string      $label Optional. The label to use instead of the test name.
+	 * @param string      $action_label Optional. The label for the action url instead of default 'Resolve'.
+	 * @param string|bool $description Optional. An HTML description to override resolution.
 	 *
 	 * @return array Test results.
 	 */
-	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical', $label = false, $action_label = 'Resolve' ) {
+	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical', $label = false, $action_label = 'Resolve', $description = false ) {
 		// Provide standard resolutions steps, but allow pass-through of non-standard ones.
 		switch ( $resolution ) {
-			case 'connect_jetpack':
-				$resolution = false;
-				break;
 			case 'cycle_connection':
 				$resolution = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
 				break;
@@ -328,6 +326,7 @@ class Jetpack_Cxn_Test_Base {
 			'severity'     => $severity,
 			'label'        => $label,
 			'action_label' => $action_label,
+			'description'  => $description,
 		);
 	}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Base class for Jetpack's debugging tests.
+ *
+ * @package Jetpack.
+ */
+
 use Automattic\Jetpack\Status;
 
 /**
@@ -239,17 +245,23 @@ class Jetpack_Cxn_Test_Base {
 	/**
 	 * Helper function to return consistent responses for a passing test.
 	 *
-	 * @param string $name Test name.
+	 * @param string      $name Test name.
+	 * @param string|bool $message Message to show when test passed.
+	 * @param string|bool $label Label to be used on Site Health card.
 	 *
 	 * @return array Test results.
 	 */
-	public static function passing_test( $name = 'Unnamed' ) {
+	public static function passing_test( $name = 'Unnamed', $message = false, $label = false ) {
+		if ( ! $message ) {
+			$message = __( 'Test Passed!', 'jetpack' );
+		}
 		return array(
 			'name'       => $name,
 			'pass'       => true,
-			'message'    => __( 'Test Passed!', 'jetpack' ),
+			'message'    => $message,
 			'resolution' => false,
 			'severity'   => false,
+			'label'      => $label,
 		);
 	}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -297,12 +297,16 @@ class Jetpack_Cxn_Test_Base {
 	 * @param string      $action Optional. URL to direct users to self-resolve.
 	 * @param string      $severity Optional. "critical" or "recommended" for failure stats. "good" for passing.
 	 * @param string      $label Optional. The label to use instead of the test name.
-	 * @param string      $action_label Optional. The label for the action url instead of default 'Resolve'.
+	 * @param string|bool $action_label Optional. The label for the action url instead of default 'Resolve'.
 	 * @param string|bool $description Optional. An HTML description to override resolution.
 	 *
 	 * @return array Test results.
 	 */
-	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical', $label = false, $action_label = 'Resolve', $description = false ) {
+	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical', $label = false, $action_label = false, $description = false ) {
+		if ( ! $action_label ) {
+			/* translators: Resolve is used as a verb, a command that when invoked will lead to a problem's solution. */
+			$action_label = __( 'Resolve', 'jetpack' );
+		}
 		// Provide standard resolutions steps, but allow pass-through of non-standard ones.
 		switch ( $resolution ) {
 			case 'cycle_connection':

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -101,7 +101,20 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		} elseif ( ( new Status() )->is_development_mode() ) {
 			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {
-			$result = self::failing_test( $name, __( 'Jetpack is not connected.', 'jetpack' ), 'cycle_connection' );
+			$result = self::failing_test(
+				$name,
+				sprintf(
+					'<p>%s</p><p>%s<strong>%s</strong></p>',
+					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
+					__( '❌ Your site is not connected to Jetpack.', 'jetpack' ),
+					__( 'We recommend connecting Jetpack.', 'jetpack' )
+				),
+				'connect_jetpack',
+				admin_url( 'admin.php?page=jetpack#/dashboard' ),
+				'critical',
+				__( 'Your site is not connected to Jetpack', 'jetpack' ),
+				__( 'Learn more about this process', 'jetpack' )
+			);
 		}
 
 		return $result;

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -96,9 +96,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				__( 'Test passed!', 'jetpack' ),
 				__( 'Your site is connected to Jetpack', 'jetpack' ),
 				sprintf(
-					'<p>%s</p><p>%s</p>',
+					'<p>%1$s</p>' .
+					'<p><span class="dashicons pass"><span class="screen-reader-text">%2$s</span></span> %3$s</p>',
 					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
-					__( '✅ Your site is connected to Jetpack.', 'jetpack' )
+					/* translators: Screen reader text indicating a test has passed */
+					__( 'Passed', 'jetpack' ),
+					__( 'Your site is connected to Jetpack.', 'jetpack' )
 				)
 			);
 		} elseif ( ( new Status() )->is_development_mode() ) {
@@ -113,9 +116,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				__( 'Your site is not connected to Jetpack', 'jetpack' ),
 				__( 'Learn more about this process', 'jetpack' ),
 				sprintf(
-					'<p>%s</p><p>%s<strong>%s</strong></p>',
+					'<p>%1$s</p>' .
+					'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
 					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
-					__( '❌ Your site is not connected to Jetpack.', 'jetpack' ),
+					/* translators: screen reader text indicating a test failed */
+					__( 'Error', 'jetpack' ),
+					__( 'Your site is not connected to Jetpack.', 'jetpack' ),
 					__( 'We recommend connecting Jetpack.', 'jetpack' )
 				)
 			);

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -91,29 +91,33 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__check_if_connected() {
 		$name = __FUNCTION__;
 		if ( $this->helper_is_jetpack_connected() ) {
-			$description = sprintf(
-				'<p>%s</p><p>%s</p>',
-				__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
-				__( '✅ Your site is connected to Jetpack.', 'jetpack' )
+			$result = self::passing_test(
+				$name,
+				__( 'Test passed!', 'jetpack' ),
+				__( 'Your site is connected to Jetpack', 'jetpack' ),
+				sprintf(
+					'<p>%s</p><p>%s</p>',
+					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
+					__( '✅ Your site is connected to Jetpack.', 'jetpack' )
+				)
 			);
-			$label       = __( 'Your site is connected to Jetpack', 'jetpack' );
-			$result      = self::passing_test( $name, false, $label, $description );
 		} elseif ( ( new Status() )->is_development_mode() ) {
 			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {
 			$result = self::failing_test(
 				$name,
+				__( 'Jetpack is not connected.', 'jetpack' ),
+				'connect_jetpack',
+				admin_url( 'admin.php?page=jetpack#/dashboard' ),
+				'critical',
+				__( 'Your site is not connected to Jetpack', 'jetpack' ),
+				__( 'Learn more about this process', 'jetpack' ),
 				sprintf(
 					'<p>%s</p><p>%s<strong>%s</strong></p>',
 					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
 					__( '❌ Your site is not connected to Jetpack.', 'jetpack' ),
 					__( 'We recommend connecting Jetpack.', 'jetpack' )
-				),
-				'connect_jetpack',
-				admin_url( 'admin.php?page=jetpack#/dashboard' ),
-				'critical',
-				__( 'Your site is not connected to Jetpack', 'jetpack' ),
-				__( 'Learn more about this process', 'jetpack' )
+				)
 			);
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -114,7 +114,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				admin_url( 'admin.php?page=jetpack#/dashboard' ),
 				'critical',
 				__( 'Your site is not connected to Jetpack', 'jetpack' ),
-				__( 'Learn more about this process', 'jetpack' ),
+				__( 'Reconnect your site now', 'jetpack' ),
 				sprintf(
 					'<p>%1$s</p>' .
 					'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
@@ -122,7 +122,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 					/* translators: screen reader text indicating a test failed */
 					__( 'Error', 'jetpack' ),
 					__( 'Your site is not connected to Jetpack.', 'jetpack' ),
-					__( 'We recommend connecting Jetpack.', 'jetpack' )
+					__( 'We recommend reconnecting Jetpack.', 'jetpack' )
 				)
 			);
 		}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -91,13 +91,13 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__check_if_connected() {
 		$name = __FUNCTION__;
 		if ( $this->helper_is_jetpack_connected() ) {
-			$message = sprintf(
+			$description = sprintf(
 				'<p>%s</p><p>%s</p>',
 				__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
 				__( '✅ Your site is connected to Jetpack.', 'jetpack' )
 			);
-			$label   = __( 'Your site is connected to Jetpack', 'jetpack' );
-			$result  = self::passing_test( $name, $message, $label );
+			$label       = __( 'Your site is connected to Jetpack', 'jetpack' );
+			$result      = self::passing_test( $name, false, $label, $description );
 		} elseif ( ( new Status() )->is_development_mode() ) {
 			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {
@@ -248,7 +248,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	}
 
 	/**
-	 * Tests connection status against wp.com's test-connection endpoint
+	 * Tests connection status against wp.com's test-connection endpoint.
 	 *
 	 * @todo: Compare with the wpcom_self_test. We only need one of these.
 	 *

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -91,7 +91,13 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__check_if_connected() {
 		$name = __FUNCTION__;
 		if ( $this->helper_is_jetpack_connected() ) {
-			$result = self::passing_test( $name );
+			$message = sprintf(
+				'<p>%s</p><p>%s</p>',
+				__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
+				__( '✅ Your site is connected to Jetpack.', 'jetpack' )
+			);
+			$label   = __( 'Your site is connected to Jetpack', 'jetpack' );
+			$result  = self::passing_test( $name, $message, $label );
 		} elseif ( ( new Status() )->is_development_mode() ) {
 			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
 		} else {

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -76,6 +76,11 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 							__( '(opens in a new tab)', 'jetpack' )
 						);
 					}
+				} elseif ( true === $results['pass'] ) {
+					$return['description'] = $results['message'];
+					if ( $results['label'] ) {
+						$return['label'] = $results['label'];
+					}
 				}
 
 				return $return;

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -61,25 +61,21 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 					return;
 				}
 				if ( false === $results['pass'] ) {
+					$return['label'] = $results['message'];
 					if ( $results['label'] ) {
-						// `test__check_if_connected` is the only test that is properly using a label.
+						// Allow tests to override the strange message => label logic with an actual label.
 						$return['label'] = $results['label'];
-					} else {
-						// All other tests pass message as label.
-						// TODO: fix it so all tests use label.
-						$return['label'] = $results['message'];
 					}
 
-					if ( $results['resolution'] ) {
-						// Most tests pass a `resolution` property to use as a description.
-						$return['description'] = sprintf(
-							'<p>%s</p>',
-							$results['resolution']
-						);
-					} else {
-						// `test__check_if_connected` uses 'message' property for description.
-						// TODO: remove 'resolution' property in favor of a consistent 'message' or even 'description'.
-						$return['description'] = $results['message'];
+					// Most tests pass a `resolution` property to use as a description.
+					$return['description'] = sprintf(
+						'<p>%s</p>',
+						$results['resolution']
+					);
+
+					if ( $results['description'] ) {
+						// Allow tests to override 'resolution' with their own HTML description.
+						$return['description'] = $results['description'];
 					}
 
 					$return['status'] = $results['severity'];

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -93,9 +93,13 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 						);
 					}
 				} elseif ( true === $results['pass'] ) {
-					$return['description'] = $results['message'];
+					// Passing tests can chose to override defaults.
 					if ( $results['label'] ) {
 						$return['label'] = $results['label'];
+					}
+
+					if ( $results['description'] ) {
+						$return['description'] = $results['description'];
 					}
 				}
 

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -61,17 +61,33 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 					return;
 				}
 				if ( false === $results['pass'] ) {
-					$return['label'] = $results['message'];
-					$return['status']      = $results['severity'];
-					$return['description'] = sprintf(
-						'<p>%s</p>',
-						$results['resolution']
-					);
+					if ( $results['label'] ) {
+						// `test__check_if_connected` is the only test that is properly using a label.
+						$return['label'] = $results['label'];
+					} else {
+						// All other tests pass message as label.
+						// TODO: fix it so all tests use label.
+						$return['label'] = $results['message'];
+					}
+
+					if ( $results['resolution'] ) {
+						// Most tests pass a `resolution` property to use as a description.
+						$return['description'] = sprintf(
+							'<p>%s</p>',
+							$results['resolution']
+						);
+					} else {
+						// `test__check_if_connected` uses 'message' property for description.
+						// TODO: remove 'resolution' property in favor of a consistent 'message' or even 'description'.
+						$return['description'] = $results['message'];
+					}
+
+					$return['status'] = $results['severity'];
 					if ( ! empty( $results['action'] ) ) {
 						$return['actions'] = sprintf(
-							'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+							'<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
 							esc_url( $results['action'] ),
-							__( 'Resolve', 'jetpack' ),
+							$results['action_label'],
 							/* translators: accessibility text */
 							__( '(opens in a new tab)', 'jetpack' )
 						);


### PR DESCRIPTION
## Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Allowed failing and passing tests to override the proposed defaults for the Site Health, while preserving the functionality of test messaging in the CLI and API test environments.
* improved the messaging on the Connection test for the Site Health page.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is step one in improving Jetpack's site health section
* See: p6TEKc-3st-p2

#### Testing instructions:
* Test that CLI tests still function
* Test that all Jetpack Site Health tests still look okay ( Tools -> Site Health )
* Take a look a the new Site Health card for a connected site:

<img width="882" alt="Screen Shot 2020-02-20 at 3 06 13 PM" src="https://user-images.githubusercontent.com/2694219/74975299-d80bd080-53f4-11ea-887b-d8acdbb3bc81.png">

* Take a look at the new Site Health card for an unconnected site:

<img width="850" alt="Screen Shot 2020-02-20 at 2 57 42 PM" src="https://user-images.githubusercontent.com/2694219/74975362-f1148180-53f4-11ea-98fc-93b3cc9e1b93.png">


#### Proposed changelog entry for your changes:
* n/a
