### PR TITLE
Fix/wufoo attribute return

### DIFF
--- a/modules/shortcodes/wufoo.php
+++ b/modules/shortcodes/wufoo.php
@@ -51,6 +51,8 @@ function wufoo_shortcode( $atts ) {
 				'https://help.wufoo.com/articles/en_US/kb/Embed'
 			);
 		}
+
+		return;
 	}
 
 	/**
@@ -66,12 +68,12 @@ function wufoo_shortcode( $atts ) {
 	 * An error will be returned inside the form if they are invalid.
 	 */
 	$js_embed = sprintf(
-		'(function(){try{var wufoo_%1$s = new WufooForm();wufoo_%1$s.initialize({"userName":"%2$s","formHash":"%1$s","autoResize":"%3$s","height":"%4$d","header":"%5$s","ssl":true,"async":true});wufoo_%1$s.display();}catch(e){}})();',
+		'(function(){try{var wufoo_%1$s = new WufooForm();wufoo_%1$s.initialize({"userName":"%2$s","formHash":"%1$s","autoResize":%3$s,"height":"%4$d","header":"%5$s","ssl":true,"async":true});wufoo_%1$s.display();}catch(e){}})();',
 		esc_attr( $attr['formhash'] ),
 		esc_attr( $attr['username'] ),
-		esc_attr( $attr['autoresize'] ),
+		'true' == $attr['autoresize'] ? 'true' : 'false', // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		absint( $attr['height'] ),
-		esc_js( $attr['header'] )
+		'show' === $attr['header'] ? 'show' : 'hide'
 	);
 
 	// Embed URL.

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,7 @@ There are opportunities for developers at all levels to contribute. [Learn more 
 * Secure Sign On: do not display feature message when logging in to WordPress.com's central dashboard.
 * Stats: hide Stats smiley in post embeds.
 * WooCommerce Analytics: improve product checks to avoid errors on order pages.
+* Wufoo shortcode: Security fix return early when invalid parameters.
 
 --------
 


### PR DESCRIPTION
Wufoo shortcode: Security fix return early when invalid parameters.

#### Changes proposed in this Pull Request:
* Proper handling of shortcode attributes

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* updates wufoo shortcode

#### Testing instructions:
* Verify shortcode functions as expected

#### Proposed changelog entry for your changes:
* Wufoo shortcode: Security fix return early when invalid parameters.
