### PR TITLE
Debug tests: refactor for clarity

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -311,6 +311,9 @@ class Jetpack_Cxn_Test_Base {
 		}
 		// Provide standard resolutions steps, but allow pass-through of non-standard ones.
 		switch ( $resolution ) {
+			case 'connect_jetpack':
+				$resolution = __( 'Reconnect your site now.', 'jetpack' );
+				break;
 			case 'cycle_connection':
 				$resolution = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
 				break;

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -244,101 +244,105 @@ class Jetpack_Cxn_Test_Base {
 
 	/**
 	 * Helper function to return consistent responses for a passing test.
+	 * Possible Args:
+	 * - name: string The raw method name that runs the test. Default 'unnamed_test'.
+	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
+	 * - pass: bool|string True if the test passed. Default true.
+	 * - short_description: bool|string A brief, non-html description that will appear in CLI results. Default 'Test passed!'.
+	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
+	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
+	 * - action: bool|string A URL for the recommended action. Default: false
+	 * - action_label: bool|string The label for the recommended action. Default: false
+	 * - show_in_site_health: bool True if the test should be shown on the Site Health page. Default: true
 	 *
-	 * @param string      $name Test name.
-	 * @param string|bool $message Plain text message to show when test passed.
-	 * @param string|bool $label Label to be used on Site Health card.
-	 * @param string|bool $description HTML description to be used in Site Health card.
+	 * @param array $args Arguments to override defaults.
 	 *
 	 * @return array Test results.
 	 */
-	public static function passing_test( $name = 'Unnamed', $message = false, $label = false, $description = false ) {
-		if ( ! $message ) {
-			$message = __( 'Test Passed!', 'jetpack' );
-		}
-		return array(
-			'name'        => $name,
-			'pass'        => true,
-			'message'     => $message,
-			'description' => $description,
-			'resolution'  => false,
-			'severity'    => false,
-			'label'       => $label,
+	public static function passing_test( $args ) {
+		return wp_parse_args(
+			$args,
+			array(
+				'name'                => 'unnamed_test',
+				'label'               => false,
+				'pass'                => true,
+				'short_description'   => __( 'Test passed!', 'jetpack' ),
+				'long_description'    => false,
+				'severity'            => false,
+				'action'              => false,
+				'action_label'        => false,
+				'show_in_site_health' => true,
+			)
 		);
 	}
 
 	/**
 	 * Helper function to return consistent responses for a skipped test.
+	 * Possible Args:
+	 * - name: string The raw method name that runs the test. Default unnamed_test.
+	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
+	 * - pass: bool|string True if the test passed. Default 'skipped'.
+	 * - short_description: bool|string A brief, non-html description that will appear in CLI results, and as headings in admin UIs. Default false.
+	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
+	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
+	 * - action: bool|string A URL for the recommended action. Default: false
+	 * - action_label: bool|string The label for the recommended action. Default: false
+	 * - show_in_site_health: bool True if the test should be shown on the Site Health page. Default: true
 	 *
-	 * @param string $name Test name.
-	 * @param string $message Reason for skipping the test. Optional.
-	 * @param bool   $show_in_site_health True if we should show the skipped test on the site health page.
+	 * @param array $args Arguments to override defaults.
 	 *
 	 * @return array Test results.
 	 */
-	public static function skipped_test( $name = 'Unnamed', $message = false, $show_in_site_health = true ) {
-		return array(
-			'name'                => $name,
-			'pass'                => 'skipped',
-			'message'             => $message,
-			'resolution'          => false,
-			'severity'            => false,
-			'show_in_site_health' => $show_in_site_health,
+	public static function skipped_test( $args = array() ) {
+		return wp_parse_args(
+			$args,
+			array(
+				'name'                => 'unnamed_test',
+				'label'               => false,
+				'pass'                => 'skipped',
+				'short_description'   => false,
+				'long_description'    => false,
+				'severity'            => false,
+				'action'              => false,
+				'action_label'        => false,
+				'show_in_site_health' => true,
+			)
 		);
 	}
 
 	/**
 	 * Helper function to return consistent responses for a failing test.
+	 * Possible Args:
+	 * - name: string The raw method name that runs the test. Default unnamed_test.
+	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
+	 * - pass: bool|string True if the test passed. Default false.
+	 * - short_description: bool|string A brief, non-html description that will appear in CLI results, and as headings in admin UIs. Default 'Test failed!'.
+	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
+	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
+	 * - action: bool|string A URL for the recommended action. Default: false.
+	 * - action_label: bool|string The label for the recommended action. Default: false.
+	 * - show_in_site_health: bool True if the test should be shown on the Site Health page. Default: true
 	 *
 	 * @since 7.1.0
-	 * @since 7.3.0 Added $action for resolution action link, $severity for issue severity.
 	 *
-	 * @param string      $name Test name.
-	 * @param string      $message Message detailing the failure.
-	 * @param string      $resolution Optional. Steps to resolve.
-	 * @param string      $action Optional. URL to direct users to self-resolve.
-	 * @param string      $severity Optional. "critical" or "recommended" for failure stats. "good" for passing.
-	 * @param string      $label Optional. The label to use instead of the test name.
-	 * @param string|bool $action_label Optional. The label for the action url instead of default 'Resolve'.
-	 * @param string|bool $description Optional. An HTML description to override resolution.
+	 * @param array $args Arguments to override defaults.
 	 *
 	 * @return array Test results.
 	 */
-	public static function failing_test( $name, $message, $resolution = false, $action = false, $severity = 'critical', $label = false, $action_label = false, $description = false ) {
-		if ( ! $action_label ) {
-			/* translators: Resolve is used as a verb, a command that when invoked will lead to a problem's solution. */
-			$action_label = __( 'Resolve', 'jetpack' );
-		}
-		// Provide standard resolutions steps, but allow pass-through of non-standard ones.
-		switch ( $resolution ) {
-			case 'connect_jetpack':
-				$resolution = __( 'Reconnect your site now.', 'jetpack' );
-				break;
-			case 'cycle_connection':
-				$resolution = __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ); // @todo: Link.
-				break;
-			case 'outbound_requests':
-				$resolution = __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.', 'jetpack' );
-				break;
-			case 'support':
-			case 'enable_sync':
-				$resolution = __( 'We recommend enabling Sync.', 'jetpack' );
-				break;
-			case false:
-				$resolution = __( 'Please contact Jetpack support.', 'jetpack' ); // @todo: Link to support.
-				break;
-		}
-
-		return array(
-			'name'         => $name,
-			'pass'         => false,
-			'message'      => $message,
-			'resolution'   => $resolution,
-			'action'       => $action,
-			'severity'     => $severity,
-			'label'        => $label,
-			'action_label' => $action_label,
-			'description'  => $description,
+	public static function failing_test( $args ) {
+		return wp_parse_args(
+			$args,
+			array(
+				'name'                => 'unnamed_test',
+				'label'               => false,
+				'pass'                => false,
+				'short_description'   => __( 'Test failed!', 'jetpack' ),
+				'long_description'    => false,
+				'severity'            => 'critical',
+				'action'              => false,
+				'action_label'        => false,
+				'show_in_site_health' => true,
+			)
 		);
 	}
 
@@ -363,12 +367,12 @@ class Jetpack_Cxn_Test_Base {
 					WP_CLI::log( WP_CLI::colorize( '%gPassed:%n  ' . $test['name'] ) );
 				} elseif ( 'skipped' === $test['pass'] ) {
 					WP_CLI::log( WP_CLI::colorize( '%ySkipped:%n ' . $test['name'] ) );
-					if ( $test['message'] ) {
-						WP_CLI::log( '         ' . $test['message'] ); // Number of spaces to "tab indent" the reason.
+					if ( $test['short_description'] ) {
+						WP_CLI::log( '         ' . $test['short_description'] ); // Number of spaces to "tab indent" the reason.
 					}
 				} else { // Failed.
 					WP_CLI::log( WP_CLI::colorize( '%rFailed:%n  ' . $test['name'] ) );
-					WP_CLI::log( '         ' . $test['message'] ); // Number of spaces to "tab indent" the reason.
+					WP_CLI::log( '         ' . $test['short_description'] ); // Number of spaces to "tab indent" the reason.
 				}
 			}
 		}
@@ -458,9 +462,11 @@ class Jetpack_Cxn_Test_Base {
 
 		foreach ( $fails as $result ) {
 			$code    = 'failed_' . $result['name'];
-			$message = $result['message'];
+			$message = $result['short_description'];
 			$data    = array(
-				'resolution' => $result['resolution'],
+				'resolution' => $result['action'] ?
+					$result['action_label'] . ' :' . $result['action'] :
+					'',
 			);
 			if ( ! $error ) {
 				$error = new WP_Error( $code, $message, $data );

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -318,6 +318,9 @@ class Jetpack_Cxn_Test_Base {
 				$resolution = __( 'Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.', 'jetpack' );
 				break;
 			case 'support':
+			case 'enable_sync':
+				$resolution = __( 'We recommend enabling Sync.', 'jetpack' );
+				break;
 			case false:
 				$resolution = __( 'Please contact Jetpack support.', 'jetpack' ); // @todo: Link to support.
 				break;

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -272,16 +272,18 @@ class Jetpack_Cxn_Test_Base {
 	 *
 	 * @param string $name Test name.
 	 * @param string $message Reason for skipping the test. Optional.
+	 * @param bool   $show_in_site_health True if we should show the skipped test on the site health page.
 	 *
 	 * @return array Test results.
 	 */
-	public static function skipped_test( $name = 'Unnamed', $message = false ) {
+	public static function skipped_test( $name = 'Unnamed', $message = false, $show_in_site_health = true ) {
 		return array(
-			'name'       => $name,
-			'pass'       => 'skipped',
-			'message'    => $message,
-			'resolution' => false,
-			'severity'   => false,
+			'name'                => $name,
+			'pass'                => 'skipped',
+			'message'             => $message,
+			'resolution'          => false,
+			'severity'            => false,
+			'show_in_site_health' => $show_in_site_health,
 		);
 	}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+use Automattic\Jetpack\Sync\Settings as Sync_Settings;
 
 /**
  * Class Jetpack_Cxn_Tests contains all of the actual tests.
@@ -360,6 +361,47 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			$resolution = __( 'Try adding the following to your wp-config.php file:', 'jetpack' ) . " define( '$needed_constant', $server_port );";
 			return self::failing_test( $name, $message, $resolution );
 		}
+	}
+
+	/**
+	 * If Sync is enabled, this test will be skipped. If Sync is disabled, the test will fail.
+	 * Eventually, we'll make this test more robust with additional states. Here is the plan for possible Sync states,
+	 * including states that are planned but not yet implemented.
+	 *
+	 * Enabled: Skips test
+	 * Disabled: Results in a failing test
+	 * Healthy: @todo
+	 * In Progress: @todo
+	 * Delayed: @todo
+	 * Error: @todo
+	 */
+	protected function test__sync_health() {
+		$name = __FUNCTION__;
+		if ( ! $this->helper_is_jetpack_connected() ) {
+			// If the site is not connected, there is no point in testing Sync health.
+			return self::skipped_test( $name, false, false );
+		}
+		if ( Sync_Settings::is_sync_enabled() ) {
+			return self::skipped_test( $name, false, false );
+		}
+		return self::failing_test(
+			$name,
+			__( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
+			'enable_sync',
+			admin_url( '#' ),
+			'recommended',
+			__( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
+			__( 'Learn more about enabling Sync', 'jetpack' ),
+			sprintf(
+				'<p>%1$s</p>' .
+				'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
+				__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
+				/* translators: screen reader text indicating a test failed */
+				__( 'Error', 'jetpack' ),
+				__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work.', 'jetpack' ),
+				__( 'We recommend enabling Sync.', 'jetpack' )
+			)
+		);
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -76,6 +76,41 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	}
 
 	/**
+	 * Returns a support url based on development mode.
+	 */
+	protected function helper_get_support_url() {
+		return Jetpack::is_development_version()
+			? 'https://jetpack.com/contact-support/beta-group/'
+			: 'https://jetpack.com/contact-support/';
+	}
+
+	/**
+	 * Gets translated support text.
+	 */
+	protected function helper_get_support_text() {
+		return __( 'Please contact Jetpack support.', 'jetpack' );
+	}
+
+	/**
+	 * Gets translated text to enable outbound requests.
+	 *
+	 * @param string $protocol Either 'HTTP' or 'HTTPS'.
+	 *
+	 * @return string The translated text.
+	 */
+	protected function helper_enable_outbound_requests( $protocol ) {
+		return sprintf(
+			/* translators: %1$s - request protocol, either http or https */
+			__(
+				'Your server did not successfully connect to the Jetpack server using %1$s
+				Please ask your hosting provider to confirm your server can make outbound requests to jetpack.com.',
+				'jetpack'
+			),
+			$protocol
+		);
+	}
+
+	/**
 	 * Returns 30 for use with a filter.
 	 *
 	 * To allow time for WP.com to run upstream testing, this function exists to increase the http_request_timeout value
@@ -94,37 +129,42 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = __FUNCTION__;
 		if ( $this->helper_is_jetpack_connected() ) {
 			$result = self::passing_test(
-				$name,
-				__( 'Test passed!', 'jetpack' ),
-				__( 'Your site is connected to Jetpack', 'jetpack' ),
-				sprintf(
-					'<p>%1$s</p>' .
-					'<p><span class="dashicons pass"><span class="screen-reader-text">%2$s</span></span> %3$s</p>',
-					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
-					/* translators: Screen reader text indicating a test has passed */
-					__( 'Passed', 'jetpack' ),
-					__( 'Your site is connected to Jetpack.', 'jetpack' )
+				array(
+					'name'             => $name,
+					'label'            => __( 'Your site is connected to Jetpack', 'jetpack' ),
+					'long_description' => sprintf(
+						'<p>%1$s</p>' .
+						'<p><span class="dashicons pass"><span class="screen-reader-text">%2$s</span></span> %3$s</p>',
+						__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
+						/* translators: Screen reader text indicating a test has passed */
+						__( 'Passed', 'jetpack' ),
+						__( 'Your site is connected to Jetpack.', 'jetpack' )
+					),
 				)
 			);
 		} elseif ( ( new Status() )->is_development_mode() ) {
-			$result = self::skipped_test( $name, __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(), __( 'Disable development mode.', 'jetpack' ) );
+			$result = self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(),
+				)
+			);
 		} else {
 			$result = self::failing_test(
-				$name,
-				__( 'Jetpack is not connected.', 'jetpack' ),
-				'connect_jetpack',
-				admin_url( 'admin.php?page=jetpack#/dashboard' ),
-				'critical',
-				__( 'Your site is not connected to Jetpack', 'jetpack' ),
-				__( 'Reconnect your site now', 'jetpack' ),
-				sprintf(
-					'<p>%1$s</p>' .
-					'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
-					__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
-					/* translators: screen reader text indicating a test failed */
-					__( 'Error', 'jetpack' ),
-					__( 'Your site is not connected to Jetpack.', 'jetpack' ),
-					__( 'We recommend reconnecting Jetpack.', 'jetpack' )
+				array(
+					'name'             => $name,
+					'label'            => __( 'Your site is not connected to Jetpack', 'jetpack' ),
+					'action'           => admin_url( 'admin.php?page=jetpack#/dashboard' ),
+					'action_label'     => __( 'Reconnect your site now', 'jetpack' ),
+					'long_description' => sprintf(
+						'<p>%1$s</p>' .
+						'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
+						__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),
+						/* translators: screen reader text indicating a test failed */
+						__( 'Error', 'jetpack' ),
+						__( 'Your site is not connected to Jetpack.', 'jetpack' ),
+						__( 'We recommend reconnecting Jetpack.', 'jetpack' )
+					),
 				)
 			);
 		}
@@ -140,14 +180,26 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__master_user_exists_on_site() {
 		$name = __FUNCTION__;
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return self::skipped_test( $name, __( 'Jetpack is not connected. No master user to check.', 'jetpack' ) ); // Skip test.
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Jetpack is not connected. No master user to check.', 'jetpack' ),
+				)
+			);
 		}
 		$local_user = $this->helper_retrieve_local_master_user();
 
 		if ( $local_user->exists() ) {
-			$result = self::passing_test( $name );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test( $name, __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ), 'cycle_connection' );
+			$result = self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'The user who setup the Jetpack connection no longer exists on this site.', 'jetpack' ),
+					'action_label'      => __( 'Please disconnect and reconnect Jetpack.', 'jetpack' ),
+					'action'            => 'https://jetpack.com/support/reconnecting-reinstalling-jetpack/',
+				)
+			);
 		}
 
 		return $result;
@@ -163,15 +215,27 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__master_user_can_manage_options() {
 		$name = __FUNCTION__;
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return self::skipped_test( $name, __( 'Jetpack is not connected.', 'jetpack' ) ); // Skip test.
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Jetpack is not connected.', 'jetpack' ),
+				)
+			);
 		}
 		$master_user = $this->helper_retrieve_local_master_user();
 
 		if ( user_can( $master_user, 'manage_options' ) ) {
-			$result = self::passing_test( $name );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			/* translators: a WordPress username */
-			$result = self::failing_test( $name, sprintf( __( 'The user (%s) who setup the Jetpack connection is not an administrator.', 'jetpack' ), $master_user->user_login ), __( 'Either upgrade the user or disconnect and reconnect Jetpack.', 'jetpack' ) ); // @todo: Link to the right places.
+			$result = self::failing_test(
+				array(
+					'name'              => $name,
+					/* translators: a WordPress username */
+					'short_description' => sprintf( __( 'The user (%s) who setup the Jetpack connection is not an administrator.', 'jetpack' ), $master_user->user_login ),
+					'action_label'      => __( 'Either upgrade the user or disconnect and reconnect Jetpack.', 'jetpack' ),
+					'action'            => 'https://jetpack.com/support/reconnecting-reinstalling-jetpack/',
+				)
+			);
 		}
 
 		return $result;
@@ -187,11 +251,18 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__xml_parser_available() {
 		$name = __FUNCTION__;
 		if ( function_exists( 'xml_parser_create' ) ) {
-			$result = self::passing_test( $name );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test( $name, __( 'PHP XML manipulation libraries are not available.', 'jetpack' ), __( "Please ask your hosting provider to refer to our server requirements at https://jetpack.com/support/server-requirements/ and enable PHP's XML module.", 'jetpack' ) );
+			$result = self::failing_test(
+				array(
+					'name'              => $name,
+					'label'             => __( 'PHP XML manipulation libraries are not available.', 'jetpack' ),
+					'short_description' => __( 'Please ask your hosting provider to refer to our server requirements and enable PHP\'s XML module.', 'jetpack' ),
+					'action_label'      => __( 'View our server requirements', 'jetpack' ),
+					'action'            => 'https://jetpack.com/support/server-requirements/',
+				)
+			);
 		}
-
 		return $result;
 	}
 
@@ -206,9 +277,14 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$code    = wp_remote_retrieve_response_code( $request );
 
 		if ( 200 === intval( $code ) ) {
-			$result = self::passing_test( $name );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTP', 'jetpack' ), 'outbound_requests' );
+			$result = self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => $this->helper_enable_outbound_requests( 'HTTP' ),
+				)
+			);
 		}
 
 		return $result;
