### PR TITLE
Crowdsignal: Fix poll embeds on P2

### DIFF
--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -446,7 +446,7 @@ if (
 							/**
 							 * Hook into the Crowdsignal shortcode before rendering.
 							 *
-							 * @since 8.3.0
+							 * @since 8.4.0
 							 *
 							 * @param int $poll Poll ID.
 							 */

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -443,6 +443,15 @@ if (
 								)
 							);
 
+							/**
+							 * Hook into the Crowdsignal shortcode before rendering.
+							 *
+							 * @since 8.3.0
+							 *
+							 * @param int $poll Poll ID.
+							 */
+							do_action( 'crowdsignal_shortcode_before', intval( $poll ) );
+
 							return sprintf(
 								'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="%2$s" style="display:inline-block;%3$s%4$s"></div><div id="PD_superContainer"></div><noscript>%5$s</noscript>',
 								absint( $poll ),
@@ -463,6 +472,9 @@ if (
 								JETPACK__VERSION,
 								true
 							);
+
+							/** This action is already documented in modules/shortcodes/crowdsignal.php */
+							do_action( 'crowdsignal_shortcode_before', intval( $poll ) );
 
 							return sprintf(
 								'<a id="pd_a_%1$s"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$s" style="display:inline-block;%2$s%3$s"></div><div id="PD_superContainer"></div><noscript>%4$s</noscript>',
@@ -729,7 +741,7 @@ if (
 
 	if ( ! function_exists( 'crowdsignal_link' ) ) {
 		/**
-		 * Replace link by embed.
+		 * Replace link with shortcode.
 		 * Example: http://polldaddy.com/poll/1562975/?view=results&msg=voted
 		 *
 		 * @param string $content Post content.
@@ -744,9 +756,8 @@ if (
 
 			return jetpack_preg_replace_outside_tags(
 				'!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i',
-				"\n<script type='text/javascript' charset='utf-8' src='//static.polldaddy.com/p/$2.js'></script><noscript> <a href='https://poll.fm/$2'>View Poll</a></noscript>\n", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-				$content,
-				'polldaddy.com/poll'
+				'[crowdsignal poll=$2]',
+				$content
 			);
 		}
 


### PR DESCRIPTION
This commit syncs r203465-wpcom.
D35940-code

Fixes 478-gh-greenhouse

#### Changes proposed in this Pull Request:

P2 appears to load posts async, so the Crowdsignal code was attempting to load content into a div that wasn't in the DOM yet. This workaround adds a delay to the rendering call from the Crowdsignal js.

#### Testing instructions:

* Insert a crowdsignal link or shortcode for a poll into a P2 post. It should render the poll and you should be able to place your vote. Also ensure that poll shortcodes still work as expected on other themes.

#### Proposed changelog entry for your changes:

* Shortcodes: Fix Crowdsignal poll embeds when using the P2 theme.
