### PR TITLE
Added a Slurper example to the analyzer package.

### DIFF
--- a/packages/analyzer/scripts/jetpack-slurper.php
+++ b/packages/analyzer/scripts/jetpack-slurper.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * A script to scan the entire WordPress.org plugins directory for breaking changes between
+ * two different versions of Jetpack.
+ *
+ * @package automattic/jetpack-analyzer
+ */
+
+/**
+ * This script is meant to run outside of typical WordPress environments and only by knowledgeable folks.
+ * Disabling some phpcs scripts:
+ *
+ * phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
+ * phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+ * phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+ *
+ * To prepare for scanning Jetpack against all plugins of WordPress.org directory you need to
+ * use the slurper tool. 
+ *
+ * @see https://github.com/markjaquith/WordPress-Plugin-Directory-Slurper
+ *
+ * Note: the full repository checkout takes a lot of disk space (around 70Gb) and takes a long time
+ * to finish for the first time. After you're done, you can use the path to the `plugins` folder
+ * inside the slurper checkout as the value for the `$slurper_path` variable below.
+ * The old and new Jetpack path are pretty straightforward: the new path is the path after changes were
+ * made, the old - before changes were made.
+ * After running this script you'll get a csv file in the `scipts` folder for every plugin that is
+ * affected by the changes.
+ */
+
+require dirname( dirname( __FILE__ ) ) . '/vendor/autoload.php';
+
+$base_path = dirname( dirname( dirname( __DIR__ ) ) );
+
+$jetpack_new_path   = '/path/to/new/jetpack';
+$jetpack_old_path   = '/path/to/old/jetpack';
+$slurper_path       = '/path/to/slurper/plugins';
+$jetpack_exclude    = array( '.git', 'vendor', 'tests', 'docker', 'bin', 'scss', 'images', 'docs', 'languages', 'node_modules' );
+
+echo "Scanning new declarations\n";
+$jetpack_new_declarations = new Automattic\Jetpack\Analyzer\Declarations();
+$jetpack_new_declarations->scan( $jetpack_new_path, $jetpack_exclude );
+
+echo "Scanning old declarations\n";
+$jetpack_old_declarations = new Automattic\Jetpack\Analyzer\Declarations();
+$jetpack_old_declarations->scan( $jetpack_old_path, $jetpack_exclude );
+
+echo "Looking for differences\n";
+$differences = new Automattic\Jetpack\Analyzer\Differences();
+$differences->find( $jetpack_new_declarations, $jetpack_old_declarations, $jetpack_new_path );
+
+foreach ( glob( $slurper_path . '/*' ) as $folder_name ) {
+	echo "Looking for invocations in:\n${folder_name}\n\n";
+	$invocations = new Automattic\Jetpack\Analyzer\Invocations();
+	$invocations->scan( $folder_name );
+
+	echo "Generate warnings\n";
+	$warnings = new Automattic\Jetpack\Analyzer\Warnings();
+	$warnings->generate( $invocations, $differences );
+	$warnings->output();
+	$warnings->save( __DIR__ . '/' . basename( $folder_name ) . '.csv', false );
+}
+
+// phpcs:enable


### PR DESCRIPTION
This script helps run the analyzer on Mark Jaquith's slurper tool results.
Caveat: for some reason the analyzer uses up *a lot* of memory, I haven't had time to profile it yet.

#### Changes proposed in this Pull Request:
* Added an example script that helps run the analyzer on all published WordPress plugins.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a helper tool as part of the DNA project.

#### Testing instructions:
* You don't need to download everything to test, you can test the script by placing any plugins in a folder, and supplying that as the "slurper" path.
* Edit the paths in `jetpack-slurper.php` to your local paths.
* Create a new version of Jetpack code by, for example, cloning the repo to separate folder and changing any code that third party plugins are using.
* Run the script using the command `cd packages/analyzer; php ./scripts/jetpack-slurper.php`.
* Observe the created csv files for every plugin that uses changed code.

#### Proposed changelog entry for your changes:
* N/A
