### PR TITLE
E2E Tests: Move Pinterest tests to a free test site

### DIFF
--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -19,12 +19,12 @@ export default class EventbriteBlock {
 		return 'Eventbrite';
 	}
 
-	static embedUrl() {
-		return 'https://www.eventbrite.co.nz/e/96820156695';
+	static eventId() {
+		return '96820156695';
 	}
 
-	static eventUrl() {
-		return 'https://www.eventbrite.co.nz/e/javascript-for-beginners-tickets-96820156695';
+	static embedUrl() {
+		return `https://www.eventbrite.co.nz/e/${ EventbriteBlock.eventId }`;
 	}
 
 	async addEmbed() {
@@ -46,7 +46,7 @@ export default class EventbriteBlock {
 	 * @param {Page} page Puppeteer page instance
 	 */
 	static async isRendered( page ) {
-		const containerSelector = `.entry-content a[href='${ EventbriteBlock.eventUrl() }']`;
+		const containerSelector = `.entry-content iframe[data-automation='checkout-widget-iframe-${ EventbriteBlock.eventId }']`;
 
 		await waitForSelector( page, containerSelector );
 	}

--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -1,0 +1,53 @@
+/**
+ * Internal dependencies
+ */
+import { waitForSelector, waitAndClick, waitAndType } from '../page-helper';
+
+export default class EventbriteBlock {
+	constructor( block, page ) {
+		this.blockTitle = EventbriteBlock.title();
+		this.block = block;
+		this.page = page;
+		this.blockSelector = '#block-' + block.clientId;
+	}
+
+	static name() {
+		return 'eventbrite';
+	}
+
+	static title() {
+		return 'Eventbrite';
+	}
+
+	static embedUrl() {
+		return 'https://www.eventbrite.co.nz/e/96820156695';
+	}
+
+	static eventUrl() {
+		return 'https://www.eventbrite.co.nz/e/javascript-for-beginners-tickets-96820156695';
+	}
+
+	async addEmbed() {
+		const inputSelector = this.getSelector( '.components-placeholder__input' );
+		const descriptionSelector = this.getSelector( "button[type='submit']" );
+
+		await waitAndClick( this.page, inputSelector );
+		await waitAndType( this.page, inputSelector, EventbriteBlock.embedUrl() );
+
+		await waitAndClick( this.page, descriptionSelector );
+	}
+
+	getSelector( selector ) {
+		return `${ this.blockSelector } ${ selector }`;
+	}
+
+	/**
+	 * Checks whether block is rendered on frontend
+	 * @param {Page} page Puppeteer page instance
+	 */
+	static async isRendered( page ) {
+		const containerSelector = `.entry-content a[href='${ EventbriteBlock.eventUrl() }']`;
+
+		await waitForSelector( page, containerSelector );
+	}
+}

--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -24,7 +24,7 @@ export default class EventbriteBlock {
 	}
 
 	static embedUrl() {
-		return `https://www.eventbrite.co.nz/e/${ EventbriteBlock.eventId }`;
+		return `https://www.eventbrite.co.nz/e/${ EventbriteBlock.eventId() }`;
 	}
 
 	async addEmbed() {
@@ -46,7 +46,7 @@ export default class EventbriteBlock {
 	 * @param {Page} page Puppeteer page instance
 	 */
 	static async isRendered( page ) {
-		const containerSelector = `.entry-content iframe[data-automation='checkout-widget-iframe-${ EventbriteBlock.eventId }']`;
+		const containerSelector = `.entry-content iframe[data-automation='checkout-widget-iframe-${ EventbriteBlock.eventId() }']`;
 
 		await waitForSelector( page, containerSelector );
 	}

--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -41,6 +41,7 @@ export default class EventbriteBlock {
 	/**
 	 * Checks whether block is rendered on frontend
 	 * @param {Page} page Puppeteer page instance
+	 * @param {Object} args An object of any additional required instance values
 	 */
 	static async isRendered( page, args ) {
 		const containerSelector = `.entry-content iframe[data-automation='checkout-widget-iframe-${ args.eventId }']`;

--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -4,11 +4,12 @@
 import { waitForSelector, waitAndClick, waitAndType } from '../page-helper';
 
 export default class EventbriteBlock {
-	constructor( block, page ) {
+	constructor( block, page, eventId ) {
 		this.blockTitle = EventbriteBlock.title();
 		this.block = block;
 		this.page = page;
 		this.blockSelector = '#block-' + block.clientId;
+		this.eventId = eventId;
 	}
 
 	static name() {
@@ -19,12 +20,8 @@ export default class EventbriteBlock {
 		return 'Eventbrite';
 	}
 
-	static eventId() {
-		return '96820156695';
-	}
-
-	static embedUrl() {
-		return `https://www.eventbrite.co.nz/e/${ EventbriteBlock.eventId() }`;
+	embedUrl() {
+		return `https://www.eventbrite.co.nz/e/${ this.eventId }`;
 	}
 
 	async addEmbed() {
@@ -32,7 +29,7 @@ export default class EventbriteBlock {
 		const descriptionSelector = this.getSelector( "button[type='submit']" );
 
 		await waitAndClick( this.page, inputSelector );
-		await waitAndType( this.page, inputSelector, EventbriteBlock.embedUrl() );
+		await waitAndType( this.page, inputSelector, this.embedUrl() );
 
 		await waitAndClick( this.page, descriptionSelector );
 	}
@@ -45,8 +42,8 @@ export default class EventbriteBlock {
 	 * Checks whether block is rendered on frontend
 	 * @param {Page} page Puppeteer page instance
 	 */
-	static async isRendered( page ) {
-		const containerSelector = `.entry-content iframe[data-automation='checkout-widget-iframe-${ EventbriteBlock.eventId() }']`;
+	static async isRendered( page, args ) {
+		const containerSelector = `.entry-content iframe[data-automation='checkout-widget-iframe-${ args.eventId }']`;
 
 		await waitForSelector( page, containerSelector );
 	}

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -89,7 +89,7 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	jetpackPage = await JetpackPage.init( page );
-	if ( ! mockPlanData && plan !== 'free' ) {
+	if ( ! mockPlanData ) {
 		await jetpackPage.reload( { waitFor: 'networkidle0' } );
 
 		await page.waitForResponse(

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -77,7 +77,8 @@ export async function connectThroughWPAdminIfNeeded( {
 	// await ( await JetpackUserTypePage.init( page ) ).selectUserType( 'creator' );
 
 	if ( mockPlanData ) {
-		await persistPlanData( 'jetpack_free' );
+		const planType = plan === 'free' ? 'jetpack_free' : 'jetpack_business';
+		await persistPlanData( planType );
 		await ( await PickAPlanPage.init( page ) ).selectFreePlan();
 	} else {
 		await ( await PickAPlanPage.init( page ) ).selectBusinessPlan();

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -88,7 +88,7 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	jetpackPage = await JetpackPage.init( page );
-
+	console.log( `Debug - plan: ${ plan }, mockPlanData: ${ mockPlanData }` );
 	if ( ! mockPlanData && plan !== 'free' ) {
 		await jetpackPage.reload( { waitFor: 'networkidle0' } );
 

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -88,7 +88,6 @@ export async function connectThroughWPAdminIfNeeded( {
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
 
 	jetpackPage = await JetpackPage.init( page );
-	console.log( `Debug - plan: ${ plan }, mockPlanData: ${ mockPlanData }` );
 	if ( ! mockPlanData && plan !== 'free' ) {
 		await jetpackPage.reload( { waitFor: 'networkidle0' } );
 

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -89,7 +89,7 @@ export async function connectThroughWPAdminIfNeeded( {
 
 	jetpackPage = await JetpackPage.init( page );
 
-	if ( ! mockPlanData ) {
+	if ( ! mockPlanData && plan !== 'free' ) {
 		await jetpackPage.reload( { waitFor: 'networkidle0' } );
 
 		await page.waitForResponse(

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -77,7 +77,7 @@ export async function connectThroughWPAdminIfNeeded( {
 	// await ( await JetpackUserTypePage.init( page ) ).selectUserType( 'creator' );
 
 	if ( mockPlanData ) {
-		await persistPlanData();
+		await persistPlanData( 'jetpack_free' );
 		await ( await PickAPlanPage.init( page ) ).selectFreePlan();
 	} else {
 		await ( await PickAPlanPage.init( page ) ).selectBusinessPlan();

--- a/tests/e2e/lib/pages/postFrontend.js
+++ b/tests/e2e/lib/pages/postFrontend.js
@@ -13,9 +13,10 @@ export default class PostFrontendPage extends Page {
 	/**
 	 * Checks whether specific block is rendered on frontend. All the custom logic is defined in block's `isRendered` static method
 	 * @param {Class} BlockClass Block class that has a static `isRendered` method
+	 * @param {Object} args An object of any additional instance values required by the class `isRendered` method
 	 */
-	async isRenderedBlockPresent( BlockClass ) {
-		return await BlockClass.isRendered( this.page );
+	async isRenderedBlockPresent( BlockClass, args ) {
+		return await BlockClass.isRendered( this.page, args );
 	}
 
 	async logout() {

--- a/tests/e2e/lib/pages/wp-admin/jetpack.js
+++ b/tests/e2e/lib/pages/wp-admin/jetpack.js
@@ -21,8 +21,8 @@ export default class JetpackPage extends Page {
 	}
 
 	async isFree() {
-		const premiumPlanImage = ".my-plan-card__icon img[src*='free']";
-		return await isEventuallyVisible( this.page, premiumPlanImage, 20000 );
+		const freePlanImage = ".my-plan-card__icon img[src*='free']";
+		return await isEventuallyVisible( this.page, freePlanImage, 20000 );
 	}
 
 	async isPremium() {

--- a/tests/e2e/lib/pages/wp-admin/jetpack.js
+++ b/tests/e2e/lib/pages/wp-admin/jetpack.js
@@ -43,7 +43,7 @@ export default class JetpackPage extends Page {
 	async isPlan( plan ) {
 		switch ( plan ) {
 			case 'free':
-				return await this.isPremium();
+				return await this.isFree();
 			case 'premium':
 				return await this.isPremium();
 			case 'pro':

--- a/tests/e2e/lib/plan-helper.js
+++ b/tests/e2e/lib/plan-helper.js
@@ -242,6 +242,9 @@ function getPlanData(
 	};
 }
 
+/*
+ * @todo Share the mock data with methods in jetpack/tests/php/general/test_class.jetpack-plan.php somehow
+ */
 function getPlan( type ) {
 	if ( type === 'jetpack_business' ) {
 		return {

--- a/tests/e2e/lib/plan-helper.js
+++ b/tests/e2e/lib/plan-helper.js
@@ -7,11 +7,11 @@ import fs from 'fs';
  */
 import { getNgrokSiteUrl, execWpCommand, execShellCommand } from './utils-helper';
 
-export async function persistPlanData() {
+export async function persistPlanData( planType = 'jetpack_business' ) {
 	const planDataOption = 'e2e_jetpack_plan_data';
 	const siteUrl = getNgrokSiteUrl();
 	const siteId = await getSiteId();
-	const planData = getPlanData( siteId, siteUrl );
+	const planData = getPlanData( siteId, siteUrl, planType );
 
 	fs.writeFileSync( 'plan-data.txt', JSON.stringify( planData ) );
 
@@ -37,7 +37,7 @@ async function getSiteId() {
 function getPlanData(
 	id,
 	siteUrl,
-	planType = 'jetpack_business',
+	planType,
 	siteName = 'Whatever',
 	description = 'Just another WordPress site'
 ) {
@@ -314,6 +314,67 @@ function getPlan( type ) {
 			},
 		};
 	}
+
+	if ( type === 'jetpack_free' ) {
+		return {
+			product_id: 2002,
+			product_slug: 'jetpack_free',
+			product_name: 'Jetpack Free',
+			product_name_short: 'Free',
+			expired: false,
+			user_is_owner: false,
+			is_free: true,
+			features: {
+				active: [ 'akismet' ],
+				available: {
+					akismet: [
+						'jetpack_free',
+						'jetpack_premium',
+						'jetpack_personal',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+						'jetpack_personal_monthly',
+					],
+					'vaultpress-backups': [
+						'jetpack_premium',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-backup-archive': [
+						'jetpack_premium',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-storage-space': [
+						'jetpack_premium',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'vaultpress-automated-restores': [
+						'jetpack_premium',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					'simple-payments': [
+						'jetpack_premium',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+					],
+					support: [
+						'jetpack_premium',
+						'jetpack_personal',
+						'jetpack_premium_monthly',
+						'jetpack_business_monthly',
+						'jetpack_personal_monthly',
+					],
+					'premium-themes': [ 'jetpack_business_monthly' ],
+					'vaultpress-security-scanning': [ 'jetpack_business_monthly' ],
+					polldaddy: [ 'jetpack_business_monthly' ],
+				},
+			},
+		};
+	}
+
 	throw new Error( `${ type } is not yet supported. Add it yourself!` );
 }
 

--- a/tests/e2e/lib/plan-helper.js
+++ b/tests/e2e/lib/plan-helper.js
@@ -242,8 +242,11 @@ function getPlanData(
 	};
 }
 
-/*
- * @todo Share the mock data with methods in jetpack/tests/php/general/test_class.jetpack-plan.php somehow.
+/**
+ * Returns a JSON representation of Jetpack plan data.
+ * TODO: Share the mock data with methods in jetpack/tests/php/general/test_class.jetpack-plan.php somehow.
+ * @param {string} type Jetpack plan slug.
+ * @return {JSON} JSON Jetpack plan object.
  */
 function getPlan( type ) {
 	if ( type === 'jetpack_business' ) {

--- a/tests/e2e/lib/plan-helper.js
+++ b/tests/e2e/lib/plan-helper.js
@@ -243,7 +243,7 @@ function getPlanData(
 }
 
 /*
- * @todo Share the mock data with methods in jetpack/tests/php/general/test_class.jetpack-plan.php somehow
+ * @todo Share the mock data with methods in jetpack/tests/php/general/test_class.jetpack-plan.php somehow.
  */
 function getPlan( type ) {
 	if ( type === 'jetpack_business' ) {

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import BlockEditorPage from '../lib/pages/wp-admin/block-editor';
+import PostFrontendPage from '../lib/pages/postFrontend';
+import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
+import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/utils-helper';
+import PinterestBlock from '../lib/blocks/pinterest';
+
+describe( 'Paid blocks', () => {
+	beforeAll( async () => {
+		await resetWordpressInstall();
+		const url = getNgrokSiteUrl();
+		console.log( 'NEW SITE URL: ' + url );
+
+		await connectThroughWPAdminIfNeeded( { mockPlanData: false } );
+
+		await activateModule( page, 'publicize' );
+		await activateModule( page, 'wordads' );
+	} );
+
+	describe( 'Pinterest block', () => {
+		it( 'Can publish a post with a Pinterest block', async () => {
+			const blockEditor = await BlockEditorPage.visit( page );
+			const blockInfo = await blockEditor.insertBlock(
+				PinterestBlock.name(),
+				PinterestBlock.title()
+			);
+
+			const pinterestBlock = new PinterestBlock( blockInfo, page );
+			await pinterestBlock.addEmbed();
+
+			await blockEditor.focus();
+			await blockEditor.publishPost();
+			await blockEditor.viewPost();
+
+			const frontend = await PostFrontendPage.init( page );
+			await frontend.isRenderedBlockPresent( PinterestBlock );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -7,7 +7,7 @@ import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
 import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/utils-helper';
 import PinterestBlock from '../lib/blocks/pinterest';
 
-describe( 'Paid blocks', () => {
+describe( 'Free blocks', () => {
 	beforeAll( async () => {
 		await resetWordpressInstall();
 		const url = getNgrokSiteUrl();
@@ -36,6 +36,26 @@ describe( 'Paid blocks', () => {
 
 			const frontend = await PostFrontendPage.init( page );
 			await frontend.isRenderedBlockPresent( PinterestBlock );
+		} );
+	} );
+
+	describe( 'Eventbrite block', () => {
+		it( 'Can publish a post with a Eventbrite block', async () => {
+			const blockEditor = await BlockEditorPage.visit( page );
+			const blockInfo = await blockEditor.insertBlock(
+				EventbriteBlock.name(),
+				EventbriteBlock.title()
+			);
+
+			const eventbriteBlock = new EventbriteBlock( blockInfo, page );
+			await eventbriteBlock.addEmbed();
+
+			await blockEditor.focus();
+			await blockEditor.publishPost();
+			await blockEditor.viewPost();
+
+			const frontend = await PostFrontendPage.init( page );
+			await frontend.isRenderedBlockPresent( EventbriteBlock );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -6,6 +6,7 @@ import PostFrontendPage from '../lib/pages/postFrontend';
 import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
 import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/utils-helper';
 import PinterestBlock from '../lib/blocks/pinterest';
+import EventbriteBlock from '../lib/blocks/eventbrite';
 
 describe( 'Free blocks', () => {
 	beforeAll( async () => {

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -4,7 +4,7 @@
 import BlockEditorPage from '../lib/pages/wp-admin/block-editor';
 import PostFrontendPage from '../lib/pages/postFrontend';
 import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
-import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/utils-helper';
+import { resetWordpressInstall, getNgrokSiteUrl } from '../lib/utils-helper';
 import PinterestBlock from '../lib/blocks/pinterest';
 import EventbriteBlock from '../lib/blocks/eventbrite';
 
@@ -14,10 +14,7 @@ describe( 'Free blocks', () => {
 		const url = getNgrokSiteUrl();
 		console.log( 'NEW SITE URL: ' + url );
 
-		await connectThroughWPAdminIfNeeded( { mockPlanData: false } );
-
-		await activateModule( page, 'publicize' );
-		await activateModule( page, 'wordads' );
+		await connectThroughWPAdminIfNeeded( { mockPlanData: true } );
 	} );
 
 	describe( 'Pinterest block', () => {

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -39,13 +39,14 @@ describe( 'Free blocks', () => {
 
 	describe( 'Eventbrite block', () => {
 		it( 'Can publish a post with a Eventbrite block', async () => {
+			const eventId = '96820156695';
 			const blockEditor = await BlockEditorPage.visit( page );
 			const blockInfo = await blockEditor.insertBlock(
 				EventbriteBlock.name(),
 				EventbriteBlock.title()
 			);
 
-			const eventbriteBlock = new EventbriteBlock( blockInfo, page );
+			const eventbriteBlock = new EventbriteBlock( blockInfo, page, eventId );
 			await eventbriteBlock.addEmbed();
 
 			await blockEditor.focus();
@@ -53,7 +54,7 @@ describe( 'Free blocks', () => {
 			await blockEditor.viewPost();
 
 			const frontend = await PostFrontendPage.init( page );
-			await frontend.isRenderedBlockPresent( EventbriteBlock );
+			await frontend.isRenderedBlockPresent( EventbriteBlock, { eventId } );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -14,7 +14,7 @@ describe( 'Free blocks', () => {
 		const url = getNgrokSiteUrl();
 		console.log( 'NEW SITE URL: ' + url );
 
-		await connectThroughWPAdminIfNeeded( { mockPlanData: false, plan: 'free' } );
+		await connectThroughWPAdminIfNeeded( { mockPlanData: true, plan: 'free' } );
 	} );
 
 	describe( 'Pinterest block', () => {

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -14,7 +14,7 @@ describe( 'Free blocks', () => {
 		const url = getNgrokSiteUrl();
 		console.log( 'NEW SITE URL: ' + url );
 
-		await connectThroughWPAdminIfNeeded( { mockPlanData: true } );
+		await connectThroughWPAdminIfNeeded( { mockPlanData: false } );
 	} );
 
 	describe( 'Pinterest block', () => {

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -14,7 +14,7 @@ describe( 'Free blocks', () => {
 		const url = getNgrokSiteUrl();
 		console.log( 'NEW SITE URL: ' + url );
 
-		await connectThroughWPAdminIfNeeded( { mockPlanData: false } );
+		await connectThroughWPAdminIfNeeded( { mockPlanData: false, plan: 'free' } );
 	} );
 
 	describe( 'Pinterest block', () => {

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -8,7 +8,6 @@ import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
 import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/utils-helper';
 import SimplePaymentBlock from '../lib/blocks/simple-payments';
 import WordAdsBlock from '../lib/blocks/word-ads';
-import PinterestBlock from '../lib/blocks/pinterest';
 import { catchBeforeAll } from '../lib/jest.test.failure';
 
 describe( 'Paid blocks', () => {

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -84,24 +84,4 @@ describe( 'Paid blocks', () => {
 			await frontend.isRenderedBlockPresent( WordAdsBlock );
 		} );
 	} );
-
-	describe( 'Pinterest block', () => {
-		it( 'Can publish a post with a Pinterest block', async () => {
-			const blockEditor = await BlockEditorPage.visit( page );
-			const blockInfo = await blockEditor.insertBlock(
-				PinterestBlock.name(),
-				PinterestBlock.title()
-			);
-
-			const pinterestBlock = new PinterestBlock( blockInfo, page );
-			await pinterestBlock.addEmbed();
-
-			await blockEditor.focus();
-			await blockEditor.publishPost();
-			await blockEditor.viewPost();
-
-			const frontend = await PostFrontendPage.init( page );
-			await frontend.isRenderedBlockPresent( PinterestBlock );
-		} );
-	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This moves the Pinterest test to a new file which tests free blocks, as Pinterest is a free block.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Change to an existing feature

#### Testing instructions:
* This will run on Travis, or run `yarn test-e2e`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog

Fixes #14715