### PR TITLE
Remove PHP Notice when there is no logo an we are looking for an logo ID

### DIFF
--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -103,7 +103,7 @@ function jetpack_has_site_logo() {
 function jetpack_the_site_logo() {
 	$logo    = site_logo()->logo;
 	$logo_id = get_theme_mod( 'custom_logo' ); // Check for WP 4.5 Site Logo
-	$logo_id = $logo_id ? $logo_id : $logo['id']; // Use WP Core logo if present, otherwise use Jetpack's.
+	$logo_id = $logo_id ? $logo_id : ( isset( $logo['id'] ) ? $logo['id'] : false ); // Use WP Core logo if present, otherwise use Jetpack's.
 	$size    = site_logo()->theme_size();
 	$html    = '';
 

--- a/modules/theme-tools/site-logo/inc/functions.php
+++ b/modules/theme-tools/site-logo/inc/functions.php
@@ -101,26 +101,59 @@ function jetpack_has_site_logo() {
  * @since 1.0
  */
 function jetpack_the_site_logo() {
-	$logo    = site_logo()->logo;
-	$logo_id = get_theme_mod( 'custom_logo' ); // Check for WP 4.5 Site Logo
-	$logo_id = $logo_id ? $logo_id : ( isset( $logo['id'] ) ? $logo['id'] : false ); // Use WP Core logo if present, otherwise use Jetpack's.
-	$size    = site_logo()->theme_size();
-	$html    = '';
+	$size = site_logo()->theme_size();
 
 	// If no logo is set, but we're in the Customizer, leave a placeholder (needed for the live preview).
-	if ( ! jetpack_has_site_logo() ) {
-		if ( jetpack_is_customize_preview() ) {
-			$html = sprintf(
+	if (
+		! jetpack_has_site_logo()
+		&& jetpack_is_customize_preview()
+	) {
+		/*
+		 * Reason: the output is escaped in the sprintf.
+		 * phpcs:disable WordPress.Security.EscapeOutput
+		 */
+		/** This filter is documented in modules/theme-tools/site-logo/inc/functions.php */
+		echo apply_filters(
+			'jetpack_the_site_logo',
+			sprintf(
 				'<a href="%1$s" class="site-logo-link" style="display:none;"><img class="site-logo" data-size="%2$s" /></a>',
 				esc_url( home_url( '/' ) ),
 				esc_attr( $size )
-			);
-		}
+			),
+			array(),
+			$size
+		);
+		/* phpcs:enable WordPress.Security.EscapeOutput */
+		return;
 	}
 
-	// We have a logo. Logo is go.
-	else {
-		$html = sprintf(
+	// Check for WP 4.5 Site Logo and Jetpack logo.
+	$logo_id      = get_theme_mod( 'custom_logo' );
+	$jetpack_logo = site_logo()->logo;
+
+	// Use WP Core logo if present, otherwise use Jetpack's.
+	if ( ! $logo_id && isset( $jetpack_logo['id'] ) ) {
+		$logo_id = $jetpack_logo['id'];
+	}
+
+	/*
+	 * Reason: the output is escaped in the sprintf.
+	 * phpcs:disable WordPress.Security.EscapeOutput
+	 */
+	/**
+	 * Filter the Site Logo output.
+	 *
+	 * @module theme-tools
+	 *
+	 * @since 3.2.0
+	 *
+	 * @param string $html Site Logo HTML output.
+	 * @param array $jetpack_logo Array of Site Logo details.
+	 * @param string $size Size specified in add_theme_support declaration, or 'thumbnail' default.
+	 */
+	echo apply_filters(
+		'jetpack_the_site_logo',
+		sprintf(
 			'<a href="%1$s" class="site-logo-link" rel="home" itemprop="url">%2$s</a>',
 			esc_url( home_url( '/' ) ),
 			wp_get_attachment_image(
@@ -133,21 +166,11 @@ function jetpack_the_site_logo() {
 					'itemprop'  => 'logo',
 				)
 			)
-		);
-	}
-
-	/**
-	 * Filter the Site Logo output.
-	 *
-	 * @module theme-tools
-	 *
-	 * @since 3.2.0
-	 *
-	 * @param string $html Site Logo HTML output.
-	 * @param array $logo Array of Site Logo details.
-	 * @param string $size Size specified in add_theme_support declaration, or 'thumbnail' default.
-	 */
-	echo apply_filters( 'jetpack_the_site_logo', $html, $logo, $size );
+		),
+		$jetpack_logo,
+		$size
+	);
+	/* phpcs:enable WordPress.Security.EscapeOutput */
 }
 
 /**


### PR DESCRIPTION
Fixes #14747 

#### Changes proposed in this Pull Request:
* Removes a php notice when we are looking for a logo id but no logo id is set yet.

#### Testing instructions:
* Create a new site or a site where no logo has been set yet. 
* Make sure you have debugging enabled. 
* Notice that you don't see a php error when you visit the customizer. 

#### Proposed changelog entry for your changes:
* Removes the PHP notice on the customizer page. 
