### PR TITLE
Infinite scroll: rewrite from jQuery to vanilla JS

### DIFF
--- a/modules/infinite-scroll.php
+++ b/modules/infinite-scroll.php
@@ -215,23 +215,6 @@ class Jetpack_Infinite_Scroll_Extras {
 		if ( Jetpack::is_module_active( 'tiled-gallery' ) ) {
 			Jetpack_Tiled_Gallery::default_scripts_and_styles();
 		}
-
-		// Core's Audio and Video Shortcodes
-		if (
-			/** This filter is already documented in core/wp-includes/media.php */
-			'mediaelement' === apply_filters( 'wp_audio_shortcode_library', 'mediaelement' )
-		) {
-			wp_enqueue_style( 'wp-mediaelement' );
-			wp_enqueue_script( 'wp-mediaelement' );
-		}
-
-		if (
-			/** This filter is already documented in core/wp-includes/media.php */
-			'mediaelement' === apply_filters( 'wp_video_shortcode_library', 'mediaelement' )
-		) {
-			wp_enqueue_style( 'wp-mediaelement' );
-			wp_enqueue_script( 'wp-mediaelement' );
-		}
 	}
 }
 Jetpack_Infinite_Scroll_Extras::instance();

--- a/modules/infinite-scroll/infinity-customizer.js
+++ b/modules/infinite-scroll/infinity-customizer.js
@@ -1,0 +1,54 @@
+/* globals wp */
+( function( $ ) {
+	/**
+	 * Ready, set, go!
+	 */
+	$( document ).ready( function() {
+		// Integrate with Selective Refresh in the Customizer.
+		if ( 'undefined' !== typeof wp && wp.customize && wp.customize.selectiveRefresh ) {
+			/**
+			 * Handle rendering of selective refresh partials.
+			 *
+			 * Make sure that when a partial is rendered, the Jetpack post-load event
+			 * will be triggered so that any dynamic elements will be re-constructed,
+			 * such as ME.js elements, Photon replacements, social sharing, and more.
+			 * Note that this is applying here not strictly to posts being loaded.
+			 * If a widget contains a ME.js element and it is previewed via selective
+			 * refresh, the post-load would get triggered allowing any dynamic elements
+			 * therein to also be re-constructed.
+			 *
+			 * @param {wp.customize.selectiveRefresh.Placement} placement
+			 */
+			wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
+				var content;
+				if ( 'string' === typeof placement.addedContent ) {
+					content = placement.addedContent;
+				} else if ( placement.container ) {
+					content = $( placement.container ).html();
+				}
+
+				if ( content ) {
+					$( document.body ).trigger( 'post-load', { html: content } );
+				}
+			} );
+
+			/*
+			 * Add partials for posts added via infinite scroll.
+			 *
+			 * This is unnecessary when MutationObserver is supported by the browser
+			 * since then this will be handled by Selective Refresh in core.
+			 */
+			if ( 'undefined' === typeof MutationObserver ) {
+				$( document.body ).on( 'post-load', function( e, response ) {
+					var rootElement = null;
+					if ( response.html && -1 !== response.html.indexOf( 'data-customize-partial' ) ) {
+						if ( window.infiniteScroll.settings.id ) {
+							rootElement = $( '#' + window.infiniteScroll.settings.id );
+						}
+						wp.customize.selectiveRefresh.addPartials( rootElement );
+					}
+				} );
+			}
+		}
+	} );
+} )( jQuery ); // Close closure

--- a/modules/infinite-scroll/infinity.css
+++ b/modules/infinite-scroll/infinity.css
@@ -1,13 +1,11 @@
 /* =Infinity Styles
 -------------------------------------------------------------- */
 
-.infinite-wrap {
-}
 .infinite-loader {
 	color: #000;
 	display: block;
 	height: 28px;
-	text-indent: -9999px;
+	text-align: center;
 }
 #infinite-handle span {
 	background: #333;
@@ -16,6 +14,103 @@
 	cursor: pointer;
 	font-size: 13px;
 	padding: 6px 16px;
