### PR TITLE
Google Calendar block: Remove min width for iframe

### DIFF
--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -2,18 +2,8 @@
  * Editor styles for Google Calendar
  */
 
-@media screen and ( min-width: 700px ) {
-	.block-editor__container {
-		.wp-block-jetpack-google-calendar {
-			iframe.components-sandbox { 
-				min-width: 600px; 
-			}
-		}
-	}
-}
-
 .wp-block-jetpack-google-calendar {
-    
+
 	&-embed-form-sidebar {
 		textarea {
 			width: 100%;


### PR DESCRIPTION
Remove the min width from the calendar iframe to prevent the calendar from overflowing the block on smaller viewport sizes.

Fixes #14815

![2020-02-26 10 55 24](https://user-images.githubusercontent.com/1464705/75377411-a4aec300-5886-11ea-950b-74529b38df11.gif)

#### Testing instructions:
* Add a Google Calendar block and connect a calendar
* Resize the widow from very small to big, and confirm the calendar in the block does not overflow the block frame as shown in #14815

#### Proposed changelog entry for your changes:
* None