### PR TITLE
Instant Search: Iterate on overlay interface

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -83,19 +83,29 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$widget_options = end( $widget_options );
 		}
 
-		$overlay_widget_ids = array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
+		$overlay_widget_ids      = array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
 			get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'] : array();
-		$filters            = Jetpack_Search_Helpers::get_filters_from_widgets( $overlay_widget_ids );
-		$widgets            = array();
-		foreach ( $filters as $key => $filter ) {
-			if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
-				$widgets[ $filter['widget_id'] ]['filters']   = array();
-				$widgets[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+		$filters                 = Jetpack_Search_Helpers::get_filters_from_widgets();
+		$widgets                 = array();
+		$widgets_outside_overlay = array();
+		foreach ( $filters as $key => &$filter ) {
+			$filter['filter_id'] = $key;
+
+			if ( in_array( $filter['widget_id'], $overlay_widget_ids, true ) ) {
+				if ( ! isset( $widgets[ $filter['widget_id'] ] ) ) {
+					$widgets[ $filter['widget_id'] ]['filters']   = array();
+					$widgets[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+				}
+				$widgets[ $filter['widget_id'] ]['filters'][] = $filter;
+			} else {
+				if ( ! isset( $widgets_outside_overlay[ $filter['widget_id'] ] ) ) {
+					$widgets_outside_overlay[ $filter['widget_id'] ]['filters']   = array();
+					$widgets_outside_overlay[ $filter['widget_id'] ]['widget_id'] = $filter['widget_id'];
+				}
+				$widgets_outside_overlay[ $filter['widget_id'] ]['filters'][] = $filter;
 			}
-			$new_filter                                   = $filter;
-			$new_filter['filter_id']                      = $key;
-			$widgets[ $filter['widget_id'] ]['filters'][] = $new_filter;
 		}
+		unset( $filter );
 
 		$post_type_objs   = get_post_types( array(), 'objects' );
 		$post_type_labels = array();
@@ -108,7 +118,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		$prefix  = Jetpack_Search_Options::OPTION_PREFIX;
 		$options = array(
-			'overlayOptions'  => array(
+			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
 				'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', false ),
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
@@ -117,16 +127,17 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			),
 
 			// core config.
-			'homeUrl'         => home_url(),
-			'locale'          => str_replace( '_', '-', Jetpack_Search_Helpers::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
-			'postsPerPage'    => get_option( 'posts_per_page' ),
-			'siteId'          => Jetpack::get_option( 'id' ),
+			'homeUrl'               => home_url(),
+			'locale'                => str_replace( '_', '-', Jetpack_Search_Helpers::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
+			'postsPerPage'          => get_option( 'posts_per_page' ),
+			'siteId'                => Jetpack::get_option( 'id' ),
 
 			// filtering.
-			'postTypeFilters' => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
-			'postTypes'       => $post_type_labels,
-			'sort'            => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
-			'widgets'         => array_values( $widgets ),
+			'postTypeFilters'       => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
+			'postTypes'             => $post_type_labels,
+			'sort'                  => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
+			'widgets'               => array_values( $widgets ),
+			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
 		);
 
 		/**

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -118,7 +118,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 			// core config.
 			'homeUrl'         => home_url(),
-			'locale'          => str_replace( '_', '-', get_locale() ),
+			'locale'          => str_replace( '_', '-', Jetpack_Search_Helpers::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
 			'postsPerPage'    => get_option( 'posts_per_page' ),
 			'siteId'          => Jetpack::get_option( 'id' ),
 

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -680,4 +680,24 @@ class Jetpack_Search_Helpers {
 	public static function get_max_offset() {
 		return Jetpack_Search_Options::site_has_vip_index() ? 9000 : 1000;
 	}
+
+	/**
+	 * Returns the maximum offset for a search query.
+	 *
+	 * @since 8.4.0
+	 * @param string $locale    A potentially valid locale string.
+	 *
+	 * @return bool
+	 */
+	public static function is_valid_locale( $locale ) {
+		if ( ! class_exists( 'GP_Locales' ) ) {
+			if ( defined( 'JETPACK__GLOTPRESS_LOCALES_PATH' ) && file_exists( JETPACK__GLOTPRESS_LOCALES_PATH ) ) {
+				require JETPACK__GLOTPRESS_LOCALES_PATH;
+			} else {
+				// Assume locale to be valid if we can't check with GlotPress.
+				return true;
+			}
+		}
+		return false !== GP_Locales::by_field( 'wp_locale', $locale );
+	}
 }

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -30,7 +30,7 @@ const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) =
 				`jetpack-instant-search__overlay--${ colorTheme }`,
 				isVisible ? '' : 'is-hidden',
 			].join( ' ' ) }
