### PR TITLE
Update the tests for block gating so that they don't fail on wpcom

### DIFF
--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -161,11 +161,14 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 		$this->assertEquals( false, $version_gated );
 	}
 
-	function test_returns_true_if_core_wp_version_greater_or_equal_to_minimum() {
+	/**
+	 * Tests whether the environment has the minimum Gutenberg/WordPress installation needed by a block
+	 */
+	public function test_returns_true_if_gutenberg_or_core_wp_version_greater_or_equal_to_minimum() {
 		$version_gated = Jetpack_Gutenberg::is_gutenberg_version_available(
 			array(
 				'wp'        => '1',
-				'gutenberg' => '999999',
+				'gutenberg' => '1',
 			),
 			'ungated_block'
 		);


### PR DESCRIPTION
The tests introduced in https://github.com/Automattic/jetpack/pull/14703 fail on WPCOM. This PR fixes them.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* We should lower the minimum version requirement for gutenberg as well as wp so that the test passes when the Gutenberg plugin is installed.

#### Testing instructions:
* Run `yarn docker:phpunit --filter test_returns_true_if_gutenberg_or_core_wp_version_greater_or_equal_to_minimum `
* Check that the tests on code-D38972 don't fail

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
