### PR TITLE
Blocks: Update placeholders to use the withNotices HOC

### DIFF
--- a/extensions/blocks/amazon/edit.js
+++ b/extensions/blocks/amazon/edit.js
@@ -17,10 +17,10 @@ import {
 	Button,
 	ExternalLink,
 	FormTokenField,
-	Notice,
 	PanelBody,
 	Placeholder,
 	ToggleControl,
+	withNotices,
 } from '@wordpress/components';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
 import { useState } from '@wordpress/element';
@@ -32,7 +32,7 @@ import icon from './icon';
 import data from './dummy-data';
 import './editor.scss';
 
-export default function AmazonEdit( {
+function AmazonEdit( {
 	attributes: {
 		backgroundColor,
 		textColor,
@@ -46,10 +46,10 @@ export default function AmazonEdit( {
 	},
 	className,
 	name,
+	noticeUI,
 	setAttributes,
 } ) {
 	const defaultClassName = getBlockDefaultClassName( name );
-	const notice = false; // TODO
 
 	const [ suggestions, setSuggestions ] = useState( [] );
 	const onInputChange = () => {
@@ -81,13 +81,7 @@ export default function AmazonEdit( {
 			label={ __( 'Amazon', 'jetpack' ) }
 			instructions={ __( 'Search by entering an Amazon product name or ID below.', 'jetpack' ) }
 			icon={ <BlockIcon icon={ icon } /> }
-			notices={
-				notice && (
-					<Notice status="error" isDismissible={ false }>
-						{ notice }
-					</Notice>
-				)
-			}
+			notices={ noticeUI } // TODO
 		>
 			<form>
 				<FormTokenField
@@ -255,3 +249,5 @@ export default function AmazonEdit( {
 		</div>
 	);
 }
+
+export default withNotices( AmazonEdit );

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -17,6 +17,7 @@ import {
 	Placeholder,
 	ToggleControl,
 	Toolbar,
+	withNotices,
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
@@ -34,8 +35,16 @@ import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
 
-export default function CalendlyEdit( props ) {
-	const { attributes, name, className, clientId, setAttributes } = props;
+function CalendlyEdit( props ) {
+	const {
+		attributes,
+		className,
+		clientId,
+		name,
+		noticeOperations,
+		noticeUI,
+		setAttributes,
+	} = props;
 	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( attributeDetails, attributes );
 
@@ -53,17 +62,13 @@ export default function CalendlyEdit( props ) {
 		url,
 	} = validatedAttributes;
 	const [ embedCode, setEmbedCode ] = useState( '' );
-	const [ notice, setNotice ] = useState();
 
-	const setErrorNotice = () =>
-		setNotice(
-			<>
-				{ __(
-					"Your calendar couldn't be embedded. Please double check your URL or code.",
-					'jetpack'
-				) }
-			</>
+	const setErrorNotice = () => {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice(
+			__( "Your calendar couldn't be embedded. Please double check your URL or code.", 'jetpack' )
 		);
+	};
 
 	const parseEmbedCode = event => {
 		if ( ! event ) {
@@ -82,6 +87,7 @@ export default function CalendlyEdit( props ) {
 		const newValidatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
 
 		setAttributes( newValidatedAttributes );
+		noticeOperations.removeAllNotices();
 	};
 
 	const embedCodeForm = (
@@ -114,13 +120,7 @@ export default function CalendlyEdit( props ) {
 			label={ __( 'Calendly', 'jetpack' ) }
 			instructions={ __( 'Enter your Calendly web address or embed code below.', 'jetpack' ) }
 			icon={ <BlockIcon icon={ icon } /> }
-			notices={
-				notice && (
-					<Notice status="error" isDismissible={ false }>
-						{ notice }
-					</Notice>
-				)
-			}
+			notices={ noticeUI }
 		>
 			{ embedCodeForm }
 		</Placeholder>
@@ -267,3 +267,5 @@ export default function CalendlyEdit( props ) {
 		</div>
 	);
 }
+
+export default withNotices( CalendlyEdit );

--- a/extensions/blocks/google-calendar/editor.scss
+++ b/extensions/blocks/google-calendar/editor.scss
@@ -3,23 +3,22 @@
  */
 
 .wp-block-jetpack-google-calendar {
-
 	&-embed-form-sidebar {
 		textarea {
 			width: 100%;
 			height: 75px;
-		};
+		}
 		button {
 			margin-top: 8px;
 			display: block;
-		};
+		}
 	}
 
 	&-embed-form-editor {
 		textarea {
 			height: 36px;
 			padding-top: 9px;
-		};
+		}
 	}
 
 	&-placeholder-links {
@@ -46,9 +45,5 @@
 		p {
 			margin: 0px 0px 19px 0px;
 		}
-	}
-
-	.components-notice {
-		margin: 0 0 20px 0;
 	}
 }

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -16,14 +16,13 @@ import {
 } from '@wordpress/block-editor';
 import {
 	ExternalLink,
-	Notice,
 	PanelBody,
 	Placeholder,
 	SelectControl,
 	ToggleControl,
 	Toolbar,
+	withNotices,
 } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
 
@@ -46,7 +45,15 @@ import {
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { getAttributesFromEmbedCode } from './utils';
 
-export default function OpenTableEdit( { attributes, setAttributes, name, className, clientId } ) {
+function OpenTableEdit( {
+	attributes,
+	className,
+	clientId,
+	name,
+	noticeOperations,
+	noticeUI,
+	setAttributes,
+} ) {
 	const defaultClassName = getBlockDefaultClassName( name );
 	const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
 
@@ -55,25 +62,26 @@ export default function OpenTableEdit( { attributes, setAttributes, name, classN
 	}
 
 	const { align, rid, style, iframe, domain, lang, newtab } = attributes;
-	const [ notice, setNotice ] = useState();
-
-	const setErrorNotice = () =>
-		setNotice(
-			<>
-				<strong>{ __( 'We ran into an issue', 'jetpack' ) }</strong>
-				<br />
-				{ __( 'Please ensure this embed matches the one from your OpenTable account', 'jetpack' ) }
-			</>
-		);
 
 	const parseEmbedCode = embedCode => {
 		const newAttributes = getAttributesFromEmbedCode( embedCode );
 		if ( ! newAttributes ) {
-			setErrorNotice();
+			noticeOperations.removeAllNotices();
+			noticeOperations.createErrorNotice(
+				<>
+					<strong>{ __( 'We ran into an issue', 'jetpack' ) }</strong>
+					<br />
+					{ __(
+						'Please ensure this embed matches the one from your OpenTable account',
+						'jetpack'
+					) }
+				</>
+			);
 		}
 
 		const validatedNewAttributes = getValidatedAttributes( defaultAttributes, newAttributes );
 		setAttributes( validatedNewAttributes );
+		noticeOperations.removeAllNotices();
 	};
 
 	const styleOptions = getStyleOptions( rid );
@@ -200,13 +208,7 @@ export default function OpenTableEdit( { attributes, setAttributes, name, classN
 				'Enter your restaurant name, or paste an OpenTable Reservation Widget embed code.',
 				'jetpack'
 			) }
-			notices={
-				notice && (
-					<Notice status="error" isDismissible={ false }>
-						{ notice }
-					</Notice>
-				)
-			}
+			notices={ noticeUI }
 		>
 			<RestaurantPicker rids={ rid } onSubmit={ onPickerSubmit } />
 			<div className={ `${ defaultClassName }-placeholder-links` }>
@@ -236,3 +238,5 @@ export default function OpenTableEdit( { attributes, setAttributes, name, classN
 		</div>
 	);
 }
+
+export default withNotices( OpenTableEdit );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the Amazon, Calendly, Google Calendar, and OpenTable blocks to use the `withNotices` HOC instead of manually handling the error notices.

<img width="629" alt="Screenshot 2020-03-04 at 13 12 20" src="https://user-images.githubusercontent.com/2070010/75914118-cfb28d00-5e19-11ea-96ed-4594e308ee98.png">

Pros: it's the Core Gutenberg way of handling placeholder notices; manual notices are incorrectly positioned on recent Gutenberg versions (see https://github.com/Automattic/jetpack/pull/14833 for a CSS-only fix).

Cons: notices created with `withNotices` are always dismissable, while all our manual notices aren't. I don't think it's a big deal to be honest.

#### Note

Other blocks already use the `withNotices` HOC, but some in a slightly peculiar way.
According to the Gutenberg docs, `withNotices` exposes a `noticeUI` prop that is passed to the Placeholder through the `notices` prop.
E.g.
```jsx
<Placeholder notices={ props.noticeUI } />
```

Some blocks instead use the `noticeUI` _outside_ the Placeholder (the notice would appear above the block content—but still inside its container), while passing a `notices` prop to the Placeholder `notices` prop.
E.g.
```jsx
<Fragment>
  { props.noticeUI }
  <Placeholder notices={ props.notices } />
</Fragment>
```

https://github.com/Automattic/jetpack/blob/0fd1874f8ee31a69e08dbb38ab0a2ae7e8496671/extensions/blocks/map/edit.js#L399
https://github.com/Automattic/jetpack/blob/0fd1874f8ee31a69e08dbb38ab0a2ae7e8496671/extensions/blocks/map/edit.js#L492

I'm not exactly sure why this happens, and for example why this doesn't end up displaying two notices, one in the Placeholder, and one above the block content.
I've chosen to not touch these blocks, to avoid unexpected regressions.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert the Amazon, Calendly, Google Calendar, and OpenTable blocks, and try triggering an error notice by inserting an incorrect URL or embed code.
* Make sure the notice still works and is positioned consistently.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Update the Amazon, Calendly, Google Calendar, and OpenTable blocks to use the `withNotices` higher-order component.