### PR TITLE
Fix calender block placeholder layout in older versions of gutenberg

### DIFF
--- a/extensions/blocks/google-calendar/edit.js
+++ b/extensions/blocks/google-calendar/edit.js
@@ -147,6 +147,17 @@ class GoogleCalendarEdit extends Component {
 						className={ className }
 						label={ __( 'Google Calendar', 'jetpack' ) }
 						icon={ <BlockIcon icon={ icon } /> }
+						instructions={
+							<ol className={ `${ defaultClassName }-placeholder-instructions` }>
+								<li>{ permissionsLink }</li>
+								<li>
+									{ __(
+										'Paste the embed code you copied from your Google Calendar below',
+										'jetpack'
+									) }
+								</li>
+							</ol>
+						}
 						notices={
 							this.state.notice && (
 								<Notice status="error" isDismissible={ false }>
@@ -155,15 +166,6 @@ class GoogleCalendarEdit extends Component {
 							)
 						}
 					>
-						<ol className={ `${ defaultClassName }-placeholder-instructions` }>
-							<li>{ permissionsLink }</li>
-							<li>
-								{ __(
-									'Paste the embed code you copied from your Google Calendar below',
-									'jetpack'
-								) }
-							</li>
-						</ol>
 						{ this.getEditForm( `${ defaultClassName }-embed-form-editor`, editedEmbed ) }
 						<div className={ `${ defaultClassName }-placeholder-links` }>
 							<ExternalLink href={ supportLink }>{ __( 'Learn more', 'jetpack' ) }</ExternalLink>

--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -28,8 +28,10 @@
 
 	ol.wp-block-jetpack-google-calendar-placeholder-instructions {
 		margin: 0;
+		font-family: inherit;
 		li {
 			margin-bottom: 19px;
+			text-align: left;
 		}
 	}
 

--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -27,8 +27,11 @@
 	}
 
 	ol.wp-block-jetpack-google-calendar-placeholder-instructions {
-		margin: 0;
 		font-family: inherit;
+		list-style-position: inside;
+		margin: 0;
+		padding: 0;
+
 		li {
 			margin-bottom: 19px;
 			text-align: left;


### PR DESCRIPTION
In 8.3 release and with Gutenberg < 7.2 the Google Calendar block placeholder layout is slightly broken.

Fixes #14836

#### Changes proposed in this Pull Request:
* Just a minor CSS update

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:
* On an 8.3 install with gutenberg < 7.2 add a Google Calendar block and ensure that the placeholder content layout is correct:

Before:
<img width="587" alt="gc-before" src="https://user-images.githubusercontent.com/3629020/75498998-8e8f3700-5a2d-11ea-8a6b-6e66f9643d80.png">

After:
<img width="590" alt="after-gc" src="https://user-images.githubusercontent.com/3629020/75499005-9222be00-5a2d-11ea-9787-3720f4988632.png">

Also make sure that the layout is still correct in Gutenberg >=7.2

<img width="620" alt="Screen Shot 2020-02-28 at 1 27 17 PM" src="https://user-images.githubusercontent.com/3629020/75499165-14ab7d80-5a2e-11ea-892d-9eea57e03db2.png">

#### Proposed changelog entry for your changes:
* Minor css change, no changelog entry required
