### PR TITLE
Single product: update post-purchase card

### DIFF
--- a/_inc/client/components/product-card/index.jsx
+++ b/_inc/client/components/product-card/index.jsx
@@ -65,33 +65,22 @@ class ProductCard extends Component {
 			title,
 			translate,
 		} = this.props;
-		const cardClassNames = classNames( 'product-card', {
+		const cardClassNames = classNames( 'single-product__accented-card', {
 			'is-placeholder': isPlaceholder,
 			'is-purchased': !! purchase,
 		} );
 
 		return (
 			<Card className={ cardClassNames }>
-				<div className="product-card__header">
+				<div className="single-product__accented-card-header">
 					{ title && (
-						<div className="product-card__header-primary">
+						<div className="single-product__accented-card-header-primary">
 							{ purchase && <Gridicon icon="checkmark" size={ 18 } /> }
-							<h3 className="product-card__title">{ title }</h3>
+							<h3 className="single-product-backup__header-title">{ title }</h3>
 						</div>
 					) }
-					<div className="product-card__header-secondary">
-						{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
-						{ ! purchase && (
-							<ProductCardPriceGroup
-								billingTimeFrame={ billingTimeFrame }
-								currencyCode={ currencyCode }
-								discountedPrice={ discountedPrice }
-								fullPrice={ fullPrice }
-							/>
-						) }
-					</div>
 				</div>
-				<div className="product-card__description">
+				<div className="single-product__accented-card-body">
 					{ description && <p>{ description }</p> }
 					{ purchase && isCurrent && (
 						<ProductCardAction
@@ -99,6 +88,15 @@ class ProductCard extends Component {
 							href={ this.getManagePurchaseLink( purchase.domain, purchase.ID ) }
 							label={ translate( 'Manage Subscription' ) }
 							primary={ false }
+						/>
+					) }
+					{ subtitle && <div className="product-card__subtitle">{ subtitle }</div> }
+					{ ! purchase && (
+						<ProductCardPriceGroup
+							billingTimeFrame={ billingTimeFrame }
+							currencyCode={ currencyCode }
+							discountedPrice={ discountedPrice }
+							fullPrice={ fullPrice }
 						/>
 					) }
 				</div>

--- a/_inc/client/components/product-card/style.scss
+++ b/_inc/client/components/product-card/style.scss
@@ -101,9 +101,10 @@
 
 .product-card__subtitle {
 	font-size: 12px;
-	line-height: 20px;
 	font-style: italic;
+	line-height: 20px;
 	color: #646970;
+	text-align: center;
 }
 
 // Price group

--- a/_inc/client/plans/single-products.scss
+++ b/_inc/client/plans/single-products.scss
@@ -127,6 +127,17 @@
 	text-align: center;
 }
 
+.single-product__accented-card-header-primary {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+
+	svg {
+		margin-right: 8px;
+		fill: $alert-green;
+	}
+}
+
 .single-product-backup__savings {
 	font-style: italic;
 }


### PR DESCRIPTION
Fixes issue reported in https://github.com/Automattic/jetpack/pull/15011#pullrequestreview-376093515

#### Changes proposed in this Pull Request:
* Updates single product cards on post-purchase.

Currently, the header for the existing single product block changes format depending if pre or post-purchase. This creates an inconsistent UI when used side by side with other single products like Search on https://github.com/Automattic/jetpack/pull/15011.

**Note**: this PR was very roughly put together to reach an acceptable visual solution. Code might not be up to par, hence the `In Progress` label.

#### Before

![image](https://user-images.githubusercontent.com/390760/76873847-3c8c4500-6866-11ea-9f2f-0b5bf8290d6c.png)

#### After

![image](https://user-images.githubusercontent.com/390760/76873771-1a92c280-6866-11ea-9e86-a06300dca006.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:

* Fire up this branch.
* Go to `/wp-admin/admin.php?page=jetpack#/plans` and ensure pre-purchase single product block looks good.
* Purchase a Premium plan or any Backup solution.
* Go to `/wp-admin/admin.php?page=jetpack#/plans` again and ensure post-purchase single product block looks good.

#### Proposed changelog entry for your changes:
* None.
