### PR TITLE
Set OpenGraph title meta attribute on search pages.

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -161,9 +161,8 @@ function jetpack_og_tags() {
 			}
 		}
 	} elseif ( is_search() ) {
-		$query_param = get_query_var( 's', '' );
-		if ( '' !== $query_param ) {
-			$tags['og:title'] = __( 'Search results: ', 'jetpack' ) . $query_param;
+		if ( '' !== get_query_var( 's', '' ) ) {
+			$tags['og:title'] = wp_get_document_title();
 		}
 	}
 	/**

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -161,7 +161,10 @@ function jetpack_og_tags() {
 			}
 		}
 	} elseif ( is_search() ) {
-		$tags['og:title'] = 'Search results: ' . get_query_var( 's', '(no title)' );
+		$query_param = get_query_var( 's', '' );
+		if ( '' !== $query_param ) {
+			$tags['og:title'] = __( 'Search results: ', 'jetpack' ) . $query_param;
+		}
 	}
 	/**
 	 * Allow plugins to inject additional template-specific Open Graph tags.

--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -152,16 +152,17 @@ function jetpack_og_tags() {
 			$tags['og:description'] = wp_kses( trim( convert_chars( wptexturize( $tags['og:description'] ) ) ), array() );
 		}
 
-		$tags['article:published_time'] = date( 'c', strtotime( $data->post_date_gmt ) );
-		$tags['article:modified_time']  = date( 'c', strtotime( $data->post_modified_gmt ) );
+		$tags['article:published_time'] = gmdate( 'c', strtotime( $data->post_date_gmt ) );
+		$tags['article:modified_time']  = gmdate( 'c', strtotime( $data->post_modified_gmt ) );
 		if ( post_type_supports( get_post_type( $data ), 'author' ) && isset( $data->post_author ) ) {
 			$publicize_facebook_user = get_post_meta( $data->ID, '_publicize_facebook_user', true );
 			if ( ! empty( $publicize_facebook_user ) ) {
 				$tags['article:author'] = esc_url( $publicize_facebook_user );
 			}
 		}
+	} elseif ( is_search() ) {
+		$tags['og:title'] = 'Search results: ' . get_query_var( 's', '(no title)' );
 	}
-
 	/**
 	 * Allow plugins to inject additional template-specific Open Graph tags.
 	 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14677 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an OpenGraph `title` metadata tag based on the search terms, to the search results page.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds a feature to the existing OpenGraph component.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a WP post. View the source and see in the `head` section a set of `meta` tags for OpenGraph, including a descriptive `og:title` tag.
* Search for a term. In the search results page, view the source and look in the `head` section again for `meta` tags. You should find an `og:title` one with a value of `Search results for "{search term}" - {site name}`.

The output should look like:

```
<!-- Jetpack Open Graph Tags -->
<meta property="og:title" content="Search Results for “foo” – blah">
<meta property="og:site_name" content="blah">
<meta property="og:image" content="https://s0.wp.com/i/blank.jpg">
<meta property="og:locale" content="en_US">

<!-- End Jetpack Open Graph Tags -->
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds OpenGraph title attribute to the search results page.
