### PR TITLE
Instant Search: Add support in glance and performance sections

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -15,7 +15,6 @@ import analytics from 'lib/analytics';
 import DashItem from 'components/dash-item';
 import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
-import { isModuleFound } from 'state/search';
 import { isDevMode } from 'state/connection';
 import { getSitePlan } from 'state/site';
 import { getUpgradeUrl } from 'state/initial-state';
@@ -67,11 +66,14 @@ class DashSearch extends Component {
 		} );
 	}
 
-	activateSearch = () => this.props.updateOptions( { search: true, instant_search_enabled: true } );
+	activateSearch = () => {
+		this.props.updateOptions( {
+			search: true,
+			...( this.props.isSearchPlan ? { instant_search_enabled: true } : {} ),
+		} );
+	};
 
 	render() {
-		const hasPro = 'is-business-plan' === this.props.planClass;
-
 		if ( this.props.isDevMode ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
@@ -81,7 +83,7 @@ class DashSearch extends Component {
 			} );
 		}
 
-		if ( ! hasPro ) {
+		if ( ! this.props.isBusinessPlan && ! this.props.isSearchPlan ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
@@ -123,13 +125,23 @@ class DashSearch extends Component {
 							{ __( 'Jetpack Search is powering search on your site.' ) }
 						</p>
 					</DashItem>
-					<Card
-						compact
-						className="jp-search-config-aag"
-						href="customize.php?autofocus[section]=jetpack_search"
-					>
-						{ __( 'Customize' ) }
-					</Card>
+					{ this.props.isSearchPlan ? (
+						<Card
+							compact
+							className="jp-search-config-aag"
+							href="customize.php?autofocus[section]=jetpack_search"
+						>
+							{ __( 'Customize' ) }
+						</Card>
+					) : (
+						<Card
+							compact
+							className="jp-search-config-aag"
+							href="customize.php?autofocus[panel]=widgets"
+						>
+							{ __( 'Add Search (Jetpack) Widget' ) }
+						</Card>
+					) }
 				</div>
 			);
 		}
@@ -150,10 +162,11 @@ class DashSearch extends Component {
 }
 
 export default connect( state => {
+	const planClass = getPlanClass( getSitePlan( state ).product_slug );
 	return {
-		foundSearch: isModuleFound( state, 'search' ),
-		planClass: getPlanClass( getSitePlan( state ).product_slug ),
+		isBusinessPlan: 'is-business-plan' === planClass,
 		isDevMode: isDevMode( state ),
+		isSearchPlan: 'is-search-plan' === planClass,
 		upgradeUrl: getUpgradeUrl( state, 'aag-search' ),
 	};
 } )( DashSearch );

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import { noop } from 'lodash';
-import { getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import { getPlanClass, PLAN_JETPACK_SEARCH } from 'lib/plans/constants';
 
 /**
  * Internal dependencies
@@ -67,7 +67,7 @@ class DashSearch extends Component {
 		} );
 	}
 
-	activateSearch = () => this.props.updateOptions( { search: true } );
+	activateSearch = () => this.props.updateOptions( { search: true, instant_search_enabled: true } );
 
 	render() {
 		const hasPro = 'is-business-plan' === this.props.planClass;
@@ -90,13 +90,13 @@ class DashSearch extends Component {
 					<JetpackBanner
 						callToAction={ __( 'Upgrade' ) }
 						title={ __(
-							"Replace your site's basic search with customizable search that helps visitors find answers faster."
+							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.'
 						) }
 						disableHref="false"
 						href={ this.props.upgradeUrl }
 						eventFeature="search"
 						path="dashboard"
-						plan={ PLAN_JETPACK_PREMIUM }
+						plan={ PLAN_JETPACK_SEARCH }
 						icon="search"
 					/>
 				),
@@ -107,11 +107,11 @@ class DashSearch extends Component {
 			return (
 				<div className="jp-dash-item">
 					<DashItem
-						label={ __( 'Jetpack Search' ) }
+						label={ __( 'Search' ) }
 						module="search"
 						support={ {
 							text: __(
-								'Jetpack Search is a powerful replacement for the search capability built into WordPress.'
+								'Jetpack Search helps visitors quickly find answers with highly relevant instant search results and powerful filtering.'
 							),
 							link: 'https://jetpack.com/support/search/',
 						} }
@@ -126,9 +126,9 @@ class DashSearch extends Component {
 					<Card
 						compact
 						className="jp-search-config-aag"
-						href="customize.php?autofocus[panel]=widgets"
+						href="customize.php?autofocus[section]=jetpack_search"
 					>
-						{ __( 'Add Search (Jetpack) Widget' ) }
+						{ __( 'Customize' ) }
 					</Card>
 				</div>
 			);
@@ -138,7 +138,7 @@ class DashSearch extends Component {
 			className: 'jp-dash-item__is-inactive',
 			pro_inactive: false,
 			content: __(
-				'{{a}}Activate{{/a}} to replace the WordPress built-in search with Jetpack Search, an advanced search experience.',
+				'{{a}}Activate{{/a}} to help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
 				{
 					components: {
 						a: <a href="javascript:void(0)" onClick={ this.activateSearch } />,

--- a/_inc/client/components/dev-card/index.jsx
+++ b/_inc/client/components/dev-card/index.jsx
@@ -228,6 +228,19 @@ export class DevCard extends React.Component {
 							Jetpack Backup Reatime
 						</label>
 					</li>
+					<li>
+						<label htmlFor="jetpack_search">
+							<input
+								type="radio"
+								id="jetpack_search"
+								value="jetpack_search"
+								name="jetpack_search"
+								checked={ 'is-search-plan' === planClass }
+								onChange={ this.onPlanChange }
+							/>
+							Search
+						</label>
+					</li>
 				</ul>
 				<hr />
 				<ul>

--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -28,6 +28,8 @@ export const PLAN_JETPACK_BACKUP_DAILY = 'jetpack_backup_daily';
 export const PLAN_JETPACK_BACKUP_DAILY_MONTHLY = 'jetpack_backup_daily_monthly';
 export const PLAN_JETPACK_BACKUP_REALTIME = 'jetpack_backup_realtime';
 export const PLAN_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';
+export const PLAN_JETPACK_SEARCH = 'jetpack_search';
+export const PLAN_JETPACK_SEARCH_MONTHLY = 'jetpack_search_monthly';
 export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_VIP = 'vip';
@@ -163,6 +165,9 @@ export function getPlanClass( plan ) {
 		case PLAN_JETPACK_BACKUP_REALTIME:
 		case PLAN_JETPACK_BACKUP_REALTIME_MONTHLY:
 			return 'is-realtime-backup-plan';
+		case PLAN_JETPACK_SEARCH:
+		case PLAN_JETPACK_SEARCH_MONTHLY:
+			return 'is-search-plan';
 		default:
 			return '';
 	}

--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -52,9 +52,9 @@ class Performance extends Component {
 					}
 					className="jp-settings-description"
 				/>
-				<SpeedUpSite { ...commonProps } />
-				<Media { ...commonProps } />
 				<Search { ...commonProps } />
+				<Media { ...commonProps } />
+				<SpeedUpSite { ...commonProps } />
 			</div>
 		);
 	}

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -65,7 +65,7 @@ function Search( props ) {
 			>
 				<p>
 					{ __(
-						'Help visitors quickly find answers with highly relevant instant search results and powerful filtering hosted in the WordPress.com cloud.'
+						'Help visitors quickly find answers with highly relevant instant search results and powerful filtering. Powered by the WordPress.com cloud.'
 					) }{ ' ' }
 				</p>
 				{ ( props.isBusinessPlan || props.isSearchPlan ) && (
@@ -92,7 +92,7 @@ function Search( props ) {
 							</CompactFormToggle>
 							<p className="jp-form-setting-explanation jp-form-search-setting-explanation">
 								{ __(
-									'Instant Search will allow your visitors to get search results as soon as they start typing. ' +
+									'Instant search will allow your visitors to get search results as soon as they start typing. ' +
 										'If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.'
 								) }
 							</p>

--- a/_inc/client/performance/style.scss
+++ b/_inc/client/performance/style.scss
@@ -1,0 +1,3 @@
+.jp-form-fieldset > .jp-form-search-setting-explanation {
+	margin-left: 2.25rem;
+}

--- a/_inc/client/scss/style.scss
+++ b/_inc/client/scss/style.scss
@@ -51,6 +51,7 @@
 // Page Templates
 @import '../at-a-glance/style';
 @import '../my-plan/style';
+@import '../performance/style';
 @import '../plans/style';
 @import '../plans-prompt/style';
 @import '../settings/style';

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2058,6 +2058,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'related-posts',
 			),
 
+			// Search.
+			'instant_search_enabled'               => array(
+				'description'       => esc_html__( 'Enable Instant Search', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'search',
+			),
+
 			// Verification Tools
 			'google' => array(
 				'description'       => esc_html__( 'Google Search Console', 'jetpack' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
1) Updates the Search section of the At-a-Glance page with an updated copy.
  a) Activating Search will also activate Instant Search if the site has a Search plan.
  b) Customers are encouraged to upgrade to the Jetpack Search plan instead of the Premium plan. (Not sure why we were recommending them to upgrade to a Premium plan for search; search is only included in the Professional plan.)
  c) If on a Search plan, they will be linked to the Jetpack Search settings in the Customizer instead of Widget panel.

<img width="1073" alt="Screen Shot 2020-03-18 at 3 43 16 PM" src="https://user-images.githubusercontent.com/4044428/77018515-610a1f00-6943-11ea-99ba-563408dfefe2.png">

<img width="1073" alt="Screen Shot 2020-03-18 at 3 43 05 PM" src="https://user-images.githubusercontent.com/4044428/77018530-6ff0d180-6943-11ea-8dbb-6aa4d6fb3c56.png">

2. Updates the Search section in the Performance settings page. Also reorders sections so that the Search section is now at the top.
  a) Adds another toggle for enabling Instant Search. This toggle is only interactable for sites with a Search plan.
  b) Sites with either business or search plans are prompted to enable the search module.
  c) If Instant Search is toggled on, we include a link to the Jetpack Search section of the Customizer. If not, we link to the widget panel of the Customizer.

<img width="1062" alt="Screen Shot 2020-03-19 at 2 36 53 PM" src="https://user-images.githubusercontent.com/4044428/77112729-21990c80-69ef-11ea-8138-e41d663c1038.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, but this PR merges into a feature branch.

#### Testing instructions:
1. Apply these changes to your site. 

For a site without an active Jetpack plan subscription:

2. Navigate to the At-a-Glance page (`/wp-admin/admin.php?page=jetpack#/dashboard`). You should be prompted to purchase a Jetpack Search plan via an upgrade link.
3. Navigate to the Performance tab in the settings page (`/wp-admin/admin.php?page=jetpack#/performance`). You should be prompted to purchase a Search plan here as well.

For a site with a Jetpack Professional plan:

4. Navigate to the At-a-Glance page. There should be a toggle to enable/disable Jetpack Search as well as a link to add a Jetpack Search widget via the Customizer.
5. Navigate to the Performance tab in the settings page. You should be able to toggle Jetpack Search on and off.

For a site with a Jetpack Search plan (it's not possible to test these steps quite yet):

6. Navigate to the At-a-Glance page. There should be a toggle to enable/disable Jetpack Instant Search as well as a link to the Jetpack Search section of the Customizer.
7. Navigate to the Performance tab in the settings page. Enabling Jetpack Search should automatically enable Instant Search as well.

#### Proposed changelog entry for your changes:
* None. This PR merged into a feature branch.
