### PR TITLE
Remove composer dependency listing for built branches

### DIFF
--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -261,12 +261,11 @@ yarn cache clean
 COMPOSER_MIRROR_PATH_REPOS=1 yarn run build-production
 echo "Done"
 
-# Remove composer dependencies listing.
+echo "Remove composer dependencies listing"
 # Workaround for https://github.com/Automattic/jetpack/issues/13497
 # TODO: Keep dependencies away from built branches and fetch them before publishing on WP-org plugins repository.
-awk '!/automattic\/jetpack-/' composer.json > temp && mv temp composer.json
-sed 's/openssl": "\*",/openssl": "\*"/' composer.json > temp && mv temp composer.json
-rm -f composer.lock
+composer remove "automattic/*" --no-update
+echo "Done"
 
 # Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.
 rm -rf TMP_REMOTE_BUILT_VERSION

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -304,6 +304,7 @@ echo "Done! Branch $BUILD_TARGET has been updated."
 
 echo "Cleaning up the mess"
 cd $DIR
+git checkout -- composer.json
 rm -rf TMP_REMOTE_BUILT_VERSION
 rm -rf TMP_LOCAL_BUILT_VERSION
 echo "All clean!"

--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -261,6 +261,13 @@ yarn cache clean
 COMPOSER_MIRROR_PATH_REPOS=1 yarn run build-production
 echo "Done"
 
+# Remove composer dependencies listing.
+# Workaround for https://github.com/Automattic/jetpack/issues/13497
+# TODO: Keep dependencies away from built branches and fetch them before publishing on WP-org plugins repository.
+awk '!/automattic\/jetpack-/' composer.json > temp && mv temp composer.json
+sed 's/openssl": "\*",/openssl": "\*"/' composer.json > temp && mv temp composer.json
+rm -f composer.lock
+
 # Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.
 rm -rf TMP_REMOTE_BUILT_VERSION
 rm -rf TMP_LOCAL_BUILT_VERSION


### PR DESCRIPTION
Fixes #13497

#### Changes proposed in this Pull Request:

* Remove composer dependency listing for built branches.
Ref: https://github.com/Automattic/jetpack/issues/13497

See my comments inline for detail, and please let me know if there is a better way!

#### Testing instructions:

N/A

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not sure it's really needed.

🚀 