### PR TITLE
E2E tests: Catch errors in beforeAll hook

### DIFF
--- a/tests/e2e/lib/jest.test.failure.js
+++ b/tests/e2e/lib/jest.test.failure.js
@@ -8,6 +8,7 @@ import { wrap } from 'lodash';
 import { sendFailedTestScreenshotToSlack, sendFailedTestMessageToSlack } from './reporters/slack';
 import { takeScreenshot } from './reporters/screenshot';
 import { logHTML, logDebugLog } from './page-helper';
+
 /**
  * Override the test case method so we can take screenshots of assertion failures.
  *
@@ -15,6 +16,39 @@ import { logHTML, logDebugLog } from './page-helper';
  */
 let currentBlock;
 const { CI, E2E_DEBUG, E2E_LOG_HTML } = process.env;
+
+export const defaultErrorHandler = async error => {
+	// If running tests in CI
+	if ( CI ) {
+		const filePath = await takeScreenshot( currentBlock, name );
+		await sendFailedTestMessageToSlack( { block: currentBlock, name, error } );
+		await sendFailedTestScreenshotToSlack( filePath );
+		await logDebugLog();
+	}
+
+	if ( E2E_LOG_HTML ) {
+		logHTML();
+	}
+
+	if ( E2E_DEBUG ) {
+		console.log( error );
+		await jestPuppeteer.debug();
+	}
+
+	throw error;
+};
+
+// Wrapper around `beforeAll` to be able to handle thrown exceptions within the hook.
+// Main reason is to be able to universaly capture screenshots on puppeteer exceptions.
+export const catchBeforeAll = async ( callback, errorHandler = defaultErrorHandler ) => {
+	beforeAll( async () => {
+		try {
+			await callback();
+		} catch ( error ) {
+			await errorHandler( error );
+		}
+	} );
+};
 
 // Use wrap to preserve all previous `wrap`s
 jasmine.getEnv().describe = wrap( jasmine.getEnv().describe, ( func, ...args ) => {
@@ -31,24 +65,7 @@ global.it = async ( name, func ) => {
 		try {
 			await func();
 		} catch ( error ) {
-			// If running tests in CI
-			if ( CI ) {
-				const filePath = await takeScreenshot( currentBlock, name );
-				await sendFailedTestMessageToSlack( { block: currentBlock, name, error } );
-				await sendFailedTestScreenshotToSlack( filePath );
-				await logDebugLog();
-			}
-
-			if ( E2E_LOG_HTML ) {
-				logHTML();
-			}
-
-			if ( E2E_DEBUG ) {
-				console.log( error );
-				await jestPuppeteer.debug();
-			}
-
-			throw error;
+			await defaultErrorHandler( error );
 		}
 	} );
 };

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -9,9 +9,10 @@ import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/u
 import SimplePaymentBlock from '../lib/blocks/simple-payments';
 import WordAdsBlock from '../lib/blocks/word-ads';
 import PinterestBlock from '../lib/blocks/pinterest';
+import { catchBeforeAll } from '../lib/jest.test.failure';
 
 describe( 'Paid blocks', () => {
-	beforeAll( async () => {
+	catchBeforeAll( async () => {
 		await resetWordpressInstall();
 		const url = getNgrokSiteUrl();
 		console.log( 'NEW SITE URL: ' + url );


### PR DESCRIPTION
Sometimes we see test errors in `beforeAll` hook where the test environment is being configured. Most of these issues I saw are related to WPCOM login. With this change, we'll be able to catch these errors and act on them (in this case just take a screenshot and send it to slack)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add a wrapper around `beforeAll` hook to handle exceptions

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test
* Make sure the tests are green

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
