### PR TITLE
Blocks: update all blocks to use namespaces and constants for consistency

### DIFF
--- a/extensions/blocks/amazon/amazon.php
+++ b/extensions/blocks/amazon/amazon.php
@@ -7,10 +7,25 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/amazon',
-	array( 'render_callback' => 'jetpack_amazon_block_load_assets' )
-);
+namespace Automattic\Jetpack\Amazon_Block;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'amazon';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Amazon block registration/dependency declaration.
@@ -20,7 +35,7 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_amazon_block_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'amazon' );
+function load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	return $content;
 }

--- a/extensions/blocks/amazon/amazon.php
+++ b/extensions/blocks/amazon/amazon.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Amazon_Block;
+namespace Automattic\Jetpack\Extensions\Amazon;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Business_Hours_Block;
+namespace Automattic\Jetpack\Extensions\Business_Hours;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/business-hours/business-hours.php
+++ b/extensions/blocks/business-hours/business-hours.php
@@ -7,17 +7,32 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/business-hours',
-	array( 'render_callback' => 'jetpack_business_hours_render' )
-);
+namespace Automattic\Jetpack\Business_Hours_Block;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'business-hours';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\render' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Get's default days / hours to render a business hour block with no data provided.
  *
  * @return array
  */
-function jetpack_business_hours_get_default_days() {
+function get_default_days() {
 	return array(
 		array(
 			'name'  => 'Sun',
@@ -82,11 +97,11 @@ function jetpack_business_hours_get_default_days() {
  *
  * @return string
  */
-function jetpack_business_hours_render( $attributes ) {
+function render( $attributes ) {
 	global $wp_locale;
 
 	if ( empty( $attributes['days'] ) || ! is_array( $attributes['days'] ) ) {
-		$attributes['days'] = jetpack_business_hours_get_default_days();
+		$attributes['days'] = get_default_days();
 	}
 
 	$start_of_week = (int) get_option( 'start_of_week', 0 );
@@ -119,8 +134,8 @@ function jetpack_business_hours_render( $attributes ) {
 			}
 			$days_hours .= sprintf(
 				'%1$s - %2$s',
-				date( $time_format, $opening ),
-				date( $time_format, $closing )
+				gmdate( $time_format, $opening ),
+				gmdate( $time_format, $closing )
 			);
 			if ( $key + 1 < count( $day['hours'] ) ) {
 				$days_hours .= ', ';
@@ -136,7 +151,7 @@ function jetpack_business_hours_render( $attributes ) {
 
 	$content .= '</dl>';
 
-	Jetpack_Gutenberg::load_assets_as_required( 'business-hours' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	/**
 	 * Allows folks to filter the HTML content for the Business Hours block

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -7,7 +7,9 @@
  * @package Jetpack
  */
 
-namespace Jetpack\Calendly_Block;
+namespace Automattic\Jetpack\Calendly_Block;
+
+use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'calendly';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -44,11 +46,11 @@ function register_block() {
 	if ( is_available() ) {
 		jetpack_register_block(
 			BLOCK_NAME,
-			array( 'render_callback' => 'Jetpack\Calendly_Block\load_assets' )
+			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 		);
 	}
 }
-add_action( 'init', 'Jetpack\Calendly_Block\register_block' );
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Set the availability of the block as the editor
@@ -56,9 +58,9 @@ add_action( 'init', 'Jetpack\Calendly_Block\register_block' );
  */
 function set_availability() {
 	if ( is_available() ) {
-		\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
+		Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
 	} else {
-		\Jetpack_Gutenberg::set_extension_unavailable(
+		Jetpack_Gutenberg::set_extension_unavailable(
 			BLOCK_NAME,
 			'missing_plan',
 			array(
@@ -68,7 +70,7 @@ function set_availability() {
 		);
 	}
 }
-add_action( 'init', 'Jetpack\Calendly_Block\set_availability' );
+add_action( 'init', __NAMESPACE__ . '\set_availability' );
 
 /**
  * Calendly block registration/dependency declaration.
@@ -82,7 +84,7 @@ function load_assets( $attr, $content ) {
 	if ( is_admin() ) {
 		return;
 	}
-	$url = \Jetpack_Gutenberg::validate_block_embed_url(
+	$url = Jetpack_Gutenberg::validate_block_embed_url(
 		get_attribute( $attr, 'url' ),
 		array( 'calendly.com' )
 	);
@@ -93,7 +95,7 @@ function load_assets( $attr, $content ) {
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
-	\Jetpack_Gutenberg::load_assets_as_required( 'calendly' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	wp_enqueue_script(
 		'jetpack-calendly-external-js',
 		'https://assets.calendly.com/assets/external/widget.js',
@@ -111,7 +113,7 @@ function load_assets( $attr, $content ) {
 	$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
 	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
 	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
-	$classes                        = \Jetpack_Gutenberg::block_classes( 'calendly', $attr, array( 'calendly-style-' . $style ) );
+	$classes                        = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, array( 'calendly-style-' . $style ) );
 	$block_id                       = wp_unique_id( 'calendly-block-' );
 
 	$url = add_query_arg(

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Calendly_Block;
+namespace Automattic\Jetpack\Extensions\Calendly;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -66,7 +66,7 @@ function render_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
-		$classes = \Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+		$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
 
 		$content .= sprintf(
 			'<div id="%1$s" class="%2$s"></div>',

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Eventbrite_Block;
+namespace Automattic\Jetpack\Extensions\Eventbrite;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -7,12 +7,25 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/eventbrite',
-	array(
-		'render_callback' => 'jetpack_render_eventbrite_block',
-	)
-);
+namespace Automattic\Jetpack\Eventbrite_Block;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'eventbrite';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Eventbrite block registration/dependency delclaration.
@@ -22,7 +35,7 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_render_eventbrite_block( $attr, $content ) {
+function render_block( $attr, $content ) {
 	if ( is_admin() || empty( $attr['eventId'] ) || empty( $attr['url'] ) ) {
 		return '';
 	}
@@ -38,7 +51,7 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 	wp_enqueue_script( 'eventbrite-widget', 'https://www.eventbrite.com/static/widgets/eb_widgets.js', array(), JETPACK__VERSION, true );
 
 	// Add CSS to hide direct link.
-	Jetpack_Gutenberg::load_assets_as_required( 'eventbrite' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	// Show the embedded version.
 	if ( empty( $attr['useModal'] ) ) {
@@ -53,7 +66,7 @@ function jetpack_render_eventbrite_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
-		$classes = \Jetpack_Gutenberg::block_classes( 'eventbrite', $attr );
+		$classes = \Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
 
 		$content .= sprintf(
 			'<div id="%1$s" class="%2$s"></div>',

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Gif_Block;
+namespace Automattic\Jetpack\Extensions\Gif;
 
 use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;

--- a/extensions/blocks/gif/gif.php
+++ b/extensions/blocks/gif/gif.php
@@ -7,12 +7,26 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/gif',
-	array(
-		'render_callback' => 'jetpack_gif_block_render',
-	)
-);
+namespace Automattic\Jetpack\Gif_Block;
+
+use Jetpack_AMP_Support;
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'gif';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Gif block registration/dependency declaration.
@@ -21,7 +35,7 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_gif_block_render( $attr ) {
+function render_block( $attr ) {
 	$padding_top = isset( $attr['paddingTop'] ) ? $attr['paddingTop'] : 0;
 	$style       = 'padding-top:' . $padding_top;
 	$giphy_url   = isset( $attr['giphyUrl'] )
@@ -34,7 +48,7 @@ function jetpack_gif_block_render( $attr ) {
 		return null;
 	}
 
-	$classes = Jetpack_Gutenberg::block_classes( 'gif', $attr );
+	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
 
 	$placeholder = sprintf( '<a href="%s">%s</a>', esc_url( $giphy_url ), esc_attr( $search_text ) );
 
@@ -61,7 +75,7 @@ function jetpack_gif_block_render( $attr ) {
 	<?php
 	$html = ob_get_clean();
 
-	Jetpack_Gutenberg::load_assets_as_required( 'gif' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	return $html;
 }

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Google_Calendar_Block;
+namespace Automattic\Jetpack\Extensions\Google_Calendar;
 
 use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -7,7 +7,10 @@
  * @package Jetpack
  */
 
-namespace Jetpack\Google_Calendar_Block;
+namespace Automattic\Jetpack\Google_Calendar_Block;
+
+use Jetpack_AMP_Support;
+use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'google-calendar';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -21,12 +24,11 @@ function register_block() {
 	jetpack_register_block(
 		BLOCK_NAME,
 		array(
-			'render_callback' => 'Jetpack\Google_Calendar_Block\load_assets',
+			'render_callback' => __NAMESPACE__ . '\load_assets',
 		)
 	);
 }
-
-add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Google Calendar block registration/dependency declaration.
@@ -37,17 +39,17 @@ add_action( 'init', 'Jetpack\Google_Calendar_Block\register_block' );
 function load_assets( $attr ) {
 	$height  = isset( $attr['height'] ) ? $attr['height'] : '600';
 	$url     = isset( $attr['url'] )
-		? \Jetpack_Gutenberg::validate_block_embed_url( $attr['url'], array( 'calendar.google.com' ) ) :
+		? Jetpack_Gutenberg::validate_block_embed_url( $attr['url'], array( 'calendar.google.com' ) ) :
 		'';
-	$classes = \Jetpack_Gutenberg::block_classes( 'google-calendar', $attr );
+	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
 
-	\Jetpack_Gutenberg::load_assets_as_required( 'google-calendar' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	if ( empty( $url ) ) {
 		return;
 	}
 
-	if ( class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request() ) {
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		return sprintf(
 			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
 			esc_attr( $classes ),

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -7,4 +7,17 @@
  * @package Jetpack
  */
 
-jetpack_register_block( 'jetpack/instagram-gallery' );
+namespace Automattic\Jetpack\Instagram_Block;
+
+const FEATURE_NAME = 'instagram-gallery';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block( BLOCK_NAME );
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Instagram_Block;
+namespace Automattic\Jetpack\Extensions\Instagram_Gallery;
 
 const FEATURE_NAME = 'instagram-gallery';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Mailchimp_Block;
+namespace Automattic\Jetpack\Extensions\Mailchimp;
 
 use Jetpack;
 use Jetpack_AMP_Support;

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -7,14 +7,35 @@
  * @package Jetpack
  */
 
-if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
-	jetpack_register_block(
-		'jetpack/mailchimp',
-		array(
-			'render_callback' => 'jetpack_mailchimp_block_load_assets',
-		)
-	);
+namespace Automattic\Jetpack\Mailchimp_Block;
+
+use Jetpack;
+use Jetpack_AMP_Support;
+use Jetpack_Gutenberg;
+use Jetpack_Options;
+
+const FEATURE_NAME = 'mailchimp';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	if (
+		( defined( 'IS_WPCOM' ) && IS_WPCOM )
+		|| Jetpack::is_active()
+	) {
+		jetpack_register_block(
+			BLOCK_NAME,
+			array(
+				'render_callback' => __NAMESPACE__ . '\load_assets',
+			)
+		);
+	}
 }
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Mailchimp block registration/dependency declaration.
@@ -23,9 +44,9 @@ if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
  *
  * @return string
  */
-function jetpack_mailchimp_block_load_assets( $attr ) {
+function load_assets( $attr ) {
 
-	if ( ! jetpack_mailchimp_verify_connection() ) {
+	if ( ! verify_connection() ) {
 		return null;
 	}
 
@@ -33,7 +54,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 	$blog_id = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
 		? get_current_blog_id()
 		: Jetpack_Options::get_option( 'id' );
-	Jetpack_Gutenberg::load_assets_as_required( 'mailchimp' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	$defaults = array(
 		'emailPlaceholder' => esc_html__( 'Enter your email', 'jetpack' ),
 		'submitButtonText' => esc_html__( 'Join my email list', 'jetpack' ),
@@ -51,7 +72,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
 
 	$values['submitButtonText'] = empty( $values['submitButtonText'] ) ? $defaults['submitButtonText'] : $values['submitButtonText'];
 
-	$classes = Jetpack_Gutenberg::block_classes( 'mailchimp', $attr );
+	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
 
 	$button_styles = array();
 	if ( ! empty( $attr['customBackgroundButtonColor'] ) ) {
@@ -190,7 +211,7 @@ function jetpack_mailchimp_block_load_assets( $attr ) {
  *
  * @return boolean
  */
-function jetpack_mailchimp_verify_connection() {
+function verify_connection() {
 	$option = get_option( 'jetpack_mailchimp' );
 	if ( ! $option ) {
 		return false;

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Map_Block;
+namespace Automattic\Jetpack\Extensions\Map;
 
 use Automattic\Jetpack\Tracking;
 use Jetpack;

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -7,23 +7,43 @@
  * @package Jetpack
  */
 
+namespace Automattic\Jetpack\Map_Block;
+
+use Automattic\Jetpack\Tracking;
+use Jetpack;
+use Jetpack_AMP_Support;
+use Jetpack_Gutenberg;
+use Jetpack_Mapbox_Helper;
+use Jetpack_Options;
+
+const FEATURE_NAME = 'map';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
 if ( ! class_exists( 'Jetpack_Mapbox_Helper' ) ) {
-	jetpack_require_lib( 'class-jetpack-mapbox-helper' );
+	\jetpack_require_lib( 'class-jetpack-mapbox-helper' );
 }
 
-jetpack_register_block(
-	'jetpack/map',
-	array(
-		'render_callback' => 'jetpack_map_block_load_assets',
-	)
-);
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\load_assets',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Record a Tracks event every time the Map block is loaded on WordPress.com and Atomic.
  *
  * @param string $access_token_source The Mapbox API access token source.
  */
-function jetpack_record_mapbox_wpcom_load_event( $access_token_source ) {
+function wpcom_load_event( $access_token_source ) {
 	if ( 'wpcom' !== $access_token_source ) {
 		return;
 	}
@@ -33,7 +53,7 @@ function jetpack_record_mapbox_wpcom_load_event( $access_token_source ) {
 		require_lib( 'tracks/client' );
 		tracks_record_event( wp_get_current_user(), $event_name );
 	} elseif ( jetpack_is_atomic_site() && Jetpack::is_active() ) {
-		$tracking = new Automattic\Jetpack\Tracking();
+		$tracking = new Tracking();
 		$tracking->record_user_event( $event_name );
 	}
 }
@@ -46,10 +66,10 @@ function jetpack_record_mapbox_wpcom_load_event( $access_token_source ) {
  *
  * @return string
  */
-function jetpack_map_block_load_assets( $attr, $content ) {
+function load_assets( $attr, $content ) {
 	$access_token = Jetpack_Mapbox_Helper::get_access_token();
 
-	jetpack_record_mapbox_wpcom_load_event( $access_token['source'] );
+	wpcom_load_event( $access_token['source'] );
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		static $map_block_counter = array();
@@ -79,7 +99,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 		);
 	}
 
-	Jetpack_Gutenberg::load_assets_as_required( 'map' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	return preg_replace( '/<div /', '<div data-api-key="' . esc_attr( $access_token['key'] ) . '" ', $content, 1 );
 }
@@ -87,7 +107,7 @@ function jetpack_map_block_load_assets( $attr, $content ) {
 /**
  * Render a page containing only a single Map block.
  */
-function jetpack_map_block_render_single_block_page() {
+function render_single_block_page() {
 	// phpcs:ignore WordPress.Security.NonceVerification
 	$map_block_counter = isset( $_GET, $_GET['map-block-counter'] ) ? absint( $_GET['map-block-counter'] ) : null;
 	// phpcs:ignore WordPress.Security.NonceVerification
@@ -104,7 +124,7 @@ function jetpack_map_block_render_single_block_page() {
 		return;
 	}
 
-	$post_html = new DOMDocument();
+	$post_html = new \DOMDocument();
 	/** This filter is already documented in core/wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', $post->post_content );
 
@@ -113,7 +133,7 @@ function jetpack_map_block_render_single_block_page() {
 	@$post_html->loadHTML( $content ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 	libxml_use_internal_errors( false );
 
-	$xpath     = new DOMXPath( $post_html );
+	$xpath     = new \DOMXPath( $post_html );
 	$container = $xpath->query( '//div[ contains( @class, "wp-block-jetpack-map" ) ]' )->item( $map_block_counter - 1 );
 
 	/* Check that we have a block matching the counter position */
@@ -126,7 +146,7 @@ function jetpack_map_block_render_single_block_page() {
 
 	add_filter( 'jetpack_is_amp_request', '__return_false' );
 
-	Jetpack_Gutenberg::load_assets_as_required( 'map' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	wp_scripts()->do_items();
 	wp_styles()->do_items();
 
@@ -145,5 +165,4 @@ function jetpack_map_block_render_single_block_page() {
 	echo $page_html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	exit;
 }
-
-add_action( 'wp', 'jetpack_map_block_render_single_block_page' );
+add_action( 'wp', __NAMESPACE__ . '\render_single_block_page' );

--- a/extensions/blocks/markdown/markdown.php
+++ b/extensions/blocks/markdown/markdown.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Jetpack\Markdown_Block;
+namespace Automattic\Jetpack\Extensions\Markdown;
 
 const FEATURE_NAME = 'markdown';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;

--- a/extensions/blocks/markdown/markdown.php
+++ b/extensions/blocks/markdown/markdown.php
@@ -7,4 +7,17 @@
  * @package Jetpack
  */
 
-jetpack_register_block( 'jetpack/markdown' );
+namespace Jetpack\Markdown_Block;
+
+const FEATURE_NAME = 'markdown';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block( BLOCK_NAME );
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Jetpack\OpenTable_Block;
+namespace Automattic\Jetpack\Extensions\OpenTable;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -9,6 +9,8 @@
 
 namespace Jetpack\OpenTable_Block;
 
+use Jetpack_Gutenberg;
+
 const FEATURE_NAME = 'opentable';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
 
@@ -44,11 +46,11 @@ function register_block() {
 	if ( is_available() ) {
 		jetpack_register_block(
 			BLOCK_NAME,
-			array( 'render_callback' => 'Jetpack\OpenTable_Block\load_assets' )
+			array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
 		);
 	}
 }
-add_action( 'init', 'Jetpack\OpenTable_Block\register_block' );
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Set the availability of the block as the editor
@@ -56,9 +58,9 @@ add_action( 'init', 'Jetpack\OpenTable_Block\register_block' );
  */
 function set_availability() {
 	if ( is_available() ) {
-		\Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
+		Jetpack_Gutenberg::set_extension_available( BLOCK_NAME );
 	} else {
-		\Jetpack_Gutenberg::set_extension_unavailable(
+		Jetpack_Gutenberg::set_extension_unavailable(
 			BLOCK_NAME,
 			'missing_plan',
 			array(
@@ -68,7 +70,7 @@ function set_availability() {
 		);
 	}
 }
-add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\set_availability' );
+add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\set_availability' );
 
 /**
  * Adds an inline script which updates the block editor settings to
@@ -79,7 +81,7 @@ add_action( 'jetpack_register_gutenberg_extensions', 'Jetpack\OpenTable_Block\se
 function add_language_setting() {
 	wp_add_inline_script( 'jetpack-blocks-editor', sprintf( "wp.data.dispatch( 'core/block-editor' ).updateSettings( { siteLocale: '%s' } )", str_replace( '_', '-', get_locale() ) ), 'before' );
 }
-add_action( 'enqueue_block_assets', 'Jetpack\OpenTable_Block\add_language_setting' );
+add_action( 'enqueue_block_assets', __NAMESPACE__ . '\add_language_setting' );
 
 /**
  * OpenTable block registration/dependency declaration.
@@ -89,13 +91,13 @@ add_action( 'enqueue_block_assets', 'Jetpack\OpenTable_Block\add_language_settin
  * @return string
  */
 function load_assets( $attributes ) {
-	\Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	$classes = array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) );
 	if ( count( $attributes['rid'] ) > 1 ) {
 		$classes[] = 'is-multi';
 	}
-	$classes = \Jetpack_Gutenberg::block_classes(
+	$classes = Jetpack_Gutenberg::block_classes(
 		FEATURE_NAME,
 		$attributes,
 		$classes

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -7,10 +7,23 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/pinterest',
-	array( 'render_callback' => 'jetpack_pinterest_block_load_assets' )
-);
+namespace Automattic\Jetpack\Pinterest_Block;
+
+const FEATURE_NAME = 'pinterest';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Pinterest block registration/dependency declaration.
@@ -20,7 +33,7 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_pinterest_block_load_assets( $attr, $content ) {
+function load_assets( $attr, $content ) {
 	wp_enqueue_script( 'pinterest-pinit', 'https://assets.pinterest.com/js/pinit.js', array(), JETPACK__VERSION, true );
 	return $content;
 }

--- a/extensions/blocks/pinterest/pinterest.php
+++ b/extensions/blocks/pinterest/pinterest.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Pinterest_Block;
+namespace Automattic\Jetpack\Extensions\Pinterest;
 
 const FEATURE_NAME = 'pinterest';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -125,7 +125,7 @@ function render_player( $track_list, $attributes ) {
 	 * Enqueue necessary scripts and styles.
 	 */
 	wp_enqueue_style( 'mediaelement' );
-	Jetpack_Gutenberg::load_assets_as_required( 'podcast-player', array( 'mediaelement' ) );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME, array( 'mediaelement' ) );
 
 	return ob_get_clean();
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Jetpack\Podcast_Player_Block;
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 use WP_Error;
 use Jetpack_Gutenberg;

--- a/extensions/blocks/rating-star/rating-star.php
+++ b/extensions/blocks/rating-star/rating-star.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Rating_Star_Block;
+namespace Automattic\Jetpack\Extensions\Rating_Star;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/rating-star/rating-star.php
+++ b/extensions/blocks/rating-star/rating-star.php
@@ -7,8 +7,54 @@
  * @package Jetpack
  */
 
+namespace Automattic\Jetpack\Rating_Star_Block;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'rating-star';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
 // Load generic function definitions.
 require_once __DIR__ . '/rating-meta.php';
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array(
+			'render_callback' => __NAMESPACE__ . '\render_block',
+			'attributes'      => array(
+				'rating'      => array(
+					'type'    => 'number',
+					'default' => 1,
+				),
+				'maxRating'   => array(
+					'type'    => 'number',
+					'default' => 5,
+				),
+				'color'       => array(
+					'type' => 'string',
+				),
+				'ratingStyle' => array(
+					'type'    => 'string',
+					'default' => 'star',
+				),
+				'className'   => array(
+					'type' => 'string',
+				),
+				'align'       => array(
+					'type'    => 'string',
+					'default' => 'left',
+				),
+			),
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Dynamic rendering of the block.
@@ -17,9 +63,9 @@ require_once __DIR__ . '/rating-meta.php';
  *
  * @return string
  */
-function jetpack_rating_star_render_block( $attributes ) {
+function render_block( $attributes ) {
 	// Tell Jetpack to load the assets registered via jetpack_register_block.
-	Jetpack_Gutenberg::load_assets_as_required( 'rating-star' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	return jetpack_rating_meta_render_block( $attributes );
 }
@@ -34,33 +80,3 @@ function jetpack_rating_star_amp_add_inline_css() {
 }
 add_action( 'amp_post_template_css', 'jetpack_rating_star_amp_add_inline_css', 11 );
 
-jetpack_register_block(
-	'jetpack/rating-star',
-	array(
-		'render_callback' => 'jetpack_rating_star_render_block',
-		'attributes'      => array(
-			'rating'      => array(
-				'type'    => 'number',
-				'default' => 1,
-			),
-			'maxRating'   => array(
-				'type'    => 'number',
-				'default' => 5,
-			),
-			'color'       => array(
-				'type' => 'string',
-			),
-			'ratingStyle' => array(
-				'type'    => 'string',
-				'default' => 'star',
-			),
-			'className'   => array(
-				'type' => 'string',
-			),
-			'align'       => array(
-				'type'    => 'string',
-				'default' => 'left',
-			),
-		),
-	)
-);

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Repeat_Visitor_Block;
+namespace Automattic\Jetpack\Extensions\Repeat_Visitor;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/repeat-visitor/repeat-visitor.php
+++ b/extensions/blocks/repeat-visitor/repeat-visitor.php
@@ -7,12 +7,25 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/repeat-visitor',
-	array(
-		'render_callback' => 'jetpack_repeat_visitor_block_render',
-	)
-);
+namespace Automattic\Jetpack\Repeat_Visitor_Block;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'repeat-visitor';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Repeat Visitor block dependency declaration.
@@ -22,10 +35,10 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_repeat_visitor_block_render( $attributes, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'repeat-visitor' );
+function render_block( $attributes, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	$classes = Jetpack_Gutenberg::block_classes( 'repeat-visitor', $attributes );
+	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
 
 	$count     = isset( $_COOKIE['jp-visit-counter'] ) ? intval( $_COOKIE['jp-visit-counter'] ) : 0;
 	$criteria  = isset( $attributes['criteria'] ) ? $attributes['criteria'] : 'after-visits';

--- a/extensions/blocks/revue/revue.php
+++ b/extensions/blocks/revue/revue.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Revue_Block;
+namespace Automattic\Jetpack\Extensions\Revue;
 
 use Jetpack_Gutenberg;
 

--- a/extensions/blocks/revue/revue.php
+++ b/extensions/blocks/revue/revue.php
@@ -7,12 +7,25 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/revue',
-	array(
-		'render_callback' => 'jetpack_render_revue_block',
-	)
-);
+namespace Automattic\Jetpack\Revue_Block;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'revue';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\render_block' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Revue block render callback.
@@ -21,24 +34,24 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_render_revue_block( $attributes ) {
+function render_block( $attributes ) {
 	if ( ! array_key_exists( 'revueUsername', $attributes ) ) {
 		return '';
 	}
 
-	$email_label            = jetpack_get_revue_attribute( 'emailLabel', $attributes );
-	$email_placeholder      = jetpack_get_revue_attribute( 'emailPlaceholder', $attributes );
-	$first_name_label       = jetpack_get_revue_attribute( 'firstNameLabel', $attributes );
-	$first_name_placeholder = jetpack_get_revue_attribute( 'firstNamePlaceholder', $attributes );
-	$first_name_show        = jetpack_get_revue_attribute( 'firstNameShow', $attributes );
-	$last_name_label        = jetpack_get_revue_attribute( 'lastNameLabel', $attributes );
-	$last_name_placeholder  = jetpack_get_revue_attribute( 'lastNamePlaceholder', $attributes );
-	$last_name_show         = jetpack_get_revue_attribute( 'lastNameShow', $attributes );
+	$email_label            = get_revue_attribute( 'emailLabel', $attributes );
+	$email_placeholder      = get_revue_attribute( 'emailPlaceholder', $attributes );
+	$first_name_label       = get_revue_attribute( 'firstNameLabel', $attributes );
+	$first_name_placeholder = get_revue_attribute( 'firstNamePlaceholder', $attributes );
+	$first_name_show        = get_revue_attribute( 'firstNameShow', $attributes );
+	$last_name_label        = get_revue_attribute( 'lastNameLabel', $attributes );
+	$last_name_placeholder  = get_revue_attribute( 'lastNamePlaceholder', $attributes );
+	$last_name_show         = get_revue_attribute( 'lastNameShow', $attributes );
 	$url                    = sprintf( 'https://www.getrevue.co/profile/%s/add_subscriber', $attributes['revueUsername'] );
-	$base_class             = Jetpack_Gutenberg::block_classes( 'revue', array() ) . '__';
-	$classes                = Jetpack_Gutenberg::block_classes( 'revue', $attributes );
+	$base_class             = Jetpack_Gutenberg::block_classes( FEATURE_NAME, array() ) . '__';
+	$classes                = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
 
-	Jetpack_Gutenberg::load_assets_as_required( 'revue' );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	ob_start();
 	?>
@@ -94,7 +107,7 @@ function jetpack_render_revue_block( $attributes ) {
 			<?php
 			endif;
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo jetpack_get_revue_button( $attributes );
+			echo get_revue_button( $attributes );
 		?>
 	</form>
 	<div class="<?php echo esc_attr( $base_class . 'message' ); ?>">
@@ -120,11 +133,11 @@ function jetpack_render_revue_block( $attributes ) {
  *
  * @return string
  */
-function jetpack_get_revue_button( $attributes ) {
+function get_revue_button( $attributes ) {
 	$classes = array( 'wp-block-button__link' );
 	$styles  = array();
 
-	$text                        = jetpack_get_revue_attribute( 'text', $attributes );
+	$text                        = get_revue_attribute( 'text', $attributes );
 	$has_class_name              = array_key_exists( 'className', $attributes );
 	$has_named_text_color        = array_key_exists( 'textColor', $attributes );
 	$has_custom_text_color       = array_key_exists( 'customTextColor', $attributes );
@@ -207,7 +220,7 @@ function jetpack_get_revue_button( $attributes ) {
  *
  * @return mixed
  */
-function jetpack_get_revue_attribute( $attribute, $attributes ) {
+function get_revue_attribute( $attribute, $attributes ) {
 	if ( array_key_exists( $attribute, $attributes ) ) {
 		return $attributes[ $attribute ];
 	}

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -7,12 +7,26 @@
  * @package Jetpack
  */
 
-jetpack_register_block(
-	'jetpack/slideshow',
-	array(
-		'render_callback' => 'jetpack_slideshow_block_load_assets',
-	)
-);
+namespace Automattic\Jetpack\Slideshow_Block;
+
+use Jetpack_AMP_Support;
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'slideshow';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
  * Slideshow block registration/dependency declaration.
@@ -22,10 +36,10 @@ jetpack_register_block(
  *
  * @return string
  */
-function jetpack_slideshow_block_load_assets( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( 'slideshow' );
+function load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		return jetpack_slideshow_block_render_amp( $attr );
+		return render_amp( $attr );
 	}
 	return $content;
 }
@@ -37,7 +51,7 @@ function jetpack_slideshow_block_load_assets( $attr, $content ) {
  *
  * @return string
  */
-function jetpack_slideshow_block_render_amp( $attr ) {
+function render_amp( $attr ) {
 	static $wp_block_jetpack_slideshow_id = 0;
 	$wp_block_jetpack_slideshow_id++;
 
@@ -49,15 +63,15 @@ function jetpack_slideshow_block_render_amp( $attr ) {
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay' : null,
 		$autoplay ? 'wp-block-jetpack-slideshow__autoplay-playing' : null,
 	);
-	$classes = Jetpack_Gutenberg::block_classes( 'slideshow', $attr, $extras );
+	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, $extras );
 
 	return sprintf(
 		'<div class="%1$s" id="wp-block-jetpack-slideshow__%2$d"><div class="wp-block-jetpack-slideshow_container swiper-container">%3$s%4$s%5$s</div></div>',
 		esc_attr( $classes ),
 		absint( $wp_block_jetpack_slideshow_id ),
-		jetpack_slideshow_block_amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
-		$autoplay ? jetpack_slideshow_block_autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',
-		jetpack_slideshow_block_bullets( $ids, $wp_block_jetpack_slideshow_id )
+		amp_carousel( $attr, $wp_block_jetpack_slideshow_id ),
+		$autoplay ? autoplay_ui( $wp_block_jetpack_slideshow_id ) : '',
+		bullets( $ids, $wp_block_jetpack_slideshow_id )
 	);
 }
 
@@ -69,7 +83,7 @@ function jetpack_slideshow_block_render_amp( $attr ) {
  *
  * @return string amp-carousel markup.
  */
-function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
+function amp_carousel( $attr, $block_ordinal ) {
 	$ids         = empty( $attr['ids'] ) ? array() : $attr['ids'];
 	$first_image = wp_get_attachment_metadata( $ids[0] );
 	$delay       = empty( $attr['delay'] ) ? 3 : absint( $attr['delay'] );
@@ -84,7 +98,7 @@ function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
 		esc_attr__( 'Previous Slide', 'jetpack' ),
 		$autoplay ? 'autoplay delay=' . esc_attr( $delay * 1000 ) : '',
 		absint( $block_ordinal ),
-		implode( '', jetpack_slideshow_block_slides( $ids, $width, $height ) )
+		implode( '', slides( $ids, $width, $height ) )
 	);
 }
 
@@ -97,7 +111,7 @@ function jetpack_slideshow_block_amp_carousel( $attr, $block_ordinal ) {
  *
  * @return array Array of slides markup.
  */
-function jetpack_slideshow_block_slides( $ids = array(), $width = 400, $height = 300 ) {
+function slides( $ids = array(), $width = 400, $height = 300 ) {
 	return array_map(
 		function( $id ) use ( $width, $height ) {
 			$caption    = wp_get_attachment_caption( $id );
@@ -132,7 +146,7 @@ function jetpack_slideshow_block_slides( $ids = array(), $width = 400, $height =
  *
  * @return array Array of bullets markup.
  */
-function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
+function bullets( $ids = array(), $block_ordinal = 0 ) {
 	$buttons = array_map(
 		function( $index ) {
 			$aria_label = sprintf(
@@ -164,7 +178,7 @@ function jetpack_slideshow_block_bullets( $ids = array(), $block_ordinal = 0 ) {
  *
  * @return string Autoplay UI markup.
  */
-function jetpack_slideshow_block_autoplay_ui( $block_ordinal = 0 ) {
+function autoplay_ui( $block_ordinal = 0 ) {
 	$block_id        = sprintf(
 		'wp-block-jetpack-slideshow__%d',
 		absint( $block_ordinal )

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\Slideshow_Block;
+namespace Automattic\Jetpack\Extensions\Slideshow;
 
 use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -1,19 +1,25 @@
 <?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 /**
- * Tiled Gallery block. Depends on the Photon module.
+ * Tiled Gallery block.
+ * Relies on Photon, but can be used even when the module is not active.
  *
  * @since 6.9.0
  *
  * @package Jetpack
  */
 
+namespace Automattic\Jetpack;
+
 /**
  * Jetpack Tiled Gallery Block class
  *
  * @since 7.3
  */
-class Jetpack_Tiled_Gallery_Block {
+class Tiled_Gallery_Block {
+	const FEATURE_NAME = 'tiled-gallery';
+	const BLOCK_NAME   = 'jetpack/' . self::FEATURE_NAME;
+
 	/* Values for building srcsets */
 	const IMG_SRCSET_WIDTH_MAX  = 2000;
 	const IMG_SRCSET_WIDTH_MIN  = 600;
@@ -24,7 +30,7 @@ class Jetpack_Tiled_Gallery_Block {
 	 */
 	public static function register() {
 		jetpack_register_block(
-			'jetpack/tiled-gallery',
+			self::BLOCK_NAME,
 			array(
 				'render_callback' => array( __CLASS__, 'render' ),
 			)
@@ -40,7 +46,7 @@ class Jetpack_Tiled_Gallery_Block {
 	 * @return string
 	 */
 	public static function render( $attr, $content ) {
-		Jetpack_Gutenberg::load_assets_as_required( 'tiled-gallery' );
+		Jetpack_Gutenberg::load_assets_as_required( self::FEATURE_NAME );
 
 		$is_squareish_layout = self::is_squareish_layout( $attr );
 
@@ -169,4 +175,4 @@ class Jetpack_Tiled_Gallery_Block {
 	}
 }
 
-Jetpack_Tiled_Gallery_Block::register();
+Tiled_Gallery_Block::register();

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -10,6 +10,9 @@
 
 namespace Automattic\Jetpack\Extensions;
 
+use Jetpack_Gutenberg;
+use Jetpack_Plan;
+
 /**
  * Jetpack Tiled Gallery Block class
  *

--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -1,5 +1,4 @@
 <?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
-
 /**
  * Tiled Gallery block.
  * Relies on Photon, but can be used even when the module is not active.
@@ -9,14 +8,14 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack;
+namespace Automattic\Jetpack\Extensions;
 
 /**
  * Jetpack Tiled Gallery Block class
  *
  * @since 7.3
  */
-class Tiled_Gallery_Block {
+class Tiled_Gallery {
 	const FEATURE_NAME = 'tiled-gallery';
 	const BLOCK_NAME   = 'jetpack/' . self::FEATURE_NAME;
 
@@ -175,4 +174,4 @@ class Tiled_Gallery_Block {
 	}
 }
 
-Tiled_Gallery_Block::register();
+Tiled_Gallery::register();

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -6,8 +6,20 @@
  *
  * @package Jetpack
  */
-class Jetpack_WordAds_Gutenblock {
-	const BLOCK_NAME = 'jetpack/wordads';
+
+namespace Automattic\Jetpack;
+
+use Jetpack;
+use Jetpack_Gutenberg;
+
+/**
+ * Jetpack's Ads Block class.
+ *
+ * @since 7.1.0
+ */
+class WordAds_Block {
+	const FEATURE_NAME = 'wordads';
+	const BLOCK_NAME   = 'jetpack/' . self::FEATURE_NAME;
 
 	/**
 	 * Check if site is on WP.com Simple.
@@ -47,7 +59,7 @@ class Jetpack_WordAds_Gutenblock {
 			jetpack_register_block(
 				self::BLOCK_NAME,
 				array(
-					'render_callback' => array( 'Jetpack_WordAds_Gutenblock', 'gutenblock_render' ),
+					'render_callback' => array( __CLASS__, 'gutenblock_render' ),
 				)
 			);
 		}
@@ -115,12 +127,5 @@ class Jetpack_WordAds_Gutenblock {
 	}
 }
 
-add_action(
-	'init',
-	array( 'Jetpack_WordAds_Gutenblock', 'register' )
-);
-
-add_action(
-	'jetpack_register_gutenberg_extensions',
-	array( 'Jetpack_WordAds_Gutenblock', 'set_availability' )
-);
+add_action( 'init', array( 'Automattic\\Jetpack\\WordAds_Block', 'register' ) );
+add_action( 'jetpack_register_gutenberg_extensions', array( 'Automattic\\Jetpack\\WordAds_Block', 'set_availability' ) );

--- a/extensions/blocks/wordads/wordads.php
+++ b/extensions/blocks/wordads/wordads.php
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack;
+namespace Automattic\Jetpack\Extensions;
 
 use Jetpack;
 use Jetpack_Gutenberg;
@@ -17,7 +17,7 @@ use Jetpack_Gutenberg;
  *
  * @since 7.1.0
  */
-class WordAds_Block {
+class WordAds {
 	const FEATURE_NAME = 'wordads';
 	const BLOCK_NAME   = 'jetpack/' . self::FEATURE_NAME;
 
@@ -127,5 +127,5 @@ class WordAds_Block {
 	}
 }
 
-add_action( 'init', array( 'Automattic\\Jetpack\\WordAds_Block', 'register' ) );
-add_action( 'jetpack_register_gutenberg_extensions', array( 'Automattic\\Jetpack\\WordAds_Block', 'set_availability' ) );
+add_action( 'init', array( 'Automattic\\Jetpack\\Extensions\\WordAds', 'register' ) );
+add_action( 'jetpack_register_gutenberg_extensions', array( 'Automattic\\Jetpack\\Extensions\\WordAds', 'set_availability' ) );

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -7,7 +7,7 @@
  * @package Jetpack
  */
 
-namespace Jetpack\{{ underscoredTitle }}_Block;
+namespace Automattic\Jetpack\{{ underscoredTitle }}_Block;
 
 const FEATURE_NAME = '{{ slug }}';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -37,7 +37,7 @@ function load_assets( $attr, $content ) {
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
-	\Jetpack_Gutenberg::load_assets_as_required( '{{ slug }}' );
+	\Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	return $content;
 }

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -41,5 +41,9 @@ function load_assets( $attr, $content ) {
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	return $content;
+	return sprintf(
+		'<div class="%1$s">%2$s</div>',
+		esc_attr( Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr ) ),
+		$content
+	);
 }

--- a/wp-cli-templates/block-register-php.mustache
+++ b/wp-cli-templates/block-register-php.mustache
@@ -7,7 +7,9 @@
  * @package Jetpack
  */
 
-namespace Automattic\Jetpack\{{ underscoredTitle }}_Block;
+namespace Automattic\Jetpack\Extensions\{{ underscoredTitle }};
+
+use Jetpack_Gutenberg;
 
 const FEATURE_NAME = '{{ slug }}';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -37,7 +39,7 @@ function load_assets( $attr, $content ) {
 	/*
 	 * Enqueue necessary scripts and styles.
 	 */
-	\Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	return $content;
 }


### PR DESCRIPTION
Fixes #14843

#### Changes proposed in this Pull Request:

This PR does not introduce any new functionality or changes anything in the way the blocks work today. It does, however, change the way blocks are registered to bring all blocks to the same level and be consistent across all blocks. It should help new Jetpack contributors who work on blocks, by giving them one approach they can follow to register a new block.

- I've updated the template used when using WP Cli to create a new block. This is work that was already started in #14728.
- I've updated all blocks to be under the `Automattic\Jetpack` namespace (vs. just `Jetpack` before, or no namespace at all). Adding the vendor name to the namespace is how we work with all other namespaces in Jetpack. **Part of me wonders if we shouldn't introduce one more level there, so all blocks live under an `Automattic\Jetpack\Blocks` or `Automattic\Jetpack\Extensions` namespace. It may make things easier if one day we move those blocks into a package.**


#### Testing instructions:

* You should be able to use all those blocks with no issues or notices in your logs:
    - Amazon (Beta)
    - Business Hours
    - Calendly
    - Eventbrite
    - Gif
    - Google Calendar
    - Instagram Gallery (Beta)
    - Mailchimp
    - Map
    - Markdown
    - Opentable
    - Pinterest
    - Podcast Player (Beta)
    - Rating Star
    - Repeat Visitor
    - Revue
    - Slideshow
    - Tiled Gallery
    - WordAds

#### Proposed changelog entry for your changes:

* N/A
