### PR TITLE
Add core site editor status to site api

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -420,6 +420,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_core_site_editor_enabled':
 				$response[ $key ] = $this->site->is_core_site_editor_enabled();
+				break;
 		}
 
 		do_action( 'post_render_site_response_key', $key );

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -55,6 +55,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_migration'    => '(array) Data about any migration into the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
+		'is_core_site_editor_enabled'	=> '(bool) If the site has the core site editor enabled.',
 	);
 
 	protected static $no_member_fields = array(
@@ -78,6 +79,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_migration',
 		'is_fse_active',
 		'is_fse_eligible',
+		'is_core_site_editor_enabled',
 	);
 
 	protected static $site_options_format = array(
@@ -416,6 +418,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'is_fse_eligible':
 				$response[ $key ] = $this->site->is_fse_eligible();
 				break;
+			case 'is_core_site_editor_enabled':
+				$response[ $key ] = $this->site->is_core_site_editor_enabled();
 		}
 
 		do_action( 'post_render_site_response_key', $key );

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -52,6 +52,7 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'site_migration'    => '(array) Data about any migration into the site.',
 		'is_fse_active'     => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'   => '(bool) If the site is capable of Full Site Editing or not',
+		'is_core_site_editor_enabled'	=> '(bool) If the site has the core site editor enabled.',
 	);
 
 

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -227,6 +227,20 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
+	 * Check if site should be considered as eligible for use of the core Site Editor.
+	 * The Site Editor requires the FSE plugin to be installed and activated.
+	 * The plugin can be explicitly enabled via the a8c_enable_core_site_editor filter.
+	 *
+	 * @return bool true if site is eligible for the Site Editor
+	 */
+	public function is_core_site_editor_enabled() {
+		if ( ! Jetpack::is_plugin_active( 'full-site-editing/full-site-editing-plugin.php' ) ) {
+			return false;
+		}
+		return function_exists( '\A8C\FSE\is_site_editor_active' ) && \A8C\FSE\is_site_editor_active();
+	}
+
+	/**
 	 * Return the last engine used for an import on the site.
 	 *
 	 * This option is not used in Jetpack.


### PR DESCRIPTION
Summary:
As part of enabling the site editor experiment on selected sites through calypso, we must add a function to the site api to return the status of the site editor for a given site.

The calypso side of this functionality is found in - https://github.com/Automattic/wp-calypso/pull/40036 .

Test Plan: Test along with instructions on wp-calypso PR - https://github.com/Automattic/wp-calypso/pull/40036

Reviewers: #cylon_team, vindl

Reviewed By: #cylon_team, vindl

Subscribers: vindl, noahtallen

Tags: #cylon_team, #touches_jetpack_files

Differential Revision: D40145-code

This commit syncs r204221-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->