### PR TITLE
Revue Block: Update Input Placeholders Color and Default Text

### DIFF
--- a/extensions/blocks/revue/attributes.js
+++ b/extensions/blocks/revue/attributes.js
@@ -18,7 +18,7 @@ export default {
 	},
 	emailPlaceholder: {
 		type: 'string',
-		default: __( 'Your email address…', 'jetpack' ),
+		default: __( 'Enter your email address', 'jetpack' ),
 	},
 	firstNameLabel: {
 		type: 'string',
@@ -26,7 +26,7 @@ export default {
 	},
 	firstNamePlaceholder: {
 		type: 'string',
-		default: __( 'First name… (Optional)', 'jetpack' ),
+		default: __( 'Enter your first name', 'jetpack' ),
 	},
 	firstNameShow: {
 		type: 'boolean',
@@ -38,7 +38,7 @@ export default {
 	},
 	lastNamePlaceholder: {
 		type: 'string',
-		default: __( 'Last name… (Optional)', 'jetpack' ),
+		default: __( 'Enter your last name', 'jetpack' ),
 	},
 	lastNameShow: {
 		type: 'boolean',

--- a/extensions/blocks/revue/editor.scss
+++ b/extensions/blocks/revue/editor.scss
@@ -2,11 +2,16 @@
 	.components-base-control {
 		margin-bottom: 16px;
 	}
+
 	.components-base-control__label {
 		display: block;
 	}
 
 	.components-placeholder__learn-more {
 		margin-top: 1em;
+	}
+
+	.components-text-control__input {
+		color: #72777c;
 	}
 }

--- a/extensions/blocks/revue/revue.php
+++ b/extensions/blocks/revue/revue.php
@@ -215,12 +215,12 @@ function jetpack_get_revue_attribute( $attribute, $attributes ) {
 	$default_attributes = array(
 		'text'                 => __( 'Subscribe', 'jetpack' ),
 		'emailLabel'           => __( 'Email address', 'jetpack' ),
-		'emailPlaceholder'     => __( 'Your email address…', 'jetpack' ),
+		'emailPlaceholder'     => __( 'Enter your email address', 'jetpack' ),
 		'firstNameLabel'       => __( 'First name', 'jetpack' ),
-		'firstNamePlaceholder' => __( 'First name… (Optional)', 'jetpack' ),
+		'firstNamePlaceholder' => __( 'Enter your first name', 'jetpack' ),
 		'firstNameShow'        => true,
 		'lastNameLabel'        => __( 'Last name', 'jetpack' ),
-		'lastNamePlaceholder'  => __( 'Last name… (Optional)', 'jetpack' ),
+		'lastNamePlaceholder'  => __( 'Enter your last name', 'jetpack' ),
 		'lastNameShow'         => true,
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the Revue block placeholders color in the editor when the field is not being edited in order to make it look more like a placeholder than the value of an input field (which it technically is).
The chosen color is the same used by the Contact Form block for the same purpose.

* Update the Revue block placeholders default texts, removing the unnecessary "(Optional)" text, and making them more similar to the Mailchimp block placeholders.
Mailchimp uses a simple "Enter your email" text, but for Revue I've chosen to use "Enter your email address", as the field label is "Email address", and just "email" felt a bit awkward to me.
cc @davemart-in if you have any thoughts on improving the input placeholders here

<img width="614" alt="Screenshot 2020-03-04 at 15 26 08" src="https://user-images.githubusercontent.com/2070010/75925605-96384c80-5e2e-11ea-81f6-c8f8c39aa06b.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p58i-8Du-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Revue block.
* Make sure the new default placeholders are the same as in the screenshot.
* Make sure the input fields placeholders color is gray when the field is not selected, and black when editing it.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Revue block: update input placeholders color and default text
