### PR TITLE
add extra properties to woocommerceanalytics events

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -93,9 +93,9 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 *
 	 * @param string  $event_name The name of the event to record.
 	 * @param integer $product_id The id of the product relating to the event.
-	 * @param array   $properties Array of key => value event properties.
+	 * @param array   $properties Optional array of (key => value) event properties.
 	 */
-	public function record_event( $event_name, $product_id, $properties ) {
+	public function record_event( $event_name, $product_id, $properties = array() ) {
 		$product = wc_get_product( $product_id );
 		if ( ! $product instanceof WC_Product ) {
 			return;

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -103,6 +103,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 								'pq': '" . esc_js( $data_instance['quantity'] ) . "',
 								'pt': '" . esc_js( $product_details['type'] ) . "',
 								'ui': '" . esc_js( $this->get_user_id() ) . "',
+								'url': '" . esc_js( home_url() ) . "',
+								'woo_version': '" . esc_js( WC()->version ) . "',
 							} );"
 					);
 				}
@@ -135,6 +137,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 					'pi': productDetails.id,
 					'pq': productDetails.quantity,
 					'ui': '" . esc_js( $this->get_user_id() ) . "',
+					'url': '" . esc_js( home_url() ) . "',
+					'woo_version': '" . esc_js( WC()->version ) . "',
 				} );
 			} );"
 		);
@@ -200,6 +204,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				'pp': '" . esc_js( $product_details['price'] ) . "',
 				'pt': '" . esc_js( $product_details['type'] ) . "',
 				'ui': '" . esc_js( $this->get_user_id() ) . "',
+				'url': '" . esc_js( home_url() ) . "',
+				'woo_version': '" . esc_js( WC()->version ) . "',
 			} );"
 		);
 	}
@@ -235,6 +241,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				'pq': '" . esc_js( $cart_item['quantity'] ) . "',
 				'pt': '" . esc_js( $product_details['type'] ) . "',
 				'ui': '" . esc_js( $this->get_user_id() ) . "',
+				'url': '" . esc_js( home_url() ) . "',
+				'woo_version': '" . esc_js( WC()->version ) . "',
 			} );";
 		}
 
@@ -268,6 +276,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				'pt': '" . esc_js( $product_details['type'] ) . "',
 				'oi': '" . esc_js( $order->get_order_number() ) . "',
 				'ui': '" . esc_js( $this->get_user_id() ) . "',
+				'url': '" . esc_js( home_url() ) . "',
+				'woo_version': '" . esc_js( WC()->version ) . "',
 			} );";
 		}
 
@@ -294,6 +304,8 @@ class Jetpack_WooCommerce_Analytics_Universal {
 							'blog_id': '" . esc_js( $blogid ) . "',
 							'pi': productID,
 							'ui': '" . esc_js( $this->get_user_id() ) . "',
+							'url': '" . esc_js( home_url() ) . "',
+							'woo_version': '" . esc_js( WC()->version ) . "',
 						} );
 					}
 				} );


### PR DESCRIPTION
This PR adds some extra properties to `woocommerceanalytics` events. For example, these properties allow us to filter events on WooCommerce version.

#### Changes proposed in this Pull Request:
* Adds `url` property to all `woocommerceanalytics` events.
* Adds `woo_version` property to all `woocommerceanalytics` events.

pb0Spc-ou-p2

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This adds features to the existing [`woocommerce-analytics`](https://github.com/Automattic/jetpack/tree/master/modules/woocommerce-analytics) module.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* This requires Jetpack and WooCommerce – if necessary, install WooCommerce, set it up (use the onboarding wizard), and add some products. Use `Cash on delivery` payment method for easy test checkout - you can enable this in `WooCommerce > Settings > Payment`.
* The events are disabled for development sites. You can circumvent (hack) this by adding `return true;` at the start of [`Jetpack_WooCommerce_Analytics::shouldTrackStore()`](https://github.com/Automattic/jetpack/blob/master/modules/woocommerce-analytics/wp-woocommerce-analytics.php#L40).
- Open network tab in browser dev tools, search for `pixel.wp.com`.
- View a product on the front end of your site. You should see a request for `woocommerceanalytics_product_view` event. This should have new properties (parameters) `url` and `woo_version`, and the values should match the home url and Woo version (respectively).
- Add/remove products from cart, view cart / checkout, complete purchase - the relevant events should all include the new properties.

#### Proposed changelog entry for your changes:
* Added url and woo_version to WooCommerce Analytics events.

(Not sure if this needs a changelog entry.)
