### PR TITLE
Coming Soon: return Atomic site's launch status in /sites/ endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -404,9 +404,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'quota' :
 				$response[ $key ] = $this->site->get_quota();
 				break;
-			case 'launch_status' :
-				$response[ $key ] = $this->site->get_launch_status();
-				break;
 			case 'site_migration' :
 				$response[ $key ] = $this->site->get_migration_meta();
 				break;

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -139,7 +139,36 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	function is_private() {
-		return false;
+		return $this->get_cloud_site_option( 'blog_public' ) === -1;
+	}
+
+	/**
+	 * Return site's launch status.
+	 *
+	 * @return string|boolean  Launch status ('launched', 'unlaunched', or false).
+	 */
+	public function get_launch_status() {
+		return $this->get_cloud_site_option( 'launch-status' );
+	}
+
+	/**
+	 * Returns an option value from the current site's cloud site.
+	 *
+	 * @param string $option  Option name.
+	 * @return mixed  Option value.
+	 */
+	private function get_cloud_site_option( $option ) {
+		$jetpack = Jetpack::init();
+		if ( ! method_exists( $jetpack, 'get_cloud_site_options' ) ) {
+			return false;
+		}
+
+		$result = $jetpack->get_cloud_site_options( array( $option ) );
+		if ( ! array_key_exists( $option, $result ) ) {
+			return false;
+		}
+
+		return $result[ $option ];
 	}
 
 	function get_plan() {


### PR DESCRIPTION
Summary: This updates SAL to return an Atomic site's launch status.

Test Plan:
1. Create a simple site, atomic site, and a non-atomic jetpack site
1. For each site, run `update_blog_option(<SITE ID>, 'launch-status', 1);` in `wpsh`
1. Request `/sites` endpoint and confirm that for both simple and atomic site the response contains `"launch_status": "1"`
1. Confirm that for a non-atomic jetpack site the response says `"launch_status": "1"`

Reviewers: #zelda_team, zieladam

Reviewed By: zieladam

Tags: #touches_jetpack_files

Differential Revision: D39843-code

This commit syncs r204094-wpcom.
