### PR TITLE
Calendly Block: Show an error when the embed url is not found

### DIFF
--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -36,6 +36,7 @@ import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
+import { CALENDLY_EXAMPLE_URL } from './';
 
 function CalendlyEdit( props ) {
 	const {
@@ -74,7 +75,7 @@ function CalendlyEdit( props ) {
 	};
 
 	useEffect( () => {
-		if ( ! url || 'link' === style ) {
+		if ( ! url || CALENDLY_EXAMPLE_URL === url || 'link' === style ) {
 			return;
 		}
 		setResolveUrl( true );

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -91,7 +91,7 @@ function CalendlyEdit( props ) {
 			},
 			() => setResolveUrl( false )
 		);
-	}, [ url ] );
+	}, [] );
 
 	const parseEmbedCode = event => {
 		if ( ! event ) {

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -17,6 +17,8 @@ import { getAttributesFromEmbedCode, REGEX } from './utils';
  */
 import './editor.scss';
 
+export const CALENDLY_EXAMPLE_URL = 'https://calendly.com/wordpresscom/jetpack-block-example';
+
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
 export const settings = {
@@ -44,7 +46,7 @@ export const settings = {
 			submitButtonText: __( 'Schedule time with me', 'jetpack' ),
 			hideEventTypeDetails: false,
 			style: 'inline',
-			url: 'https://calendly.com/wordpresscom/jetpack-block-example',
+			url: CALENDLY_EXAMPLE_URL,
 		},
 	},
 	transforms: {

--- a/extensions/shared/test-embed-url.js
+++ b/extensions/shared/test-embed-url.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Test if a URL is accessible and respond with status code < 400.
+ *
+ * @example
+ * const [ isResolvingUrl, setIsResolvingUrl ] = useState();
+ * testEmbedUrl( url, setIsResolvingUrl )
+ *   .then( () => setAttributes( url ) )
+ *   .catch( () => setErrorNotice() );
+ *
+ * @param {String} url The URL to test.
+ * @param {Function} [setIsResolvingUrl=noop] An optional function to track the resolving state. Typically used to update the calling component's state.
+ * @returns {Promise} Resolve if the URL is valid, reject otherwise.
+ */
+export default function testEmbedUrl( url, setIsResolvingUrl = noop ) {
+	setIsResolvingUrl( true );
+	return new Promise( async ( resolve, reject ) => {
+		try {
+			const response = await apiFetch( { path: `/wpcom/v2/resolve-redirect/${ url }` } );
+			setIsResolvingUrl( false );
+			const responseStatusCode = response.status ? parseInt( response.status, 10 ) : null;
+			if ( responseStatusCode && responseStatusCode >= 400 ) {
+				reject();
+			} else {
+				resolve();
+			}
+		} catch ( error ) {
+			setIsResolvingUrl( false );
+			reject();
+		}
+	} );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14805

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Show a loading spinner when loading the embed.
* Show an error when the embed url is not found.

When inserting an URL, the block tests it through the `resolve-redirect` endpoint.
On success, it sets the block's attributes and loads the embed.
On fail, it empties the URL attributes and shows an error notice.

![Feb-26-2020 16-45-27](https://user-images.githubusercontent.com/2070010/75366960-75647a00-58b7-11ea-9a3c-7726ef08db0b.gif)

To make this work with the automatic block transformation when pasting a Calendly URL, the `resolve-redirect` check runs on block mount, and whenever the URL attribute changes.
This, unless the block style is `link`, as this implies that the URL passed the test already (and showing a "loading spinner" would look awkward.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Calendly block and add a correct Calendly URL.
* Make sure the block has a loading spinner and then show the embed as expected.
* Insert a second Calendly block with a correct URL, and set it as `link` style.
* Save and reload the editor.
* Make sure both blocks show up fine; the embedded one should show the loading spinner, while the other should not.
* Insert another Calendly block, this time using an incorrect Calendly URL (e.g. `https://calendly.com/totally-incorrect-url`).
* After the loading spinner, the block should revert to the placeholder with an error notice.
* Save and reload. The incorrect block should show up in placeholder state.
* Try again by pasting a correct and an incorrect URL in the editor. Make sure the behaviour of both transforms is the same as described above.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Calendly block: Show an error when the embed URL is not found.
