### PR TITLE
Pinterest Block: Check for valid URL before embedding

### DIFF
--- a/extensions/blocks/pinterest/edit.js
+++ b/extensions/blocks/pinterest/edit.js
@@ -14,8 +14,6 @@ import apiFetch from '@wordpress/api-fetch';
 import { fallback, pinType } from './utils';
 import { icon } from '.';
 
-const PINIT_URL_REGEX = /^\s*https?:\/\/pin\.it\//i;
-
 class PinterestEdit extends Component {
 	constructor() {
 		super( ...arguments );
@@ -24,10 +22,11 @@ class PinterestEdit extends Component {
 			editedUrl: this.props.attributes.url || '',
 			editingUrl: false,
 			// If this is a pin.it URL, we're going to need to find where it redirects to.
-			resolvingRedirect: PINIT_URL_REGEX.test( this.props.attributes.url ),
+			resolvingRedirect: false,
 			// The interactive-related magic comes from Core's EmbedPreview component,
 			// which currently isn't exported in a way we can use.
 			interactive: false,
+			resolvedStatusCode: null,
 		};
 	}
 
@@ -54,6 +53,8 @@ class PinterestEdit extends Component {
 	resolveRedirect = () => {
 		const { url } = this.props.attributes;
 
+		this.setState( { resolvedStatusCode: null } );
+
 		this.fetchRequest = apiFetch( {
 			path: `/wpcom/v2/resolve-redirect/${ url }`,
 		} );
@@ -62,10 +63,14 @@ class PinterestEdit extends Component {
 			response => {
 				// resolve
 				this.fetchRequest = null;
+				const resolvedUrl = response.url || url;
+				const resolvedStatusCode = response.status ? parseInt( response.status, 10 ) : null;
+
 				this.props.setAttributes( { url: response.url } );
 				this.setState( {
 					resolvingRedirect: false,
-					editedUrl: response.url,
+					resolvedStatusCode,
+					editedUrl: resolvedUrl,
 				} );
 			},
 			xhr => {
@@ -112,12 +117,18 @@ class PinterestEdit extends Component {
 		this.props.setAttributes( { url } );
 		this.setState( { editingUrl: false } );
 
-		if ( PINIT_URL_REGEX.test( url ) ) {
-			// Setting the `resolvingRedirect` state here, then waiting for `componentDidUpdate()` to
-			// be called before actually resolving it ensures that the `editedUrl` state has also been
-			// updated before resolveRedirect() is called.
-			this.setState( { resolvingRedirect: true } );
-		}
+		// Setting the `resolvingRedirect` state here, then waiting for `componentDidUpdate()` to
+		// be called before actually resolving it ensures that the `editedUrl` state has also been
+		// updated before resolveRedirect() is called.
+		this.setState( { resolvingRedirect: true } );
+	};
+
+	cannotEmbed = () => {
+		const { url } = this.props.attributes;
+		const { resolvedStatusCode } = this.state;
+		const type = pinType( url );
+
+		return ( url && ! type ) || ( resolvedStatusCode && resolvedStatusCode >= 400 );
 	};
 
 	/**
@@ -142,8 +153,6 @@ class PinterestEdit extends Component {
 		const type = pinType( url );
 		const html = `<a data-pin-do='${ type }' href='${ url }'></a>`;
 
-		const cannotEmbed = url && ! type;
-
 		const controls = (
 			<BlockControls>
 				<Toolbar>
@@ -157,10 +166,9 @@ class PinterestEdit extends Component {
 			</BlockControls>
 		);
 
-		if ( editingUrl || ! url || cannotEmbed ) {
+		if ( editingUrl || ! url || this.cannotEmbed() ) {
 			return (
 				<div className={ className }>
-					{ controls }
 					<Placeholder label={ __( 'Pinterest', 'jetpack' ) } icon={ <BlockIcon icon={ icon } /> }>
 						<form onSubmit={ this.setUrl }>
 							<input
@@ -174,7 +182,7 @@ class PinterestEdit extends Component {
 							<Button isLarge isSecondary type="submit">
 								{ _x( 'Embed', 'button label', 'jetpack' ) }
 							</Button>
-							{ cannotEmbed && (
+							{ this.cannotEmbed() && (
 								<p className="components-placeholder__error">
 									{ __( 'Sorry, this content could not be embedded.', 'jetpack' ) }
 									<br />


### PR DESCRIPTION
Fixes: #14157

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Check more than just pin.it URLs to make sure they resolve a valid URL before embedding.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a pinterest block
* Try to embed the URL `https://www.pinterest.co.uk/invalidurltest/`
* Make sure that an error is returned to say that the URL could not be embedded
* Check a valud URL like `https://www.pinterest.co.uk/apeatling/` and make sure the embed works (I don't have any pins).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed issue where invalid Pinterest URLs would be incorrectly embedded.
