### PR TITLE
Coming Soon SAL changes

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -309,28 +309,12 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'user_can_manage' :
 				$response[ $key ] = $this->site->user_can_manage();
 			case 'is_private' :
-				/**
-				 * Filters the value of `is_private` value about the site to return.
-				 *
-				 * @module json-api
-				 *
-				 * @since 8.4.0
-				 *
-				 * @param bool $is_private Is site private.
-				 */
-				$response[ $key ] = apply_filters( 'sites_site_is_private', $this->site->is_private() );
+				$response[ $key ] = $this->site->is_private();
 				break;
 			case 'is_coming_soon' :
-				/**
-				 * Filters the value of `is_coming_soon` value about the site to return.
-				 *
-				 * @module json-api
-				 *
-				 * @since 8.4.0
-				 *
-				 * @param bool $is_coming_soon Is site in the Coming Soon mode.
-				 */
-				$response[ $key ] = apply_filters( 'sites_site_is_coming_soon', false );
+				// This option is stored on wp.com for both simple and atomic sites. @see mu-plugins/private-blog.php
+				$response[ $key ] = $this->site->is_coming_soon();;
+				break;
 			case 'visible' :
 				$response[ $key ] = $this->site->is_visible();
 				break;

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -315,6 +315,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				// This option is stored on wp.com for both simple and atomic sites. @see mu-plugins/private-blog.php
 				$response[ $key ] = $this->site->is_coming_soon();;
 				break;
+			case 'launch_status' :
+				$response[ $key ] = $this->site->get_launch_status();
+				break;
 			case 'visible' :
 				$response[ $key ] = $this->site->is_visible();
 				break;
@@ -387,9 +390,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'quota' :
 				$response[ $key ] = $this->site->get_quota();
-				break;
-			case 'launch_status' :
-				$response[ $key ] = $this->site->get_launch_status();
 				break;
 			case 'site_migration' :
 				$response[ $key ] = $this->site->get_migration_meta();

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -71,6 +71,8 @@ abstract class SAL_Site {
 
 	abstract public function is_private();
 
+	abstract public function is_coming_soon();
+
 	abstract public function is_following();
 
 	abstract public function get_subscribers_count();

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -162,7 +162,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	 * @return string|boolean  Launch status ('launched', 'unlaunched', or false).
 	 */
 	function get_launch_status() {
-		return $this->get_cloud_site_option( 'launch-status' );
+		return $this->get_atomic_cloud_site_option( 'launch-status' );
 	}
 
 	function get_atomic_cloud_site_option( $option ) {

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -139,11 +139,11 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_private() {
-		return $this->get_atomic_cloud_site_option( 'blog_public' ) == -1;
+		return $this->get_atomic_cloud_site_option( 'blog_public' ) === -1;
 	}
 
 	function is_coming_soon() {
-		return $this->is_private() && $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) == 1;
+		return $this->is_private() && $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) === 1;
 	}
 
 	function get_atomic_cloud_site_option( $option ) {

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -139,14 +139,18 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_private() {
-		return $this->get_cloud_site_option( 'blog_public' ) == -1;
+		return $this->get_atomic_cloud_site_option( 'blog_public' ) == -1;
 	}
 
 	function is_coming_soon() {
-		return $this->is_private() && $this->get_cloud_site_option( 'wpcom_coming_soon' ) == 1;
+		return $this->is_private() && $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) == 1;
 	}
 
-	function get_cloud_site_option( $option ) {
+	function get_atomic_cloud_site_option( $option ) {
+		if ( ! jetpack_is_atomic_site() ) {
+			return false;
+		}
+
 		$jetpack = Jetpack::init();
 		if ( ! method_exists( $jetpack, 'get_cloud_site_options' ) ) {
 			return false;

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -139,11 +139,11 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_private() {
-		return $this->get_atomic_cloud_site_option( 'blog_public' ) === -1;
+		return (int) $this->get_atomic_cloud_site_option( 'blog_public' ) === -1;
 	}
 
 	function is_coming_soon() {
-		return $this->is_private() && $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) === 1;
+		return $this->is_private() && (int) $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) === 1;
 	}
 
 	function get_atomic_cloud_site_option( $option ) {

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -139,7 +139,25 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_private() {
-		return false;
+		return $this->get_cloud_site_option( 'blog_public' ) == -1;
+	}
+
+	function is_coming_soon() {
+		return $this->is_private() && $this->get_cloud_site_option( 'wpcom_coming_soon' ) == 1;
+	}
+
+	function get_cloud_site_option( $option ) {
+		$jetpack = Jetpack::init();
+		if ( ! method_exists( $jetpack, 'get_cloud_site_options' ) ) {
+			return false;
+		}
+
+		$result = $jetpack->get_cloud_site_options( [ $option ] );
+		if ( ! array_key_exists( $option, $result ) ) {
+			return false;
+		}
+
+		return $result[ $option ];
 	}
 
 	function get_plan() {

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -138,12 +138,31 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 		return $allowed_file_types;
 	}
 
+	/**
+	 * Return site's privacy status.
+	 *
+	 * @return boolean  Is site private?
+	 */
 	function is_private() {
 		return (int) $this->get_atomic_cloud_site_option( 'blog_public' ) === -1;
 	}
 
+	/**
+	 * Return site's coming soon status.
+	 *
+	 * @return boolean  Is site "Coming soon"?
+	 */
 	function is_coming_soon() {
 		return $this->is_private() && (int) $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) === 1;
+	}
+	
+	/**
+	 * Return site's launch status.
+	 *
+	 * @return string|boolean  Launch status ('launched', 'unlaunched', or false).
+	 */
+	function get_launch_status() {
+		return $this->get_cloud_site_option( 'launch-status' );
 	}
 
 	function get_atomic_cloud_site_option( $option ) {


### PR DESCRIPTION
**Summary:**

This PR is revisited version of https://github.com/Automattic/jetpack/pull/14794 - done "properly" by updating SAL.

**Test Plan:**
1. Test on an atomic Jetpack site, and non-atomic Jetpack site
1. Call the site info endpoint (`/wp-json/jetpack/v4/site`), confirm it says `is_private: false` and `is_coming_soon: false`
1. Update `blog_public` to -1 on the site, make sure it gets synced to via Jetpack Sync
1. Call the site info endpoint, confirm it says `is_private: true` and `is_coming_soon: false`
1. Update `wpcom_coming_soon` to 1 on shadow site on wp.com
1. Call the site info endpoint, confirm it says `is_private: true` and `is_coming_soon: true`

Reviewers: #jetpack, jblz

Subscribers: jeherve

Tags: #touches_jetpack_files

Differential Revision: D39264-code D39843-code
This commit syncs r203615-wpcom r204094-wpcom
