### PR TITLE
Simple Payments: Fix the upgrade nudge

### DIFF
--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -17,7 +17,8 @@ export const BlockNudge = ( { autosaveAndRedirect, buttonLabel, href, icon, subt
 					href={ href } // Only for server-side rendering, since onClick doesn't work there.
 					onClick={ autosaveAndRedirect }
 					target="_top"
-					isDefault
+					isSecondary
+					isLarge
 				>
 					{ buttonLabel }
 				</Button>,

--- a/modules/simple-payments/simple-payments.php
+++ b/modules/simple-payments/simple-payments.php
@@ -157,7 +157,7 @@ class Jetpack_Simple_Payments {
 
 		if ( ! $this->is_enabled_jetpack_simple_payments() ) {
 			if ( ! is_feed() ) {
-				$this->output_admin_warning( $data );
+				return $this->output_admin_warning( $data );
 			}
 			return;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14743

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This makes sure we output the UpgradeNotice on WPCOM when a user has a SimplePayments block but no plan.
* Also fixes the display of a button

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* bug fix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the D40071-code patch
* Open the block editor on a Simple site without a plan
* Add a Simple Payments block
* Verify that you see the Upgrade Nudge
* Add all the block details and save the page
* Open the page in the front end
* Check that you see the upgrade nudge like this:
<img width="876" alt="Screenshot 2020-03-09 at 16 55 02" src="https://user-images.githubusercontent.com/275961/76237794-bac56780-6226-11ea-97bd-6b97fce29883.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
