### PR TITLE
Update block scaffolding to use the withNotices HOC

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -28,5 +28,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "seo", "cool-block" ]
+	"beta": [ "amazon", "seo" ]
 }

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -28,5 +28,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "seo" ]
+	"beta": [ "amazon", "seo", "cool-block" ]
 }

--- a/wp-cli-templates/block-edit-js.mustache
+++ b/wp-cli-templates/block-edit-js.mustache
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockIcon } from '@wordpress/block-editor';
-import { Notice, Placeholder } from '@wordpress/components';
+import { Placeholder, withNotices } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 /**
@@ -12,7 +12,7 @@ import { useState } from '@wordpress/element';
 import './editor.scss';
 import icon from './icon';
 
-export default function {{ className }}Edit( { attributes, className, setAttributes } ) {
+function {{ className }}Edit( { attributes, className, noticeOperations, noticeUI, setAttributes } ) {
 	/**
 	 * Write the block editor UI.
 	 *
@@ -21,7 +21,10 @@ export default function {{ className }}Edit( { attributes, className, setAttribu
 	const [ notice, setNotice ] = useState();
 
 	/* Call this function when you want to show an error in the placeholder. */
-	const setErrorNotice = () => setNotice( __( 'Put error message here.', 'jetpack' ) );
+	const setErrorNotice = () => {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice( __( 'Put error message here.', 'jetpack' ) );
+	};
 
 	return (
 		<div className={ className }>
@@ -29,16 +32,12 @@ export default function {{ className }}Edit( { attributes, className, setAttribu
 				label={ __( '{{ title }}', 'jetpack' ) }
 				instructions={ __( 'Instructions go here.', 'jetpack' ) }
 				icon={ <BlockIcon icon={ icon } /> }
-				notices={
-					notice && (
-						<Notice status="error" isDismissible={ false }>
-							{ notice }
-						</Notice>
-					)
-				}
+				notices={ noticeUI }
 			>
 				{ __( 'User input goes here?', 'jetpack' ) }
 			</Placeholder>
 		</div>
 	);
 }
+
+export default {{ className }}Edit;


### PR DESCRIPTION
In of https://github.com/Automattic/jetpack/pull/14884 we realised we were doing notices wrongly. We should update the block scaffolding to do it the right way.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the block scaffolding to use the `withNotices` HOC

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- change to existing feature

#### Testing instructions:

- Run yarn docker:wp jetpack scaffold block "Cool block"
- Open the editor
- Try adding a "Cool block" to the editor.
- Check that the block loads correctly

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
