### PR TITLE
add new Odesli/Songlink domains

### DIFF
--- a/tests/php/modules/shortcodes/test-class.others.php
+++ b/tests/php/modules/shortcodes/test-class.others.php
@@ -25,6 +25,9 @@ class WP_Test_Jetpack_Shortcodes_Others extends WP_UnitTestCase {
 	public function test_shortcodes_songlink() {
 		global $post;
 
+		/**
+		 * Adding a comment so I can reopen the PR
+		 */
 		$url  = 'https://song.link/hu/i/1051332387';
 		$post = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- added new Songlink/Odesli domains. Songlink used to run only at https://song.link, but now it supports a handleful of other pretty domains, such as album.link and artist.link. As part of these changes, Songlink rebranded to Odesli, with song.link, album.link, etc. now different domains under Odesli name. 
- https://song.link/oembed is still supported (and always will be), but figured it's better to use the top-level/main domain https://odesli.co for oEmebd endpoint
- Let me know if you'd like me to provide any example URLs for testing; e.g. https://song.link/i/1051394215, https://album.link/i/1051394208, https://artist.link/mars. I can give you a fuller list of all possibilities/types of URLs
- Original whitelisting of Songlink was tracked [here](https://github.com/Automattic/jetpack/issues/9973). 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Enhances support of a pre-existing feature

#### Testing instructions:
- The [original PR](https://github.com/Automattic/jetpack/pull/12954/files) that added whitelist support did not add tests, but if you show me how to add tests for this, I can do so.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
- Added support for all domains supported by Odesli (formerly Songlink): song.link, album.link, artist.link, playlist.link, pods.link, mylink.page, and odesli.co