### PR TITLE
In-place connection flow: Fix redirect after success when connecting via plugins popup. 

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -154,10 +154,16 @@ jQuery( document ).ready( function( $ ) {
 		},
 		handleAuthorizationComplete: function() {
 			jetpackConnectButton.isRegistering = false;
+
 			if ( jetpackConnectButton.isPaidPlan ) {
 				window.location.assign( jpConnect.dashboardUrl );
 			} else {
 				window.location.assign( jpConnect.plansPromptUrl );
+			}
+
+			// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
+			if ( window.location.hash ) {
+				window.location.reload( true );
 			}
 		},
 		handleConnectionError: function( error ) {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -154,13 +154,11 @@ jQuery( document ).ready( function( $ ) {
 		},
 		handleAuthorizationComplete: function() {
 			jetpackConnectButton.isRegistering = false;
-
 			if ( jetpackConnectButton.isPaidPlan ) {
 				window.location.assign( jpConnect.dashboardUrl );
 			} else {
 				window.location.assign( jpConnect.plansPromptUrl );
 			}
-			window.location.reload( true );
 		},
 		handleConnectionError: function( error ) {
 			jetpackConnectButton.isRegistering = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue with the in-place flow not redirecting to the plans page after connection when initiated outside of the Jetpack admin area. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Only use `window.location.reload` if necessary - i.e. when on a Jetpack admin page. 
- Does not attempt to run `window.location.reload` if the URL doesn't have a hash in the URL. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Fixes an existing feature. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- `define( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME', true );` in wp-config.php
- Navigate to `/wp-admin/plugins.php`. Deactivate Jetpack. 
- Activate Jetpack. You should see the full-screen modal popup to connect. Click it!
- After authorization, you should be redirected to `/wp-admin/admin.php?page=jetpack#/plans-prompt`, if your site is on a free plan. 
- Test again with a paid plan, and make sure you're redirected to `/wp-admin/admin.php?page=jetpack#/dashboard`. 
- Make sure these redirects still work properly when initiating the in-place connection within the Jetpack admin area as well. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
NA 
