### PR TITLE
Add/release scripts package

### DIFF
--- a/packages/scripts/.gitattributes
+++ b/packages/scripts/.gitattributes
@@ -1,0 +1,4 @@
+# Files not needed to be distributed in the package.
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -1,0 +1,9 @@
+# Jetpack scripts
+
+A set of scripts that is used for Jetpack development (and other stuff).
+
+### Usage
+
+- Add this package as one of `dev` dependencies into your composer.json
+- add a new script such as: `"run-release-script": "Automattic\\Jetpack\\Scripts\\Release::run"`
+- run it with `composer run-release-script`

--- a/packages/scripts/composer.json
+++ b/packages/scripts/composer.json
@@ -1,0 +1,27 @@
+{
+	"name": "automattic/jetpack-scripts",
+	"description": "Set of (release) scripts for Jetpack",
+	"type": "library",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"mikehaertl/php-shellcommand": "^1.6"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",
+		"php-mock/php-mock": "^2.1",
+		"jms/composer-deps-analyzer": "^1.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"phpunit": [
+			"@composer install",
+			"./vendor/phpunit/phpunit/phpunit --colors=always"
+		]
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
+}

--- a/packages/scripts/phpunit.xml
+++ b/packages/scripts/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="tests/php/bootstrap.php" backupGlobals="false" colors="true">
+	<testsuites>
+		<testsuite name="main">
+			<directory prefix="test" suffix=".php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/packages/scripts/src/class-cmd.php
+++ b/packages/scripts/src/class-cmd.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Class for running shell scripts
+ *
+ * @package automattic/jetpack-scripts
+ */
+
+namespace Automattic\Jetpack\Scripts;
+
+/**
+ * Class for running shell commands
+ */
+class Cmd {
+	/**
+	 * Shell command
+	 *
+	 * @var String
+	 */
+	public $cmd = '';
+
+	/**
+	 * Process pipes
+	 *
+	 * @var Array
+	 */
+	public $pipes = null;
+
+	/**
+	 * Proc itself
+	 *
+	 * @var Process
+	 */
+	public $resource = null;
+
+	/**
+	 * Timestamp when command was fired
+	 *
+	 * @var int
+	 */
+	private $strt_tm = 0;
+
+	/**
+	 * Command exit code
+	 *
+	 * @var int
+	 */
+	private $exitcode = null;
+
+	/**
+	 * Descriptors to use in new process
+	 *
+	 * @var Array
+	 */
+	private $descriptors = array(
+		0 => array( 'pipe', 'r' ),
+		1 => array( 'pipe', 'w' ),
+		2 => array( 'pipe', 'w' ),
+	);
+
+	/**
+	 * Opens a process with the provided shell command
+	 *
+	 * @param {String} $cmd shell command to run.
+	 */
+	public function __construct( $cmd = '' ) {
+			$this->cmd = $cmd;
+
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_proc_open
+			$this->resource = proc_open( $this->cmd, $this->descriptors, $this->pipes, realpath( './' ) );
+			$this->strt_tm  = microtime( true );
+	}
+
+	/**
+	 * Class entry point
+	 *
+	 * @param {String} $cmd shell command to run.
+	 * @param {bool}   $interactive wether or not to output interactively.
+	 */
+	public static function run( $cmd, $interactive = true ) {
+		$proc = new Cmd( $cmd );
+		// phpcs:ignore
+		error_log( print_r( 'RUNNING: ' . $cmd, 1 ) );
+
+		$out = '';
+
+		while ( $proc->is_running() ) {
+			if ( $interactive ) {
+				$s = fgets( $proc->pipes[1] );
+				while ( $s ) {
+					$out = $out . $s;
+					error_log( $s ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					$s = fgets( $proc->pipes[1] );
+				}
+			}
+		}
+
+		return array(
+			'output'    => trim( $interactive ? $out : stream_get_contents( $proc->pipes[1] ) ),
+			'exit_code' => $proc->get_exitcode(),
+			'stderr'    => stream_get_contents( $proc->pipes[2] ),
+		);
+	}
+
+	/**
+	 * Checks if the process is still running. Also populates an $exitcode once the process is done running
+	 */
+	public function is_running() {
+		$status = proc_get_status( $this->resource );
+
+		/**
+		 * `proc_get_status` will only pull valid exitcode one
+		 * time after process has ended, so cache the exitcode
+		 * if the process is finished and $exitcode is uninitialized
+		 */
+		if ( false === $status['running'] && null === $this->exitcode ) {
+			$this->exitcode = $status['exitcode'];
+		}
+		return $status['running'];
+	}
+
+	/**
+	 * Exit code accessor
+	 */
+	public function get_exitcode() {
+		return $this->exitcode;
+	}
+
+	/**
+	 * Return elapsed time
+	 */
+	public function get_elapsed() {
+		return microtime( true ) - $this->strt_tm;
+	}
+}

--- a/packages/scripts/src/class-dependency-tree.php
+++ b/packages/scripts/src/class-dependency-tree.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Extended Composer's ShowCommand to get access to
+ *
+ * @package automattic/jetpack-scripts
+ */
+
+namespace Automattic\Jetpack\Scripts;
+
+use Composer\Console\Application;
+use Composer\Command\ShowCommand;
+use Composer\Package\Version\VersionParser;
+
+/**
+ * Extended Composer's ShowCommand to get access to
+ */
+class Dependency_Tree extends ShowCommand {
+	/**
+	 * Composer instance
+	 *
+	 * @var Composer|null
+	 */
+	private $composer;
+
+	/**
+	 * Simple constructor
+	 */
+	public function __construct() {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->versionParser = new VersionParser();
+	}
+
+	/**
+	 * Returns Composer instance
+	 */
+	public function get_composer() {
+		if ( null === $this->composer ) {
+			$application    = new Application();
+			$this->composer = $application->getComposer( true, null );
+		}
+
+		return $this->composer;
+	}
+
+	/**
+	 * Generates a dependency tree
+	 */
+	public static function generate() {
+		$it             = new Dependency_Tree();
+		$package        = $it->get_composer()->getPackage();
+		$repos          = $it->get_composer()->getRepositoryManager()->getLocalRepository();
+		$installed_repo = $repos;
+
+		$array_tree = $it->generatePackageTree( $package, $installed_repo, $repos );
+
+		return $array_tree;
+	}
+}

--- a/packages/scripts/src/class-git-shell-command.php
+++ b/packages/scripts/src/class-git-shell-command.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Git shell commands
+ *
+ * @package automattic/jetpack-scripts
+ */
+
+namespace Automattic\Jetpack\Scripts;
+
+/**
+ * Wrapper around some git commands
+ */
+class Git_Shell_Command {
+	/**
+	 * Constructor!
+	 *
+	 * @param String $name repository name.
+	 */
+	public function __construct( $name ) {
+		$this->name    = $name;
+		$this->path    = explode( '/', $name )[1];
+		$this->dir_arg = "--git-dir=$this->path/.git";
+	}
+
+	/**
+	 * Returns the latest repo tag
+	 */
+	public function get_latest_tag() {
+		$cmd    = "git $this->dir_arg describe --abbrev=0";
+		$result = Cmd::run( $cmd );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Returns a `shortstat` diff between two tags
+	 *
+	 * @param String $source git tag or branch.
+	 * @param String $target git tag or branch.
+	 */
+	public function get_diff_between( $source, $target ) {
+		$cmd    = "git $this->dir_arg diff $source $target --shortstat";
+		$result = Cmd::run( $cmd );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Clones a repository
+	 *
+	 * @param String $type URL type to use.
+	 */
+	public function clone_repository( $type = 'ssh' ) {
+		if ( 'ssh' === $type ) {
+			$url = "git@github.com:$this->name.git";
+		} else {
+			$url = "https://github.com/$this->name.git";
+
+		}
+		Cmd::run( "rm -rf $this->path" );
+
+		$cmd    = "git clone $url 2>&1";
+		$result = Cmd::run( $cmd );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Checkout to a new branch
+	 *
+	 * @param String $branch branch name.
+	 */
+	public function checkout_new_branch( $branch ) {
+		$cmd    = "git $this->dir_arg checkout -b release-$branch 2>&1";
+		$result = Cmd::run( $cmd );
+
+		return $result['output'];
+	}
+}

--- a/packages/scripts/src/class-git-shell-command.php
+++ b/packages/scripts/src/class-git-shell-command.php
@@ -71,7 +71,7 @@ class Git_Shell_Command {
 	 * @param String $branch branch name.
 	 */
 	public function checkout_new_branch( $branch ) {
-		$cmd    = "git $this->dir_arg checkout -b release-$branch 2>&1";
+		$cmd    = "git $this->dir_arg checkout -b $branch 2>&1";
 		$result = Cmd::run( $cmd );
 
 		return $result['output'];

--- a/packages/scripts/src/class-git-shell-command.php
+++ b/packages/scripts/src/class-git-shell-command.php
@@ -19,7 +19,7 @@ class Git_Shell_Command {
 	public function __construct( $name ) {
 		$this->name    = $name;
 		$this->path    = explode( '/', $name )[1];
-		$this->dir_arg = "--git-dir=$this->path/.git";
+		$this->dir_arg = "--git-dir=$this->path/.git --work-tree=$this->path";
 	}
 
 	/**
@@ -71,7 +71,52 @@ class Git_Shell_Command {
 	 * @param String $branch branch name.
 	 */
 	public function checkout_new_branch( $branch ) {
-		$cmd    = "git $this->dir_arg checkout -b $branch 2>&1";
+		$cmd    = "git $this->dir_arg checkout -q -b $branch 2>&1";
+		$result = Cmd::run( $cmd );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Tag new version
+	 *
+	 * @param String $name tag name.
+	 */
+	public function tag_new_version( $name ) {
+		$cmd    = "git $this->dir_arg tag -a $name -m 'New release for $name' 2>&1";
+		$result = Cmd::run( $cmd );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Get status
+	 */
+	public function status() {
+		$result = Cmd::run( "git $this->dir_arg status --porcelain --untracked-files=no" );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Commit all changes
+	 */
+	public function commit() {
+		$result = Cmd::run( "git $this->dir_arg commit -a -m 'Add changes'" );
+
+		return $result['output'];
+	}
+
+	/**
+	 * Checkout to a new branch
+	 *
+	 * @param String $branch branch name.
+	 */
+	public function push_to_remote( $branch ) {
+		$cmd    = "git $this->dir_arg push --set-upstream origin $branch 2>&1";
+		$result = Cmd::run( $cmd );
+
+		$cmd    = "git $this->dir_arg push origin --tags 2>&1";
 		$result = Cmd::run( $cmd );
 
 		return $result['output'];

--- a/packages/scripts/src/class-logger.php
+++ b/packages/scripts/src/class-logger.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Set of scripts for Jetpack.
+ *
+ * @package automattic/jetpack-scripts
+ */
+
+namespace Automattic\Jetpack\Scripts;
+
+/**
+ * Fancy logger
+ */
+class Logger {
+	/**
+	 * Array of foreground colors
+	 *
+	 * @var Array
+	 */
+	private $foreground_colors = array();
+	/**
+	 * Array of background colors
+	 *
+	 * @var Array
+	 */
+	private $background_colors = array();
+
+	/**
+	 * A generic log command
+	 *
+	 * @param String $string string to log.
+	 * @param String $foreground_color foreground color.
+	 * @param String $background_color background color.
+	 */
+	public static function log( $string, $foreground_color = null, $background_color = null ) {
+		$logger = new Logger();
+		$out    = $string;
+
+		if ( ! is_string( $out ) ) {
+			$out = print_r( $string, 1 ); //phpcs:ignore
+		}
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( $logger->get_colored_string( $out, $foreground_color, $background_color ) );
+	}
+
+	/**
+	 * Info log command in yellow
+	 *
+	 * @param String $string string to log.
+	 */
+	public static function info( $string ) {
+		self::log( $string, 'yellow' );
+	}
+
+	/**
+	 * Set up shell colors
+	 */
+	public function __construct() {
+		$this->foreground_colors['black']        = '0;30';
+		$this->foreground_colors['dark_gray']    = '1;30';
+		$this->foreground_colors['blue']         = '0;34';
+		$this->foreground_colors['light_blue']   = '1;34';
+		$this->foreground_colors['green']        = '0;32';
+		$this->foreground_colors['light_green']  = '1;32';
+		$this->foreground_colors['cyan']         = '0;36';
+		$this->foreground_colors['light_cyan']   = '1;36';
+		$this->foreground_colors['red']          = '0;31';
+		$this->foreground_colors['light_red']    = '1;31';
+		$this->foreground_colors['purple']       = '0;35';
+		$this->foreground_colors['light_purple'] = '1;35';
+		$this->foreground_colors['brown']        = '0;33';
+		$this->foreground_colors['yellow']       = '1;33';
+		$this->foreground_colors['light_gray']   = '0;37';
+		$this->foreground_colors['white']        = '1;37';
+
+		$this->background_colors['black']      = '40';
+		$this->background_colors['red']        = '41';
+		$this->background_colors['green']      = '42';
+		$this->background_colors['yellow']     = '43';
+		$this->background_colors['blue']       = '44';
+		$this->background_colors['magenta']    = '45';
+		$this->background_colors['cyan']       = '46';
+		$this->background_colors['light_gray'] = '47';
+	}
+
+	/**
+	 * Returns colored string
+	 *
+	 * @param String $string string to log.
+	 * @param String $foreground_color foreground color.
+	 * @param String $background_color background color.
+	 */
+	public function get_colored_string( $string, $foreground_color = null, $background_color = null ) {
+		$colored_string = '';
+
+		// Check if given foreground color found.
+		if ( isset( $this->foreground_colors[ $foreground_color ] ) ) {
+			$colored_string .= "\033[" . $this->foreground_colors[ $foreground_color ] . 'm';
+		}
+		// Check if given background color found.
+		if ( isset( $this->background_colors[ $background_color ] ) ) {
+			$colored_string .= "\033[" . $this->background_colors[ $background_color ] . 'm';
+		}
+
+		// Add string and end coloring.
+		$colored_string .= $string . "\033[0m";
+
+		return $colored_string;
+	}
+
+	/**
+	 * Returns all foreground color names
+	 */
+	public function get_foreground_colors() {
+		return array_keys( $this->foreground_colors );
+	}
+
+	/**
+	 * Returns all background color names
+	 */
+	public function get_background_colors() {
+		return array_keys( $this->background_colors );
+	}
+}

--- a/packages/scripts/src/class-release.php
+++ b/packages/scripts/src/class-release.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Set of scripts for Jetpack.
+ *
+ * @package automattic/jetpack-scripts
+ */
+
+namespace Automattic\Jetpack\Scripts;
+
+// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+
+/**
+ * Package release handler
+ */
+class Release {
+	/**
+	 * List of update statuses for dependencies
+	 *
+	 * @var Array
+	 */
+	private $update_statuses = array();
+
+	/**
+	 * Class entry point. Called externally via composer script
+	 */
+	public static function run() {
+		$release = new Release();
+		error_log( 'Doing stuff...' );
+		$root = Dependency_Tree::generate();
+		error_log( $root );
+
+		$list = $release->get_package_dependencies_to_update( $root );
+
+		if ( ! empty( $list ) ) {
+			$release->handle_dependencies_updates( $list );
+		}
+
+		$release->handle_package_update( $root['name'] );
+
+		error_log( 'Done with running!' );
+	}
+
+	/**
+	 * Handles root package update
+	 *
+	 * @param String $name package name.
+	 */
+	public function handle_package_update( $name ) {
+		$sh = new Git_Shell_Command( $name );
+
+		$sh->clone_repository();
+
+		$tag  = $sh->get_latest_tag();
+		$diff = $sh->get_diff_between( $tag, 'master' );
+
+		if ( $this->is_update_requested( $name, $tag, $diff ) ) {
+			$this->do_dependency_update( $name );
+		}
+	}
+
+	/**
+	 * Checks if user requested an update
+	 *
+	 * @param String $name repo name.
+	 * @param String $tag latest released version.
+	 * @param String $diff short diff of unreleased changes.
+	 */
+	public function is_update_requested( $name, $tag, $diff ) {
+		error_log( "Updating $name" );
+		error_log( "Latest stable version: $tag" );
+		error_log( "Unreleased changes: $diff" );
+
+		return $this->handle_polar_question( "Do you want to update $name [y/n]? " );
+	}
+
+	/**
+	 * Loops through provided list of dependencies and tries to update them
+	 *
+	 * @param Array $list list of dependencies.
+	 */
+	public function handle_dependencies_updates( $list ) {
+		error_log( 'Here is the list of dependencies with some unreleased changes:' );
+		error_log( $list );
+
+		foreach ( $list as $dep ) {
+			if ( $this->is_update_requested( $dep[0], $dep[2], $dep[1] ) ) {
+				$this->do_dependency_update( $dep[0] );
+			}
+		}
+	}
+
+	/**
+	 * Run an actual package update
+	 *
+	 * @param String $name package name.
+	 * @throws \Exception Invalid provided version.
+	 */
+	public function do_dependency_update( $name ) {
+		error_log( "Updating dependency: $name" );
+
+		$version = readline( 'Please provide a version number that should be used for new release in SemVer format (x.x.x): ' );
+
+		if ( 3 !== count( explode( '.', $version ) ) ) {
+			throw new \Exception( "$version is not in a SemVer format" );
+		}
+
+		$version = 'v' . $version;
+		$branch  = "release-$version";
+
+		$sh = new Git_Shell_Command( $name );
+		$sh->clone_repository();
+		$sh->checkout_new_branch( $branch );
+
+		return true;
+	}
+
+	/**
+	 * Prompts a polar (Y/N) question to a user, and returns a bool
+	 *
+	 * @param String $prompt question to ask.
+	 * @throws \Exception Invalid response.
+	 */
+	public function handle_polar_question( $prompt ) {
+		$in = readline( $prompt );
+
+		if ( 'y' === $in || 'Y' === $in ) {
+			return true;
+		} elseif ( 'n' === $in || 'N' === $in ) {
+			return false;
+		} else {
+			throw new \Exception( 'Invalid response. Expected Y/y/N/n' );
+		}
+	}
+
+
+	/**
+	 * Checks wether a package have some unreleased changes
+	 *
+	 * @param String $name repository name.
+	 */
+	public function is_update_possible( $name ) {
+		/**
+		 * Inside $name repository:
+		 * - get latest tag: `git describe --abbrev=0`
+		 * - compare tag against master: `git diff $tag master --shortstat`
+		 * - if output is not empty - there is a difference
+		 */
+
+		if ( array_key_exists( $name, $this->update_statuses ) ) {
+			return $this->update_statuses[ $name ];
+		}
+
+		$sh = new Git_Shell_Command( $name );
+		$sh->clone_repository();
+		$tag = $sh->get_latest_tag();
+		$out = $sh->get_diff_between( $tag, 'master' );
+
+		$result = array(
+			'status' => true,
+			'diff'   => $out,
+			'tag'    => $tag,
+		);
+		if ( 0 === strlen( $out ) ) {
+			$result['status'] = false;
+		}
+
+		$this->update_statuses[ $name ] = $result;
+		return $result;
+	}
+
+	/**
+	 * Walks through the dependency tree and builds a list of deps that needs to be updated
+	 * This list is build in order from branch up to root, meaning it is the order that could be used for updating the whole tree in single run
+	 *
+	 * @param Array $object tree node.
+	 */
+	public function get_package_dependencies_to_update( $object ) {
+		$object_requires = $object['requires'];
+		$deps_to_update  = array();
+
+		foreach ( $object_requires as $dependency ) {
+			// Check if we need to update this package.
+			$update = $this->is_update_possible( $dependency['name'] );
+			if ( $update['status'] ) {
+				array_unshift( $deps_to_update, array( $dependency['name'], $update['diff'], $update['tag'] ) );
+				if ( array_key_exists( 'requires', $dependency ) ) {
+					// $dependency have dependencies, lets recursively go through them too.
+					$deps = $this->get_package_dependencies_to_update( $dependency );
+					array_merge( $deps, $deps_to_update );
+				}
+			}
+		}
+
+		return $deps_to_update;
+	}
+}

--- a/packages/scripts/src/class-release.php
+++ b/packages/scripts/src/class-release.php
@@ -27,7 +27,7 @@ class Release {
 		$release = new Release();
 		error_log( 'Doing stuff...' );
 		$root = Dependency_Tree::generate();
-		error_log( $root );
+		error_log( print_r( $root, 1 ) ); // phpcs:ignore
 
 		$list = $release->get_package_dependencies_to_update( $root );
 

--- a/packages/scripts/src/class-release.php
+++ b/packages/scripts/src/class-release.php
@@ -155,7 +155,11 @@ class Release {
 		}
 
 		$sh->tag_new_version( $version );
-		$sh->push_to_remote( $branch );
+
+		$answer = $this->handle_polar_question( 'All set! We are ready to push a new release. Proceed [y/n]? ' );
+		if ( true === $answer ) {
+			$sh->push_to_remote( $branch );
+		}
 
 		return true;
 	}

--- a/packages/sync/composer.json
+++ b/packages/sync/composer.json
@@ -10,6 +10,9 @@
 		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-status": "@dev"
 	},
+	"require-dev": {
+		"automattic/jetpack-scripts": "@dev"
+	},
 	"autoload": {
 		"classmap": [
 			"src/"
@@ -21,6 +24,9 @@
 			"url": "../*"
 		}
 	],
+	"scripts": {
+		"run-release-script": "Automattic\\Jetpack\\Scripts\\Release::run"
+	},
 	"minimum-stability": "dev",
 	"prefer-stable": true
 }


### PR DESCRIPTION
Fixes #13382 
Fixes #13793 
Fixes #12680 

This PR adds a new package that allow us to update other packages and it's dependencies

What the script does:

1. Builds a dependency tree
1. Walks through the dree and creates an ordered list of dependencies with outstanding changes.
1. for every dependency in the list it will release a new package version, and as the list is ordered, parent dependencies will update after child dependencies thus pulling newest versions
1. release a new version of root package

What's happens during package release

1. gets the new version from user
1. clones the repo and checks into new release branch
1. update composer dependencies to the latest versions
1. commits any changes in the repo (should be only composer.json)
1. tags a new version
1. pushes to remote

What's not done/missing

1. the script will not try to update composer dependencies for package dependencies that don't have outstanding changes for a new release. Let me explain: 
- Lets say we have packages A, B & C.
- A uses B (v1) as a package dependency.
- B uses C (v1) as a package dependency.
- If v2 for B or C was released outside of this script (so the packages
1. Maybe more prompts or more details in prompts such as whether or not to update the dependency
1. all the stuff that I missed 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

p9dueE-1fT-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* it's a bit hard to test it end-to-end without messing up actual package releases.
* BUT it's safe to play around with most of the steps until the question about a push to master
* `cd packages/sync`
* `composer install` to get a new dependency
* `composer run-release-script` to run the command. It's not committing anywhere, so it's harmless to run it

To test it end-to-end will require some forking and updating the scripts:
- first of all, decide which package you would like to use for the update. for sake of example I'll use `sync`.
- fork https://github.com/Automattic/jetpack-sync
- fork https://github.com/Automattic/jetpack-connection since it now has some outstanding changes
- update package name for `jetpack-connection` in composer.json :`	"name": "$your_handle/jetpack-connection",`
 - add your `jetpack-connection` package to packagist.org
- mock the generated dependency tree. basically add the above snippet after this line https://github.com/Automattic/jetpack/blob/e31e151bb17103af09fd2c94617cf5c4e5b470cb/packages/scripts/src/class-release.php#L34

(make sure to replace `brbrr` with your handle)
```
$root = json_decode( 
  '{"name":"brbrr/jetpack-sync","version":"@dev","description":"Everything needed to allow syncing to the WP.com infrastructure.","requires":[{"name":"brbrr/jetpack-connection","version":"@dev","requires":[{"name":"automattic/jetpack-constants","version":"@dev"},{"name":"automattic/jetpack-options","version":"@dev","requires":[{"name":"automattic/jetpack-constants","version":"@dev"}]},{"name":"automattic/jetpack-roles","version":"@dev"}]},{"name":"automattic/jetpack-constants","version":"@dev"},{"name":"automattic/jetpack-options","version":"@dev","requires":[{"name":"automattic/jetpack-constants","version":"@dev"}]},{"name":"automattic/jetpack-roles","version":"@dev"},{"name":"automattic/jetpack-status","version":"@dev"}]}', true
)
```

- mock list of dependencies similar to above:

```
$list = array(
  array(
    'brbrr/jetpack-connection',
    '3 files changed, 173 insertions(+), 6 deletions(-)',
    'v1.9.0',
    json_decode( '{"name":"brbrr/jetpack-connection","version":"@dev","requires":[{"name":"automattic/jetpack-constants","version":"@dev"},{"name":"automattic/jetpack-options","version":"@dev","requires":[{"name":"automattic/jetpack-constants","version":"@dev"}]},{"name":"automattic/jetpack-roles","version":"@dev"}]}', true ),
  ),
);
```

This should allow you to actually release a new version `sync` package along side with releasing `connection` package as well 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
