### PR TITLE
SSO: Pass error value to wp_login_failed

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -687,8 +687,10 @@ class Jetpack_SSO {
 				'error_message' => 'error_msg_enable_two_step'
 			) );
 
+			$error = new WP_Error( 'two_step_required', __( 'You must have Two-Step Authentication enabled on your WordPress.com account.', 'jetpack' ) );
+
 			/** This filter is documented in core/src/wp-includes/pluggable.php */
-			do_action( 'wp_login_failed', $user_data->login );
+			do_action( 'wp_login_failed', $user_data->login, $error );
 			add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'error_msg_enable_two_step' ) );
 			return;
 		}
@@ -831,8 +833,11 @@ class Jetpack_SSO {
 		) );
 
 		$this->user_data = $user_data;
+
+		$error = new WP_Error( 'account_not_found', __( 'Account not found. If you already have an account, make sure you have connected to WordPress.com.', 'jetpack' ) );
+
 		/** This filter is documented in core/src/wp-includes/pluggable.php */
-		do_action( 'wp_login_failed', $user_data->login );
+		do_action( 'wp_login_failed', $user_data->login, $error );
 		add_filter( 'login_message', array( 'Jetpack_SSO_Notices', 'cant_find_user' ) );
 	}
 


### PR DESCRIPTION
WP 5.4 now passes the authentication error via the wp_login_failed filter. 

Adding this prevents notices, etc if code utilizes the new arg.

Open question for a future PR on if we should have been passing that error in the return. We haven't so don't want to conflate that with this. 

Marking it for 8.3 late commit consideration to beat the Core release.

#### Changes proposed in this Pull Request:
* Sets a WP_Error and passes it to the filter.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBA
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* SSO: Add error argument for compatibility with a WordPress 5.4 hook change.
