### PR TITLE
Compat: use require_once instead of jetpack_require_lib()

### DIFF
--- a/packages/compat/functions.php
+++ b/packages/compat/functions.php
@@ -17,9 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Load necessary functions.
  */
 function jetpack_compat_require_defined_functions() {
-	jetpack_require_lib( 'tracks/client' );
+	require_once __DIR__ . '/lib/tracks/client.php';
 }
 
 add_action( 'plugins_loaded', 'jetpack_compat_require_defined_functions' );
-
-


### PR DESCRIPTION
The Compat package uses the `jetpack_require_lib()` function, which is provided by Jetpack. The package should not depend on Jetpack, so replace this call with a `require_once` statement.

Fixes #15036

#### Changes proposed in this Pull Request:
* Replace the `jetpack_require_lib()` call with a require_once statement. This doesn't change the functionality because `jetpack_require_lib()` checks the `jetpack-compat\lib` [directory first](https://github.com/Automattic/jetpack/blob/master/require-lib.php#L24) when it searches for a valid file location.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
I can't find any uses of the functions in `/lib/tracks/client.php`. They've been deprecated and Jetpack is using the new functions in `Automattic\Jetpack\Tracking`. WooCommerce is also using the new functions in `Automattic\Jetpack\Tracking` for [Jetpack versions greater than 7.4](https://github.com/woocommerce/woocommerce/blob/master/includes/tracks/class-wc-tracks-client.php#L146). So, I'm not sure how to test this.

#### Proposed changelog entry for your changes:
* n/a
