### PR TITLE
Remove unused AB test code

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -48,11 +48,6 @@ class Jetpack_Connection_Banner {
 			false,
 			sprintf( 'connect-banner-%s-%s', $jp_version_banner_added, $current_screen->base )
 		);
-		// Add a tracks event corresponding to the A/B version displayed
-		$ab_test = Jetpack_Options::get_option( 'ab_connect_banner_green_bar' );
-		if ( in_array( $ab_test, array( 'a', 'b' ), true ) ) {
-			$url = add_query_arg( 'ab_connect_banner_green_bar', $ab_test, $url );
-		}
 		return add_query_arg( 'auth_approved', 'true', $url );
 	}
 
@@ -192,33 +187,6 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
-	 * Performs an A/B test showing or hiding the green bar at the top of the connection dialog displayed in Dashboard or Plugins.
-	 * We save which version we're showing so we always show the same to the same user.
-	 * The "A" version displays the green bar at the top.
-	 * The "B" version doesn't display it.
-	 *
-	 * @return void
-	 */
-	function get_ab_banner_top_bar() {
-		$ab_test = Jetpack_Options::get_option( 'ab_connect_banner_green_bar' );
-		// If it doesn't exist yet, generate it for later use and save it, so we always show the same to this user
-		if ( ! $ab_test ) {
-			$ab_test = 1 === rand( 1, 2 ) ? 'a' : 'b';
-			Jetpack_Options::update_option( 'ab_connect_banner_green_bar', $ab_test );
-		}
-		if ( 'a' === $ab_test ) {
-			?>
-			<div class="jp-wpcom-connect__container-top-text">
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
-				<span>
-					<?php esc_html_e( 'You’re almost done. Set up Jetpack to enable powerful security and performance tools for WordPress.', 'jetpack' ); ?>
-				</span>
-			</div>
-			<?php
-		}
-	}
-
-	/**
 	 * Renders the new connection banner as of 4.4.0.
 	 *
 	 * @since 7.2   Copy and visual elements reduced to show the new focus of Jetpack on Security and Performance.
@@ -227,7 +195,12 @@ class Jetpack_Connection_Banner {
 	function render_banner() {
 		?>
 		<div id="message" class="updated jp-wpcom-connect__container">
-			<?php $this->get_ab_banner_top_bar(); ?>
+			<div class="jp-wpcom-connect__container-top-text">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="0" fill="none" width="24" height="24"/><g><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 15h-2v-2h2v2zm0-4h-2l-.5-6h3l-.5 6z"/></g></svg>
+				<span>
+					<?php esc_html_e( 'You’re almost done. Set up Jetpack to enable powerful security and performance tools for WordPress.', 'jetpack' ); ?>
+				</span>
+			</div>
 			<div class="jp-wpcom-connect__inner-container">
 				<span
 					class="notice-dismiss connection-banner-dismiss"

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -458,6 +458,11 @@ class Jetpack {
 					}
 				}
 
+				// Upgrade to 8.4.0.
+				if ( Jetpack_Options::get_option( 'ab_connect_banner_green_bar' ) ) {
+					Jetpack_Options::delete_option( 'ab_connect_banner_green_bar' );
+				}
+
 				if ( did_action( 'wp_loaded' ) ) {
 					self::upgrade_on_load();
 				} else {

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -64,7 +64,6 @@ class Jetpack_Options {
 					'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 					'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 					'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
-					'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
 					'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 					'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
 					'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Removes an old AB test that we weren't looking at any more. Option A wins, FWIW.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove old AB test code and data

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate this branch (fake our version upgrade if you need to)
* Check there's no Jetpack option called `ab_connect_banner_green_bar` (should be deleted on upgrade)
* Check that connect banner renders correctly with the green top bar present:

<img width="789" alt="connect-banner" src="https://user-images.githubusercontent.com/51896/76569824-4a5e5680-6471-11ea-87a8-c6aa004adb8d.png">

