### PR TITLE
Revert "OpenTable & Calendly: Improve save functions by wrapping links in divs"

### DIFF
--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -19,11 +19,6 @@ import './editor.scss';
 
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
-const supports = {
-	align: true,
-	alignWide: false,
-	html: false,
-};
 export const settings = {
 	title,
 	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
@@ -34,13 +29,13 @@ export const settings = {
 		__( 'schedule', 'jetpack' ),
 		__( 'appointments', 'jetpack' ),
 	],
-	supports,
+	supports: {
+		align: true,
+		alignWide: false,
+		html: false,
+	},
 	edit,
-	save: ( { attributes: { url } } ) => (
-		<div>
-			<a href={ url }>{ url }</a>
-		</div>
-	),
+	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
 	attributes,
 	example: {
 		attributes: {
@@ -62,10 +57,4 @@ export const settings = {
 			},
 		],
 	},
-	deprecated: [
-		{
-			attributes,
-			save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
-		},
-	],
 };

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -20,10 +20,7 @@ import './view.scss';
 export const name = 'opentable';
 export const title = __( 'OpenTable', 'jetpack' );
 import { getAttributesFromEmbedCode, restRefRegex, ridRegex } from './utils';
-const supports = {
-	align: true,
-	html: false,
-};
+
 export const settings = {
 	title,
 	description: __( 'Allow visitors to book a reservation with OpenTable', 'jetpack' ),
@@ -34,16 +31,19 @@ export const settings = {
 		__( 'reservation', 'jetpack' ),
 		__( 'restaurant', 'jetpack' ),
 	],
-	supports,
+	supports: {
+		align: true,
+		html: false,
+	},
 	edit,
 	save: ( { attributes: { rid } } ) => (
-		<div>
+		<>
 			{ rid.map( restaurantId => (
 				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
 					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
 				</a>
 			) ) }
-		</div>
+		</>
 	),
 	attributes: defaultAttributes,
 	example: {
@@ -71,18 +71,4 @@ export const settings = {
 			},
 		],
 	},
-	deprecated: [
-		{
-			attributes: defaultAttributes,
-			save: ( { attributes: { rid } } ) => (
-				<>
-					{ rid.map( restaurantId => (
-						<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
-							{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
-						</a>
-					) ) }
-				</>
-			),
-		},
-	],
 };


### PR DESCRIPTION
Reverts Automattic/jetpack#14754

Internal reference: p1582631245057200-slack-jetpack-crew

We'll take a different approach on this.

#### Testing instructions:
* Add a Calendly and OpenTable block to a page
* Make sure they still work.
