### PR TITLE
Recurring Payments: AMP + analytics

### DIFF
--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -29,7 +29,8 @@ function handleIframeResult( eventFromIframe ) {
 }
 
 function activateSubscription( block, checkoutURL ) {
-	block.addEventListener( 'click', () => {
+	block.addEventListener( 'click', event => {
+		event.preventDefault();
 		window.scrollTo( 0, 0 );
 		tb_show( null, checkoutURL + '&display=alternate&TB_iframe=true', null );
 		window.addEventListener( 'message', handleIframeResult, false );

--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -28,21 +28,10 @@ function handleIframeResult( eventFromIframe ) {
 	}
 }
 
-function activateSubscription( block, blogId, planId, lang ) {
+function activateSubscription( block, checkoutURL ) {
 	block.addEventListener( 'click', () => {
 		window.scrollTo( 0, 0 );
-		tb_show(
-			null,
-			'https://subscribe.wordpress.com/memberships/?blog=' +
-				blogId +
-				'&plan=' +
-				planId +
-				'&lang=' +
-				lang +
-				'&display=alternate' +
-				'TB_iframe=true',
-			null
-		);
+		tb_show( null, checkoutURL + '&display=alternate&TB_iframe=true', null );
 		window.addEventListener( 'message', handleIframeResult, false );
 		const tbWindow = document.querySelector( '#TB_window' );
 		tbWindow.classList.add( 'jetpack-memberships-modal' );
@@ -57,14 +46,12 @@ const initializeMembershipButtonBlocks = () => {
 		document.querySelectorAll( '.' + blockClassName + ' a' )
 	);
 	membershipButtonBlocks.forEach( block => {
-		const blogId = block.getAttribute( 'data-blog-id' );
-		const planId = block.getAttribute( 'data-plan-id' );
-		const lang = block.getAttribute( 'data-lang' );
+		const checkoutURL = block.getAttribute( 'href' );
 		try {
-			activateSubscription( block, blogId, planId, lang );
+			activateSubscription( block, checkoutURL );
 		} catch ( err ) {
 			// eslint-disable-next-line no-console
-			console.error( 'Problem activating Recurring Payments ' + planId, err );
+			console.error( 'Problem activating Recurring Payments ' + checkoutURL, err );
 		}
 	} );
 };

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -250,16 +250,18 @@ class Jetpack_Memberships {
 		}
 		$button_styles = implode( ';', $button_styles );
 		add_thickbox();
+		global $wp;
 		return sprintf(
-			'<div class="wp-block-button %1$s"><a role="button" data-blog-id="%2$d" data-powered-text="%3$s" data-plan-id="%4$d" data-lang="%5$s" class="%6$s" style="%7$s">%8$s</a></div>',
+			'<div class="wp-block-button %1$s"><a role="button" href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&redirect=%3$s&p=%9$d" class="%6$s" style="%7$s">%8$s</a></div>',
 			esc_attr( Jetpack_Gutenberg::block_classes( self::$button_block_name, $attrs ) ),
 			esc_attr( $data['blog_id'] ),
-			esc_attr( $data['powered_text'] ),
+			esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
 			esc_attr( $data['id'] ),
 			esc_attr( get_locale() ),
 			isset( $attrs['submitButtonClasses'] ) ? esc_attr( $attrs['submitButtonClasses'] ) : 'wp-block-button__link',
 			esc_attr( $button_styles ),
-			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button )
+			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button ),
+			esc_attr( get_the_ID() ) // Needed for analytics purposes.
 		);
 	}
 

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -252,7 +252,7 @@ class Jetpack_Memberships {
 		add_thickbox();
 		global $wp;
 		return sprintf(
-			'<div class="wp-block-button %1$s"><a role="button" href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&pid=%9$d&redirect=%3$s" class="%6$s" style="%7$s">%8$s</a></div>',
+			'<div class="wp-block-button %1$s"><a role="button" target="_blank" href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&pid=%9$d&redirect=%3$s" class="%6$s" style="%7$s">%8$s</a></div>',
 			esc_attr( Jetpack_Gutenberg::block_classes( self::$button_block_name, $attrs ) ),
 			esc_attr( $data['blog_id'] ),
 			esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -262,7 +262,7 @@ class Jetpack_Memberships {
 			esc_attr( $button_styles ),
 			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button ),
 			esc_attr( get_the_ID() ), // Needed for analytics purposes.
-			isset( $attrs['submitButtonAttributes'] ) ? wp_kses( $attrs['submitButtonAttributes'] ) : ''
+			isset( $attrs['submitButtonAttributes'] ) ? wp_kses( $attrs['submitButtonAttributes'] ) : '' // Needed for arbitrary target=_blank on WPCOM VIP.
 		);
 	}
 

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -262,7 +262,7 @@ class Jetpack_Memberships {
 			esc_attr( $button_styles ),
 			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button ),
 			esc_attr( get_the_ID() ), // Needed for analytics purposes.
-			isset( $attrs['submitButtonAttributes'] ) ? wp_kses( $attrs['submitButtonAttributes'] ) : '' // Needed for arbitrary target=_blank on WPCOM VIP.
+			isset( $attrs['submitButtonAttributes'] ) ? sanitize_text_field( $attrs['submitButtonAttributes'] ) : '' // Needed for arbitrary target=_blank on WPCOM VIP.
 		);
 	}
 

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -252,7 +252,7 @@ class Jetpack_Memberships {
 		add_thickbox();
 		global $wp;
 		return sprintf(
-			'<div class="wp-block-button %1$s"><a role="button" href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&redirect=%3$s&p=%9$d" class="%6$s" style="%7$s">%8$s</a></div>',
+			'<div class="wp-block-button %1$s"><a role="button" href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&pid=%9$d&redirect=%3$s" class="%6$s" style="%7$s">%8$s</a></div>',
 			esc_attr( Jetpack_Gutenberg::block_classes( self::$button_block_name, $attrs ) ),
 			esc_attr( $data['blog_id'] ),
 			esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -252,7 +252,7 @@ class Jetpack_Memberships {
 		add_thickbox();
 		global $wp;
 		return sprintf(
-			'<div class="wp-block-button %1$s"><a role="button" target="_blank" href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&pid=%9$d&redirect=%3$s" class="%6$s" style="%7$s">%8$s</a></div>',
+			'<div class="wp-block-button %1$s"><a role="button" %10$s href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&pid=%9$d&redirect=%3$s" class="%6$s" style="%7$s">%8$s</a></div>',
 			esc_attr( Jetpack_Gutenberg::block_classes( self::$button_block_name, $attrs ) ),
 			esc_attr( $data['blog_id'] ),
 			esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
@@ -261,7 +261,8 @@ class Jetpack_Memberships {
 			isset( $attrs['submitButtonClasses'] ) ? esc_attr( $attrs['submitButtonClasses'] ) : 'wp-block-button__link',
 			esc_attr( $button_styles ),
 			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button ),
-			esc_attr( get_the_ID() ) // Needed for analytics purposes.
+			esc_attr( get_the_ID() ), // Needed for analytics purposes.
+			isset( $attrs['submitButtonAttributes'] ) ? wp_kses( $attrs['submitButtonAttributes'] ) : ''
 		);
 	}
 

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -210,8 +210,8 @@ class Jetpack_Memberships {
 		if ( empty( $attrs['planId'] ) ) {
 			return;
 		}
-		$id      = intval( $attrs['planId'] );
-		$product = get_post( $id );
+		$plan_id = intval( $attrs['planId'] );
+		$product = get_post( $plan_id );
 		if ( ! $product || is_wp_error( $product ) ) {
 			return;
 		}
@@ -221,9 +221,8 @@ class Jetpack_Memberships {
 
 		$data = array(
 			'blog_id'      => self::get_blog_id(),
-			'id'           => $id,
+			'plan_id'      => $plan_id,
 			'button_label' => __( 'Your contribution', 'jetpack' ),
-			'powered_text' => __( 'Powered by WordPress.com', 'jetpack' ),
 		);
 
 		if ( isset( $attrs['submitButtonText'] ) ) {
@@ -255,7 +254,7 @@ class Jetpack_Memberships {
 		$button_url = add_query_arg(
 			array(
 				'blog'     => esc_attr( $data['blog_id'] ),
-				'plan'     => esc_attr( $data['id'] ),
+				'plan'     => esc_attr( $data['plan_id'] ),
 				'lang'     => esc_attr( get_locale() ),
 				'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
 				'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -251,17 +251,30 @@ class Jetpack_Memberships {
 		$button_styles = implode( ';', $button_styles );
 		add_thickbox();
 		global $wp;
+
+		$button_url = add_query_arg(
+			array(
+				'blog'     => esc_attr( $data['blog_id'] ),
+				'plan'     => esc_attr( $data['id'] ),
+				'lang'     => esc_attr( get_locale() ),
+				'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
+				'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
+			),
+			'https://subscribe.wordpress.com/memberships/'
+		);
 		return sprintf(
-			'<div class="wp-block-button %1$s"><a role="button" %10$s href="https://subscribe.wordpress.com/memberships/?blog=%2$d&plan=%4$d&lang=%5$s&pid=%9$d&redirect=%3$s" class="%6$s" style="%7$s">%8$s</a></div>',
-			esc_attr( Jetpack_Gutenberg::block_classes( self::$button_block_name, $attrs ) ),
-			esc_attr( $data['blog_id'] ),
-			esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
-			esc_attr( $data['id'] ),
-			esc_attr( get_locale() ),
+			'<div class="%1$s"><a role="button" %6$s href="%2$s" class="%3$s" style="%4$s">%5$s</a></div>',
+			esc_attr(
+				Jetpack_Gutenberg::block_classes(
+					self::$button_block_name,
+					$attrs,
+					array( 'wp-block-button' )
+				)
+			),
+			esc_url( $button_url ),
 			isset( $attrs['submitButtonClasses'] ) ? esc_attr( $attrs['submitButtonClasses'] ) : 'wp-block-button__link',
 			esc_attr( $button_styles ),
 			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button ),
-			esc_attr( get_the_ID() ), // Needed for analytics purposes.
 			isset( $attrs['submitButtonAttributes'] ) ? sanitize_text_field( $attrs['submitButtonAttributes'] ) : '' // Needed for arbitrary target=_blank on WPCOM VIP.
 		);
 	}


### PR DESCRIPTION
There are no functional changes, this PR just reshuffles things in order to properly behave in AMP environment

#### Changes proposed in this Pull Request:
* Introduce URL fallback, so the block works in AMP
* pass the redirect URL, so the checkout flow from AMP redirects back to the page where it started
* pass the `pid` parameter, which is the source post id. We want to start gathering this data, so we can provide analytics on which posts are most effective so our users can do proper testing of different approaches.

#### Testing instructions:
* Add a recurring payments block to a page, set up a payment button
* Open the page in the front end
* See that it opens the checkout window as before (no regressions)
* Install [AMP plugin](https://pl.wordpress.org/plugins/amp/) , activate 
* Go to the page where you set up recurring payments, append `/amp/` at the end
* Checkout button should work, will just redirect you to the checkout window instead of opening the modal

#### Proposed changelog entry for your changes:
* Recurring Payments now supports Accelerated Mobile Pages

Yes, checkout window is still WIP, but even in the current state it is better than the broken experience we have right now.
