### PR TITLE
Ensure correct translation loading when loading assets via CDN

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -127,7 +127,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 	}
 
 	/**
-	 * Ensure use of the correct relative path when loading the JavaScript translation file.
+	 * Ensure use of the correct local path when loading the JavaScript translation file for a CDN'ed asset.
 	 *
 	 * @param string $file   The path that's going to be loaded.
 	 * @param string $handle The script handle.
@@ -135,9 +135,10 @@ class Jetpack_Photon_Static_Assets_CDN {
 	 * @return string The transformed local languages path.
 	 */
 	public static function fix_local_script_translation_path( $file, $handle, $domain ) {
-		switch ( $handle ) {
-			case 'jetpack-blocks-editor':
-				return str_replace( 'wp-content/languages/jetpack', 'wp-content/languages/plugins/jetpack', $file );
+		global $wp_scripts;
+		// This is a rewritten plugin URL, so load the language file from the plugins path.
+		if ( isset( $wp_scripts->registered[ $handle ] ) && wp_startswith( $wp_scripts->registered[ $handle ]->src, self::CDN . 'p' ) ) {
+			return WP_LANG_DIR . '/plugins/' . basename( $file );
 		}
 		return $file;
 	}

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -31,6 +31,7 @@ class Jetpack_Photon_Static_Assets_CDN {
 		add_action( 'admin_print_styles', array( __CLASS__, 'cdnize_assets' ) );
 		add_action( 'wp_footer', array( __CLASS__, 'cdnize_assets' ) );
 		add_filter( 'load_script_textdomain_relative_path', array( __CLASS__, 'fix_script_relative_path' ), 10, 2 );
+		add_filter( 'load_script_translation_file', array( __CLASS__, 'fix_local_script_translation_path' ), 10, 3 );
 	}
 
 	/**
@@ -113,10 +114,32 @@ class Jetpack_Photon_Static_Assets_CDN {
 
 		// We only treat URLs that have wp-includes in them. Cases like language textdomains
 		// can also use this filter, they don't need to be touched because they are local paths.
-		if ( false === $strpos ) {
-			return $relative;
+		if ( false !== $strpos ) {
+			return substr( $src, 1 + $strpos );
 		}
-		return substr( $src, 1 + $strpos );
+
+		// Reverse cdnize_plugin_assets for loading the path
+		if ( preg_match( '#' . preg_quote( self::CDN, '#' ) . 'p/[^/]+/[^/]+/(.*)$#', $src, $m ) ) {
+			return $m[1];
+		}
+
+		return $relative;
+	}
+
+	/**
+	 * Ensure use of the correct relative path when loading the JavaScript translation file.
+	 *
+	 * @param string $file   The path that's going to be loaded.
+	 * @param string $handle The script handle.
+	 * @param string $domain The text domain.
+	 * @return string The transformed local languages path.
+	 */
+	public static function fix_local_script_translation_path( $file, $handle, $domain ) {
+		switch ( $handle ) {
+			case 'jetpack-blocks-editor':
+				return str_replace( 'wp-content/languages/jetpack', 'wp-content/languages/plugins/jetpack', $file );
+		}
+		return $file;
 	}
 
 	/**

--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -118,8 +118,8 @@ class Jetpack_Photon_Static_Assets_CDN {
 			return substr( $src, 1 + $strpos );
 		}
 
-		// Reverse cdnize_plugin_assets for loading the path
-		if ( preg_match( '#' . preg_quote( self::CDN, '#' ) . 'p/[^/]+/[^/]+/(.*)$#', $src, $m ) ) {
+		// Get the local path from a URL which was CDN'ed by cdnize_plugin_assets().
+		if ( preg_match( '#^' . preg_quote( self::CDN, '#' ) . 'p/[^/]+/[^/]+/(.*)$#', $src, $m ) ) {
 			return $m[1];
 		}
 


### PR DESCRIPTION
When activating the CDN, the Jetpack blocks don't load their translations properly. This is because Core language loading assumes local files. This fixes the paths under the hood before the JSONs are loaded.

#### Testing instructions:

1. Change your UI language to something other than English (with sufficient translation percentage, e.g. German, Spanish, or French).
2. Activate Jetpack CDN in the Jetpack Settings.
3. Create a new post with the Gutenberg editor.
4. Click "Add New Block" and scroll down to the Jetpack blocks. Block names and descriptions should be translated.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed Translation loading of Gutenberg blocks with activated CDN.