### PR TITLE
Instant Search: Show Clear Filters link only once

### DIFF
--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -18,6 +18,10 @@ import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/qu
 import { mapFilterToFilterKey, mapFilterToType } from '../lib/filters';
 
 export default class SearchFilters extends Component {
+	static defaultProps = {
+		showClearFiltersButton: true,
+	};
+
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
 		this.props.onChange && this.props.onChange();
@@ -66,7 +70,7 @@ export default class SearchFilters extends Component {
 		const aggregations = get( this.props.results, 'aggregations' );
 		return (
 			<div className="jetpack-instant-search__filters">
-				{ this.hasActiveFilters() && (
+				{ this.props.showClearFiltersButton && this.hasActiveFilters() && (
 					<a
 						class="jetpack-instant-search__clear-filters-link"
 						href="#"

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -12,7 +12,13 @@ import JetpackColophon from './jetpack-colophon';
 import SearchBox from './search-box';
 import SearchFilters from './search-filters';
 
-import { getFilterQuery, getSearchQuery, setSearchQuery, setSortQuery } from '../lib/query-string';
+import {
+	getFilterQuery,
+	getSearchQuery,
+	hasPreselectedFilters,
+	setSearchQuery,
+	setSortQuery,
+} from '../lib/query-string';
 import PreselectedSearchFilters from './preselected-search-filters';
 
 const noop = event => event.preventDefault();
@@ -67,7 +73,7 @@ class SearchForm extends Component {
 							widgets={ this.props.widgets }
 							widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 						/>
-						{ this.props.widgets.map( widget => (
+						{ this.props.widgets.map( ( widget, index ) => (
 							<SearchFilters
 								filters={ getFilterQuery() }
 								loading={ this.props.isLoading }
@@ -75,6 +81,10 @@ class SearchForm extends Component {
 								onChange={ this.hideFilters }
 								postTypes={ this.props.postTypes }
 								results={ this.props.response }
+								showClearFiltersButton={
+									! hasPreselectedFilters( this.props.widgets, this.props.widgetsOutsideOverlay ) &&
+									index === 0
+								}
 								widget={ widget }
 							/>
 						) ) }

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -13,6 +13,7 @@ import WidgetAreaContainer from './widget-area-container';
  */
 import JetpackColophon from './jetpack-colophon';
 import PreselectedSearchFilters from './preselected-search-filters';
+import { hasPreselectedFilters } from '../lib/query-string';
 
 const SearchSidebar = props => {
 	return (
@@ -26,7 +27,7 @@ const SearchSidebar = props => {
 				widgetsOutsideOverlay={ props.widgetsOutsideOverlay }
 			/>
 			<WidgetAreaContainer />
-			{ props.widgets.map( widget => {
+			{ props.widgets.map( ( widget, index ) => {
 				return createPortal(
 					<div
 						id={ `${ widget.widget_id }-portaled-wrapper` }
@@ -37,6 +38,9 @@ const SearchSidebar = props => {
 							locale={ props.locale }
 							postTypes={ props.postTypes }
 							results={ props.response }
+							showClearFiltersButton={
+								! hasPreselectedFilters( props.widgets, props.widgetsOutsideOverlay ) && index === 0
+							}
 							widget={ widget }
 						/>
 					</div>,

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -180,6 +180,10 @@ export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay )
 		.filter( filter => keys.includes( mapFilterToFilterKey( filter ) ) );
 }
 
+export function hasPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
+	return getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ).length > 0;
+}
+
 export function hasFilter() {
 	return getFilterKeys().some( key => getFilterQueryByKey( key ).length > 0 );
 }


### PR DESCRIPTION
Fixes #14873.

#### Changes proposed in this Pull Request:
* If multiple Jetpack Search widgets have been added to the overlay sidebar, only the first widget will contain the `Clear Filters` link.
* If a filter was preselected through a Jetpack Search widget outside of the overlay, the `Clear Filters` link will appear with the preselected filters section above the overlay sidebar widget area.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Add two Jetpack Search widgets inside the overlay sidebar and one Jetpack Search widget in the site footer/sidebar. Make sure that there are no filter overlays between the site footer/sidebar widget and the overlay widgets.

2. Click on a filter in your site's footer/sidebar. Ensure that the search overlay appears with your search results.

3. Ensure that the `Clear Filters` link appears near the top of the overlay sidebar.

4. Click the `Clear Filters` in the overlay sidebar. Ensure that the preselected filters checkboxes disappear.

5. Click on a filter in the overlay sidebar. Ensure that the `Clear Filters` link appears once within the first Jetpack Search widget in the overlay sidebar.

#### Proposed changelog entry for your changes:
* None.
