### PR TITLE
Sync: consistent id field when syncing terms 

### DIFF
--- a/packages/sync/src/modules/class-terms.php
+++ b/packages/sync/src/modules/class-terms.php
@@ -34,7 +34,7 @@ class Terms extends Module {
 	 * @return string
 	 */
 	public function id_field() {
-		return 'term_id';
+		return 'term_taxonomy_id';
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-terms.php
+++ b/tests/php/sync/test_class.jetpack-sync-terms.php
@@ -45,7 +45,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 	public function test_insert_term_is_synced() {
 		$terms        = $this->get_terms();
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
-		$this->assertEqualsObject( $terms, $server_terms );
+		$this->assertEqualsObject( $terms, $server_terms, 'Synced terms do not match local terms.' );
 
 		$event_data = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_add_term' );
 		$this->assertTrue( (bool) $event_data );
@@ -61,7 +61,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 
 		$terms        = $this->get_terms();
 		$server_terms = $this->server_replica_storage->get_terms( $this->taxonomy );
-		$this->assertEqualsObject( $terms, $server_terms );
+		$this->assertEqualsObject( $terms, $server_terms, 'Synced terms do not match local terms.' );
 	}
 
 	public function test_delete_term_is_synced() {
@@ -80,7 +80,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 
 		$object_terms        = get_the_terms( $this->post_id, $this->taxonomy );
 		$server_object_terms = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
-		$this->assertEqualsObject( $object_terms, $server_object_terms );
+		$this->assertEqualsObject( $object_terms, $server_object_terms, 'Synced terms do not match local terms.' );
 	}
 
 	public function test_added_terms_to_post_is_synced_appended() {
@@ -94,7 +94,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$object_terms        = get_the_terms( $this->post_id, $this->taxonomy );
 		$server_object_terms = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
 		$server_object_terms = array_reverse( $server_object_terms );
-		$this->assertEqualsObject( $object_terms, $server_object_terms );
+		$this->assertEqualsObject( $object_terms, $server_object_terms, 'Synced terms do not match local terms.' );
 	}
 
 	public function test_deleted_terms_to_post_is_synced() {
@@ -112,7 +112,7 @@ class WP_Test_Jetpack_Sync_Terms extends WP_Test_Jetpack_Sync_Base {
 		$server_object_terms = $this->server_replica_storage->get_the_terms( $this->post_id, $this->taxonomy );
 		$server_object_terms = array_reverse( $server_object_terms );
 
-		$this->assertEqualsObject( $object_terms, $server_object_terms );
+		$this->assertEqualsObject( $object_terms, $server_object_terms, 'Synced terms do not match local terms.' );
 	}
 
 	public function test_delete_object_term_relationships() {


### PR DESCRIPTION
Fixes #14752

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* From the issue report:
"In short, the Sender is sending terms_ids but then later querying for the data as if it sent term_taxonomony_id.
On newer WP sites, this wouldn't be an issue because term_id === term_taxonomony_id usually I believe. This is prevalent on sites before the term split days though, as these two ids are not the same thing."

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
- With this patch applied, try a full sync and ensure terms are synced properly
- Try a `pull` from the server
- Observe incremental sync while syncing terms

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
