### PR TITLE
OpenTable Block: Make sure the placeholder is a block element

### DIFF
--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -222,6 +222,7 @@ function OpenTableEdit( {
 
 	const editClasses = classnames( className, {
 		[ `${ defaultClassName }-theme-${ style }` ]: ! isEmpty( rid ) && styleValues.includes( style ),
+		'is-placeholder': isEmpty( rid ),
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
 		[ `align${ align }` ]: align,
 	} );

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -9,7 +9,8 @@
 	display: inline-block;
 	position: relative;
 
-	&-theme-wide {
+	&-theme-wide,
+	&.is-placeholder {
 		display: block;
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14976

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure the placeholder of the OpenTable block is a `display: block` element.

| Before | After |
| - | - |
| <img width="1072" alt="Screenshot 2020-03-13 at 15 54 37" src="https://user-images.githubusercontent.com/2070010/76637977-94b00800-6543-11ea-99c6-e8284abd814d.png"> | <img width="1069" alt="Screenshot 2020-03-13 at 15 54 18" src="https://user-images.githubusercontent.com/2070010/76637983-97126200-6543-11ea-9815-5910f7cc3b41.png"> |

Props to @simison for reporting this!

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On Gutenberg 7.7, insert an OpenTable block.
* Without embedding anything, try setting it to wide or full width.
* Make sure the placeholder fills the entire space available.
* Embed something and set the embed style to Wide.
* Make sure the embedded widget fills the entire space available.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix OpenTable block placeholder when in wide or full width.
