### PR TITLE
Instant Search: add dark theme input styles

### DIFF
--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -10,25 +10,47 @@
 }
 
 input.jetpack-instant-search__box-input.search-field {
-	background: #fff;
 	border-radius: 5px;
 	border-style: solid;
 	border-width: 2px;
-	border-color: #b8b8b8;
-	color: black;
 	font-size: 18px;
 	line-height: 1;
 	margin: 0;
 	padding: 4px 14px;
 	text-indent: 32px;
 	vertical-align: middle;
+	transition: all 0.15s ease-in-out;
 
-	&:hover {
-		border-color: #8E8E8E;
+	.jetpack-instant-search__overlay--light & {
+		color: #666666;
+		background: #ffffff;
+		border-color: #b8b8b8;
+
+		&:hover {
+			color: #000000;
+			border-color: #8e8e8e;
+		}
+
+		&:focus {
+			color: #000000;
+			border-color: #5A5A5A;
+		}
 	}
 
-	&:focus {
-		border-color: #5A5A5A;
+	.jetpack-instant-search__overlay--dark & {
+		color: #b0b0b0;
+		background: #000000;
+		border-color: #5a5a5a;
+
+		&:hover {
+			color: #ffffff;
+			border-color: #8e8e8e;
+		}
+
+		&:focus {
+			color: #ffffff;
+			border-color: #c8c8c8;
+		}
 	}
 }
 

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -19,7 +19,6 @@ input.jetpack-instant-search__box-input.search-field {
 	padding: 4px 14px;
 	text-indent: 32px;
 	vertical-align: middle;
-	transition: all 0.15s ease-in-out;
 
 	.jetpack-instant-search__overlay--light & {
 		color: #666666;
@@ -180,8 +179,8 @@ input.jetpack-instant-search__box-input.search-field {
 .jetpack-instant-search__box input,
 .jetpack-instant-search__box input[type='search'].jetpack-instant-search__box-input {
 	width: 100%;
-  height: 52px;
-	transition: color, border-color 0.25s ease-in-out;
+	height: 52px;
+	transition: color 0.15s ease-in-out, border-color 0.25s ease-in-out;
 
 	&::-webkit-search-decoration,
 	&::-webkit-search-cancel-button,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds search box/input styles for the dark theme as shown in p6TEKc-3sr-p2
* Tweaks the light theme a tiny bit.

![image](https://user-images.githubusercontent.com/390760/76117950-c295c980-5fe4-11ea-8191-a3f03f5aa863.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site.
1. Activate the dark theme on JPS.
1. Trigger a search on your site.
1. Ensure everything looks good and the search box is legible and accessible.

#### Proposed changelog entry for your changes:
* None.
