### PR TITLE
Add version requirements for the google calendar block

### DIFF
--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -21,7 +21,11 @@ function register_block() {
 	jetpack_register_block(
 		BLOCK_NAME,
 		array(
-			'render_callback' => 'Jetpack\Google_Calendar_Block\load_assets',
+			'render_callback'      => 'Jetpack\Google_Calendar_Block\load_assets',
+			'version_requirements' => array(
+				'gutenberg' => '7.2',
+				'wp'        => '5.4',
+			),
 		)
 	);
 }


### PR DESCRIPTION
Currently the google calendar block required gutenberg 7.2 or higher in order for Google Apps short codes to be successfully converted to Google Calendar blocks, and for pasted embed codes to be converted:

- [WordPress/gutenberg#10674](https://github.com/WordPress/gutenberg/issues/10674)
- [WordPress/gutenberg#18390](https://github.com/WordPress/gutenberg/issues/18390)

Apologies for not getting this up sooner - it slipped through the cracks. The options with this are:
- Cherry pick to 8.3 release
- Leave until 8.4 and keep Google Calendar block in beta until then
- Release the block without this version limit knowing that users without Gutenberg 7.2 or higher will not get Google Apps shortcodes converted to Calendar blocks when converting Classic Posts/Blocks, and will not get automatic transforming to a Calendar block when pasting embed codes into paragraph blocks

#### Changes proposed in this Pull Request:
* Add version requirements for Google Calendar block to limit it to installs with gutenberg 7.2 or wp 5.4.

#### Testing instructions:
Check out this branch to an install that has  gutenberg < 7.2 and wp < 5.4 and ensure that the google calendar block is not available even if Jetpack beta is enabled.

#### Proposed changelog entry for your changes:
* No changelog entry needed
