### PR TITLE
Instant Search: Simplify result load indicator

### DIFF
--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -93,13 +93,8 @@ export default class SearchFilters extends Component {
 		}
 
 		const aggregations = get( this.props.results, 'aggregations' );
-		const cls =
-			this.props.loading === true
-				? 'jetpack-instant-search__filters jetpack-instant-search__is-loading'
-				: 'jetpack-instant-search__filters';
-
 		return (
-			<div className={ cls }>
+			<div className="jetpack-instant-search__filters">
 				{ this.hasActiveFilters() && (
 					<a
 						class="jetpack-instant-search__clear-filters-link"

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -23,6 +23,9 @@ class SearchResults extends Component {
 		const hasCorrectedQuery = corrected_query !== false;
 		const num = new Intl.NumberFormat().format( total );
 
+		if ( this.props.isLoading ) {
+			return sprintf( __( 'Looking for "%s"', 'jetpack' ), this.props.query );
+		}
 		if ( total === 0 || this.props.hasError ) {
 			return sprintf( __( 'No results for "%s".', 'jetpack' ), this.props.query );
 		}
@@ -99,9 +102,7 @@ class SearchResults extends Component {
 				) }
 				{ hasResults && ! this.props.hasError && (
 					<ol
-						className={ `jetpack-instant-search__search-results-list is-format-${
-							this.props.resultFormat
-						}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
+						className={ `jetpack-instant-search__search-results-list is-format-${ this.props.resultFormat }` }
 					>
 						{ results.map( ( result, index ) => (
 							<SearchResult
@@ -158,9 +159,7 @@ class SearchResults extends Component {
 			<main
 				aria-hidden={ this.props.isLoading === true }
 				aria-live="polite"
-				className={ `jetpack-instant-search__search-results ${
-					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
-				}` }
+				className="jetpack-instant-search__search-results"
 			>
 				<a
 					className="jetpack-instant-search__overlay-close"

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -24,25 +24,25 @@ class SearchResults extends Component {
 		const num = new Intl.NumberFormat().format( total );
 
 		if ( this.props.isLoading ) {
-			return sprintf( __( 'Looking for "%s"', 'jetpack' ), this.props.query );
+			return sprintf( __( 'Searching…', 'jetpack' ), this.props.query );
 		}
 		if ( total === 0 || this.props.hasError ) {
-			return sprintf( __( 'No results for "%s".', 'jetpack' ), this.props.query );
+			return sprintf( __( 'No results found', 'jetpack' ), this.props.query );
 		}
 		if ( hasQuery && hasCorrectedQuery ) {
 			return sprintf(
-				_n( 'Showing %s result for "%s"', 'Showing %s results for "%s"', total, 'jetpack' ),
+				_n( 'Found %s result for "%s"', 'Found %s results for "%s"', total, 'jetpack' ),
 				num,
 				corrected_query
 			);
 		} else if ( hasQuery ) {
 			return sprintf(
-				_n( '%s result for "%s"', '%s results for "%s"', total, 'jetpack' ),
+				_n( 'Found %s result', 'Found %s results', total, 'jetpack' ),
 				num,
 				this.props.query
 			);
 		}
-		return sprintf( _n( '%s result', '%s results', total, 'jetpack' ), num );
+		return sprintf( _n( 'Found %s result', 'Found %s results', total, 'jetpack' ), num );
 	}
 
 	renderPrimarySection() {
@@ -72,13 +72,7 @@ class SearchResults extends Component {
 					widgets={ this.props.widgets }
 				/>
 
-				<div
-					className={
-						hasResults
-							? 'jetpack-instant-search__search-results-real-query'
-							: 'jetpack-instant-search__search-results-empty'
-					}
-				>
+				<div className="jetpack-instant-search__search-results-title">
 					{ this.getSearchTitle() }
 				</div>
 

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -65,13 +65,13 @@
 	}
 }
 
-.jetpack-instant-search__search-results-real-query {
+.jetpack-instant-search__search-results-title {
 	font-size: 1em;
 	font-weight: bold;
 }
 
-.jetpack-instant-search__search-results-unused-query,
-.jetpack-instant-search__search-results-real-query {
+.jetpack-instant-search__search-results-title,
+.jetpack-instant-search__search-results-unused-query {
 	overflow: hidden;
 	margin: 0;
 	padding: 0;

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -26,10 +26,6 @@ $grid-size-large: 16px;
 @import './components/search-result-product.scss';
 @import './components/search-sidebar.scss';
 
-.jetpack-instant-search__is-loading {
-	opacity: 0.2;
-}
-
 .jetpack-search-filters-widget__filter-list {
 	list-style-type: none;
 }


### PR DESCRIPTION
Fixes #14781.

#### Changes proposed in this Pull Request:
* Removes the gray overlay that appears during API load.
* Replaces result counter with loading message during API load.

<img width="703" alt="Screen Shot 2020-03-02 at 5 45 05 PM" src="https://user-images.githubusercontent.com/4044428/75731783-d4f2c900-5cad-11ea-870c-bf292ab1ed8c.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. 

2. Enter a site search. Ensure that the result counter shows `Looking for "QUERY"` while search results are being loaded.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None.
