### PR TITLE
Blocks: remove typo in upgrade nudge

### DIFF
--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -43,12 +43,9 @@ export const UpgradeNudge = ( { planName, trackViewEvent, trackClickEvent, upgra
 			onClick={ trackClickEvent }
 			title={
 				planName
-					? sprintf(
-							__( 'Upgrade to %(planName)s to use this block on your site bob.', 'jetpack' ),
-							{
-								planName,
-							}
-					  )
+					? sprintf( __( 'Upgrade to %(planName)s to use this block on your site.', 'jetpack' ), {
+							planName,
+					  } )
 					: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' )
 			}
 			subtitle={ __(


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Remove a word that slipped in #14724 but that should not be there.

#### Testing instructions:

* Add `add_filter( 'jetpack_block_editor_enable_upgrade_nudge', '__return_true' );` to a brand new site.
* Connect to WordPress.com; do not buy a plan.
* Try to add a Simple Payments block to the editor, and ensure that the string is correct.

#### Proposed changelog entry for your changes:

* N/A
