### PR TITLE
fusion sync D40145

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -55,6 +55,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_migration'    => '(array) Data about any migration into the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
+		'is_core_site_editor_enabled'	=> '(bool) If the site has the core site editor enabled.',
 	);
 
 	protected static $no_member_fields = array(
@@ -78,6 +79,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_migration',
 		'is_fse_active',
 		'is_fse_eligible',
+		'is_core_site_editor_enabled',
 	);
 
 	protected static $site_options_format = array(
@@ -416,6 +418,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_fse_eligible':
 				$response[ $key ] = $this->site->is_fse_eligible();
 				break;
+			case 'is_core_site_editor_enabled':
+				$response[ $key ] = $this->site->is_core_site_editor_enabled();
 		}
 
 		do_action( 'post_render_site_response_key', $key );

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -52,6 +52,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'site_migration'    => '(array) Data about any migration into the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
+		'is_core_site_editor_enabled'	=> '(bool) If the site has the core site editor enabled.',
 	);
 
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Manually adds changes from D40145:

I recently deployed D40145 to wpcom and recieved the message about jetpack files directing me to the FG's "Using the Build Script" page.  From there, I followed the isntructions for auto-generating a PR based on D40145 but it generated a PR with no changes (perhaps since the diff was auto-merged just before running this?):
![Screen Shot 2020-03-12 at 3 48 32 PM](https://user-images.githubusercontent.com/28742426/76561070-f22b5280-6478-11ea-8035-98bffd1ad141.png)
branch: fusion-sync/addiestavlo/D40145-code-1584040496

I have created this PR instead by adding the changes manually.

