### PR TITLE
Docs: add instructions to enable beta blocks on JN sites

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -57,7 +57,7 @@ Generally, all new extensions should start out as a beta.
 - In the `wp-config.php` for your Docker environment (`docker/wordpress/wp-config.php`) or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
 - When you use this constant, you'll get all blocks: Beta blocks, Experimental blocks, and Production blocks.
 - In the WordPress.com environment, Automatticians will be able to see beta extensions with no further configuration
-- In a Jurassic Ninja site, you must go to Settings > Jetpack Constants, and enable the `JETPACK_BETA_BLOCKS` there.
+- In a Jurassic Ninja site, you must go to Settings > Jetpack Constants, and enable the `JETPACK_BETA_BLOCKS` option there.
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -57,6 +57,7 @@ Generally, all new extensions should start out as a beta.
 - In the `wp-config.php` for your Docker environment (`docker/wordpress/wp-config.php`) or in your custom mu-plugins file (`docker/mu-plugins/yourfile.php`), enable beta extensions with the following snippet: `define( 'JETPACK_BETA_BLOCKS', true );`
 - When you use this constant, you'll get all blocks: Beta blocks, Experimental blocks, and Production blocks.
 - In the WordPress.com environment, Automatticians will be able to see beta extensions with no further configuration
+- In a Jurassic Ninja site, you must go to Settings > Jetpack Constants, and enable the `JETPACK_BETA_BLOCKS` there.
 - Once you've successfully beta tested your new extension, you can open new PR to make your extension live!
 - Simply move the extension's slug out of the beta array and into the production array in `extensions/index.json`.
 


### PR DESCRIPTION
Adds instructions on how to enable Beta blocks in a Jurassic Ninja site.

#### Changes proposed in this Pull Request:

* Changes the README for extensions, adding instructions on how to enable Beta blocks in a Jurassic Ninja site.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No, just documentation 

#### Testing instructions:

* Check if the instructions are correct and that it should be there
