### PR TITLE
Eventbrite Block: Add alignment support

### DIFF
--- a/extensions/blocks/eventbrite/editor.scss
+++ b/extensions/blocks/eventbrite/editor.scss
@@ -1,5 +1,9 @@
-.wp-block-jetpack-eventbrite .components-placeholder__learn-more {
-	margin-top: 1em;
+.wp-block-jetpack-eventbrite {
+	position: relative;
+
+	.components-placeholder__learn-more {
+		margin-top: 1em;
+	}
 }
 
 // Styles needed to display block style options correctly when using Button & Modal embed type.

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -47,8 +47,15 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
+		$class_names = array();
+		array_push( $class_names, 'eventbrite__in-page-checkout' );
+
+		if ( isset( $attr['align'] ) ) {
+			array_push( $class_names, 'align' . esc_attr( $attr['align'] ) );
+		}
+
 		$content .= sprintf(
-			'<div id="%s" class="eventbrite__in-page-checkout"></div>',
+			'<div id="%s" class="' . implode( ' ', $class_names ) . '"></div>',
 			esc_attr( $widget_id )
 		);
 

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -47,7 +47,7 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
-		$classes = \Jetpack_Gutenberg::block_classes( 'eventbrite__in-page-checkout', $attr );
+		$classes = \Jetpack_Gutenberg::block_classes( 'eventbrite', $attr );
 
 		$content .= sprintf(
 			'<div id="%1$s" class="%2$s"></div>',

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -47,16 +47,12 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
-		$class_names = array();
-		array_push( $class_names, 'eventbrite__in-page-checkout' );
-
-		if ( isset( $attr['align'] ) ) {
-			array_push( $class_names, 'align' . esc_attr( $attr['align'] ) );
-		}
+		$classes = \Jetpack_Gutenberg::block_classes( 'eventbrite__in-page-checkout', $attr );
 
 		$content .= sprintf(
-			'<div id="%s" class="' . implode( ' ', $class_names ) . '"></div>',
-			esc_attr( $widget_id )
+			'<div id="%1$s" class="%2$s"></div>',
+			esc_attr( $widget_id ),
+			esc_attr( $classes )
 		);
 
 		return sprintf(

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -44,6 +44,7 @@ export const settings = {
 	keywords: [ __( 'events', 'jetpack' ), __( 'tickets', 'jetpack' ) ],
 	supports: {
 		html: false,
+		align: [ 'left', 'center', 'right' ],
 	},
 	attributes,
 	edit,

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -44,7 +44,7 @@ export const settings = {
 	keywords: [ __( 'events', 'jetpack' ), __( 'tickets', 'jetpack' ) ],
 	supports: {
 		html: false,
-		align: [ 'left', 'center', 'right' ],
+		align: true,
 	},
 	attributes,
 	edit,

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -6,7 +6,7 @@
 // default/minimum value set by Eventbrite (425px), by overriding
 // the container's inline height (set by Eventbrite, sometimes incorrectly as 0px),
 // and setting the default height directly to the iframe.
-.eventbrite__in-page-checkout {
+.wp-block-jetpack-eventbrite {
 	height: auto !important;
 	iframe {
 		height: 425px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Add alignment support to the Eventbrite block. This works for both the modal button and in-page embed styles.

Fixes #14505

<img width="412" alt="Screen Shot 2020-02-26 at 10 20 40 AM" src="https://user-images.githubusercontent.com/1464705/75374735-aa55da00-5881-11ea-8f62-d9e04e275592.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes an existing feature.

#### Testing instructions:

* Add an Eventbrite block to a post or page, and add an event (example: https://www.eventbrite.ca/e/5th-construction-expo-2020-tickets-31941745621)
* Confirm you can see the "left, center, right" alignment option in the block settings bar when using the in-page embed style.
* Confirm you can also see alignment options when the Button & Modal style is selected
* Choose left, right, and center alignment options, and confirm these work correctly in the editor.

#### Proposed changelog entry for your changes:
* None.
