### PR TITLE
[Private sites] Request site and rewind data as user and not as blog

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1125,7 +1125,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'site_id_missing' );
 		}
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) .'?force=wpcom', '2', array(), null, 'wpcom' );
+		$response = Client::wpcom_json_api_request_as_user( sprintf( '/sites/%d/rewind', $site_id ) .'?force=wpcom', '2', array(), null, 'wpcom' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'rewind_data_fetch_failed' );
@@ -1453,7 +1453,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			$args['headers']['Cookie'] = "store_sandbox=$secret;";
 		}
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', $site_id ) .'?force=wpcom', '1.1', $args );
+		$response = Client::wpcom_json_api_request_as_user( sprintf( '/sites/%d', $site_id ) .'?force=wpcom', '1.1', $args );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'site_data_fetch_failed' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

When a site is atomic and private at the same time, Jetpack dashboard is broken. This is because the request it makes to `/wp-json/jetpack/v4/site` returns the following response:

`{"code":"site_data_fetch_failed","message":"Failed fetching site data. Try again later.","data":{"status":400}}`

This can be traced to the fact that site_data endpoint handler requests site data using `wpcom_json_api_request_as_blog`. Blogs tokens are not granted access to private data so the request fails. This PR ensures the data is requested as user and not as blog.

For an alternative approach, see D40270-code

#### Testing instructions:

1. Go to `wpcalypso.wordpress.com` (important!) and create a new site.
1. Go atomic via wpcalypso.wordpress.com, make sure your site is still private and unlaunched
1. Apply changes from this branch the atomic site you just created. One idea is described in test plan of D40270-code
1. Confirm Jetpack dashboard works properly

