### PR TITLE
Recurring Payments: do not display Product panel when no products

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -382,7 +382,7 @@ class MembershipsButtonEdit extends Component {
 						label={ __( 'Payment plan', 'jetpack' ) }
 						value={ this.props.attributes.planId }
 						onChange={ this.setMembershipAmount }
-						options={ this.state.products.map( product => ( {
+						options={ products.map( product => ( {
 							label: this.renderAmount( product ),
 							value: product.id,
 							key: product.id,
@@ -476,7 +476,7 @@ class MembershipsButtonEdit extends Component {
 							</Placeholder>
 						</div>
 					) }
-				{ this.state.products && inspectorControls }
+				{ products.length > 0 && inspectorControls }
 				{ ( ( ( this.hasUpgradeNudge || ! this.state.shouldUpgrade ) &&
 					connected !== API_STATE_LOADING ) ||
 					this.props.attributes.planId ) && (


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Do not display the Product side panel until we have created at least one product.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This was suggested in p58i-8JL-p2

#### Testing instructions:

* start with a new site with a Premium Plan.
* go to Posts > Add new and add a new Recurring Payments block
* Note that there is no "Product" side panel in the block sidebar.
* Connect your site to Stripe, head back to your post editor.
* There should still be no product side panel.
* Create a new product
* The panel should now appear.

#### Proposed changelog entry for your changes:

* N/A
