### PR TITLE
Calendly: Fix the overlay when the block is left or right aligned

### DIFF
--- a/extensions/blocks/calendly/editor.scss
+++ b/extensions/blocks/calendly/editor.scss
@@ -3,6 +3,8 @@
  */
 
 .wp-block-jetpack-calendly {
+	position: relative;
+
 	&-overlay {
 		position: absolute;
 		width: 100%;


### PR DESCRIPTION
In WordPress/Gutenberg#19593 a wrapper `div` was removed, which had a
`position` value of `relative`. Our overlay `div` to prevent the iframe
from being interacted with, relies on a parent element being
`positino: relative`. This is still the case when the block is in the
main flow/centre aligned, but when the block is left or right aligned,
it can't be selected, and clicks are handled by the iframe.

#### Changes proposed in this Pull Request:
This simply adds `position:relative` to the block container, so the overlay always covers it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a bug fix

#### Testing instructions:
* Setup a test site not running the Gutenberg plugin and the TwentyTwenty theme
* Add a Calendly block
* Set it's alignment to left or right.
* Check that you can still select and deselect the block.
* Install and activate the Gutenberg plugin.
* Check that you now can't select the block.
* Apply this patch
* Check that you can now select the block again by clicking on it.

#### Proposed changelog entry for your changes:
Bug fixed that caused the overlay not to render properly for the Calendly block in the editor.
