### PR TITLE
Remove the paid plan restriction on the google calendar block

### DIFF
--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -29,16 +29,6 @@ function register_block() {
 add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
 
 /**
- * Set the availability of the block as the editor
- * is loaded
- */
-function set_availability() {
-	\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
-}
-
-add_action( 'init', 'Jetpack\Google_Calendar_Block\set_availability' );
-
-/**
  * Google Calendar block registration/dependency declaration.
  *
  * @param array $attr Array containing the Google Calendar block attributes.

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -11,28 +11,6 @@ namespace Jetpack\Google_Calendar_Block;
 
 const FEATURE_NAME = 'google-calendar';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
-/**
- * Check if the block should be available on the site.
- *
- * @return bool
- */
-function is_available() {
-	if (
-		defined( 'IS_WPCOM' )
-		&& IS_WPCOM
-		&& function_exists( 'has_any_blog_stickers' )
-	) {
-		if ( has_any_blog_stickers(
-			array( 'premium-plan', 'business-plan', 'ecommerce-plan' ),
-			get_current_blog_id()
-		) ) {
-			return true;
-		}
-		return false;
-	}
-
-	return true;
-}
 
 /**
  * Registers the block for use in Gutenberg
@@ -40,15 +18,14 @@ function is_available() {
  * registration if we need to.
  */
 function register_block() {
-	if ( is_available() ) {
-		jetpack_register_block(
-			BLOCK_NAME,
-			array(
-				'render_callback' => 'Jetpack\Google_Calendar_Block\load_assets',
-			)
-		);
-	}
+	jetpack_register_block(
+		BLOCK_NAME,
+		array(
+			'render_callback' => 'Jetpack\Google_Calendar_Block\load_assets',
+		)
+	);
 }
+
 add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
 
 /**
@@ -56,19 +33,9 @@ add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
  * is loaded
  */
 function set_availability() {
-	if ( is_available() ) {
-		\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
-	} else {
-		\Jetpack_Gutenberg::set_extension_unavailable(
-			BLOCK_NAME,
-			'missing_plan',
-			array(
-				'required_feature' => 'google_calendar',
-				'required_plan'    => 'value_bundle',
-			)
-		);
-	}
+	\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
 }
+
 add_action( 'init', 'Jetpack\Google_Calendar_Block\set_availability' );
 
 /**


### PR DESCRIPTION
Removes the paid plan restriction on the google calendar block as this block was intended to be a free one on WP.com

#### Changes proposed in this Pull Request:

* Removes the is_available check from the block initialisation

#### Testing instructions:

Check out this branch and make sure you are still able to add and edit a Google Calendar Block - you will still need to have JETPACK_BETA_BLOCKS as true

#### Proposed changelog entry for your changes:
* No change needs to be noted as just reverting to original intent of block for 8.3 release 