### PR TITLE
Use vanilla JS instead of jQuery for the Cookies & Consents widget

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -105,7 +105,7 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 					'_inc/build/widgets/eu-cookie-law/eu-cookie-law.min.js',
 					'modules/widgets/eu-cookie-law/eu-cookie-law.js'
 				),
-				array( 'jquery' ),
+				array(),
 				'20180522',
 				true
 			);

--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -1,44 +1,52 @@
-( function( $ ) {
+( function() {
 	var cookieValue = document.cookie.replace(
 			/(?:(?:^|.*;\s*)eucookielaw\s*\=\s*([^;]*).*$)|^.*$/,
 			'$1'
 		),
-		overlay = $( '#eu-cookie-law' ),
+		overlay = document.getElementById( 'eu-cookie-law' ),
+		widget = document.querySelector( '.widget_eu_cookie_law_widget' ),
+		getScrollTop,
 		initialScrollPosition,
 		scrollFunction;
 
-	if ( overlay.hasClass( 'top' ) ) {
-		$( '.widget_eu_cookie_law_widget' ).addClass( 'top' );
+	/**
+	 * Gets the amount that the window is scrolled.
+	 *
+	 * @return int The distance from the top of the document.
+	 */
+	getScrollTop = function() {
+		return Math.abs( document.body.getBoundingClientRect().y );
+	};
+
+	if ( overlay.classList.contains( 'top' ) ) {
+		widget.classList.add( 'top' );
 	}
 
-	if ( overlay.hasClass( 'ads-active' ) ) {
+	if ( overlay.classList.contains( 'ads-active' ) ) {
 		var adsCookieValue = document.cookie.replace(
 			/(?:(?:^|.*;\s*)personalized-ads-consent\s*\=\s*([^;]*).*$)|^.*$/,
 			'$1'
 		);
 		if ( '' !== cookieValue && '' !== adsCookieValue ) {
-			overlay.remove();
+			overlay.parentNode.removeChild( overlay );
 		}
 	} else if ( '' !== cookieValue ) {
-		overlay.remove();
+		overlay.parentNode.removeChild( overlay );
 	}
 
-	$( '.widget_eu_cookie_law_widget' )
-		.appendTo( 'body' )
-		.fadeIn();
+	document.body.appendChild( widget );
+	overlay.querySelector( 'form' ).addEventListener( 'submit', accept );
 
-	overlay.find( 'form' ).on( 'submit', accept );
-
-	if ( overlay.hasClass( 'hide-on-scroll' ) ) {
-		initialScrollPosition = $( window ).scrollTop();
+	if ( overlay.classList.contains( 'hide-on-scroll' ) ) {
+		initialScrollPosition = getScrollTop();
 		scrollFunction = function() {
-			if ( Math.abs( $( window ).scrollTop() - initialScrollPosition ) > 50 ) {
+			if ( Math.abs( getScrollTop() - initialScrollPosition ) > 50 ) {
 				accept();
 			}
 		};
-		$( window ).on( 'scroll', scrollFunction );
-	} else if ( overlay.hasClass( 'hide-on-time' ) ) {
-		setTimeout( accept, overlay.data( 'hide-timeout' ) * 1000 );
+		window.addEventListener( 'scroll', scrollFunction );
+	} else if ( overlay.classList.contains( 'hide-on-time' ) ) {
+		setTimeout( accept, overlay.getAttribute( 'data-hide-timeout' ) * 1000 );
 	}
 
 	var accepted = false;
@@ -52,18 +60,21 @@
 			event.preventDefault();
 		}
 
-		if ( overlay.hasClass( 'hide-on-scroll' ) ) {
-			$( window ).off( 'scroll', scrollFunction );
+		if ( overlay.classList.contains( 'hide-on-scroll' ) ) {
+			window.removeEventListener( 'scroll', scrollFunction );
 		}
 
 		var expireTime = new Date();
 		expireTime.setTime(
-			expireTime.getTime() + overlay.data( 'consent-expiration' ) * 24 * 60 * 60 * 1000
+			expireTime.getTime() + overlay.getAttribute( 'data-consent-expiration' ) * 24 * 60 * 60 * 1000
 		);
 
 		document.cookie =
 			'eucookielaw=' + expireTime.getTime() + ';path=/;expires=' + expireTime.toGMTString();
-		if ( overlay.hasClass( 'ads-active' ) && overlay.hasClass( 'hide-on-button' ) ) {
+		if (
+			overlay.classList.contains( 'ads-active' ) &&
+			overlay.classList.contains( 'hide-on-button' )
+		) {
 			document.cookie =
 				'personalized-ads-consent=' +
 				expireTime.getTime() +
@@ -71,10 +82,11 @@
 				expireTime.toGMTString();
 		}
 
-		overlay.fadeOut( 400, function() {
-			overlay.remove();
+		overlay.classList.add( 'hide' );
+		setTimeout( function() {
+			overlay.parentNode.removeChild( overlay );
 			var widgetSection = document.querySelector( '.widget.widget_eu_cookie_law_widget' );
 			widgetSection.parentNode.removeChild( widgetSection );
-		} );
+		}, 400 );
 	}
-} )( jQuery );
+} )();

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -1,7 +1,7 @@
 .widget_eu_cookie_law_widget {
+	animation: fadeIn 800ms;
 	border: none;
 	bottom: 1em;
-	display: none;
 	left: 1em;
 	margin: 0;
 	padding: 0;
@@ -9,6 +9,11 @@
 	right: 1em;
 	width: auto;
 	z-index: 50001;
+}
+
+@keyframes fadeIn {
+	from { opacity: 0; visibility: hidden; }
+	to { opacity: 1; visibility: visible; }
 }
 
 .widget_eu_cookie_law_widget.widget.top {
@@ -48,6 +53,12 @@
 	background-color: #000;
 	border: none;
 	color: #fff;
+}
+
+#eu-cookie-law.hide {
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 400ms, visibility 400ms;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* No expected change in functionality.
* Uses vanilla JS instead of jQuery

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This isn't a new feature, it only modifies an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. In the Customizer, add a Cookies & Consents Banner widget to a sidebar
2. Exit the Customizer 
3. Expected: the widget appears at the bottom
4. Expected: clicking 'Close and accept' dismisses it
![cookies-conte](https://user-images.githubusercontent.com/4063887/75022331-86e2f780-545b-11ea-9252-dbfd90e592b7.gif)


5. Delete the `eucookielaw` cookie from the browser
6. In the Customizer, change some of the widget options. Like 'after the user scrolls the page.'
7. Ensure the widget works as expected

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Use vanilla JavaScript in the Cookies and Consents widget
