### PR TITLE
DNA: don't allow committing changes that would destroy a package

### DIFF
--- a/bin/update-package.sh
+++ b/bin/update-package.sh
@@ -60,14 +60,18 @@ for package in packages/*; do
 
 	cp -r $BASE/packages/$NAME/. .
 
-	# Commit if there is anything to
-	if [ -n "$(git status --porcelain)" ]; then
+	# Before we commit any changes, ensure that the repo has the basics we need for any package.
+	if [ ! -f "composer.json" -o ! -d "src" ]; then
+		echo "  Those changes remove essential parts of the package. They will not be committed."
+	# Commit if there is any change that could be committed
+	elif [ -n "$(git status --porcelain)" ]; then
+
 		echo  "  Committing $NAME to $NAME's mirror repository"
 		git add -A
 		git commit --author="${COMMIT_ORIGINAL_AUTHOR}" -m "${COMMIT_MESSAGE}"
 		git push origin master
 		echo  "  Completed $NAME"
-		else
+	else
 		echo "  No changes, skipping $NAME"
 	fi
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

When the Package Update action runs and attempts to commit changes to a mirror repo, it should not commit changes that would be missing an essential part of a package, a `src` directory and a `composer.json` file.

#### Testing instructions:

* Same as in #14930, but this time in your test commit, try to completely remove part of a package, such a the `src` directory. The action should not push to the mirror repo in those cases. 
* Make sure you also test a regular package update to make sure things still work.

#### Proposed changelog entry for your changes:

* N/A