@@ -225,9 +301,14 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$code    = wp_remote_retrieve_response_code( $request );
 
 		if ( 200 === intval( $code ) ) {
-			$result = self::passing_test( $name );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$result = self::failing_test( $name, __( 'Your server did not successfully connect to the Jetpack server using HTTPS', 'jetpack' ), 'outbound_requests' );
+			$result = self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => $this->helper_enable_outbound_requests( 'HTTPS' ),
+				)
+			);
 		}
 
 		return $result;
@@ -241,20 +322,31 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__identity_crisis() {
 		$name = __FUNCTION__;
 		if ( ! $this->helper_is_jetpack_connected() ) {
-			return self::skipped_test( $name, __( 'Jetpack is not connected.', 'jetpack' ) ); // Skip test.
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Jetpack is not connected.', 'jetpack' ),
+				)
+			);
 		}
 		$identity_crisis = Jetpack::check_identity_crisis();
 
 		if ( ! $identity_crisis ) {
-			$result = self::passing_test( $name );
+			$result = self::passing_test( array( 'name' => $name ) );
 		} else {
-			$message = sprintf(
-				/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
-				__( 'Your url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`!', 'jetpack' ),
-				$identity_crisis['home'],
-				$identity_crisis['wpcom_home']
+			$result = self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => sprintf(
+						/* translators: Two URLs. The first is the locally-recorded value, the second is the value as recorded on WP.com. */
+						__( 'Your url is set as `%1$s`, but your WordPress.com connection lists it as `%2$s`!', 'jetpack' ),
+						$identity_crisis['home'],
+						$identity_crisis['wpcom_home']
+					),
+					'action_label'      => $this->helper_get_support_text(),
+					'action'            => $this->helper_get_support_url(),
+				)
 			);
