### PR TITLE
Fix bug that prevented legacy full sync suite from running standalone

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -74,6 +74,7 @@
 			<exclude>tests/php/sync/test_class.jetpack-sync-full.php</exclude>
 		</testsuite>
 		<testsuite name="legacy-full-sync">
+			<file>tests/php/sync/test_class.jetpack-sync-base.php</file>
 			<file>tests/php/sync/test_class.jetpack-sync-full.php</file>
 		</testsuite>
 		<testsuite name="theme-tools">


### PR DESCRIPTION
There was an error, `Fatal error: Uncaught Error: Class 'WP_Test_Jetpack_Sync_Base' not found`

This fixes the error by including that class.