### PR TITLE
Connection: Do not show plans grid if site has pending plan

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -138,7 +138,8 @@ jQuery( document ).ready( function( $ ) {
 				},
 				success: function( data ) {
 					var siteData = JSON.parse( data.data );
-					jetpackConnectButton.isPaidPlan = siteData.is_pending_plan || ! siteData.plan.is_free;
+					jetpackConnectButton.isPaidPlan =
+						siteData.options.is_pending_plan || ! siteData.plan.is_free;
 				},
 			} );
 		},

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -138,7 +138,7 @@ jQuery( document ).ready( function( $ ) {
 				},
 				success: function( data ) {
 					var siteData = JSON.parse( data.data );
-					jetpackConnectButton.isPaidPlan = ! siteData.plan.is_free;
+					jetpackConnectButton.isPaidPlan = siteData.is_pending_plan || ! siteData.plan.is_free;
 				},
 			} );
 		},


### PR DESCRIPTION
The in-place connection creates a regression in the connection flow for users that have a pending plan. Specifically, users with a pending plan, should be treated as users that already have a plan, and as such, those users should not see the plans grid after connecting their site.

#### Changes proposed in this Pull Request:

* Do not redirect the user to a plans grid after in-place connection if the user has a pending plan.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This is a bug fix for a relatively new connection flow.

#### Testing instructions:

* Checkout D40032-code in your sandbox
* Ensure that your Jetpack site is sandboxing the API
* Ensure that your Jetpack site has a pending plan. Ping @Automattic/jetpack-infinity to help with this
* Connect your test site through the in-place connection flow
* Ensure that you are not shown a plans grid after the connection

#### Proposed changelog entry for your changes:

* Fixed a connection flow issue for sites that had a pending plan that was provisioned by a partner.
