### PR TITLE
Renovate config: group React and WordPress monorepos

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,16 @@
 	"timezone": "UTC",
 	"schedule": [ "every weekend" ],
 	"updateNotScheduled": false,
-	"ignoreDeps": [ "mockery/mockery", "php-mock/php-mock", "phpunit/phpunit" ]
+	"ignoreDeps": [ "mockery/mockery", "php-mock/php-mock", "phpunit/phpunit" ],
+	"packageRules": [
+		{
+			"extends": "monorepo:wordpress",
+			"separateMajorMinor": false,
+			"prPriority": 1
+		},
+		{
+			"depTypeList": [ "monorepo:wordpress", "monorepo:react" ],
+			"groupName": "React and WordPress monorepos"
+		}
+	]
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Let's try to group updates for those 2 monorepos together, as they rely on each other to remain at a matching version.
See https://github.com/Automattic/jetpack/pull/15059#issuecomment-601641849

I am not quite sure about the syntax to use in the Renovate config file though:
https://docs.renovatebot.com/configuration-options/#groupname

#### Testing instructions:

* Not sure how to test yet.

#### Proposed changelog entry for your changes:

* N/A
