### PR TITLE
Instant Search: Display filters selected outside of overlay

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -83,19 +83,29 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$widget_options = end( $widget_options );
 		}
 
-		$overlay_widget_ids = array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
+		$overlay_widget_ids      = array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
 			get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'] : array();
-		$filters            = Jetpack_Search_Helpers::get_filters_from_widgets( $overlay_widget_ids );
-		$widgets            = array();
-		foreach ( $filters as $key => $filter ) {
-			if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
-				$widgets[ $filter['widget_id'] ]['filters']   = array();
-				$widgets[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+		$filters                 = Jetpack_Search_Helpers::get_filters_from_widgets();
+		$widgets                 = array();
+		$widgets_outside_overlay = array();
+		foreach ( $filters as $key => &$filter ) {
+			$filter['filter_id'] = $key;
+
+			if ( in_array( $filter['widget_id'], $overlay_widget_ids, true ) ) {
+				if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
+					$widgets[ $filter['widget_id'] ]['filters']   = array();
+					$widgets[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+				}
+				$widgets[ $filter['widget_id'] ]['filters'][] = $filter;
+			} else {
+				if ( ! isset( $widgets_outside_overlay[ $filter['widget_id'] ] ) ) {
+					$widgets_outside_overlay[ $filter['widget_id'] ]['filters']   = array();
+					$widgets_outside_overlay[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+				}
+				$widgets_outside_overlay[ $filter['widget_id'] ]['filters'][] = $filter;
 			}
-			$new_filter                                   = $filter;
-			$new_filter['filter_id']                      = $key;
-			$widgets[ $filter['widget_id'] ]['filters'][] = $new_filter;
 		}
+		unset( $filter );
 
 		$post_type_objs   = get_post_types( array(), 'objects' );
 		$post_type_labels = array();
@@ -108,7 +118,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		$prefix  = Jetpack_Search_Options::OPTION_PREFIX;
 		$options = array(
-			'overlayOptions'  => array(
+			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
 				'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', false ),
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
@@ -117,16 +127,17 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			),
 
 			// core config.
-			'homeUrl'         => home_url(),
-			'locale'          => str_replace( '_', '-', get_locale() ),
-			'postsPerPage'    => get_option( 'posts_per_page' ),
-			'siteId'          => Jetpack::get_option( 'id' ),
+			'homeUrl'               => home_url(),
+			'locale'                => str_replace( '_', '-', get_locale() ),
+			'postsPerPage'          => get_option( 'posts_per_page' ),
+			'siteId'                => Jetpack::get_option( 'id' ),
 
 			// filtering.
-			'postTypeFilters' => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
-			'postTypes'       => $post_type_labels,
-			'sort'            => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
-			'widgets'         => array_values( $widgets ),
+			'postTypeFilters'       => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
+			'postTypes'             => $post_type_labels,
+			'sort'                  => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
+			'widgets'               => array_values( $widgets ),
+			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
 		);
 
 		/**

--- a/modules/search/instant-search/components/preselected-search-filters.jsx
+++ b/modules/search/instant-search/components/preselected-search-filters.jsx
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import { getPreselectedFilters } from '../lib/query-string';
+import SearchFilters from './search-filters';
+
+const PreselectedSearchFilters = props => {
+	const preselectedFilters = getPreselectedFilters( props.widgets, props.widgetsOutsideOverlay );
+
+	return (
+		<div className="jetpack-instant-search__testing">
+			{ preselectedFilters.length > 0 && (
+				<SearchFilters
+					loading={ props.isLoading }
+					locale={ props.locale }
+					postTypes={ props.postTypes }
+					results={ props.results }
+					widget={ { filters: preselectedFilters } }
+				/>
+			) }
+		</div>
+	);
+};
+export default PreselectedSearchFilters;

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -259,6 +259,7 @@ class SearchApp extends Component {
 					resultFormat={ getResultFormatQuery() }
 					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
 					widgets={ this.props.options.widgets }
+					widgetsOutsideOverlay={ this.props.options.widgetsOutsideOverlay }
 				/>
 			</Overlay>,
 			document.body

--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -28,9 +28,6 @@ function getDateOptions( interval ) {
 // TODO: Fix this in the API
 // TODO: Remove once format is fixed in the API
 function fixDateFormat( dateString ) {
-	if ( dateString[ dateString.length - 1 ] !== 'Z' ) {
-		dateString += 'Z';
-	}
 	return dateString.split( ' ' ).join( 'T' );
 }
 
@@ -77,7 +74,7 @@ export default class SearchFilter extends Component {
 					{ new Date( fixDateFormat( key ) ).toLocaleString(
 						locale,
 						getDateOptions( this.props.configuration.interval )
-					) }{' '}
+					) }{ ' ' }
 					({ count })
 				</label>
 			</div>

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -15,7 +15,7 @@ import get from 'lodash/get';
  */
 import SearchFilter from './search-filter';
 import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/query-string';
-import { mapFilterToFilterKey } from '../lib/filters';
+import { mapFilterToFilterKey, mapFilterToType } from '../lib/filters';
 
 export default class SearchFilters extends Component {
 	onChangeFilter = ( filterName, filterValue ) => {
@@ -45,48 +45,18 @@ export default class SearchFilters extends Component {
 		return getFilterQuery();
 	}
 
-	renderFilterComponent = ( { configuration, results } ) => {
-		switch ( configuration.type ) {
-			case 'date_histogram':
-				return (
-					results && (
-						<SearchFilter
-							aggregation={ results }
-							configuration={ configuration }
-							locale={ this.props.locale }
-							type="date"
-							value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
-							onChange={ this.onChangeFilter }
-						/>
-					)
-				);
-			case 'taxonomy':
-				return (
-					results && (
-						<SearchFilter
-							aggregation={ results }
-							configuration={ configuration }
-							value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
-							onChange={ this.onChangeFilter }
-							type="taxonomy"
-						/>
-					)
-				);
-			case 'post_type':
-				return (
-					results && (
-						<SearchFilter
-							aggregation={ results }
-							configuration={ configuration }
-							value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
-							onChange={ this.onChangeFilter }
-							postTypes={ this.props.postTypes }
-							type="postType"
-						/>
-					)
-				);
-		}
-	};
+	renderFilterComponent = ( { configuration, results } ) =>
+		results && (
+			<SearchFilter
+				aggregation={ results }
+				configuration={ configuration }
+				locale={ this.props.locale }
+				onChange={ this.onChangeFilter }
+				postTypes={ this.props.postTypes }
+				type={ mapFilterToType( configuration ) }
+				value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
+			/>
+		);
 
 	render() {
 		if ( ! this.props.widget ) {

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -15,6 +15,7 @@ import get from 'lodash/get';
  */
 import SearchFilter from './search-filter';
 import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/query-string';
+import { mapFilterToFilterKey } from '../lib/filters';
 
 export default class SearchFilters extends Component {
 	onChangeFilter = ( filterName, filterValue ) => {
@@ -54,7 +55,7 @@ export default class SearchFilters extends Component {
 							configuration={ configuration }
 							locale={ this.props.locale }
 							type="date"
-							value={ this.getFilters()[ `${ configuration.interval }_${ configuration.field }` ] }
+							value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
 							onChange={ this.onChangeFilter }
 						/>
 					)
@@ -65,7 +66,7 @@ export default class SearchFilters extends Component {
 						<SearchFilter
 							aggregation={ results }
 							configuration={ configuration }
-							value={ this.getFilters()[ configuration.taxonomy ] }
+							value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
 							onChange={ this.onChangeFilter }
 							type="taxonomy"
 						/>
@@ -77,7 +78,7 @@ export default class SearchFilters extends Component {
 						<SearchFilter
 							aggregation={ results }
 							configuration={ configuration }
-							value={ this.getFilters().post_types }
+							value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
 							onChange={ this.onChangeFilter }
 							postTypes={ this.props.postTypes }
 							type="postType"

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -13,6 +13,7 @@ import SearchBox from './search-box';
 import SearchFilters from './search-filters';
 
 import { getFilterQuery, getSearchQuery, setSearchQuery, setSortQuery } from '../lib/query-string';
+import PreselectedSearchFilters from './preselected-search-filters';
 
 const noop = event => event.preventDefault();
 
@@ -58,6 +59,14 @@ class SearchForm extends Component {
 				{ this.state.showFilters && (
 					<div className="jetpack-instant-search__search-form-filters">
 						<div className="jetpack-instant-search__search-form-filters-arrow" />
+						<PreselectedSearchFilters
+							loading={ this.props.isLoading }
+							locale={ this.props.locale }
+							postTypes={ this.props.postTypes }
+							results={ this.props.response }
+							widgets={ this.props.widgets }
+							widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
+						/>
 						{ this.props.widgets.map( widget => (
 							<SearchFilters
 								filters={ getFilterQuery() }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -67,6 +67,7 @@ class SearchResults extends Component {
 					postTypes={ this.props.postTypes }
 					response={ this.props.response }
 					widgets={ this.props.widgets }
+					widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 				/>
 
 				<div
@@ -137,6 +138,7 @@ class SearchResults extends Component {
 				response={ this.props.response }
 				showPoweredBy={ this.props.showPoweredBy }
 				widgets={ this.props.widgets }
+				widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 			/>
 		);
 	}

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -12,10 +12,19 @@ import WidgetAreaContainer from './widget-area-container';
  * Internal dependencies
  */
 import JetpackColophon from './jetpack-colophon';
+import PreselectedSearchFilters from './preselected-search-filters';
 
 const SearchSidebar = props => {
 	return (
 		<div className="jetpack-instant-search__sidebar">
+			<PreselectedSearchFilters
+				loading={ props.isLoading }
+				locale={ props.locale }
+				postTypes={ props.postTypes }
+				results={ props.response }
+				widgets={ props.widgets }
+				widgetsOutsideOverlay={ props.widgetsOutsideOverlay }
+			/>
 			<WidgetAreaContainer />
 			{ props.widgets.map( widget => {
 				return createPortal(

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -18,7 +18,10 @@ import { buildFilterAggregations } from './lib/api';
 const injectSearchApp = () => {
 	render(
 		<SearchApp
-			aggregations={ buildFilterAggregations( window[ SERVER_OBJECT_NAME ].widgets ) }
+			aggregations={ buildFilterAggregations( [
+				...window[ SERVER_OBJECT_NAME ].widgets,
+				...window[ SERVER_OBJECT_NAME ].widgetsOutsideOverlay,
+			] ) }
 			initialHref={ window.location.href }
 			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -10,7 +10,7 @@ import Cache from 'cache';
 /**
  * Internal dependencies
  */
-import { getFilterKeys } from './query-string';
+import { getFilterKeys } from './filters';
 import { MINUTE_IN_MILLISECONDS } from './constants';
 
 const isLengthyArray = array => Array.isArray( array ) && array.length > 0;

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -62,3 +62,13 @@ export function mapFilterToFilterKey( filter ) {
 	}
 	return null;
 }
+
+export function mapFilterToType( filter ) {
+	if ( filter.type === 'date_histogram' ) {
+		return 'date';
+	} else if ( filter.type === 'taxonomy' ) {
+		return 'taxonomy';
+	} else if ( filter.type === 'post_type' ) {
+		return 'postType';
+	}
+}

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -1,0 +1,64 @@
+// NOTE: We only import the difference package here for to reduced bundle size.
+//       Do not import the entire lodash library!
+// eslint-disable-next-line lodash/import-scope
+import difference from 'lodash/difference';
+
+/**
+ * Internal dependencies
+ */
+import { SERVER_OBJECT_NAME } from './constants';
+
+const FILTER_KEYS = Object.freeze( [
+	// Post types
+	'post_types',
+	// Date filters
+	'month_post_date',
+	'month_post_date_gmt',
+	'month_post_modified',
+	'month_post_modified_gmt',
+	'year_post_date',
+	'year_post_date_gmt',
+	'year_post_modified',
+	'year_post_modified_gmt',
+] );
+
+export function getFilterKeys() {
+	// Extract taxonomy names from server widget data
+	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
+		.map( w => w.filters )
+		.filter( filters => Array.isArray( filters ) )
+		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
+		.filter( filter => filter.type === 'taxonomy' )
+		.map( filter => filter.taxonomy );
+	return [ ...FILTER_KEYS, ...taxonomies ];
+}
+
+// These filter keys are selectable from sidebar filters
+function getSelectableFilterKeys( overlayWidgets ) {
+	return overlayWidgets
+		.map( extractFilters )
+		.reduce( ( prev, current ) => prev.concat( current ), [] );
+}
+
+// These filter keys are not selectable from sidebar filters
+// In other words, they were selected via filters outside the search sidebar
+export function getUnselectableFilterKeys( overlayWidgets ) {
+	return difference( getFilterKeys(), getSelectableFilterKeys( overlayWidgets ) );
+}
+
+function extractFilters( widget ) {
+	return widget.filters
+		.map( mapFilterToFilterKey )
+		.filter( filterName => typeof filterName === 'string' );
+}
+
+export function mapFilterToFilterKey( filter ) {
+	if ( filter.type === 'date_histogram' ) {
+		return `${ filter.interval }_${ filter.field }`;
+	} else if ( filter.type === 'taxonomy' ) {
+		return `${ filter.taxonomy }`;
+	} else if ( filter.type === 'post_type' ) {
+		return `${ filter.post_types }`;
+	}
+	return null;
+}

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -56,9 +56,9 @@ export function mapFilterToFilterKey( filter ) {
 	if ( filter.type === 'date_histogram' ) {
 		return `${ filter.interval }_${ filter.field }`;
 	} else if ( filter.type === 'taxonomy' ) {
-		return `${ filter.taxonomy }`;
+		return 'taxonomy';
 	} else if ( filter.type === 'post_type' ) {
-		return `${ filter.post_types }`;
+		return 'post_types';
 	}
 	return null;
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -14,6 +14,7 @@ import {
 	RESULT_FORMAT_MINIMAL,
 	RESULT_FORMAT_PRODUCT,
 } from './constants';
+import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { getSortOption } from './sort';
 
 const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
@@ -151,31 +152,6 @@ function getFilterQueryByKey( filterKey ) {
 	return query[ filterKey ];
 }
 
-export function getFilterKeys() {
-	const keys = [
-		// Post types
-		'post_types',
-		// Date filters
-		'month_post_date',
-		'month_post_date_gmt',
-		'month_post_modified',
-		'month_post_modified_gmt',
-		'year_post_date',
-		'year_post_date_gmt',
-		'year_post_modified',
-		'year_post_modified_gmt',
-	];
-
-	// Extract taxonomy names from server widget data
-	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
-		.map( w => w.filters )
-		.filter( filters => Array.isArray( filters ) )
-		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
-		.filter( filter => filter.type === 'taxonomy' )
-		.map( filter => filter.taxonomy );
-	return [ ...keys, ...taxonomies ];
-}
-
 export function getFilterQuery( filterKey ) {
 	if ( filterKey ) {
 		return getFilterQueryByKey( filterKey );
@@ -187,6 +163,21 @@ export function getFilterQuery( filterKey ) {
 			[ key ]: getFilterQueryByKey( key ),
 		} ) )
 	);
+}
+
+// These filter keys have been activated/selected outside of the overlay sidebar
+export function getPreselectedFilterKeys( overlayWidgets ) {
+	return getUnselectableFilterKeys( overlayWidgets ).filter(
+		key => Array.isArray( getFilterQueryByKey( key ) ) && getFilterQueryByKey( key ).length > 0
+	);
+}
+
+export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
+	const keys = getPreselectedFilterKeys( widgetsInOverlay );
+	return widgetsOutsideOverlay
+		.map( widget => widget.filters )
+		.reduce( ( prev, current ) => prev.concat( current ), [] )
+		.filter( filter => keys.includes( mapFilterToFilterKey( filter ) ) );
 }
 
 export function hasFilter() {


### PR DESCRIPTION
Fixes #14615.

#### Changes proposed in this Pull Request:
* Adds appropriate checkboxes for filters selected outside of the search overlay. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Please make sure to add the Jetpack Search widget to two locations: 
    1. once to your site sidebar/footer. Make sure to define some filters for this widget.
    2. once to the Jetpack Search Sidebar within the search overlay. Make sure to define different filters than the ones in your site sidebar/footer.

2. Click on one of the filter links in your site sidebar/footer. Ensure that the search overlay opens with your search results.

3. Check your overlay sidebar. Ensure that the filter you've selected in step 2 shows up as a selected checkbox in the overlay sidebar.

4. Resize your window to be narrower than 768 pixels. Ensure that the filters button appears underneath the overlay input.

5. Click on the filters button to spawn the mobile filter popover. Ensure that the filter you've selected in step 2 appears as a selected checkbox in the popover.

#### Proposed changelog entry for your changes:
* None.
