### PR TITLE
Fix for recurring payments not scrolling to 0,0 in Firefox

### DIFF
--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -46,6 +46,7 @@ function activateSubscription( block, blogId, planId, lang ) {
 		window.addEventListener( 'message', handleIframeResult, false );
 		const tbWindow = document.querySelector( '#TB_window' );
 		tbWindow.classList.add( 'jetpack-memberships-modal' );
+		window.scrollTo( 0, 0 );
 	} );
 }
 


### PR DESCRIPTION
Firefox has trouble scrolling to 0,0 on checkout click.
I don't know why and what introduced that error. 
I discovered the issue while testing https://github.com/Automattic/jetpack/pull/14809

#### Changes proposed in this Pull Request:
* Additional command to scroll post loading the iframe

#### Testing instructions:
- Proceed with instructions on https://github.com/Automattic/jetpack/pull/14809
- Notice that on clicking the button, the page does not scroll to 0,0 on Firefox
- apply this PR
- Notice that it does.

## Post merging https://github.com/Automattic/jetpack/pull/14809 this has to be rebased against master

