### PR TITLE
Debug tests: adds sync health card, and allows test to be hidden on site health page

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -429,9 +429,9 @@ class Jetpack_Cxn_Test_Base {
 				}
 			} else {
 				$result['description'] .= sprintf(
-					                          '<p>%s</p>',
-					                          __( 'There was another problem:', 'jetpack' )
-				                          ) . ' ' . $fail['message'] . ': ' . $fail['resolution'];
+					'<p>%s</p>',
+					__( 'There was another problem:', 'jetpack' )
+				) . ' ' . $fail['message'] . ': ' . $fail['resolution'];
 				if ( 'critical' === $fail['severity'] ) { // In case the initial failure is only "recommended".
 					$result['status'] = 'critical';
 				}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -318,7 +318,7 @@ class Jetpack_Cxn_Test_Base {
 	 * - pass: bool|string True if the test passed. Default false.
 	 * - short_description: bool|string A brief, non-html description that will appear in CLI results, and as headings in admin UIs. Default 'Test failed!'.
 	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
-	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
+	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: 'critical'.
 	 * - action: bool|string A URL for the recommended action. Default: false.
 	 * - action_label: bool|string The label for the recommended action. Default: false.
 	 * - show_in_site_health: bool True if the test should be shown on the Site Health page. Default: true
@@ -429,9 +429,9 @@ class Jetpack_Cxn_Test_Base {
 				}
 			} else {
 				$result['description'] .= sprintf(
-					'<p>%s</p>',
-					__( 'There was another problem:', 'jetpack' )
-				) . ' ' . $fail['message'] . ': ' . $fail['resolution'];
+					                          '<p>%s</p>',
+					                          __( 'There was another problem:', 'jetpack' )
+				                          ) . ' ' . $fail['message'] . ': ' . $fail['resolution'];
 				if ( 'critical' === $fail['severity'] ) { // In case the initial failure is only "recommended".
 					$result['status'] = 'critical';
 				}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -495,6 +495,48 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	}
 
 	/**
+	 * If Sync is enabled, this test will be skipped. If Sync is disabled, the test will fail.
+	 * Eventually, we'll make this test more robust with additional states. Here is the plan for possible Sync states,
+	 * including states that are planned but not yet implemented.
+	 *
+	 * Enabled: Skips test
+	 * Disabled: Results in a failing test
+	 * Healthy: @todo
+	 * In Progress: @todo
+	 * Delayed: @todo
+	 * Error: @todo
+	 */
+	protected function test__sync_health() {
+		$name = __FUNCTION__;
+		if ( ! $this->helper_is_jetpack_connected() ) {
+			// If the site is not connected, there is no point in testing Sync health.
+			return self::skipped_test( array( 'name' => $name, 'show_in_site_health' => false ) );
+		}
+		if ( Sync_Settings::is_sync_enabled() ) {
+			return self::skipped_test( array( 'name' => $name ) );
+		}
+		return self::failing_test( array(
+			'name' => $name,
+			'label' => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
+			'severity' => 'recommended',
+			'action' => 'https://github.com/Automattic/jetpack/blob/master/packages/sync/src/class-settings.php',
+			'action_label' => __( 'See Github for more on Sync Settings', 'jetpack' ),
+			'short_description' => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
+			'long_description' => sprintf(
+				'<p>%1$s</p>' .
+				'<p>%2$s</p>' .
+				'<p><span class="dashicons fail"><span class="screen-reader-text">%3$s</span></span> %4$s<strong> %5$s</strong></p>',
+				__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
+				__( 'Developers may enable / disable syncing using the Sync Settings API.', 'jetpack' ),
+				/* translators: screen reader text indicating a test failed */
+				__( 'Error', 'jetpack' ),
+				__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work.', 'jetpack' ),
+				__( 'We recommend enabling Sync.', 'jetpack' )
+			)
+		) );
+	}
+
+	/**
 	 * Calls to WP.com to run the connection diagnostic testing suite.
 	 *
 	 * Intentionally added last as it will be skipped if any local failed conditions exist.

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -103,3 +103,4 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 
 	return $core_tests;
 }
+

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -103,4 +103,3 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 
 	return $core_tests;
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes n/a

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On the site health page, if sync is disabled, let's show a recommended improvement:
![Screen Shot 2020-03-06 at 2 54 08 PM](https://user-images.githubusercontent.com/2694219/76117783-76ce2a80-5fba-11ea-905e-079f94ecbc96.png)

* This PR also refactors debug tests to allow a test to be hidden on the site health page. For example, current a skipped test will still appear on the Site Health page as being successfully passed. For sync health, there are some cases where we don't want to show it at all.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds a new debug test

#### Testing instructions:
* Apply this PR to a testing site.
* Ensure the site is connected.
* On the debug page for your site (https://jetpack.com/support/debug/?url=$url) disable sync
* Visit the site health page in wp-admin ( tools->site health )
* Ensure you see the card for Jetpack sync
* There should be no sync card when Jetpack is disconnected, nor when Jetpack is connected and sync is enabled.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