-			$result = self::failing_test( $name, $message, 'support' );
 		}
 		return $result;
 	}
@@ -271,7 +363,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$status = new Status();
 		if ( ! Jetpack::is_active() || $status->is_development_mode() || $status->is_staging_site() || ! $this->pass ) {
-			return self::skipped_test( $name );
+			return self::skipped_test( array( 'name' => $name ) );
 		}
 
 		add_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ) );
@@ -282,19 +374,36 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		remove_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ) );
 
 		if ( is_wp_error( $response ) ) {
-			/* translators: %1$s is the error code, %2$s is the error message */
-			$message = sprintf( __( 'Connection test failed (#%1$s: %2$s)', 'jetpack' ), $response->get_error_code(), $response->get_error_message() );
-			return self::failing_test( $name, $message );
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					/* translators: %1$s is the error code, %2$s is the error message */
+					'short_description' => sprintf( __( 'Connection test failed (#%1$s: %2$s)', 'jetpack' ), $response->get_error_code(), $response->get_error_message() ),
+					'action_label'      => $this->helper_get_support_text(),
+					'action'            => $this->helper_get_support_url(),
+				)
+			);
 		}
 
 		$body = wp_remote_retrieve_body( $response );
 		if ( ! $body ) {
-			$message = __( 'Connection test failed (empty response body)', 'jetpack' ) . wp_remote_retrieve_response_code( $response );
-			return self::failing_test( $name, $message );
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Connection test failed (empty response body)', 'jetpack' ) . wp_remote_retrieve_response_code( $response ),
+					'action_label'      => $this->helper_get_support_text(),
+					'action'            => $this->helper_get_support_url(),
+				)
+			);
 		}
 
 		if ( 404 === wp_remote_retrieve_response_code( $response ) ) {
-			return self::skipped_test( $name, __( 'The WordPress.com API returned a 404 error.', 'jetpack' ) );
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'The WordPress.com API returned a 404 error.', 'jetpack' ),
+				)
+			);
 		}
 
 		$result       = json_decode( $body );