-			style={ { opacity: opacity / 100 } }
+			style={ { opacity: isVisible ? opacity / 100 : 0 } }
 		>
 			{ children }
 		</div>

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -9,7 +9,7 @@
 	background: rgba(255, 255, 255, 0.975);
 	overflow-y: auto;
 	overflow-x: hidden;
-	transition: opacity 0.5s linear, 0.25s transform ease-in-out;
+	transition: opacity 0.3s linear, 0.5s transform ease-in-out;
 
 	&.is-hidden {
 		transform: translateX( 100vw );

--- a/modules/search/instant-search/components/preselected-search-filters.jsx
+++ b/modules/search/instant-search/components/preselected-search-filters.jsx
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+/**
+ * External dependencies
+ */
+import { h } from 'preact';
+
+/**
+ * Internal dependencies
+ */
+import { getPreselectedFilters } from '../lib/query-string';
+import SearchFilters from './search-filters';
+
+const PreselectedSearchFilters = props => {
+	const preselectedFilters = getPreselectedFilters( props.widgets, props.widgetsOutsideOverlay );
+
+	return (
+		<div className="jetpack-instant-search__testing">
+			{ preselectedFilters.length > 0 && (
+				<SearchFilters
+					loading={ props.isLoading }
+					locale={ props.locale }
+					postTypes={ props.postTypes }
+					results={ props.results }
+					widget={ { filters: preselectedFilters } }
+				/>
+			) }
+		</div>
+	);
+};
+export default PreselectedSearchFilters;

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -272,6 +272,7 @@ class SearchApp extends Component {
 					resultFormat={ getResultFormatQuery() }
 					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
 					widgets={ this.props.options.widgets }
+					widgetsOutsideOverlay={ this.props.options.widgetsOutsideOverlay }
 				/>
 			</Overlay>,
 			document.body

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -122,12 +122,18 @@ class SearchApp extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
+		this.handleInput.flush();
+		setSearchQuery( event.target.elements.s.value );
 		this.showResults();
 	};
 
-	handleInput = event => {
+	handleInput = debounce( event => {
+		// Reference: https://rawgit.com/w3c/input-events/v1/index.html#interface-InputEvent-Attributes
+		if ( event.inputType.includes( 'delete' ) || event.inputType.includes( 'format' ) ) {
+			return;
+		}
 		setSearchQuery( event.target.value );
-	};
+	}, 200 );
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
@@ -169,7 +175,11 @@ class SearchApp extends Component {
 	};
 
 	onChangeQueryString = () => {
-		this.getResults();
+		if ( !! getSearchQuery() || hasFilter() ) {
+			this.getResults().then( () => {
+				! this.state.showResults && this.showResults();
+			} );
+		}
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.value = getSearchQuery();
@@ -178,6 +188,9 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.value = getSortOptionFromSortKey( getSortQuery() );
 		} );
