### PR TITLE
Tiled gallery: hide movers when only one image

### DIFF
--- a/extensions/blocks/tiled-gallery/gallery-image/edit.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/edit.js
@@ -78,6 +78,7 @@ class GalleryImageEdit extends Component {
 			onMoveForward,
 			onRemove,
 			origUrl,
+			showMovers,
 			srcSet,
 			url,
 			width,
@@ -131,24 +132,26 @@ class GalleryImageEdit extends Component {
 					[ `filter__${ imageFilter }` ]: !! imageFilter,
 				} ) }
 			>
-				<div className="tiled-gallery__item__move-menu">
-					<IconButton
-						icon={ columns === 1 ? upChevron : leftChevron }
-						onClick={ isFirstItem ? undefined : onMoveBackward }
-						className="tiled-gallery__item__move-backward"
-						label={ __( 'Move image backward', 'jetpack' ) }
-						aria-disabled={ isFirstItem }
-						disabled={ ! isSelected }
-					/>
-					<IconButton
-						icon={ columns === 1 ? downChevron : rightChevron }
-						onClick={ isLastItem ? undefined : onMoveForward }
-						className="tiled-gallery__item__move-forward"
-						label={ __( 'Move image forward', 'jetpack' ) }
-						aria-disabled={ isLastItem }
-						disabled={ ! isSelected }
-					/>
-				</div>
+				{ showMovers && (
+					<div className="tiled-gallery__item__move-menu">
+						<IconButton
+							icon={ columns === 1 ? upChevron : leftChevron }
+							onClick={ isFirstItem ? undefined : onMoveBackward }
+							className="tiled-gallery__item__move-backward"
+							label={ __( 'Move image backward', 'jetpack' ) }
+							aria-disabled={ isFirstItem }
+							disabled={ ! isSelected }
+						/>
+						<IconButton
+							icon={ columns === 1 ? downChevron : rightChevron }
+							onClick={ isLastItem ? undefined : onMoveForward }
+							className="tiled-gallery__item__move-forward"
+							label={ __( 'Move image forward', 'jetpack' ) }
+							aria-disabled={ isLastItem }
+							disabled={ ! isSelected }
+						/>
+					</div>
+				) }
 				<div className="tiled-gallery__item__inline-menu">
 					<IconButton
 						icon={ close }

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -67,6 +67,7 @@ export default class Layout extends Component {
 				onSelect={ isSave ? undefined : onSelectImage( i ) }
 				origUrl={ img.url }
 				setAttributes={ isSave ? undefined : setImageAttributes( i ) }
+				showMovers={ images.length > 1 }
 				srcSet={ srcSet }
 				url={ src }
 				width={ img.width }


### PR DESCRIPTION
Small bugfix follow up to movers PR: https://github.com/Automattic/jetpack/pull/14702

#### Changes proposed in this Pull Request:
* Hide tiled gallery image movers if there's just one image in gallery

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
*

#### Testing instructions:
- Add Tiled gallery block with one image

- Confirm you see movers placeholder:
    <img width="177" alt="Screenshot 2020-02-23 at 23 21 54" src="https://user-images.githubusercontent.com/87168/75120305-508fbd00-5693-11ea-820e-53cbbbbe5a14.png">

- Now re-build, confirm no movers:
    <img width="171" alt="Screenshot 2020-02-23 at 23 08 46" src="https://user-images.githubusercontent.com/87168/75120313-643b2380-5693-11ea-96e9-a80d52640d21.png">

- Add another image, confirm movers are there on all layouts
    <img width="311" alt="Screenshot 2020-02-23 at 23 17 40" src="https://user-images.githubusercontent.com/87168/75120288-2d650d80-5693-11ea-8da2-2d39c60d77d1.png">
 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
