### PR TITLE
REST API: Add site checklist completeness status

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -140,7 +140,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_goals',
 		'site_segment',
 		'import_engine',
-		'is_checklist_complete',
+		'is_site_setup_complete',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -168,7 +168,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// and defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site.
 		// See https://github.com/Automattic/jetpack/blob/58638f46094b36f5df9cbc4570006544f0ad300c/sal/class.json-api-site-base.php#L387.
 		'created_at',
-		'is_checklist_complete',
+		'is_site_setup_complete',
 	);
 
 	private $site;
@@ -620,8 +620,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'import_engine':
 					$options[ $key ] = $site->get_import_engine();
 					break;
-				case 'is_checklist_complete':
-					$options[ $key ] = $site->is_checklist_complete();
+				case 'is_site_setup_complete':
+					$options[ $key ] = $site->is_site_setup_complete();
 					break;
 			}
 		}

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -140,7 +140,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_goals',
 		'site_segment',
 		'import_engine',
-		'is_site_setup_complete',
+		'is_wpcom_site_setup_complete',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -168,7 +168,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// and defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site.
 		// See https://github.com/Automattic/jetpack/blob/58638f46094b36f5df9cbc4570006544f0ad300c/sal/class.json-api-site-base.php#L387.
 		'created_at',
-		'is_site_setup_complete',
 	);
 
 	private $site;
@@ -620,8 +619,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'import_engine':
 					$options[ $key ] = $site->get_import_engine();
 					break;
-				case 'is_site_setup_complete':
-					$options[ $key ] = $site->is_site_setup_complete();
+				case 'is_wpcom_site_setup_complete':
+					$options[ $key ] = $site->is_wpcom_site_setup_complete();
 					break;
 			}
 		}

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -140,6 +140,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_goals',
 		'site_segment',
 		'import_engine',
+		'is_checklist_complete',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -167,6 +168,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// and defaults to `0000-00-00T00:00:00+00:00` from the Jetpack site.
 		// See https://github.com/Automattic/jetpack/blob/58638f46094b36f5df9cbc4570006544f0ad300c/sal/class.json-api-site-base.php#L387.
 		'created_at',
+		'is_checklist_complete',
 	);
 
 	private $site;
@@ -617,6 +619,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 				case 'import_engine':
 					$options[ $key ] = $site->get_import_engine();
+					break;
+				case 'is_checklist_complete':
+					$options[ $key ] = $site->is_checklist_complete();
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -664,7 +664,7 @@ abstract class SAL_Site {
 	 *
 	 * @return bool Whether the checklist is complete.
 	 */
-	public function is_site_setup_complete() {
+	public function is_wpcom_site_setup_complete() {
 		return null;
 	}
 }

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -664,7 +664,7 @@ abstract class SAL_Site {
 	 *
 	 * @return bool Whether the checklist is complete.
 	 */
-	public function is_checklist_complete() {
+	public function is_site_setup_complete() {
 		return null;
 	}
 }

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -658,4 +658,13 @@ abstract class SAL_Site {
 	function get_site_segment() {
 		return false;
 	}
+
+	/**
+	 * Determines if the site setup checklist has been completed.
+	 *
+	 * @return bool Whether the checklist is complete.
+	 */
+	public function is_checklist_complete() {
+		return null;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Adds a new option to the site API response indicating if all the checklist tasks provided during onboarding have been completed.

<img width="1171" alt="Screen Shot 2020-03-24 at 15 09 41" src="https://user-images.githubusercontent.com/1233880/77435580-c26a3c00-6de2-11ea-9301-bced4eb37756.png">

This is the counterpart PR of D40618-code.

### Is this a new feature or does it add/remove features to an existing part of Jetpack?
We'd like to render an activity dot in the "My Home" section on the Calypso's sidebar in order to let users know if there is any uncompleted task. Exposing a new flag in the API helps with that goal.
Further reading: pbAPfg-aQ-p2

### Testing instructions:
- Apply this diff and sandbox the API.

**Simple sites**
- Pick a Simple site with the site setup checklist uncomplete (i.e. a brand new site).
- As blog owner, make a `GET` request to `https://public-api.wordpress.com/rest/v1.1/sites/:site?fields=ID,name,URL,options&options=is_wpcom_checklist_complete`.
- Verify the response includes a `is_wpcom_checklist_complete` property under the `options` field.
- Make sure the value is set to `false`.
- Complete the checklist (in `wordpress.com/home/:site`) and repeat the API request.
- Make sure the value is now `true`.

**Jetpack sites**
- [Spin up a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=add/rest-site-checklist-complete).
- Set up Jetpack.
- As blog owner, make a `GET` request to `https://public-api.wordpress.com/rest/v1.1/sites/:site?fields=ID,name,URL,options&options=is_wpcom_checklist_complete`.
- Verify the response includes a `is_wpcom_checklist_complete` property under the `options` field.
- Make sure the value is set to `null` (since Calypso doesn't support the WP.com site setup checklist for Jetpack sites).

**Atomic sites**
- Pick a Simple site with the site setup checklist uncomplete (i.e. a brand new site).
- Transfer it to Atomic by installing a plugin.
- Install the Jetpack beta plugin and activate the `add/rest-site-checklist-complete` branch.
- As blog owner, make a `GET` request to `https://public-api.wordpress.com/rest/v1.1/sites/:site?fields=ID,name,URL,options&options=is_wpcom_checklist_complete`.
- Verify the response includes a `is_wpcom_checklist_complete` property under the `options` field.
- Make sure the value is set to `false`.
- Calypso currently does not support the site setup checklist for Atomic sites, so `is_wpcom_checklist_complete` will remain always false (unless it was completed before transferring to Atomic).

### Proposed changelog entry for your changes:
N/A
