### PR TITLE
General: update minimum WordPress version for Jetpack

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
-	<config name="minimum_supported_wp_version" value="5.2" />
+	<config name="minimum_supported_wp_version" value="5.3" />
 	<config name="testVersion" value="5.6-"/>
 
 	<rule ref="PHPCompatibilityWP"/>

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
 - "7.0"
 - "7.2"
 - "7.3"
-- "7.4"
+# 7.4 can not be included here until 5.3 is the "previous" version of WP.
 
 env:
   # Global variable is re-defined in matrix-include -list
@@ -51,6 +51,9 @@ matrix:
 
   - php: "nightly"
     name: "PHP Nightly"
+  - php: "7.4snapshot"
+    env: WP_BRANCH=master SIMPLE_AND_MULTISITE=1
+    # add a new entry for "latest" WP once 5.3 has shipped. Remove snapshot once 7.4 is GA.
 
   # Code Climate code coverage.
   - php: "7.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
 - "7.0"
 - "7.2"
 - "7.3"
-# 7.4 can not be included here until 5.3 is the "previous" version of WP.
+- "7.4snapshot"
 
 env:
   # Global variable is re-defined in matrix-include -list
@@ -51,9 +51,6 @@ matrix:
 
   - php: "nightly"
     name: "PHP Nightly"
-  - php: "7.4snapshot"
-    env: WP_BRANCH=master SIMPLE_AND_MULTISITE=1
-    # add a new entry for "latest" WP once 5.3 has shipped. Remove snapshot once 7.4 is GA.
 
   # Code Climate code coverage.
   - php: "7.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
 - "7.0"
 - "7.2"
 - "7.3"
-# 7.4 can not be included here until 5.3 is the "previous" version of WP.
+- "7.4"
 
 env:
   # Global variable is re-defined in matrix-include -list
@@ -51,9 +51,6 @@ matrix:
 
   - php: "nightly"
     name: "PHP Nightly"
-  - php: "7.4snapshot"
-    env: WP_BRANCH=master SIMPLE_AND_MULTISITE=1
-    # add a new entry for "latest" WP once 5.3 has shipped. Remove snapshot once 7.4 is GA.
 
   # Code Climate code coverage.
   - php: "7.3"

--- a/functions.global.php
+++ b/functions.global.php
@@ -19,38 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! function_exists( 'wp_timezone' ) ) {
-	/**
-	 * Shim for WordPress 5.3's wp_timezone() function.
-	 *
-	 * This is a mix of wp_timezone(), which calls wp_timezone_string().
-	 * We don't need both in Jetpack, so providing only one function.
-	 *
-	 * @since 7.9.0
-	 * @todo Remove when WP 5.3 is Jetpack's minimum
-	 *
-	 * @return DateTimeZone Site's DateTimeZone
-	 */
-	function wp_timezone() {
-		$timezone_string = get_option( 'timezone_string' );
-
-		if ( $timezone_string ) {
-			return new DateTimeZone( $timezone_string );
-		}
-
-		$offset  = (float) get_option( 'gmt_offset' );
-		$hours   = (int) $offset;
-		$minutes = ( $offset - $hours );
-
-		$sign      = ( $offset < 0 ) ? '-' : '+';
-		$abs_hour  = abs( $hours );
-		$abs_mins  = abs( $minutes * 60 );
-		$tz_offset = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
-
-		return new DateTimeZone( $tz_offset );
-	}
-}
-
 /**
  * Set the admin language, based on user language.
  *
@@ -113,7 +81,7 @@ function jetpack_store_migration_data( $option_name, $option_value ) {
 		'post_title'            => $option_name,
 		'post_content_filtered' => $option_value,
 		'post_type'             => 'jetpack_migration',
-		'post_date'             => date( 'Y-m-d H:i:s', time() ),
+		'post_date'             => gmdate( 'Y-m-d H:i:s', time() ),
 	);
 
 	$post = get_page_by_title( $option_name, 'OBJECT', 'jetpack_migration' );

--- a/jetpack.php
+++ b/jetpack.php
@@ -13,7 +13,7 @@
  * @package Jetpack
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '5.2' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '5.3' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '8.4-alpha' );
 define( 'JETPACK_MASTER_USER', true );

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -406,22 +406,6 @@ EOT;
 			$rows_markup .= $this->render_block_row( $lower_row_posts, $block_attributes );
 		}
 
-		/*
-		 * Below is a hack to get the block content to render correctly.
-		 *
-		 * This functionality should be covered in /inc/blocks.php but due to an error,
-		 * this has not been fixed as of this writing.
-		 *
-		 * Alda has submitted a patch to Core in order to have this issue fixed at
-		 * https://core.trac.wordpress.org/ticket/45495 and
-		 * made it into WordPress 5.2.
-		 *
-		 * @todo update when WP 5.2 is the minimum support version.
-		 */
-		$priority = has_filter( 'the_content', 'wpautop' );
-		remove_filter( 'the_content', 'wpautop', $priority );
-		add_filter( 'the_content', '_restore_wpautop_hook', $priority + 1 );
-
 		return sprintf(
 			'<nav class="jp-relatedposts-i2" data-layout="%1$s">%2$s%3$s</nav>',
 			esc_attr( $block_attributes['layout'] ),

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -765,13 +765,4 @@ if (
 		add_filter( 'the_content', 'crowdsignal_link', 1 );
 		add_filter( 'the_content_rss', 'crowdsignal_link', 1 );
 	}
-
-	/**
-	 * Note that Core has the oembed of '#https?://survey\.fm/.*#i' as of 5.1.
-	 * This should be removed after Core has the current regex is in our minimum version.
-	 *
-	 * @see https://core.trac.wordpress.org/ticket/46467
-	 * @todo Remove once 5.2 is the minimum version.
-	 */
-	wp_oembed_add_provider( '#https?://.+\.survey\.fm/.*#i', 'https://api.crowdsignal.com/oembed', true );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, scottsweb, sdquirk, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 8.2.3
-Requires at least: 5.2
+Requires at least: 5.3
 Requires PHP: 5.6
-Tested up to: 5.3
+Tested up to: 5.4
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.
 

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -38,7 +38,7 @@ latest)
 	git clone --depth=1 --branch $(php ./tests/get-wp-version.php) git://develop.git.wordpress.org/ /tmp/wordpress-latest
 	;;
 previous)
-	git clone --depth=1 --branch $(php ./tests/get-wp-version.php --previous) git://develop.git.wordpress.org/ /tmp/wordpress-previous
+	git clone --depth=1 --branch 5.3 git://develop.git.wordpress.org/ /tmp/wordpress-previous
 	;;
 esac
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

WordPress 5.4 is scheduled for release before the next version of Jetpack will ship.

Let's consequently aim to update Jetpack to keep our WP-1 support standard.

I've taken the opportunity to try again to ~switch on Unit Tests on PHP 7.4 (see #14171)~ (Edit: nope, that still does not work, had to revert), and remove old shims.

Related PRs:
- Related Posts: #11220
- Crowdsignal: #11540
- Time utils: #13521

#### Testing instructions:

* See PRs above for each functionality change.

#### Proposed changelog entry for your changes:

* General: Jetpack now supports WordPress 5.3 and newer.
