### PR TITLE
Contact Form Block: Fix text color override

### DIFF
--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -20,7 +20,6 @@
 	}
 
 	.help-message {
-		color: $dark-gray-150;
 		width: 100%;
 		margin: 0 0 1em;
 	}


### PR DESCRIPTION
Fixes #14975

#### Changes proposed in this Pull Request:

* Fix the color overrides in Gutenberg latest so that they are not light grey.

| Before  | After |
| ------------- | ------------- |
| <img width="492" alt="76626014-076bb400-6541-11ea-96bd-ab26c697ba56" src="https://user-images.githubusercontent.com/1464705/77013763-fdc1c200-692d-11ea-856b-32506da299df.png"> | <img width="628" alt="Screen Shot 2020-03-18 at 3 34 59 PM" src="https://user-images.githubusercontent.com/1464705/77013784-0c0fde00-692e-11ea-8f5d-2579f7698182.png"> |

#### Testing instructions:
* Add a contact form block
* Add an invalid email address, confirm the error and explanation text are not light grey.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
