### PR TITLE
E2E tests: fix WPCOM login flakiness

### DIFF
--- a/tests/e2e/lib/pages/wpcom/login.js
+++ b/tests/e2e/lib/pages/wpcom/login.js
@@ -29,12 +29,11 @@ export default class LoginPage extends Page {
 		await waitAndClick( this.page, continueButtonSelector );
 
 		// sometimes it failing to type the whole password correctly. Trying to wait for the transition to happen
-		this.page.waitFor( 2000 );
+		this.page.waitFor( 1000 );
 		await waitAndType( this.page, passwordSelector, password );
-		this.page.waitFor( 2000 );
+		this.page.waitFor( 1000 );
 
 		await waitAndType( this.page, passwordSelector, password );
-		// await waitAndClick( this.page, submitButtonSelector );
 
 		const submitButton = await waitForSelector( this.page, submitButtonSelector );
 		await submitButton.press( 'Enter' );
@@ -46,6 +45,7 @@ export default class LoginPage extends Page {
 			} );
 		} catch ( e ) {
 			if ( retry === true ) {
+				console.log( `The login didn't work as expected - retrying now: '${ e }'` );
 				return await this.login( wpcomUser, { retry: false } );
 			}
 			throw e;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Attempt to address flakiness in WPCOM login by trying use 'Enter' to submit the form, and to add a way to retry login on failure 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Not much to test. tests should be green
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
