### PR TITLE
Google Calendar block: Fix full width support

### DIFF
--- a/extensions/blocks/google-calendar/edit.js
+++ b/extensions/blocks/google-calendar/edit.js
@@ -118,12 +118,12 @@ class GoogleCalendarEdit extends Component {
 	render() {
 		const { attributes, className, name, noticeUI } = this.props;
 		const defaultClassName = getBlockDefaultClassName( name );
-		const { url } = attributes;
+		const { url, height } = attributes;
 		const { editedEmbed, interactive, editingUrl } = this.state;
 
-		const height = this.props.isMobile ? '300' : '500';
+		const iframeHeight = this.props.isMobile ? '300' : height;
 
-		const html = `<iframe src="${ url }" style="border:0" scrolling="no" frameborder="0" width="100%" height=${ height }></iframe>`;
+		const html = `<iframe src="${ url }" style="border:0" scrolling="no" frameborder="0" height="${ iframeHeight }"></iframe>`;
 
 		const permissionsLink = (
 			<ExternalLink href="https://en.support.wordpress.com/google-calendar/">

--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -1,6 +1,7 @@
 /**
  * Editor styles for Google Calendar
  */
+ @import './view.scss';
 
 .wp-block-jetpack-google-calendar {
 	&-embed-form-sidebar {

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -35,12 +35,13 @@ add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
  * @return string
  */
 function load_assets( $attr ) {
-	$width   = isset( $attr['width'] ) ? $attr['width'] : '800';
 	$height  = isset( $attr['height'] ) ? $attr['height'] : '600';
 	$url     = isset( $attr['url'] )
 		? \Jetpack_Gutenberg::validate_block_embed_url( $attr['url'], array( 'calendar.google.com' ) ) :
 		'';
 	$classes = \Jetpack_Gutenberg::block_classes( 'google-calendar', $attr );
+
+	\Jetpack_Gutenberg::load_assets_as_required( 'google-calendar' );
 
 	if ( empty( $url ) ) {
 		return;
@@ -48,18 +49,16 @@ function load_assets( $attr ) {
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request() ) {
 		return sprintf(
-			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" width="%3$d" height="%4$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
+			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
 			esc_attr( $classes ),
 			esc_url( $url ),
-			absint( $width ),
 			absint( $height )
 		);
 	} else {
 		return sprintf(
-			'<div class="%1$s"><iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" width="%3$d" height="%4$d"></iframe></div>',
+			'<div class="%1$s"><iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d"></iframe></div>',
 			esc_attr( $classes ),
 			esc_url( $url ),
-			absint( $width ),
 			absint( $height )
 		);
 	}

--- a/extensions/blocks/google-calendar/index.js
+++ b/extensions/blocks/google-calendar/index.js
@@ -35,10 +35,6 @@ export const settings = {
 		url: {
 			type: 'string',
 		},
-		width: {
-			type: 'integer',
-			default: 800,
-		},
 		height: {
 			type: 'integer',
 			default: 600,
@@ -76,8 +72,8 @@ export const settings = {
 				type: 'raw',
 				isMatch: node => node.nodeName === 'FIGURE' && IFRAME_REGEX.test( node.innerHTML ),
 				transform: node => {
-					const { url, width, height } = extractAttributesFromIframe( node.innerHTML.trim() );
-					return createBlock( 'jetpack/google-calendar', { url, width, height } );
+					const { url, height } = extractAttributesFromIframe( node.innerHTML.trim() );
+					return createBlock( 'jetpack/google-calendar', { url, height } );
 				},
 			},
 		],

--- a/extensions/blocks/google-calendar/view.js
+++ b/extensions/blocks/google-calendar/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './view.scss';

--- a/extensions/blocks/google-calendar/view.scss
+++ b/extensions/blocks/google-calendar/view.scss
@@ -1,0 +1,8 @@
+/**
+ * Shared Editor and Front End styles for Google Calendar
+ */
+.wp-block-jetpack-google-calendar {
+	iframe {
+		width: 100%;
+	}
+}

--- a/extensions/blocks/google-calendar/view.scss
+++ b/extensions/blocks/google-calendar/view.scss
@@ -2,6 +2,7 @@
  * Shared Editor and Front End styles for Google Calendar
  */
 .wp-block-jetpack-google-calendar {
+	min-width: 420px;
 	iframe {
 		width: 100%;
 	}


### PR DESCRIPTION
Make sure that the Google Calendar block widths match in the editor and front end, and that full and wide widths are supported correctly.

Fixes #14823

#### Testing instructions:
* Add the Google Calendar block, and embed a calendar. Example: 
```<iframe src="https://calendar.google.com/calendar/embed?src=tl4njqffodltemv385vnifrjadm345g2%40import.calendar.google.com&ctz=America%2FVancouver" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>```
* Modify the alignment of the block to `full width`.
* Save the changes and look at the block on the front end and confirm it is full width (edge to edge).
* Try the `left` and `right` alignment options and confirm the width of the block matches in the front end and the editor.

Note: on some themes (e.g. Twenty Twenty) the left/right positioning of this block in the front end might overflow outside of the viewport because of its `min-width`. Eventually we decided that having a readable calendar on _most_ themes is better than having a squished calendar on _all_ themes. (See discussion in the PR comments)

#### Proposed changelog entry for your changes:
* None
