### PR TITLE
E2E tests: fail Travis builds on E2E test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,6 @@ matrix:
     env: LEGACY_FULL_SYNC=1 WP_BRANCH=latest
 
   allow_failures:
-    - name: "E2E tests"
     - name: "PHP Nightly"
     - name: "Spell check Markdown files"
     - name: "Code Coverage"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves E2E tests job to the list of required jobs for Travis to be green  

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much. Verify that E2E tests job now in the main group in Travis (and not in the "allow failures")

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
