### PR TITLE
Podcast Player: Add block settings

### DIFF
--- a/extensions/blocks/podcast-player/attributes.js
+++ b/extensions/blocks/podcast-player/attributes.js
@@ -12,4 +12,12 @@ export default {
 		type: 'integer',
 		default: 5,
 	},
+	showCoverArt: {
+		type: 'boolean',
+		default: true,
+	},
+	showEpisodeDescription: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -35,6 +35,12 @@ const handleSSRError = () => {
 	return <p>{ __( 'Failed to load Block', 'jetpack' ) }</p>;
 };
 
+// Support page link.
+const supportLink =
+	isSimpleSite() || isAtomicSite()
+		? 'http://en.support.wordpress.com/wordpress-editor/blocks/podcast-player-block/'
+		: 'https://jetpack.com/support/jetpack-blocks/podcast-player-block/';
+
 const PodcastPlayerEdit = ( {
 	attributes,
 	setAttributes,
@@ -77,11 +83,6 @@ const PodcastPlayerEdit = ( {
 		setAttributes( { url: editedUrl } );
 		setIsEditing( false );
 	};
-
-	const supportLink =
-		isSimpleSite() || isAtomicSite()
-			? 'http://en.support.wordpress.com/wordpress-editor/blocks/podcast-player-block/'
-			: 'https://jetpack.com/support/jetpack-blocks/podcast-player-block/';
 
 	if ( isEditing || ! url ) {
 		return (

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -17,6 +17,7 @@ import {
 	TextControl,
 	Toolbar,
 	withNotices,
+	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, BlockIcon, InspectorControls } from '@wordpress/block-editor';
@@ -80,7 +81,10 @@ const PodcastPlayerEdit = ( {
 	noticeUI,
 } ) => {
 	// Validated attributes.
-	const { url, itemsToShow } = getValidatedAttributes( attributesValidation, attributes );
+	const { url, itemsToShow, showCoverArt, showEpisodeDescription } = getValidatedAttributes(
+		attributesValidation,
+		attributes
+	);
 
 	// State.
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
@@ -168,6 +172,18 @@ const PodcastPlayerEdit = ( {
 						min={ DEFAULT_MIN_ITEMS }
 						max={ DEFAULT_MAX_ITEMS }
 						required
+					/>
+
+					<ToggleControl
+						label={ __( 'Show Cover Art', 'jetpack' ) }
+						checked={ showCoverArt }
+						onChange={ value => setAttributes( { showCoverArt: value } ) }
+					/>
+
+					<ToggleControl
+						label={ __( 'Show Episode Description', 'jetpack' ) }
+						checked={ showEpisodeDescription }
+						onChange={ value => setAttributes( { showEpisodeDescription: value } ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -45,17 +50,26 @@ const supportLink =
  * Control component used either inside of the Podcast block
  * as well as into the InspectorControls section (sidebar)
  *
- * @param {string}   url         Podcast Feed URL
- * @param {Function} setUrlValue onChange text handler.
- * @return {*} React component
+ * @param {string}   url                    Podcast Feed URL
+ * @param {Function} setUrlValue            onChange text handler.
+ * @param {Function} triggerOnEnterKeyPress onChange text handler.
+ * @param {Function} triggerOnBlur          onBlur element handler.
+ * @return {*}                              React component
  */
-const FeedURLControl = ( { url, onUrlChange: setUrlValue } ) => (
+const FeedURLControl = ( {
+	url,
+	onUrlChange: setUrlValue,
+	onEnterKeyPress: triggerOnEnterKeyPress = noop,
+	onBlur: triggerOnBlur = noop,
+} ) => (
 	<TextControl
 		type="url"
 		placeholder={ __( 'Enter URL here…', 'jetpack' ) }
 		value={ url || '' }
-		onChange={ setUrlValue }
 		className={ 'components-placeholder__input' }
+		onChange={ setUrlValue }
+		onKeyPress={ ev => ( ev.key === 'Enter' ? triggerOnEnterKeyPress( ev ) : noop ) }
+		onBlur={ triggerOnBlur }
 	/>
 );
 
@@ -140,6 +154,13 @@ const PodcastPlayerEdit = ( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
+					<FeedURLControl
+						url={ editedUrl || '' }
+						onUrlChange={ setEditedUrl }
+						onEnterKeyPress={ checkPodcastLink }
+						onBlur={ checkPodcastLink }
+					/>
+
 					<RangeControl
 						label={ __( 'Number of items', 'jetpack' ) }
 						value={ itemsToShow }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import {
 	Button,
 	Disabled,
@@ -101,7 +101,7 @@ const PodcastPlayerEdit = ( {
 	 *
 	 * @param {object} event Form on submit event object.
 	 */
-	const checkPodcastLink = event => {
+	const checkPodcastLink = useCallback( event => {
 		event.preventDefault();
 		removeAllNotices();
 
@@ -121,7 +121,7 @@ const PodcastPlayerEdit = ( {
 
 		setAttributes( { url: editedUrl } );
 		setIsEditing( false );
-	};
+	} );
 
 	if ( isEditing || ! url ) {
 		return (

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -51,19 +51,19 @@ const supportLink =
  * Control component used either inside of the Podcast block
  * as well as into the InspectorControls section (sidebar)
  *
- * @param {string}   url                    Podcast Feed URL
- * @param {string}   label                  Input field label (optional)
- * @param {Function} setUrlValue            onChange text handler.
- * @param {Function} triggerOnEnterKeyPress onChange text handler.
- * @param {Function} triggerOnBlur          onBlur element handler.
- * @return {*}                              React component
+ * @param {string}      url             Podcast Feed URL
+ * @param {string|Null} label           Input field label. Optional.
+ * @param {Function}    onUrlChange     onChange text handler.
+ * @param {Function}    onEnterKeyPress on Enter key input event handler. Optional.
+ * @param {Function}    onBlur          onBlur input handler. Optional.
+ * @return {*}                          React component
  */
 const FeedURLControl = ( {
 	url,
 	label = null,
-	onUrlChange: setUrlValue,
-	onEnterKeyPress: triggerOnEnterKeyPress = noop,
-	onBlur: triggerOnBlur = noop,
+	onUrlChange,
+	onEnterKeyPress = noop,
+	onBlur = noop,
 } ) => (
 	<TextControl
 		label={ label }
@@ -71,9 +71,9 @@ const FeedURLControl = ( {
 		placeholder={ __( 'Enter URL here…', 'jetpack' ) }
 		value={ url || '' }
 		className={ 'components-placeholder__input' }
-		onChange={ setUrlValue }
-		onKeyPress={ ev => ( ev.key === 'Enter' ? triggerOnEnterKeyPress( ev ) : noop ) }
-		onBlur={ triggerOnBlur }
+		onChange={ onUrlChange }
+		onKeyPress={ ev => ( ev.key === 'Enter' ? onEnterKeyPress( ev ) : noop ) }
+		onBlur={ onBlur }
 	/>
 );
 

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
 import {
@@ -40,6 +40,24 @@ const supportLink =
 	isSimpleSite() || isAtomicSite()
 		? 'http://en.support.wordpress.com/wordpress-editor/blocks/podcast-player-block/'
 		: 'https://jetpack.com/support/jetpack-blocks/podcast-player-block/';
+
+/**
+ * Control component used either inside of the Podcast block
+ * as well as into the InspectorControls section (sidebar)
+ *
+ * @param {string}   url         Podcast Feed URL
+ * @param {Function} setUrlValue onChange text handler.
+ * @return {*} React component
+ */
+const FeedURLControl = ( { url, onUrlChange: setUrlValue } ) => (
+	<TextControl
+		type="url"
+		placeholder={ __( 'Enter URL here…', 'jetpack' ) }
+		value={ url || '' }
+		onChange={ setUrlValue }
+		className={ 'components-placeholder__input' }
+	/>
+);
 
 const PodcastPlayerEdit = ( {
 	attributes,
@@ -93,13 +111,7 @@ const PodcastPlayerEdit = ( {
 			>
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
-					<TextControl
-						type="url"
-						placeholder={ __( 'Enter URL here…', 'jetpack' ) }
-						value={ editedUrl || '' }
-						onChange={ setEditedUrl }
-						className={ 'components-placeholder__input' }
-					/>
+					<FeedURLControl url={ editedUrl || '' } onUrlChange={ setEditedUrl } />
 					<Button isPrimary type="submit">
 						{ __( 'Embed', 'jetpack' ) }
 					</Button>

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -52,6 +52,7 @@ const supportLink =
  * as well as into the InspectorControls section (sidebar)
  *
  * @param {string}   url                    Podcast Feed URL
+ * @param {string}   label                  Input field label (optional)
  * @param {Function} setUrlValue            onChange text handler.
  * @param {Function} triggerOnEnterKeyPress onChange text handler.
  * @param {Function} triggerOnBlur          onBlur element handler.
@@ -59,11 +60,13 @@ const supportLink =
  */
 const FeedURLControl = ( {
 	url,
+	label = null,
 	onUrlChange: setUrlValue,
 	onEnterKeyPress: triggerOnEnterKeyPress = noop,
 	onBlur: triggerOnBlur = noop,
 } ) => (
 	<TextControl
+		label={ label }
 		type="url"
 		placeholder={ __( 'Enter URL here…', 'jetpack' ) }
 		value={ url || '' }
@@ -159,6 +162,7 @@ const PodcastPlayerEdit = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
 					<FeedURLControl
+						label={ __( 'RSS Feed URL', 'jetpack' ) }
 						url={ editedUrl || '' }
 						onUrlChange={ setEditedUrl }
 						onEnterKeyPress={ checkPodcastLink }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -163,7 +163,7 @@ const PodcastPlayerEdit = ( {
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
 					<FeedURLControl
 						label={ __( 'RSS Feed URL', 'jetpack' ) }
-						url={ editedUrl || '' }
+						url={ editedUrl  }
 						onUrlChange={ setEditedUrl }
 						onEnterKeyPress={ checkPodcastLink }
 						onBlur={ checkPodcastLink }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -132,7 +132,7 @@ const PodcastPlayerEdit = ( {
 			>
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
-					<FeedURLControl url={ editedUrl || '' } onUrlChange={ setEditedUrl } />
+					<FeedURLControl url={ editedUrl  } onUrlChange={ setEditedUrl } />
 					<Button isPrimary type="submit">
 						{ __( 'Embed', 'jetpack' ) }
 					</Button>

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -42,7 +42,7 @@ const handleSSRError = () => {
 };
 
 // Support page link.
-const supportLink =
+const supportUrl =
 	isSimpleSite() || isAtomicSite()
 		? 'http://en.support.wordpress.com/wordpress-editor/blocks/podcast-player-block/'
 		: 'https://jetpack.com/support/jetpack-blocks/podcast-player-block/';
@@ -132,13 +132,13 @@ const PodcastPlayerEdit = ( {
 			>
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
-					<FeedURLControl url={ editedUrl  } onUrlChange={ setEditedUrl } />
+					<FeedURLControl url={ editedUrl } onUrlChange={ setEditedUrl } />
 					<Button isPrimary type="submit">
 						{ __( 'Embed', 'jetpack' ) }
 					</Button>
 				</form>
 				<div className="components-placeholder__learn-more">
-					<ExternalLink href={ supportLink }>
+					<ExternalLink href={ supportUrl }>
 						{ __( 'Learn more about embeds', 'jetpack' ) }
 					</ExternalLink>
 				</div>
@@ -163,7 +163,7 @@ const PodcastPlayerEdit = ( {
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
 					<FeedURLControl
 						label={ __( 'RSS Feed URL', 'jetpack' ) }
-						url={ editedUrl  }
+						url={ editedUrl }
 						onUrlChange={ setEditedUrl }
 						onEnterKeyPress={ checkPodcastLink }
 						onBlur={ checkPodcastLink }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -46,36 +45,6 @@ const supportUrl =
 	isSimpleSite() || isAtomicSite()
 		? 'http://en.support.wordpress.com/wordpress-editor/blocks/podcast-player-block/'
 		: 'https://jetpack.com/support/jetpack-blocks/podcast-player-block/';
-
-/**
- * Control component used either inside of the Podcast block
- * as well as into the InspectorControls section (sidebar)
- *
- * @param {string}      url             Podcast Feed URL
- * @param {string|Null} label           Input field label. Optional.
- * @param {Function}    onUrlChange     onChange text handler.
- * @param {Function}    onEnterKeyPress on Enter key input event handler. Optional.
- * @param {Function}    onBlur          onBlur input handler. Optional.
- * @return {*}                          React component
- */
-const FeedURLControl = ( {
-	url,
-	label = null,
-	onUrlChange,
-	onEnterKeyPress = noop,
-	onBlur = noop,
-} ) => (
-	<TextControl
-		label={ label }
-		type="url"
-		placeholder={ __( 'Enter URL here…', 'jetpack' ) }
-		value={ url || '' }
-		className={ 'components-placeholder__input' }
-		onChange={ onUrlChange }
-		onKeyPress={ ev => ( ev.key === 'Enter' ? onEnterKeyPress( ev ) : noop ) }
-		onBlur={ onBlur }
-	/>
-);
 
 const PodcastPlayerEdit = ( {
 	attributes,
@@ -132,7 +101,13 @@ const PodcastPlayerEdit = ( {
 			>
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
-					<FeedURLControl url={ editedUrl } onUrlChange={ setEditedUrl } />
+					<TextControl
+						type="url"
+						placeholder={ __( 'Enter URL here…', 'jetpack' ) }
+						value={ editedUrl || '' }
+						className={ 'components-placeholder__input' }
+						onChange={ setEditedUrl }
+					/>
 					<Button isPrimary type="submit">
 						{ __( 'Embed', 'jetpack' ) }
 					</Button>
@@ -161,14 +136,6 @@ const PodcastPlayerEdit = ( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>
-					<FeedURLControl
-						label={ __( 'RSS Feed URL', 'jetpack' ) }
-						url={ editedUrl }
-						onUrlChange={ setEditedUrl }
-						onEnterKeyPress={ checkPodcastLink }
-						onBlur={ checkPodcastLink }
-					/>
-
 					<RangeControl
 						label={ __( 'Number of items', 'jetpack' ) }
 						value={ itemsToShow }

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -25,6 +25,12 @@ export const settings = {
 	icon: queueMusic,
 	category: 'jetpack',
 	keywords: [],
+
+	styles: [
+		{ name: 'small', label: __( 'Small' ), isDefault: true },
+		{ name: 'large', label: __( 'Large' ) },
+	],
+
 	supports: {
 		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
 		align: false /* if set to true, the 'align' option below can be used*/,

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -25,12 +25,20 @@ function register_block() {
 		BLOCK_NAME,
 		array(
 			'attributes'      => array(
-				'url'         => array(
+				'url'                    => array(
 					'type' => 'url',
 				),
-				'itemsToShow' => array(
+				'itemsToShow'            => array(
 					'type'    => 'integer',
 					'default' => 5,
+				),
+				'showCoverArt'           => array(
+					'type'    => 'boolean',
+					'default' => true,
+				),
+				'showEpisodeDescription' => array(
+					'type'    => 'boolean',
+					'default' => true,
 				),
 			),
 			'render_callback' => __NAMESPACE__ . '\render_block',

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -131,7 +131,7 @@ function render_player( $track_list, $attributes ) {
  * Gets a list of tracks for the supplied RSS feed.
  *
  * @param string $feed     The RSS feed to load and list tracks for.
- * @param int    $quantity Optional. The number of tracks to return. Default 5.
+ * @param int    $quantity Optional. The number of tracks to return.
  * @return array|WP_Error The feed's tracks or a error object.
  */
 function get_track_list( $feed, $quantity = 5 ) {

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -80,9 +80,9 @@ function render_block( $attributes ) {
 /**
  * Renders the HTML for the Podcast player and tracklist.
  *
- * @param array $track_list the list of podcast tracks.
+ * @param array $track_list The list of podcast tracks.
  * @param array $attributes Array containing the Podcast Player block attributes.
- * @return string the HTML for the podcast player.
+ * @return string The HTML for the podcast player.
  */
 function render_player( $track_list, $attributes ) {
 	// If there are no tracks (it is possible) then display appropriate user facing error message.
@@ -117,9 +117,10 @@ function render_player( $track_list, $attributes ) {
 	</div>
 	<script>window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);window.jetpackPodcastPlayers.push( <?php echo wp_json_encode( $instance_id ); ?> );</script>
 	<?php
+
 	/*
-	* Enqueue necessary scripts and styles.
-	*/
+	 * Enqueue necessary scripts and styles.
+	 */
 	wp_enqueue_style( 'wp-mediaelement' );
 	Jetpack_Gutenberg::load_assets_as_required( 'podcast-player', array( 'wp-mediaelement' ) );
 

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -117,7 +117,6 @@ function render_player( $track_list, $attributes ) {
 	</div>
 	<script>window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);window.jetpackPodcastPlayers.push( <?php echo wp_json_encode( $instance_id ); ?> );</script>
 	<?php
-
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
@@ -134,7 +133,7 @@ function render_player( $track_list, $attributes ) {
  * @param int    $quantity Optional. The number of tracks to return.
  * @return array|WP_Error The feed's tracks or a error object.
  */
-function get_track_list( $feed, $quantity = 5 ) {
+function get_track_list( $feed, $quantity = 10 ) {
 	$rss = fetch_feed( $feed );
 
 	if ( is_wp_error( $rss ) ) {

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -68,7 +68,7 @@ function render_block( $attributes ) {
 	// Sanitize the URL.
 	$attributes['url'] = esc_url_raw( $attributes['url'] );
 
-	$track_list = get_track_list( $attributes['url'], $attributes['itemsToShow'] );
+	$track_list = get_track_list( $attributes['url'], absint( $attributes['itemsToShow'] ) );
 
 	if ( is_wp_error( $track_list ) ) {
 		return '<p>' . esc_html( $track_list->get_error_message() ) . '</p>';

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -68,7 +68,7 @@ function render_block( $attributes ) {
 	// Sanitize the URL.
 	$attributes['url'] = esc_url_raw( $attributes['url'] );
 
-	$track_list = get_track_list( $attributes['url'], 10 );
+	$track_list = get_track_list( $attributes['url'], $attributes['itemsToShow'] );
 
 	if ( is_wp_error( $track_list ) ) {
 		return '<p>' . esc_html( $track_list->get_error_message() ) . '</p>';
@@ -130,11 +130,11 @@ function render_player( $track_list, $attributes ) {
 /**
  * Gets a list of tracks for the supplied RSS feed.
  *
- * @param string $feed the RSS feed to load and list tracks for.
- * @param int    $quantity the number of tracks to return.
- * @return array|WP_Error the feed's tracks or a error object.
+ * @param string $feed     The RSS feed to load and list tracks for.
+ * @param int    $quantity Optional. The number of tracks to return. Default 5.
+ * @return array|WP_Error The feed's tracks or a error object.
  */
-function get_track_list( $feed, $quantity = 10 ) {
+function get_track_list( $feed, $quantity = 5 ) {
 	$rss = fetch_feed( $feed );
 
 	if ( is_wp_error( $rss ) ) {


### PR DESCRIPTION
This PR adds the following setting sections to the block:

* Block Stypes: it adds `small` (default) and `large` styles
* Feed URL: refact the code creating a `<FeedUrlControl />` to be used in both block itself and sidebar.
* Add `Show Cover Art` and `Show Episode Description` toggle elements.

The colors section will be tackled in another PR.

**Depends on https://github.com/Automattic/jetpack/pull/14948**
Fixes #14940 (partially)

### Design

<img width="1115" alt="Screen Shot 2020-03-13 at 12 46 33 PM" src="https://user-images.githubusercontent.com/77539/76637014-c798d280-6528-11ea-9a4d-bc6072207fc0.png">

#### Testing instructions:
* Create/edit podcast player.
* Check that you can edit the block styles, Feed URL, and the _cover art_ and _episode description_ status
* Confirm that these changes are persistent. Hard refresh and they still should be there.

<img width="957" alt="Screen Shot 2020-03-17 at 10 18 29 AM" src="https://user-images.githubusercontent.com/77539/76859796-be657980-6838-11ea-9c65-decdf90b841e.png">

### Proposed changelog entry for your changes:

*
