### PR TITLE
Jetpack class mocking (static binding)

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5202,7 +5202,7 @@ endif;
 	 * @return Automattic\Jetpack\Connection\Manager
 	 */
 	public static function connection() {
-		$jetpack = self::init();
+		$jetpack = static::init();
 
 		// If the connection manager hasn't been instantiated, do that now.
 		if ( ! $jetpack->connection_manager ) {

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -64,6 +64,14 @@ class WP_Test_Jetpack extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Make sure that MockJetpack creates separate instances of `Jetpack` and `Automattic\Jetpack\Connection\Manager`.
+	 */
+	public function test_static_binding() {
+		$this->assertNotEquals( spl_object_hash( MockJetpack::init() ), spl_object_hash( Jetpack::init() ) );
+		$this->assertNotEquals( spl_object_hash( MockJetpack::connection() ), spl_object_hash( Jetpack::connection() ) );
+	}
+
+	/**
 	 * @author blobaugh
 	 * @covers Jetpack::init
 	 * @since 2.3.3

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -8,6 +8,27 @@ use Automattic\Jetpack\Status;
 
 // Extend with a public constructor so that can be mocked in tests
 class MockJetpack extends Jetpack {
+
+	/**
+	 * Holds the singleton instance of this class
+	 *
+	 * @var MockJetpack
+	 */
+	public static $instance = false;
+
+	/**
+	 * We are redefining this to overcome the lack of late static binding in the parent Jetpack class.
+	 *
+	 * @static
+	 */
+	public static function init() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
 	public function __construct() {
 		$this->connection_manager = new Connection_Manager();
 	}


### PR DESCRIPTION
#### The Issue
The `Jetpack` class (`class.jetpack.php`) cannot be properly extended due to lack of "late static binding".
More on the late static binding: https://www.php.net/manual/en/language.oop5.late-static-bindings.php

#### Details
I discovered that PHPUnit test class `WP_Test_Jetpack` doesn't properly clean up the environment after it's been run.
To be more specific, class `WP_Test_Jetpack` creates a `MockJetpack` object that extends the `Jetpack` singleton. However, the `Jetpack` class relies on the `self::` keyword to access its methods and properties, so all static calls to the `MockJetpack` actually return static properties of the parent `Jetpack` class.

Here's an example.
A test method of the class `WP_Test_Jetpack` creates a `MockJetpack` instance and retrieves the connection object (supposedly new instance of `Automattic\Jetpack\Connection\Manager`):
```
$jetpack = new MockJetpack();
$date = $jetpack::connection()->get_assumed_site_creation_date();
```
Then happens the following:
1. `$jetpack::connection()` calls the parent `Jetpack::connection()` method
2. That method retrieves the `Jetpack` singleton instance: `$jetpack = self::init();`
3. The `Jetpack::init()` method returns its own instance: `return self::$instance;`

The `WP_Test_Jetpack` test is supposed to be working with its own `MockJetpack` and `Connection\Manager` instances, but in fact uses the global instances stored in the `Jetpack` class. Because of this the test class doesn't revert the environment to its original state, causing issues with further tests that rely on the environment (e.g. `WP_Test_Jetpack_REST_API_Authentication`).

#### The Fix
One way to fix it is to reset the connection data after the test class is run: `MockJetpack::connection()->reset_raw_post_data();`
However, it looks a bit hacky because it doesn't really solve the problem.
Class `Jetpack` cannot be properly extended, and that same issue might appear again and again when somebody creates a mock Jetpack class.

So instead of using tricks to make the test work, I decided to make some minimal changes to the `Jetpack` class to allow mock classes to properly extend it.

#### Hidden in the Darkness
The issue only appears in certain conditions.
In normal circumstances, the tests run with no issues, and there' no way to notice the problem.
The changes to the `raw_post_data` that `MockJetpack` introduces are reset by the `WP_Test_Jetpack_Sync_Functions` class, so the doesn't affect any tests at the moment.

Test utility method `WP_Test_Jetpack_Sync_Functions::mock_authenticated_xml_rpc_cleanup()` cleans up the data by calling `Jetpack::connection()->reset_raw_post_data()`, so all tests that run after it don't experience the problem.

In particular, tests in the class `WP_Test_Jetpack_REST_API_Authentication` are affected by this, but they usually run with no issues because those tests run after the connection instance is cleaned up by the test class `WP_Test_Jetpack_Sync_Functions`.

#### Testing instructions
To reproduce the issue we can run specific sets of test classes:
1. This command will not fail any tests, meaning that test class:
`WP_Test_Jetpack_REST_API_Authentication` doesn't have any issues: `yarn docker:phpunit --filter='WP_Test_Jetpack_REST_API_Authentication::*'`
2. This command will fail the REST authentication tests because `WP_Test_Jetpack` changes the environment (the global connection instance):
`yarn docker:phpunit --filter='WP_Test_Jetpack::*|WP_Test_Jetpack_REST_API_Authentication::*'`
3. This command is equivalent of running all the tests (for our purposes). It will not fail any tests:`yarn docker:phpunit --filter='WP_Test_Jetpack::*|WP_Test_Jetpack_Sync_Functions::test_xml_rpc_request_callables_has_actor|WP_Test_Jetpack_REST_API_Authentication::*'`
Although `WP_Test_Jetpack` modifies the connection instance and the test should fail, running the test `WP_Test_Jetpack_Sync_Functions::test_xml_rpc_request_callables_has_actor` leads to calling `Jetpack::connection()->reset_raw_post_data()`. That resets the environment just enough for `WP_Test_Jetpack_REST_API_Authentication` tests to run.

After the fix is applied, the failed command (step 2) will run with no issues:
`yarn docker:phpunit --filter='WP_Test_Jetpack::*|WP_Test_Jetpack_REST_API_Authentication::*'`

#### Is That Enough?
Probably not. The `Jetpack` class has a huge number of calls to `self::`, and replacing them all with `static::` may have undesired implications.

We don't know how if anybody extends the `Jetpack` class, why they decided to go down that road, and how they implemented it. This may raise compatibility issues, so I limited changes to the `Jetpack` class to the necessary minimum.

#### Backward Compatibility
I don't anticipate any compatibility issues.
To change its behavior, a class that extends `Jetpack` should have following changes implemented:
1. Static property `$instance` that stores the instance
2. Static function `init()` that create the object (if necessary), and saves it into the `$instance` property.

It doesn't seem to be very likely that someone would have extended `Jetpack` class and have these changes implemented, so I believe the change will not break anything.

#### Discussion Topics
In the light of the above, I'd like to raise following questions:
1. Is `Jetpack` class supposed to be extended? If so, only for mocking purposes, or to adjust its functionality as well? Or should we discourage this kind of changes everywhere?
2. Do you anticipate any compatibility issues if we apply the suggested solution?
3. Should we make additional steps to ease extending the `Jetpack` class?

#### Proposed changelog entry for your changes
I'm not sure if it's needed, but if we do we could probably use this:
* Late static binding for the Jetpack Connection Manager class.