### PR TITLE
OpenTable & Calendly: Improve save functions by wrapping links in divs

### DIFF
--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -65,7 +65,6 @@ export const settings = {
 	deprecated: [
 		{
 			attributes,
-			supports,
 			save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
 		},
 	],

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -35,7 +35,11 @@ export const settings = {
 		html: false,
 	},
 	edit,
-	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
+	save: ( { attributes: { url } } ) => (
+		<div>
+			<a href={ url }>{ url }</a>
+		</div>
+	),
 	attributes,
 	example: {
 		attributes: {

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -19,6 +19,11 @@ import './editor.scss';
 
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
+const supports = {
+	align: true,
+	alignWide: false,
+	html: false,
+};
 export const settings = {
 	title,
 	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
@@ -29,11 +34,7 @@ export const settings = {
 		__( 'schedule', 'jetpack' ),
 		__( 'appointments', 'jetpack' ),
 	],
-	supports: {
-		align: true,
-		alignWide: false,
-		html: false,
-	},
+	supports,
 	edit,
 	save: ( { attributes: { url } } ) => (
 		<div>
@@ -61,4 +62,11 @@ export const settings = {
 			},
 		],
 	},
+	deprecated: [
+		{
+			attributes,
+			supports,
+			save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
+		},
+	],
 };

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -74,7 +74,6 @@ export const settings = {
 	deprecated: [
 		{
 			attributes: defaultAttributes,
-			supports,
 			save: ( { attributes: { rid } } ) => (
 				<>
 					{ rid.map( restaurantId => (

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -20,7 +20,10 @@ import './view.scss';
 export const name = 'opentable';
 export const title = __( 'OpenTable', 'jetpack' );
 import { getAttributesFromEmbedCode, restRefRegex, ridRegex } from './utils';
-
+const supports = {
+	align: true,
+	html: false,
+};
 export const settings = {
 	title,
 	description: __( 'Allow visitors to book a reservation with OpenTable', 'jetpack' ),
@@ -31,10 +34,7 @@ export const settings = {
 		__( 'reservation', 'jetpack' ),
 		__( 'restaurant', 'jetpack' ),
 	],
-	supports: {
-		align: true,
-		html: false,
-	},
+	supports,
 	edit,
 	save: ( { attributes: { rid } } ) => (
 		<div>
@@ -71,4 +71,19 @@ export const settings = {
 			},
 		],
 	},
+	deprecated: [
+		{
+			attributes: defaultAttributes,
+			supports,
+			save: ( { attributes: { rid } } ) => (
+				<>
+					{ rid.map( restaurantId => (
+						<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
+							{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
+						</a>
+					) ) }
+				</>
+			),
+		},
+	],
 };

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -37,13 +37,13 @@ export const settings = {
 	},
 	edit,
 	save: ( { attributes: { rid } } ) => (
-		<>
+		<div>
 			{ rid.map( restaurantId => (
 				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
 					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
 				</a>
 			) ) }
-		</>
+		</div>
 	),
 	attributes: defaultAttributes,
 	example: {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When links aren't wrapped in block level elements they can create strange display issues:
<img width="1412" alt="Screenshot 2020-02-21 at 13 18 22" src="https://user-images.githubusercontent.com/275961/75037763-d6054880-54ac-11ea-843b-872797cc1374.png">
Let's wrap them in `<div>`s to work around this.
I've also had to add deprecations for the old save functions.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Spotted by @Copons in https://github.com/Automattic/jetpack/pull/14732#pullrequestreview-362596796

#### Testing instructions:
* Add a Calendly and OpenTable block to a page
* Make the blocks unavailable (you can do this by commenting out the line that registers them)
* Check that the links appear inside the theme content like this:
<img width="834" alt="Screenshot 2020-02-21 at 13 16 55" src="https://user-images.githubusercontent.com/275961/75037750-cd147700-54ac-11ea-8922-2b4268acef40.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
