### PR TITLE
Blocks: Include dependencies passed to load_assets_as_required

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -574,26 +574,26 @@ class Jetpack_Gutenberg {
 	 * Only enqueue block scripts when needed.
 	 *
 	 * @param string $type Slug of the block.
-	 * @param array  $dependencies Script dependencies. Will be merged with automatically
+	 * @param array  $script_dependencies Script dependencies. Will be merged with automatically
 	 *                             detected script dependencies from the webpack build.
 	 *
 	 * @since 7.2.0
 	 *
 	 * @return void
 	 */
-	public static function load_scripts_as_required( $type, $dependencies = array() ) {
+	public static function load_scripts_as_required( $type, $script_dependencies = array() ) {
 		if ( is_admin() ) {
 			// A block's view assets will not be required in wp-admin.
 			return;
 		}
 
 		// Enqueue script.
-		$script_relative_path = self::get_blocks_directory() . $type . '/view.js';
-		$script_deps_path     = JETPACK__PLUGIN_DIR . self::get_blocks_directory() . $type . '/view.asset.php';
-		$script_dependencies  = array( 'wp-polyfill' );
+		$script_relative_path  = self::get_blocks_directory() . $type . '/view.js';
+		$script_deps_path      = JETPACK__PLUGIN_DIR . self::get_blocks_directory() . $type . '/view.asset.php';
+		$script_dependencies[] = 'wp-polyfill';
 		if ( file_exists( $script_deps_path ) ) {
 			$asset_manifest      = include $script_deps_path;
-			$script_dependencies = $asset_manifest['dependencies'];
+			$script_dependencies = array_unique( array_merge( $script_dependencies, $asset_manifest['dependencies'] ) );
 		}
 
 		if ( ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) && self::block_has_asset( $script_relative_path ) ) {

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -288,21 +288,4 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		$this->assertFalse( $validated_url );
 	}
-
-	/**
-	 * Tests that passed dependencies are included.
-	 *
-	 * @covers Jetpack_Gutenberg::load_scripts_as_required
-	 * @author kraftbj
-	 * @see https://github.com/Automattic/jetpack/pull/14958
-	 */
-	public function test_passed_dependencies_are_included() {
-		// Setup a fake script.
-		wp_register_script( 'example-apple', 'example-apple.js', array(), '1.0', true );
-
-		// calendly used as an example. Needs to be a real block that has a `view.asset.php` file when built.
-		Jetpack_Gutenberg::load_scripts_as_required( 'calendly', array( 'example-apple' ) );
-
-		$this->assertTrue( wp_script_is( 'example-apple', 'enqueued' ) );
-	}
 }

--- a/tests/php/general/test-class.jetpack-gutenberg.php
+++ b/tests/php/general/test-class.jetpack-gutenberg.php
@@ -288,4 +288,21 @@ class WP_Test_Jetpack_Gutenberg extends WP_UnitTestCase {
 
 		$this->assertFalse( $validated_url );
 	}
+
+	/**
+	 * Tests that passed dependencies are included.
+	 *
+	 * @covers Jetpack_Gutenberg::load_scripts_as_required
+	 * @author kraftbj
+	 * @see https://github.com/Automattic/jetpack/pull/14958
+	 */
+	public function test_passed_dependencies_are_included() {
+		// Setup a fake script.
+		wp_register_script( 'example-apple', 'example-apple.js', array(), '1.0', true );
+
+		// calendly used as an example. Needs to be a real block that has a `view.asset.php` file when built.
+		Jetpack_Gutenberg::load_scripts_as_required( 'calendly', array( 'example-apple' ) );
+
+		$this->assertTrue( wp_script_is( 'example-apple', 'enqueued' ) );
+	}
 }


### PR DESCRIPTION
In \Jetpack_Gutenberg::load_assets_as_required, we have a second arg for dependencies to accept an array, as is usual with enqueuing scripts generally in WP.

However, we end up not actually including this array when enqueuing the assets created from the block creation process.

This corrects that be including the passed values.

#### Changes proposed in this Pull Request:
* Pass dependencies to wp_enqueue_script. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* In a block's php file, add something like `\Jetpack_Gutenberg::load_assets_as_required( 'podcast-episodes', array( 'wp-mediaelement ') );`
* Before the patch, notice that wp-mediaelement would not be printed as a dependency. After it should.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*

cc: @jeryj
