### PR TITLE
Google Calendar: Add support for shareable URLs

### DIFF
--- a/extensions/blocks/google-calendar/edit.js
+++ b/extensions/blocks/google-calendar/edit.js
@@ -19,7 +19,13 @@ import { getBlockDefaultClassName } from '@wordpress/blocks';
  * Internal dependencies
  */
 import icon from './icon';
-import { extractAttributesFromIframe, IFRAME_REGEX, URL_REGEX } from './utils';
+import {
+	extractAttributesFromIframe,
+	convertShareableUrl,
+	IFRAME_REGEX,
+	URL_REGEX,
+	SHAREABLE_REGEX,
+} from './utils';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 
 class GoogleCalendarEdit extends Component {
@@ -64,6 +70,8 @@ class GoogleCalendarEdit extends Component {
 
 		if ( IFRAME_REGEX.test( embedString ) ) {
 			attributes = extractAttributesFromIframe( embedString );
+		} else if ( SHAREABLE_REGEX.test( embedString ) ) {
+			attributes = { url: convertShareableUrl( embedString ) };
 		} else {
 			attributes = { url: embedString };
 		}

--- a/extensions/blocks/google-calendar/utils.js
+++ b/extensions/blocks/google-calendar/utils.js
@@ -1,11 +1,34 @@
-const url_regex_string = 's*https?://calendar.google.com/calendar/embed';
+const url_regex_string = 's*https?://calendar.google.com/calendar';
 export const URL_REGEX = new RegExp( `^${ url_regex_string }`, 'i' );
 export const IFRAME_REGEX = new RegExp(
 	`<iframe((?:\\s+\\w+=(['"]).*?\\2)*)\\s+src=(["'])(${ url_regex_string }.*?)\\3((?:\\s+\\w+=(['"]).*?\\6)*)`,
 	'i'
 );
+export const SHAREABLE_REGEX = new RegExp(
+	`${ url_regex_string }\\?cid=([-A-Za-z0-9+/]+={0,3})`,
+	'i'
+);
 
 const ATTRIBUTE_REGEX = /\s+(\w+)=(["'])(.*?)\2/gi;
+
+/**
+ * Converts a Google Calendar shareable URL of the format:
+ * https://calendar.google.com/calendar?cid=Z2xlbi5kYXZpZXNAYThjLmNvbQ
+ *
+ * to an embed URL.
+ *
+ * @param {string} shareableUrl The Google Calendar shareable URL
+ * @returns {string} The embed URL or undefined if the conversion fails
+ */
+export function convertShareableUrl( shareableUrl ) {
+	const parsedUrl = SHAREABLE_REGEX.exec( shareableUrl );
+	if ( ! parsedUrl ) {
+		return;
+	}
+	return (
+		'https://calendar.google.com/calendar/embed?src=' + encodeURIComponent( atob( parsedUrl[ 1 ] ) )
+	);
+}
 
 /**
  * Given an <iframe> that matches IFRAME_REGEX, extract the url, width, and height.


### PR DESCRIPTION
After reading @scruffian's [comment](https://github.com/Automattic/jetpack/issues/14838#issuecomment-592440553) about supporting shareable URLs in the Google Calendar block, I did some investigation and discovered that the shareable URL includes the calendar `src`
parameter that is used in the standard embed, but it's base64 encoded.

#### Changes proposed in this Pull Request:

This adds support for those URLs to the Google Calendar block, and is an alternative to #14839 which added a better error message if these URLs were used.

Fixes #14838

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
It's an enhancement to a new feature

#### Testing instructions:
* Using this branch on a test site
* Add a Google Calendar block
* Check that you can embed a shareable URL for a calendar e.g. https://calendar.google.com/calendar?cid=Z2xlbi5kYXZpZXNAYThjLmNvbQ

#### Proposed changelog entry for your changes:
No changelog required
