### PR TITLE
Fixed lack of space between button and link in MailChimp blank slate …

### DIFF
--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -142,7 +142,7 @@ class MailchimpSubscribeEdit extends Component {
 			signupFieldTag,
 			signupFieldValue,
 		} = attributes;
-		const classPrefix = 'wp-block-jetpack-mailchimp_';
+		const classPrefix = 'wp-block-jetpack-mailchimp';
 		const waiting = (
 			<Placeholder icon={ icon } notices={ notices }>
 				<Spinner />
@@ -162,7 +162,7 @@ class MailchimpSubscribeEdit extends Component {
 				<Button isDefault isLarge href={ connectURL } target="_blank">
 					{ __( 'Set up Mailchimp form', 'jetpack' ) }
 				</Button>
-				<div>
+				<div className={ `${ classPrefix }-recheck` }>
 					<Button isLink onClick={ this.apiCall }>
 						{ __( 'Re-check Connection', 'jetpack' ) }
 					</Button>
@@ -237,7 +237,7 @@ class MailchimpSubscribeEdit extends Component {
 			</InspectorControls>
 		);
 		const blockClasses = classnames( className, {
-			[ `${ classPrefix }notication-audition` ]: audition,
+			[ `${ classPrefix }_notication-audition` ]: audition,
 		} );
 		const blockContent = (
 			<div className={ blockClasses }>
@@ -260,7 +260,7 @@ class MailchimpSubscribeEdit extends Component {
 				/>
 				{ audition && (
 					<div
-						className={ `${ classPrefix }notification ${ classPrefix }${ audition }` }
+						className={ `${ classPrefix }_notification ${ classPrefix }_${ audition }` }
 						role={ this.roleForAuditionType( audition ) }
 					>
 						{ this.labelForAuditionType( audition ) }

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -159,14 +159,14 @@ class MailchimpSubscribeEdit extends Component {
 					'jetpack'
 				) }
 			>
+				<Button isDefault isLarge href={ connectURL } target="_blank">
+					{ __( 'Set up Mailchimp form', 'jetpack' ) }
+				</Button>
 				<div>
-					<Button isDefault isLarge href={ connectURL } target="_blank">
-						{ __( 'Set up Mailchimp form', 'jetpack' ) }
+					<Button isLink onClick={ this.apiCall }>
+						{ __( 'Re-check Connection', 'jetpack' ) }
 					</Button>
 				</div>
-				<Button isLink onClick={ this.apiCall }>
-					{ __( 'Re-check Connection', 'jetpack' ) }
-				</Button>
 			</Placeholder>
 		);
 		const inspectorControls = (

--- a/extensions/blocks/mailchimp/editor.scss
+++ b/extensions/blocks/mailchimp/editor.scss
@@ -17,6 +17,10 @@
 		}
 	}
 
+	&-recheck {
+		margin-top: 1em;
+	}
+
 	// Hide everything else except notification when modifying notification labels
 	&.wp-block-jetpack-mailchimp_notication-audition > *:not( .wp-block-jetpack-mailchimp_notification ) {
 		display: none;

--- a/extensions/blocks/mailchimp/editor.scss
+++ b/extensions/blocks/mailchimp/editor.scss
@@ -38,6 +38,10 @@
 		display: block;
 		flex-direction: unset;
 		flex-wrap: unset;
+
+		.components-button {
+			margin-bottom: 0;
+		}
 	}
 
 }


### PR DESCRIPTION
**Expected**
Adequate padding between the MailChimp blank slate button and the link below it.

**Actual**
There is a lack of padding, causing the button and link to feel too cramped.

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/5634774/76873162-cbd43100-6843-11ea-8af2-5ebbee4c6627.png)  | ![after](https://user-images.githubusercontent.com/5634774/76873196-d55d9900-6843-11ea-89b9-0c03778044eb.png)|

Fixes #14979

#### Changes proposed in this Pull Request:
* Moved the wrapper div from around the button to be around the link below it

#### Proposed changelog entry for your changes:
* Fixed lack of space between button and link in MailChimp block blank slate 
