### PR TITLE
Search: Add Search plan to wp-admin Plans page

### DIFF
--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -240,5 +240,6 @@ export default connect( state => {
 		isFetchingData:
 			isFetchingSiteData( state ) || isFetchingProducts( state ) || ! getAvailablePlans( state ),
 		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ), // Redirect to https://jetpack.com/upgrade/backup/
+		isInstantSearchEnabled: !! get( state, 'jetpack.initialState.isInstantSearchEnabled', false ),
 	};
 } )( ProductSelector );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -4,6 +4,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
+import classNames from 'classnames';
 import { get } from 'lodash';
 
 /**
@@ -14,6 +15,7 @@ import ExternalLink from 'components/external-link';
 import ProductCard from 'components/product-card';
 import ProductExpiration from 'components/product-expiration';
 import SingleProductBackup from './single-product-backup';
+import SingleProductSearch from './single-product-search';
 import { getPlanClass } from '../lib/plans/constants';
 import {
 	getActiveSitePurchases,
@@ -185,7 +187,16 @@ class ProductSelector extends Component {
 	}
 
 	renderSingleProductContent() {
-		return <div className="plans-section__single-product">{ this.renderBackupProduct() }</div>;
+		return (
+			<div
+				className={ classNames( 'plans-section__single-product', {
+					'plans-section__single-product--with-search': this.props.isInstantSearchEnabled,
+				} ) }
+			>
+				{ this.renderBackupProduct() }
+				{ this.props.isInstantSearchEnabled && this.renderSearchProduct() }
+			</div>
+		);
 	}
 
 	renderBackupProduct() {
@@ -218,6 +229,16 @@ class ProductSelector extends Component {
 		);
 	}
 
+	renderSearchProduct() {
+		return (
+			<SingleProductSearch
+				isFetching={ this.props.isFetchingData }
+				products={ this.props.products }
+				searchUpgradeUrl={ this.props.searchUpgradeUrl }
+			/>
+		);
+	}
+
 	render() {
 		return (
 			<Fragment>
@@ -235,6 +256,7 @@ export default connect( state => {
 		multisite: isMultisite( state ),
 		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
+		searchUpgradeUrl: getUpgradeUrl( state, 'jetpack-search' ),
 		sitePlan: getSitePlan( state ),
 		siteRawlUrl: getSiteRawUrl( state ),
 		isFetchingData:

--- a/_inc/client/plans/single-product-backup/index.jsx
+++ b/_inc/client/plans/single-product-backup/index.jsx
@@ -60,11 +60,11 @@ export default function SingleProductBackupCard( props ) {
 	return props.isFetching ? (
 		<div className="plans-section__single-product-skeleton is-placeholder" />
 	) : (
-		<div className="single-product-backup__accented-card dops-card">
-			<div className="single-product-backup__accented-card-header">
+		<div className="single-product__accented-card dops-card">
+			<div className="single-product__accented-card-header">
 				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
 			</div>
-			<div className="single-product-backup__accented-card-body">
+			<div className="single-product__accented-card-body">
 				<SingleProductBackupBody
 					billingTimeFrame={ billingTimeFrame }
 					currencyCode={ currencyCode }

--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+import { get, noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import PlanRadioButton from '../single-product-components/plan-radio-button';
+
+const PLACEHOLDER_RECORD_COUNT = 53;
+const PLACEHOLDER_PRICE = 50;
+const PLACEHOLDER_LABEL = 'Tier 1: Up to 100 records';
+
+export default function SingleProductSearchCard( props ) {
+	const currencyCode = get( props.products, 'jetpack_backup_daily.currency_code', '' );
+
+	return props.isFetching ? (
+		<div className="plans-section__single-product-skeleton is-placeholder" />
+	) : (
+		<div className="single-product__accented-card dops-card">
+			<div className="single-product__accented-card-header">
+				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Search' ) }</h3>
+			</div>
+			<div className="single-product__accented-card-body">
+				<p>
+					{ __(
+						'Enhanced Search for your WordPress site that provides more relevant results using modern ' +
+							'ranking algorithms, boosting of specific results, advanced filtering and faceting, and more. '
+					) }
+					<a href="https://jetpack.com/search" target="_blank" rel="noopener noreferrer">
+						{ __( 'Learn More' ) }
+					</a>
+				</p>
+				<h4 className="single-product-backup__options-header">
+					{ __(
+						'Your current site record size: %d record',
+						'Your current site record size: %d records',
+						{ args: PLACEHOLDER_RECORD_COUNT, count: PLACEHOLDER_RECORD_COUNT }
+					) }
+				</h4>
+				<div className="single-product-search__radio-buttons-container">
+					<PlanRadioButton
+						billingTimeFrame="yearly"
+						checked={ true }
+						currencyCode={ currencyCode }
+						fullPrice={ PLACEHOLDER_PRICE }
+						onChange={ noop }
+						planName={ PLACEHOLDER_LABEL }
+						radioValue={ PLACEHOLDER_PRICE }
+					/>
+				</div>
+				<div className="single-product-search__upgrade-button-container">
+					<Button href={ props.searchUpgradeUrl } primary>
+						{ __( 'Get Jetpack Search' ) }
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/_inc/client/plans/single-products.scss
+++ b/_inc/client/plans/single-products.scss
@@ -2,7 +2,6 @@
 @import 'scss/variables/_colors.scss';
 @import 'scss/calypso-colors.scss';
 
-// Single product backup
 .single-product-backup__header-title {
 	margin: 5px 20px 5px 0;
 	font-size: 17px;
@@ -47,6 +46,18 @@
 	display: flex;
 	justify-content: center;
 	margin: 24px auto 40px;
+
+	&.plans-section__single-product--with-search {
+		.single-product__accented-card,
+		.plans-section__single-product-skeleton {
+			&:first-child {
+				margin-right: 0.5em;
+			}
+			&:last-child {
+				margin-left: 0.5em;
+			}
+		}
+	}
 }
 
 .plans-section__single-product-skeleton {
@@ -79,6 +90,7 @@
 	}
 }
 
+.single-product-search__upgrade-button-container,
 .single-product-backup__upgrade-button-container {
 	text-align: center;
 	margin-top: 24px;
@@ -91,13 +103,13 @@
 }
 
 // Accented card
-.single-product-backup__accented-card {
+.single-product__accented-card {
 	max-width: 518px;
 	width: 100%;
 	font-size: 14px;
 }
 
-.single-product-backup__accented-card-header {
+.single-product__accented-card-header {
 	padding: 8px 16px;
 	margin: -16px -16px 16px;
 	border-bottom: solid 2px $alert-green;
@@ -108,7 +120,7 @@
 	}
 }
 
-.single-product-backup__accented-card-body p {
+.single-product__accented-card-body p {
 	margin-top: 14px;
 	font-size: 14px;
 	color: $gray-text-min;
@@ -124,4 +136,34 @@
 	.plan-price__integer {
 		color: $gray-text-min;
 	}
+}
+
+.single-product-search__radio-buttons-container,
+.single-product-backup__radio-buttons-container {
+	display: flex;
+	flex-flow: column nowrap;
+	margin-bottom: 21px;
+
+	@include breakpoint( '>660px' ) {
+		flex-flow: row wrap;
+		justify-content: space-around; // IE11 fallback.
+		justify-content: space-evenly;
+		position: relative;
+	}
+}
+
+.single-product-search__radio-buttons-container {
+	.plan-price {
+		margin-right: 0.25em;
+	}
+}
+
+.single-product-backup__radio-buttons-container::before {
+	display: block;
+	border-left: 1px solid $light-gray-700;
+	position: absolute;
+	content: '';
+	height: 100%;
+	width: 0;
+	order: 2;
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -1,4 +1,5 @@
 <?php
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Partner;
 
@@ -170,7 +171,8 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		}
 
 		// Add objects to be passed to the initial state of the app.
-		wp_localize_script( 'react-plugin', 'Initial_State', $this->get_initial_state() );
+		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
+		wp_add_inline_script( 'react-plugin', 'var Initial_State=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $this->get_initial_state() ) ) . '"));', 'before' );
 	}
 
 	function get_initial_state() {
@@ -304,6 +306,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'lastPostUrl'                 => esc_url( $last_post ),
 			'externalServicesConnectUrls' => $this->get_external_services_connect_urls(),
 			'calypsoEnv'                  => Jetpack::get_calypso_env(),
+			'isInstantSearchEnabled'      => (bool) Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ),
 		);
 	}
 


### PR DESCRIPTION
<img width="1066" alt="Screen Shot 2020-03-16 at 7 14 06 PM" src="https://user-images.githubusercontent.com/4044428/76812396-540df400-67ba-11ea-9ce6-1b16aafb456f.png">

#### Changes proposed in this Pull Request:
* Adds Jetpack Search to wp-admin's plans page (`/wp-admin/admin.php?page=jetpack#/plans`).
* This feature is gated behind a constant `JETPACK_SEARCH_PROTOTYPE` in PHP.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, this will add the Jetpack Search plan to the wp-admin plans page.
* We're merging this into a feature branch, however.

#### Testing instructions:
1. Apply the change from this branch.
2. Add `define( "JETPACK_SEARCH_PROTOTYPE", true );` to your `wp-config.php`. If using Jetpack's Docker development environment, you can create a file at `/docker/mu-plugins/instant-search.php` and add the define there.
3. Navigate to the wp-admin Jetpack Plans page (`/wp-admin/admin.php?page=jetpack#/plans`).
4. Ensure that the Search plan renders as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None. This is being merged into a feature branch.
