### PR TITLE
Podcast Player: Load data from embedded JSON

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -84,13 +84,8 @@ function render_player( $track_list, $attributes ) {
 	$instance_id = wp_unique_id( 'podcast-player-block-' );
 
 	$player_data = array(
-		'type'         => 'audio',
-		// Don't pass strings to JSON, will be truthy in JS.
-		'tracklist'    => true,
-		'tracknumbers' => true,
-		'images'       => true,
-		'artists'      => true,
-		'tracks'       => $track_list,
+		'tracks'     => $track_list,
+		'attributes' => $attributes,
 	);
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -20,13 +20,29 @@ const initializeBlock = function( id ) {
 		id,
 		block,
 		currentTrack: 0,
+		tracks: [],
+		attributes: {},
 	};
+
+	// Load data from the embedded JSON.
+	const dataContainer = block.querySelector( 'script[type="application/json"]' );
+	if ( dataContainer ) {
+		try {
+			const data = JSON.parse( dataContainer.text );
+			player.tracks = data.tracks;
+			player.attributes = data.attributes;
+		} catch ( e ) {
+			return;
+		}
+	}
+
+	if ( ! player.tracks.length ) {
+		return;
+	}
 
 	// Initialize player UI.
 	player.audio = document.createElement( 'audio' );
-	player.audio.src = block
-		.querySelector( '[data-jetpack-podcast-audio]' )
-		.getAttribute( 'data-jetpack-podcast-audio' );
+	player.audio.src = player.tracks[ 0 ].src;
 	block.insertBefore( player.audio, block.firstChild );
 	player.mediaElement = new MediaElementPlayer( player.audio, meJsSettings );
 
@@ -42,6 +58,7 @@ if ( window.jetpackPodcastPlayers !== undefined ) {
 // Replace the queue with an immediate initialization for async loaded players.
 window.jetpackPodcastPlayers = {
 	push: initializeBlock,
+	playerInstances,
 };
 
 // Add global handler for clicks.


### PR DESCRIPTION
Our backend renders the block together with JSON data to pass params to the frontend script. This PR adds the parsing step and makes data available to our code.

#### Changes proposed in this Pull Request:
* parse data from embedded JSON
* extract a list of episodes
* extract attributes
* exposes player instances globally for an easier debugging

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
paYJgx-sH-p2

#### Testing instructions:
- build extensions
- insert the block with some podcast feed
- load the block on the frontend and from now on test there:
  - after the player shows, click the "play" button and make sure the first episode started playing
  - in devtools, lookup `window.jetpackPodcastPlayers` - there should be one item and it should have props `tracks` (an array of track objects) and an `attributes` object (with URL and no. of items)

<img width="574" alt="Screenshot 2020-03-17 at 15 41 34" src="https://user-images.githubusercontent.com/156676/76868451-419dc400-6867-11ea-8ffd-fe6df660b473.png">

#### Proposed changelog entry for your changes:
* none, feature WIP