@@ -302,9 +411,16 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$message      = $result->message . ': ' . wp_remote_retrieve_response_code( $response );
 
 		if ( $is_connected ) {
-			return self::passing_test( $name );
+			return self::passing_test( array( 'name' => $name ) );
 		} else {
-			return self::failing_test( $name, $message );
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => $message,
+					'action_label'      => $this->helper_get_support_text(),
+					'action'            => $this->helper_get_support_url(),
+				)
+			);
 		}
 	}
 
@@ -327,8 +443,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	protected function test__server_port_value() {
 		$name = __FUNCTION__;
 		if ( ! isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) && ! isset( $_SERVER['SERVER_PORT'] ) ) {
-			$message = 'The server port values are not defined. This is most common when running PHP via a CLI.';
-			return self::skipped_test( $name, $message );
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'The server port values are not defined. This is most common when running PHP via a CLI.', 'jetpack' ),
+				)
+			);
 		}
 		$site_port   = wp_parse_url( home_url(), PHP_URL_PORT );
 		$server_port = isset( $_SERVER['HTTP_X_FORWARDED_PORT'] ) ? (int) $_SERVER['HTTP_X_FORWARDED_PORT'] : (int) $_SERVER['SERVER_PORT'];
@@ -344,64 +464,34 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		}
 
 		if ( $site_port ) {
-			return self::skipped_test( $name ); // Not currently testing for this situation.
+			return self::skipped_test( array( 'name' => $name ) ); // Not currently testing for this situation.
 		}
 
 		if ( is_ssl() && in_array( $server_port, $https_ports, true ) ) {
-			return self::passing_test( $name );
+			return self::passing_test( array( 'name' => $name ) );
 		} elseif ( in_array( $server_port, $http_ports, true ) ) {
-			return self::passing_test( $name );
+			return self::passing_test( array( 'name' => $name ) );
 		} else {
 			if ( is_ssl() ) {
 				$needed_constant = 'JETPACK_SIGNATURE__HTTPS_PORT';
 			} else {
 				$needed_constant = 'JETPACK_SIGNATURE__HTTP_PORT';
 			}
-			$message    = __( 'The server port value is unexpected.', 'jetpack' );
-			$resolution = __( 'Try adding the following to your wp-config.php file:', 'jetpack' ) . " define( '$needed_constant', $server_port );";
-			return self::failing_test( $name, $message, $resolution );
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => sprintf(
+						/* translators: %1$s - a PHP code snippet */
+						__(
+							'The server port value is unexpected.
+						Try adding the following to your wp-config.php file: %1$s',
+							'jetpack'
+						),
+						"define( '$needed_constant', $server_port )"
+					),
+				)
+			);
 		}
