### PR TITLE
E2E tests: update tests according to upstream changes

### DIFF
--- a/tests/e2e/lib/pages/wpcom/login.js
+++ b/tests/e2e/lib/pages/wpcom/login.js
@@ -45,7 +45,7 @@ export default class LoginPage extends Page {
 	}
 
 	async isLoggedIn() {
-		const publishSelector = '#header .masterbar__publish';
-		return await isEventuallyVisible( this.page, publishSelector, 4000 );
+		const continueAsUserSelector = '#content .continue-as-user';
+		return await isEventuallyVisible( this.page, continueAsUserSelector, 4000 );
 	}
 }

--- a/tests/e2e/specs/connection.test.js
+++ b/tests/e2e/specs/connection.test.js
@@ -7,9 +7,10 @@ import PluginsPage from '../lib/pages/wp-admin/plugins';
 import DashboardPage from '../lib/pages/wp-admin/dashboard';
 import JetpackPage from '../lib/pages/wp-admin/jetpack';
 import { resetWordpressInstall, getNgrokSiteUrl } from '../lib/utils-helper';
+import { catchBeforeAll } from '../lib/jest.test.failure';
 
 describe( 'Jetpack connection', () => {
-	beforeAll( async () => {
+	catchBeforeAll( async () => {
 		await resetWordpressInstall();
 		const url = getNgrokSiteUrl();
 		await ( await WPLoginPage.visit( page, url + '/wp-login.php' ) ).login();

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -7,9 +7,10 @@ import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
 import { resetWordpressInstall, getNgrokSiteUrl } from '../lib/utils-helper';
 import PinterestBlock from '../lib/blocks/pinterest';
 import EventbriteBlock from '../lib/blocks/eventbrite';
+import { catchBeforeAll } from '../lib/jest.test.failure';
 
 describe( 'Free blocks', () => {
-	beforeAll( async () => {
+	catchBeforeAll( async () => {
 		await resetWordpressInstall();
 		const url = getNgrokSiteUrl();
 		console.log( 'NEW SITE URL: ' + url );


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/40125 introduced a new design for logged-in `log-in` screen. This PR updates the old locator to use a new one. 
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* use `catchBeforeAll` instead of `beforeAll` in all tests
* update locator for `isLogedIn` method

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Tests should be green 🥗 
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
