### PR TITLE
Instant Search: Open overlay while typing if results have loaded

### DIFF
--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -30,7 +30,7 @@ const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) =
 				`jetpack-instant-search__overlay--${ colorTheme }`,
 				isVisible ? '' : 'is-hidden',
 			].join( ' ' ) }
-			style={ { opacity: opacity / 100 } }
+			style={ { opacity: isVisible ? opacity / 100 : 0 } }
 		>
 			{ children }
 		</div>

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -9,7 +9,7 @@
 	background: rgba(255, 255, 255, 0.975);
 	overflow-y: auto;
 	overflow-x: hidden;
-	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
+	transition: opacity 0.3s linear, 0.5s transform ease-in-out;
 
 	&.is-hidden {
 		transform: translateX( 100vw );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -118,9 +118,9 @@ class SearchApp extends Component {
 		return !! this.state.response.page_handle && ! this.state.hasError;
 	}
 
-	handleInput = event => {
+	handleInput = debounce( event => {
 		setSearchQuery( event.target.value );
-	};
+	}, 350 );
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -73,7 +73,6 @@ class SearchApp extends Component {
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
-			input.form.addEventListener( 'submit', this.handleSubmit );
 			input.addEventListener( 'input', this.handleInput );
 		} );
 
@@ -91,7 +90,6 @@ class SearchApp extends Component {
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
-			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
 		} );
 
@@ -119,11 +117,6 @@ class SearchApp extends Component {
 	hasNextPage() {
 		return !! this.state.response.page_handle && ! this.state.hasError;
 	}
-
-	handleSubmit = event => {
-		event.preventDefault();
-		this.showResults();
-	};
 
 	handleInput = event => {
 		setSearchQuery( event.target.value );
@@ -169,7 +162,11 @@ class SearchApp extends Component {
 	};
 
 	onChangeQueryString = () => {
-		this.getResults();
+		if ( !! getSearchQuery() || hasFilter() ) {
+			this.getResults().then( () => {
+				! this.state.showResults && this.showResults();
+			} );
+		}
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.value = getSearchQuery();
@@ -178,6 +175,9 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.value = getSortOptionFromSortKey( getSortQuery() );
 		} );
+
+		// NOTE: This is necessary to ensure that the search query has been propagated to SearchBox
+		this.forceUpdate();
 	};
 
 	loadNextPage = () => {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -193,45 +193,45 @@ class SearchApp extends Component {
 	} = {} ) => {
 		const requestId = this.state.requestId + 1;
 
-		this.setState( { requestId, isLoading: true }, () => {
-			search( {
-				// Skip aggregations when requesting for paged results
-				aggregations: !! pageHandle ? {} : this.props.aggregations,
-				filter,
-				pageHandle,
-				query,
-				resultFormat,
-				siteId: this.props.options.siteId,
-				sort,
-				postsPerPage: this.props.options.postsPerPage,
+		this.setState( { requestId, isLoading: true } );
+		return search( {
+			// Skip aggregations when requesting for paged results
+			aggregations: !! pageHandle ? {} : this.props.aggregations,
+			filter,
+			pageHandle,
+			query,
+			resultFormat,
+			siteId: this.props.options.siteId,
+			sort,
+			postsPerPage: this.props.options.postsPerPage,
+		} )
+			.then( newResponse => {
+				if ( this.state.requestId === requestId ) {
+					const response = { ...newResponse };
+					if ( !! pageHandle ) {
+						response.aggregations = {
+							...( 'aggregations' in this.state.response && ! Array.isArray( this.state.response )
+								? this.state.response.aggregations
+								: {} ),
+							...( ! Array.isArray( newResponse.aggregations ) ? newResponse.aggregations : {} ),
+						};
+						response.results = [
+							...( 'results' in this.state.response ? this.state.response.results : [] ),
+							...newResponse.results,
+						];
+					}
+					this.setState( { response, hasError: false, isLoading: false } );
+					return;
+				}
+				this.setState( { isLoading: false } );
 			} )
-				.then( newResponse => {
-					if ( this.state.requestId === requestId ) {
-						const response = { ...newResponse };
-						if ( !! pageHandle ) {
-							response.aggregations = {
-								...( 'aggregations' in this.state.response && ! Array.isArray( this.state.response )
-									? this.state.response.aggregations
-									: {} ),
-								...( ! Array.isArray( newResponse.aggregations ) ? newResponse.aggregations : {} ),
-							};
-							response.results = [
-								...( 'results' in this.state.response ? this.state.response.results : [] ),
-								...newResponse.results,
-							];
-						}
-						this.setState( { response, hasError: false } );
-					}
-					this.setState( { isLoading: false } );
-				} )
-				.catch( error => {
-					if ( error instanceof ProgressEvent ) {
-						this.setState( { isLoading: false, hasError: true } );
-						return;
-					}
-					throw error;
-				} );
-		} );
+			.catch( error => {
+				if ( error instanceof ProgressEvent ) {
+					this.setState( { isLoading: false, hasError: true } );
+					return;
+				}
+				throw error;
+			} );
 	};
 
 	render() {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -133,7 +133,7 @@ class SearchApp extends Component {
 			return;
 		}
 		setSearchQuery( event.target.value );
-	}, 350 );
+	}, 200 );
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -119,6 +119,10 @@ class SearchApp extends Component {
 	}
 
 	handleInput = debounce( event => {
+		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
+		if ( event.inputType.includes( 'delete' ) || event.inputType.includes( 'format' ) ) {
+			return;
+		}
 		setSearchQuery( event.target.value );
 	}, 350 );
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -73,6 +73,7 @@ class SearchApp extends Component {
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.form.addEventListener( 'submit', this.handleSubmit );
 			input.addEventListener( 'input', this.handleInput );
 		} );
 
