### PR TITLE
Jetpack Backup: update AAG status message to account for daily backups

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import DashItem from 'components/dash-item';
 import { translate as __ } from 'i18n-calypso';
 import { get, isEmpty, noop } from 'lodash';
-import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -15,6 +14,7 @@ import { PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
+import { getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
@@ -154,7 +154,7 @@ class DashBackups extends Component {
 	}
 
 	getRewindContent() {
-		const { rewindStatus, siteRawUrl } = this.props;
+		const { planClass, rewindStatus, siteRawUrl } = this.props;
 		const buildAction = ( url, message ) => (
 			<Card compact key="manage-backups" className="jp-dash-item__manage-in-wpcom" href={ url }>
 				{ message }
@@ -188,9 +188,13 @@ class DashBackups extends Component {
 					</React.Fragment>
 				);
 			case 'active':
+				const message = [ 'is-business-plan', 'is-realtime-backup-plan' ].includes( planClass )
+					? __( 'We are backing up your site in real-time.' )
+					: __( 'We are backing up your site daily.' );
+
 				return (
 					<React.Fragment>
-						{ buildCard( __( 'We are backing up your site in real-time.' ) ) }
+						{ buildCard( message ) }
 						{ buildAction(
 							`https://wordpress.com/activity-log/${ siteRawUrl }?group=rewind`,
 							__( "View your site's backups" )
@@ -233,9 +237,12 @@ class DashBackups extends Component {
 }
 
 export default connect( state => {
+	const sitePlan = getSitePlan( state );
+
 	return {
 		vaultPressData: getVaultPressData( state ),
-		sitePlan: getSitePlan( state ),
+		sitePlan,
+		planClass: getPlanClass( sitePlan ),
 		isDevMode: isDevMode( state ),
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		showBackups: showBackups( state ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Before, the Backup card on the AAG dashboard would always display "We are backing up your site in real time" even if the site was on a plan that had daily backups:

<img width="530" alt="image" src="https://user-images.githubusercontent.com/42627630/76566835-9ca47500-647b-11ea-81fa-a2788ac3d2ea.png">

This PR changes the display so that it will reflect the site plan and display daily or realtime as appropriate:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/42627630/76566997-e5f4c480-647b-11ea-82c6-85ef81767f29.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For a site with each of the following plans, visit `/wp-admin/admin.php?page=jetpack#/dashboard` and verify that the backup card displays the correct message:
* Jetpack Backup Daily
* Jetpack Backup Realtime
* Jetpack Personal
* Jetpack Premium
* Jetpack Professional

#### Proposed changelog entry for your changes:
* Fixed issue where plans with daily backups would see a message stating that the site is being backed up in real time.
