### PR TITLE
Shortlinks: Fix the UI in newer version of Gutenberg

### DIFF
--- a/extensions/shared/clipboard-input.scss
+++ b/extensions/shared/clipboard-input.scss
@@ -1,7 +1,12 @@
 .jetpack-clipboard-input {
 	display: flex;
 
+	.components-text-control__input,
 	.components-clipboard-button {
-		margin: 2px 0 0 6px;
+		min-height: 36px;
+	}
+
+	.components-clipboard-button {
+		margin-left: 6px;
 	}
 }

--- a/extensions/shared/clipboard-input.scss
+++ b/extensions/shared/clipboard-input.scss
@@ -1,9 +1,11 @@
+@import 'styles/gutenberg-base-styles.scss';
+
 .jetpack-clipboard-input {
 	display: flex;
 
 	.components-text-control__input,
 	.components-clipboard-button {
-		min-height: 36px;
+		min-height: $button-size;
 	}
 
 	.components-clipboard-button {


### PR DESCRIPTION
Fixes #14982

Before:
<img width="288" alt="Screen Shot 2020-03-19 at 12 01 42 PM" src="https://user-images.githubusercontent.com/1464705/77104973-1c7d9280-69da-11ea-9b93-11febc0d45c1.png">

After:
<img width="297" alt="Screen Shot 2020-03-19 at 12 01 26 PM" src="https://user-images.githubusercontent.com/1464705/77104979-1f788300-69da-11ea-888b-18107ad13eb6.png">

#### Testing instructions:
* Make sure the Shortlinks module is active on your site.
* Publish a post on a publicly accessable site
* Hit the Jetpack logo in the editor
* Make sure the button and textbox line up
* Disable the Gutenberg plugin and make sure they still line up on the core WP version of Gutenberg.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
