### PR TITLE
Add caching for VideoPress functions with meta queries

### DIFF
--- a/modules/videopress/class.videopress-player.php
+++ b/modules/videopress/class.videopress-player.php
@@ -108,8 +108,8 @@ class VideoPress_Player {
 
 			if ( ! defined( 'WP_DEBUG' ) || WP_DEBUG !== true ) {
 				$expire = 3600;
-				if ( isset( $video->expires ) && is_int( $video->expires ) ) {
-					$expires_diff = time() - $video->expires;
+				if ( isset( $this->video->expires ) && is_int( $this->video->expires ) ) {
+					$expires_diff = time() - $this->video->expires;
 					if ( $expires_diff > 0 && $expires_diff < 86400 ) { // allowed range: 1 second to 1 day
 						$expire = $expires_diff;
 					}

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -622,7 +622,7 @@ function video_format_done( $info, $format ) {
  */
 function video_image_url_by_guid( $guid, $format ) {
 
-	$post = video_get_post_by_guid( $guid );
+	$post = videopress_get_post_by_guid( $guid );
 
 	if ( is_wp_error( $post ) ) {
 		return null;
@@ -639,11 +639,11 @@ function video_image_url_by_guid( $guid, $format ) {
 /**
  * Using a GUID, find a post.
  *
- * @param string $guid
+ * @param string $guid The post guid.
  * @return WP_Post|false The post for that guid, or false if none is found.
  */
-function video_get_post_by_guid( $guid ) {
-	$cache_key   = 'video_get_post_by_guid_' . $guid;
+function videopress_get_post_by_guid( $guid ) {
+	$cache_key   = 'get_post_by_guid_' . $guid;
 	$cache_group = 'videopress';
 	$cached_post = wp_cache_get( $cache_key, $cache_group );
 
@@ -661,6 +661,22 @@ function video_get_post_by_guid( $guid ) {
 	}
 
 	return false;
+}
+
+/**
+ * Using a GUID, find a post.
+ *
+ * Kept for backward compatibility. Use videopress_get_post_by_guid() instead.
+ *
+ * @deprecated since 8.4.0
+ * @see videopress_get_post_by_guid()
+ *
+ * @param string $guid The post guid.
+ * @return WP_Post|false The post for that guid, or false if none is found.
+ */
+function video_get_post_by_guid( $guid ) {
+	_deprecated_function( __FUNCTION__, 'jetpack-8.4' );
+	return videopress_get_post_by_guid( $guid );
 }
 
 /**

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -74,6 +74,7 @@ function videopress_get_video_details( $guid ) {
  * Modified from https://wpscholar.com/blog/get-attachment-id-from-wp-image-url/
  *
  * @deprecated since 8.4.0
+ * @see video_get_post_id_by_guid()
  *
  * @param string $url
  *

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -695,7 +695,7 @@ function video_get_post_id_by_guid( $guid ) {
 	if ( $query->have_posts() ) {
 		$post = $query->next_post();
 		// Only store the ID, to prevent filling the database.
-		set_transient( $cache_key, $post->ID );
+		set_transient( $cache_key, $post->ID, HOUR_IN_SECONDS );
 
 		return $post->ID;
 	}

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -666,6 +666,7 @@ function video_get_post_by_guid( $guid ) {
 /**
  * Using a GUID, find the associated post ID.
  *
+ * @since 8.4.0
  * @param string $guid The guid to look for the post ID of.
  * @return int|false The post ID for that guid, or false if none is found.
  */

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -74,7 +74,7 @@ function videopress_get_video_details( $guid ) {
  * Modified from https://wpscholar.com/blog/get-attachment-id-from-wp-image-url/
  *
  * @deprecated since 8.4.0
- * @see video_get_post_id_by_guid()
+ * @see videopress_get_post_id_by_guid()
  *
  * @param string $url
  *
@@ -651,7 +651,7 @@ function video_get_post_by_guid( $guid ) {
 		return $cached_post;
 	}
 
-	$post_id = video_get_post_id_by_guid( $guid );
+	$post_id = videopress_get_post_id_by_guid( $guid );
 
 	if ( is_int( $post_id ) ) {
 		$post = get_post( $post_id );
@@ -669,8 +669,8 @@ function video_get_post_by_guid( $guid ) {
  * @param string $guid The guid to look for the post ID of.
  * @return int|false The post ID for that guid, or false if none is found.
  */
-function video_get_post_id_by_guid( $guid ) {
-	$cache_key = 'video_get_post_id_by_guid_' . $guid;
+function videopress_get_post_id_by_guid( $guid ) {
+	$cache_key = 'videopress_get_post_id_by_guid_' . $guid;
 	$cached_id = get_transient( $cache_key );
 
 	if ( is_int( $cached_id ) ) {
@@ -682,6 +682,7 @@ function video_get_post_id_by_guid( $guid ) {
 		'post_mime_type' => 'video/videopress',
 		'post_status'    => 'inherit',
 		'no_found_rows'  => true,
+		'fields'         => 'ids',
 		'meta_query'     => array(
 			array(
 				'key'     => 'videopress_guid',
@@ -694,11 +695,11 @@ function video_get_post_id_by_guid( $guid ) {
 	$query = new WP_Query( $args );
 
 	if ( $query->have_posts() ) {
-		$post = $query->next_post();
+		$post_id = $query->next_post();
 		// Only store the ID, to prevent filling the database.
-		set_transient( $cache_key, $post->ID, HOUR_IN_SECONDS );
+		set_transient( $cache_key, $post_id, HOUR_IN_SECONDS );
 
-		return $post->ID;
+		return $post_id;
 	}
 
 	return false;

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -697,7 +697,6 @@ function videopress_get_post_id_by_guid( $guid ) {
 
 	if ( $query->have_posts() ) {
 		$post_id = $query->next_post();
-		// Only store the ID, to prevent filling the database.
 		set_transient( $cache_key, $post_id, HOUR_IN_SECONDS );
 
 		return $post_id;

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -73,6 +73,8 @@ function videopress_get_video_details( $guid ) {
  *
  * Modified from https://wpscholar.com/blog/get-attachment-id-from-wp-image-url/
  *
+ * @todo: Add some caching in here.
+ *
  * @param string $url
  *
  * @return int|bool Attachment ID on success, false on failure
@@ -85,21 +87,13 @@ function videopress_get_attachment_id_by_url( $url ) {
 	// Is URL in uploads directory?
 	if ( false !== strpos( $url, $dir ) ) {
 
-		$file        = basename( $url );
-		$cache_key   = 'videopress_get_attachment_id_by_url_' . md5( $url );
-		$cache_group = 'videopress';
-		$cached_id   = wp_cache_get( $cache_key, $cache_group );
-		if ( false !== $cached_id ) {
-			return $cached_id;
-		}
+		$file = basename( $url );
 
 		$query_args = array(
-			'post_type'              => 'attachment',
-			'post_status'            => 'inherit',
-			'fields'                 => 'ids',
-			'no_found_rows'          => true,
-			'update_post_term_cache' => false,
-			'meta_query'             => array(
+			'post_type'   => 'attachment',
+			'post_status' => 'inherit',
+			'fields'      => 'ids',
+			'meta_query'  => array(
 				array(
 					'key'     => '_wp_attachment_metadata',
 					'compare' => 'LIKE',
@@ -117,9 +111,7 @@ function videopress_get_attachment_id_by_url( $url ) {
 				$cropped_files = wp_list_pluck( $meta['sizes'], 'file' );
 
 				if ( $original_file === $file || in_array( $file, $cropped_files ) ) {
-					$attachment_id = (int) $attachment_id;
-					wp_cache_set( $cache_key, $attachment_id, $cache_group, HOUR_IN_SECONDS );
-					return $attachment_id;
+					return (int) $attachment_id;
 				}
 			}
 		}

--- a/modules/videopress/utility-functions.php
+++ b/modules/videopress/utility-functions.php
@@ -73,6 +73,7 @@ function videopress_get_video_details( $guid ) {
  *
  * Modified from https://wpscholar.com/blog/get-attachment-id-from-wp-image-url/
  *
+ * @deprecated since 8.4.0
  * @todo: Add some caching in here.
  *
  * @param string $url
@@ -80,6 +81,8 @@ function videopress_get_video_details( $guid ) {
  * @return int|bool Attachment ID on success, false on failure
  */
 function videopress_get_attachment_id_by_url( $url ) {
+	_deprecated_function( __FUNCTION__, 'jetpack-8.4' );
+
 	$wp_upload_dir = wp_upload_dir();
 	// Strip out protocols, so it doesn't fail because searching for http: in https: dir.
 	$dir = set_url_scheme( trailingslashit( $wp_upload_dir['baseurl'] ), 'relative' );

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -25,6 +25,8 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	/**
 	 * Gets the test data for test_non_cached_video_get_post_by_guid().
 	 *
+	 * @since 8.4.0
+	 *
 	 * @return array The test data.
 	 */
 	public function get_data_test_video_non_cached() {
@@ -79,6 +81,8 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	/**
 	 * Gets the test data for test_cached_video_get_post_by_guid().
 	 *
+	 * @since 8.4.0
+	 *
 	 * @return array The test data.
 	 */
 	public function get_data_test_video_cached() {
@@ -131,6 +135,8 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 
 	/**
 	 * Gets the test data for test_cached_invalid_video_get_post_by_guid().
+	 *
+	 * @since 8.4.0
 	 *
 	 * @return array The test data.
 	 */

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -15,15 +15,15 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	/**
 	 * Tests a helper function to get the post by guid, when there is no post found.
 	 *
-	 * @covers ::video_get_post_by_guid
+	 * @covers ::videopress_get_post_by_guid
 	 * @since 8.4.0
 	 */
-	public function test_no_post_found_video_get_post_by_guid() {
-		$this->assertFalse( video_get_post_by_guid( wp_generate_uuid4() ) );
+	public function test_no_post_found_videopress_get_post_by_guid() {
+		$this->assertFalse( videopress_get_post_by_guid( wp_generate_uuid4() ) );
 	}
 
 	/**
-	 * Gets the test data for test_non_cached_video_get_post_by_guid().
+	 * Gets the test data for test_non_cached_videopress_get_post_by_guid().
 	 *
 	 * @since 8.4.0
 	 *
@@ -34,7 +34,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 			'external_object_cache_is_enabled'     => array(
 				'wp_cache_get',
 				true,
-				'video_get_post_by_guid_',
+				'get_post_by_guid_',
 				'videopress',
 			),
 			'external_object_cache_is_not_enabled' => array(
@@ -49,7 +49,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * Tests a helper function to get the post by guid, when there's initially no cached value.
 	 *
 	 * @dataProvider get_data_test_video_non_cached
-	 * @covers ::video_get_post_by_guid
+	 * @covers ::videopress_get_post_by_guid
 	 * @since 8.4.0
 	 *
 	 * @param callable    $callback The callback to get the caching.
@@ -57,11 +57,11 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * @param string      $cache_key_base The base of the cache key.
 	 * @param string|null $cache_group The cache group, if any.
 	 */
-	public function test_non_cached_video_get_post_by_guid( $callback, $should_cache_object, $cache_key_base, $cache_group = null ) {
+	public function test_non_cached_videopress_get_post_by_guid( $callback, $should_cache_object, $cache_key_base, $cache_group = null ) {
 		$guid          = wp_generate_uuid4();
 		$expected_id   = videopress_create_new_media_item( 'Example', $guid );
 		$expected_post = get_post( $expected_id );
-		$actual_post   = video_get_post_by_guid( $guid );
+		$actual_post   = videopress_get_post_by_guid( $guid );
 
 		$this->assertEquals( $expected_post, $actual_post );
 
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gets the test data for test_cached_video_get_post_by_guid().
+	 * Gets the test data for test_cached_videopress_get_post_by_guid().
 	 *
 	 * @since 8.4.0
 	 *
@@ -106,19 +106,19 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * this should return that instead of instantiating WP_Query.
 	 *
 	 * @dataProvider get_data_test_video_cached
-	 * @covers ::video_get_post_by_guid
+	 * @covers ::videopress_get_post_by_guid
 	 * @since 8.4.0
 	 *
 	 * @param callable    $callback The callback to set the caching.
 	 * @param bool        $should_cache_object Whether the entire WP_Post should be cached, or simply the post ID.
 	 * @param string|null $cache_group The cache group, if any.
 	 */
-	public function test_cached_video_get_post_by_guid( $callback, $should_cache_object, $cache_group = null ) {
+	public function test_cached_videopress_get_post_by_guid( $callback, $should_cache_object, $cache_group = null ) {
 		$guid            = wp_generate_uuid4();
 		$attachment_id   = videopress_create_new_media_item( 'Example Title', $guid );
 		$attachment_post = get_post( $attachment_id );
 		$post_to_cache   = $should_cache_object ? $attachment_post : $attachment_id;
-		$caching_args    = array( 'video_get_post_by_guid_' . $guid, $post_to_cache );
+		$caching_args    = array( 'get_post_by_guid_' . $guid, $post_to_cache );
 
 		if ( $cache_group ) {
 			$caching_args[] = $cache_group;
@@ -129,12 +129,12 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 		// This should always return the WP_Post, even though the post ID is stored in the transient.
 		$this->assertEquals(
 			$attachment_post,
-			video_get_post_by_guid( $guid )
+			videopress_get_post_by_guid( $guid )
 		);
 	}
 
 	/**
-	 * Gets the test data for test_cached_invalid_video_get_post_by_guid().
+	 * Gets the test data for test_cached_invalid_videopress_get_post_by_guid().
 	 *
 	 * @since 8.4.0
 	 *
@@ -156,20 +156,20 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * the tested method should ignore it and query for the post.
 	 *
 	 * @dataProvider get_data_cached_invalid
-	 * @covers ::video_get_post_by_guid
+	 * @covers ::videopress_get_post_by_guid
 	 * @since 8.4.0
 	 *
 	 * @param mixed $invalid_cached_value A cached value that should be ignored.
 	 */
-	public function test_cached_invalid_video_get_post_by_guid( $invalid_cached_value ) {
+	public function test_cached_invalid_videopress_get_post_by_guid( $invalid_cached_value ) {
 		$guid          = wp_generate_uuid4();
 		$attachment_id = videopress_create_new_media_item( 'Example Title', $guid );
 
-		wp_cache_set( 'video_get_post_by_guid_' . $guid, $invalid_cached_value, 'videopress' );
+		wp_cache_set( 'get_post_by_guid_' . $guid, $invalid_cached_value, 'videopress' );
 
 		$this->assertEquals(
 			get_post( $attachment_id ),
-			video_get_post_by_guid( $guid )
+			videopress_get_post_by_guid( $guid )
 		);
 	}
 

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -38,7 +38,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 			'external_object_cache_is_not_enabled' => array(
 				'get_transient',
 				false,
-				'video_get_post_id_by_guid_',
+				'videopress_get_post_id_by_guid_',
 			),
 		);
 	}
@@ -170,20 +170,20 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	/**
 	 * Tests a helper function to get the post id by guid.
 	 *
-	 * @covers ::video_get_post_id_by_guid
+	 * @covers ::videopress_get_post_id_by_guid
 	 * @since 8.4.0
 	 */
-	public function test_non_cached_video_get_post_id_by_guid() {
+	public function test_non_cached_videopress_get_post_id_by_guid() {
 		$guid           = wp_generate_uuid4();
 		$expected_id    = videopress_create_new_media_item( 'Example', $guid );
-		$actual_post_id = video_get_post_id_by_guid( $guid );
+		$actual_post_id = videopress_get_post_id_by_guid( $guid );
 
 		$this->assertEquals( $expected_id, $actual_post_id );
 
 		// The function should have cached the value.
 		$this->assertEquals(
 			$expected_id,
-			get_transient( 'video_get_post_id_by_guid_' . $guid )
+			get_transient( 'videopress_get_post_id_by_guid_' . $guid )
 		);
 	}
 

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -23,7 +23,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Gets the test data for test_cached_video_get_post_by_guid().
+	 * Gets the test data for test_non_cached_video_get_post_by_guid().
 	 *
 	 * @return array The test data.
 	 */

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -23,26 +23,6 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests a helper function to get the post by guid, when there's initially no cached value.
-	 *
-	 * @covers ::video_get_post_by_guid
-	 * @since 8.4.0
-	 */
-	public function test_non_cached_video_get_post_id_by_guid() {
-		$guid           = wp_generate_uuid4();
-		$expected_id    = videopress_create_new_media_item( 'Example', $guid );
-		$actual_post_id = video_get_post_id_by_guid( $guid );
-
-		$this->assertEquals( $expected_id, $actual_post_id );
-
-		// The function should have cached the value.
-		$this->assertEquals(
-			$expected_id,
-			get_transient( 'video_get_post_id_by_guid_' . $guid )
-		);
-	}
-
-	/**
 	 * Gets the test data for test_cached_video_get_post_by_guid().
 	 *
 	 * @return array The test data.
@@ -184,6 +164,26 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 		$this->assertEquals(
 			get_post( $attachment_id ),
 			video_get_post_by_guid( $guid )
+		);
+	}
+
+	/**
+	 * Tests a helper function to get the post id by guid.
+	 *
+	 * @covers ::video_get_post_id_by_guid
+	 * @since 8.4.0
+	 */
+	public function test_non_cached_video_get_post_id_by_guid() {
+		$guid           = wp_generate_uuid4();
+		$expected_id    = videopress_create_new_media_item( 'Example', $guid );
+		$actual_post_id = video_get_post_id_by_guid( $guid );
+
+		$this->assertEquals( $expected_id, $actual_post_id );
+
+		// The function should have cached the value.
+		$this->assertEquals(
+			$expected_id,
+			get_transient( 'video_get_post_id_by_guid_' . $guid )
 		);
 	}
 

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -72,7 +72,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 
 		$_wp_using_ext_object_cache = $is_external_object_cache_enabled;
 		$guid                       = wp_generate_uuid4();
-		$expected_id                = $this->create_videopress_attachment( $guid );
+		$expected_id                = videopress_create_new_media_item( 'Example', $guid );
 		$expected_post              = get_post( $expected_id );
 		$actual_post                = video_get_post_by_guid( $guid );
 
@@ -132,7 +132,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 
 		$_wp_using_ext_object_cache = $is_external_object_cache_enabled;
 		$guid                       = wp_generate_uuid4();
-		$attachment_id              = $this->create_videopress_attachment( $guid );
+		$attachment_id              = videopress_create_new_media_item( 'Example Title', $guid );
 		$attachment_post            = get_post( $attachment_id );
 		$post_to_cache              = $should_cache_object ? $attachment_post : $attachment_id;
 		$caching_args               = array( 'video_get_post_by_guid_' . $guid, $post_to_cache );
@@ -181,7 +181,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 
 		$_wp_using_ext_object_cache = true;
 		$guid                       = wp_generate_uuid4();
-		$attachment_id              = $this->create_videopress_attachment( $guid );
+		$attachment_id              = videopress_create_new_media_item( 'Example Title', $guid );
 
 		wp_cache_set( 'video_get_post_by_guid_' . $guid, $invalid_cached_value, 'videopress' );
 
@@ -205,26 +205,6 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 		$filtered = jetpack_videopress_flash_embed_filter( $content );
 
 		$this->assertContains( $contains, $filtered );
-	}
-
-	/**
-	 * Creates a videopress attachment (video), given a guid.
-	 *
-	 * @param string $guid The guid to create an attachment for.
-	 * @return int|WP_Error The attachment ID that was created, or WP_Error.
-	 */
-	public function create_videopress_attachment( $guid ) {
-		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
-
-		wp_insert_attachment(
-			array(
-				'ID'             => $attachment_id,
-				'post_mime_type' => 'video/videopress',
-			)
-		);
-		add_post_meta( $attachment_id, 'videopress_guid', $guid );
-
-		return $attachment_id;
 	}
 
 }

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -16,7 +16,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * Tests a helper function to get the attachment ID, when there's no cached value.
 	 *
 	 * @covers ::videopress_get_attachment_id_by_url
-	 * @since 8.3.0
+	 * @since 8.4.0
 	 */
 	public function test_non_cached_videopress_get_attachment_id_by_url() {
 		$expected_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
@@ -29,7 +29,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * Tests a helper function to get the attachment ID, when there is a cached value.
 	 *
 	 * @covers ::videopress_get_attachment_id_by_url
-	 * @since 8.3.0
+	 * @since 8.4.0
 	 */
 	public function test_cached_videopress_get_attachment_id_by_url() {
 		$cached_id = 512351;
@@ -45,7 +45,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * Tests a helper function to get the post by guid, when there is no post found.
 	 *
 	 * @covers ::video_get_post_by_guid
-	 * @since 8.3.0
+	 * @since 8.4.0
 	 */
 	public function test_no_post_found_video_get_post_by_guid() {
 		$this->assertFalse( video_get_post_by_guid( wp_generate_uuid4() ) );
@@ -55,7 +55,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * Tests a helper function to get the post by guid, when there's no cached value.
 	 *
 	 * @covers ::video_get_post_by_guid
-	 * @since 8.3.0
+	 * @since 8.4.0
 	 */
 	public function test_non_cached_video_get_post_by_guid() {
 		$guid        = wp_generate_uuid4();
@@ -79,7 +79,7 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * this should return that instead of instantiating WP_Query.
 	 *
 	 * @covers ::video_get_post_by_guid
-	 * @since 8.3.0
+	 * @since 8.4.0
 	 */
 	public function test_cached_video_get_post_by_guid() {
 		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -13,6 +13,18 @@
 class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 
 	/**
+	 * Tear down the tests.
+	 *
+	 * @inheritDoc
+	 */
+	public function tearDown() {
+		global $_wp_using_ext_object_cache;
+
+		$_wp_using_ext_object_cache = false;
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests a helper function to get the post by guid, when there is no post found.
 	 *
 	 * @covers ::video_get_post_by_guid
@@ -23,24 +35,81 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests a helper function to get the post by guid, when there's no cached value.
+	 * Gets the test data for test_cached_video_get_post_by_guid().
 	 *
+	 * @return array The test data.
+	 */
+	public function get_data_test_video_non_cached() {
+		return array(
+			'external_object_cache_is_enabled'     => array(
+				true,
+				'wp_cache_get',
+				true,
+				'videopress',
+			),
+			'external_object_cache_is_not_enabled' => array(
+				false,
+				'get_transient',
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Tests a helper function to get the post by guid, when there's initially no cached value.
+	 *
+	 * @dataProvider get_data_test_video_non_cached
 	 * @covers ::video_get_post_by_guid
 	 * @since 8.4.0
+	 *
+	 * @param bool        $is_external_object_cache_enabled Whether external object cache is enabled.
+	 * @param callable    $callback The callback to get the caching.
+	 * @param bool        $should_cache_object Whether the entire WP_Post should be cached, or simply the post ID.
+	 * @param string|null $cache_group The cache group, if any.
 	 */
-	public function test_non_cached_video_get_post_by_guid() {
-		$guid        = wp_generate_uuid4();
-		$expected_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
-		wp_insert_attachment(
-			array(
-				'ID'             => $expected_id,
-				'post_mime_type' => 'video/videopress',
-			)
-		);
-		add_post_meta( $expected_id, 'videopress_guid', $guid );
+	public function test_non_cached_video_get_post_by_guid( $is_external_object_cache_enabled, $callback, $should_cache_object, $cache_group = null ) {
+		global $_wp_using_ext_object_cache;
 
-		$actual_post = video_get_post_by_guid( $guid );
-		$this->assertEquals( $expected_id, $actual_post->ID );
+		$_wp_using_ext_object_cache = $is_external_object_cache_enabled;
+		$guid                       = wp_generate_uuid4();
+		$expected_id                = $this->create_videopress_attachment( $guid );
+		$expected_post              = get_post( $expected_id );
+		$actual_post                = video_get_post_by_guid( $guid );
+
+		$this->assertEquals( $expected_post, $actual_post );
+
+		$caching_args = array( 'video_get_post_by_guid_' . $guid );
+		if ( $cache_group ) {
+			$caching_args[] = $cache_group;
+		}
+		$expected_cached = $should_cache_object ? $expected_post : $expected_id;
+
+		// The function should have cached the value.
+		$this->assertEquals(
+			$expected_cached,
+			call_user_func_array( $callback, $caching_args )
+		);
+	}
+
+	/**
+	 * Gets the test data for test_cached_video_get_post_by_guid().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_data_test_video_cached() {
+		return array(
+			'external_object_cache_is_enabled'     => array(
+				true,
+				'wp_cache_set',
+				true,
+				'videopress',
+			),
+			'external_object_cache_is_not_enabled' => array(
+				false,
+				'set_transient',
+				false,
+			),
+		);
 	}
 
 	/**
@@ -49,25 +118,77 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 	 * As long as there is a non-expired cache value,
 	 * this should return that instead of instantiating WP_Query.
 	 *
+	 * @dataProvider get_data_test_video_cached
 	 * @covers ::video_get_post_by_guid
 	 * @since 8.4.0
+	 *
+	 * @param bool        $is_external_object_cache_enabled Whether external object cache is enabled.
+	 * @param callable    $callback The callback to set the caching.
+	 * @param bool        $should_cache_object Whether the entire WP_Post should be cached, or simply the post ID.
+	 * @param string|null $cache_group The cache group, if any.
 	 */
-	public function test_cached_video_get_post_by_guid() {
-		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
-		wp_insert_attachment(
-			array(
-				'ID'             => $attachment_id,
-				'post_mime_type' => 'video/videopress',
-			)
+	public function test_cached_video_get_post_by_guid( $is_external_object_cache_enabled, $callback, $should_cache_object, $cache_group = null ) {
+		global $_wp_using_ext_object_cache;
+
+		$_wp_using_ext_object_cache = $is_external_object_cache_enabled;
+		$guid                       = wp_generate_uuid4();
+		$attachment_id              = $this->create_videopress_attachment( $guid );
+		$attachment_post            = get_post( $attachment_id );
+		$post_to_cache              = $should_cache_object ? $attachment_post : $attachment_id;
+		$caching_args               = array( 'video_get_post_by_guid_' . $guid, $post_to_cache );
+
+		if ( $cache_group ) {
+			$caching_args[] = $cache_group;
+		}
+
+		call_user_func_array( $callback, $caching_args );
+
+		// This should always return the WP_Post, even though the post ID is stored in the transient.
+		$this->assertEquals(
+			$attachment_post,
+			video_get_post_by_guid( $guid )
 		);
-		add_post_meta( $attachment_id, 'videopress_guid', wp_generate_uuid4() );
+	}
 
-		$cached_guid    = wp_generate_uuid4();
-		$cached_post_id = $this->factory()->post->create();
-		wp_cache_set( 'video_get_post_by_guid_' . $cached_guid, $cached_post_id, 'videopress' );
+	/**
+	 * Gets the test data for test_cached_invalid_video_get_post_by_guid().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_data_cached_invalid() {
+		return array(
+			'non_post_object'           => array( new stdClass() ),
+			'int_but_not_valid_post_id' => array( PHP_INT_MAX ),
+			'null'                      => array( null ),
+			'zero'                      => array( 0 ),
+		);
+	}
 
-		$actual_post = video_get_post_by_guid( $cached_guid );
-		$this->assertEquals( $cached_post_id, $actual_post->ID );
+	/**
+	 * Tests invalid cached values that should be ignored.
+	 *
+	 * Unless the cached value is a WP_Post or a post ID to a WP_Post,
+	 * the tested method should ignore it and query for the post.
+	 *
+	 * @dataProvider get_data_cached_invalid
+	 * @covers ::video_get_post_by_guid
+	 * @since 8.4.0
+	 *
+	 * @param mixed $invalid_cached_value A cached value that should be ignored.
+	 */
+	public function test_cached_invalid_video_get_post_by_guid( $invalid_cached_value ) {
+		global $_wp_using_ext_object_cache;
+
+		$_wp_using_ext_object_cache = true;
+		$guid                       = wp_generate_uuid4();
+		$attachment_id              = $this->create_videopress_attachment( $guid );
+
+		wp_cache_set( 'video_get_post_by_guid_' . $guid, $invalid_cached_value, 'videopress' );
+
+		$this->assertEquals(
+			get_post( $attachment_id ),
+			video_get_post_by_guid( $guid )
+		);
 	}
 
 	/**
@@ -84,6 +205,26 @@ class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 		$filtered = jetpack_videopress_flash_embed_filter( $content );
 
 		$this->assertContains( $contains, $filtered );
+	}
+
+	/**
+	 * Creates a videopress attachment (video), given a guid.
+	 *
+	 * @param string $guid The guid to create an attachment for.
+	 * @return int|WP_Error The attachment ID that was created, or WP_Error.
+	 */
+	public function create_videopress_attachment( $guid ) {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
+
+		wp_insert_attachment(
+			array(
+				'ID'             => $attachment_id,
+				'post_mime_type' => 'video/videopress',
+			)
+		);
+		add_post_meta( $attachment_id, 'videopress_guid', $guid );
+
+		return $attachment_id;
 	}
 
 }

--- a/tests/php/modules/videopress/test_functions.utility-functions.php
+++ b/tests/php/modules/videopress/test_functions.utility-functions.php
@@ -13,35 +13,6 @@
 class WP_Test_Jetpack_VideoPress_Utility_Functions extends WP_UnitTestCase {
 
 	/**
-	 * Tests a helper function to get the attachment ID, when there's no cached value.
-	 *
-	 * @covers ::videopress_get_attachment_id_by_url
-	 * @since 8.4.0
-	 */
-	public function test_non_cached_videopress_get_attachment_id_by_url() {
-		$expected_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
-		$url         = wp_get_attachment_url( $expected_id );
-
-		$this->assertEquals( $expected_id, videopress_get_attachment_id_by_url( $url ) );
-	}
-
-	/**
-	 * Tests a helper function to get the attachment ID, when there is a cached value.
-	 *
-	 * @covers ::videopress_get_attachment_id_by_url
-	 * @since 8.4.0
-	 */
-	public function test_cached_videopress_get_attachment_id_by_url() {
-		$cached_id = 512351;
-		self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg', 0 );
-		$upload_dir  = wp_get_upload_dir();
-		$url         = trailingslashit( $upload_dir['url'] ) . 'random.jpg';
-		wp_cache_set( 'videopress_get_attachment_id_by_url_' . md5( $url ), $cached_id, 'videopress' );
-
-		$this->assertEquals( $cached_id, videopress_get_attachment_id_by_url( $url ) );
-	}
-
-	/**
 	 * Tests a helper function to get the post by guid, when there is no post found.
 	 *
 	 * @covers ::video_get_post_by_guid


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Caches functions that use `WP_Query`
* Adds some arguments to `WP_Query` to improve performance, like `'no_found_rows'  => true`
* Adds a few unit tests

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhances an existing feature, no intended change to functionality

#### Testing instructions:
(Regression testing for VideoPress)
1. Ensure VideoPress is enabled:
![settings-jetpack](https://user-images.githubusercontent.com/4063887/75300287-04608c00-57fd-11ea-8134-362c1546c824.png)

2. Create a new post
3. Add a Video block
4. Upload a video to it
5. Expected: the video plays in the editor.
6. Expected: the video plays on the front-end

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Performance enhancement for VideoPress, caching and improving queries
