### PR TITLE
Podcast Player: Better enclosure selection

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -152,20 +152,18 @@ function get_track_list( $feed, $quantity = 10 ) {
  * @return array
  */
 function setup_tracks_callback( \SimplePie_Item $episode ) {
-	$enclosure = $episode->get_enclosure();
-
-	$url = ! empty( $episode->data['child']['']['enclosure'][0]['attribs']['']['url'] ) ? $episode->data['child']['']['enclosure'][0]['attribs']['']['url'] : null;
+	$enclosure = get_audio_enclosure( $episode );
 
 	// If there is no link return an empty array. We will filter out later.
-	if ( ! $url ) {
+	if ( empty( $enclosure->link ) ) {
 		return array();
 	}
 
 	// Build track data.
 	$track = array(
 		'link'        => esc_url( $episode->get_link() ),
-		'src'         => esc_url( $url ),
-		'type'        => $enclosure->type,
+		'src'         => esc_url( $enclosure->link ),
+		'type'        => esc_attr( $enclosure->type ),
 		'caption'     => '',
 		'description' => wp_kses_post( $episode->get_description() ),
 		'meta'        => array(),
@@ -178,4 +176,21 @@ function setup_tracks_callback( \SimplePie_Item $episode ) {
 	}
 
 	return $track;
+}
+
+/**
+ * Retrieves an audio enclosure.
+ *
+ * @param \SimplePie_Item $episode SimplePie_Item object, representing a podcast episode.
+ * @return \SimplePie_Enclosure|null
+ */
+function get_audio_enclosure( \SimplePie_Item $episode ) {
+	foreach ( $episode->get_enclosures() as $enclosure ) {
+		if ( 0 === strpos( $enclosure->type, 'audio/' ) ) {
+			return $enclosure;
+		}
+	}
+
+	// Default to empty SimplePie_Enclosure object.
+	return $episode->get_enclosure();
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -185,7 +185,7 @@ function setup_tracks_callback( \SimplePie_Item $episode ) {
  * @return \SimplePie_Enclosure|null
  */
 function get_audio_enclosure( \SimplePie_Item $episode ) {
-	foreach ( $episode->get_enclosures() as $enclosure ) {
+	foreach ( (array) $episode->get_enclosures() as $enclosure ) {
 		if ( 0 === strpos( $enclosure->type, 'audio/' ) ) {
 			return $enclosure;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Makes sure we only attempt to get data from audio enclosures. Enclosures of other media types (like images) break our data preparation.

Fixes CJS75TX3R/p1584444326075400-ajax-slack

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces a helper function to select audio enclosures.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test the podcast player with the following RSS urls,
* Preview the changes in the front-end
* Make sure episodes are playable as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry.
