### PR TITLE
Instant Search: improve grid structure in overlay

### DIFF
--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -38,7 +38,8 @@
 
 	@include break-medium() {
 		position: absolute;
-		top: -32px;
+		top: -22px;
+		right: 8px;
 		width: 64px;
 		height: 64px;
 		padding: 20px;

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -49,7 +49,7 @@ const SearchBox = props => {
 	return (
 		<div className="jetpack-instant-search__box">
 			{ /* TODO: Add support for preserving label text */ }
-			<label htmlFor={ inputId }>
+			<label className="jetpack-instant-search__box-label" htmlFor={ inputId }>
 				<span className="screen-reader-text">{ __( 'Site Search', 'jetpack' ) }</span>
 				<div className="jetpack-instant-search__box-gridicon">
 					<Gridicon icon="search" size={ 24 } />

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -5,6 +5,10 @@
 	flex: 0 0 100%;
 }
 
+.jetpack-instant-search__box-label {
+	width: 100%;
+}
+
 input.jetpack-instant-search__box-input.search-field {
 	background: #fff;
 	border-radius: 5px;

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -4,7 +4,7 @@
 	z-index: 10;
 	max-width: 1080px;
 	margin: 0 auto;
-	padding: 0.125em 1em;
+	padding: 0 0.5em;
 	text-align: left;
 
 	mark {
@@ -57,7 +57,7 @@
 		display: block;
 		flex: 2;
 		width: auto;
-		padding: 0;
+		padding: 10em 0 0;
 		background: none;
 		border: 0;
 		border-radius: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds some tweaks to improve the grid structure of the Jetpack Search overlay.

Here's how it looks now in some of the themes.

![image](https://user-images.githubusercontent.com/390760/74949448-ae9f7480-53f5-11ea-87a0-052e24e6d35a.png)

![image](https://user-images.githubusercontent.com/390760/74949454-b19a6500-53f5-11ea-830e-94f657616c35.png)

![image](https://user-images.githubusercontent.com/390760/74949459-b3642880-53f5-11ea-875e-f977ae723a78.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
2. Search your site to trigger the Jetpack Search overlay.
3. Ensure that the Jetpack Search overlay looks good in a multitude of themes.

#### Proposed changelog entry for your changes:
* None.
