### PR TITLE
Protect: no empty headers

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -407,7 +407,7 @@ class Jetpack_Protect_Module {
 		);
 
 		foreach ( $ip_related_headers as $header ) {
-			if ( isset( $_SERVER[ $header ] ) && ! empty( $_SERVER[ $header ] ) ) {
+			if ( ! empty( $_SERVER[ $header ] ) ) {
 				$output[ $header ] = $_SERVER[ $header ];
 			}
 		}

--- a/modules/protect.php
+++ b/modules/protect.php
@@ -407,7 +407,7 @@ class Jetpack_Protect_Module {
 		);
 
 		foreach ( $ip_related_headers as $header ) {
-			if ( isset( $_SERVER[ $header ] ) ) {
+			if ( isset( $_SERVER[ $header ] ) && ! empty( $_SERVER[ $header ] ) ) {
 				$output[ $header ] = $_SERVER[ $header ];
 			}
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes an issue where sending empty IP-related headers can result in false positives for a misconfigured server.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* There are some IP related headers that Protect gives priority, example `GD_PHP_HANDLER`
* In some cases, this header exists, but it's empty
* When Protect tries to use an empty trusted header, it results in the module shutting off because of a perceived misconfiguration
* This PR aims to mitigate false positives by not sending empty headers

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Issue is discussed more here: p9dueE-1fl-p2

#### Testing instructions:
* Try spinning up a new Jurassic.ninja website
* in `wp-config.php` set `$_SERVER['GD_PHP_HANDLER'] = ''` ( an empty string )
* ensure that a trusted header is not set to `GD_PHP_HANDLER`
* try setting `$_SERVER['GD_PHP_HANDLER'] = '1.1.1.1'`
* ensure that a trusted header is set to `GD_PHP_HANDLER`

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
