### PR TITLE
Blocks: introduce new Podcast Episodes block

### DIFF
--- a/extensions/blocks/podcast-episodes/attributes.js
+++ b/extensions/blocks/podcast-episodes/attributes.js
@@ -1,0 +1,3 @@
+export default {
+	// @TODO - Add block attributes here
+};

--- a/extensions/blocks/podcast-episodes/edit.js
+++ b/extensions/blocks/podcast-episodes/edit.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { BlockIcon } from '@wordpress/block-editor';
+import { Placeholder, withNotices } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import icon from './icon';
+
+function PodcastEpisodesEdit( {
+	attributes,
+	className,
+	noticeOperations,
+	noticeUI,
+	setAttributes,
+} ) {
+	/**
+	 * Write the block editor UI.
+	 *
+	 * @returns {object} The UI displayed when user edits this block.
+	 */
+	const [ notice, setNotice ] = useState();
+
+	/* Call this function when you want to show an error in the placeholder. */
+	const setErrorNotice = () => {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice( __( 'Put error message here.', 'jetpack' ) );
+	};
+
+	return (
+		<div className={ className }>
+			<Placeholder
+				label={ __( 'Podcast Episodes', 'jetpack' ) }
+				instructions={ __( 'Instructions go here.', 'jetpack' ) }
+				icon={ <BlockIcon icon={ icon } /> }
+				notices={ noticeUI }
+			>
+				{ __( 'User input goes here?', 'jetpack' ) }
+			</Placeholder>
+		</div>
+	);
+}
+
+export default PodcastEpisodesEdit;

--- a/extensions/blocks/podcast-episodes/edit.js
+++ b/extensions/blocks/podcast-episodes/edit.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 /**
  * External dependencies
  */

--- a/extensions/blocks/podcast-episodes/editor.js
+++ b/extensions/blocks/podcast-episodes/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/extensions/blocks/podcast-episodes/editor.scss
+++ b/extensions/blocks/podcast-episodes/editor.scss
@@ -1,0 +1,5 @@
+/**
+ * Editor styles for Podcast Episodes
+ */
+
+.wp-block-jetpack-podcast-episodes { }

--- a/extensions/blocks/podcast-episodes/icon.js
+++ b/extensions/blocks/podcast-episodes/icon.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export default (
+	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
+	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+	</SVG>
+);

--- a/extensions/blocks/podcast-episodes/icon.js
+++ b/extensions/blocks/podcast-episodes/icon.js
@@ -1,11 +1,22 @@
 /**
  * External dependencies
  */
-import { SVG, Path } from '@wordpress/components';
+import { G, Path, Rect, SVG } from '@wordpress/components';
 
 export default (
-	/* @TODO Add the icon. You can use one of these https://material.io/tools/icons/?style=outline */
 	<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-		<Path d="M9 15h2V9H9v6zm1-10c-.5 0-1 .5-1 1s.5 1 1 1 1-.5 1-1-.5-1-1-1zm0-4c-5 0-9 4-9 9s4 9 9 9 9-4 9-9-4-9-9-9zm0 16c-3.9 0-7-3.1-7-7s3.1-7 7-7 7 3.1 7 7-3.1 7-7 7z" />
+		<G>
+			<Rect fill="none" height="24" width="24" />
+			<Rect fill="none" height="24" width="24" />
+			<Rect fill="none" height="24" width="24" />
+		</G>
+		<G>
+			<G />
+			<G>
+				<G transform="matrix(1 0 0 1 144 120)">
+					<Path d="M-122-114h-5v8.18c-0.31-0.11-0.65-0.18-1-0.18c-1.66,0-3,1.34-3,3s1.34,3,3,3s3-1.34,3-3v-9h3V-114 L-122-114z M-129-114h-12v2h12V-114L-129-114z M-129-110h-12v2h12V-110L-129-110z M-133-106h-8v2h8V-106L-133-106z M-129-103 c0-0.55,0.45-1,1-1c0.55,0,1,0.45,1,1s-0.45,1-1,1C-128.55-102-129-102.45-129-103z" />
+				</G>
+			</G>
+		</G>
 	</SVG>
 );

--- a/extensions/blocks/podcast-episodes/index.js
+++ b/extensions/blocks/podcast-episodes/index.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import edit from './edit';
+import icon from './icon';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+export const name = 'podcast-episodes';
+export const title = __( 'Podcast Episodes', 'jetpack' );
+export const settings = {
+	title,
+	description: (
+		<Fragment>
+			<p>{ __( 'Podcast Episodes', 'jetpack' ) }</p>
+			<ExternalLink href="#">{ __( 'Learn more about Podcast Episodes', 'jetpack' ) }</ExternalLink>
+		</Fragment>
+	),
+	icon,
+	category: 'jetpack',
+	keywords: [],
+	supports: {
+		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
+		align: false /* if set to true, the 'align' option below can be used*/,
+		// Pick which alignment options to display.
+		/*align: [ 'left', 'right', 'full' ],*/
+		// Support for wide alignment, that requires additional support in themes.
+		alignWide: true,
+		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		anchor: false,
+		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		customClassName: true,
+		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		className: true,
+		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		html: false,
+		// Passing false hides this block in Gutenberg's visual inserter.
+		/*inserter: true,*/
+		// When false, user will only be able to insert the block once per post.
+		multiple: true,
+		// When false, the block won't be available to be converted into a reusable block.
+		reusable: true,
+	},
+	edit,
+	/* @TODO Write the block editor output */
+	save: () => null,
+	attributes,
+	example: {
+		attributes: {
+			// @TODO: Add default values for block attributes, for generating the block preview.
+		},
+	},
+};

--- a/extensions/blocks/podcast-episodes/podcast-episodes.php
+++ b/extensions/blocks/podcast-episodes/podcast-episodes.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Podcast Episodes Block.
+ *
+ * @since 8.x
+ *
+ * @package Jetpack
+ */
+
+namespace Jetpack\Podcast_Episodes_Block;
+
+const FEATURE_NAME = 'podcast-episodes';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Podcast Episodes block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Podcast Episodes block attributes.
+ * @param string $content String containing the Podcast Episodes block content.
+ *
+ * @return string
+ */
+function load_assets( $attr, $content ) {
+	/*
+	 * Enqueue necessary scripts and styles.
+	 */
+	\Jetpack_Gutenberg::load_assets_as_required( 'podcast-episodes' );
+
+	return $content;
+}

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -28,5 +28,5 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "seo" ]
+	"beta": [ "amazon", "seo", "podcast-episodes" ]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds scaffolding for a Podcast Episodes block. Implementation to follow in separate PRs.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* paYJgx-sH-p2

#### Testing instructions:

* Check out the PR and build extensions.
* Make sure there is a Podcast Episodes (beta) block in the block selector.
* Insert in to the editor and make sure it doesn't break the editor or the frontend.

#### Proposed changelog entry for your changes:

* Introduces a beta Podcasts Episodes block.
