### PR TITLE
Dashboard: Scan card layout looks bad when threats are found

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -96,7 +96,7 @@ class DashScan extends Component {
 				if ( threats !== 0 ) {
 					return renderCard( {
 						content: [
-							<h3>
+							<h3 className="jp-dash-item__title jp-dash-item__title_fullwidth jp-dash-item__title_top">
 								{ __( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', {
 									count: threats,
 									args: { number: numberFormat( threats ) },

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -37,7 +37,7 @@
 	display: inline-block;
 	border: 1px solid $light-gray-700;
 	border-radius: 4px;
-	padding: 0px 4px;
+	padding: 0 4px;
 	min-width: 36px;
 	text-align: center;
 
@@ -47,6 +47,18 @@
 
 	+ .jp-dash-item__description {
 		max-width: 61%;
+	}
+}
+
+.jp-dash-item__title {
+	max-width: calc( 100% - 18px ); // For the support icon
+
+	&.jp-dash-item__title_fullwidth {
+		flex-basis: 100%;
+	}
+
+	&.jp-dash-item__title_top {
+		margin-top: 0;
 	}
 }
 


### PR DESCRIPTION
#### Dashboard: Scan card layout fix (issue #14914)

When threats are found, the "Scan" card styling gets a little bit messed up.

Fixes #14914

#### Changes proposed in this Pull Request:
Minor styling adjustments.

#### Testing instructions:
Steps to reproduce the issue:
1. Purchase a Jetpack plan (Premium or Pro)
2. Install/activate VaultPress
3. Go to the Jetpack AAG dashboard in wp-admin
4. In Jetpack footer, click "Dev Tools", and then click the button for "threats":

<img width="480" alt="76113550-5b5f2180-5fb2-11ea-9271-671328dac3d6" src="https://user-images.githubusercontent.com/1341249/77116135-a25f0500-69fd-11ea-8e88-43876b3e81f5.png">

5. Scroll up to the "Security" section, find the "Scan" card.
This is what you should see:

<img width="531" alt="Screen Shot 2020-03-19 at 4 21 41 PM" src="https://user-images.githubusercontent.com/1341249/77116315-fff35180-69fd-11ea-831b-d226a913ea6b.png">

**If you see this, the fix does not work:**
<img width="531" alt="Screen Shot 2020-03-19 at 4 05 57 PM" src="https://user-images.githubusercontent.com/1341249/77115284-0bde1400-69fc-11ea-9d38-30e1c1b82dd4.png">

<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Proposed changelog entry for your changes:
No entry needed.