### PR TITLE
Validate urls are from expected sources. (#14866)

### DIFF
--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -82,7 +82,10 @@ function load_assets( $attr, $content ) {
 	if ( is_admin() ) {
 		return;
 	}
-	$url = get_attribute( $attr, 'url' );
+	$url = \Jetpack_Gutenberg::validate_block_embed_url(
+		get_attribute( $attr, 'url' ),
+		array( 'calendly.com' )
+	);
 	if ( empty( $url ) ) {
 		return;
 	}

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -27,6 +27,12 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 		return '';
 	}
 
+	$attr['url'] = Jetpack_Gutenberg::validate_block_embed_url(
+		$attr['url'],
+		array( '#^https?:\/\/(?:[0-9a-z]+\.)?eventbrite\.(?:com|co\.uk|com\.ar|com\.au|be|com\.br|ca|cl|co|dk|de|es|fi|fr|hk|ie|it|com\.mx|nl|co\.nz|at|com\.pe|pt|ch|sg|se)\/e\/[^\/]*?(?:\d+)\/?(?:\?[^\/]*)?$#' ),
+		true
+	);
+
 	$widget_id = wp_unique_id( 'eventbrite-widget-' );
 
 	wp_enqueue_script( 'eventbrite-widget', 'https://www.eventbrite.com/static/widgets/eb_widgets.js', array(), JETPACK__VERSION, true );

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -24,7 +24,9 @@ jetpack_register_block(
 function jetpack_gif_block_render( $attr ) {
 	$padding_top = isset( $attr['paddingTop'] ) ? $attr['paddingTop'] : 0;
 	$style       = 'padding-top:' . $padding_top;
-	$giphy_url   = isset( $attr['giphyUrl'] ) ? $attr['giphyUrl'] : null;
+	$giphy_url   = isset( $attr['giphyUrl'] )
+		? Jetpack_Gutenberg::validate_block_embed_url( $attr['giphyUrl'], array( 'giphy.com' ) )
+		: null;
 	$search_text = isset( $attr['searchText'] ) ? $attr['searchText'] : '';
 	$caption     = isset( $attr['caption'] ) ? $attr['caption'] : null;
 

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -37,7 +37,9 @@ add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
 function load_assets( $attr ) {
 	$width   = isset( $attr['width'] ) ? $attr['width'] : '800';
 	$height  = isset( $attr['height'] ) ? $attr['height'] : '600';
-	$url     = isset( $attr['url'] ) ? $attr['url'] : '';
+	$url     = isset( $attr['url'] )
+		? \Jetpack_Gutenberg::validate_block_embed_url( $attr['url'], array( 'calendar.google.com' ) ) :
+		'';
 	$classes = \Jetpack_Gutenberg::block_classes( 'google-calendar', $attr );
 
 	if ( empty( $url ) ) {


### PR DESCRIPTION
Helper utility for whitelisting domains

Syncs r203720-wpcom.

#### Changes proposed in this Pull Request:
* validate_block_embed_url added to help whitelist domains

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* N/A

#### Testing instructions:
* Validate Google Calendar, Eventbrite and other plugins are functional

#### Proposed changelog entry for your changes:
* N/A
