### PR TITLE
Widgets: Migrate front-end jQuery code to vanilla JS

### DIFF
--- a/modules/widgets/milestone/milestone.js
+++ b/modules/widgets/milestone/milestone.js
@@ -1,19 +1,26 @@
 /* global MilestoneConfig */
 
-var Milestone = ( function( $ ) {
+var Milestone = ( function() {
 	var Milestone = function( args ) {
-		var $widget = $( '#' + args.id ),
+		var widget = document.getElementById( args.id ),
 			id = args.id,
 			refresh = args.refresh * 1000;
 
 		this.timer = function() {
 			var instance = this;
+			var xhr = new XMLHttpRequest();
 
-			$.ajax( {
-				url: MilestoneConfig.api_root + 'jetpack/v4/widgets/' + id,
-				success: function( result ) {
-					$widget.find( '.milestone-countdown' ).replaceWith( result.message );
-					refresh = result.refresh * 1000;
+			xhr.onload = function() {
+				var response = JSON.parse( xhr.responseText ),
+					httpCheck = xhr.status >= 200 && xhr.status < 300,
+					responseCheck =
+						'undefined' !== typeof response.message && 'undefined' !== typeof response.refresh;
+
+				if ( httpCheck && responseCheck ) {
+					var countdownElement = widget.querySelector( '.milestone-countdown' );
+
+					countdownElement.outerHTML = response.message;
+					refresh = response.refresh * 1000;
 
 					if ( ! refresh ) {
 						return;
@@ -22,8 +29,11 @@ var Milestone = ( function( $ ) {
 					setTimeout( function() {
 						instance.timer();
 					}, refresh );
-				},
-			} );
+				}
+			};
+
+			xhr.open( 'GET', MilestoneConfig.api_root + 'jetpack/v4/widgets/' + id );
+			xhr.send();
 		};
 
 		if ( refresh > 0 ) {
@@ -33,7 +43,7 @@ var Milestone = ( function( $ ) {
 	return function( args ) {
 		return new Milestone( args );
 	};
-} )( jQuery );
+} )();
 
 ( function() {
 	var i,

--- a/modules/widgets/milestone/milestone.php
+++ b/modules/widgets/milestone/milestone.php
@@ -86,7 +86,7 @@ class Milestone_Widget extends WP_Widget {
 				'_inc/build/widgets/milestone/milestone.min.js',
 				'modules/widgets/milestone/milestone.js'
 			),
-			array( 'jquery' ),
+			array(),
 			'20160520',
 			true
 		);

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -182,7 +182,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		wp_enqueue_script(
 			'jetpack-search-widget',
 			plugins_url( 'search/js/search-widget.js', __FILE__ ),
-			array( 'jquery' ),
+			array(),
 			JETPACK__VERSION,
 			true
 		);
@@ -552,39 +552,46 @@ class Jetpack_Search_Widget extends WP_Widget {
 		if ( ! empty( $instance['user_sort_enabled'] ) ) :
 		?>
 		<script type="text/javascript">
-				jQuery( document ).ready( function( $ ) {
-					var orderByDefault = '<?php echo 'date' === $orderby ? 'date' : 'relevance'; ?>',
-						orderDefault   = '<?php echo 'ASC' === $order ? 'ASC' : 'DESC'; ?>',
-						widgetId       = decodeURIComponent( '<?php echo rawurlencode( $this->id ); ?>' ),
-						searchQuery    = decodeURIComponent( '<?php echo rawurlencode( get_query_var( 's', '' ) ); ?>' ),
-						isSearch       = <?php echo (int) is_search(); ?>;
+			var jetpackSearchModuleSorting = function() {
+				var orderByDefault = '<?php echo 'date' === $orderby ? 'date' : 'relevance'; ?>',
+					orderDefault   = '<?php echo 'ASC' === $order ? 'ASC' : 'DESC'; ?>',
+					widgetId       = decodeURIComponent( '<?php echo rawurlencode( $this->id ); ?>' ),
+					searchQuery    = decodeURIComponent( '<?php echo rawurlencode( get_query_var( 's', '' ) ); ?>' ),
+					isSearch       = <?php echo (int) is_search(); ?>;
 
-					var container = $( '#' + widgetId + '-wrapper' ),
-						form = container.find('.jetpack-search-form form'),
-						orderBy = form.find( 'input[name=orderby]'),
-						order = form.find( 'input[name=order]'),
-						searchInput = form.find( 'input[name="s"]' );
+				var container = document.getElementById( widgetId + '-wrapper' ),
+					form = container.querySelector( '.jetpack-search-form form' ),
+					orderBy = form.querySelector( 'input[name=orderby]' ),
+					order = form.querySelector( 'input[name=order]' ),
+					searchInput = form.querySelector( 'input[name="s"]' ),
+					sortSelectInput = container.querySelector( '.jetpack-search-sort' );
 
-					orderBy.val( orderByDefault );
-					order.val( orderDefault );
+				orderBy.value = orderByDefault;
+				order.value = orderDefault;
 
-					// Some themes don't set the search query, which results in the query being lost
-					// when doing a sort selection. So, if the query isn't set, let's set it now. This approach
-					// is chosen over running a regex over HTML for every search query performed.
-					if ( isSearch && ! searchInput.val() ) {
-						searchInput.val( searchQuery );
-					}
+				// Some themes don't set the search query, which results in the query being lost
+				// when doing a sort selection. So, if the query isn't set, let's set it now. This approach
+				// is chosen over running a regex over HTML for every search query performed.
+				if ( isSearch && ! searchInput.value ) {
+					searchInput.value = searchQuery;
+				}
 
-					searchInput.addClass( 'show-placeholder' );
+				searchInput.classList.add( 'show-placeholder' );
 
-					container.find( '.jetpack-search-sort' ).change( function( event ) {
-						var values  = event.target.value.split( '|' );
-						orderBy.val( values[0] );
-						order.val( values[1] );
+				sortSelectInput.addEventListener( 'change', function( event ) {
+					var values  = event.target.value.split( '|' );
+					orderBy.value = values[0];
+					order.value = values[1];
 
-						form.submit();
-					});
+					form.submit();
 				} );
+			}
+
+			if ( document.readyState === 'interactive' || document.readyState === 'complete' ) {
+				jetpackSearchModuleSorting();
+			} else {
+				document.addEventListener( 'DOMContentLoaded', jetpackSearchModuleSorting );
+			}
 			</script>
 		<?php
 		endif;

--- a/modules/widgets/search/js/search-widget.js
+++ b/modules/widgets/search/js/search-widget.js
@@ -1,19 +1,47 @@
-jQuery( document ).ready( function() {
-	var filter_list = jQuery( '.jetpack-search-filters-widget__filter-list' );
+var jetpackSearchModule = function() {
+	var i,
+		j,
+		checkboxes,
+		filter_list = document.querySelectorAll( '.jetpack-search-filters-widget__filter-list' );
 
-	filter_list.on( 'click', 'a', function() {
-		var checkbox = jQuery( this ).siblings( 'input[type="checkbox"]' );
-		checkbox.prop( 'checked', ! checkbox.prop( 'checked' ) );
-	} );
+	for ( i = 0; i < filter_list.length; i++ ) {
+		filter_list[ i ].addEventListener( 'click', function( event ) {
+			var target = event.target;
+			var precedingCheckbox;
+			var nextAnchor;
 
-	filter_list
-		.find( 'input[type="checkbox"]' )
-		.prop( 'disabled', false )
-		.css( 'cursor', 'inherit' )
-		.on( 'click', function() {
-			var anchor = jQuery( this ).siblings( 'a' );
-			if ( anchor.length ) {
-				window.location.href = anchor.prop( 'href' );
+			// If the target is an anchor, we want to toggle the checkbox.
+			if ( target.nodeName && 'a' === target.nodeName.toLowerCase() ) {
+				precedingCheckbox = target.previousElementSibling;
+				if (
+					precedingCheckbox &&
+					precedingCheckbox.type &&
+					'checkbox' === precedingCheckbox.type
+				) {
+					precedingCheckbox.checked = ! precedingCheckbox.checked;
+				}
+			}
+
+			// If the target is a checkbox, we want to navigate.
+			if ( target.type && 'checkbox' === target.type ) {
+				nextAnchor = target.nextElementSibling;
+				if ( nextAnchor && 'a' === nextAnchor.nodeName.toLowerCase() ) {
+					window.location.href = nextAnchor.getAttribute( 'href' );
+				}
 			}
 		} );
-} );
+
+		// Enable checkboxes now that we're setup.
+		checkboxes = filter_list[ i ].querySelectorAll( 'input[type="checkbox"]' );
+		for ( j = 0; j < checkboxes.length; j++ ) {
+			checkboxes[ j ].disabled = false;
+			checkboxes[ j ].style.cursor = 'inherit';
+		}
+	}
+};
+
+if ( document.readyState === 'interactive' || document.readyState === 'complete' ) {
+	jetpackSearchModule();
+} else {
+	document.addEventListener( 'DOMContentLoaded', jetpackSearchModule );
+}


### PR DESCRIPTION
These pieces of the codebase have been reviewed:

* `/modules/widget-visibility`
* `/modulels/widgets/*`

These widgets are using jQuery in some capacity:

* `social-icons`: In the admin context only.
* `simple-payments`: In the admin context only.
* `contact-info`: In the admin context only.
* **`search`**: Ordering + filters functionality on the front-end + admin context.
* `eu-cookie-law`: In the admin context only. (Frontend handled by @kienstra in https://github.com/Automattic/jetpack/pull/14753/files)
* **`milestone`**: Dynamic countdown on the front-end + admin context.
* `gravatar-profile`: In the admin context only.
* `gallery`: FE + admin context, but not addressed, because the widget is not available in WP 4.9+ (superseded by the core gallery widget).
* `rsslinks`: In the admin context only.
* `customizer-utils`: In the admin context only.
* `twitter-timeline`: In the admin context only.
* `widget-visibility: feature: In the admin context only.

The two widgets in **bold** have been converted to vanilla JS. Others are either not relevant anymore (`gallery`) or use jQuery in the admin context only, which was not in scope for this PR.

It doesn't seem like a good use of development time to rewrite the admin jQuery scripts because jQuery is arguably going to remain to be loaded in the admin context for a long time. However if this assumption is incorrect and we want to fully strip all jQuery code, please let me know.

Fixes #14864 

#### Changes proposed in this Pull Request:
* Rewrite the FE jQuery code to vanilla JS in the `search` and `milestone` widgets.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an update to the existing extra Jetpack widgets.

#### Testing instructions:
* Go to WP Admin > Jetpack > Settings > Writing.
* Enable _"Make extra widgets available for use on your site including subscription forms and Twitter streams"_.
* Add the Search (Jetpack) and Milestone (Jetpack) widgets to the website.
* Test the added plugins
  * Search widget: Make sure that when the "Sort by" select box value is changed, the page is automatically refreshed and new sorting rules are applied.
  * Search widget: Make sure the category filters that appear after any initial search work as intended.
  * Milestone widget: Set the milestone to happen in the next minute.
  * Milestone widget: On the front-end, observe the live countdown, i.e. the seconds are updated live and when the timer hits 0, the milestone message is displayed.
    * Note: Please be aware of [an existing issue](https://github.com/Automattic/jetpack/pull/14904) with `twentytwenty` (and potentially other themes) and pick a there that exposes the widget ID. Failing to do that will lead to the widget not updating on the front-end.

#### Tested in:
* Chrome 80 (Ubuntu).
* IE 11 (Win 10).

#### Proposed changelog entry for your changes:
* Rewritten the front-end jQuery code of the Search and Milestone widgets into vanilla JS.
