### PR TITLE
Docker: Ignore heavy directories for docker context

### DIFF
--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,5 @@
+data
+wordpress
+wordpress-develop
+develop
+logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When running `docker-compose up --build` via `yarn docker:compose up --build` it takes a noticeable amount of time for the docker context to get set up.

The "tell" is that the build output pauses for a while:

```
Building wordpress
# Wait for a little bit
Step 1/20 : FROM ubuntu:xenial
```

Some people (e.g. me) sometimes use docker hosts that are not on their local network (this makes things like exposing services to the general internet a bit more straight forward).

This means the local docker client needs to transfer the docker context over the network before starting the build described in the `Dockerfile`.

```
du -sh docker
210M docker
```

Ouch.

After reviewing what the `docker/Dockerfile` does it became apparent that the volumes mounted within the `docker/` folder were the heaviest bits and these volumes are _not_ used in any of the `COPY` operations within `docker/Dockerfile`:

```
du -sh docker/*
4.0K    docker/Dockerfile
 24K    docker/README.md
 20K    docker/bin
 24K    docker/config
150M    docker/data
4.0K    docker/default.env
4.0K    docker/docker-compose-ngrok.yml
4.0K    docker/docker-compose.yml
648K    docker/logs
 16K    docker/mu-plugins
 48M    docker/wordpress
 12M    docker/wordpress-develop
```

So lets exclude them from the docker context (`docker/.dockerignore`):

```
data
wordpress
wordpress-develop
logs
```

Now the pause between `building wordpress` and `Step 1/20` is imperceptible, even with a remote docker host!

Bonus! The docker context is no longer changing as much because we no longer send the logs, that means the build caches won't expire!

#### Testing Instructions

Assuming you have docker already configured, build at least once:

```
yarn docker:compose up
```

Kill the processes and build again

```
yarn docker:compose up --build
```

Observe that nothing is different except it no longer pauses between `Building wordpress` and `Step 1/20 ...`.

#### Proposed changelog entry for your changes:

I do not propose any changelog entries for this.

