### PR TITLE
Add the UpgradeNotice to the Calendly and OpenTable blocks

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -952,11 +952,14 @@ class Jetpack_Gutenberg {
 	 * @return string
 	 */
 	public static function upgrade_nudge( $plan ) {
-		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
-		if ( ! current_user_can( 'manage_options' )
+		if (
+			! current_user_can( 'manage_options' )
+			/** This filter is documented in class.jetpack-gutenberg.php */
 			|| ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
+			/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 			|| ! apply_filters( 'jetpack_show_promotions', true )
-			|| is_feed() ) {
+			|| is_feed()
+		) {
 			return;
 		}
 

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -942,4 +942,26 @@ class Jetpack_Gutenberg {
 		return false;
 	}
 
+	/**
+	 * Output an UpgradeNudge Component on the frontend of a site.
+	 *
+	 * @since 8.4.0
+	 *
+	 * @param string $plan The plan that users need to purchase to make the block work.
+	 *
+	 * @return string
+	 */
+	public static function upgrade_nudge( $plan ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		jetpack_require_lib( 'components' );
+		return Jetpack_Components::render_upgrade_nudge(
+			array(
+				'plan' => $plan,
+			)
+		);
+	}
+
 }

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -953,7 +953,8 @@ class Jetpack_Gutenberg {
 	 */
 	public static function upgrade_nudge( $plan ) {
 		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
-		if ( ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
+		if ( ! current_user_can( 'manage_options' )
+			|| ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
 			|| ! apply_filters( 'jetpack_show_promotions', true )
 			|| is_feed() ) {
 			return;

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -952,7 +952,10 @@ class Jetpack_Gutenberg {
 	 * @return string
 	 */
 	public static function upgrade_nudge( $plan ) {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
+		if ( ! apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false )
+			|| ! apply_filters( 'jetpack_show_promotions', true )
+			|| is_feed() ) {
 			return;
 		}
 

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -63,7 +63,7 @@ function set_availability() {
 			BLOCK_NAME,
 			'missing_plan',
 			array(
-				'required_feature' => 'calendly',
+				'required_feature' => FEATURE_NAME,
 				'required_plan'    => REQUIRED_PLAN,
 			)
 		);

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -11,8 +11,9 @@ namespace Automattic\Jetpack\Extensions\Calendly;
 
 use Jetpack_Gutenberg;
 
-const FEATURE_NAME = 'calendly';
-const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+const FEATURE_NAME  = 'calendly';
+const BLOCK_NAME    = 'jetpack/' . FEATURE_NAME;
+const REQUIRED_PLAN = 'value_bundle';
 
 /**
  * Check if the block should be available on the site.
@@ -43,12 +44,10 @@ function is_available() {
  * registration if we need to.
  */
 function register_block() {
-	if ( is_available() ) {
-		jetpack_register_block(
-			BLOCK_NAME,
-			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
-		);
-	}
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
@@ -65,7 +64,7 @@ function set_availability() {
 			'missing_plan',
 			array(
 				'required_feature' => 'calendly',
-				'required_plan'    => 'value_bundle',
+				'required_plan'    => REQUIRED_PLAN,
 			)
 		);
 	}
@@ -81,6 +80,10 @@ add_action( 'init', __NAMESPACE__ . '\set_availability' );
  * @return string
  */
 function load_assets( $attr, $content ) {
+	if ( ! is_available() ) {
+		return \Jetpack_Gutenberg::upgrade_nudge( REQUIRED_PLAN );
+	}
+
 	if ( is_admin() ) {
 		return;
 	}

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -63,8 +63,8 @@ function set_availability() {
 			BLOCK_NAME,
 			'missing_plan',
 			array(
-				'required_feature' => 'opentable',
-				'required_plan'    => 'value_bundle',
+				'required_feature' => FEATURE_NAME,
+				'required_plan'    => REQUIRED_PLAN,
 			)
 		);
 	}

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -11,8 +11,9 @@ namespace Automattic\Jetpack\Extensions\OpenTable;
 
 use Jetpack_Gutenberg;
 
-const FEATURE_NAME = 'opentable';
-const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+const FEATURE_NAME  = 'opentable';
+const BLOCK_NAME    = 'jetpack/' . FEATURE_NAME;
+const REQUIRED_PLAN = 'value_bundle';
 
 /**
  * Check if the block should be available on the site.
@@ -43,12 +44,10 @@ function is_available() {
  * registration if we need to.
  */
 function register_block() {
-	if ( is_available() ) {
-		jetpack_register_block(
-			BLOCK_NAME,
-			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
-		);
-	}
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
 }
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
@@ -91,6 +90,10 @@ add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_language_setting' );
  * @return string
  */
 function load_assets( $attributes ) {
+	if ( ! is_available() ) {
+		return Jetpack_Gutenberg::upgrade_nudge( REQUIRED_PLAN );
+	}
+
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	$classes = array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14743

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When viewing the block on a site in which the block it is not available, display and upgrade notice with a button

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply the phab patch to your sandbox
* Add a Calendly block and and OpenTable block to a free Simple site
* Open the front end of the site as an admin
* Check that you see a notice for both blocks like this:
<img width="728" alt="Screenshot 2020-03-11 at 16 34 01" src="https://user-images.githubusercontent.com/275961/76440690-2427b080-63b6-11ea-93c6-85101b318e84.png">

Note, your preview may not look like this, if you have an older version of the components package installed. See https://github.com/Automattic/jetpack/pull/14934

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
