### PR TITLE
Shortcodes: enable inline PDFs

### DIFF
--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -1,12 +1,26 @@
 <?php
+/**
+ * Embed support for Inline PDFs
+ *
+ * Takes a plain-text PDF URL (*.pdf), and attempts to embed it directly
+ * in the post instead of leaving it as a bare link.
+ *
+ * @package Jetpack
+ */
+
+wp_embed_register_handler( 'inline-pdfs', '#https?://[^<]*\.pdf$#i', 'jetpack_inline_pdf_embed_handler' );
 
 /**
- * Inline PDFs
- * Takes one-line embeds of a PDF URL (*.pdf), and attempts to embed it directly in the post instead of leaving it as a link.
+ * Callback to modify the output of embedded PDF files.
+ *
+ * @param array $matches Regex partial matches against the URL passed.
+ * @param array $attr    Attributes received in embed response.
+ * @param array $url     Requested URL to be embedded.
  */
-wp_embed_register_handler( 'inline-pdfs', '#https?://[^<]*\.pdf$#i', 'inline_pdf_embed_handler' );
+function jetpack_inline_pdf_embed_handler( $matches, $attr, $url ) {
+	/** This action is documented in modules/widgets/social-media-icons.php */
+	do_action( 'jetpack_bump_stats_extras', 'embeds', 'inline-pdf' );
 
-function inline_pdf_embed_handler( $matches, $attr, $url ) {
 	return sprintf(
 		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
 		  <p><a href="%1$s">%1$s</a></p>

--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Inline PDFs
+ * Takes one-line embeds of a PDF URL (*.pdf), and attempts to embed it directly in the post instead of leaving it as a link.
+ */
+wp_embed_register_handler( 'inline-pdfs', '#https?://[^<]*\.pdf$#i', 'inline_pdf_embed_handler' );
+
+function inline_pdf_embed_handler( $matches, $attr, $url ) {
+	return sprintf(
+		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
+		  <p><a href="%1$s">%2$s</a></p>
+		</object>',
+		esc_attr( $url )
+	);
+}

--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -9,7 +9,7 @@ wp_embed_register_handler( 'inline-pdfs', '#https?://[^<]*\.pdf$#i', 'inline_pdf
 function inline_pdf_embed_handler( $matches, $attr, $url ) {
 	return sprintf(
 		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
-		  <p><a href="%1$s">%2$s</a></p>
+		  <p><a href="%1$s">%1$s</a></p>
 		</object>',
 		esc_attr( $url )
 	);

--- a/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -1,8 +1,15 @@
 <?php
-
+/**
+ * Unit test for Inline PDF embeds.
+ *
+ * @package Jetpack
+ * @since   8.4
+ */
 class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 
 	/**
+	 * Unit test for Inline PDF embeds.
+	 *
 	 * @author lancewillett
 	 * @covers ::jetpack_inline_pdf_embed_handler
 	 * @since  8.4
@@ -10,8 +17,8 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 	public function test_shortcodes_inline_pdf() {
 		global $post;
 
-		$url         = 'https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf';
-		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+		$url  = 'https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf';
+		$post = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
 
 		setup_postdata( $post );
 
@@ -21,9 +28,7 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 		$this->assertContains(
 			sprintf(
-				'<object data="%1$s" type="application/pdf" width="100%%" height="800">
-					<p><a href="%1$s">%1$s</a></p>
-				</object>',
+				'<p><object data="%1$s" type="application/pdf" width="100 height="800"><p><a href="%1$s">%1$s</a></p></object></p>' . "\n",
 				$url
 			),
 			$actual

--- a/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -26,9 +26,12 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 		ob_start();
 		the_content();
 		$actual = ob_get_clean();
+
+		wp_reset_postdata();
+
 		$this->assertContains(
 			sprintf(
-				'<p><object data="%1$s" type="application/pdf" width="100 height="800"><p><a href="%1$s">%1$s</a></p></object></p>' . "\n",
+				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">%1$s</a></p></object></p>' . "\n",
 				$url
 			),
 			$actual

--- a/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -1,0 +1,32 @@
+<?php
+
+class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
+
+	/**
+	 * @author lancewillett
+	 * @covers ::jetpack_inline_pdf_embed_handler
+	 * @since  8.4
+	 */
+	public function test_shortcodes_inline_pdf() {
+		global $post;
+
+		$url         = 'https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf';
+		$post        = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		setup_postdata( $post );
+
+		// Test HTML version.
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+		$this->assertContains(
+			sprintf(
+				'<object data="%1$s" type="application/pdf" width="100%%" height="800">
+					<p><a href="%1$s">%1$s</a></p>
+				</object>',
+				$url
+			),
+			$actual
+		);
+	}
+}


### PR DESCRIPTION
Fixes #14959

#### Changes proposed in this Pull Request:

Adds new file to enable inline PDF embed handling.

The block editor view:
<img width="832" alt="editor" src="https://user-images.githubusercontent.com/66797/76469331-5089ff80-63ab-11ea-812a-f8afd5a550d4.png">

Before, frontend:
<img width="841" alt="before" src="https://user-images.githubusercontent.com/66797/76469343-57187700-63ab-11ea-8ea5-4db9c5f24d3e.png"> 

After, frontend:
<img width="835" alt="after" src="https://user-images.githubusercontent.com/66797/76469359-5ed81b80-63ab-11ea-9616-1d18ffa966b6.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- New feature. Internal reference: p7DVsv-8fu-p2

#### Testing instructions:

* Edit a post or page
* Put a PDF file URL on its own line (not a link, just bare URL)
* Preview the post
* You should see a visual embed instead of the bare URL

If not supported in a given environment, the embed object should fall back to a plain link.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Enable inline PDF embeds

Apologies if I missed a lot of steps any important code flags and formatting... Jetpack development has increased in complexity 10x since I last contributed a patch.