-	}
-
-	/**
-	 * If Sync is enabled, this test will be skipped. If Sync is disabled, the test will fail.
-	 * Eventually, we'll make this test more robust with additional states. Here is the plan for possible Sync states,
-	 * including states that are planned but not yet implemented.
-	 *
-	 * Enabled: Skips test
-	 * Disabled: Results in a failing test
-	 * Healthy: @todo
-	 * In Progress: @todo
-	 * Delayed: @todo
-	 * Error: @todo
-	 */
-	protected function test__sync_health() {
-		$name = __FUNCTION__;
-		if ( ! $this->helper_is_jetpack_connected() ) {
-			// If the site is not connected, there is no point in testing Sync health.
-			return self::skipped_test( $name, false, false );
-		}
-		if ( Sync_Settings::is_sync_enabled() ) {
-			return self::skipped_test( $name, false, false );
-		}
-		return self::failing_test(
-			$name,
-			__( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
-			'enable_sync',
-			admin_url( '#' ),
-			'recommended',
-			__( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
-			__( 'Learn more about enabling Sync', 'jetpack' ),
-			sprintf(
-				'<p>%1$s</p>' .
-				'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
-				__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
-				/* translators: screen reader text indicating a test failed */
-				__( 'Error', 'jetpack' ),
-				__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work.', 'jetpack' ),
-				__( 'We recommend enabling Sync.', 'jetpack' )
-			)
-		);
 	}
 
 	/**
@@ -419,7 +509,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$status = new Status();
 		if ( ! Jetpack::is_active() || $status->is_development_mode() || $status->is_staging_site() || ! $this->pass ) {
-			return self::skipped_test( $name );
+			return self::skipped_test( array( 'name' => $name ) );
 		}
 
 		$self_xml_rpc_url = site_url( 'xmlrpc.php' );
@@ -432,30 +522,28 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		remove_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ) );
 
-		$error_msg = wp_kses(
-			sprintf(
-				/* translators: Placeholder is a link to site's Jetpack debug page. */
-				__(
-					'<a target="_blank" rel="noopener noreferrer" href="%s">Visit the Jetpack.com debug page</a> for more information or <a target="_blank" rel="noopener noreferrer" href="https://jetpack.com/contact-support/">contact support</a>.',
-					'jetpack'
-				),
-				esc_url( add_query_arg( 'url', rawurlencode( site_url() ), 'https://jetpack.com/support/debug/' ) )
-			),
-			array(
-				'a' => array(
-					'href'   => array(),
-					'target' => array(),
-					'rel'    => array(),
-				),
-			)
-		);
-
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
-			return self::passing_test( $name );
+			return self::passing_test( array( 'name' => $name ) );
 		} elseif ( is_wp_error( $response ) && false !== strpos( $response->get_error_message(), 'cURL error 28' ) ) { // Timeout.
-			return self::skipped_test( $name, __( 'The test timed out which may sometimes indicate a failure or may be a false failure.', 'jetpack' ) );
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'The test timed out which may sometimes indicate a failure or may be a false failure.', 'jetpack' ),
+				)
+			);
 		} else {
-			return self::failing_test( $name, __( 'Jetpack.com detected an error on the WPcom Self Test.', 'jetpack' ), $error_msg );
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					'short_description' => sprintf(
+						/* translators: %1$s - A debugging url */
+						__( 'Jetpack.com detected an error on the WP.com Self Test. Visit the Jetpack Debug page for more info: %1$s, or contact support.', 'jetpack' ),
+						esc_url( add_query_arg( 'url', rawurlencode( site_url() ), 'https://jetpack.com/support/debug/' ) )
+					),
+					'action_label'      => $this->helper_get_support_text(),
+					'action'            => $this->helper_get_support_url(),
+				)
+			);
 		}
 	}
 }

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -36,18 +36,37 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 			'label' => __( 'Jetpack: ', 'jetpack' ) . $test['name'],
 			'test'  => function() use ( $test, $cxn_tests ) { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.Found
 				$results = $cxn_tests->run_test( $test['name'] );
+				if ( is_wp_error( $results ) ) {
+					return;
+				}
 
 				if ( isset( $results['show_in_site_health'] ) && false === $results['show_in_site_health'] ) {
 					return;
 				}
-				// Test names are, by default, `test__some_string_of_text`. Let's convert to "Some String Of Text" for humans.
-				$label = ucwords(
-					str_replace(
-						'_',
-						' ',
-						str_replace( 'test__', '', $test['name'] )
-					)
-				);
+
+				$label = $results['label'] ?
+					$results['label'] :
+					ucwords(
+						str_replace(
+							'_',
+							' ',
+							str_replace( 'test__', '', $test['name'] )
+						)
+					);
+				if ( $results['long_description'] ) {
+					$description = $results['long_description'];
+				} elseif ( $results['short_description'] ) {
+					$description = sprintf(
+						'<p>%s</p>',
+						$results['short_description']
+					);
+				} else {
+					$description = sprintf(
+						'<p>%s</p>',
+						__( 'This test successfully passed!', 'jetpack' )
+					);
+				}
+
 				$return = array(
 					'label'       => $label,
 					'status'      => 'good',
@@ -55,34 +74,12 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 						'label' => __( 'Jetpack', 'jetpack' ),
 						'color' => 'green',
 					),
-					'description' => sprintf(
-						'<p>%s</p>',
-						__( 'This test successfully passed!', 'jetpack' )
-					),
+					'description' => $description,
 					'actions'     => '',
 					'test'        => 'jetpack_' . $test['name'],
 				);
