### PR TITLE
Release Build: ensure the first built release branch is cleaned

### DIFF
--- a/tools/build-release-branch.sh
+++ b/tools/build-release-branch.sh
@@ -74,11 +74,34 @@ function create_release_gitignore {
 	git commit .gitignore -m "updated .gitignore"
 }
 
-# Remove stuff from .svnignore for releases
-function modify_svnignore {
-	awk '!/.eslintrc.js/' .svnignore > temp && mv temp .svnignore
-	awk '!/.eslintignore/' .svnignore > temp && mv temp .svnignore
-	git commit .svnignore -m "Updated .svnignore"
+# Build a clean built branch
+# without any development or non-prod files
+function purge_dev_files {
+	echo "Purging paths included in .svnignore"
+
+	# We'll be making some exceptions.
+	for file in $( cat .svnignore 2>/dev/null ); do
+		# We want to keep testing instructions.
+		if [[ $file == "to-test.md" ]]; then
+			continue;
+		fi
+
+		# Let's keep .git for now, since we'll be committing into that branch later on.
+		if [[ $file == ".git" ]]; then
+			continue;
+		fi
+
+		# Let's keep tools. We use them within the release branches.
+		if [[ $file == "tools" ]]; then
+			continue;
+		fi
+
+		rm -rf $file
+	done
+
+	git commit -am "Remove non-prod files from built"
+
+	echo "Done!"
 }
 
 # This function will create a new set of release branches.
@@ -134,8 +157,8 @@ function create_new_release_branches {
 			echo ""
 			create_release_gitignore
 
-			# Remove stuff from svnignore
-			modify_svnignore
+			# Remove non-prod files
+			purge_dev_files
 
 			git checkout $NEW_UNBUILT_BRANCH
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This PR aims to clean the first built branch that is created when you branch off `master` and create your first `branch-x.x` / `branch-x.x-built` set.

We don't want that built branch to include things like `/packages`, because those then remain behind later on when you update the built branch with `tools/build-release-branch.sh -u branch-x.x-built`.

By purging it the first time around (when you run `tools/build-release-branch.sh -n`), we ensure that when you update it later on and you rsync the local built version (which is stripped of files from `.svnignore`) to your remote built version, you do not bring files listed on `.svnignore` back.

The only things listed in `svnignore` that we do need in the built branch for now are:
1. The testing list.
2. The `.git` directory since we'll be committing to that branch.
3. The `tools` directory since we use tools there to update our branch and ship it to svn later on.

#### Testing instructions:

That's not an easy one to test, but this should do it.

* Fork this repo under your own username.
* In a new location on your machine, git clone your copy.
* Fetch this branch and switch to it.
* Merge this branch into master.
* Edit `tools/build-release-branch.sh` and change `git@github.com:Automattic/jetpack.git` into your own fork's address.
* Commit that change to `master`.
* Push `master` to your forked remote.
* Run `tools/build-release-branch.sh -n`
* A new `branch-x.x` / `branch-x.x-built` set will be created locally and on your forked remote.
* Check that both branches look good. You'll want to pay extra attention to the built branch; it should include a `/vendor` dir, but no `/packages` dir for example.

#### Proposed changelog entry for your changes:

* N/A
