### PR TITLE
Contact Form Block: Fix Missing Button Color Attributes

### DIFF
--- a/extensions/blocks/amazon/attributes.js
+++ b/extensions/blocks/amazon/attributes.js
@@ -1,18 +1,20 @@
-const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
-const colourValidator = value => hexRegex.test( value );
+/**
+ * Internal dependencies
+ */
+import colorValidator from '../../shared/colorValidator';
 
 export default {
 	backgroundColor: {
 		type: 'string',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	textColor: {
 		type: 'string',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	buttonAndLinkColor: {
 		type: 'string',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	style: {
 		type: 'string',

--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -3,9 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 
-const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
-
-const colourValidator = value => hexRegex.test( value );
+/**
+ * Internal dependencies
+ */
+import colorValidator from '../../shared/colorValidator';
 
 const urlValidator = url => ! url || url.startsWith( 'https://calendly.com/' );
 
@@ -13,7 +14,7 @@ export default {
 	backgroundColor: {
 		type: 'string',
 		default: 'ffffff',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	submitButtonText: {
 		type: 'string',
@@ -33,12 +34,12 @@ export default {
 	primaryColor: {
 		type: 'string',
 		default: '00A2FF',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	textColor: {
 		type: 'string',
 		default: '4D5055',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	style: {
 		type: 'string',
@@ -57,10 +58,10 @@ export default {
 	},
 	customBackgroundButtonColor: {
 		type: 'string',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	customTextButtonColor: {
 		type: 'string',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 };

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -17,6 +17,7 @@ import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import renderMaterialIcon from '../../shared/render-material-icon';
+import colorValidator from '../../shared/colorValidator';
 
 export const name = 'contact-form';
 
@@ -48,8 +49,20 @@ export const settings = {
 			type: 'string',
 			default: __( 'Submit', 'jetpack' ),
 		},
-		customBackgroundButtonColor: { type: 'string' },
-		customTextButtonColor: { type: 'string' },
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
+		customBackgroundButtonColor: {
+			type: 'string',
+			validator: colorValidator,
+		},
+		customTextButtonColor: {
+			type: 'string',
+			validator: colorValidator,
+		},
 		submitButtonClasses: { type: 'string' },
 		hasFormSettingsSet: {
 			type: 'string',

--- a/extensions/shared/colorValidator.js
+++ b/extensions/shared/colorValidator.js
@@ -1,5 +1,5 @@
 const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
 
-export default function colourValidator( value ) {
+export default function colorValidator( value ) {
 	return hexRegex.test( value );
 }

--- a/extensions/shared/colorValidator.js
+++ b/extensions/shared/colorValidator.js
@@ -1,0 +1,5 @@
+const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
+
+export default function colourValidator( value ) {
+	return hexRegex.test( value );
+}

--- a/extensions/shared/test/get-validated-attributes.js
+++ b/extensions/shared/test/get-validated-attributes.js
@@ -1,11 +1,8 @@
 /**
  * Internal dependencies
  */
+import colorValidator from '../colorValidator';
 import { getValidatedAttributes } from '../get-validated-attributes';
-
-const hexRegex = /^#?[A-Fa-f0-9]{6}$/;
-
-const colourValidator = value => hexRegex.test( value );
 
 const urlValidator = url => ! url || url.startsWith( 'http' );
 
@@ -17,7 +14,7 @@ const defaultAttributes = {
 	color: {
 		default: 'ffffff',
 		type: 'string',
-		validator: colourValidator,
+		validator: colorValidator,
 	},
 	language: {
 		default: 'en',
@@ -36,116 +33,80 @@ const defaultAttributes = {
 
 describe( 'getValidatedAttributes', () => {
 	test( 'boolean attributes', () => {
-		expect(
-			getValidatedAttributes( defaultAttributes, { boolean: true } )
-		).toStrictEqual(
-			{ boolean: true }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { boolean: true } ) ).toStrictEqual( {
+			boolean: true,
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { boolean: 'true' } )
-		).toStrictEqual(
-			{ boolean: true }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { boolean: 'true' } ) ).toStrictEqual( {
+			boolean: true,
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { boolean: false } )
-		).toStrictEqual(
-			{ boolean: false }
-		);
+		expect( getValidatedAttributes( defaultAttributes, { boolean: false } ) ).toStrictEqual( {
+			boolean: false,
+		} );
 
-        expect(
-			getValidatedAttributes( defaultAttributes, { boolean: 'false' } )
-		).toStrictEqual(
-			{ boolean: false }
-		);
-
+		expect( getValidatedAttributes( defaultAttributes, { boolean: 'false' } ) ).toStrictEqual( {
+			boolean: false,
+		} );
 	} );
 
 	test( 'attributes with a validator function', () => {
-		expect(
-			getValidatedAttributes( defaultAttributes, { color: 'ffffff' } )
-		).toStrictEqual(
-			{ color: 'ffffff' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { color: 'ffffff' } ) ).toStrictEqual( {
+			color: 'ffffff',
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { color: 'white' } )
-		).toStrictEqual(
-			{ color: 'ffffff' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { color: 'white' } ) ).toStrictEqual( {
+			color: 'ffffff',
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { color: '000000' } )
-		).toStrictEqual(
-			{ color: '000000' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { color: '000000' } ) ).toStrictEqual( {
+			color: '000000',
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { color: 'black' } )
-		).toStrictEqual(
-			{ color: 'ffffff' }
-        );
-    } );
+		expect( getValidatedAttributes( defaultAttributes, { color: 'black' } ) ).toStrictEqual( {
+			color: 'ffffff',
+		} );
+	} );
 
 	test( 'attributes with valid values', () => {
-		expect(
-			getValidatedAttributes( defaultAttributes, { language: 'en' } )
-		).toStrictEqual(
-			{ language: 'en' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { language: 'en' } ) ).toStrictEqual( {
+			language: 'en',
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { language: 'fr' } )
-		).toStrictEqual(
-			{ language: 'fr' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { language: 'fr' } ) ).toStrictEqual( {
+			language: 'fr',
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { language: 'pt' } )
-		).toStrictEqual(
-			{ language: 'en' }
-        );
-    } );
+		expect( getValidatedAttributes( defaultAttributes, { language: 'pt' } ) ).toStrictEqual( {
+			language: 'en',
+		} );
+	} );
 
 	test( 'attributes without a default values', () => {
 		expect(
 			getValidatedAttributes( defaultAttributes, { url: 'http://jetpack.com' } )
-		).toStrictEqual(
-			{ url: 'http://jetpack.com' }
-        );
+		).toStrictEqual( { url: 'http://jetpack.com' } );
 
 		expect(
 			getValidatedAttributes( defaultAttributes, { url: 'https://jetpack.com' } )
-		).toStrictEqual(
-			{ url: 'https://jetpack.com' }
-        );
+		).toStrictEqual( { url: 'https://jetpack.com' } );
 
-
-		expect(
-			getValidatedAttributes( defaultAttributes, { url: 'jetpack.com' } )
-		).toStrictEqual(
-			{ url: undefined }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { url: 'jetpack.com' } ) ).toStrictEqual( {
+			url: undefined,
+		} );
 	} );
 
 	test( 'attributes without validation', () => {
-		expect(
-			getValidatedAttributes( defaultAttributes, { freeform: 'one' } )
-		).toStrictEqual(
-			{ freeform: 'one' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { freeform: 'one' } ) ).toStrictEqual( {
+			freeform: 'one',
+		} );
 
-		expect(
-			getValidatedAttributes( defaultAttributes, { freeform: 'two' } )
-		).toStrictEqual(
-			{ freeform: 'two' }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { freeform: 'two' } ) ).toStrictEqual( {
+			freeform: 'two',
+		} );
 
-        expect(
-			getValidatedAttributes( defaultAttributes, { freeform: undefined } )
-		).toStrictEqual(
-			{ freeform: undefined }
-        );
+		expect( getValidatedAttributes( defaultAttributes, { freeform: undefined } ) ).toStrictEqual( {
+			freeform: undefined,
+		} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The Contact Form block was missing the `textButtonColor` and `backgroundButtonColor` attributes, necessary to make it work with the `SubmitButton` shared component.
This practically means that, currently, you can change the colors of the Contact Form submit button, you will see the button preview updating correctly (as the colors are applied as CSS classes in the editor), but if you save the post and reload, the colors are not saved.
This only happens for "named" colors; custom colors work fine, as their attributes are not missing.

This PR adds those missing two attributes to the Contact Form block.
Also, externalizes the `colourValidator` utility that was being carelessly copypasted around.
I've also americanized the function name, as it's more consistent with the fact that we use `color` everywhere, and I'm ready to fight my British colleagues about it! 😄 

Note: most changed lines here are automatic Prettier changes on the test file. 😭 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Contact Form block.
* Modify the button colors, picking from the named colors palette.
* Make sure the button updates correctly.
* Save and reload the editor.
* Make sure the button shows up with the correct colors.
* Try again with custom colors, and make sure there are no regressions.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Contact Form Block: Fix button colors not saving correctly.