### PR TITLE
Always display the mobile nav menu when disconnecting sites

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -360,10 +360,10 @@
 
 .jp-connection-settings__modal.dops-modal {
 	max-width: 635px;
-  	min-height: 400px;
+	min-height: 400px;
 
 	@include breakpoint( '>660px' ) {
-	  min-height: auto;
+		min-height: auto;
 	}
 }
 

--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -360,6 +360,11 @@
 
 .jp-connection-settings__modal.dops-modal {
 	max-width: 635px;
+  	min-height: 400px;
+
+	@include breakpoint( '>660px' ) {
+	  min-height: auto;
+	}
 }
 
 .jp-connection-settings__modal-body {

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -144,8 +144,8 @@
 	}
 
   	@include breakpoint( '>480px' ) {
-	  margin-left: -24px;
-	  padding: 10px 24px;
+		margin-left: -24px;
+		padding: 10px 24px;
   	}
 
 	@include breakpoint( '>660px' ) {

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -51,6 +51,7 @@
 
 	.jetpack-termination-dialog__feature {
 		width: calc( 100% - 2em );
+
 		@include breakpoint( '>660px' ) {
 			width: calc( 50% - 2em );
 		}
@@ -113,10 +114,14 @@
 	font-weight: normal;
 	line-height: 24px;
 	margin-top: 29px;
+  	margin-bottom: 120px;
 
 	// replicates behavior from .dops-card and keeps this centered
 	@include breakpoint( '>480px' ) {
 		margin-top: 37px;
+	}
+  	@include breakpoint( '>680px' ) {
+	  margin-bottom: 0;
 	}
 }
 
@@ -124,14 +129,31 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+  	position: fixed;
+  	background: #FFF;
+  	bottom: 0;
+	margin-left: -16px;
+  	width: 100%;
+  	padding: 10px 16px;
+  	border-top: 1px solid $gray;
+  	box-sizing: border-box;
 
 	p {
 		text-align: center;
 		margin-top: 0;
 	}
 
+  	@include breakpoint( '>480px' ) {
+	  margin-left: -24px;
+	  padding: 10px 24px;
+  	}
+
 	@include breakpoint( '>660px' ) {
 		flex-direction: row;
+	  	position: relative;
+	  	margin-left: 0;
+	  	padding: 0;
+	  	border-top: none;
 
 		p {
 			text-align: auto;

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -130,7 +130,7 @@
 	flex-direction: column;
 	justify-content: space-between;
   	position: fixed;
-  	background: #FFF;
+  	background: $white;
   	bottom: 0;
 	margin-left: -16px;
   	width: 100%;

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -114,22 +114,22 @@
 	font-weight: normal;
 	line-height: 24px;
 	margin-top: 29px;
-  	margin-bottom: 120px;
+	margin-bottom: 120px;
 
 	// replicates behavior from .dops-card and keeps this centered
 	@include breakpoint( '>480px' ) {
 		margin-top: 37px;
 	}
-  	@include breakpoint( '>680px' ) {
-	  margin-bottom: 0;
+	@include breakpoint( '>680px' ) {
+		margin-bottom: 0;
 	}
 }
 
 .admin-bar .dops-modal-wrapper {
-	@media only screen and (min-width: 600px) {
+	@media only screen and ( min-width: 600px ) {
 		top: 46px;
 	}
-	@media only screen and (min-width: 782px) {
+	@media only screen and ( min-width: 782px ) {
 		top: 32px;
 	}
 }
@@ -138,31 +138,31 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-  	position: fixed;
-  	background: $white;
-  	bottom: 0;
+	position: fixed;
+	background: $white;
+	bottom: 0;
 	margin-left: -16px;
-  	width: 100%;
-  	padding: 10px 16px;
-  	border-top: 1px solid $gray;
-  	box-sizing: border-box;
+	width: 100%;
+	padding: 10px 16px;
+	border-top: 1px solid $gray;
+	box-sizing: border-box;
 
 	p {
 		text-align: center;
 		margin-top: 0;
 	}
 
-  	@include breakpoint( '>480px' ) {
+	@include breakpoint( '>480px' ) {
 		margin-left: -24px;
 		padding: 10px 24px;
-  	}
+	}
 
 	@include breakpoint( '>660px' ) {
 		flex-direction: row;
-	  	position: relative;
-	  	margin-left: 0;
-	  	padding: 0;
-	  	border-top: none;
+		position: relative;
+		margin-left: 0;
+		padding: 0;
+		border-top: none;
 
 		p {
 			text-align: auto;

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -125,6 +125,15 @@
 	}
 }
 
+.admin-bar .dops-modal-wrapper {
+	@media only screen and (min-width: 600px) {
+		top: 46px;
+	}
+	@media only screen and (min-width: 782px) {
+		top: 32px;
+	}
+}
+
 .jetpack-termination-dialog__button-row {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Make the cancel and disconnect buttons always visible on mobile devices.

Fixes #8726
Before:
<img width="448" alt="Screen Shot 2020-03-09 at 11 56 49 AM" src="https://user-images.githubusercontent.com/115071/76206879-12e77400-61fd-11ea-82e6-e5f5ab5567a4.png">


After:
<img width="438" alt="Screen Shot 2020-03-09 at 11 55 56 AM" src="https://user-images.githubusercontent.com/115071/76206799-f21f1e80-61fc-11ea-8b2a-d1542f3542ea.png">


#### Changes proposed in this Pull Request:
*

#### Testing instructions:
* Connect your site.
* On a mobile iPhone or any other device (use browserstack.com ) device try disconnection.
* Are you able to do it? Do you see the button as expected?


#### Proposed changelog entry for your changes:
* Fix broken flow. Show the disconnect button on mobile always.
