### PR TITLE
Actions: push to master of each package when updated in monorepo

### DIFF
--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -1,0 +1,19 @@
+name: Update a package when it is updated in the monorepo
+on:
+  push:
+    branches:
+      - master # Every time a PR is merged to master.
+    paths:
+      - 'packages/**' # Only when package files are modified.
+
+jobs:
+  update_package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Keep Jetpack Packages up to date
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        run: |
+          sh ./bin/update-package.sh

--- a/bin/update-package.sh
+++ b/bin/update-package.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+git_setup()
+{
+  cat <<- EOF > "$HOME/.netrc"
+		machine github.com
+			login $GITHUB_ACTOR
+			password $GITHUB_TOKEN
+		machine api.github.com
+			login $GITHUB_ACTOR
+			password $GITHUB_TOKEN
+EOF
+  chmod 600 "$HOME/.netrc"
+
+  git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  git config --global user.name "$GITHUB_ACTOR"
+}
+
+# Halt on error
+set -e
+
+git_setup
+
+BASE=$(pwd)
+COMMIT_MESSAGE=$(git show -s --format=%B $GITHUB_SHA)
+
+git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+git config --global user.name "$GITHUB_ACTOR"
+
+echo "Cloning folders in /packages and pushing to Automattic package repos"
+
+# sync to read-only clones
+for package in packages/*; do
+	[ -d "$package" ] || continue # We are only interested in directories (i.e. packages)
+
+	cd $BASE
+
+	# Only keep the package's name
+	NAME=${package##*/}
+
+	echo " Name: $NAME"
+
+	CLONE_DIR="__${NAME}__clone__"
+	echo "  Clone dir: $CLONE_DIR"
+
+	# Check if a remote exists for that package.
+	$( git ls-remote --exit-code -h "https://github.com/automattic/jetpack-${NAME}.git" >/dev/null 2>&1 ) || continue
+	echo "  ${NAME} exists. Let's clone it."
+
+	# clone, delete files in the clone, and copy (new) files over
+	# this handles file deletions, additions, and changes seamlessly
+	git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/jetpack-$NAME.git $CLONE_DIR
+
+	echo "  Cloning of ${NAME} completed"
+
+	cd $CLONE_DIR
+
+	find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
+
+	echo "  Copying from ${BASE}/packages/${NAME}/."
+
+	cp -r $BASE/packages/$NAME/. .
+
+	# Commit if there is anything to
+	if [ -n "$(git status --porcelain)" ]; then
+		echo  "  Committing $NAME to $NAME's mirror repository"
+		git add -A
+		git commit -m "${COMMIT_MESSAGE}"
+		git push origin master
+		echo  "  Completed $NAME"
+		else
+		echo "  No changes, skipping $NAME"
+	fi
+
+	cd $BASE
+done


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This is a first step aiming to replace https://github.com/Automattic/jetpack/blob/master/bin/release-package.php
This would also eliminate the need for #14287, and https://github.com/Automattic/jetpack/blob/master/.github/labeler.yml

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p9dueE-1fT-p2

#### Testing instructions:

This is not an easy one to test. Here is what I would recommend, but if there is a better way, let me know:

* Fork [the Jetpack sync repo](https://github.com/Automattic/Jetpack-sync) onto your own repo, under your own username.
* Fork the Jetpack repository onto your own repo, at `username/jetpack`
* In that fork, go to Settings > Secrets, and add a new secret named `API_TOKEN_GITHUB`. In that secret, paste an access token you will have created [here](https://github.com/settings/tokens), with repo access.
* In that fork, on `master`, `git cherry-pick e9b00990c9adba60e930a80b094790d73ae93fe8` to bring the changes from this PR to your fork's `master`, thus enabling the action on your fork.
- Edit `bin/update-package.sh` on your fork, and replace all instances of `automattic/` to your own username.
- Commit and push your changes to your fork's master.
- Still on your fork's `master`, edit one of the files in the Sync package (at packages/sync/src/class-main.php` for example), commit, and push those changes.
- In your fork's Actions menu, you should see the action being triggered.
- In your Sync repo fork, you should see the change coming over.

#### Proposed changelog entry for your changes:

* N/A
