### PR TITLE
Actions: do not commit to mirror repo if composer.json is broken

### DIFF
--- a/bin/update-package.sh
+++ b/bin/update-package.sh
@@ -63,9 +63,14 @@ for package in packages/*; do
 	# Before we commit any changes, ensure that the repo has the basics we need for any package.
 	if [ ! -f "composer.json" -o ! -d "src" ]; then
 		echo "  Those changes remove essential parts of the package. They will not be committed."
-	# Commit if there is any change that could be committed
-	elif [ -n "$(git status --porcelain)" ]; then
+		continue
+	fi
 
+	# Let's make sure composer.json is valid.
+	$( composer validate -n >/dev/null 2>&1 ) || continue
+
+	# Commit if there is any change that could be committed
+	if [ -n "$(git status --porcelain)" ]; then
 		echo  "  Committing $NAME to $NAME's mirror repository"
 		git add -A
 		git commit --author="${COMMIT_ORIGINAL_AUTHOR}" -m "${COMMIT_MESSAGE}"


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

When the Package Update action runs and attempts to commit changes to a mirror repo, it should not commit changes that would be breaking the mirror repo's `composer.json` file.

See https://github.com/Automattic/jetpack/pull/14955#discussion_r391476296

#### Testing instructions:

- Same as in #14930, but this time in your test commit, try to edit composer.json and remove a comma for example, to break validation of the file.
- Make sure you also test a regular package update to make sure things still work.

#### Proposed changelog entry for your changes:

* N/A
