### PR TITLE
Ads module: Use vanilla JS instead of jQuery

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -423,7 +423,7 @@ HTML;
 	}
 
 	/**
-	 * Special cases for inserting header unit via jQuery
+	 * Special cases for inserting header unit via JS
 	 *
 	 * @since 4.5.0
 	 */
@@ -459,7 +459,15 @@ HTML;
 		if ( ! self::is_amp() ) {
 			echo <<<HTML
 		<script type="text/javascript">
-			jQuery('.wpcnt-header').insertBefore('$selector');
+			(function ( selector ) {
+				var main = document.querySelector( selector );
+				var headerAd = document.querySelector('.wpcnt-header');
+
+				if ( main ) {
+					main.parentNode.insertBefore( headerAd, main );
+				}
+			})( '$selector' );
+
 		</script>
 HTML;
 		}

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -70,6 +70,7 @@ class WordAds {
 
 	/**
 	 * Checks for AMP support and returns true iff active & AMP request
+	 *
 	 * @return boolean True if supported AMP request
 	 *
 	 * @since 7.5.0
@@ -108,6 +109,7 @@ class WordAds {
 
 	/**
 	 * Returns the ad tag property array for supported ad types.
+	 *
 	 * @return array      array with ad tags
 	 *
 	 * @since 7.1.0
@@ -118,6 +120,7 @@ class WordAds {
 
 	/**
 	 * Returns the solo css for unit
+	 *
 	 * @return string the special css for solo units
 	 *
 	 * @since 7.1.0
@@ -596,7 +599,7 @@ HTML;
 
 		$ad_number = count( $this->ads ) . '-' . uniqid();
 		$data_tags = $this->params->cloudflare ? ' data-cfasync="false"' : '';
-		$css = esc_attr( $css );
+		$css       = esc_attr( $css );
 
 		$loc_id = 100;
 		if ( ! empty( self::$ad_location_ids[ $location ] ) ) {
@@ -625,10 +628,10 @@ HTML;
 	/**
 	 * Returns the complete ad div with snippet to be inserted into the page
 	 *
-	 * @param  string  $spot top, side, inline, or belowpost
-	 * @param  string  $snippet The snippet to insert into the div
-	 * @param  array  $css_classes
-	 * @return string The supporting ad unit div
+	 * @param  string $spot top, side, inline, or belowpost.
+	 * @param  string $snippet The snippet to insert into the div.
+	 * @param  array  $css_classes CSS classes.
+	 * @return string The supporting ad unit div.
 	 *
 	 * @since 7.1
 	 */
@@ -642,9 +645,9 @@ HTML;
 			$css_classes[] = 'wpcnt-header';
 		}
 
-		$spot = esc_attr( $spot );
+		$spot    = esc_attr( $spot );
 		$classes = esc_attr( implode( ' ', $css_classes ) );
-		$about  = esc_html__( 'Advertisements', 'jetpack' );
+		$about   = esc_html__( 'Advertisements', 'jetpack' );
 		return <<<HTML
 		<div class="$classes">
 			<div class="wpa">
@@ -723,5 +726,3 @@ add_action( 'jetpack_deactivate_module_wordads', array( 'WordAds_Cron', 'deactiv
 
 global $wordads;
 $wordads = new WordAds();
-
-

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -450,7 +450,7 @@ HTML;
 				$selector = '#main';
 				break;
 			case 'twentyfourteen':
-				$selector = 'article:first';
+				$selector = 'article';
 				break;
 		}
 
@@ -723,3 +723,5 @@ add_action( 'jetpack_deactivate_module_wordads', array( 'WordAds_Cron', 'deactiv
 
 global $wordads;
 $wordads = new WordAds();
+
+


### PR DESCRIPTION
For some(†) legacy themes the top ad is dynamically moved to a better
position using JavaScript. This commit rewrites the funcionality
to use vanilla JavaScript instead of depending on jQuery.

† twentyseventeen, twentyfifteen, twentyfourteen

#### Changes proposed in this Pull Request:
* Drop a small dependency on jQuery in favor of using vanilla JS.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an iteration on the existing WordAds module.

#### Testing instructions:
* Go to WP Admin > Jetpack > Settings > Traffic.
* Enable Ads and make sure the _Top of each page_ is enabled.
* Go to WP Admin > Appearance > Themes and enable one of the themes that use this functionality: `twentyseventeen`, `twentyfifteen` or `twentyfourteen`.
* Go to the front-page of the site and observe the top ad being placed correctly.
* Make sure there are no JS errors raised in the browser's dev tools.

#### Proposed changelog entry for your changes:
* Replaces jQuery code in the Ads module by vanilla JS.
