### PR TITLE
Instant Search: Fix inputted characters being dropped

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -17,40 +17,19 @@ import SearchSort from './search-sort';
 import { getSortQuery } from '../lib/query-string';
 
 let initiallyFocusedElement = null;
-
-const cb = ( overlayElement, inputElement ) => event => {
-	if (
-		event &&
-		event.target &&
-		! event.target.classList.contains( 'jetpack-instant-search__overlay' )
-	) {
-		return;
-	}
-
-	if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
-		initiallyFocusedElement = document.activeElement;
-		inputElement.focus();
-		return;
-	}
-	initiallyFocusedElement && initiallyFocusedElement.focus();
+const stealFocusWithInput = inputElement => () => {
+	initiallyFocusedElement = document.activeElement;
+	inputElement.focus();
 };
+const restoreFocus = () => initiallyFocusedElement && initiallyFocusedElement.focus();
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	const inputRef = useRef( null );
 
 	useEffect( () => {
-		const overlayElement = document.querySelector( '.jetpack-instant-search__overlay' );
-		overlayElement.addEventListener(
-			'transitionend',
-			cb( overlayElement, inputRef.current ),
-			true
-		);
-		cb( overlayElement, inputRef.current )(); // invoke focus if page loads with overlay already present
-		return () => {
-			overlayElement.removeEventListener( 'transitionend', cb );
-		};
-	}, [] );
+		props.isVisible ? stealFocusWithInput( inputRef.current )() : restoreFocus();
+	}, [ props.isVisible ] );
 
 	return (
 		<Fragment>

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -48,6 +48,7 @@ class SearchForm extends Component {
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
 						enableFilters
+						isVisible={ this.props.isVisible }
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -66,6 +66,7 @@ class SearchResults extends Component {
 				<SearchForm
 					className="jetpack-instant-search__search-results-search-form"
 					isLoading={ this.props.isLoading }
+					isVisible={ this.props.isVisible }
 					locale={ this.props.locale }
 					postTypes={ this.props.postTypes }
 					response={ this.props.response }


### PR DESCRIPTION
Fixes #14872.

#### Changes proposed in this Pull Request:
* Simplifies focus capture logic by relying on overlay state toggle instead of the browser's `transitionend` event.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. 

2. Enter a site search. Ensure that no characters are being dropped while the overlay is being transitioned onto the page.

#### Proposed changelog entry for your changes:
* None.