+
+		// NOTE: This is necessary to ensure that the search query has been propagated to SearchBox
+		this.forceUpdate();
 	};
 
 	loadNextPage = () => {
@@ -193,45 +206,45 @@ class SearchApp extends Component {
 	} = {} ) => {
 		const requestId = this.state.requestId + 1;
 
-		this.setState( { requestId, isLoading: true }, () => {
-			search( {
-				// Skip aggregations when requesting for paged results
-				aggregations: !! pageHandle ? {} : this.props.aggregations,
-				filter,
-				pageHandle,
-				query,
-				resultFormat,
-				siteId: this.props.options.siteId,
-				sort,
-				postsPerPage: this.props.options.postsPerPage,
+		this.setState( { requestId, isLoading: true } );
+		return search( {
+			// Skip aggregations when requesting for paged results
+			aggregations: !! pageHandle ? {} : this.props.aggregations,
+			filter,
+			pageHandle,
+			query,
+			resultFormat,
+			siteId: this.props.options.siteId,
+			sort,
+			postsPerPage: this.props.options.postsPerPage,
+		} )
+			.then( newResponse => {
+				if ( this.state.requestId === requestId ) {
+					const response = { ...newResponse };
+					if ( !! pageHandle ) {
+						response.aggregations = {
+							...( 'aggregations' in this.state.response && ! Array.isArray( this.state.response )
+								? this.state.response.aggregations
+								: {} ),
+							...( ! Array.isArray( newResponse.aggregations ) ? newResponse.aggregations : {} ),
+						};
+						response.results = [
+							...( 'results' in this.state.response ? this.state.response.results : [] ),
+							...newResponse.results,
+						];
+					}
+					this.setState( { response, hasError: false, isLoading: false } );
+					return;
+				}
+				this.setState( { isLoading: false } );
 			} )
-				.then( newResponse => {
-					if ( this.state.requestId === requestId ) {
-						const response = { ...newResponse };
-						if ( !! pageHandle ) {
-							response.aggregations = {
-								...( 'aggregations' in this.state.response && ! Array.isArray( this.state.response )
-									? this.state.response.aggregations
-									: {} ),
-								...( ! Array.isArray( newResponse.aggregations ) ? newResponse.aggregations : {} ),
-							};
-							response.results = [
-								...( 'results' in this.state.response ? this.state.response.results : [] ),
-								...newResponse.results,
-							];
-						}
-						this.setState( { response, hasError: false } );
-					}
-					this.setState( { isLoading: false } );
-				} )
-				.catch( error => {
-					if ( error instanceof ProgressEvent ) {
-						this.setState( { isLoading: false, hasError: true } );
-						return;
-					}
-					throw error;
-				} );
-		} );
+			.catch( error => {
+				if ( error instanceof ProgressEvent ) {
+					this.setState( { isLoading: false, hasError: true } );
+					return;
+				}
+				throw error;
+			} );
 	};
 
 	render() {

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -18,31 +18,35 @@ import { getSortQuery } from '../lib/query-string';
 
 let initiallyFocusedElement = null;
 
+const cb = ( overlayElement, inputElement ) => event => {
+	if (
+		event &&
+		event.target &&
+		! event.target.classList.contains( 'jetpack-instant-search__overlay' )
+	) {
+		return;
+	}
+
+	if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
+		initiallyFocusedElement = document.activeElement;
+		inputElement.focus();
+		return;
+	}
+	initiallyFocusedElement && initiallyFocusedElement.focus();
+};
+
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	const inputRef = useRef( null );
 
-	const cb = overlayElement => event => {
-		if (
-			event &&
-			event.target &&
-			! event.target.classList.contains( '.jetpack-instant-search__overlay' )
-		) {
-			return;
-		}
-
-		if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
-			initiallyFocusedElement = document.activeElement;
-			inputRef.current.focus();
-			return;
-		}
-		initiallyFocusedElement && initiallyFocusedElement.focus();
-	};
-
 	useEffect( () => {
 		const overlayElement = document.querySelector( '.jetpack-instant-search__overlay' );
-		overlayElement.addEventListener( 'transitionend', cb( overlayElement ), true );
-		cb( overlayElement )(); // invoke focus if page loads with overlay already present
+		overlayElement.addEventListener(
+			'transitionend',
+			cb( overlayElement, inputRef.current ),
+			true
+		);
+		cb( overlayElement, inputRef.current )(); // invoke focus if page loads with overlay already present
 		return () => {
 			overlayElement.removeEventListener( 'transitionend', cb );
 		};

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -17,40 +17,19 @@ import SearchSort from './search-sort';
 import { getSortQuery } from '../lib/query-string';
 
 let initiallyFocusedElement = null;
-
-const cb = ( overlayElement, inputElement ) => event => {
-	if (
-		event &&
-		event.target &&
-		! event.target.classList.contains( 'jetpack-instant-search__overlay' )
-	) {
-		return;
-	}
-
-	if ( ! overlayElement.classList.contains( 'is-hidden' ) ) {
-		initiallyFocusedElement = document.activeElement;
-		inputElement.focus();
-		return;
-	}
-	initiallyFocusedElement && initiallyFocusedElement.focus();
+const stealFocusWithInput = inputElement => () => {
+	initiallyFocusedElement = document.activeElement;
+	inputElement.focus();
 };
+const restoreFocus = () => initiallyFocusedElement && initiallyFocusedElement.focus();
 
 const SearchBox = props => {
 	const [ inputId ] = useState( () => uniqueId( 'jetpack-instant-search__box-input-' ) );
 	const inputRef = useRef( null );
 
 	useEffect( () => {
-		const overlayElement = document.querySelector( '.jetpack-instant-search__overlay' );
-		overlayElement.addEventListener(
-			'transitionend',
-			cb( overlayElement, inputRef.current ),
-			true
-		);
-		cb( overlayElement, inputRef.current )(); // invoke focus if page loads with overlay already present
-		return () => {
-			overlayElement.removeEventListener( 'transitionend', cb );
-		};
-	}, [] );
+		props.isVisible ? stealFocusWithInput( inputRef.current )() : restoreFocus();
+	}, [ props.isVisible ] );
 
 	return (
 		<Fragment>

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -10,12 +10,9 @@
 }
 
 input.jetpack-instant-search__box-input.search-field {
-	background: #fff;
 	border-radius: 5px;
 	border-style: solid;
 	border-width: 2px;
-	border-color: #b8b8b8;
-	color: black;
 	font-size: 18px;
 	line-height: 1;
 	margin: 0;
@@ -23,12 +20,36 @@ input.jetpack-instant-search__box-input.search-field {
 	text-indent: 32px;
 	vertical-align: middle;
 
-	&:hover {
-		border-color: #8E8E8E;
+	.jetpack-instant-search__overlay--light & {
+		color: #666666;
+		background: #ffffff;
+		border-color: #b8b8b8;
+
+		&:hover {
+			color: #000000;
+			border-color: #8e8e8e;
+		}
+
+		&:focus {
+			color: #000000;
+			border-color: #5A5A5A;
+		}
 	}
 
-	&:focus {
-		border-color: #5A5A5A;
+	.jetpack-instant-search__overlay--dark & {
+		color: #b0b0b0;
+		background: #000000;
+		border-color: #5a5a5a;
+
+		&:hover {
+			color: #ffffff;
+			border-color: #8e8e8e;
+		}
+
+		&:focus {
+			color: #ffffff;
+			border-color: #c8c8c8;
+		}
 	}
 }
 
@@ -158,8 +179,8 @@ input.jetpack-instant-search__box-input.search-field {
 .jetpack-instant-search__box input,
 .jetpack-instant-search__box input[type='search'].jetpack-instant-search__box-input {
 	width: 100%;
-  height: 52px;
-	transition: color, border-color 0.25s ease-in-out;
+	height: 52px;
+	transition: color 0.15s ease-in-out, border-color 0.25s ease-in-out;
 
 	&::-webkit-search-decoration,
 	&::-webkit-search-cancel-button,

--- a/modules/search/instant-search/components/search-filter.jsx
+++ b/modules/search/instant-search/components/search-filter.jsx
@@ -28,9 +28,6 @@ function getDateOptions( interval ) {
 // TODO: Fix this in the API
 // TODO: Remove once format is fixed in the API
 function fixDateFormat( dateString ) {
-	if ( dateString[ dateString.length - 1 ] !== 'Z' ) {
-		dateString += 'Z';
-	}
 	return dateString.split( ' ' ).join( 'T' );
 }
 
@@ -77,7 +74,7 @@ export default class SearchFilter extends Component {
 					{ new Date( fixDateFormat( key ) ).toLocaleString(
 						locale,
 						getDateOptions( this.props.configuration.interval )
-					) }{' '}
+					) }{ ' ' }
 					({ count })
 				</label>
 			</div>

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -64,13 +64,8 @@ export default class SearchFilters extends Component {
 		}
 
 		const aggregations = get( this.props.results, 'aggregations' );
-		const cls =
-			this.props.loading === true
-				? 'jetpack-instant-search__filters jetpack-instant-search__is-loading'
-				: 'jetpack-instant-search__filters';
-
 		return (
-			<div className={ cls }>
+			<div className="jetpack-instant-search__filters">
 				{ this.hasActiveFilters() && (
 					<a
 						class="jetpack-instant-search__clear-filters-link"

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -15,6 +15,7 @@ import get from 'lodash/get';
  */
 import SearchFilter from './search-filter';
 import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/query-string';
+import { mapFilterToFilterKey, mapFilterToType } from '../lib/filters';
 
 export default class SearchFilters extends Component {
 	onChangeFilter = ( filterName, filterValue ) => {
@@ -44,48 +45,18 @@ export default class SearchFilters extends Component {
 		return getFilterQuery();
 	}
 
-	renderFilterComponent = ( { configuration, results } ) => {
-		switch ( configuration.type ) {
-			case 'date_histogram':
-				return (
-					results && (
-						<SearchFilter
-							aggregation={ results }
-							configuration={ configuration }
-							locale={ this.props.locale }
-							type="date"
-							value={ this.getFilters()[ `${ configuration.interval }_${ configuration.field }` ] }
-							onChange={ this.onChangeFilter }
-						/>
-					)
-				);
-			case 'taxonomy':
-				return (
-					results && (
-						<SearchFilter
-							aggregation={ results }
-							configuration={ configuration }
-							value={ this.getFilters()[ configuration.taxonomy ] }
-							onChange={ this.onChangeFilter }
-							type="taxonomy"
-						/>
-					)
-				);
-			case 'post_type':
-				return (
-					results && (
-						<SearchFilter
-							aggregation={ results }
-							configuration={ configuration }
-							value={ this.getFilters().post_types }
-							onChange={ this.onChangeFilter }
-							postTypes={ this.props.postTypes }
-							type="postType"
-						/>
-					)
-				);
-		}
-	};
+	renderFilterComponent = ( { configuration, results } ) =>
+		results && (
+			<SearchFilter
+				aggregation={ results }
+				configuration={ configuration }
+				locale={ this.props.locale }
+				onChange={ this.onChangeFilter }
+				postTypes={ this.props.postTypes }
+				type={ mapFilterToType( configuration ) }
+				value={ this.getFilters()[ mapFilterToFilterKey( configuration ) ] }
+			/>
+		);
 
 	render() {
 		if ( ! this.props.widget ) {

--- a/modules/search/instant-search/components/search-filters.jsx
+++ b/modules/search/instant-search/components/search-filters.jsx
@@ -18,6 +18,10 @@ import { setFilterQuery, getFilterQuery, clearFiltersFromQuery } from '../lib/qu
 import { mapFilterToFilterKey, mapFilterToType } from '../lib/filters';
 
 export default class SearchFilters extends Component {
+	static defaultProps = {
+		showClearFiltersButton: true,
+	};
+
 	onChangeFilter = ( filterName, filterValue ) => {
 		setFilterQuery( filterName, filterValue );
 		this.props.onChange && this.props.onChange();
@@ -66,7 +70,7 @@ export default class SearchFilters extends Component {
 		const aggregations = get( this.props.results, 'aggregations' );
 		return (
 			<div className="jetpack-instant-search__filters">
-				{ this.hasActiveFilters() && (
+				{ this.props.showClearFiltersButton && this.hasActiveFilters() && (
 					<a
 						class="jetpack-instant-search__clear-filters-link"
 						href="#"

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -12,7 +12,13 @@ import JetpackColophon from './jetpack-colophon';
 import SearchBox from './search-box';
 import SearchFilters from './search-filters';
 
-import { getFilterQuery, getSearchQuery, setSearchQuery, setSortQuery } from '../lib/query-string';
+import {
+	getFilterQuery,
+	getSearchQuery,
+	hasPreselectedFilters,
+	setSearchQuery,
+	setSortQuery,
+} from '../lib/query-string';
 import PreselectedSearchFilters from './preselected-search-filters';
 
 const noop = event => event.preventDefault();
@@ -68,7 +74,7 @@ class SearchForm extends Component {
 							widgets={ this.props.widgets }
 							widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 						/>
-						{ this.props.widgets.map( widget => (
+						{ this.props.widgets.map( ( widget, index ) => (
 							<SearchFilters
 								filters={ getFilterQuery() }
 								loading={ this.props.isLoading }
@@ -76,6 +82,10 @@ class SearchForm extends Component {
 								onChange={ this.hideFilters }
 								postTypes={ this.props.postTypes }
 								results={ this.props.response }
+								showClearFiltersButton={
+									! hasPreselectedFilters( this.props.widgets, this.props.widgetsOutsideOverlay ) &&
+									index === 0
+								}
 								widget={ widget }
 							/>
 						) ) }

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -48,6 +48,7 @@ class SearchForm extends Component {
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
 						enableFilters
+						isVisible={ this.props.isVisible }
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -13,6 +13,7 @@ import SearchBox from './search-box';
 import SearchFilters from './search-filters';
 
 import { getFilterQuery, getSearchQuery, setSearchQuery, setSortQuery } from '../lib/query-string';
+import PreselectedSearchFilters from './preselected-search-filters';
 
 const noop = event => event.preventDefault();
 
@@ -58,6 +59,14 @@ class SearchForm extends Component {
 				{ this.state.showFilters && (
 					<div className="jetpack-instant-search__search-form-filters">
 						<div className="jetpack-instant-search__search-form-filters-arrow" />
+						<PreselectedSearchFilters
+							loading={ this.props.isLoading }
+							locale={ this.props.locale }
+							postTypes={ this.props.postTypes }
+							results={ this.props.response }
+							widgets={ this.props.widgets }
+							widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
+						/>
 						{ this.props.widgets.map( widget => (
 							<SearchFilters
 								filters={ getFilterQuery() }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -67,6 +67,7 @@ class SearchResults extends Component {
 					postTypes={ this.props.postTypes }
 					response={ this.props.response }
 					widgets={ this.props.widgets }
+					widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 				/>
 
 				<div
@@ -137,6 +138,7 @@ class SearchResults extends Component {
 				response={ this.props.response }
 				showPoweredBy={ this.props.showPoweredBy }
 				widgets={ this.props.widgets }
+				widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 			/>
 		);
 	}

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -66,6 +66,7 @@ class SearchResults extends Component {
 				<SearchForm
 					className="jetpack-instant-search__search-results-search-form"
 					isLoading={ this.props.isLoading }
+					isVisible={ this.props.isVisible }
 					locale={ this.props.locale }
 					postTypes={ this.props.postTypes }
 					response={ this.props.response }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -23,23 +23,26 @@ class SearchResults extends Component {
 		const hasCorrectedQuery = corrected_query !== false;
 		const num = new Intl.NumberFormat().format( total );
 
+		if ( this.props.isLoading ) {
+			return sprintf( __( 'Searching…', 'jetpack' ), this.props.query );
+		}
 		if ( total === 0 || this.props.hasError ) {
-			return sprintf( __( 'No results for "%s".', 'jetpack' ), this.props.query );
+			return sprintf( __( 'No results found', 'jetpack' ), this.props.query );
 		}
 		if ( hasQuery && hasCorrectedQuery ) {
 			return sprintf(
-				_n( 'Showing %s result for "%s"', 'Showing %s results for "%s"', total, 'jetpack' ),
+				_n( 'Found %s result for "%s"', 'Found %s results for "%s"', total, 'jetpack' ),
 				num,
 				corrected_query
 			);
 		} else if ( hasQuery ) {
 			return sprintf(
-				_n( '%s result for "%s"', '%s results for "%s"', total, 'jetpack' ),
+				_n( 'Found %s result', 'Found %s results', total, 'jetpack' ),
 				num,
 				this.props.query
 			);
 		}
-		return sprintf( _n( '%s result', '%s results', total, 'jetpack' ), num );
+		return sprintf( _n( 'Found %s result', 'Found %s results', total, 'jetpack' ), num );
 	}
 
 	renderPrimarySection() {
@@ -70,13 +73,7 @@ class SearchResults extends Component {
 					widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 				/>
 
-				<div
-					className={
-						hasResults
-							? 'jetpack-instant-search__search-results-real-query'
-							: 'jetpack-instant-search__search-results-empty'
-					}
-				>
+				<div className="jetpack-instant-search__search-results-title">
 					{ this.getSearchTitle() }
 				</div>
 
@@ -100,9 +97,7 @@ class SearchResults extends Component {
 				) }
 				{ hasResults && ! this.props.hasError && (
 					<ol
-						className={ `jetpack-instant-search__search-results-list is-format-${
-							this.props.resultFormat
-						}${ this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : '' }` }
+						className={ `jetpack-instant-search__search-results-list is-format-${ this.props.resultFormat }` }
 					>
 						{ results.map( ( result, index ) => (
 							<SearchResult
@@ -160,9 +155,7 @@ class SearchResults extends Component {
 			<main
 				aria-hidden={ this.props.isLoading === true }
 				aria-live="polite"
-				className={ `jetpack-instant-search__search-results ${
-					this.props.isLoading === true ? ' jetpack-instant-search__is-loading' : ''
-				}` }
+				className="jetpack-instant-search__search-results"
 			>
 				<a
 					className="jetpack-instant-search__overlay-close"

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -65,13 +65,13 @@
 	}
 }
 
-.jetpack-instant-search__search-results-real-query {
+.jetpack-instant-search__search-results-title {
 	font-size: 1em;
 	font-weight: bold;
 }
 
-.jetpack-instant-search__search-results-unused-query,
-.jetpack-instant-search__search-results-real-query {
+.jetpack-instant-search__search-results-title,
+.jetpack-instant-search__search-results-unused-query {
 	overflow: hidden;
 	margin: 0;
 	padding: 0;

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -12,10 +12,19 @@ import WidgetAreaContainer from './widget-area-container';
  * Internal dependencies
  */
 import JetpackColophon from './jetpack-colophon';
+import PreselectedSearchFilters from './preselected-search-filters';
 
 const SearchSidebar = props => {
 	return (
 		<div className="jetpack-instant-search__sidebar">
+			<PreselectedSearchFilters
+				loading={ props.isLoading }
+				locale={ props.locale }
+				postTypes={ props.postTypes }
+				results={ props.response }
+				widgets={ props.widgets }
+				widgetsOutsideOverlay={ props.widgetsOutsideOverlay }
+			/>
 			<WidgetAreaContainer />
 			{ props.widgets.map( widget => {
 				return createPortal(

--- a/modules/search/instant-search/components/search-sidebar.jsx
+++ b/modules/search/instant-search/components/search-sidebar.jsx
@@ -13,6 +13,7 @@ import WidgetAreaContainer from './widget-area-container';
  */
 import JetpackColophon from './jetpack-colophon';
 import PreselectedSearchFilters from './preselected-search-filters';
+import { hasPreselectedFilters } from '../lib/query-string';
 
 const SearchSidebar = props => {
 	return (
@@ -26,7 +27,7 @@ const SearchSidebar = props => {
 				widgetsOutsideOverlay={ props.widgetsOutsideOverlay }
 			/>
 			<WidgetAreaContainer />
-			{ props.widgets.map( widget => {
+			{ props.widgets.map( ( widget, index ) => {
 				return createPortal(
 					<div
 						id={ `${ widget.widget_id }-portaled-wrapper` }
@@ -37,6 +38,9 @@ const SearchSidebar = props => {
 							locale={ props.locale }
 							postTypes={ props.postTypes }
 							results={ props.response }
+							showClearFiltersButton={
+								! hasPreselectedFilters( props.widgets, props.widgetsOutsideOverlay ) && index === 0
+							}
 							widget={ widget }
 						/>
 					</div>,

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -18,7 +18,10 @@ import { buildFilterAggregations } from './lib/api';
 const injectSearchApp = () => {
 	render(
 		<SearchApp
-			aggregations={ buildFilterAggregations( window[ SERVER_OBJECT_NAME ].widgets ) }
+			aggregations={ buildFilterAggregations( [
+				...window[ SERVER_OBJECT_NAME ].widgets,
+				...window[ SERVER_OBJECT_NAME ].widgetsOutsideOverlay,
+			] ) }
 			initialHref={ window.location.href }
 			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }

--- a/modules/search/instant-search/instant-search.scss
+++ b/modules/search/instant-search/instant-search.scss
@@ -26,10 +26,6 @@ $grid-size-large: 16px;
 @import './components/search-result-product.scss';
 @import './components/search-sidebar.scss';
 
-.jetpack-instant-search__is-loading {
-	opacity: 0.2;
-}
-
 .jetpack-search-filters-widget__filter-list {
 	list-style-type: none;
 }

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -10,7 +10,7 @@ import Cache from 'cache';
 /**
  * Internal dependencies
  */
-import { getFilterKeys } from './query-string';
+import { getFilterKeys } from './filters';
 import { MINUTE_IN_MILLISECONDS } from './constants';
 
 const isLengthyArray = array => Array.isArray( array ) && array.length > 0;

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -1,0 +1,74 @@
+// NOTE: We only import the difference package here for to reduced bundle size.
+//       Do not import the entire lodash library!
+// eslint-disable-next-line lodash/import-scope
+import difference from 'lodash/difference';
+
+/**
+ * Internal dependencies
+ */
+import { SERVER_OBJECT_NAME } from './constants';
+
+const FILTER_KEYS = Object.freeze( [
+	// Post types
+	'post_types',
+	// Date filters
+	'month_post_date',
+	'month_post_date_gmt',
+	'month_post_modified',
+	'month_post_modified_gmt',
+	'year_post_date',
+	'year_post_date_gmt',
+	'year_post_modified',
+	'year_post_modified_gmt',
+] );
+
+export function getFilterKeys() {
+	// Extract taxonomy names from server widget data
+	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
+		.map( w => w.filters )
+		.filter( filters => Array.isArray( filters ) )
+		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
+		.filter( filter => filter.type === 'taxonomy' )
+		.map( filter => filter.taxonomy );
+	return [ ...FILTER_KEYS, ...taxonomies ];
+}
+
+// These filter keys are selectable from sidebar filters
+function getSelectableFilterKeys( overlayWidgets ) {
+	return overlayWidgets
+		.map( extractFilters )
+		.reduce( ( prev, current ) => prev.concat( current ), [] );
+}
+
+// These filter keys are not selectable from sidebar filters
+// In other words, they were selected via filters outside the search sidebar
+export function getUnselectableFilterKeys( overlayWidgets ) {
+	return difference( getFilterKeys(), getSelectableFilterKeys( overlayWidgets ) );
+}
+
+function extractFilters( widget ) {
+	return widget.filters
+		.map( mapFilterToFilterKey )
+		.filter( filterName => typeof filterName === 'string' );
+}
+
+export function mapFilterToFilterKey( filter ) {
+	if ( filter.type === 'date_histogram' ) {
+		return `${ filter.interval }_${ filter.field }`;
+	} else if ( filter.type === 'taxonomy' ) {
+		return 'taxonomy';
+	} else if ( filter.type === 'post_type' ) {
+		return 'post_types';
+	}
+	return null;
+}
+
+export function mapFilterToType( filter ) {
+	if ( filter.type === 'date_histogram' ) {
+		return 'date';
+	} else if ( filter.type === 'taxonomy' ) {
+		return 'taxonomy';
+	} else if ( filter.type === 'post_type' ) {
+		return 'postType';
+	}
+}

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -56,7 +56,7 @@ export function mapFilterToFilterKey( filter ) {
 	if ( filter.type === 'date_histogram' ) {
 		return `${ filter.interval }_${ filter.field }`;
 	} else if ( filter.type === 'taxonomy' ) {
-		return 'taxonomy';
+		return `${ filter.taxonomy }`;
 	} else if ( filter.type === 'post_type' ) {
 		return 'post_types';
 	}

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -180,6 +180,10 @@ export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay )
 		.filter( filter => keys.includes( mapFilterToFilterKey( filter ) ) );
 }
 
+export function hasPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
+	return getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ).length > 0;
+}
+
 export function hasFilter() {
 	return getFilterKeys().some( key => getFilterQueryByKey( key ).length > 0 );
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -229,8 +229,7 @@ export function restorePreviousHref( initialHref, callback ) {
 			return;
 		}
 
-		// Otherwise, invoke the callback and emit a QS change event
+		// Otherwise, invoke the callback
 		callback();
-		window.dispatchEvent( new Event( 'queryStringChange' ) );
 	}
 }

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -14,6 +14,7 @@ import {
 	RESULT_FORMAT_MINIMAL,
 	RESULT_FORMAT_PRODUCT,
 } from './constants';
+import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { getSortOption } from './sort';
 
 const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
@@ -151,31 +152,6 @@ function getFilterQueryByKey( filterKey ) {
 	return query[ filterKey ];
 }
 
-export function getFilterKeys() {
-	const keys = [
-		// Post types
-		'post_types',
-		// Date filters
-		'month_post_date',
-		'month_post_date_gmt',
-		'month_post_modified',
-		'month_post_modified_gmt',
-		'year_post_date',
-		'year_post_date_gmt',
-		'year_post_modified',
-		'year_post_modified_gmt',
-	];
-
-	// Extract taxonomy names from server widget data
-	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
-		.map( w => w.filters )
-		.filter( filters => Array.isArray( filters ) )
-		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )
-		.filter( filter => filter.type === 'taxonomy' )
-		.map( filter => filter.taxonomy );
-	return [ ...keys, ...taxonomies ];
-}
-
 export function getFilterQuery( filterKey ) {
 	if ( filterKey ) {
 		return getFilterQueryByKey( filterKey );
@@ -187,6 +163,21 @@ export function getFilterQuery( filterKey ) {
 			[ key ]: getFilterQueryByKey( key ),
 		} ) )
 	);
+}
+
+// These filter keys have been activated/selected outside of the overlay sidebar
+export function getPreselectedFilterKeys( overlayWidgets ) {
+	return getUnselectableFilterKeys( overlayWidgets ).filter(
+		key => Array.isArray( getFilterQueryByKey( key ) ) && getFilterQueryByKey( key ).length > 0
+	);
+}
+
+export function getPreselectedFilters( widgetsInOverlay, widgetsOutsideOverlay ) {
+	const keys = getPreselectedFilterKeys( widgetsInOverlay );
+	return widgetsOutsideOverlay
+		.map( widget => widget.filters )
+		.reduce( ( prev, current ) => prev.concat( current ), [] )
+		.filter( filter => keys.includes( mapFilterToFilterKey( filter ) ) );
 }
 
 export function hasFilter() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* #14848: Add server-side locale validation.
* #14788: Open overlay while the user is typing into a search input.
* #14834: Show filters selected outside of the search overlay.
* #14858: Update load indicator visuals
* #14889: Bugfix for 14788.
* #14875: Show `Clear Filters` button only once in the overlay.
* #14915: Improve overlay input styling in dark mode.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No, this is an incremental update to the unreleased Jetpack Instant Search product.

#### Testing instructions:
1. Follow [these setup instructions](https://github.com/Automattic/jetpack/blob/instant-search-master/modules/search/instant-search/README.md#testing-instructions) to set up Jetpack Instant Search on your site. Please note that the Jetpack Search widget will need to be added to twice: once to your site sidebar/footer and once to the Jetpack Search Sidebar within the search overlay.

2. Start typing something into your site search input. The overlay should appear while you're typing your query.

3. Try adjusting the search query in the search overlay. The text below the search input (`Found N results`) should briefly update to `Searching…` while the results are loading.

4. Close the overlay and try applying a filter via your search widget in your sidebar/footer. Ensure that the search overlay opens upon clicking the search filter; also ensure that the selected filter renders in the uppermost section of the overlay sidebar.

5. Ensure that only a single instance of the `Clear Filters` link appears in the overlay sidebar. 

#### Proposed changelog entry for your changes:
* No changelog necessary.
