### PR TITLE
Podcast Player: Add settings colors

### DIFF
--- a/extensions/blocks/podcast-player/attributes.js
+++ b/extensions/blocks/podcast-player/attributes.js
@@ -20,4 +20,16 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	textColor: {
+		type: 'string',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
 };

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -74,10 +74,8 @@ const PodcastPlayerEdit = ( {
 	fallbackBackgroundColor,
 } ) => {
 	// Validated attributes.
-	const { url, itemsToShow, showCoverArt, showEpisodeDescription } = getValidatedAttributes(
-		attributesValidation,
-		attributes
-	);
+	const validatedAttributes = getValidatedAttributes( attributesValidation, attributes );
+	const { url, itemsToShow, showCoverArt, showEpisodeDescription } = validatedAttributes;
 
 	// State.
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
@@ -212,7 +210,7 @@ const PodcastPlayerEdit = ( {
 			<Disabled>
 				<ServerSideRender
 					block={ namespaceName }
-					attributes={ { url, itemsToShow } }
+					attributes={ validatedAttributes }
 					EmptyResponsePlaceholder={ handleSSRError }
 					ErrorResponsePlaceholder={ handleSSRError }
 				/>

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -23,7 +23,9 @@ import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
 	BlockIcon,
+	ContrastChecker,
 	InspectorControls,
+	PanelColorSettings,
 	withColors,
 	__experimentalUseColors as useColors,
 } from '@wordpress/block-editor';
@@ -60,8 +62,16 @@ const supportUrl =
 const PodcastPlayerEdit = ( {
 	attributes,
 	setAttributes,
+
 	noticeOperations: { createErrorNotice, removeAllNotices },
 	noticeUI,
+
+	textColor,
+	setTextColor,
+	fallbackTextColor,
+	backgroundColor,
+	setBackgroundColor,
+	fallbackBackgroundColor,
 } ) => {
 	// Validated attributes.
 	const { url, itemsToShow, showCoverArt, showEpisodeDescription } = getValidatedAttributes(
@@ -168,6 +178,36 @@ const PodcastPlayerEdit = ( {
 						onChange={ value => setAttributes( { showEpisodeDescription: value } ) }
 					/>
 				</PanelBody>
+
+				{ ! isUseColorsAvailable && (
+					<PanelColorSettings
+						title={ __( 'Color Settings', 'jetpack' ) }
+						colorSettings={ [
+							{
+								value: textColor.color,
+								onChange: setTextColor,
+								label: __( 'Text Color', 'jetpack' ),
+							},
+							{
+								value: backgroundColor.color,
+								onChange: setBackgroundColor,
+								label: __( 'Background', 'jetpack' ),
+							},
+						] }
+					>
+						<ContrastChecker
+							{ ...{
+								// Text is considered large if font size is greater or equal to 18pt or 24px,
+								// currently that's not the case for button.
+								isLargeText: false,
+								textColor: textColor.color,
+								backgroundColor: backgroundColor.color,
+								fallbackBackgroundColor,
+								fallbackTextColor,
+							} }
+						/>
+					</PanelColorSettings>
+				) }
 			</InspectorControls>
 			<Disabled>
 				<ServerSideRender

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -58,10 +58,8 @@ const supportUrl =
 const PodcastPlayerEdit = ( {
 	attributes,
 	setAttributes,
-
 	noticeOperations: { createErrorNotice, removeAllNotices },
 	noticeUI,
-
 	textColor,
 	setTextColor,
 	fallbackTextColor,

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -27,7 +27,6 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 	withColors,
-	__experimentalUseColors as useColors,
 } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import { isURL } from '@wordpress/url';
@@ -42,9 +41,6 @@ import { edit, queueMusic } from './icons/';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import attributesValidation from './attributes';
 import { applyFallbackStyles } from '../../shared/apply-fallback-styles';
-
-// Check if useColors is available.
-const isUseColorsAvailable = !! useColors;
 
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 10;
@@ -177,35 +173,33 @@ const PodcastPlayerEdit = ( {
 					/>
 				</PanelBody>
 
-				{ ! isUseColorsAvailable && (
-					<PanelColorSettings
-						title={ __( 'Color Settings', 'jetpack' ) }
-						colorSettings={ [
-							{
-								value: textColor.color,
-								onChange: setTextColor,
-								label: __( 'Text Color', 'jetpack' ),
-							},
-							{
-								value: backgroundColor.color,
-								onChange: setBackgroundColor,
-								label: __( 'Background', 'jetpack' ),
-							},
-						] }
-					>
-						<ContrastChecker
-							{ ...{
-								// Text is considered large if font size is greater or equal to 18pt or 24px,
-								// currently that's not the case for button.
-								isLargeText: false,
-								textColor: textColor.color,
-								backgroundColor: backgroundColor.color,
-								fallbackBackgroundColor,
-								fallbackTextColor,
-							} }
-						/>
-					</PanelColorSettings>
-				) }
+				<PanelColorSettings
+					title={ __( 'Color Settings', 'jetpack' ) }
+					colorSettings={ [
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color', 'jetpack' ),
+						},
+						{
+							value: backgroundColor.color,
+							onChange: setBackgroundColor,
+							label: __( 'Background', 'jetpack' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							// Text is considered large if font size is greater or equal to 18pt or 24px,
+							// currently that's not the case for button.
+							isLargeText: false,
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
+							fallbackBackgroundColor,
+							fallbackTextColor,
+						} }
+					/>
+				</PanelColorSettings>
 			</InspectorControls>
 			<Disabled>
 				<ServerSideRender
@@ -219,10 +213,8 @@ const PodcastPlayerEdit = ( {
 	);
 };
 
-export default ! isUseColorsAvailable
-	? compose( [
-			withColors( 'backgroundColor', { textColor: 'color' } ),
-			withNotices,
-			applyFallbackStyles,
-	  ] )( PodcastPlayerEdit )
-	: withNotices( PodcastPlayerEdit );
+export default compose( [
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	withNotices,
+	applyFallbackStyles,
+] )( PodcastPlayerEdit );

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -18,11 +18,13 @@ import {
 	withNotices,
 	ToggleControl,
 } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
+	withColors,
 	__experimentalUseColors as useColors,
 } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
@@ -37,6 +39,7 @@ import './editor.scss';
 import { edit, queueMusic } from './icons/';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import attributesValidation from './attributes';
+import { applyFallbackStyles } from '../../shared/apply-fallback-styles';
 
 // Check if useColors is available.
 const isUseColorsAvailable = !! useColors;
@@ -178,4 +181,10 @@ const PodcastPlayerEdit = ( {
 	);
 };
 
-export default withNotices( PodcastPlayerEdit );
+export default ! isUseColorsAvailable
+	? compose( [
+			withColors( 'backgroundColor', { textColor: 'color' } ),
+			withNotices,
+			applyFallbackStyles,
+	  ] )( PodcastPlayerEdit )
+	: withNotices( PodcastPlayerEdit );

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -19,7 +19,12 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { BlockControls, BlockIcon, InspectorControls } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	BlockIcon,
+	InspectorControls,
+	__experimentalUseColors as useColors,
+} from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import { isURL } from '@wordpress/url';
 
@@ -32,6 +37,9 @@ import './editor.scss';
 import { edit, queueMusic } from './icons/';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import attributesValidation from './attributes';
+
+// Check if useColors is available.
+const isUseColorsAvailable = !! useColors;
 
 const DEFAULT_MIN_ITEMS = 1;
 const DEFAULT_MAX_ITEMS = 10;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -110,13 +110,15 @@ function render_player( $track_list, $attributes ) {
 
 	$colors          = get_colors( $attributes );
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $colors['css_classes'] );
+	$title_classname = 'podcast-player__episode' . $colors['text_class_name'];
 
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<ol class="podcast-player__episodes">
 			<?php foreach ( $track_list as $attachment ) : ?>
-			<li class="podcast-player__episode">
+
+				<li class="<?php echo esc_attr( $title_classname ); ?>">
 				<a
 					class="podcast-player__episode-link"
 					href="<?php echo esc_url( $attachment['link'] ); ?>"
@@ -242,9 +244,11 @@ function format_track_duration( $duration ) {
  */
 function get_colors( $attributes ) {
 	$colors = array(
-		'css_classes' => array(),
-		'style'       => '',
-		'class_name'  => '',
+		'css_classes'      => array(),
+		'css_text_classes' => array(),
+		'style'            => '',
+		'class_name'       => '',
+		'text_class_name'  => '',
 	);
 
 	// Text color.
@@ -254,12 +258,14 @@ function get_colors( $attributes ) {
 	// If has text color.
 	if ( $has_custom_text_color || $has_named_text_color ) {
 		// Add has-text-color class.
-		$colors['css_classes'][] = 'has-text-color';
+		$colors['css_classes'][]      = 'has-text-color';
+		$colors['css_text_classes'][] = 'has-text-color';
 	}
 
 	if ( $has_named_text_color ) {
 		// Add the color class.
-		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
+		$colors['css_classes'][]      = sprintf( 'has-%s-color', $attributes['textColor'] );
+		$colors['css_text_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
 		$colors['style'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
@@ -285,6 +291,10 @@ function get_colors( $attributes ) {
 
 	if ( ! empty( $colors['css_classes'] ) ) {
 		$colors['class_name'] = implode( ' ', $colors['css_classes'] );
+	}
+
+	if ( ! empty( $colors['css_text_classes'] ) ) {
+		$colors['text_class_name'] = ' ' . implode( ' ', $colors['css_text_classes'] );
 	}
 
 	return $colors;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -40,6 +40,18 @@ function register_block() {
 					'type'    => 'boolean',
 					'default' => true,
 				),
+				'textColor'              => array(
+					'type' => 'string',
+				),
+				'customTextColor'        => array(
+					'type' => 'string',
+				),
+				'backgroundColor'        => array(
+					'type' => 'string',
+				),
+				'customBackgroundColor'  => array(
+					'type' => 'string',
+				),
 			),
 			'render_callback' => __NAMESPACE__ . '\render_block',
 		)

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -108,7 +108,8 @@ function render_player( $track_list, $attributes ) {
 		'attributes' => $attributes,
 	);
 
-	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
+	$colors          = get_colors( $attributes );
+	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $colors['css_classes'] );
 
 	ob_start();
 	?>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -241,8 +241,9 @@ function format_track_duration( $duration ) {
  */
 function get_colors( $attributes ) {
 	$colors = array(
-			'css_classes'   => array(),
-			'inline_styles' => '',
+		'css_classes' => array(),
+		'style'       => '',
+		'class_name'  => '',
 	);
 
 	// Text color.
@@ -260,7 +261,7 @@ function get_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
 	} elseif ( $has_custom_text_color ) {
 		// Add the custom color inline style.
-		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
+		$colors['style'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
 	}
 
 	// Background color.
@@ -278,7 +279,11 @@ function get_colors( $attributes ) {
 		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
 	} elseif ( $has_custom_background_color ) {
 		// Add the custom background-color inline style.
-		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
+		$colors['style'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
+	}
+
+	if ( ! empty( $colors['css_classes'] ) ) {
+		$colors['class_name'] = implode( ' ', $colors['css_classes'] );
 	}
 
 	return $colors;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -218,3 +218,56 @@ function format_track_duration( $duration ) {
 
 	return date_i18n( $format, $duration );
 }
+
+/**
+ * Build an array with CSS classes and inline styles defining the colors
+ * which will be applied to player either in the editor-canvas
+ * as well as in the front-end side.
+ *
+ * @param  array $attributes block attributes.
+ * @return array Colors CSS classes and inline styles.
+ */
+function get_colors( $attributes ) {
+	$colors = array(
+			'css_classes'   => array(),
+			'inline_styles' => '',
+	);
+
+	// Text color.
+	$has_named_text_color  = isset( $attributes['textColor'] );
+	$has_custom_text_color = isset( $attributes['customTextColor'] );
+
+	// If has text color.
+	if ( $has_custom_text_color || $has_named_text_color ) {
+		// Add has-text-color class.
+		$colors['css_classes'][] = 'has-text-color';
+	}
+
+	if ( $has_named_text_color ) {
+		// Add the color class.
+		$colors['css_classes'][] = sprintf( 'has-%s-color', $attributes['textColor'] );
+	} elseif ( $has_custom_text_color ) {
+		// Add the custom color inline style.
+		$colors['inline_styles'] .= sprintf( 'color: %s;', $attributes['customTextColor'] );
+	}
+
+	// Background color.
+	$has_named_background_color  = isset( $attributes['backgroundColor'] );
+	$has_custom_background_color = isset( $attributes['customBackgroundColor'] );
+
+	// If has background color.
+	if ( $has_custom_background_color || $has_named_background_color ) {
+		// Add has-background class.
+		$colors['css_classes'][] = 'has-background';
+	}
+
+	if ( $has_named_background_color ) {
+		// Add the background-color class.
+		$colors['css_classes'][] = sprintf( 'has-%s-background-color', $attributes['backgroundColor'] );
+	} elseif ( $has_custom_background_color ) {
+		// Add the custom background-color inline style.
+		$colors['inline_styles'] .= sprintf( 'background-color: %s;', $attributes['customBackgroundColor'] );
+	}
+
+	return $colors;
+}

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -110,11 +110,16 @@ function render_player( $track_list, $attributes ) {
 
 	$colors          = get_colors( $attributes );
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $colors['css_classes'] );
+	$block_style     = $colors['style'];
 	$title_classname = 'podcast-player__episode' . $colors['text_class_name'];
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
+	<div
+		<?php echo empty( $block_style ) ? '' : 'style="' . esc_attr( $block_style ) . '"'; ?>
+		class="<?php echo esc_attr( $block_classname ); ?>"
+		id="<?php echo esc_attr( $instance_id ); ?>"
+	>
 		<ol class="podcast-player__episodes">
 			<?php foreach ( $track_list as $attachment ) : ?>
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -143,3 +143,4 @@ $block-border-color: $dark-gray-100;
 		color: inherit;
 	}
 }
+

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -30,6 +30,13 @@ $block-border-color: $dark-gray-100;
 	audio {
 		display: none;
 	}
+
+	// Anchors inherit text color from the main class,
+	// if they have defined background and/or text color.
+	&.has-text-color .podcast-player__episode-link,
+	&.has-background .podcast-player__episode-link {
+		color: inherit;
+	}
 }
 
 .podcast-player__episodes {
@@ -143,4 +150,3 @@ $block-border-color: $dark-gray-100;
 		color: inherit;
 	}
 }
-

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -49,9 +49,13 @@ $block-border-color: $dark-gray-100;
 
 .podcast-player__episode {
 	margin: 0;
-	color: $text-color;
 	font-family: $default-font;
 	font-size: $editor-font-size;
+
+	// Apply text color only if hasn't been by the user.
+	&:not(.has-text-color) {
+		color: $text-color;
+	}
 
 	&:hover,
 	&:focus {

--- a/extensions/shared/apply-fallback-styles.js
+++ b/extensions/shared/apply-fallback-styles.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { withFallbackStyles } from '@wordpress/components';
+
+/**
+ * HoC which will try to pick up the `color` and `backgroundColor`
+ * values through DOM manipulation.
+ */
+export const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textColor, backgroundColor } = ownProps;
+	const backgroundColorValue = backgroundColor && backgroundColor.color;
+	const textColorValue = textColor && textColor.color;
+	//avoid the use of querySelector if textColor color is known and verify if node is available.
+	const textNode =
+		! textColorValue && node ? node.querySelector( '[contenteditable="true"]' ) : null;
+	return {
+		fallbackBackgroundColor:
+			backgroundColorValue || ! node ? undefined : getComputedStyle( node ).backgroundColor,
+		fallbackTextColor:
+			textColorValue || ! textNode ? undefined : getComputedStyle( textNode ).color,
+	};
+} );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR allows set text and/or background color to the Podcast Player block.


![image](https://user-images.githubusercontent.com/77539/77070087-5ba2e800-69c8-11ea-825b-456589ff92f8.png)

![image](https://user-images.githubusercontent.com/77539/77070072-55ad0700-69c8-11ea-818f-b6548dbac748.png)



Fixes https://github.com/Automattic/jetpack/issues/14940
Depends on https://github.com/Automattic/jetpack/pull/14989

#### Changes proposed in this Pull Request:

* Add `Colors Settings` control to the sidebar.
* Allows set text and background color, either using custom colors or pick them up from the palette defined by the theme.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1) Create/edit a Podcast Player block.
`https://distributed.blog/category/podcast/feed`, just in case ;-)

2) Open and focus block settings.

3) Set text and background color. Every change should be propagated to the block.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
