### PR TITLE
E2E Tests: Fix mailchimp test flakiness

### DIFF
--- a/tests/e2e/lib/blocks/mailchimp.js
+++ b/tests/e2e/lib/blocks/mailchimp.js
@@ -32,9 +32,10 @@ export default class MailchimpBlock {
 	 */
 	async connect( isLoggedIn = true ) {
 		const setupFormSelector = this.getSelector( "a[href*='marketing/connections']" );
-		const connectionsUrl = await (
-			await ( await waitForSelector( this.page, setupFormSelector ) ).getProperty( 'href' )
-		 ).jsonValue();
+		const hrefProperty = await (
+			await waitForSelector( this.page, setupFormSelector )
+		 ).getProperty( 'href' );
+		const connectionsUrl = await hrefProperty.jsonValue();
 		const loginTab = await clickAndWaitForNewPage( this.page, setupFormSelector );
 		global.page = loginTab;
 

--- a/tests/e2e/lib/blocks/mailchimp.js
+++ b/tests/e2e/lib/blocks/mailchimp.js
@@ -32,9 +32,8 @@ export default class MailchimpBlock {
 	 */
 	async connect( isLoggedIn = true ) {
 		const setupFormSelector = this.getSelector( "a[href*='marketing/connections']" );
-		const hrefProperty = await (
-			await waitForSelector( this.page, setupFormSelector )
-		 ).getProperty( 'href' );
+		const formSelector = await waitForSelector( this.page, setupFormSelector );
+		const hrefProperty = await formSelector.getProperty( 'href' );
 		const connectionsUrl = await hrefProperty.jsonValue();
 		const loginTab = await clickAndWaitForNewPage( this.page, setupFormSelector );
 		global.page = loginTab;

--- a/tests/e2e/lib/blocks/mailchimp.js
+++ b/tests/e2e/lib/blocks/mailchimp.js
@@ -65,7 +65,7 @@ export default class MailchimpBlock {
 			}
 		}
 
-		await loginTab.waitForNavigation( { waitFor: 'networkidle0' } );
+		await loginTab.reload( { waitFor: 'networkidle0' } );
 
 		await ( await ConnectionsPage.init( loginTab ) ).selectMailchimpList();
 

--- a/tests/e2e/lib/blocks/mailchimp.js
+++ b/tests/e2e/lib/blocks/mailchimp.js
@@ -32,10 +32,9 @@ export default class MailchimpBlock {
 	 */
 	async connect( isLoggedIn = true ) {
 		const setupFormSelector = this.getSelector( "a[href*='marketing/connections']" );
-		const connectionsUrl = await ( await ( await waitForSelector(
-			this.page,
-			setupFormSelector
-		) ).getProperty( 'href' ) ).jsonValue();
+		const connectionsUrl = await (
+			await ( await waitForSelector( this.page, setupFormSelector ) ).getProperty( 'href' )
+		 ).jsonValue();
 		const loginTab = await clickAndWaitForNewPage( this.page, setupFormSelector );
 		global.page = loginTab;
 
@@ -65,6 +64,8 @@ export default class MailchimpBlock {
 				}
 			}
 		}
+
+		await loginTab.waitForNavigation( { waitFor: 'networkidle0' } );
 
 		await ( await ConnectionsPage.init( loginTab ) ).selectMailchimpList();
 


### PR DESCRIPTION
Sometimes MailChimp test fails when trying to enable MailChimp connection under https://wordpress.com/marketing/connections/:site

I assume it happens because of the unexpected re-rendering

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the tests are green

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
