### PR TITLE
Override the display settings in the editor for wide blocks

### DIFF
--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -9,6 +9,10 @@
 	display: inline-block;
 	position: relative;
 
+	&-theme-wide {
+		display: block;
+	}
+
 	.components-base-control {
 		width: 100%;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* I added `display: inline-block` so that the preview looks good in the block inserter, but for wide blocks we need `display: block` to match how they show in the front end.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* bugfix - raised here:https://github.com/Automattic/jetpack/pull/14672#issuecomment-590575877

#### Testing instructions:
* Add an OpenTable block
* Switch to Wide mode
* In master you see:
<img width="1440" alt="Screenshot 2020-02-25 at 13 43 00" src="https://user-images.githubusercontent.com/275961/75253077-c734d380-57d5-11ea-81a3-4bc4ed6d19ed.png">

* In this branch you see:
<img width="1440" alt="Screenshot 2020-02-25 at 13 42 45" src="https://user-images.githubusercontent.com/275961/75253087-cac85a80-57d5-11ea-8098-3eeb2dee1cc1.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog