### PR TITLE
Update Package action: expand generated commit to include link

### DIFF
--- a/bin/update-package.sh
+++ b/bin/update-package.sh
@@ -22,7 +22,8 @@ set -e
 git_setup
 
 BASE=$(pwd)
-COMMIT_MESSAGE=$(git show -s --format=%B $GITHUB_SHA)
+MONOREPO_COMMIT_MESSAGE=$(git show -s --format=%B $GITHUB_SHA)
+COMMIT_MESSAGE=$( echo "${MONOREPO_COMMIT_MESSAGE}\n\nCommitted via a GitHub action: https://github.com/automattic/jetpack/runs/${GITHUB_RUN_ID}" )
 
 git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
 git config --global user.name "$GITHUB_ACTOR"


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Automatically generated commits on the mirror repos will now include a link to the action job that triggered them, like so:

![image](https://user-images.githubusercontent.com/426388/76405711-d21c6600-6388-11ea-8e9e-873e0b732cda.png)

This will allow one to quickly understand how a commit was generated in a mirror repo.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Internal discussion: p1583881552156100-slack-jetpack-crew

#### Testing instructions:

* Same as in #14930 

#### Proposed changelog entry for your changes:

* N/A
