### PR TITLE
Update keywords for blocks

### DIFF
--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -90,6 +90,7 @@ export const settings = {
 		_x( 'opening hours', 'block search term', 'jetpack' ),
 		_x( 'closing time', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),
+		_x( 'working day', 'block search term', 'jetpack' ),
 	],
 	attributes: {
 		days: {

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -28,6 +28,8 @@ export const settings = {
 		_x( 'calendar', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),
 		_x( 'appointments', 'block search term', 'jetpack' ),
+		_x( 'events', 'block search term', 'jetpack' ),
+		_x( 'dates', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		align: true,

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -25,9 +25,9 @@ export const settings = {
 	icon,
 	category: 'jetpack',
 	keywords: [
-		__( 'calendar', 'jetpack' ),
-		__( 'schedule', 'jetpack' ),
-		__( 'appointments', 'jetpack' ),
+		_x( 'calendar', 'block search term', 'jetpack' ),
+		_x( 'schedule', 'block search term', 'jetpack' ),
+		_x( 'appointments', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		align: true,

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { G, Path, Rect, SVG } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
 
@@ -41,7 +41,10 @@ export const settings = {
 	description: __( 'Embed Eventbrite event details and ticket checkout.', 'jetpack' ),
 	icon,
 	category: 'jetpack',
-	keywords: [ __( 'events', 'jetpack' ), __( 'tickets', 'jetpack' ) ],
+	keywords: [
+		_x( 'events', 'block search term', 'jetpack' ),
+		_x( 'tickets', 'block search term', 'jetpack' ),
+	],
 	supports: {
 		html: false,
 	},

--- a/extensions/blocks/google-calendar/index.js
+++ b/extensions/blocks/google-calendar/index.js
@@ -21,6 +21,7 @@ export const settings = {
 	keywords: [
 		_x( 'events', 'block search term', 'jetpack' ),
 		_x( 'dates', 'block search term', 'jetpack' ),
+		_x( 'schedule', 'block search term', 'jetpack' ),
 	],
 	icon,
 	category: 'jetpack',

--- a/extensions/blocks/google-calendar/index.js
+++ b/extensions/blocks/google-calendar/index.js
@@ -22,6 +22,7 @@ export const settings = {
 		_x( 'events', 'block search term', 'jetpack' ),
 		_x( 'dates', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),
+		_x( 'appointments', 'block search term', 'jetpack' ),
 	],
 	icon,
 	category: 'jetpack',

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -26,7 +26,6 @@ export const settings = {
 	),
 	category: 'jetpack',
 	keywords: [
-		_x( 'map', 'block search term', 'jetpack' ),
 		_x( 'maps', 'block search term', 'jetpack' ),
 		_x( 'location', 'block search term', 'jetpack' ),
 		_x( 'navigation', 'block search term', 'jetpack' ),

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
 /**
@@ -27,9 +27,9 @@ export const settings = {
 	icon,
 	category: 'jetpack',
 	keywords: [
-		__( 'opentable', 'jetpack' ),
-		__( 'reservation', 'jetpack' ),
-		__( 'restaurant', 'jetpack' ),
+		_x( 'booking', 'block search term', 'jetpack' ),
+		_x( 'reservation', 'block search term', 'jetpack' ),
+		_x( 'restaurant', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		align: true,

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -34,7 +34,11 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ _x( 'social', 'block search term', 'jetpack' ) ],
+	keywords: [
+		_x( 'social', 'block search term', 'jetpack' ),
+		_x( 'pinboard', 'block search term', 'jetpack' ),
+		_x( 'pins', 'block search term', 'jetpack' ),
+	],
 
 	supports: {
 		align: false,

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -28,9 +28,9 @@ export const settings = {
 	category: 'jetpack',
 	keywords: [
 		_x( 'sell', 'block search term', 'jetpack' ),
-		_x( 'subscription', 'block search term', 'jetpack' ),
+		_x( 'subscriptions', 'block search term', 'jetpack' ),
 		'stripe',
-		_x( 'membership', 'block search term', 'jetpack' ),
+		_x( 'memberships', 'block search term', 'jetpack' ),
 	],
 	attributes: {
 		planId: {

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -30,6 +30,7 @@ export const settings = {
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),
 		'stripe',
+		_x( 'membership', 'block search term', 'jetpack' ),
 	],
 	attributes: {
 		planId: {

--- a/extensions/blocks/related-posts/index.js
+++ b/extensions/blocks/related-posts/index.js
@@ -26,9 +26,9 @@ export const settings = {
 	category: 'jetpack',
 
 	keywords: [
-		_x( 'Similar content', 'block search term', 'jetpack' ),
-		_x( 'Linked', 'block search term', 'jetpack' ),
-		_x( 'Connected', 'block search term', 'jetpack' ),
+		_x( 'similar content', 'block search term', 'jetpack' ),
+		_x( 'linked', 'block search term', 'jetpack' ),
+		_x( 'connected', 'block search term', 'jetpack' ),
 	],
 
 	attributes: {

--- a/extensions/blocks/revue/index.js
+++ b/extensions/blocks/revue/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,6 +17,11 @@ export const settings = {
 	description: __( 'Add a subscription form for your Revue newsletter.', 'jetpack' ),
 	icon,
 	category: 'jetpack',
+	keywords: [
+		_x( 'email', 'block search term', 'jetpack' ),
+		_x( 'subscription', 'block search term', 'jetpack' ),
+		_x( 'newsletter', 'block search term', 'jetpack' ),
+	],
 	supports: {
 		html: false,
 	},

--- a/extensions/blocks/revue/index.js
+++ b/extensions/blocks/revue/index.js
@@ -21,6 +21,7 @@ export const settings = {
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),
 		_x( 'newsletter', 'block search term', 'jetpack' ),
+		_x( 'mailing list', 'block search term', 'jetpack' ),
 	],
 	supports: {
 		html: false,

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -42,10 +42,7 @@ export const settings = {
 				) }
 			</p>
 			<p>
-				{ __(
-					'Good for collecting donations or payments for products and services.',
-					'jetpack'
-				) }
+				{ __( 'Good for collecting donations or payments for products and services.', 'jetpack' ) }
 			</p>
 			<ExternalLink href={ supportLink }>{ __( 'Support reference', 'jetpack' ) }</ExternalLink>
 		</Fragment>
@@ -61,8 +58,11 @@ export const settings = {
 	category: 'jetpack',
 
 	keywords: [
-		_x( 'shop', 'block search term', 'jetpack' ),
+		_x( 'buy', 'block search term', 'jetpack' ),
+		_x( 'commerce', 'block search term', 'jetpack' ),
+		_x( 'purchase', 'block search term', 'jetpack' ),
 		_x( 'sell', 'block search term', 'jetpack' ),
+		_x( 'shop', 'block search term', 'jetpack' ),
 		'PayPal',
 	],
 

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -60,6 +60,7 @@ export const settings = {
 	keywords: [
 		_x( 'buy', 'block search term', 'jetpack' ),
 		_x( 'commerce', 'block search term', 'jetpack' ),
+		_x( 'products', 'block search term', 'jetpack' ),
 		_x( 'purchase', 'block search term', 'jetpack' ),
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'shop', 'block search term', 'jetpack' ),

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -116,6 +116,7 @@ export const settings = {
 		_x( 'image', 'block search term', 'jetpack' ),
 		_x( 'gallery', 'block search term', 'jetpack' ),
 		_x( 'slider', 'block search term', 'jetpack' ),
+		_x( 'carousel', 'block search term', 'jetpack' ),
 	],
 	description: __( 'Add an interactive slideshow.', 'jetpack' ),
 	attributes,

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -116,7 +116,6 @@ export const settings = {
 		_x( 'image', 'block search term', 'jetpack' ),
 		_x( 'gallery', 'block search term', 'jetpack' ),
 		_x( 'slider', 'block search term', 'jetpack' ),
-		_x( 'carousel', 'block search term', 'jetpack' ),
 	],
 	description: __( 'Add an interactive slideshow.', 'jetpack' ),
 	attributes,

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -208,6 +208,10 @@ export const settings = {
 		_x( 'images', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),
 		_x( 'pictures', 'block search term', 'jetpack' ),
+		_x( 'square', 'block search term', 'jetpack' ),
+		_x( 'circle', 'block search term', 'jetpack' ),
+		_x( 'mosaic', 'block search term', 'jetpack' ),
+		_x( 'masonry', 'block search term', 'jetpack' ),
 	],
 	styles: layoutStylesWithLabels,
 	supports: {

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -205,13 +205,13 @@ export const settings = {
 			: '' ),
 	icon,
 	keywords: [
+		_x( 'columns', 'block search term', 'jetpack' ),
 		_x( 'images', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),
 		_x( 'pictures', 'block search term', 'jetpack' ),
 		_x( 'square', 'block search term', 'jetpack' ),
 		_x( 'circle', 'block search term', 'jetpack' ),
 		_x( 'mosaic', 'block search term', 'jetpack' ),
-		_x( 'masonry', 'block search term', 'jetpack' ),
 	],
 	styles: layoutStylesWithLabels,
 	supports: {

--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -61,7 +61,7 @@ export const settings = {
 	keywords: [
 		_x( 'ads', 'block search term', 'jetpack' ),
 		'WordAds',
-		_x( 'Advertisement', 'block search term', 'jetpack' ),
+		_x( 'advertisement', 'block search term', 'jetpack' ),
 	],
 
 	supports: {

--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { ExternalLink, Path, SVG } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 
@@ -58,7 +58,11 @@ export const settings = {
 
 	category: 'jetpack',
 
-	keywords: [ __( 'ads', 'jetpack' ), 'WordAds', __( 'Advertisement', 'jetpack' ) ],
+	keywords: [
+		_x( 'ads', 'block search term', 'jetpack' ),
+		'WordAds',
+		_x( 'Advertisement', 'block search term', 'jetpack' ),
+	],
 
 	supports: {
 		align: [ 'left', 'center', 'right' ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Some of the comments on the CfT for Google Calendar and Revue mentioned about our keyword use, so I reviewed every block and made a few changes to make our keywords more consistent.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Added keywords where there were none.
* Added additional keywords (up to 3) when there were more relevant ones
* Removed pointless keywords, so that we only have 3 per block
* Used `_x` for all keywords for consistency

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Changes to blocks

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Try searching for blocks in the inserter using the relevant keywords and ensure they show

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
