### PR TITLE
Connection: Persist from parameter on connection button to in-place connection iFrame

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -7,9 +7,17 @@ jQuery( document ).ready( function( $ ) {
 	var connectionHelpSections = $(
 		'#jetpack-connection-cards, .jp-connect-full__dismiss-paragraph'
 	);
+	var connectButtonFrom = '';
 
 	connectButton.on( 'click', function( event ) {
 		event.preventDefault();
+
+		var searchParams =
+			'undefined' !== typeof URLSearchParams
+				? new URLSearchParams( $( this ).prop( 'search' ) )
+				: null;
+
+		connectButtonFrom = searchParams && searchParams.get( 'from' );
 
 		if ( connectionHelpSections.length ) {
 			connectionHelpSections.fadeOut( 600 );
@@ -114,7 +122,7 @@ jQuery( document ).ready( function( $ ) {
 		handleConnectionSuccess: function( data ) {
 			jetpackConnectButton.fetchPlanType();
 			window.addEventListener( 'message', jetpackConnectButton.receiveData );
-			jetpackConnectIframe.attr( 'src', data.authorizeUrl );
+			jetpackConnectIframe.attr( 'src', data.authorizeUrl + '&from=' + connectButtonFrom );
 			jetpackConnectIframe.on( 'load', function() {
 				jetpackConnectIframe.show();
 				$( '.jp-connect-full__button-container' ).hide();

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -12,12 +12,12 @@ jQuery( document ).ready( function( $ ) {
 	connectButton.on( 'click', function( event ) {
 		event.preventDefault();
 
-		var searchParams =
-			'undefined' !== typeof URLSearchParams
-				? new URLSearchParams( $( this ).prop( 'search' ) )
-				: null;
-
-		connectButtonFrom = searchParams && searchParams.get( 'from' );
+		if ( 'undefined' === typeof URLSearchParams ) {
+			connectButtonFrom = '';
+		} else {
+			var searchParams = new URLSearchParams( $( this ).prop( 'search' ) );
+			connectButtonFrom = searchParams && searchParams.get( 'from' );
+		}
 
 		if ( connectionHelpSections.length ) {
 			connectionHelpSections.fadeOut( 600 );


### PR DESCRIPTION
There is an issue right now where the `from` argument is not being persisted from the connection button to the in-place connection iFrame. From what I can tell, the `from` argument is only placed on the connection button. But, when we load the iFrame, we're not transferring that `from` argument to the iFrame.

#### Changes proposed in this Pull Request:

* Persist `from` query arg from connection button to the in-place connection iFrame

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This is a bug fix that is affecting attribution of connections

#### Testing instructions:

* Check out patch
* Click "Set Up Jetpack" button
* Once the in-place connection iFrame loads, inspect the element
* Ensure that the `from` is properly appended to the URL

#### Proposed changelog entry for your changes:

This should not be necessary.
