### PR TITLE
Blocks: allow enabling Experimental blocks via a filter

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -314,6 +314,17 @@ class Jetpack_Gutenberg {
 		}
 
 		/**
+		 * Alternative to `JETPACK_EXPERIMENTAL_BLOCKS`, set to `true` to load Experimental Blocks.
+		 *
+		 * @since 8.4.0
+		 *
+		 * @param boolean
+		 */
+		if ( apply_filters( 'jetpack_load_experimental_blocks', false ) ) {
+			Constants::set_constant( 'JETPACK_EXPERIMENTAL_BLOCKS', true );
+		}
+
+		/**
 		 * Filter the whitelist of block editor extensions that are available through Jetpack.
 		 *
 		 * @since 7.0.0


### PR DESCRIPTION
Follow-up from #14104.

#### Changes proposed in this Pull Request:

* In some environments (like on WordPress.com), it may be easier to use a filter to change the way we load blocks.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It will mostly be useful on WordPress.com. Once this PR lands, I will ship DD39996-code

#### Testing instructions:

* Add `add_filter( 'jetpack_load_experimental_blocks', '__return_true' );` to a functionality plugin on your site.
* Go to Posts > Add New
* Ensure that the block bundle loaded on the page (via your browser's network panel) is the experimental bundle.

#### Proposed changelog entry for your changes:

* N/A