@@ -90,6 +91,7 @@ class SearchApp extends Component {
 		window.removeEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
 		} );
 
@@ -117,6 +119,13 @@ class SearchApp extends Component {
 	hasNextPage() {
 		return !! this.state.response.page_handle && ! this.state.hasError;
 	}
+
+	handleSubmit = event => {
+		event.preventDefault();
+		this.handleInput.flush();
+		setSearchQuery( event.target.elements.s.value );
+		this.showResults();
+	};
 
 	handleInput = debounce( event => {
 		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -18,31 +18,35 @@ import { getSortQuery } from '../lib/query-string';
 
 let initiallyFocusedElement = null;
 
+const cb = ( overlayElement, inputElement ) => event => {
+	if (
+		event &&
+		event.target &&
+		! event.target.classList.contains( 'jetpack-instant-search__overlay' )
+	) {
+		return;
+	}
+
+	if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
+		initiallyFocusedElement = document.activeElement;
+		inputElement.focus();
+		return;
+	}
+	initiallyFocusedElement && initiallyFocusedElement.focus();
+};
+
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	const inputRef = useRef( null );
 
-	const cb = overlayElement => event => {
-		if (
-			event &&
-			event.target &&
-			! event.target.classList.contains( '.jetpack-instant-search__overlay' )
-		) {
-			return;
-		}
-
-		if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
-			initiallyFocusedElement = document.activeElement;
-			inputRef.current.focus();
-			return;
-		}
-		initiallyFocusedElement && initiallyFocusedElement.focus();
-	};
-
 	useEffect( () => {
 		const overlayElement = document.querySelector( '.jetpack-instant-search__overlay' );
-		overlayElement.addEventListener( 'transitionend', cb( overlayElement ), true );
-		cb( overlayElement )(); // invoke focus if page loads with overlay already present
+		overlayElement.addEventListener(
+			'transitionend',
+			cb( overlayElement, inputRef.current ),
+			true
+		);
+		cb( overlayElement, inputRef.current )(); // invoke focus if page loads with overlay already present
 		return () => {
 			overlayElement.removeEventListener( 'transitionend', cb );
 		};

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -229,8 +229,7 @@ export function restorePreviousHref( initialHref, callback ) {
 			return;
 		}
 
-		// Otherwise, invoke the callback and emit a QS change event
+		// Otherwise, invoke the callback
 		callback();
-		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }


### PR DESCRIPTION
Fixes #14612.

#### Changes proposed in this Pull Request:
* Opens search overlay while the user is typing into a site search input if the client has loaded search results from the API.
* Fixes an overlay input focusing bug introduced by one of my hotfixes during one of the input polish PRs.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Please note that the Jetpack Search widget will need to be added to twice: once to your site sidebar/footer and once to the Jetpack Search Sidebar within the search overlay.

2. Start typing into one of your site search inputs. 

3. Ensure that the overlay appears with your results as you are typing. 

4. Ensure that your browser focus has shifted smoothly from your original site search input to the overlay search input.

5. Close the search overlay and clear one of the site search inputs (e.g. `cmd + a` and `delete`). Ensure that the overlay does not spawn in this instance. 

#### Proposed changelog entry for your changes:
* None.
