### PR TITLE
Private Sites: Make /sites return is_private based on blog_public site option

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -309,12 +309,28 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'user_can_manage' :
 				$response[ $key ] = $this->site->user_can_manage();
 			case 'is_private' :
-				$response[ $key ] = $this->site->is_private();
+				/**
+				 * Filters the value of `is_private` value about the site to return.
+				 *
+				 * @module json-api
+				 *
+				 * @since 8.4.0
+				 *
+				 * @param bool $is_private Is site private.
+				 */
+				$response[ $key ] = apply_filters( 'sites_site_is_private', $this->site->is_private() );
 				break;
 			case 'is_coming_soon' :
-				// This option is stored on wp.com for both simple and atomic sites. @see mu-plugins/private-blog.php
-				$response[ $key ] = $this->site->is_private() && get_option( 'wpcom_coming_soon' );
-				break;
+				/**
+				 * Filters the value of `is_coming_soon` value about the site to return.
+				 *
+				 * @module json-api
+				 *
+				 * @since 8.4.0
+				 *
+				 * @param bool $is_coming_soon Is site in the Coming Soon mode.
+				 */
+				$response[ $key ] = apply_filters( 'sites_site_is_coming_soon', false );
 			case 'visible' :
 				$response[ $key ] = $this->site->is_visible();
 				break;


### PR DESCRIPTION
**Changes proposed in this Pull Request:**
Differential Revision: D39262-code

This commit syncs 203325-wpcom.

At the moment, /sites endpoint will always return false for atomic sites. That's because privacy was never supported on atomic sites. Since this support is coming, we want to base that on blog_public setting. The ultimate fix would be updating SAL, and that's what we're going to do in longer term. A short term fix is to use filters to consult site options.

**Testing instructions:**
See D39262-code
Proposed changelog entry for your changes:
N/A