### PR TITLE
Actions: always commit to mirror repos as matticbot

### DIFF
--- a/bin/update-package.sh
+++ b/bin/update-package.sh
@@ -4,16 +4,16 @@ git_setup()
 {
   cat <<- EOF > "$HOME/.netrc"
 		machine github.com
-			login $GITHUB_ACTOR
+			login matticbot
 			password $GITHUB_TOKEN
 		machine api.github.com
-			login $GITHUB_ACTOR
+			login matticbot
 			password $GITHUB_TOKEN
 EOF
   chmod 600 "$HOME/.netrc"
 
-  git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  git config --global user.name "$GITHUB_ACTOR"
+  git config --global user.email "matticbot@users.noreply.github.com"
+  git config --global user.name "matticbot"
 }
 
 # Halt on error
@@ -24,9 +24,7 @@ git_setup
 BASE=$(pwd)
 MONOREPO_COMMIT_MESSAGE=$(git show -s --format=%B $GITHUB_SHA)
 COMMIT_MESSAGE=$( echo "${MONOREPO_COMMIT_MESSAGE}\n\nCommitted via a GitHub action: https://github.com/automattic/jetpack/runs/${GITHUB_RUN_ID}" )
-
-git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-git config --global user.name "$GITHUB_ACTOR"
+COMMIT_ORIGINAL_AUTHOR="${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
 
 echo "Cloning folders in /packages and pushing to Automattic package repos"
 
@@ -66,7 +64,7 @@ for package in packages/*; do
 	if [ -n "$(git status --porcelain)" ]; then
 		echo  "  Committing $NAME to $NAME's mirror repository"
 		git add -A
-		git commit -m "${COMMIT_MESSAGE}"
+		git commit --author="${COMMIT_ORIGINAL_AUTHOR}" -m "${COMMIT_MESSAGE}"
 		git push origin master
 		echo  "  Completed $NAME"
 		else


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This PR changes the author of each one of the commits to our mirror repos, to be authored by `matticbot`.

This should allow us to restrict the list of folks who can commit to master in mirror repos, thus protecting them against accidental updates.

This PR still preserves attribution of the commit to the original commit author though.

#### Testing instructions:

* Same as in #14930, although in your mirror repo fork, you'll need to invite an additional contributor and update `bin/update-package.sh` to replace `matticbot` by them. You can invite me for example. :)

#### Proposed changelog entry for your changes:

* N/A
