### PR TITLE
Instant Search: use link to clear filters instead of button

### DIFF
--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -22,9 +22,16 @@ export default class SearchFilters extends Component {
 		this.props.onChange && this.props.onChange();
 	};
 
-	onClearFilters = () => {
-		clearFiltersFromQuery();
-		this.props.onChange && this.props.onChange();
+	onClearFilters = event => {
+		event.preventDefault();
+
+		if (
+			event.type === 'click' ||
+			( event.type === 'keydown' && ( event.key === 'Enter' || event.key === ' ' ) )
+		) {
+			clearFiltersFromQuery();
+			this.props.onChange && this.props.onChange();
+		}
 	};
 
 	hasActiveFilters() {
@@ -94,12 +101,16 @@ export default class SearchFilters extends Component {
 		return (
 			<div className={ cls }>
 				{ this.hasActiveFilters() && (
-					<button
-						class="jetpack-instant-search__clear-filters-button"
+					<a
+						class="jetpack-instant-search__clear-filters-link"
+						href="#"
 						onClick={ this.onClearFilters }
+						onKeyDown={ this.onClearFilters }
+						role="button"
+						tabIndex="0"
 					>
-						{ __( 'Clear Filters', 'jetpack' ) }
-					</button>
+						{ __( 'Clear filters', 'jetpack' ) }
+					</a>
 				) }
 				{ get( this.props.widget, 'filters' )
 					.map( configuration =>

--- a/modules/search/instant-search/components/search-filters.scss
+++ b/modules/search/instant-search/components/search-filters.scss
@@ -19,6 +19,6 @@
 	cursor: pointer;
 }
 
-.jetpack-instant-search__clear-filters-button {
+.jetpack-instant-search__clear-filters-link {
 	margin-bottom: 1em;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/14616

#### Changes proposed in this Pull Request:
* Transforms “Clear filters” button into a more subtle link.

#### Before

![image](https://user-images.githubusercontent.com/390760/74944476-05a14b80-53ee-11ea-8f19-8813f3b51fbf.png)


#### After

![image](https://user-images.githubusercontent.com/390760/74944484-0803a580-53ee-11ea-97f4-3b1ff888ac43.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Search your site to trigger the Jetpack Search overlay.
3. Apply some filtering to your search results.
4. Ensure the link is visible, actionable, and accessible.

#### Proposed changelog entry for your changes:
* None.
