### PR TITLE
Lazy Images: Drop jQuery, convert to vanilla JS

### DIFF
--- a/3rd-party/woocommerce.php
+++ b/3rd-party/woocommerce.php
@@ -97,7 +97,17 @@ function jetpack_woocommerce_infinite_scroll_style() {
 function jetpack_woocommerce_lazy_images_compat() {
 	wp_add_inline_script( 'wc-cart-fragments', "
 		jQuery( 'body' ).bind( 'wc_fragments_refreshed', function() {
-			jQuery( 'body' ).trigger( 'jetpack-lazy-images-load' );
+			var jetpackLazyImagesLoadEvent;
+			try {
+				jetpackLazyImagesLoadEvent = new Event( 'jetpack-lazy-images-load', {
+					bubbles: true,
+					cancelable: true
+				} );
+			} catch ( e ) {
+				jetpackLazyImagesLoadEvent = document.createEvent( 'Event' )
+				jetpackLazyImagesLoadEvent.initEvent( 'jetpack-lazy-images-load', true, true );
+			}
+			jQuery( 'body' ).get( 0 ).dispatchEvent( jetpackLazyImagesLoadEvent );
 		} );
 	" );
 }

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -737,7 +737,7 @@
 		/**
 		 * Emit the event in a jQuery way for backwards compatibility where necessary.
 		 */
-		if ( opts.jqueryEventName && jQuery ) {
+		if ( opts.jqueryEventName && 'undefined' !== typeof jQuery ) {
 			jQuery( el ).trigger( opts.jqueryEventName, opts.data || null );
 		}
 

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -126,26 +126,16 @@
 	 * Renders the results from a successful response.
 	 */
 	Scroller.prototype.render = function( response ) {
-		var postLoadEvent;
-
 		this.body.addClass( 'infinity-success' );
 
 		// Check if we can wrap the html
 		this.element.append( response.html );
 
-		try {
-			postLoadEvent = new CustomEvent( 'post-load', {
-				bubbles: true,
-				cancelable: true,
-				detail: response,
-			} );
-		} catch ( e ) {
-			postLoadEvent = document.createEvent( 'CustomEvent' );
-			postLoadEvent.initCustomEvent( 'post-load', true, true, response );
-		}
+		this.trigger( this.body.get( 0 ), 'is.post-load', {
+			jqueryEventName: 'post-load',
+			data: response,
+		} );
 
-		this.body.get( 0 ).dispatchEvent( postLoadEvent );
-		this.body.trigger( 'post-load', response );
 		this.ready = true;
 	};
 
@@ -634,7 +624,10 @@
 				$set.css( 'min-height', '' ).removeClass( 'is--replaced' );
 				if ( this.pageNum in self.pageCache ) {
 					$set.html( self.pageCache[ this.pageNum ].html );
-					self.body.trigger( 'post-load', self.pageCache[ this.pageNum ] );
+					self.trigger( self.body.get( 0 ), 'is.post-load', {
+						jqueryEventName: 'post-load',
+						data: self.pageCache[ this.pageNum ],
+					} );
 				}
 			}
 		} );
@@ -729,6 +722,40 @@
 	 */
 	Scroller.prototype.resume = function() {
 		this.disabled = false;
+	};
+
+	/**
+	 * Emits custom JS events.
+	 *
+	 * @param {Node}   el
+	 * @param {string} eventName
+	 * @param {*}      data
+	 */
+	Scroller.prototype.trigger = function( el, eventName, opts ) {
+		opts = opts || {};
+
+		/**
+		 * Emit the event in a jQuery way for backwards compatibility where necessary.
+		 */
+		if ( opts.jqueryEventName && jQuery ) {
+			jQuery( el ).trigger( opts.jqueryEventName, opts.data || null );
+		}
+
+		/**
+		 * Emit the event in a standard way.
+		 */
+		var e;
+		try {
+			e = new CustomEvent( eventName, {
+				bubbles: true,
+				cancelable: true,
+				detail: opts.data || null,
+			} );
+		} catch ( err ) {
+			e = document.createEvent( 'CustomEvent' );
+			e.initCustomEvent( eventName, true, true, opts.data || null );
+		}
+		el.dispatchEvent( e );
 	};
 
 	/**

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -126,10 +126,25 @@
 	 * Renders the results from a successful response.
 	 */
 	Scroller.prototype.render = function( response ) {
+		var postLoadEvent;
+
 		this.body.addClass( 'infinity-success' );
 
 		// Check if we can wrap the html
 		this.element.append( response.html );
+
+		try {
+			postLoadEvent = new CustomEvent( 'post-load', {
+				bubbles: true,
+				cancelable: true,
+				detail: response,
+			} );
+		} catch ( e ) {
+			postLoadEvent = document.createEvent( 'CustomEvent' );
+			postLoadEvent.initCustomEvent( 'post-load', true, true, response );
+		}
+
+		this.body.get( 0 ).dispatchEvent( postLoadEvent );
 		this.body.trigger( 'post-load', response );
 		this.ready = true;
 	};

