### PR TITLE
Revue Block: Minor Fixes

### DIFF
--- a/extensions/blocks/revue/edit.js
+++ b/extensions/blocks/revue/edit.js
@@ -6,16 +6,14 @@ import { isEqual } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { BlockControls, BlockIcon, InspectorControls } from '@wordpress/block-editor';
+import { BlockIcon, InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	ToggleControl,
 	ExternalLink,
-	IconButton,
 	PanelBody,
 	Placeholder,
 	TextControl,
-	Toolbar,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -63,7 +61,7 @@ export default function RevueEdit( props ) {
 
 	const saveUsername = event => {
 		event.preventDefault();
-		setAttributes( { revueUsername: username } );
+		setAttributes( { revueUsername: username.trim() } );
 	};
 
 	const supportLink =
@@ -82,7 +80,7 @@ export default function RevueEdit( props ) {
 					<form onSubmit={ saveUsername }>
 						<input
 							className="components-placeholder__input"
-							onChange={ event => setUsername( event.target.value ) }
+							onChange={ event => setUsername( event.target.value.trim() ) }
 							placeholder={ __( 'Enter your Revue username here…', 'jetpack' ) }
 							type="text"
 							value={ username }
@@ -104,7 +102,7 @@ export default function RevueEdit( props ) {
 			{ revueUsername && (
 				<>
 					<InspectorControls>
-						<PanelBody title={ __( 'Form Settings', 'jetpack' ) }>
+						<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 							<ToggleControl
 								label={ __( 'Show first name field.', 'jetpack' ) }
 								checked={ firstNameShow }
@@ -115,19 +113,16 @@ export default function RevueEdit( props ) {
 								checked={ lastNameShow }
 								onChange={ () => setAttributes( { lastNameShow: ! lastNameShow } ) }
 							/>
+							<TextControl
+								label={ __( 'Revue Username', 'jetpack' ) }
+								onChange={ value => {
+									setUsername( value.trim() );
+									setAttributes( { revueUsername: value.trim() } );
+								} }
+								value={ revueUsername }
+							/>
 						</PanelBody>
 					</InspectorControls>
-
-					<BlockControls>
-						<Toolbar>
-							<IconButton
-								className="components-toolbar__control"
-								label={ __( 'Edit Username', 'jetpack' ) }
-								icon="edit"
-								onClick={ () => setAttributes( { revueUsername: undefined } ) }
-							/>
-						</Toolbar>
-					</BlockControls>
 
 					<TextControl
 						label={

--- a/extensions/blocks/revue/revue.php
+++ b/extensions/blocks/revue/revue.php
@@ -35,16 +35,18 @@ function jetpack_render_revue_block( $attributes ) {
 	$last_name_placeholder  = jetpack_get_revue_attribute( 'lastNamePlaceholder', $attributes );
 	$last_name_show         = jetpack_get_revue_attribute( 'lastNameShow', $attributes );
 	$url                    = sprintf( 'https://www.getrevue.co/profile/%s/add_subscriber', $attributes['revueUsername'] );
+	$base_class             = Jetpack_Gutenberg::block_classes( 'revue', array() ) . '__';
+	$classes                = Jetpack_Gutenberg::block_classes( 'revue', $attributes );
 
 	Jetpack_Gutenberg::load_assets_as_required( 'revue' );
 
 	ob_start();
 	?>
 
-<div class="wp-block-jetpack-revue">
+<div class="<?php echo esc_attr( $classes ); ?>">
 	<form
 		action="<?php echo esc_url( $url ); ?>"
-		class="wp-block-jetpack-revue__form is-visible"
+		class="<?php echo esc_attr( $base_class . 'form is-visible' ); ?>"
 		method="post"
 		name="revue-form"
 		target="_blank"
@@ -54,7 +56,7 @@ function jetpack_render_revue_block( $attributes ) {
 				<?php echo esc_html( $email_label ); ?>
 				<span class="required"><?php esc_html_e( '(required)', 'jetpack' ); ?></span>
 				<input
-					class="wp-block-jetpack-revue__email"
+					class="<?php echo esc_attr( $base_class . 'email' ); ?>"
 					name="member[email]"
 					placeholder="<?php echo esc_attr( $email_placeholder ); ?>"
 					required
@@ -67,7 +69,7 @@ function jetpack_render_revue_block( $attributes ) {
 				<label>
 					<?php echo esc_html( $first_name_label ); ?>
 					<input
-						class="wp-block-jetpack-revue__first-name"
+						class="<?php echo esc_attr( $base_class . 'first-name' ); ?>"
 						name="member[first_name]"
 						placeholder="<?php echo esc_attr( $first_name_placeholder ); ?>"
 						type="text"
@@ -82,7 +84,7 @@ function jetpack_render_revue_block( $attributes ) {
 				<label>
 					<?php echo esc_html( $last_name_label ); ?>
 					<input
-						class="wp-block-jetpack-revue__last-name"
+						class="<?php echo esc_attr( $base_class . 'last-name' ); ?>"
 						name="member[last_name]"
 						placeholder="<?php echo esc_attr( $last_name_placeholder ); ?>"
 						type="text"
@@ -95,7 +97,7 @@ function jetpack_render_revue_block( $attributes ) {
 			echo jetpack_get_revue_button( $attributes );
 		?>
 	</form>
-	<div class="wp-block-jetpack-revue__message">
+	<div class="<?php echo esc_attr( $base_class . 'message' ); ?>">
 		<p>
 			<strong><?php esc_html_e( 'Subscription received!', 'jetpack' ); ?></strong>
 		</p>

--- a/extensions/blocks/revue/view.scss
+++ b/extensions/blocks/revue/view.scss
@@ -7,15 +7,25 @@
 	> div {
 		margin-bottom: 0.75em;
 	}
+
 	.wp-block-button {
 		margin-top: 0;
 	}
+
 	input {
+		display: block;
 		margin-top: 0.25em;
+		width: 100%;
+		@media screen and ( min-width: 600px ) {
+			width: 50%;
+		}
 	}
+
 	label {
+		display: block;
 		font-weight: bold;
 	}
+
 	.required {
 		color: #aaaaaa;
 		font-weight: normal;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make the input fields block elements and responsive.
* Trim the Revue username on save to prevent issues caused by unwanted whitespaces.
* Move the Edit Username flow to the block sidebar.
* Dynamically create the CSS classes in the SSR.

These minor fixes were partly requested in the post-merge comments on the original Revue Block PR (starting from [this comment](https://github.com/Automattic/jetpack/pull/14645#issuecomment-590484681)).

#### Screenshots

In some themes, labels and input fields are inline elements. In others, like Twenty Twenty, they are block elements.
25d3f05fbffa8af4a3879cf78921e65703dffc80 makes them block elements regardless.
The following comparison screenshots contains the Revue block followed by the Contact Form block, which is the look we are trying to obtain.

| Before | After |
| - | - |
| <img width="799" alt="Screenshot 2020-02-25 at 11 30 29" src="https://user-images.githubusercontent.com/2070010/75247346-9d75af80-57c9-11ea-8a43-348db9405b35.png"> | <img width="791" alt="Screenshot 2020-02-25 at 11 32 10" src="https://user-images.githubusercontent.com/2070010/75247351-a2d2fa00-57c9-11ea-9ef5-106b6acff250.png"> |

1dc853cf0809adeaf879c0a26daf8fda2f250183 removes the "Edit Username" button from the block toolbar that reverted the block to the placeholder view, and replaces it with a simple text field in the block sidebar.

<img width="274" alt="Screenshot 2020-02-25 at 11 39 30" src="https://user-images.githubusercontent.com/2070010/75247542-0fe68f80-57ca-11ea-8c37-6e5d96d96e0a.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Revue block and save the post.
* Switch to a theme with inline labels and inputs (Mayland and Maywood, for example), and make sure the inputs in the rendered block are (CSS) block element.
* In the editor, make sure there is no "Edit username" button in the block toolbar, and instead there is an input field in the block sidebar.
* Make sure that input field works as expected.
* Try the subscription form, and make sure it still works even after the CSS class changes. In particular, the form should be replaced by a confirmation message on submit. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (block unreleased)
