### PR TITLE
gravatar-hovercards: Only load when gravatars are on the page

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -213,14 +213,22 @@ function grofiles_admin_cards() {
 }
 
 function grofiles_extra_data() {
+	$authors = grofiles_gravatars_to_append();
+
+	if ( ! $authors ) {
+		wp_dequeue_script( 'grofiles-cards' );
+		wp_dequeue_script( 'wpgroho' );
+	} else {
 ?>
 	<div style="display:none">
 <?php
-	foreach ( grofiles_gravatars_to_append() as $author )
-		grofiles_hovercards_data_html( $author );
+		foreach ( $authors as $author ) {
+			grofiles_hovercards_data_html( $author );
+		}
 ?>
 	</div>
 <?php
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #14860

#### Changes proposed in this Pull Request:
* Dequeue the FE assets when there are no gravatars on the page to be displayed.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This updates the existing `gravatar-hovercards` module.

#### Testing instructions:
* Go to Jetpack Settings > Discussion > Comments.
* Enable pop-up business cards over commenters’ Gravatars.
* Enable a theme that displays user avatars, e.g. `twentysixteen`.
* Go to a _single post_ and observe the gravatar being displayed.
* Hover over the gravatar and observe the business card to pop-up.
* Open the browser's dev tools and check that `https://secure.gravatar.com/js/gprofiles.js` and `wpgroho.js` assets are loaded.
* Go to any _page_ (as in `page` post type) and observe no gravatars on the page.
* Open the browser's dev tools and check that `https://secure.gravatar.com/js/gprofiles.js` and `wpgroho.js` assets are NOT loaded.

#### Proposed changelog entry for your changes:
* Gravatar hovercards do not load assets on the front-end when there are no avatars on the page.