-				if ( is_wp_error( $results ) ) {
-					return;
-				}
+
 				if ( false === $results['pass'] ) {
-					$return['label'] = $results['message'];
-					if ( $results['label'] ) {
-						// Allow tests to override the strange message => label logic with an actual label.
-						$return['label'] = $results['label'];
-					}
-
-					// Most tests pass a `resolution` property to use as a description.
-					$return['description'] = sprintf(
-						'<p>%s</p>',
-						$results['resolution']
-					);
-
-					if ( $results['description'] ) {
-						// Allow tests to override 'resolution' with their own HTML description.
-						$return['description'] = $results['description'];
-					}
-
 					$return['status'] = $results['severity'];
 					if ( ! empty( $results['action'] ) ) {
 						$return['actions'] = sprintf(
@@ -92,15 +89,6 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 							/* translators: accessibility text */
 							__( '(opens in a new tab)', 'jetpack' )
 						);
-					}
-				} elseif ( true === $results['pass'] ) {
-					// Passing tests can chose to override defaults.
-					if ( $results['label'] ) {
-						$return['label'] = $results['label'];
-					}
-
-					if ( $results['description'] ) {
-						$return['description'] = $results['description'];
 					}
 				}
 

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -31,10 +31,15 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 	$cxn_tests = new Jetpack_Cxn_Tests();
 	$tests     = $cxn_tests->list_tests( 'direct' );
 	foreach ( $tests as $test ) {
+
 		$core_tests['direct'][ $test['name'] ] = array(
 			'label' => __( 'Jetpack: ', 'jetpack' ) . $test['name'],
 			'test'  => function() use ( $test, $cxn_tests ) { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.Found
 				$results = $cxn_tests->run_test( $test['name'] );
+
+				if ( isset( $results['show_in_site_health'] ) && false === $results['show_in_site_health'] ) {
+					return;
+				}
 				// Test names are, by default, `test__some_string_of_text`. Let's convert to "Some String Of Text" for humans.
 				$label = ucwords(
 					str_replace(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes na

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* A few of my previous PRs have introduced some complexity into the debug tests
* This PR aims to simplify the debug tests so that running tests provides simple, clear and consistent results regardless of the environment.
* Simplification will make adding new tests easier in the future
* Simplification will make improving existing tests easier

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Not a new feature

#### Testing instructions:

* Apply this PR to a testing site, and run the debug tests in the following environements, and make sure there are no errors
* Run in CLI: `wp jetpack status`
* Visit the debug page for the site and find the 'local connection suite'
* Visit the Site Health page in wp-admin

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none
