### PR TITLE
Podcast Player Block: Add list's front-end styles & UI handling

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -184,8 +184,7 @@ function setup_tracks_callback( \SimplePie_Item $episode ) {
 	}
 
 	if ( ! empty( $enclosure->duration ) ) {
-		$format            = $enclosure->duration > HOUR_IN_SECONDS ? 'H:i:s' : 'i:s';
-		$track['duration'] = esc_html( date_i18n( $format, $enclosure->duration ) );
+		$track['duration'] = format_track_duration( $enclosure->duration );
 	}
 
 	return $track;
@@ -206,4 +205,16 @@ function get_audio_enclosure( \SimplePie_Item $episode ) {
 
 	// Default to empty SimplePie_Enclosure object.
 	return $episode->get_enclosure();
+}
+
+/**
+ * Returns the track duration as a formatted string.
+ *
+ * @param number $duration of the track in seconds.
+ * @return string
+ */
+function format_track_duration( $duration ) {
+	$format = $duration > HOUR_IN_SECONDS ? 'H:i:s' : 'i:s';
+
+	return esc_html( date_i18n( $format, $duration ) );
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -216,5 +216,5 @@ function get_audio_enclosure( \SimplePie_Item $episode ) {
 function format_track_duration( $duration ) {
 	$format = $duration > HOUR_IN_SECONDS ? 'H:i:s' : 'i:s';
 
-	return esc_html( date_i18n( $format, $duration ) );
+	return date_i18n( $format, $duration );
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -113,7 +113,7 @@ function render_player( $track_list, $attributes ) {
 				>
 					<span class="podcast-player__episode-status-icon"></span>
 					<span class="podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-					<time class="podcast-player__episode-duration"><?php echo esc_html( $attachment['duration'] ); ?></time>
+					<time class="podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
 				</a>
 			</li>
 			<?php endforeach; ?>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -113,6 +113,7 @@ function render_player( $track_list, $attributes ) {
 						role="button"
 						aria-pressed="false"
 					>
+						<span class="podcast-player__episode-status-icon"></span>
 						<span class="podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
 						<time class="podcast-player__episode-duration"><?php echo esc_html( $attachment['meta']['length_formatted'] ); ?></time>
 					</a>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -125,9 +125,8 @@ function render_player( $track_list, $attributes ) {
 	/**
 	 * Enqueue necessary scripts and styles.
 	 */
-	wp_enqueue_script( 'mediaelement' );
 	wp_enqueue_style( 'mediaelement' );
-	Jetpack_Gutenberg::load_assets_as_required( 'podcast-player' );
+	Jetpack_Gutenberg::load_assets_as_required( 'podcast-player', array( 'mediaelement' ) );
 
 	return ob_get_clean();
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -101,10 +101,23 @@ function render_player( $track_list, $attributes ) {
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
-		<ol>
+		<ol class="podcast-player__episodes">
 			<?php
 			foreach ( $track_list as $attachment ) :
-				printf( '<li><a href="%1$s" data-jetpack-podcast-audio="%2$s">%3$s</a></li>', esc_url( $attachment['link'] ), esc_url( $attachment['src'] ), esc_html( $attachment['title'] ) );
+				?>
+				<li class="podcast-player__episode">
+					<a
+						class="podcast-player__episode-link"
+						href="<?php echo esc_url( $attachment['link'] ); ?>"
+						data-jetpack-podcast-audio="<?php echo esc_url( $attachment['src'] ); ?>"
+						role="button"
+						aria-pressed="false"
+					>
+						<span class="podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+						<time class="podcast-player__episode-duration"><?php echo esc_html( $attachment['meta']['length_formatted'] ); ?></time>
+					</a>
+				</li>
+				<?php
 			endforeach;
 			?>
 		</ol>
@@ -112,11 +125,12 @@ function render_player( $track_list, $attributes ) {
 	</div>
 	<script>window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);window.jetpackPodcastPlayers.push( <?php echo wp_json_encode( $instance_id ); ?> );</script>
 	<?php
-	/*
+	/**
 	 * Enqueue necessary scripts and styles.
 	 */
-	wp_enqueue_style( 'wp-mediaelement' );
-	Jetpack_Gutenberg::load_assets_as_required( 'podcast-player', array( 'wp-mediaelement' ) );
+	wp_enqueue_script( 'mediaelement' );
+	wp_enqueue_style( 'mediaelement' );
+	Jetpack_Gutenberg::load_assets_as_required( 'podcast-player' );
 
 	return ob_get_clean();
 }
@@ -173,6 +187,11 @@ function setup_tracks_callback( \SimplePie_Item $episode ) {
 
 	if ( empty( $track['title'] ) ) {
 		$track['title'] = esc_html__( '(no title)', 'jetpack' );
+	}
+
+	if ( ! empty( $enclosure->duration ) ) {
+		$format                            = $enclosure->duration > 3600 ? 'H:i:s' : 'i:s';
+		$track['meta']['length_formatted'] = esc_html( date_i18n( $format, $enclosure->duration ) );
 	}
 
 	return $track;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -102,25 +102,21 @@ function render_player( $track_list, $attributes ) {
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<ol class="podcast-player__episodes">
-			<?php
-			foreach ( $track_list as $attachment ) :
-				?>
-				<li class="podcast-player__episode">
-					<a
-						class="podcast-player__episode-link"
-						href="<?php echo esc_url( $attachment['link'] ); ?>"
-						data-jetpack-podcast-audio="<?php echo esc_url( $attachment['src'] ); ?>"
-						role="button"
-						aria-pressed="false"
-					>
-						<span class="podcast-player__episode-status-icon"></span>
-						<span class="podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="podcast-player__episode-duration"><?php echo esc_html( $attachment['meta']['length_formatted'] ); ?></time>
-					</a>
-				</li>
-				<?php
-			endforeach;
-			?>
+			<?php foreach ( $track_list as $attachment ) : ?>
+			<li class="podcast-player__episode">
+				<a
+					class="podcast-player__episode-link"
+					href="<?php echo esc_url( $attachment['link'] ); ?>"
+					data-jetpack-podcast-audio="<?php echo esc_url( $attachment['src'] ); ?>"
+					role="button"
+					aria-pressed="false"
+				>
+					<span class="podcast-player__episode-status-icon"></span>
+					<span class="podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+					<time class="podcast-player__episode-duration"><?php echo esc_html( $attachment['duration'] ); ?></time>
+				</a>
+			</li>
+			<?php endforeach; ?>
 		</ol>
 		<script type="application/json"><?php echo wp_json_encode( $player_data ); ?></script>
 	</div>
@@ -179,9 +175,7 @@ function setup_tracks_callback( \SimplePie_Item $episode ) {
 		'link'        => esc_url( $episode->get_link() ),
 		'src'         => esc_url( $enclosure->link ),
 		'type'        => esc_attr( $enclosure->type ),
-		'caption'     => '',
 		'description' => wp_kses_post( $episode->get_description() ),
-		'meta'        => array(),
 	);
 
 	$track['title'] = esc_html( trim( wp_strip_all_tags( $episode->get_title() ) ) );
@@ -191,8 +185,8 @@ function setup_tracks_callback( \SimplePie_Item $episode ) {
 	}
 
 	if ( ! empty( $enclosure->duration ) ) {
-		$format                            = $enclosure->duration > 3600 ? 'H:i:s' : 'i:s';
-		$track['meta']['length_formatted'] = esc_html( date_i18n( $format, $enclosure->duration ) );
+		$format            = $enclosure->duration > HOUR_IN_SECONDS ? 'H:i:s' : 'i:s';
+		$track['duration'] = esc_html( date_i18n( $format, $enclosure->duration ) );
 	}
 
 	return $track;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -11,20 +11,23 @@ $text-color-active: $text-color-hover;
 $text-color-error: #db5051;
 $block-bg-color: #fff;
 $block-border-color: $text-color;
-$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
+	'Helvetica Neue', sans-serif;
 $font-size: 16px;
 
 /**
- * Player's (block) parent element
+ * Player's (block) parent element.
  */
 .wp-block-jetpack-podcast-player {
 	border: 1px solid $text-color;
 	background-color: $block-bg-color;
 
-	// Player's state classes added to this element:
-	// &.is-playing {} // When audio starts playing
-	// &.is-paused {}  // When audio is paused
-	// &.is-error {}   // When playback error occured
+	/**
+	 * Player's state classes added to this element:
+	 * &.is-playing {} // When audio starts playing.
+	 * &.is-paused {}  // When audio is paused.
+	 * &.is-error {}   // When playback error occured.
+	 */
 
 	audio {
 		display: none;
@@ -43,16 +46,19 @@ $font-size: 16px;
 .podcast-player__episode {
 	margin: 0;
 	color: $text-color;
+	font-family: $font-family;
+	font-size: $font-size;
 
-	&:hover {
+	&:hover,
+	&:focus {
 		color: $text-color-hover;
 	}
 
 	/**
-     * When episode "is-active", it means that it's been clicked by a user to
-     * start playback. Combine this class with the Player's state classes (see
-     * above) to apply styling for different scenarios.
-     */
+	 * When episode "is-active", it means that it's been clicked by a user to
+	 * start playback. Combine this class with the Player's state classes (see
+	 * above) to apply styling for different scenarios.
+	 */
 	&.is-active {
 		color: $text-color-hover;
 		font-weight: bold;
@@ -64,11 +70,9 @@ $font-size: 16px;
 	flex-flow: row nowrap;
 	justify-content: space-between;
 	padding: $episode-h-padding $episode-v-padding;
-	font-family: $font-family;
-	font-size: $font-size;
-
 	text-decoration: none;
 	color: inherit;
+	transition: none;
 
 	.podcast-player__episode.is-active & {
 		.wp-block-jetpack-podcast-player.is-error & {
@@ -77,9 +81,12 @@ $font-size: 16px;
 	}
 }
 
-// Fixes a chrome where in 2020 and other themes that apply a path { transition: ____} definition, 
-// our svg specified colors do not get applied as this definition gets applied to the symbol definitions 
-// and we can't override them since we're applying via the shadow DOM
+/**
+ * Fixes a Chrome bug where in TwentyTwenty and other themes that apply a
+ * transition to a path element, our svg specified colors do not get applied as
+ * this definition gets applied to the symbol definitions and we can't override
+ * them since we're applying via the shadow DOM.
+ */
 .podcast-player-icons path {
 	transition: none;
 }
@@ -111,7 +118,7 @@ $font-size: 16px;
 }
 
 .podcast-player__episode-duration {
-	word-break: normal;
+	word-break: normal; // Prevents the time breaking into multiple lines.
 }
 
 /**
@@ -124,11 +131,11 @@ $font-size: 16px;
 	margin-bottom: $episode-h-padding;
 	color: $text-color-error;
 	font-family: $font-family;
-	font-size: 0.8 * $font-size;
+	font-size: 0.8em;
 	font-weight: normal;
 
-	.wp-block-jetpack-podcast-player.is-error & {
-		display: block; // Show only when error occurs
+	.wp-block-jetpack-podcast-player.is-error .podcast-player__episode.is-active & {
+		display: block; // Show only when error occurs.
 	}
 
 	span {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -77,6 +77,13 @@ $font-size: 16px;
 	}
 }
 
+// Fixes a chrome where in 2020 and other themes that apply a path { transition: ____} definition, 
+// our svg specified colors do not get applied as this definition gets applied to the symbol definitions 
+// and we can't override them since we're applying via the shadow DOM
+.podcast-player-icons path {
+	transition: none;
+}
+
 .podcast-player__episode-status-icon {
 	width: $episode-status-icon-size;
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -1,25 +1,23 @@
 /**
  * Podcast Player block shared styles (editor & front-end).
  */
+ @import '../../shared/styles/gutenberg-base-styles.scss';
 
 $episode-v-padding: 15px;
 $episode-h-padding: 10px;
 $episode-status-icon-size: 22px;
-$text-color: #92959a;
-$text-color-hover: #000;
+$text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
+$text-color-hover: $black;
 $text-color-active: $text-color-hover;
-$text-color-error: #db5051;
-$block-bg-color: #fff;
-$block-border-color: $text-color;
-$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,
-	'Helvetica Neue', sans-serif;
-$font-size: 16px;
+$block-bg-color: $white;
+$block-border-color: $dark-gray-100;
+
 
 /**
  * Player's (block) parent element.
  */
 .wp-block-jetpack-podcast-player {
-	border: 1px solid $text-color;
+	border: 1px solid $block-border-color;
 	background-color: $block-bg-color;
 
 	/**
@@ -38,7 +36,6 @@ $font-size: 16px;
 	list-style-type: none;
 	display: flex;
 	flex-direction: column;
-
 	margin: 0;
 	padding: $episode-v-padding 0;
 }
@@ -46,8 +43,8 @@ $font-size: 16px;
 .podcast-player__episode {
 	margin: 0;
 	color: $text-color;
-	font-family: $font-family;
-	font-size: $font-size;
+	font-family: $default-font;
+	font-size: $editor-font-size;
 
 	&:hover,
 	&:focus {
@@ -107,7 +104,7 @@ $font-size: 16px;
 			fill: $text-color-active;
 		}
 		.wp-block-jetpack-podcast-player.is-error & {
-			fill: $text-color-error;
+			fill: $alert-red;
 		}
 	}
 }
@@ -129,8 +126,8 @@ $font-size: 16px;
 	display: none;
 	margin-left: 2 * $episode-v-padding + $episode-status-icon-size;
 	margin-bottom: $episode-h-padding;
-	color: $text-color-error;
-	font-family: $font-family;
+	color: $alert-red;
+	font-family: $default-font;
 	font-size: 0.8em;
 	font-weight: normal;
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -71,7 +71,7 @@ $font-size: 16px;
 	color: inherit;
 
 	.podcast-player__episode.is-active & {
-		.wp-block-jetpack-podcast-player.is-error {
+		.wp-block-jetpack-podcast-player.is-error & {
 			padding-bottom: 0; // Make space for the error element that will be appended.
 		}
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -138,11 +138,11 @@ $font-size: 16px;
 		display: block; // Show only when error occurs.
 	}
 
-	span {
+	& > span {
 		color: $text-color;
 	}
 
-	a {
+	& > span > a {
 		color: inherit;
 	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -75,30 +75,20 @@ $font-size: 16px;
 			padding-bottom: 0; // Make space for the error element that will be appended.
 		}
 	}
+}
 
-	&:before {
-		content: '';
-		width: $episode-status-icon-size;
+.podcast-player__episode-status-icon {
+	width: $episode-status-icon-size;
 
-		background-repeat: no-repeat;
-		background-position: center top;
-
-		.podcast-player__episode.is-active & {
-			.wp-block-jetpack-podcast-player.is-paused & {
-				background-image: none; // (How) do we want paused state indication?
-			}
-			.wp-block-jetpack-podcast-player.is-playing & {
-				/**
-                 * Removing the hash from color string in order to provide it
-                 * for the escaped value of the SVG fill color in the URL below:
-				 */
-				$color-unhashed: str-slice( quote( $text-color-active ), 2, 7 );
-				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 24 24' width='24'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath fill='%23#{$color-unhashed}' d='M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z'/%3E%3C/svg%3E" );
-			}
-			.wp-block-jetpack-podcast-player.is-error & {
-				$color-unhashed: str-slice( quote( $text-color-error ), 2, 7 );
-				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 24 24' width='24'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath fill='%23#{$color-unhashed}' d='M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z'/%3E%3C/svg%3E" );
-			}
+	.podcast-player__episode.is-active & {
+		.wp-block-jetpack-podcast-player.is-paused & {
+			fill: none; // Currently there's no icon for paused state.
+		}
+		.wp-block-jetpack-podcast-player.is-playing & {
+			fill: $text-color-active;
+		}
+		.wp-block-jetpack-podcast-player.is-error & {
+			fill: $text-color-error;
 		}
 	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -1,11 +1,139 @@
 /**
- * Frontend (site) styles for Podcast Episodes
+ * Podcast Player block shared styles (editor & front-end).
  */
 
+$episode-v-padding: 15px;
+$episode-h-padding: 10px;
+$episode-status-icon-size: 22px;
+$text-color: #92959a;
+$text-color-hover: #000;
+$text-color-active: $text-color-hover;
+$text-color-error: #db5051;
+$block-bg-color: #fff;
+$block-border-color: $text-color;
+$font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+$font-size: 16px;
+
+/**
+ * Player's (block) parent element
+ */
 .wp-block-jetpack-podcast-player {
-	border: 1px solid;
+	border: 1px solid $text-color;
+	background-color: $block-bg-color;
+
+	// Player's state classes added to this element:
+	// &.is-playing {} // When audio starts playing
+	// &.is-paused {}  // When audio is paused
+	// &.is-error {}   // When playback error occured
+
+	audio {
+		display: none;
+	}
 }
 
-.wp-block-jetpack-podcast-player audio {
+.podcast-player__episodes {
+	list-style-type: none;
+	display: flex;
+	flex-direction: column;
+
+	margin: 0;
+	padding: $episode-v-padding 0;
+}
+
+.podcast-player__episode {
+	margin: 0;
+	color: $text-color;
+
+	&:hover {
+		color: $text-color-hover;
+	}
+
+	/**
+     * When episode "is-active", it means that it's been clicked by a user to
+     * start playback. Combine this class with the Player's state classes (see
+     * above) to apply styling for different scenarios.
+     */
+	&.is-active {
+		color: $text-color-hover;
+		font-weight: bold;
+	}
+}
+
+.podcast-player__episode-link {
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-between;
+	padding: $episode-h-padding $episode-v-padding;
+	font-family: $font-family;
+	font-size: $font-size;
+
+	text-decoration: none;
+	color: inherit;
+
+	.podcast-player__episode.is-active & {
+		.wp-block-jetpack-podcast-player.is-error {
+			padding-bottom: 0; // Make space for the error element that will be appended.
+		}
+	}
+
+	&:before {
+		content: '';
+		width: $episode-status-icon-size;
+
+		background-repeat: no-repeat;
+		background-position: center top;
+
+		.podcast-player__episode.is-active & {
+			.wp-block-jetpack-podcast-player.is-paused & {
+				background-image: none; // (How) do we want paused state indication?
+			}
+			.wp-block-jetpack-podcast-player.is-playing & {
+				/**
+                 * Removing the hash from color string in order to provide it
+                 * for the escaped value of the SVG fill color in the URL below:
+				 */
+				$color-unhashed: str-slice( quote( $text-color-active ), 2, 7 );
+				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 24 24' width='24'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath fill='%23#{$color-unhashed}' d='M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z'/%3E%3C/svg%3E" );
+			}
+			.wp-block-jetpack-podcast-player.is-error & {
+				$color-unhashed: str-slice( quote( $text-color-error ), 2, 7 );
+				background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 0 24 24' width='24'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath fill='%23#{$color-unhashed}' d='M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z'/%3E%3C/svg%3E" );
+			}
+		}
+	}
+}
+
+.podcast-player__episode-title {
+	flex-grow: 1;
+	padding: 0 $episode-v-padding;
+}
+
+.podcast-player__episode-duration {
+	word-break: normal;
+}
+
+/**
+ * Error element, appended as the last child of the Episode element
+ * (.podcast-player__episode) when Player's error has been caught.
+ */
+.podcast-player__episode-error {
 	display: none;
+	margin-left: 2 * $episode-v-padding + $episode-status-icon-size;
+	margin-bottom: $episode-h-padding;
+	color: $text-color-error;
+	font-family: $font-family;
+	font-size: 0.8 * $font-size;
+	font-weight: normal;
+
+	.wp-block-jetpack-podcast-player.is-error & {
+		display: block; // Show only when error occurs
+	}
+
+	span {
+		color: $text-color;
+	}
+
+	a {
+		color: inherit;
+	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -80,6 +80,11 @@ $font-size: 16px;
 .podcast-player__episode-status-icon {
 	width: $episode-status-icon-size;
 
+	svg {
+		width: $episode-status-icon-size;
+		height: $episode-status-icon-size;
+	}
+
 	.podcast-player__episode.is-active & {
 		.wp-block-jetpack-podcast-player.is-paused & {
 			fill: none; // Currently there's no icon for paused state.

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -69,10 +69,12 @@ function createSVGs() {
 	svgTemplate.setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
 	svgTemplate.setAttribute( 'xmlns:xlink', 'http://www.w3.org/1999/xlink' );
 
-	const soundIcon =
-		'<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><title id="podcast-player-icon__sound-title">Playing</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
-	const errorIcon =
-		'<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><title id="podcast-player-icon__error-title">Error</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
+	const soundIcon = `<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><title id="podcast-player-icon__sound-title">${ __(
+		'Playing'
+	) }</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>`;
+	const errorIcon = `<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><title id="podcast-player-icon__error-title">${ __(
+		'Error'
+	) }</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>`;
 	svgTemplate.innerHTML = `<defs>${ soundIcon }${ errorIcon }</defs>`;
 	// put it in the body
 	document.body.appendChild( svgTemplate );

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -70,9 +70,9 @@ function createSVGs() {
 	svgTemplate.setAttribute( 'xmlns:xlink', 'http://www.w3.org/1999/xlink' );
 
 	const soundIcon =
-		'<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
+		'<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><title id="podcast-player-icon__sound-title">Playing</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
 	const errorIcon =
-		'<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
+		'<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><title id="podcast-player-icon__error-title">Error</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
 	svgTemplate.innerHTML = `<defs>${ soundIcon }${ errorIcon }</defs>`;
 	// put it in the body
 	document.body.appendChild( svgTemplate );
@@ -292,9 +292,9 @@ function handleError( episodeEl ) {
 }
 
 function getSoundIconHTML() {
-	return '<svg><use xlink:href="#podcast-player-icon__sound" /></svg>';
+	return '<svg aria-labelledby="podcast-player-icon__sound-title"><use xlink:href="#podcast-player-icon__sound" /></svg>';
 }
 
 function getErrorIconHTML() {
-	return '<svg><use xlink:href="#podcast-player-icon__error" /></svg>';
+	return '<svg aria-labelledby="podcast-player-icon__error-title"><use xlink:href="#podcast-player-icon__error" /></svg>';
 }

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -109,7 +109,7 @@ function handleEpisodeLinkEvent( e ) {
 document.addEventListener( 'click', handleEpisodeLinkEvent );
 document.addEventListener( 'keydown', handleEpisodeLinkKeydown );
 
-function handleEpisodeLinkClick( episodeLinkEl ) {
+async function handleEpisodeLinkClick( episodeLinkEl ) {
 	// Get clicked episode element
 	const episodeEl = episodeLinkEl.closest( '.podcast-player__episode' );
 	if ( ! episodeEl ) {
@@ -140,7 +140,11 @@ function handleEpisodeLinkClick( episodeLinkEl ) {
 
 	if ( activeEpisodeEl && activeEpisodeEl.isSameNode( episodeEl ) ) {
 		if ( player.audio.paused ) {
-			player.audio.play().then( () => handlePlay( activeEpisodeEl ) );
+			try {
+				await player.audio.play();
+			} catch ( _error ) {
+				return handleError( episodeEl );
+			}
 		} else {
 			player.audio.pause();
 			handlePause( activeEpisodeEl );
@@ -158,10 +162,13 @@ function handleEpisodeLinkClick( episodeLinkEl ) {
 
 		player.audio.src = audioUrl;
 
-		player.audio
-			.play()
-			.then( () => handlePlay( episodeEl ) )
-			.catch( () => handleError( episodeEl ) );
+		try {
+			await player.audio.play();
+		} catch ( _error ) {
+			return handleError( episodeEl );
+		}
+
+		handlePlay( episodeEl );
 	}
 }
 

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -136,31 +136,31 @@ function handleEpisodeLinkClick( episodeLinkEl ) {
 	// Get currently active episode element
 	const activeEpisodeEl = blockEl.querySelector( '.podcast-player__episode.is-active' );
 
-	if ( activeEpisodeEl ) {
-		if ( activeEpisodeEl.isSameNode( episodeEl ) ) {
-			if ( player.audio.paused ) {
-				player.audio.play().then( () => handlePlay( activeEpisodeEl ) );
-			} else {
-				player.audio.pause();
-				handlePause( activeEpisodeEl );
-			}
-			return;
+	if ( activeEpisodeEl && activeEpisodeEl.isSameNode( episodeEl ) ) {
+		if ( player.audio.paused ) {
+			player.audio.play().then( () => handlePlay( activeEpisodeEl ) );
+		} else {
+			player.audio.pause();
+			handlePause( activeEpisodeEl );
 		}
-		// Make episode inactive
-		activeEpisodeEl.classList.remove( 'is-active' );
-		activeEpisodeEl
-			.querySelector( '[aria-pressed="true"]' )
-			.setAttribute( 'aria-pressed', 'false' );
+	} else {
+		if ( activeEpisodeEl ) {
+			// Make episode inactive
+			activeEpisodeEl.classList.remove( 'is-active' );
+			activeEpisodeEl
+				.querySelector( '[aria-pressed="true"]' )
+				.setAttribute( 'aria-pressed', 'false' );
 
-		handlePause( activeEpisodeEl );
+			handlePause( activeEpisodeEl );
+		}
+
+		player.audio.src = audioUrl;
+
+		player.audio
+			.play()
+			.then( () => handlePlay( episodeEl ) )
+			.catch( () => handleError( episodeEl ) );
 	}
-
-	player.audio.src = audioUrl;
-
-	player.audio
-		.play()
-		.then( () => handlePlay( episodeEl ) )
-		.catch( () => handleError( episodeEl ) );
 }
 
 function renderEpisodeError( episodeEl ) {

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -70,10 +70,12 @@ function createSVGs() {
 	svgTemplate.setAttribute( 'xmlns:xlink', 'http://www.w3.org/1999/xlink' );
 
 	const soundIcon = `<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><title id="podcast-player-icon__sound-title">${ __(
-		'Playing'
+		'Playing',
+		'jetpack'
 	) }</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>`;
 	const errorIcon = `<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><title id="podcast-player-icon__error-title">${ __(
-		'Error'
+		'Error',
+		'jetpack'
 	) }</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>`;
 	svgTemplate.innerHTML = `<defs>${ soundIcon }${ errorIcon }</defs>`;
 	// put it in the body

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -63,6 +63,7 @@ window.jetpackPodcastPlayers = {
 
 function createSVGs() {
 	const svgTemplate = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
+	svgTemplate.classList.add( 'podcast-player-icons' );
 	svgTemplate.setAttribute( 'style', 'position: absolute; width: 0; height: 0; overflow: hidden;' );
 	svgTemplate.setAttribute( 'version', '1.1' );
 	svgTemplate.setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
@@ -291,9 +292,9 @@ function handleError( episodeEl ) {
 }
 
 function getSoundIconHTML() {
-	return '<svg><use xlink:href="#podcast-player-icon__sound"></use></svg>';
+	return '<svg><use xlink:href="#podcast-player-icon__sound" /></svg>';
 }
 
 function getErrorIconHTML() {
-	return '<svg><use xlink:href="#podcast-player-icon__error"></use></svg>';
+	return '<svg><use xlink:href="#podcast-player-icon__error" /></svg>';
 }

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -146,6 +146,7 @@ async function handleEpisodeLinkClick( episodeLinkEl ) {
 			} catch ( _error ) {
 				return handleError( episodeEl );
 			}
+			handlePlay( episodeEl );
 		} else {
 			player.audio.pause();
 			handlePause( activeEpisodeEl );

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -62,15 +62,17 @@ window.jetpackPodcastPlayers = {
 };
 
 function createSVGs() {
-	// for some reason document.createElement( 'svg' ) would not work. The HTML would work correctly, but the SVG would not render
-	const svgTemplate = document.createElement( 'div' );
+	const svgTemplate = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
 	svgTemplate.setAttribute( 'style', 'position: absolute; width: 0; height: 0; overflow: hidden;' );
+	svgTemplate.setAttribute( 'version', '1.1' );
+	svgTemplate.setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
+	svgTemplate.setAttribute( 'xmlns:xlink', 'http://www.w3.org/1999/xlink' );
 
 	const soundIcon =
 		'<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
 	const errorIcon =
 		'<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
-	svgTemplate.innerHTML = `<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs>${ soundIcon }${ errorIcon }</defs></svg>`;
+	svgTemplate.innerHTML = `<defs>${ soundIcon }${ errorIcon }</defs>`;
 	// put it in the body
 	document.body.appendChild( svgTemplate );
 }

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -112,7 +112,7 @@ function handleEpisodeLinkClick( episodeLinkEl ) {
 	const episodeEl = episodeLinkEl.closest( '.podcast-player__episode' );
 	if ( ! episodeEl ) {
 		// Append the error to closest parent if episode element is not present.
-		return handleError( episodeLinkEl.closest( '*' ) );
+		return handleError( episodeLinkEl.parentNode );
 	}
 
 	// Get clicked episode audio URL

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -134,12 +134,12 @@ function handleEpisodeLinkClick( episodeLinkEl ) {
 	}
 
 	// Get currently active episode element
-	const activeEpisodeEl = document.querySelector( '.podcast-player__episode.is-active' );
+	const activeEpisodeEl = blockEl.querySelector( '.podcast-player__episode.is-active' );
+
 	if ( activeEpisodeEl ) {
 		if ( activeEpisodeEl.isSameNode( episodeEl ) ) {
 			if ( player.audio.paused ) {
-				player.audio.play();
-				handlePlay( activeEpisodeEl );
+				player.audio.play().then( () => handlePlay( activeEpisodeEl ) );
 			} else {
 				player.audio.pause();
 				handlePause( activeEpisodeEl );
@@ -196,6 +196,14 @@ function renderEpisodeError( episodeEl ) {
 function handlePlay( episodeEl ) {
 	if ( ! episodeEl ) {
 		return;
+	}
+
+	// Check if there's any other episode playing and pause it.
+	const playingEpisodeEl = document.querySelector(
+		'.wp-block-jetpack-podcast-player.is-playing .podcast-player__episode.is-active'
+	);
+	if ( playingEpisodeEl ) {
+		handlePause( playingEpisodeEl );
 	}
 
 	// Get episode's parent block element

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -42,9 +42,15 @@ const initializeBlock = function( id ) {
 
 	// Initialize player UI.
 	player.audio = document.createElement( 'audio' );
-	player.audio.src = player.tracks[ 0 ].src;
+	player.audio.src = block
+		.querySelector( '[data-jetpack-podcast-audio]' )
+		.getAttribute( 'data-jetpack-podcast-audio' );
 	block.insertBefore( player.audio, block.firstChild );
 	player.mediaElement = new MediaElementPlayer( player.audio, meJsSettings );
+
+	player.mediaElement.media.addEventListener( 'play', handleMediaPlay );
+	player.mediaElement.media.addEventListener( 'pause', handleMediaPause );
+	player.mediaElement.media.addEventListener( 'error', handleMediaError );
 
 	// Save instance to the list of active ones.
 	playerInstances[ id ] = player;
@@ -58,26 +64,156 @@ if ( window.jetpackPodcastPlayers !== undefined ) {
 // Replace the queue with an immediate initialization for async loaded players.
 window.jetpackPodcastPlayers = {
 	push: initializeBlock,
-	playerInstances,
 };
 
-// Add global handler for clicks.
-window.addEventListener( 'click', function( e ) {
+function handleMediaPlay( e ) {
+	const audioEl = e.detail.target;
+	const parentBlockEl = audioEl.closest( '.wp-block-jetpack-podcast-player' );
+	if ( ! parentBlockEl ) {
+		return;
+	}
+
+	// Clean up any error indication if present
+	const episodeErrorEl = parentBlockEl.querySelector( '.podcast-player__episode-error' );
+	if ( episodeErrorEl ) {
+		parentBlockEl.classList.remove( 'is-error' );
+		episodeErrorEl.remove();
+	}
+
+	parentBlockEl.classList.remove( 'is-paused' );
+	parentBlockEl.classList.add( 'is-playing' );
+}
+
+function handleMediaPause( e ) {
+	const audioEl = e.detail.target;
+	const parentBlockEl = audioEl.closest( '.wp-block-jetpack-podcast-player' );
+
+	parentBlockEl.classList.remove( 'is-playing' );
+	parentBlockEl.classList.add( 'is-paused' );
+}
+
+function handleMediaError( e ) {
+	const audioEl = e.detail.target;
+	const parentBlockEl = audioEl.closest( '.wp-block-jetpack-podcast-player' );
+	const activeEpisodeLinkEl = parentBlockEl.querySelector( '.is-active > a' );
+
+	renderEpisodeError( activeEpisodeLinkEl );
+}
+
+const episodeLinkEls = document.querySelectorAll( '[data-jetpack-podcast-audio]' );
+
+Array.prototype.forEach.call( episodeLinkEls, buildEpisodeLinkClickHandler );
+
+function buildEpisodeLinkClickHandler( episodeLinkEl ) {
+	episodeLinkEl.addEventListener( 'click', handleEpisodeLinkClick );
+	episodeLinkEl.addEventListener( 'keydown', handleEpisodeLinkKeydown );
+}
+
+function handleEpisodeLinkKeydown( e ) {
+	// we only need to track spacebar, as Enter is already handled by the browser since it's an `<a>` element
+	if ( event.key === ' ' ) {
+		handleEpisodeLinkClick( e );
+	}
+}
+
+function handleEpisodeLinkClick( e ) {
 	// Prevent handling clicks if a modifier is in use.
 	if ( e.shiftKey || e.metaKey || e.altKey ) {
 		return;
 	}
 
-	// Check if the clicked element was episode link.
-	const audioUrl = e.target.getAttribute( 'data-jetpack-podcast-audio' );
-	if ( audioUrl ) {
-		const block = e.target.closest( '.wp-block-jetpack-podcast-player' );
-		const player = block && block.id && playerInstances[ block.id ];
-		if ( player ) {
-			player.audio.pause();
-			player.audio.src = audioUrl;
-			player.audio.play();
-			e.preventDefault();
-		}
+	e.preventDefault();
+
+	const episodeLinkEl = e.currentTarget;
+
+	// Get clicked episode audio URL
+	const audioUrl = episodeLinkEl.getAttribute( 'data-jetpack-podcast-audio' );
+	if ( ! audioUrl ) {
+		return renderEpisodeError( episodeLinkEl );
 	}
-} );
+
+	// Get clicked episode element
+	const episodeEl = episodeLinkEl.closest( '.podcast-player__episode' );
+	if ( ! episodeLinkEls ) {
+		return renderEpisodeError( episodeLinkEl );
+	}
+
+	// Get episode's parent block element
+	const blockEl = episodeEl.closest( '.wp-block-jetpack-podcast-player' );
+	if ( ! blockEl ) {
+		return renderEpisodeError( episodeLinkEl );
+	}
+
+	// Get player instance by block id
+	const player = playerInstances[ blockEl.id ];
+	if ( ! player ) {
+		return renderEpisodeError( episodeLinkEl );
+	}
+
+	player.audio.pause();
+
+	const activeEpisodeEl = blockEl.querySelector( '.is-active' );
+
+	if ( activeEpisodeEl ) {
+		activeEpisodeEl.classList.remove( 'is-active' );
+		activeEpisodeEl
+			.querySelector( '[aria-pressed="true"]' )
+			.setAttribute( 'aria-pressed', 'false' );
+	}
+
+	player.audio.src = audioUrl;
+
+	player.audio.play().catch( function() {
+		renderEpisodeError( episodeLinkEl );
+	} );
+
+	episodeEl.classList.add( 'is-active' );
+	episodeLinkEl.setAttribute( 'aria-pressed', 'true' );
+}
+
+function renderEpisodeError( episodeLinkEl ) {
+	if ( ! episodeLinkEl ) {
+		return;
+	}
+
+	// Find parent block element
+	const parentBlockEl = episodeLinkEl.closest( '.wp-block-jetpack-podcast-player' );
+	if ( ! parentBlockEl ) {
+		return;
+	}
+
+	parentBlockEl.classList.remove( 'is-playing', 'is-paused' );
+	parentBlockEl.classList.add( 'is-error' );
+
+	// Don't render if already rendered
+	if ( parentBlockEl.querySelector( '.podcast-player__episode-error' ) ) {
+		return;
+	}
+
+	// Get parent episode element
+	const parentEpisodeEl = episodeLinkEl.closest( '.podcast-player__episode' );
+	if ( ! parentEpisodeEl ) {
+		return;
+	}
+
+	const errorTemplate = `
+		<div class="podcast-player__episode-error">
+			Episode unavailable <span>(<a href="{{episodeUrl}}" rel="noopener noreferrer nofollow" target="_blank">Open in new tab</a>)</span>
+		</div>
+	`;
+
+	// Compile error template and create the element
+	const compiledTemplate = errorTemplate.replace( '{{episodeUrl}}', episodeLinkEl.href );
+	const errorEl = createElementFromString( compiledTemplate );
+
+	// Render the element
+	parentEpisodeEl.appendChild( errorEl );
+}
+
+function createElementFromString( html ) {
+	if ( ! html ) {
+		return;
+	}
+
+	return new DOMParser().parseFromString( html, 'text/html' ).body.firstChild;
+}

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -72,6 +72,22 @@ window.jetpackPodcastPlayers = {
 	push: initializeBlock,
 };
 
+function createSVGs() {
+	// for some reason document.createElement( 'svg' ) would not work. The HTML would work correctly, but the SVG would not render
+	const svgTemplate = document.createElement( 'div' );
+	svgTemplate.setAttribute( 'style', 'position: absolute; width: 0; height: 0; overflow: hidden;' );
+
+	const soundIcon =
+		'<symbol id="podcast-player-sound" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
+	const errorIcon =
+		'<symbol id="podcast-player-error" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
+	svgTemplate.innerHTML = `<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs>${ soundIcon }${ errorIcon }</defs></svg>`;
+	// put it in the body
+	document.body.appendChild( svgTemplate );
+}
+
+createSVGs();
+
 function handleEpisodeLinkKeydown( e ) {
 	// early return as quickly as possible to prevent potential performance issues.
 	// we only care about the spacebar
@@ -208,8 +224,7 @@ function handlePlay( episodeEl ) {
 
 	blockEl.classList.remove( 'is-paused', 'is-error' );
 	blockEl.classList.add( 'is-playing' );
-	iconContainerEl.innerHTML =
-		'<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></svg>';
+	iconContainerEl.innerHTML = getSoundIconHTML();
 	episodeEl.classList.add( 'is-active' );
 	episodeLinkEl.setAttribute( 'aria-pressed', 'true' );
 }
@@ -258,8 +273,7 @@ function handleError( episodeEl ) {
 
 	blockEl.classList.remove( 'is-playing', 'is-paused' );
 	blockEl.classList.add( 'is-error' );
-	iconContainerEl.innerHTML =
-		'<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>';
+	iconContainerEl.innerHTML = getErrorIconHTML();
 	episodeEl.classList.add( 'is-active' );
 	episodeLinkEl.setAttribute( 'aria-pressed', 'true' );
 	renderEpisodeError( episodeEl );
@@ -267,4 +281,12 @@ function handleError( episodeEl ) {
 
 function getActiveEpisodeEl() {
 	return document.querySelector( '.podcast-player__episode.is-active' );
+}
+
+function getSoundIconHTML() {
+	return '<svg><use xlink:href="#podcast-player-sound"></use></svg>';
+}
+
+function getErrorIconHTML() {
+	return '<svg><use xlink:href="#podcast-player-error"></use></svg>';
 }

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -62,22 +62,19 @@ window.jetpackPodcastPlayers = {
 	push: initializeBlock,
 };
 
-const episodeLinkEls = document.querySelectorAll( '[data-jetpack-podcast-audio]' );
-
-Array.prototype.forEach.call( episodeLinkEls, buildEpisodeLinkClickHandler );
-
-function buildEpisodeLinkClickHandler( episodeLinkEl ) {
-	episodeLinkEl.addEventListener( 'keydown', handleEpisodeLinkKeydown );
-}
-
 function handleEpisodeLinkKeydown( e ) {
-	// we only need to track spacebar, as Enter is already handled by the browser since it's an `<a>` element
-	if ( event.key === ' ' ) {
-		handleEpisodeLinkClick( e );
+	// early return as quickly as possible to prevent potential performance issues.
+	// we only care about the spacebar
+	if ( event.key !== ' ' || ! e.target.classList.contains( 'podcast-player__episode-link' ) ) {
+		return;
 	}
+
+	e.stopPropagation();
+
+	handleEpisodeLinkEvent( e );
 }
 
-document.addEventListener( 'click', function( e ) {
+function handleEpisodeLinkEvent( e ) {
 	const episodeLinkEl = e.target.closest( '[data-jetpack-podcast-audio]' );
 
 	if ( episodeLinkEl ) {
@@ -89,7 +86,11 @@ document.addEventListener( 'click', function( e ) {
 		e.preventDefault();
 		handleEpisodeLinkClick( episodeLinkEl );
 	}
-} );
+}
+
+// Add document event listeners
+document.addEventListener( 'click', handleEpisodeLinkEvent );
+document.addEventListener( 'keydown', handleEpisodeLinkKeydown );
 
 function handleEpisodeLinkClick( episodeLinkEl ) {
 	// Get clicked episode element

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -42,9 +42,7 @@ const initializeBlock = function( id ) {
 
 	// Initialize player UI.
 	player.audio = document.createElement( 'audio' );
-	player.audio.src = block
-		.querySelector( '[data-jetpack-podcast-audio]' )
-		.getAttribute( 'data-jetpack-podcast-audio' );
+	player.audio.src = player.tracks[ 0 ].src;
 	block.insertBefore( player.audio, block.firstChild );
 	player.mediaElement = new MediaElementPlayer( player.audio, meJsSettings );
 

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -47,16 +47,6 @@ const initializeBlock = function( id ) {
 	block.insertBefore( player.audio, block.firstChild );
 	player.mediaElement = new MediaElementPlayer( player.audio, meJsSettings );
 
-	player.mediaElement.media.addEventListener( 'play', function() {
-		handlePlay( getActiveEpisodeEl() );
-	} );
-	player.mediaElement.media.addEventListener( 'pause', function() {
-		handlePause( getActiveEpisodeEl() );
-	} );
-	player.mediaElement.media.addEventListener( 'error', function() {
-		handleError( getActiveEpisodeEl() );
-	} );
-
 	// Save instance to the list of active ones.
 	playerInstances[ id ] = player;
 };
@@ -77,9 +67,9 @@ function createSVGs() {
 	svgTemplate.setAttribute( 'style', 'position: absolute; width: 0; height: 0; overflow: hidden;' );
 
 	const soundIcon =
-		'<symbol id="podcast-player-sound" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
+		'<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>';
 	const errorIcon =
-		'<symbol id="podcast-player-error" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
+		'<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>';
 	svgTemplate.innerHTML = `<svg style="position: absolute; width: 0; height: 0; overflow: hidden;" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs>${ soundIcon }${ errorIcon }</defs></svg>`;
 	// put it in the body
 	document.body.appendChild( svgTemplate );
@@ -122,25 +112,25 @@ function handleEpisodeLinkClick( episodeLinkEl ) {
 	const episodeEl = episodeLinkEl.closest( '.podcast-player__episode' );
 	if ( ! episodeEl ) {
 		// Append the error to closest parent if episode element is not present.
-		return renderEpisodeError( episodeLinkEl.closest( '*' ) );
+		return handleError( episodeLinkEl.closest( '*' ) );
 	}
 
 	// Get clicked episode audio URL
 	const audioUrl = episodeLinkEl.getAttribute( 'data-jetpack-podcast-audio' );
 	if ( ! audioUrl ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	// Get episode's parent block element
 	const blockEl = episodeEl.closest( '.wp-block-jetpack-podcast-player' );
 	if ( ! blockEl ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	// Get player instance by block id
 	const player = playerInstances[ blockEl.id ];
 	if ( ! player ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	// Get currently active episode element
@@ -211,19 +201,19 @@ function handlePlay( episodeEl ) {
 	// Get episode's parent block element
 	const blockEl = episodeEl.closest( '.wp-block-jetpack-podcast-player' );
 	if ( ! blockEl ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	// Get episode's link element
 	const episodeLinkEl = episodeEl.querySelector( '.podcast-player__episode-link' );
 	if ( ! episodeLinkEl ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	// Get episode's state icon container element
 	const iconContainerEl = episodeEl.querySelector( '.podcast-player__episode-status-icon' );
 	if ( ! iconContainerEl ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	blockEl.classList.remove( 'is-paused', 'is-error' );
@@ -241,7 +231,7 @@ function handlePause( episodeEl ) {
 	// Get episode's parent block
 	const episodeBlockEl = episodeEl.closest( '.wp-block-jetpack-podcast-player' );
 	if ( ! episodeBlockEl ) {
-		return renderEpisodeError( episodeEl );
+		return handleError( episodeEl );
 	}
 
 	// Set parent block classes
@@ -283,14 +273,10 @@ function handleError( episodeEl ) {
 	renderEpisodeError( episodeEl );
 }
 
-function getActiveEpisodeEl() {
-	return document.querySelector( '.podcast-player__episode.is-active' );
-}
-
 function getSoundIconHTML() {
-	return '<svg><use xlink:href="#podcast-player-sound"></use></svg>';
+	return '<svg><use xlink:href="#podcast-player-icon__sound"></use></svg>';
 }
 
 function getErrorIconHTML() {
-	return '<svg><use xlink:href="#podcast-player-error"></use></svg>';
+	return '<svg><use xlink:href="#podcast-player-icon__error"></use></svg>';
 }

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -67,7 +67,6 @@ const episodeLinkEls = document.querySelectorAll( '[data-jetpack-podcast-audio]'
 Array.prototype.forEach.call( episodeLinkEls, buildEpisodeLinkClickHandler );
 
 function buildEpisodeLinkClickHandler( episodeLinkEl ) {
-	episodeLinkEl.addEventListener( 'click', handleEpisodeLinkClick );
 	episodeLinkEl.addEventListener( 'keydown', handleEpisodeLinkKeydown );
 }
 
@@ -78,16 +77,21 @@ function handleEpisodeLinkKeydown( e ) {
 	}
 }
 
-function handleEpisodeLinkClick( e ) {
-	// Prevent handling clicks if a modifier is in use.
-	if ( e.shiftKey || e.metaKey || e.altKey ) {
-		return;
+document.addEventListener( 'click', function( e ) {
+	const episodeLinkEl = e.target.closest( '[data-jetpack-podcast-audio]' );
+
+	if ( episodeLinkEl ) {
+		// Prevent handling clicks if a modifier is in use.
+		if ( e.shiftKey || e.metaKey || e.altKey ) {
+			return;
+		}
+
+		e.preventDefault();
+		handleEpisodeLinkClick( episodeLinkEl );
 	}
+} );
 
-	e.preventDefault();
-
-	const episodeLinkEl = e.currentTarget;
-
+function handleEpisodeLinkClick( episodeLinkEl ) {
 	// Get clicked episode element
 	const episodeEl = episodeLinkEl.closest( '.podcast-player__episode' );
 	if ( ! episodeEl ) {

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -3,6 +3,7 @@
  * Internal dependencies
  */
 import './style.scss';
+import { __ } from '@wordpress/i18n';
 
 const playerInstances = {};
 const meJsSettings = typeof _wpmejsSettings !== 'undefined' ? _wpmejsSettings : {};
@@ -182,16 +183,21 @@ function renderEpisodeError( episodeEl ) {
 
 	const episodeLinkEl = episodeEl.querySelector( '.podcast-player__episode-link' );
 
-	// ToDo: make error template translatable
-	const errorTemplate = `
-		<div class="podcast-player__episode-error">
-			Episode unavailable <span>(<a href="{{episodeUrl}}" rel="noopener noreferrer nofollow" target="_blank">Open in new tab</a>)</span>
-		</div>
-	`;
+	const linkEl = document.createElement( 'a' );
+	linkEl.rel = 'noopener noreferrer nofollow';
+	linkEl.target = '_blank';
+	linkEl.href = episodeLinkEl.href;
+	linkEl.innerText = __( 'Open in a new tab', 'jetpack' );
 
-	// Compile error template and create the element
-	const compiledTemplate = errorTemplate.replace( '{{episodeUrl}}', episodeLinkEl.href );
-	const errorEl = new DOMParser().parseFromString( compiledTemplate, 'text/html' ).body.firstChild;
+	const spanEl = document.createElement( 'span' );
+	spanEl.appendChild( new Text( '(' ) );
+	spanEl.appendChild( linkEl );
+	spanEl.appendChild( new Text( ')' ) );
+
+	const errorEl = document.createElement( 'div' );
+	errorEl.classList.add( 'podcast-player__episode-error' );
+	errorEl.appendChild( new Text( __( 'Episode unavailable', 'jetpack' ) + ' ' ) );
+	errorEl.appendChild( spanEl );
 
 	// Render the element
 	episodeEl.appendChild( errorEl );

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -156,6 +156,7 @@ function handleEpisodeLinkClick( e ) {
 
 	if ( activeEpisodeEl ) {
 		activeEpisodeEl.classList.remove( 'is-active' );
+		renderEpisodeStatusIcon( activeEpisodeEl );
 		activeEpisodeEl
 			.querySelector( '[aria-pressed="true"]' )
 			.setAttribute( 'aria-pressed', 'false' );
@@ -163,9 +164,14 @@ function handleEpisodeLinkClick( e ) {
 
 	player.audio.src = audioUrl;
 
-	player.audio.play().catch( function() {
-		renderEpisodeError( episodeLinkEl );
-	} );
+	player.audio
+		.play()
+		.then( function() {
+			renderEpisodeStatusIcon( episodeEl );
+		} )
+		.catch( function() {
+			renderEpisodeError( episodeLinkEl );
+		} );
 
 	episodeEl.classList.add( 'is-active' );
 	episodeLinkEl.setAttribute( 'aria-pressed', 'true' );
@@ -204,16 +210,38 @@ function renderEpisodeError( episodeLinkEl ) {
 
 	// Compile error template and create the element
 	const compiledTemplate = errorTemplate.replace( '{{episodeUrl}}', episodeLinkEl.href );
-	const errorEl = createElementFromString( compiledTemplate );
+	const errorEl = new DOMParser().parseFromString( compiledTemplate, 'text/html' ).body.firstChild;
 
-	// Render the element
+	// Render the element & the status icon
 	parentEpisodeEl.appendChild( errorEl );
+	renderEpisodeStatusIcon( parentEpisodeEl );
 }
 
-function createElementFromString( html ) {
-	if ( ! html ) {
+function renderEpisodeStatusIcon( episodeEl ) {
+	const iconContainerEl = episodeEl.querySelector( '.podcast-player__episode-status-icon' );
+
+	// Remove the icon if the episode is not active.
+	if ( ! episodeEl.classList.contains( 'is-active' ) ) {
+		iconContainerEl.innerHTML = '';
 		return;
 	}
 
-	return new DOMParser().parseFromString( html, 'text/html' ).body.firstChild;
+	const parentBlockEl = episodeEl.closest( '.wp-block-jetpack-podcast-player' );
+
+	if ( parentBlockEl.classList.contains( 'is-error' ) ) {
+		iconContainerEl.innerHTML =
+			'<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>';
+		return;
+	}
+
+	if ( parentBlockEl.classList.contains( 'is-playing' ) ) {
+		iconContainerEl.innerHTML =
+			'<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></svg>';
+		return;
+	}
+
+	if ( parentBlockEl.classList.contains( 'is-paused' ) ) {
+		iconContainerEl.innerHTML = '';
+		return;
+	}
 }


### PR DESCRIPTION
Related #14942
Built on #14952

#### Changes proposed in this Pull Request:

- [x] Create markup with all necessary fields for the episodes list.
- [x] Add styling according to the design.
- [x] Handle episode play, pause & error states for multiple player instances.
- [x] Add necessary aria labels. (cc @jeryj)

#### Podcast Player block's episode list design:

- Episode playback:
   <img width="297" alt="Screenshot 2020-03-16 19 44 31" src="https://user-images.githubusercontent.com/1451471/76790181-a4875080-67be-11ea-9445-5fecad45801b.png">
- Episode playback error:
   <img width="297" alt="Screenshot 2020-03-16 19 44 19" src="https://user-images.githubusercontent.com/1451471/76790179-a2bd8d00-67be-11ea-8529-8955b0837216.png">
- Icons:
   - https://material.io/resources/icons/?icon=volume_up&style=outline
   - https://material.io/resources/icons/?icon=error_outline&style=baseline
- Font family:
   `-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;`

#### Testing instructions:

1. Add couple Podcast Player blocks to your page
   Example links:
   - https://anchor.fm/s/9400d7c/podcast/rss
   - https://anchor.fm/s/807f8e8/podcast/rss
2. Open the page preview / publish.
3. Click on any episode to start playback. A playing episode should have a loudspeaker icon on its left.
4. If an episode from another Player is clicked, the current one should be paused. A paused episode should not have any icon on its left but should keep the font bold.
5. If an active episode is clicked, it should pause/resume playing.
7. When episode error occurs, a message should appear below that episode (as per design). The icon on the left should be red, but due to [some issues with SVG](https://github.com/Automattic/jetpack/pull/14989#discussion_r394262451) it is black and will be dealt with in a follow-up PR.
   _Tip: Episode error can be tested by [blocking the request](https://developers.google.com/web/updates/2017/04/devtools-release-notes#block-requests) to its URL. You can find the URL to block assigned to the `data-jetpack-podcast-audio` attribute._ 

#### Notes for Reviewers:

1. Player's controls events are not yet handled, so e.g. pausing the episode via the play/pause button won't have any visual impact on the episode list items. This will be addressed in a follow-up PR._
2. The JS implementation is being majorly overhauled into its own class here: https://github.com/Automattic/jetpack/pull/15034 Getting this PR merged would make work on improving this implementation a lot easier. We're not looking for anything close to perfection on this PR for this beta block.

#### Proposed changelog entry for your changes:

- Podcast Player Block: Add episodes list's front-end styles & UI handling
