### PR TITLE
Hide Disconnect Dialog Survey

### DIFF
--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -166,6 +166,7 @@ export class ConnectButton extends React.Component {
 				{ this.props.children }
 				<JetpackDisconnectModal
 					show={ this.state.showModal }
+					showSurvey={ false }
 					toggleModal={ this.toggleVisibility }
 				/>
 			</div>

--- a/_inc/client/components/jetpack-termination-dialog/README.md
+++ b/_inc/client/components/jetpack-termination-dialog/README.md
@@ -17,6 +17,7 @@ import JetpackDisconnectModal from 'components/jetpack-termination-dialog/discon
 
 <JetpackDisconnectDialogModal
 	show={ this.state.showModal }
+	showSurvey
 	toggleModal={ this.toggleVisibility }
 />
 ```

--- a/_inc/client/components/jetpack-termination-dialog/dialog.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/dialog.jsx
@@ -76,6 +76,7 @@ class JetpackTerminationDialog extends Component {
 		isDevVersion: PropTypes.bool,
 		location: PropTypes.oneOf( [ 'plugins', 'dashboard' ] ).isRequired,
 		purpose: PropTypes.oneOf( [ 'disconnect', 'disable' ] ).isRequired,
+		showSurvey: PropTypes.bool.isRequired,
 		siteBenefits: PropTypes.array,
 		submitSurvey: PropTypes.func,
 		terminateJetpack: PropTypes.func.isRequired,
@@ -153,9 +154,9 @@ class JetpackTerminationDialog extends Component {
 	}
 
 	renderPrimaryButton() {
-		const { purpose } = this.props;
+		const { purpose, showSurvey } = this.props;
 		const { step } = this.state;
-		return step === JetpackTerminationDialog.FEATURE_STEP ? (
+		return showSurvey && step === JetpackTerminationDialog.FEATURE_STEP ? (
 			<Button primary onClick={ this.handleContinueClick }>
 				{ __( 'Continue' ) }
 			</Button>
@@ -167,7 +168,7 @@ class JetpackTerminationDialog extends Component {
 	}
 
 	render() {
-		const { purpose, location } = this.props;
+		const { location, purpose, showSurvey } = this.props;
 		const { step } = this.state;
 
 		return (
@@ -188,7 +189,7 @@ class JetpackTerminationDialog extends Component {
 						) }
 					</div>
 				</Card>
-				{ step === JetpackTerminationDialog.FEATURE_STEP
+				{ ! showSurvey || step === JetpackTerminationDialog.FEATURE_STEP
 					? this.renderFeatures()
 					: this.renderSurvey() }
 				<Card>

--- a/_inc/client/components/jetpack-termination-dialog/disconnect-modal.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/disconnect-modal.jsx
@@ -16,11 +16,13 @@ import Modal from 'components/modal';
 class JetpackDisconnectModal extends Component {
 	static propTypes = {
 		show: PropTypes.bool,
+		showSurvey: PropTypes.bool,
 		toggleModal: PropTypes.func,
 	};
 
 	static defaultProps = {
 		show: false,
+		showSurvey: false,
 		toggleModal: noop,
 	};
 
@@ -29,16 +31,17 @@ class JetpackDisconnectModal extends Component {
 	};
 
 	render() {
-		const { show, toggleModal } = this.props;
+		const { show, showSurvey, toggleModal } = this.props;
 
 		return (
 			show && (
 				<Modal className="jp-connection-settings__modal" onRequestClose={ toggleModal }>
 					<JetpackTerminationDialog
 						closeDialog={ toggleModal }
-						terminateJetpack={ this.disconnectJetpack }
 						location={ 'dashboard' }
 						purpose={ 'disconnect' }
+						showSurvey={ showSurvey }
+						terminateJetpack={ this.disconnectJetpack }
 					/>
 				</Modal>
 			)
@@ -46,13 +49,10 @@ class JetpackDisconnectModal extends Component {
 	}
 }
 
-export default connect(
-	null,
-	dispatch => {
-		return {
-			disconnectSite: () => {
-				return dispatch( disconnectSite( true ) );
-			},
-		};
-	}
-)( JetpackDisconnectModal );
+export default connect( null, dispatch => {
+	return {
+		disconnectSite: () => {
+			return dispatch( disconnectSite( true ) );
+		},
+	};
+} )( JetpackDisconnectModal );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide Disconnect Dialog Survey via property

<img width="898" alt="Screen Shot 2020-03-18 at 3 53 31 PM" src="https://user-images.githubusercontent.com/2810519/77015111-197a9780-6931-11ea-82b2-57dcf4b14a3f.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Internal reference: parBdM-hs-p2

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to `/wp-admin/admin.php?page=jetpack#/dashboard`
2. Click "Manage site connection"
3. Verify that the dialog matches the screenshot above, specifically the rightmost button is "Disconnect" and scary
4. Click "Disconnect", confirm that the site does disconnect

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove Disconnect Dialog Survey
