### PR TITLE
Multisite: Run configure in all plugin situations

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -604,6 +604,7 @@ class Jetpack {
 		// Note how this runs at an earlier plugin_loaded hook intentionally to accomodate for other plugins.
 		add_action( 'plugin_loaded', array( $this, 'add_configure_hook' ), 90 );
 		add_action( 'network_plugin_loaded', array( $this, 'add_configure_hook' ), 90 );
+		add_action( 'mu_plugin_loaded', array( $this, 'add_configure_hook' ), 90 );
 		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
 		add_action( 'jetpack_verify_signature_error', array( $this, 'track_xmlrpc_error' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -603,6 +603,7 @@ class Jetpack {
 
 		// Note how this runs at an earlier plugin_loaded hook intentionally to accomodate for other plugins.
 		add_action( 'plugin_loaded', array( $this, 'add_configure_hook' ), 90 );
+		add_action( 'network_plugin_loaded', array( $this, 'add_configure_hook' ), 90 );
 		add_action( 'plugins_loaded', array( $this, 'late_initialization' ), 90 );
 
 		add_action( 'jetpack_verify_signature_error', array( $this, 'track_xmlrpc_error' ) );


### PR DESCRIPTION
Fixes #14748

#### Changes proposed in this Pull Request:
* Fires the `add_configure_hook` for mu-plugins and network activated plugins too.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Start a multisite.
* Install Jetpack and network activate.
* Visit a subsite's wp-admin with no "local" plugins (only network activated plugins).
* Before patch, see fatal. After patch, see wp-admin.

#### Proposed changelog entry for your changes:
* Multisite: Resolve issue view the wp-admin dashboard on subsites with no non-network-activated plugins.
