### PR TITLE
Sync: remove extension on legacy class

### DIFF
--- a/packages/compat/legacy/class-jetpack-sync-actions.php
+++ b/packages/compat/legacy/class-jetpack-sync-actions.php
@@ -12,7 +12,7 @@ use Automattic\Jetpack\Sync\Actions;
  *
  * @deprecated Use Automattic\Jetpack\Sync\Actions
  */
-class Jetpack_Sync_Actions {
+class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 
 	/**
 	 * Initializes the class.
@@ -114,12 +114,14 @@ class Jetpack_Sync_Actions {
 	 * @param Integer $queue_id the queue identifier.
 	 * @param Integer $checkout_duration time spent retrieving items.
 	 * @param Integer $preprocess_duration Time spent converting items into data.
+	 * @param Integer $queue_size The current size of the sync queue.
+	 *
 	 * @return WP_Response the response object.
 	 */
-	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration ) {
+	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration, $queue_size = null ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
 
-		return Actions::send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration );
+		return Actions::send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration, $queue_size );
 	}
 
 	/**

--- a/packages/compat/legacy/class-jetpack-sync-actions.php
+++ b/packages/compat/legacy/class-jetpack-sync-actions.php
@@ -12,7 +12,7 @@ use Automattic\Jetpack\Sync\Actions;
  *
  * @deprecated Use Automattic\Jetpack\Sync\Actions
  */
-class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
+class Jetpack_Sync_Actions {
 
 	/**
 	 * Initializes the class.


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14906 

#### Changes proposed in this Pull Request:
In #14906 were seeing that adding a new parameter to a Sync class
causes legacy classes to complain.

We can fix this updating the legacy class whenever we update the class that's replaced it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Not a new feature

#### Testing instructions:
- Get this patch running on test site
- Observe sync and full-sync actions on site and ensure no regressions.
- Ask VIP to try this patch and see if it fixes the warnings they are seeing

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none