--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -12,19 +12,16 @@ var jetpackLazyImagesModule = function() {
 		image,
 		i;
 
-
-
 	lazy_load_init();
 
 	var bodyEl = document.querySelector( 'body' );
 	if ( bodyEl ) {
 		// Lazy load images that are brought in from Infinite Scroll
-		bodyEl.addEventListener( 'post-load', lazy_load_init );
+		bodyEl.addEventListener( 'is.post-load', lazy_load_init );
 
 		// Add event to provide optional compatibility for other code.
 		bodyEl.addEventListener( 'jetpack-lazy-images-load', lazy_load_init );
 	}
-
 
 	function lazy_load_init() {
 		images = document.querySelectorAll( 'img.jetpack-lazy-image:not(.jetpack-lazy-image--handled)' );

--- a/modules/lazy-images/js/lazy-images.js
+++ b/modules/lazy-images/js/lazy-images.js
@@ -102,7 +102,6 @@ var jetpackLazyImagesModule = function() {
 	function applyImage( image ) {
 		var srcset,
 			sizes,
-			imageClone,
 			lazyLoadedImageEvent;
 
 		if ( ! image instanceof HTMLImageElement ) {
@@ -111,26 +110,25 @@ var jetpackLazyImagesModule = function() {
 
 		srcset = image.getAttribute( 'data-lazy-srcset' );
 		sizes = image.getAttribute( 'data-lazy-sizes' );
-		imageClone = image.cloneNode();
 
-		// Remove lazy attributes from the clone.
-		imageClone.removeAttribute( 'data-lazy-srcset' ),
-		imageClone.removeAttribute( 'data-lazy-sizes' );
-		imageClone.removeAttribute( 'data-lazy-src' );
+		// Remove lazy attributes.
+		image.removeAttribute( 'data-lazy-srcset' ),
+		image.removeAttribute( 'data-lazy-sizes' );
+		image.removeAttribute( 'data-lazy-src' );
 
-		// Add the attributes we want on the finished image.
-		imageClone.classList.add( 'jetpack-lazy-image--handled' );
-		imageClone.setAttribute( 'data-lazy-loaded', 1 );
-		if ( ! srcset ) {
-			imageClone.removeAttribute( 'srcset' );
-		} else {
-			imageClone.setAttribute( 'srcset', srcset );
-		}
+		// Add the attributes we want.
+		image.classList.add( 'jetpack-lazy-image--handled' );
+		image.setAttribute( 'data-lazy-loaded', 1 );
+
 		if ( sizes ) {
-			imageClone.setAttribute( 'sizes', sizes );
+			image.setAttribute( 'sizes', sizes );
 		}
 
-		image.parentNode.replaceChild( imageClone, image );
+		if ( ! srcset ) {
+			image.removeAttribute( 'srcset' );
+		} else {
+			image.setAttribute( 'srcset', srcset );
+		}
 
 		// Fire an event so that third-party code can perform actions after an image is loaded.
 		try {
@@ -143,7 +141,7 @@ var jetpackLazyImagesModule = function() {
 			lazyLoadedImageEvent.initEvent( 'jetpack-lazy-loaded-image', true, true );
 		}
 
-		imageClone.dispatchEvent( lazyLoadedImageEvent );
+		image.dispatchEvent( lazyLoadedImageEvent );
 	}
 };
 

--- a/modules/lazy-images/lazy-images.php
+++ b/modules/lazy-images/lazy-images.php
@@ -351,7 +351,7 @@ class Jetpack_Lazy_Images {
 				'_inc/build/lazy-images/js/lazy-images.min.js',
 				'modules/lazy-images/js/lazy-images.js'
 			),
-			array( 'jquery' ),
+			array(),
 			JETPACK__VERSION,
 			true
 		);


### PR DESCRIPTION
Rewrites the `lazy-images` module to not depend on jQuery.

Fixes https://github.com/Automattic/jetpack/issues/14863

#### Changes proposed in this Pull Request:
* Removed jQuery calls and rewritten the code in vanilla JS.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an improvement to the `lazy-images` module.

#### Testing instructions:
* Make sure to test on a theme that doesn't pull jQuery in by default. (Tested on `twentytwenty` locally.)
* Go to Jetpack > Settings > Performance.
* Enable Lazy Loading for images.
* Make sure no other Jetpack features are enabled.
* Create a post with a couple of images.
* Visit the post.
* Observe there is no jQuery being added to the page.
* Observe the images continue to be loaded lazily as before.

#### Proposed changelog entry for your changes:
* Rewritten the jQuery logic in `lazy-images` in vanilla JS.