### PR TITLE
In Likes and Comment Likes modules, prevent blocking page load with 2 scripts

### DIFF
--- a/modules/comment-likes.php
+++ b/modules/comment-likes.php
@@ -129,6 +129,10 @@ class Jetpack_Comment_Likes {
 	}
 
 	public function load_styles_register_scripts() {
+		if ( ! $this->settings->is_likes_visible() ) {
+			return;
+		}
+
 		if ( ! wp_style_is( 'open-sans', 'registered' ) ) {
 			wp_register_style( 'open-sans', 'https://fonts.googleapis.com/css?family=Open+Sans', array(), JETPACK__VERSION );
 		}
@@ -138,7 +142,7 @@ class Jetpack_Comment_Likes {
 			Assets::get_file_url_for_environment( '_inc/build/postmessage.min.js', '_inc/postmessage.js' ),
 			array( 'jquery' ),
 			JETPACK__VERSION,
-			false
+			true
 		);
 		wp_enqueue_script(
 			'jetpack_resize',
@@ -148,7 +152,7 @@ class Jetpack_Comment_Likes {
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION,
-			false
+			true
 		);
 		wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'likes/queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
 	}

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -253,7 +253,7 @@ class Jetpack_Likes {
 	}
 
 	function action_init() {
-		if ( is_admin() ) {
+		if ( is_admin() || ! $this->settings->is_likes_visible() ) {
 			return;
 		}
 

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -280,8 +280,8 @@ class Jetpack_Likes {
 			add_filter( 'post_flair', array( &$this, 'post_likes' ), 30, 1 );
 			add_filter( 'post_flair_block_css', array( $this, 'post_flair_service_enabled_like' ) );
 
-			wp_enqueue_script( 'postmessage', '/wp-content/js/postmessage.js', array( 'jquery' ), JETPACK__VERSION, false );
-			wp_enqueue_script( 'jetpack_resize', '/wp-content/js/jquery/jquery.jetpack-resize.js', array( 'jquery' ), JETPACK__VERSION, false );
+			wp_enqueue_script( 'postmessage', '/wp-content/js/postmessage.js', array( 'jquery' ), JETPACK__VERSION, true );
+			wp_enqueue_script( 'jetpack_resize', '/wp-content/js/jquery/jquery.jetpack-resize.js', array( 'jquery' ), JETPACK__VERSION, true );
 			wp_enqueue_script( 'jetpack_likes_queuehandler', plugins_url( 'queuehandler.js' , __FILE__ ), array( 'jquery', 'postmessage', 'jetpack_resize' ), JETPACK__VERSION, true );
 			wp_enqueue_style( 'jetpack_likes', plugins_url( 'jetpack-likes.css', __FILE__ ), array(), JETPACK__VERSION );
 		}
@@ -296,7 +296,7 @@ class Jetpack_Likes {
 			Assets::get_file_url_for_environment( '_inc/build/postmessage.min.js', '_inc/postmessage.js' ),
 			array( 'jquery' ),
 			JETPACK__VERSION,
-			false
+			true
 		);
 		wp_register_script(
 			'jetpack_resize',
@@ -306,7 +306,7 @@ class Jetpack_Likes {
 			),
 			array( 'jquery' ),
 			JETPACK__VERSION,
-			false
+			true
 		);
 		wp_register_script(
 			'jetpack_likes_queuehandler',

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,9 @@
 		<testsuite name="infinite-scroll">
 			<directory prefix="test_" suffix=".php">tests/php/modules/infinite-scroll</directory>
 		</testsuite>
+		<testsuite name="comment-likes">
+			<directory prefix="test" suffix=".php">tests/php/modules/comment-likes</directory>
+		</testsuite>
 		<testsuite name="likes">
 			<directory prefix="test_" suffix=".php">tests/php/modules/likes</directory>
 		</testsuite>

--- a/tests/php/modules/comment-likes/test-class.comment-likes.php
+++ b/tests/php/modules/comment-likes/test-class.comment-likes.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Tests for the WP_Test_Comment_Likes class.
+ *
+ * @package Jetpack
+ * @since 8.4.0
+ */
+
+require dirname( __FILE__ ) . '/../../../../modules/comment-likes.php';
+
+/**
+ * Test class for Jetpack_Comment_Likes.
+ *
+ * @since 8.4.0
+ */
+class WP_Test_Comment_Likes extends WP_UnitTestCase {
+
+	/**
+	 * Test that the assets are not enqueued if likes are not visible.
+	 *
+	 * @since 8.4.0
+	 */
+	public function test_load_styles_register_scripts_likes_not_visible() {
+		$instance = Jetpack_Comment_Likes::init();
+		$instance->load_styles_register_scripts();
+
+		$this->assertFalse( wp_style_is( 'jetpack_likes' ) );
+		$this->assertFalse( wp_script_is( 'postmessage' ) );
+	}
+
+	/**
+	 * Test that the assets are enqueued if likes are visible.
+	 *
+	 * @since 8.4.0
+	 */
+	public function test_load_styles_register_scripts_likes_visible() {
+		add_filter( 'wpl_is_likes_visible', '__return_false' );
+		$instance = Jetpack_Comment_Likes::init();
+		$instance->load_styles_register_scripts();
+
+		$this->assertFalse( wp_style_is( 'jetpack_likes' ) );
+		$this->assertFalse( wp_script_is( 'postmessage' ) );
+	}
+}

--- a/tests/php/modules/comment-likes/test-class.comment-likes.php
+++ b/tests/php/modules/comment-likes/test-class.comment-likes.php
@@ -34,11 +34,11 @@ class WP_Test_Comment_Likes extends WP_UnitTestCase {
 	 * @since 8.4.0
 	 */
 	public function test_load_styles_register_scripts_likes_visible() {
-		add_filter( 'wpl_is_likes_visible', '__return_false' );
+		add_filter( 'wpl_is_likes_visible', '__return_true' );
 		$instance = Jetpack_Comment_Likes::init();
 		$instance->load_styles_register_scripts();
 
-		$this->assertFalse( wp_style_is( 'jetpack_likes' ) );
-		$this->assertFalse( wp_script_is( 'postmessage' ) );
+		$this->assertTrue( wp_style_is( 'jetpack_likes' ) );
+		$this->assertTrue( wp_script_is( 'postmessage' ) );
 	}
 }

--- a/tests/php/modules/likes/test_class.likes.php
+++ b/tests/php/modules/likes/test_class.likes.php
@@ -4,6 +4,35 @@ require dirname( __FILE__ ) . '/../../../../modules/likes.php';
 class WP_Test_Likes extends WP_UnitTestCase {
 
 	/**
+	 * Test that the actions are not added if likes are not visible.
+	 *
+	 * @since 8.4.0
+	 */
+	public function test_action_init_likes_not_visible() {
+		$instance = new Jetpack_Likes();
+		$instance->action_init();
+
+		$this->assertFalse( has_filter( 'the_content', array( $instance, 'post_likes' ) ) );
+		$this->assertFalse( has_filter( 'the_excerpt', array( $instance, 'post_likes' ) ) );
+	}
+
+	/**
+	 * Test that the actions are added if likes are visible.
+	 *
+	 * @since 8.4.0
+	 */
+	public function test_action_init_likes_visible() {
+		$this->go_to( get_permalink( $this->factory()->post->create() ) );
+		add_filter( 'wpl_is_enabled_sitewide', '__return_true' );
+		add_filter( 'wpl_is_single_post_disabled', '__return_true' );
+		$instance = new Jetpack_Likes();
+		$instance->action_init();
+
+		$this->assertEquals( 30, has_filter( 'the_content', array( $instance, 'post_likes' ) ) );
+		$this->assertEquals( 30, has_filter( 'the_excerpt', array( $instance, 'post_likes' ) ) );
+	}
+
+	/**
 	 * Test if likes are rendered correctly.
 	 *
 	 * @since 4.6.0


### PR DESCRIPTION
Fixes #13929


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* If likes are disabled globally or for a post, prevents enqueueing scripts for the Likes or Comment Likes modules
* Passes to `wp_enqueue_script()` the 5th `$in_footer` argument of `true`, to prevent the scripts from blocking the page load
* [These](https://github.com/Automattic/jetpack/blob/8d04b28cff9294608111d3293fb2b31a5fba1191/_inc/postmessage.js) [scripts](https://github.com/Automattic/jetpack/blob/8d04b28cff9294608111d3293fb2b31a5fba1191/_inc/jquery.jetpack-resize.js) look to be mainly jQuery plugins
* So far, the 'Like' button seems to work fine with these in the footer. But this could of course use more testing.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It modifies the performance of an existing feature, no functional change intended.

#### Testing instructions:
1. On a non-local site, ensure 'Add Like buttons...' is toggled on:
![sharing-settings](https://user-images.githubusercontent.com/4063887/75521644-c797bf00-59cd-11ea-9257-fe25a5a2dd69.png)
2. Go to the front-end of a post
3. Expected: The 'Like' button should appear, and should be clickable:

![like-button](https://user-images.githubusercontent.com/4063887/75521700-e5fdba80-59cd-11ea-9671-8283a9786a60.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Performance enhancement for the Likes module

