### PR TITLE
Initial commit of an e2e test for eventbrite block

### DIFF
--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import { waitForSelector, waitAndClick, waitAndType } from '../page-helper';
+
+export default class EventbriteBlock {
+	constructor( block, page ) {
+		this.blockTitle = EventbriteBlock.title();
+		this.block = block;
+		this.page = page;
+		this.blockSelector = '#block-' + block.clientId;
+	}
+
+	static name() {
+		return 'eventbrite';
+	}
+
+	static title() {
+		return 'Eventbrite';
+	}
+
+	static embedUrl() {
+		return 'https://www.eventbrite.co.nz/e/96820156695';
+	}
+
+	static eventUrl() {
+		return 'https://www.eventbrite.co.nz/e/javascript-for-beginners-tickets-96820156695';
+	}
+
+	async addEmbed() {
+		const inputSelector = this.getSelector( '.components-placeholder__input' );
+		const descriptionSelector = this.getSelector( "button[type='submit']" );
+
+		await waitAndClick( this.page, inputSelector );
+		await waitAndType( this.page, inputSelector, EventbriteBlock.embedUrl() );
+
+		await waitAndClick( this.page, descriptionSelector );
+	}
+
+	getSelector( selector ) {
+		return `${ this.blockSelector } ${ selector }`;
+	}
+
+	/**
+	 * Checks whether block is rendered on frontend
+	 * @param {Page} page Puppeteer page instance
+	 */
+	static async isRendered( page ) {
+		const containerSelector = `.entry-content a[href='${ EventbriteBlock.eventUrl() }']`;
+
+		await waitForSelector( page, containerSelector );
+	}
+}

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -9,6 +9,7 @@ import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/u
 import SimplePaymentBlock from '../lib/blocks/simple-payments';
 import WordAdsBlock from '../lib/blocks/word-ads';
 import PinterestBlock from '../lib/blocks/pinterest';
+import EventbriteBlock from '../lib/blocks/eventbrite';
 
 describe( 'Paid blocks', () => {
 	beforeAll( async () => {
@@ -101,6 +102,26 @@ describe( 'Paid blocks', () => {
 
 			const frontend = await PostFrontendPage.init( page );
 			await frontend.isRenderedBlockPresent( PinterestBlock );
+		} );
+	} );
+
+	describe( 'Eventbrite block', () => {
+		it( 'Can publish a post with an Eventbrite block', async () => {
+			const blockEditor = await BlockEditorPage.visit( page );
+			const blockInfo = await blockEditor.insertBlock(
+				EventbriteBlock.name(),
+				EventbriteBlock.title()
+			);
+
+			const EventbriteBlock = new EventbriteBlock( blockInfo, page );
+			await EventbriteBlock.addEmbed();
+
+			await blockEditor.focus();
+			await blockEditor.publishPost();
+			await blockEditor.viewPost();
+
+			const frontend = await PostFrontendPage.init( page );
+			await frontend.isRenderedBlockPresent( EventbriteBlock );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -106,15 +106,15 @@ describe( 'Paid blocks', () => {
 	} );
 
 	describe( 'Eventbrite block', () => {
-		it( 'Can publish a post with an Eventbrite block', async () => {
+		it( 'Can publish a post with a Eventbrite block', async () => {
 			const blockEditor = await BlockEditorPage.visit( page );
 			const blockInfo = await blockEditor.insertBlock(
 				EventbriteBlock.name(),
 				EventbriteBlock.title()
 			);
 
-			const EventbriteBlock = new EventbriteBlock( blockInfo, page );
-			await EventbriteBlock.addEmbed();
+			const eventbriteBlock = new EventbriteBlock( blockInfo, page );
+			await eventbriteBlock.addEmbed();
 
 			await blockEditor.focus();
 			await blockEditor.publishPost();


### PR DESCRIPTION
Fixes #14715

#### Changes proposed in this Pull Request:
* Adds a Page object for Eventbrite block
* Adds simple e2e test to ensure block can be embeded and rendered on frontend

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* New e2e test

#### Testing instructions:
.... will add once PR finalised.

#### Proposed changelog entry for your changes:
* e2e test only, no changelog entry needed
