### PR TITLE
Removed the plugins_loaded priority notice.

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -588,11 +588,6 @@ class Jetpack {
 		$first_priority = array_shift( $taken_priorities );
 
 		if ( defined( 'PHP_INT_MAX' ) && $first_priority <= - PHP_INT_MAX ) {
-			trigger_error( // phpcs:ignore
-				/* translators: plugins_loaded is a filter name in WordPress, no need to translate. */
-				__( 'A plugin on your site is using the plugins_loaded filter with a priority that is too high. Jetpack does not support this, you may experience problems.', 'jetpack' ), // phpcs:ignore
-				E_USER_NOTICE
-			);
 			$new_priority = - PHP_INT_MAX;
 		} else {
 			$new_priority = $first_priority - 1;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See #14757
#### Changes proposed in this Pull Request:
* Removes the `trigger_error` call if a `PHP_INT_MAX` priority is detected for `plugins_loaded`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a minor fix to avoid notices.

#### Testing instructions:
* Enable `WP_DEBUG` mode on your site, `define( 'WP_DEBUG', true );`
* Add a `plugins_loaded` hook with the `PHP_INT_MAX` priority value:
```
add_action( 'plugins_loaded', '__return_true', - PHP_INT_MAX );
```
* Observe notices in your log file.
* Use this PR, observe no more notices.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Removed the plugin compatibility notice alerting about a high priority hook.
