### PR TITLE
Blocks: switch Google Calendar and Revue to production blocks

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -6,6 +6,7 @@
 		"contact-info",
 		"eventbrite",
 		"gif",
+		"google-calendar",
 		"likes",
 		"mailchimp",
 		"map",
@@ -17,6 +18,7 @@
 		"recurring-payments",
 		"related-posts",
 		"repeat-visitor",
+		"revue",
 		"sharing",
 		"shortlinks",
 		"simple-payments",
@@ -26,5 +28,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "google-calendar", "revue", "seo" ]
+	"beta": [ "amazon", "seo" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should make testing easier during the Beta period.

#### Testing instructions:

* On a brand new test site, you should see the 2 new blocks available even if you did not activate the flag to see Beta blocks.

#### Proposed changelog entry for your changes:

* N/A
