### PR TITLE
Milestone widget: Make sure the widget ID is output

### DIFF
--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -2,7 +2,7 @@
 
 var Milestone = ( function() {
 	var Milestone = function( args ) {
-		var widget = document.getElementById( args.id ),
+		var widget_content = document.getElementById( args.content_id ),
 			id = args.id,
 			refresh = args.refresh * 1000;
 
@@ -17,7 +17,7 @@ var Milestone = ( function() {
 						'undefined' !== typeof response.message && 'undefined' !== typeof response.refresh;
 
 				if ( httpCheck && responseCheck ) {
-					var countdownElement = widget.querySelector( '.milestone-countdown' );
+					var countdownElement = widget_content.querySelector( '.milestone-countdown' );
 
 					countdownElement.outerHTML = response.message;
 					refresh = response.refresh * 1000;

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -205,15 +205,23 @@ class Milestone_Widget extends WP_Widget {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
-		$data = $this->get_widget_data( $instance );
-
-		self::$config_js['instances'][] = array(
+		$data   = $this->get_widget_data( $instance );
+		$config = array(
 			'id'      => $args['widget_id'],
 			'message' => $data['message'],
-			'refresh' => $data['refresh']
+			'refresh' => $data['refresh'],
 		);
 
-		echo '<div class="milestone-content">';
+		/*
+		 * Sidebars may be configured to not expose the `widget_id`. Example: `twentytwenty` footer areas.
+		 *
+		 * We need our own unique identifier.
+		 */
+		$config['content_id'] = $args['widget_id'] . '-content';
+
+		self::$config_js['instances'][] = $config;
+
+		echo sprintf( '<div id="%s" class="milestone-content">', esc_html( $config['content_id'] ) );
 
 		echo '<div class="milestone-header">';
 		echo '<strong class="event">' . esc_html( $instance['event'] ) . '</strong>';


### PR DESCRIPTION
The Milestone widget relies on the `widget_id` being exposed by the `before_widget` argument passed to `register_sidebar` in the theme. That is not guaranteed and the widget's live countdown is currently broken in many themes, most prominently in the current [`twentytwenty`](https://github.com/WordPress/WordPress/blob/d6178e1dcf2f663089147793e1858b5a666b3932/wp-content/themes/twentytwenty/functions.php#L357).

#### Changes proposed in this Pull Request:
* Create a custom ID value derived from `widget_id` and assign it to every widgets' `.milestone-content` container.
* In JS, target the newly assigned ID instead of the unreliable `widget_id`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes a bug in the Milestone widget.

#### Testing instructions:

* On `master`, add the Milestone widget to one of the `twentytwenty`'s Footer sidebars.
* Set the Milestone date and time to one minute in the future.
* On the front-end, open the browser's Dev tools and observe XHR requests being sent every second. (**Aside:** This feels like a DDoS waiting to happen, but I'll take a look into this separately.)
* Observe the countdown to not update.
* Switch to this branch.
* Refresh the page and set the Milestone time and date to one minute in the future again.
* On the front-end, observe the countdown being updated live.

#### Proposed changelog entry for your changes:
* Fix the live countdown feature of the Milestone widget in some themes.