+}
+
+/**
+ * CSS Spinner Styles
+ */
+@keyframes spinner-inner {
+  0% { opacity: 1 }
+  100% { opacity: 0 }
+}
+.infinite-loader .spinner-inner div {
+  left: 47px;
+  top: 24px;
+  position: absolute;
+  animation: spinner-inner linear 1s infinite;
+  background: #000000;
+  width: 6px;
+  height: 12px;
+  border-radius: 3px / 6px;
+  transform-origin: 3px 26px;
+}
+.infinite-loader .spinner-inner div:nth-child(1) {
+  transform: rotate(0deg);
+  animation-delay: -0.9166666666666666s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(2) {
+  transform: rotate(30deg);
+  animation-delay: -0.8333333333333334s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(3) {
+  transform: rotate(60deg);
+  animation-delay: -0.75s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(4) {
+  transform: rotate(90deg);
+  animation-delay: -0.6666666666666666s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(5) {
+  transform: rotate(120deg);
+  animation-delay: -0.5833333333333334s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(6) {
+  transform: rotate(150deg);
+  animation-delay: -0.5s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(7) {
+  transform: rotate(180deg);
+  animation-delay: -0.4166666666666667s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(8) {
+  transform: rotate(210deg);
+  animation-delay: -0.3333333333333333s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(9) {
+  transform: rotate(240deg);
+  animation-delay: -0.25s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(10) {
+  transform: rotate(270deg);
+  animation-delay: -0.16666666666666666s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(11) {
+  transform: rotate(300deg);
+  animation-delay: -0.08333333333333333s;
+  background: #000000;
+}
+.infinite-loader .spinner-inner div:nth-child(12) {
+  transform: rotate(330deg);
+  animation-delay: 0s;
+  background: #000000;
+}
+.infinite-loader .spinner {
+  width: 28px;
+  height: 28px;
+  display: inline-block;
+  overflow: hidden;
+  background: none;
+}
+.infinite-loader .spinner-inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform: translateZ(0) scale(0.28);
+  backface-visibility: hidden;
+  transform-origin: 0 0; /* see note above */
+}
+.infinite-loader .spinner-inner div {
+	box-sizing: content-box;
 }
 
 /**

--- a/modules/infinite-scroll/infinity.css
+++ b/modules/infinite-scroll/infinity.css
@@ -20,94 +20,95 @@
  * CSS Spinner Styles
  */
 @keyframes spinner-inner {
-  0% { opacity: 1 }
-  100% { opacity: 0 }
+	0% { opacity: 1 }
+	100% { opacity: 0 }
 }
 .infinite-loader .spinner-inner div {
-  left: 47px;
-  top: 24px;
-  position: absolute;
-  animation: spinner-inner linear 1s infinite;
-  background: #000000;
-  width: 6px;
-  height: 12px;
-  border-radius: 3px / 6px;
-  transform-origin: 3px 26px;
+	left: 47px;
+	top: 24px;
+	position: absolute;
+	animation: spinner-inner linear 1s infinite;
+	background: #000000;
+	outline: 1px solid white;
+	width: 6px;
+	height: 12px;
+	border-radius: 3px / 6px;
+	transform-origin: 3px 26px;
 }
 .infinite-loader .spinner-inner div:nth-child(1) {
-  transform: rotate(0deg);
-  animation-delay: -0.9166666666666666s;
-  background: #000000;
+	transform: rotate(0deg);
+	animation-delay: -0.9166666666666666s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(2) {
-  transform: rotate(30deg);
-  animation-delay: -0.8333333333333334s;
-  background: #000000;
+	transform: rotate(30deg);
+	animation-delay: -0.8333333333333334s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(3) {
-  transform: rotate(60deg);
-  animation-delay: -0.75s;
-  background: #000000;
+	transform: rotate(60deg);
+	animation-delay: -0.75s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(4) {
-  transform: rotate(90deg);
-  animation-delay: -0.6666666666666666s;
-  background: #000000;
+	transform: rotate(90deg);
+	animation-delay: -0.6666666666666666s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(5) {
-  transform: rotate(120deg);
-  animation-delay: -0.5833333333333334s;
-  background: #000000;
+	transform: rotate(120deg);
+	animation-delay: -0.5833333333333334s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(6) {
-  transform: rotate(150deg);
-  animation-delay: -0.5s;
-  background: #000000;
+	transform: rotate(150deg);
+	animation-delay: -0.5s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(7) {
-  transform: rotate(180deg);
-  animation-delay: -0.4166666666666667s;
-  background: #000000;
+	transform: rotate(180deg);
+	animation-delay: -0.4166666666666667s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(8) {
-  transform: rotate(210deg);
-  animation-delay: -0.3333333333333333s;
-  background: #000000;
+	transform: rotate(210deg);
+	animation-delay: -0.3333333333333333s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(9) {
-  transform: rotate(240deg);
-  animation-delay: -0.25s;
-  background: #000000;
+	transform: rotate(240deg);
+	animation-delay: -0.25s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(10) {
-  transform: rotate(270deg);
-  animation-delay: -0.16666666666666666s;
-  background: #000000;
+	transform: rotate(270deg);
+	animation-delay: -0.16666666666666666s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(11) {
-  transform: rotate(300deg);
-  animation-delay: -0.08333333333333333s;
-  background: #000000;
+	transform: rotate(300deg);
+	animation-delay: -0.08333333333333333s;
+	background: #000000;
 }
 .infinite-loader .spinner-inner div:nth-child(12) {
-  transform: rotate(330deg);
-  animation-delay: 0s;
-  background: #000000;
+	transform: rotate(330deg);
+	animation-delay: 0s;
+	background: #000000;
 }
 .infinite-loader .spinner {
-  width: 28px;
-  height: 28px;
-  display: inline-block;
-  overflow: hidden;
-  background: none;
+	width: 28px;
+	height: 28px;
+	display: inline-block;
+	overflow: hidden;
+	background: none;
 }
 .infinite-loader .spinner-inner {
-  width: 100%;
-  height: 100%;
-  position: relative;
-  transform: translateZ(0) scale(0.28);
-  backface-visibility: hidden;
-  transform-origin: 0 0; /* see note above */
+	width: 100%;
+	height: 100%;
+	position: relative;
+	transform: translateZ(0) scale(0.28);
+	backface-visibility: hidden;
+	transform-origin: 0 0; /* see note above */
 }
 .infinite-loader .spinner-inner div {
 	box-sizing: content-box;

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -1,7 +1,7 @@
 /* globals infiniteScroll, _wpmejsSettings, ga, _gaq, WPCOM_sharing_counts, MediaElementPlayer */
 ( function() {
-	// Open closure
-	// Local vars
+	// Open closure.
+	// Local vars.
 	var Scroller, ajaxurl, stats, type, text, totop;
 
 	// IE requires special handling

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -1,5 +1,5 @@
-/* globals infiniteScroll, _wpmejsSettings, ga, _gaq, WPCOM_sharing_counts */
-( function( $ ) {
+/* globals infiniteScroll, _wpmejsSettings, ga, _gaq, WPCOM_sharing_counts, MediaElementPlayer */
+( function() {
 	// Open closure
 	// Local vars
 	var Scroller, ajaxurl, stats, type, text, totop;
@@ -27,9 +27,9 @@
 
 		// Initialize our variables
 		this.id = settings.id;
-		this.body = $( document.body );
-		this.window = $( window );
-		this.element = $( '#' + settings.id );
+		this.body = document.body;
+		this.window = window;
+		this.element = document.getElementById( settings.id );
 		this.wrapperClass = settings.wrapper_class;
 		this.ready = true;
 		this.disabled = false;
@@ -38,19 +38,25 @@
 		this.currentday = settings.currentday;
 		this.order = settings.order;
 		this.throttle = false;
-		this.handle =
-			'<div id="infinite-handle"><span><button>' +
-			text.replace( '\\', '' ) +
-			'</button></span></div>';
 		this.click_handle = settings.click_handle;
 		this.google_analytics = settings.google_analytics;
 		this.history = settings.history;
 		this.origURL = window.location.href;
 		this.pageCache = {};
 
+		// Handle element
+		this.handle = document.createElement( 'div' );
+		this.handle.setAttribute( 'id', 'infinite-handle' );
+		this.handle.innerHTML = '<span><button>' + text.replace( '\\', '' ) + '</button></span>';
+
 		// Footer settings
-		this.footer = $( '#infinite-footer' );
-		this.footer.wrap = settings.footer;
+		this.footer = {
+			el: document.getElementById( 'infinite-footer' ),
+			wrap: settings.footer,
+		};
+
+		// Bind methods used as callbacks
+		this.checkViewportOnLoadBound = self.checkViewportOnLoad.bind( this );
 
 		// Core's native MediaElement.js implementation needs special handling
 		this.wpMediaelement = null;
@@ -63,17 +69,17 @@
 			// Throttle to check for such case every 300ms
 
 			// On event the case becomes a fact
-			this.window.bind( 'scroll.infinity', function() {
-				this.throttle = true;
+			this.window.addEventListener( 'scroll', function() {
+				self.throttle = true;
 			} );
 
 			// Go back top method
 			self.gotop();
 
 			setInterval( function() {
-				if ( this.throttle ) {
+				if ( self.throttle ) {
 					// Once the case is the case, the action occurs and the fact is no more
-					this.throttle = false;
+					self.throttle = false;
 					// Reveal or hide footer
 					self.thefooter();
 					// Fire the refresh
@@ -84,16 +90,16 @@
 
 			// Ensure that enough posts are loaded to fill the initial viewport, to compensate for short posts and large displays.
 			self.ensureFilledViewport();
-			this.body.bind( 'post-load', { self: self }, self.checkViewportOnLoad );
+			this.body.addEventListener( 'post-load', self.checkViewportOnLoadBound );
 		} else if ( type == 'click' ) {
 			if ( this.click_handle ) {
-				this.element.append( this.handle );
+				this.element.appendChild( this.handle );
 			}
 
-			this.body.delegate( '#infinite-handle', 'click.infinity', function() {
+			this.handle.addEventListener( 'click', function() {
 				// Handle the handle
 				if ( self.click_handle ) {
-					$( '#infinite-handle' ).remove();
+					self.handle.parentNode.removeChild( self.handle );
 				}
 
 				// Fire the refresh
@@ -102,22 +108,71 @@
 		}
 
 		// Initialize any Core audio or video players loaded via IS
-		this.body.bind( 'post-load', { self: self }, self.initializeMejs );
+		this.body.addEventListener( 'post-load', self.initializeMejs );
+	};
+
+	Scroller.prototype.triggerEvent = function( eventName, el, data ) {
+		var e;
+
+		try {
+			var evtOptions = {
+				bubbles: true,
+				cancelable: true,
+			};
+
+			if ( data ) {
+				evtOptions.detail = data;
+			}
+			e = new CustomEvent( eventName, evtOptions );
+		} catch ( err ) {
+			e = document.createEvent( 'CustomEvent' );
+			e.initCustomEvent( eventName, true, true, data || null );
+		}
+
+		el.dispatchEvent( e );
+	};
+
+	/**
+	 * Normalize the access to the document scrollTop value.
+	 */
+	Scroller.prototype.getScrollTop = function() {
+		return window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+	};
+
+	/**
+	 * Polyfill jQuery.extend.
+	 */
+	Scroller.prototype.extend = function( out ) {
+		out = out || {};
+
+		for ( var i = 1; i < arguments.length; i++ ) {
+			if ( ! arguments[ i ] ) {
+				continue;
+			}
+
+			for ( var key in arguments[ i ] ) {
+				if ( arguments[ i ].hasOwnProperty( key ) ) {
+					out[ key ] = arguments[ i ][ key ];
+				}
+			}
+		}
+		return out;
 	};
 
 	/**
 	 * Check whether we should fetch any additional posts.
 	 */
 	Scroller.prototype.check = function() {
-		var container = this.element.offset();
+		var container = this.element.getBoundingClientRect();
+		var top = container.top + this.getScrollTop();
 
 		// If the container can't be found, stop otherwise errors result
 		if ( 'object' !== typeof container ) {
 			return false;
 		}
 
-		var bottom = this.window.scrollTop() + this.window.height(),
-			threshold = container.top + this.element.outerHeight( false ) - this.window.height() * 2;
+		var bottom = this.getScrollTop() + this.window.innerHeight,
+			threshold = top + this.element.offsetHeight - this.window.innerHeight * 2;
 
 		return bottom > threshold;
 	};
@@ -126,7 +181,7 @@
 	 * Renders the results from a successful response.
 	 */
 	Scroller.prototype.render = function( response ) {
-		this.body.addClass( 'infinity-success' );
+		this.body.classList.add( 'infinity-success' );
 
 		// Check if we can wrap the html
 		this.element.append( response.html );
@@ -155,18 +210,35 @@
 		};
 	};
 
+	Scroller.prototype.animate = function( cb, duration ) {
+		var start = performance.now();
+
+		requestAnimationFrame( function animate( time ) {
+			var timeFraction = Math.min( 1, ( time - start ) / duration );
+			cb( timeFraction );
+
+			if ( timeFraction < 1 ) {
+				requestAnimationFrame( animate );
+			}
+		} );
+	};
+
 	/**
 	 * Scroll back to top.
 	 */
 	Scroller.prototype.gotop = function() {
-		var blog = $( '#infinity-blog-title' );
+		var blog = document.getElementById( 'infinity-blog-title' );
+		var self = this;
 
-		blog.attr( 'title', totop );
-
-		// Scroll to top on blog title
-		blog.bind( 'click', function( e ) {
-			$( 'html, body' ).animate( { scrollTop: 0 }, 'fast' );
+		blog.setAttribute( 'title', totop );
+		blog.addEventListener( 'click', function( e ) {
+			var sourceScroll = self.window.pageYOffset;
 			e.preventDefault();
+
+			self.animate( function( progress ) {
+				var currentScroll = sourceScroll - sourceScroll * progress;
+				document.documentElement.scrollTop = document.body.scrollTop = currentScroll;
+			}, 200 );
 		} );
 	};
 
@@ -175,24 +247,71 @@
 	 */
 	Scroller.prototype.thefooter = function() {
 		var self = this,
-			width;
+			pageWrapper,
+			footerContainer,
+			width,
+			sourceBottom,
+			targetBottom;
 
 		// Check if we have an id for the page wrapper
-		if ( $.type( this.footer.wrap ) === 'string' ) {
-			width = $( 'body #' + this.footer.wrap ).outerWidth( false );
+		if ( 'string' === typeof this.footer.wrap ) {
+			try {
+				pageWrapper = document.getElementById( this.footer.wrap );
+				width = pageWrapper.getBoundingClientRect();
+				width = width.width;
+			} catch ( err ) {
+				width = 0;
+			}
 
 			// Make the footer match the width of the page
 			if ( width > 479 ) {
-				this.footer.find( '.container' ).css( 'width', width );
+				footerContainer = this.footer.el.querySelector( '.container' );
+				if ( footerContainer ) {
+					footerContainer.style.width = width + 'px';
+				}
 			}
 		}
 
 		// Reveal footer
-		if ( this.window.scrollTop() >= 350 ) {
-			self.footer.animate( { bottom: 0 }, 'fast' );
-		} else if ( this.window.scrollTop() < 350 ) {
-			self.footer.animate( { bottom: '-50px' }, 'fast' );
+		sourceBottom = parseInt( self.footer.el.style.bottom || -50, 10 );
+		targetBottom = this.window.pageYOffset >= 350 ? 0 : -50;
+
+		if ( sourceBottom !== targetBottom ) {
+			self.animate( function( progress ) {
+				var currentBottom = sourceBottom + ( targetBottom - sourceBottom ) * progress;
+				self.footer.el.style.bottom = currentBottom + 'px';
+
+				if ( 1 === progress ) {
+					sourceBottom = targetBottom;
+				}
+			}, 200 );
 		}
+	};
+
+	/**
+	 * Recursively convert a JS object into URL encoded data.
+	 */
+	Scroller.prototype.urlEncodeJSON = function( obj, prefix ) {
+		var params = [],
+			encodedKey,
+			newPrefix;
+
+		for ( var key in obj ) {
+			encodedKey = encodeURIComponent( key );
+			newPrefix = prefix ? prefix + '[' + encodedKey + ']' : encodedKey;
+
+			if ( 'object' === typeof obj[ key ] ) {
+				if ( ! Array.isArray( obj[ key ] ) || obj[ key ].length > 0 ) {
+					params.push( this.urlEncodeJSON( obj[ key ], newPrefix ) );
+				} else {
+					// Explicitly expose empty arrays with no values
+					params.push( newPrefix + '[]=' );
+				}
+			} else {
+				params.push( newPrefix + '=' + encodeURIComponent( obj[ key ] ) );
+			}
+		}
+		return params.join( '&' );
 	};
 
 	/**
@@ -201,10 +320,8 @@
 	Scroller.prototype.refresh = function() {
 		var self = this,
 			query,
-			jqxhr,
-			load,
+			xhr,
 			loader,
-			color,
 			customized;
 
 		// If we're disabled, ready, or don't pass the check, bail.
@@ -218,19 +335,18 @@
 
 		// Create a loader element to show it's working.
 		if ( this.click_handle ) {
-			loader = '<span class="infinite-loader"></span>';
-			this.element.append( loader );
-
-			loader = this.element.find( '.infinite-loader' );
-			color = loader.css( 'color' );
-
-			try {
-				loader.spin( 'medium-left', color );
-			} catch ( error ) {}
+			if ( ! loader ) {
+				loader = document.createElement( 'div' );
+				loader.classList.add( 'infinite-loader' );
+				loader.setAttribute( 'role', 'progress' );
+				loader.innerHTML =
+					'<div class="spinner"><div class="spinner-inner"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div></div>';
+			}
+			this.element.appendChild( loader );
 		}
 
 		// Generate our query vars.
-		query = $.extend(
+		query = self.extend(
 			{
 				action: 'infinite_scroll',
 			},
@@ -252,166 +368,175 @@
 		}
 
 		// Fire the ajax request.
-		jqxhr = $.post( infiniteScroll.settings.ajaxurl, query );
+		xhr = new XMLHttpRequest();
+		xhr.open( 'POST', infiniteScroll.settings.ajaxurl, true );
+		xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8' );
+		xhr.send( self.urlEncodeJSON( query ) );
 
 		// Allow refreshes to occur again if an error is triggered.
-		jqxhr.fail( function() {
+		xhr.onerror = function() {
 			if ( self.click_handle ) {
-				loader.hide();
+				loader.parentNode.removeChild( loader );
 			}
 
 			self.ready = true;
-		} );
+		};
 
 		// Success handler
-		jqxhr.done( function( response ) {
-			// On success, let's hide the loader circle.
-			if ( self.click_handle ) {
-				loader.hide();
-			}
+		xhr.onload = function() {
+			var response = JSON.parse( xhr.responseText ),
+				httpCheck = xhr.status >= 200 && xhr.status < 300,
+				responseCheck = 'undefined' !== typeof response.html;
 
-			// Check for and parse our response.
-			if ( ! response || ! response.type ) {
+			if ( ! response || ! httpCheck || ! responseCheck ) {
 				return;
 			}
 
-			// If we've succeeded...
-			if ( response.type == 'success' ) {
-				// If additional scripts are required by the incoming set of posts, parse them
-				if ( response.scripts ) {
-					$( response.scripts ).each( function() {
-						var elementToAppendTo = this.footer ? 'body' : 'head';
+			// On success, let's hide the loader circle.
+			if ( self.click_handle ) {
+				loader.parentNode.removeChild( loader );
+			}
 
-						// Add script handle to list of those already parsed
-						window.infiniteScroll.settings.scripts.push( this.handle );
+			// If additional scripts are required by the incoming set of posts, parse them
+			if ( response.scripts && Array.isArray( response.scripts ) ) {
+				response.scripts.forEach( function( item ) {
+					var elementToAppendTo = item.footer ? 'body' : 'head';
 
-						// Output extra data, if present
-						if ( this.extra_data ) {
-							var data = document.createElement( 'script' ),
-								dataContent = document.createTextNode(
-									'//<![CDATA[ \n' + this.extra_data + '\n//]]>'
-								);
+					// Add script handle to list of those already parsed
+					window.infiniteScroll.settings.scripts.push( item.handle );
 
-							data.type = 'text/javascript';
-							data.appendChild( dataContent );
+					// Output extra data, if present
+					if ( item.extra_data ) {
+						var data = document.createElement( 'script' ),
+							dataContent = document.createTextNode(
+								'//<![CDATA[ \n' + item.extra_data + '\n//]]>'
+							);
 
-							document.getElementsByTagName( elementToAppendTo )[ 0 ].appendChild( data );
-						}
+						data.type = 'text/javascript';
+						data.appendChild( dataContent );
 
-						// Build script tag and append to DOM in requested location
-						var script = document.createElement( 'script' );
-						script.type = 'text/javascript';
-						script.src = this.src;
-						script.id = this.handle;
+						document.getElementsByTagName( elementToAppendTo )[ 0 ].appendChild( data );
+					}
 
-						// If MediaElement.js is loaded in by this set of posts, don't initialize the players a second time as it breaks them all
-						if ( 'wp-mediaelement' === this.handle ) {
-							self.body.unbind( 'post-load', self.initializeMejs );
-						}
+					// Build script tag and append to DOM in requested location
+					var script = document.createElement( 'script' );
+					script.type = 'text/javascript';
+					script.src = item.src;
+					script.id = item.handle;
 
-						if ( 'wp-mediaelement' === this.handle && 'undefined' === typeof mejs ) {
-							self.wpMediaelement = {};
-							self.wpMediaelement.tag = script;
-							self.wpMediaelement.element = elementToAppendTo;
-							setTimeout( self.maybeLoadMejs.bind( self ), 250 );
-						} else {
-							document.getElementsByTagName( elementToAppendTo )[ 0 ].appendChild( script );
-						}
-					} );
-				}
+					// Dynamically loaded scripts are async by default.
+					// We don't want that, it breaks stuff, e.g. wp-mediaelement init.
+					script.async = false;
 
-				// If additional stylesheets are required by the incoming set of posts, parse them
-				if ( response.styles ) {
-					$( response.styles ).each( function() {
-						// Add stylesheet handle to list of those already parsed
-						window.infiniteScroll.settings.styles.push( this.handle );
+					// If MediaElement.js is loaded in by item set of posts, don't initialize the players a second time as it breaks them all
+					if ( 'wp-mediaelement' === item.handle ) {
+						self.body.removeEventListener( 'post-load', self.initializeMejs );
+					}
 
-						// Build link tag
-						var style = document.createElement( 'link' );
-						style.rel = 'stylesheet';
-						style.href = this.src;
-						style.id = this.handle + '-css';
-
-						// Destroy link tag if a conditional statement is present and either the browser isn't IE, or the conditional doesn't evaluate true
-						if (
-							this.conditional &&
-							( ! isIE || ! eval( this.conditional.replace( /%ver/g, IEVersion ) ) )
-						) {
-							style = false;
-						}
-
-						// Append link tag if necessary
-						if ( style ) {
-							document.getElementsByTagName( 'head' )[ 0 ].appendChild( style );
-						}
-					} );
-				}
-
-				// stash the response in the page cache
-				self.pageCache[ self.page + self.offset ] = response;
-
-				// Increment the page number
-				self.page++;
-
-				// Record pageview in WP Stats, if available.
-				if ( stats ) {
-					new Image().src =
-						document.location.protocol +
-						'//pixel.wp.com/g.gif?' +
-						stats +
-						'&post=0&baba=' +
-						Math.random();
-				}
-
-				// Add new posts to the postflair object
-				if ( 'object' === typeof response.postflair && 'object' === typeof WPCOM_sharing_counts ) {
-					WPCOM_sharing_counts = $.extend( WPCOM_sharing_counts, response.postflair ); // eslint-disable-line no-global-assign
-				}
-
-				// Render the results
-				self.render.apply( self, arguments );
-
-				// If 'click' type and there are still posts to fetch, add back the handle
-				if ( type == 'click' ) {
-					if ( response.lastbatch ) {
-						if ( self.click_handle ) {
-							$( '#infinite-handle' ).remove();
-							// Update body classes
-							self.body.addClass( 'infinity-end' ).removeClass( 'infinity-success' );
-						} else {
-							self.body.trigger( 'infinite-scroll-posts-end' );
-						}
+					if ( 'wp-mediaelement' === item.handle && 'undefined' === typeof mejs ) {
+						self.wpMediaelement = {};
+						self.wpMediaelement.tag = script;
+						self.wpMediaelement.element = elementToAppendTo;
+						setTimeout( self.maybeLoadMejs.bind( self ), 250 );
 					} else {
-						if ( self.click_handle ) {
-							self.element.append( self.handle );
-						} else {
-							self.body.trigger( 'infinite-scroll-posts-more' );
-						}
+						document.getElementsByTagName( elementToAppendTo )[ 0 ].appendChild( script );
 					}
-				} else if ( response.lastbatch ) {
-					self.disabled = true;
-					self.body.addClass( 'infinity-end' ).removeClass( 'infinity-success' );
-				}
+				} );
+			}
 
-				// Update currentday to the latest value returned from the server
-				if ( response.currentday ) {
-					self.currentday = response.currentday;
-				}
+			// If additional stylesheets are required by the incoming set of posts, parse them
+			if ( response.styles && Array.isArray( response.styles ) ) {
+				response.styles.forEach( function( item ) {
+					// Add stylesheet handle to list of those already parsed
+					window.infiniteScroll.settings.styles.push( item.handle );
 
-				// Fire Google Analytics pageview
-				if ( self.google_analytics ) {
-					var ga_url = self.history.path.replace( /%d/, self.page );
-					if ( 'object' === typeof _gaq ) {
-						_gaq.push( [ '_trackPageview', ga_url ] );
+					// Build link tag
+					var style = document.createElement( 'link' );
+					style.rel = 'stylesheet';
+					style.href = item.src;
+					style.id = item.handle + '-css';
+
+					// Destroy link tag if a conditional statement is present and either the browser isn't IE, or the conditional doesn't evaluate true
+					if (
+						item.conditional &&
+						( ! isIE || ! eval( item.conditional.replace( /%ver/g, IEVersion ) ) )
+					) {
+						style = false;
 					}
-					if ( 'function' === typeof ga ) {
-						ga( 'send', 'pageview', ga_url );
+
+					// Append link tag if necessary
+					if ( style ) {
+						document.getElementsByTagName( 'head' )[ 0 ].appendChild( style );
 					}
+				} );
+			}
+
+			// stash the response in the page cache
+			self.pageCache[ self.page + self.offset ] = response;
+
+			// Increment the page number
+			self.page++;
+
+			// Record pageview in WP Stats, if available.
+			if ( stats ) {
+				new Image().src =
+					document.location.protocol +
+					'//pixel.wp.com/g.gif?' +
+					stats +
+					'&post=0&baba=' +
+					Math.random();
+			}
+
+			// Add new posts to the postflair object
+			if ( 'object' === typeof response.postflair && 'object' === typeof WPCOM_sharing_counts ) {
+				WPCOM_sharing_counts = self.extend( WPCOM_sharing_counts, response.postflair ); // eslint-disable-line no-global-assign
+			}
+
+			// Render the results
+			self.render.call( self, response );
+
+			// If 'click' type and there are still posts to fetch, add back the handle
+			if ( type == 'click' ) {
+				if ( response.lastbatch ) {
+					if ( self.click_handle ) {
+						// Update body classes
+						self.body.classList.add( 'infinity-end' );
+						self.body.classList.remove( 'infinity-success' );
+					} else {
+						self.triggerEvent( 'infinite-scroll-posts-end', this.body, null );
+					}
+				} else {
+					if ( self.click_handle ) {
+						self.element.appendChild( self.handle );
+					} else {
+						self.triggerEvent( 'infinite-scroll-posts-more', this.body, null );
+					}
+				}
+			} else if ( response.lastbatch ) {
+				self.disabled = true;
+
+				self.body.classList.add( 'infinity-end' );
+				self.body.classList.remove( 'infinity-success' );
+			}
+
+			// Update currentday to the latest value returned from the server
+			if ( response.currentday ) {
+				self.currentday = response.currentday;
+			}
+
+			// Fire Google Analytics pageview
+			if ( self.google_analytics ) {
+				var ga_url = self.history.path.replace( /%d/, self.page );
+				if ( 'object' === typeof _gaq ) {
+					_gaq.push( [ '_trackPageview', ga_url ] );
+				}
+				if ( 'function' === typeof ga ) {
+					ga( 'send', 'pageview', ga_url );
 				}
 			}
-		} );
+		};
 
-		return jqxhr;
+		return xhr;
 	};
 
 	/**
@@ -424,7 +549,7 @@
 		}
 
 		if ( 'undefined' === typeof mejs ) {
-			setTimeout( this.maybeLoadMejs, 250 );
+			setTimeout( this.maybeLoadMejs.bind( this ), 250 );
 		} else {
 			document
 				.getElementsByTagName( this.wpMediaelement.element )[ 0 ]
@@ -432,19 +557,20 @@
 			this.wpMediaelement = null;
 
 			// Ensure any subsequent IS loads initialize the players
-			this.body.bind( 'post-load', { self: this }, this.initializeMejs );
+			this.body.addEventListener( 'post-load', this.initializeMejs );
 		}
 	};
 
 	/**
 	 * Initialize the MediaElement.js player for any posts not previously initialized
 	 */
-	Scroller.prototype.initializeMejs = function( ev, response ) {
+	Scroller.prototype.initializeMejs = function( e ) {
 		// Are there media players in the incoming set of posts?
 		if (
-			! response.html ||
-			( -1 === response.html.indexOf( 'wp-audio-shortcode' ) &&
-				-1 === response.html.indexOf( 'wp-video-shortcode' ) )
+			! e.detail ||
+			! e.detail.html ||
+			( -1 === e.detail.html.indexOf( 'wp-audio-shortcode' ) &&
+				-1 === e.detail.html.indexOf( 'wp-video-shortcode' ) )
 		) {
 			return;
 		}
@@ -456,30 +582,43 @@
 
 		// Adapted from wp-includes/js/mediaelement/wp-mediaelement.js
 		// Modified to not initialize already-initialized players, as Mejs doesn't handle that well
-		$( function() {
-			var settings = {};
+		var settings = {};
+		var audioVideoElements;
 
-			if ( typeof _wpmejsSettings !== 'undefined' ) {
-				settings.pluginPath = _wpmejsSettings.pluginPath;
+		if ( typeof _wpmejsSettings !== 'undefined' ) {
+			settings.pluginPath = _wpmejsSettings.pluginPath;
+		}
+
+		settings.success = function( mejs ) {
+			var autoplay = mejs.attributes.autoplay && 'false' !== mejs.attributes.autoplay;
+			if ( 'flash' === mejs.pluginType && autoplay ) {
+				mejs.addEventListener(
+					'canplay',
+					function() {
+						mejs.play();
+					},
+					false
+				);
 			}
+		};
 
-			settings.success = function( mejs ) {
-				var autoplay = mejs.attributes.autoplay && 'false' !== mejs.attributes.autoplay;
-				if ( 'flash' === mejs.pluginType && autoplay ) {
-					mejs.addEventListener(
-						'canplay',
-						function() {
-							mejs.play();
-						},
-						false
-					);
+		audioVideoElements = document.querySelectorAll( '.wp-audio-shortcode, .wp-video-shortcode' );
+		audioVideoElements = Array.prototype.slice.call( audioVideoElements );
+
+		// Only process already unprocessed shortcodes.
+		audioVideoElements = audioVideoElements.filter( function( el ) {
+			while ( el.parentNode ) {
+				if ( el.classList.contains( 'mejs-container' ) ) {
+					return false;
 				}
-			};
-
-			$( '.wp-audio-shortcode, .wp-video-shortcode' )
-				.not( '.mejs-container' )
-				.mediaelementplayer( settings );
+				el = el.parentNode;
+			}
+			return true;
 		} );
+
+		for ( var i = 0; i < audioVideoElements.length; i++ ) {
+			new MediaElementPlayer( audioVideoElements[ i ], settings );
+		}
 	};
 
 	/**
@@ -488,28 +627,31 @@
 	 */
 	Scroller.prototype.ensureFilledViewport = function() {
 		var self = this,
-			windowHeight = self.window.height(),
-			postsHeight = self.element.height(),
+			windowHeight = self.window.innerHeight,
+			postsHeight = self.element.offsetHeight,
 			aveSetHeight = 0,
-			wrapperQty = 0;
+			wrapperQty = 0,
+			elChildNodes = self.element.childNodes,
+			wrapperEls = document.querySelectorAll( '.' + self.wrapperClass ),
+			i;
 
 		// Account for situations where postsHeight is 0 because child list elements are floated
 		if ( postsHeight === 0 ) {
-			$( self.element.selector + ' > li' ).each( function() {
-				postsHeight += $( this ).height();
-			} );
+			for ( i = 0; elChildNodes.length; i++ ) {
+				postsHeight += elChildNodes[ i ].offsetHeight;
+			}
 
 			if ( postsHeight === 0 ) {
-				self.body.unbind( 'post-load', self.checkViewportOnLoad );
+				self.body.addEventListener( 'post-load', self.checkViewportOnLoadBound );
 				return;
 			}
 		}
 
 		// Calculate average height of a set of posts to prevent more posts than needed from being loaded.
-		$( '.' + self.wrapperClass ).each( function() {
-			aveSetHeight += $( this ).height();
+		for ( i = 0; i < wrapperEls.length; i++ ) {
+			aveSetHeight += wrapperEls[ i ].offsetHeight;
 			wrapperQty++;
-		} );
+		}
 
 		if ( wrapperQty > 0 ) {
 			aveSetHeight = aveSetHeight / wrapperQty;
@@ -522,7 +664,7 @@
 			self.ready = true;
 			self.refresh();
 		} else {
-			self.body.unbind( 'post-load', self.checkViewportOnLoad );
+			self.body.addEventListener( 'post-load', self.checkViewportOnLoadBound );
 		}
 	};
 
@@ -530,8 +672,8 @@
 	 * Event handler for ensureFilledViewport(), tied to the post-load trigger.
 	 * Necessary to ensure that the variable `this` contains the scroller when used in ensureFilledViewport(). Since this function is tied to an event, `this` becomes the DOM element the event is tied to.
 	 */
-	Scroller.prototype.checkViewportOnLoad = function( ev ) {
-		ev.data.self.ensureFilledViewport();
+	Scroller.prototype.checkViewportOnLoad = function() {
+		this.ensureFilledViewport();
 	};
 
 	function fullscreenState() {
@@ -550,13 +692,14 @@
 	 */
 	Scroller.prototype.determineURL = function() {
 		var self = this,
-			windowTop = $( window ).scrollTop(),
-			windowBottom = windowTop + $( window ).height(),
+			windowTop = self.getScrollTop(),
+			windowBottom = windowTop + this.window.innerHeight,
 			windowSize = windowBottom - windowTop,
 			setsInView = [],
 			setsHidden = [],
 			pageNum = false,
-			currentFullScreenState = fullscreenState();
+			currentFullScreenState = fullscreenState(),
+			wrapperEls;
 
 		// xor - check if the state has changed
 		if ( previousFullScrenState ^ currentFullScreenState ) {
@@ -570,19 +713,22 @@
 		}
 		previousFullScrenState = currentFullScreenState;
 
-		// Find out which sets are in view
-		$( '.' + self.wrapperClass ).each( function() {
-			var id = $( this ).attr( 'id' ),
-				setTop = $( this ).offset().top,
-				setHeight = $( this ).outerHeight( false ),
+		wrapperEls = document.querySelectorAll( '.' + self.wrapperClass );
+		for ( var i = 0; i < wrapperEls.length; i++ ) {
+			var id = wrapperEls[ i ].getAttribute( 'id' ),
+				setTop,
+				setHeight = wrapperEls[ i ].offsetHeight,
 				setBottom = 0,
-				setPageNum = $( this ).data( 'page-num' );
+				setPageNum = wrapperEls[ i ].dataset.pageNum;
+
+			setTop = wrapperEls[ i ].getBoundingClientRect();
+			setTop = setTop.top + self.getScrollTop();
 
 			// Account for containers that have no height because their children are floated elements.
 			if ( 0 === setHeight ) {
-				$( '> *', this ).each( function() {
-					setHeight += $( this ).outerHeight( false );
-				} );
+				for ( var j = 0; j < wrapperEls[ i ].childNodes.length; j++ ) {
+					setHeight += wrapperEls[ i ].childNodes[ j ].offsetHeight;
+				}
 			}
 
 			// Determine position of bottom of set by adding its height to the scroll position of its top.
@@ -601,27 +747,31 @@
 			} else {
 				setsHidden.push( { id: id, top: setTop, bottom: setBottom, pageNum: setPageNum } );
 			}
-		} );
+		}
 
-		$.each( setsHidden, function() {
-			var $set = $( '#' + this.id );
-			if ( $set.hasClass( 'is--replaced' ) ) {
+		setsHidden.forEach( function( set ) {
+			var setEl = document.getElementById( set.id );
+
+			if ( setEl.classList.contains( 'is--replaced' ) ) {
 				return;
 			}
+			self.pageCache[ set.pageNum ].html = setEl.innerHTML;
 
-			self.pageCache[ this.pageNum ].html = $set.html();
+			setEl.style.minHeight = set.bottom - set.top + 'px';
+			setEl.classList.add( 'is--replaced' );
 
-			$set
-				.css( 'min-height', this.bottom - this.top + 'px' )
-				.addClass( 'is--replaced' )
-				.empty();
+			while ( setEl.firstChild ) {
+				setEl.removeChild( setEl.firstChild );
+			}
 		} );
 
-		$.each( setsInView, function() {
-			var $set = $( '#' + this.id );
+		setsInView.forEach( function( set ) {
+			var setEl = document.getElementById( set.id );
 
-			if ( $set.hasClass( 'is--replaced' ) ) {
-				$set.css( 'min-height', '' ).removeClass( 'is--replaced' );
+			if ( setEl.classList.contains( 'is--replaced' ) ) {
+				setEl.style.minHeight = '';
+				setEl.classList.remove( 'is--replaced' );
+
 				if ( this.pageNum in self.pageCache ) {
 					$set.html( self.pageCache[ this.pageNum ].html );
 					self.trigger( self.body.get( 0 ), 'is.post-load', {
@@ -648,7 +798,7 @@
 			var majorityPercentageInView = 0;
 
 			// Identify the IS set that comprises the majority of the current window and set the URL to it.
-			$.each( setsInView, function( i, setData ) {
+			setsInView.forEach( function( setData ) {
 				var topInView = 0,
 					bottomInView = 0,
 					percentOfView = 0;
@@ -679,7 +829,8 @@
 
 		// If a page number could be determined, update the URL
 		// -1 indicates that the original requested URL should be used.
-		if ( 'number' === typeof pageNum ) {
+		pageNum = parseInt( pageNum, 10 );
+		if ( pageNum ) {
 			self.updateURL( pageNum );
 		}
 	};
@@ -761,13 +912,19 @@
 	/**
 	 * Ready, set, go!
 	 */
-	$( document ).ready( function() {
+	var jetpackInfinityModule = function() {
+		var bodyClasses = infiniteScroll.settings.body_class.split( ' ' );
+
 		// Check for our variables
 		if ( 'object' !== typeof infiniteScroll ) {
 			return;
 		}
 
-		$( document.body ).addClass( infiniteScroll.settings.body_class );
+		bodyClasses.forEach( function( className ) {
+			if ( className ) {
+				document.body.classList.add( className );
+			}
+		} );
 
 		// Set ajaxurl (for brevity)
 		ajaxurl = infiniteScroll.settings.ajaxurl;
@@ -788,7 +945,7 @@
 		 */
 		if ( type == 'click' ) {
 			var timer = null;
-			$( window ).bind( 'scroll', function() {
+			window.addEventListener( 'scroll', function() {
 				// run the real scroll handler once every 250 ms.
 				if ( timer ) {
 					return;
@@ -799,52 +956,14 @@
 				}, 250 );
 			} );
 		}
+	};
 
-		// Integrate with Selective Refresh in the Customizer.
-		if ( 'undefined' !== typeof wp && wp.customize && wp.customize.selectiveRefresh ) {
-			/**
-			 * Handle rendering of selective refresh partials.
-			 *
-			 * Make sure that when a partial is rendered, the Jetpack post-load event
-			 * will be triggered so that any dynamic elements will be re-constructed,
-			 * such as ME.js elements, Photon replacements, social sharing, and more.
-			 * Note that this is applying here not strictly to posts being loaded.
-			 * If a widget contains a ME.js element and it is previewed via selective
-			 * refresh, the post-load would get triggered allowing any dynamic elements
-			 * therein to also be re-constructed.
-			 *
-			 * @param {wp.customize.selectiveRefresh.Placement} placement
-			 */
-			wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
-				var content;
-				if ( 'string' === typeof placement.addedContent ) {
-					content = placement.addedContent;
-				} else if ( placement.container ) {
-					content = $( placement.container ).html();
-				}
-
-				if ( content ) {
-					$( document.body ).trigger( 'post-load', { html: content } );
-				}
-			} );
-
-			/*
-			 * Add partials for posts added via infinite scroll.
-			 *
-			 * This is unnecessary when MutationObserver is supported by the browser
-			 * since then this will be handled by Selective Refresh in core.
-			 */
-			if ( 'undefined' === typeof MutationObserver ) {
-				$( document.body ).on( 'post-load', function( e, response ) {
-					var rootElement = null;
-					if ( response.html && -1 !== response.html.indexOf( 'data-customize-partial' ) ) {
-						if ( infiniteScroll.settings.id ) {
-							rootElement = $( '#' + infiniteScroll.settings.id );
-						}
-						wp.customize.selectiveRefresh.addPartials( rootElement );
-					}
-				} );
-			}
-		}
-	} );
-} )( jQuery ); // Close closure
+	/**
+	 * Ready, set, go!
+	 */
+	if ( document.readyState === 'interactive' || document.readyState === 'complete' ) {
+		jetpackInfinityModule();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', jetpackInfinityModule );
+	}
+} )(); // Close closure

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -89,7 +89,7 @@
 
 			// Ensure that enough posts are loaded to fill the initial viewport, to compensate for short posts and large displays.
 			self.ensureFilledViewport();
-			this.body.addEventListener( 'post-load', self.checkViewportOnLoadBound );
+			this.body.addEventListener( 'is.post-load', self.checkViewportOnLoadBound );
 		} else if ( type == 'click' ) {
 			if ( this.click_handle ) {
 				this.element.appendChild( this.handle );
@@ -107,28 +107,7 @@
 		}
 
 		// Initialize any Core audio or video players loaded via IS
-		this.body.addEventListener( 'post-load', self.initializeMejs );
-	};
-
-	Scroller.prototype.triggerEvent = function( eventName, el, data ) {
-		var e;
-
-		try {
-			var evtOptions = {
-				bubbles: true,
-				cancelable: true,
-			};
-
-			if ( data ) {
-				evtOptions.detail = data;
-			}
-			e = new CustomEvent( eventName, evtOptions );
-		} catch ( err ) {
-			e = document.createEvent( 'CustomEvent' );
-			e.initCustomEvent( eventName, true, true, data || null );
-		}
-
-		el.dispatchEvent( e );
+		this.body.addEventListener( 'is.post-load', self.initializeMejs );
 	};
 
 	/**
@@ -187,7 +166,7 @@
 			this.element.appendChild( response.fragment.childNodes[ i ] );
 		}
 
-		this.trigger( this.body.get( 0 ), 'is.post-load', {
+		this.trigger( this.body, 'is.post-load', {
 			jqueryEventName: 'post-load',
 			data: response,
 		} );
@@ -431,7 +410,7 @@
 
 					// If MediaElement.js is loaded in by item set of posts, don't initialize the players a second time as it breaks them all
 					if ( 'wp-mediaelement' === item.handle ) {
-						self.body.removeEventListener( 'post-load', self.initializeMejs );
+						self.body.removeEventListener( 'is.post-load', self.initializeMejs );
 					}
 
 					if ( 'wp-mediaelement' === item.handle && 'undefined' === typeof mejs ) {
@@ -506,13 +485,13 @@
 						self.body.classList.add( 'infinity-end' );
 						self.body.classList.remove( 'infinity-success' );
 					} else {
-						self.triggerEvent( 'infinite-scroll-posts-end', this.body, null );
+						self.trigger( this.body, 'infinite-scroll-posts-end' );
 					}
 				} else {
 					if ( self.click_handle ) {
 						self.element.appendChild( self.handle );
 					} else {
-						self.triggerEvent( 'infinite-scroll-posts-more', this.body, null );
+						self.trigger( this.body, 'infinite-scroll-posts-more' );
 					}
 				}
 			} else if ( response.lastbatch ) {
@@ -560,7 +539,7 @@
 			this.wpMediaelement = null;
 
 			// Ensure any subsequent IS loads initialize the players
-			this.body.addEventListener( 'post-load', this.initializeMejs );
+			this.body.addEventListener( 'is.post-load', this.initializeMejs );
 		}
 	};
 
@@ -645,7 +624,7 @@
 			}
 
 			if ( postsHeight === 0 ) {
-				self.body.addEventListener( 'post-load', self.checkViewportOnLoadBound );
+				self.body.addEventListener( 'is.post-load', self.checkViewportOnLoadBound );
 				return;
 			}
 		}
@@ -667,7 +646,7 @@
 			self.ready = true;
 			self.refresh();
 		} else {
-			self.body.removeEventListener( 'post-load', self.checkViewportOnLoadBound );
+			self.body.removeEventListener( 'is.post-load', self.checkViewportOnLoadBound );
 		}
 	};
 

--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -667,7 +667,7 @@
 			self.ready = true;
 			self.refresh();
 		} else {
-			self.body.addEventListener( 'post-load', self.checkViewportOnLoadBound );
+			self.body.removeEventListener( 'post-load', self.checkViewportOnLoadBound );
 		}
 	};
 
@@ -699,7 +699,6 @@
 			windowBottom = windowTop + this.window.innerHeight,
 			windowSize = windowBottom - windowTop,
 			setsInView = [],
-			setsHidden = [],
 			pageNum = false,
 			currentFullScreenState = fullscreenState(),
 			wrapperEls;
@@ -747,8 +746,6 @@
 			} else if ( setBottom > windowTop && setBottom < windowBottom ) {
 				// bottom of set is between top (gt) and bottom (lt)
 				setsInView.push( { id: id, top: setTop, bottom: setBottom, pageNum: setPageNum } );
-			} else {
-				setsHidden.push( { id: id, top: setTop, bottom: setBottom, pageNum: setPageNum } );
 			}
 		}
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -26,16 +26,17 @@ class The_Neverending_Home_Page {
 	 * @return null
 	 */
 	function __construct() {
-		add_action( 'pre_get_posts',                  array( $this, 'posts_per_page_query' ) );
-
-		add_action( 'admin_init',                     array( $this, 'settings_api_init' ) );
-		add_action( 'template_redirect',              array( $this, 'action_template_redirect' ) );
-		add_action( 'template_redirect',              array( $this, 'ajax_response' ) );
-		add_action( 'custom_ajax_infinite_scroll',    array( $this, 'query' ) );
-		add_filter( 'infinite_scroll_query_args',     array( $this, 'inject_query_args' ) );
-		add_filter( 'infinite_scroll_allowed_vars',   array( $this, 'allowed_query_vars' ) );
-		add_action( 'the_post',                       array( $this, 'preserve_more_tag' ) );
-		add_action( 'wp_footer',                      array( $this, 'footer' ) );
+		add_action( 'pre_get_posts', array( $this, 'posts_per_page_query' ) );
+		add_action( 'admin_init', array( $this, 'settings_api_init' ) );
+		add_action( 'template_redirect', array( $this, 'action_template_redirect' ) );
+		add_action( 'customize_preview_init', array( $this, 'init_customizer_assets' ) );
+		add_action( 'template_redirect', array( $this, 'ajax_response' ) );
+		add_action( 'custom_ajax_infinite_scroll', array( $this, 'query' ) );
+		add_filter( 'infinite_scroll_query_args', array( $this, 'inject_query_args' ) );
+		add_filter( 'infinite_scroll_allowed_vars', array( $this, 'allowed_query_vars' ) );
+		add_action( 'the_post', array( $this, 'preserve_more_tag' ) );
+		add_action( 'wp_footer', array( $this, 'footer' ) );
+		add_filter( 'infinite_scroll_additional_scripts', array( $this, 'add_mejs_config' ) );
 
 		// Plugin compatibility
 		add_filter( 'grunion_contact_form_redirect_url', array( $this, 'filter_grunion_redirect_url' ) );
@@ -439,7 +440,7 @@ class The_Neverending_Home_Page {
 				'_inc/build/infinite-scroll/infinity.min.js',
 				'modules/infinite-scroll/infinity.js'
 			),
-			array( 'jquery' ),
+			array(),
 			'4.0.0',
 			true
 		);
@@ -458,8 +459,6 @@ class The_Neverending_Home_Page {
 		// Add our default styles.
 		wp_enqueue_style( 'the-neverending-homepage' );
 
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_spinner_scripts' ) );
-
 		add_action( 'wp_footer', array( $this, 'action_wp_footer_settings' ), 2 );
 
 		add_action( 'wp_footer', array( $this, 'action_wp_footer' ), 21 ); // Core prints footer scripts at priority 20, so we just need to be one later than that
@@ -468,10 +467,24 @@ class The_Neverending_Home_Page {
 	}
 
 	/**
-	 * Enqueue spinner scripts.
+	 * Initialize the Customizer logic separately from the main JS.
+	 *
+	 * @since 8.4.0
 	 */
-	function enqueue_spinner_scripts() {
-		wp_enqueue_script( 'jquery.spin' );
+	public function init_customizer_assets() {
+		// Add our scripts.
+		wp_register_script(
+			'the-neverending-homepage-customizer',
+			Assets::get_file_url_for_environment(
+				'_inc/build/infinite-scroll/infinity-customizer.min.js',
+				'modules/infinite-scroll/infinity-customizer.js'
+			),
+			array( 'customize-base' ),
+			'8.4.0',
+			true
+		);
+
+		wp_enqueue_script( 'the-neverending-homepage-customizer' );
 	}
 
 	/**
@@ -999,8 +1012,25 @@ class The_Neverending_Home_Page {
 		$styles = apply_filters( 'infinite_scroll_existing_stylesheets', $styles );
 
 		?><script type="text/javascript">
-			jQuery.extend( infiniteScroll.settings.scripts, <?php echo json_encode( $scripts ); ?> );
-			jQuery.extend( infiniteScroll.settings.styles, <?php echo json_encode( $styles ); ?> );
+			(function() {
+				var extend = function(out) {
+					out = out || {};
+
+					for (var i = 1; i < arguments.length; i++) {
+						if (!arguments[i])
+						continue;
+
+						for (var key in arguments[i]) {
+						if (arguments[i].hasOwnProperty(key))
+							out[key] = arguments[i][key];
+						}
+					}
+
+					return out;
+				};
+				extend( window.infiniteScroll.settings.scripts, <?php echo wp_json_encode( $scripts ); ?> );
+				extend( window.infiniteScroll.settings.styles, <?php echo wp_json_encode( $styles ); ?> );
+			})();
 		</script><?php
 	}
 
@@ -1032,8 +1062,12 @@ class The_Neverending_Home_Page {
 
 				foreach ( $new_scripts as $handle ) {
 					// Abort if somehow the handle doesn't correspond to a registered script
-					if ( ! isset( $wp_scripts->registered[ $handle ] ) )
+					// or if the script doesn't have `src` set.
+					$script_not_registered = ! isset( $wp_scripts->registered[ $handle ] );
+					$empty_src             = empty( $wp_scripts->registered[ $handle ]->src );
+					if ( $script_not_registered || $empty_src ) {
 						continue;
+					}
 
 					// Provide basic script data
 					$script_data = array(
@@ -1601,6 +1635,33 @@ class The_Neverending_Home_Page {
 		}
 
 		return $url;
+	}
+
+	/**
+	 * When the MediaElement is loaded in dynamically, we need to enforce that
+	 * its settings are added to the page as well.
+	 *
+	 * @param array $scripts_data New scripts exposed to the infinite scroll.
+	 *
+	 * @since 8.4.0
+	 */
+	public function add_mejs_config( $scripts_data ) {
+		foreach ( $scripts_data as $key => $data ) {
+			if ( 'mediaelement-core' === $data['handle'] ) {
+				$mejs_settings = array(
+					'pluginPath'  => includes_url( 'js/mediaelement/', 'relative' ),
+					'classPrefix' => 'mejs-',
+					'stretching'  => 'responsive',
+				);
+
+				$scripts_data[ $key ]['extra_data'] = sprintf(
+					'window.%s = %s',
+					'_wpmejsSettings',
+					wp_json_encode( apply_filters( 'mejs_settings', $mejs_settings ) )
+				);
+			}
+		}
+		return $scripts_data;
 	}
 };
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -441,7 +441,7 @@ class The_Neverending_Home_Page {
 				'modules/infinite-scroll/infinity.js'
 			),
 			array(),
-			'8.4.0',
+			JETPACK__VERSION,
 			true
 		);
 
@@ -480,7 +480,7 @@ class The_Neverending_Home_Page {
 				'modules/infinite-scroll/infinity-customizer.js'
 			),
 			array( 'customize-base' ),
-			'8.4.0',
+			JETPACK__VERSION,
 			true
 		);
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -441,7 +441,7 @@ class The_Neverending_Home_Page {
 				'modules/infinite-scroll/infinity.js'
 			),
 			array(),
-			'4.0.0',
+			'8.4.0',
 			true
 		);
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -441,7 +441,7 @@ class The_Neverending_Home_Page {
 				'modules/infinite-scroll/infinity.js'
 			),
 			array(),
-			JETPACK__VERSION,
+			JETPACK__VERSION . '-is5.0.0', // Added for ability to cachebust on WP.com.
 			true
 		);
 
@@ -480,7 +480,7 @@ class The_Neverending_Home_Page {
 				'modules/infinite-scroll/infinity-customizer.js'
 			),
 			array( 'customize-base' ),
-			JETPACK__VERSION,
+			JETPACK__VERSION . '-is5.0.0', // Added for ability to cachebust on WP.com.
 			true
 		);
 

--- a/modules/photon/photon.js
+++ b/modules/photon/photon.js
@@ -53,5 +53,5 @@
 		}
 	}
 
-	document.body.addEventListener( 'post-load', restore_dims );
+	document.body.addEventListener( 'is.post-load', restore_dims );
 } )();


### PR DESCRIPTION
Fixes #14862

#### Changes proposed in this Pull Request:
* Remove jQuery as a dependency for `infinite-scroll.js`.

This is a large change, please see comments inline of this PR for additional detail on how certain features continue to be supported in vanilla JS.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an update to the `infinite-scroll` module.

#### Testing instructions:

**Simple IS (button trigger):**

* Make sure there is enough posts on the site to trigger pagination on the home page.
* Go to Jetpack Settings > Writing > Infinite Scroll.
* Enable _Load more posts in page with a button_.
* On the front-end, make sure the `Older Posts` button is rendered.
* Click the button and observe the loader animation being rendered.
* Observe new posts being injected.
* Click the button enough times to exhaust available posts.
* Observe the `Older Posts` button not being rendered.
* Scroll up and observe the URL being changed to represent the current page.

**Simple IS (automatic trigger):**

* Make sure there is enough posts on the site to trigger pagination on the home page.
* Go to Jetpack Settings > Writing > Infinite Scroll.
* Enable _Load more posts as the reader scrolls down_.
* On the front-end, scroll down and observe new posts being injected.
* Continue scrolling down to exhaust available posts.
* Observe that no additional content is being pulled in once all posts are displayed.
* Scroll up and observe the URL being changed to represent the current page.

**IS with audio / video shortcodes:**

There is a good deal of code dedicated to making sure the `[audio]` and `[video]` shortcodes still work when infinite scroll is enabled. These shortcodes use the `MediaElementJS` from WP core to normalize media playback experience and that library is finicky and requires a lot of special treatment. The `MediaElement` library depends on jQuery and IS needs to be able to dynamically inject `MediaElement` and `jQuery` scripts lazily _only_ when required.

* Add an `[audio]` and / or `[video]` shortcodes to a post that will appear on a second page of the homepage, i.e. that post should be loaded by IS.
* Make sure `jQuery` and `wp-mediaelement` scripts are _not_ loaded on the initial page load.
* Let IS load the second page.
* Make sure `jQuery` and `wp-mediaelement` scripts are now loaded and executed dynamically.
* Observe that the shortcode is rendered correctly using the MediaElement library (to check this, observe DOM elements and search for `mejs-container` classes).
* Make sure the media player works as expected.

**IS (customizer):**

* Make sure the IS functions in the Customizer.

#### Tested in:
* Chrome 80, Ubuntu 19
* IE 11, Windows 10

#### Proposed changelog entry for your changes:
* The Infinite Scroll module has been rewritten to not depend on jQuery.