### PR TITLE
Sync: add a 'sync_speed' to modules.

### DIFF
--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -758,8 +758,7 @@ class Actions {
 		}
 
 		$full_sync_status = ( $sync_module ) ? $sync_module->get_status() : array();
-
-		$full_queue = self::$sender->get_full_sync_queue();
+		$full_queue       = self::$sender->get_full_sync_queue();
 
 		$result = array_merge(
 			$full_sync_status,

--- a/packages/sync/src/modules/class-attachments.php
+++ b/packages/sync/src/modules/class-attachments.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Sync\Modules;
  * Class to handle sync for attachments.
  */
 class Attachments extends Module {
+
 	/**
 	 * Sync module name.
 	 *

--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -16,11 +16,11 @@ class Comments extends Module {
 	/**
 	 *  An estimate of how many rows per second can be synced during a full sync.
 	 *
-	 * @access public
+	 * @access static
 	 *
 	 * @var int|null Null if speed is not important in a full sync.
 	 */
-	public $sync_speed = 43;
+	static $sync_speed = 43;
 	/**
 	 * Sync module name.
 	 *
@@ -415,5 +415,16 @@ class Comments extends Module {
 			$this->get_metadata( $comment_ids, 'comment', Settings::get_setting( 'comment_meta_whitelist' ) ),
 			$previous_interval_end,
 		);
+	}
+
+	/**
+	 * Gets the sync speed of a module.
+	 *
+	 * @access public
+	 *
+	 * @return int
+	 */
+	public function get_sync_speed() {
+		return self::$sync_speed;
 	}
 }

--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -14,6 +14,14 @@ use Automattic\Jetpack\Sync\Settings;
  */
 class Comments extends Module {
 	/**
+	 *  An estimate of how many rows per second can be synced during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @var int|null Null if speed is not important in a full sync.
+	 */
+	public $sync_speed = 43;
+	/**
 	 * Sync module name.
 	 *
 	 * @access public

--- a/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/packages/sync/src/modules/class-full-sync-immediately.php
@@ -216,6 +216,7 @@ class Full_Sync_Immediately extends Module {
 				'total'    => $module->total( $config ),
 				'sent'     => 0,
 				'finished' => false,
+				'speed'    => $module->get_sync_speed(),
 			);
 		}
 

--- a/packages/sync/src/modules/class-module.php
+++ b/packages/sync/src/modules/class-module.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Sync\Listener;
 use Automattic\Jetpack\Sync\Replicastore;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Settings;
+use PHP_CodeSniffer\Standards\PSR12\Sniffs\Functions\NullableTypeDeclarationSniff;
 
 /**
  * Basic methods implemented by Jetpack Sync extensions.
@@ -26,6 +27,15 @@ abstract class Module {
 	 * @var int
 	 */
 	const ARRAY_CHUNK_SIZE = 10;
+
+	/**
+	 *  An estimate of how many rows per second can be synced during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @var int|null Null if speed is not important in a full sync.
+	 */
+	public $sync_speed = null;
 
 	/**
 	 * Sync module name.
@@ -276,11 +286,11 @@ abstract class Module {
 		global $wpdb;
 		return $wpdb->get_col(
 			<<<SQL
-SELECT {$this->id_field()} 
-FROM {$wpdb->{$this->table_name()}} 
+SELECT {$this->id_field()}
+FROM {$wpdb->{$this->table_name()}}
 WHERE {$this->get_where_sql( $config )}
 AND {$this->id_field()} < {$status['last_sent']}
-ORDER BY {$this->id_field()} 
+ORDER BY {$this->id_field()}
 DESC LIMIT {$chunk_size}
 SQL
 		);
@@ -579,4 +589,14 @@ SQL
 		return '1=1';
 	}
 
+	/**
+	 * Gets the sync speed of a module.
+	 *
+	 * @access public
+	 *
+	 * @return int|null
+	 */
+	public function get_sync_speed() {
+		return $this->sync_speed;
+	}
 }

--- a/packages/sync/src/modules/class-module.php
+++ b/packages/sync/src/modules/class-module.php
@@ -35,7 +35,7 @@ abstract class Module {
 	 *
 	 * @var int|null Null if speed is not important in a full sync.
 	 */
-	public $sync_speed = null;
+	static $sync_speed;
 
 	/**
 	 * Sync module name.
@@ -597,6 +597,6 @@ SQL
 	 * @return int|null
 	 */
 	public function get_sync_speed() {
-		return $this->sync_speed;
+		return null;
 	}
 }

--- a/packages/sync/src/modules/class-posts.php
+++ b/packages/sync/src/modules/class-posts.php
@@ -18,11 +18,11 @@ class Posts extends Module {
 	/**
 	 *  An estimate of how many rows per second can be synced during a full sync.
 	 *
-	 * @access public
+	 * @access static
 	 *
 	 * @var int|null Null if speed is not important in a full sync.
 	 */
-	public $sync_speed = 7;
+	static $sync_speed = 7;
 	/**
 	 * The post IDs of posts that were just published but not synced yet.
 	 *
@@ -675,5 +675,16 @@ class Posts extends Module {
 	 */
 	public function get_min_max_object_ids_for_batches( $batch_size, $where_sql = false ) {
 		return parent::get_min_max_object_ids_for_batches( $batch_size, $this->get_where_sql( $where_sql ) );
+	}
+
+	/**
+	 * Gets the sync speed of a module.
+	 *
+	 * @access public
+	 *
+	 * @return int
+	 */
+	public function get_sync_speed() {
+		return self::$sync_speed;
 	}
 }

--- a/packages/sync/src/modules/class-posts.php
+++ b/packages/sync/src/modules/class-posts.php
@@ -16,6 +16,14 @@ use Automattic\Jetpack\Sync\Settings;
  */
 class Posts extends Module {
 	/**
+	 *  An estimate of how many rows per second can be synced during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @var int|null Null if speed is not important in a full sync.
+	 */
+	public $sync_speed = 7;
+	/**
 	 * The post IDs of posts that were just published but not synced yet.
 	 *
 	 * @access private

--- a/packages/sync/src/modules/class-term-relationships.php
+++ b/packages/sync/src/modules/class-term-relationships.php
@@ -14,7 +14,14 @@ use Automattic\Jetpack\Sync\Settings;
  * Class to handle sync for term relationships.
  */
 class Term_Relationships extends Module {
-
+	/**
+	 *  An estimate of how many rows per second can be synced during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @var int|null Null if speed is not important in a full sync.
+	 */
+	public $sync_speed = 14;
 	/**
 	 * Max terms to return in one single query
 	 *
@@ -164,10 +171,10 @@ class Term_Relationships extends Module {
 
 		return $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT object_id, term_taxonomy_id 
-				FROM $wpdb->term_relationships 
-				WHERE ( object_id = %d AND term_taxonomy_id < %d ) OR ( object_id < %d ) 
-				ORDER BY object_id DESC, term_taxonomy_id 
+				"SELECT object_id, term_taxonomy_id
+				FROM $wpdb->term_relationships
+				WHERE ( object_id = %d AND term_taxonomy_id < %d ) OR ( object_id < %d )
+				ORDER BY object_id DESC, term_taxonomy_id
 				DESC LIMIT %d",
 				$status['last_sent']['object_id'],
 				$status['last_sent']['term_taxonomy_id'],

--- a/packages/sync/src/modules/class-term-relationships.php
+++ b/packages/sync/src/modules/class-term-relationships.php
@@ -17,11 +17,11 @@ class Term_Relationships extends Module {
 	/**
 	 *  An estimate of how many rows per second can be synced during a full sync.
 	 *
-	 * @access public
+	 * @access static
 	 *
 	 * @var int|null Null if speed is not important in a full sync.
 	 */
-	public $sync_speed = 14;
+	static $sync_speed = 14;
 	/**
 	 * Max terms to return in one single query
 	 *
@@ -247,5 +247,16 @@ class Term_Relationships extends Module {
 			'term_relationships' => $term_relationships,
 			'previous_end'       => $previous_end,
 		);
+	}
+
+	/**
+	 * Gets the sync speed of a module.
+	 *
+	 * @access public
+	 *
+	 * @return int
+	 */
+	public function get_sync_speed() {
+		return self::$sync_speed;
 	}
 }

--- a/packages/sync/src/modules/class-terms.php
+++ b/packages/sync/src/modules/class-terms.php
@@ -17,11 +17,11 @@ class Terms extends Module {
 	/**
 	 *  An estimate of how many rows per second can be synced during a full sync.
 	 *
-	 * @access public
+	 * @access static
 	 *
 	 * @var int|null Null if speed is not important in a full sync.
 	 */
-	public $sync_speed = 769;
+	static $sync_speed = 769;
 	/**
 	 * Sync module name.
 	 *
@@ -298,4 +298,14 @@ class Terms extends Module {
 		return get_term_by( 'term_taxonomy_id', $relationship->term_taxonomy_id );
 	}
 
+	/**
+	 * Gets the sync speed of a module.
+	 *
+	 * @access public
+	 *
+	 * @return int
+	 */
+	public function get_sync_speed() {
+		return self::$sync_speed;
+	}
 }

--- a/packages/sync/src/modules/class-terms.php
+++ b/packages/sync/src/modules/class-terms.php
@@ -14,7 +14,14 @@ use Automattic\Jetpack\Sync\Settings;
  * Class to handle sync for terms.
  */
 class Terms extends Module {
-
+	/**
+	 *  An estimate of how many rows per second can be synced during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @var int|null Null if speed is not important in a full sync.
+	 */
+	public $sync_speed = 769;
 	/**
 	 * Sync module name.
 	 *

--- a/packages/sync/src/modules/class-users.php
+++ b/packages/sync/src/modules/class-users.php
@@ -15,6 +15,14 @@ use Automattic\Jetpack\Sync\Defaults;
  */
 class Users extends Module {
 	/**
+	 *  An estimate of how many rows per second can be synced during a full sync.
+	 *
+	 * @access public
+	 *
+	 * @var int|null Null if speed is not important in a full sync.
+	 */
+	public $sync_speed = 50;
+	/**
 	 * Maximum number of users to sync initially.
 	 *
 	 * @var int

--- a/packages/sync/src/modules/class-users.php
+++ b/packages/sync/src/modules/class-users.php
@@ -17,11 +17,11 @@ class Users extends Module {
 	/**
 	 *  An estimate of how many rows per second can be synced during a full sync.
 	 *
-	 * @access public
+	 * @access static
 	 *
 	 * @var int|null Null if speed is not important in a full sync.
 	 */
-	public $sync_speed = 50;
+	static $sync_speed = 50;
 	/**
 	 * Maximum number of users to sync initially.
 	 *
@@ -869,5 +869,16 @@ class Users extends Module {
 			}
 		}
 		return false;
+	}
+	
+	/**
+	 * Gets the sync speed of a module.
+	 *
+	 * @access public
+	 *
+	 * @return int
+	 */
+	public function get_sync_speed() {
+		return self::$sync_speed;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds new `speed` property that determines how quickly ( rows / second )  modules can
sync during a full sync.
* `speed` will eventually be used to calculate the duration of a full sync.
* `speed` defaults to `null` meaning its timing is not required to calculate the duration of a full sync.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a new feature.
* For designs for the eventual duration design, see: p6TEKc-3st-p2 
* For a conversation on how speed is calculated, see: p9dueE-1iF-p2

#### Testing instructions:
* Get this PR running on a local docker site or on jurassic.ninja with pre-populated content
* Start a full sync for the site
* In a shell on the site run `wp jetpack sync status` ( or `yarn docker:wp jetpack sync status` on docker )
* You should see a speed property in the `progress` output.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
