### PR TITLE
Dashboard Stats card: Footer buttons markup fix

### DIFF
--- a/_inc/client/dashboard-widget/style.scss
+++ b/_inc/client/dashboard-widget/style.scss
@@ -130,19 +130,20 @@
 
 	footer {
 		background: #fafafa;
-		padding: .75em;
+		padding: .75em .75em 0 .75em;
 		overflow: hidden;
 		border-top: 1px solid #ccc;
 
 		.protect,
 		.akismet {
-			width: 50%;
 			float: left;
 			text-align: left;
+			margin-bottom: .75em;
 		}
 
 		.protect {
 			padding-right: 3%;
+			min-width: 50%;
 		}
 
 		h3 {


### PR DESCRIPTION
#### The buttons overflow each other on certain window sizes.
When the card gets too narrow, the 'Activate brute force...' button doesn't fit into the 50% width of the card dedicated to it.

The problem was reported internally, no GitHub issue was created.

#### Changes proposed in this Pull Request:
I adjusted the styles so the button would be able to overflow beyond 50% of the card, and if the two buttons do not fit, one of them gets pushed down to the next line.

#### Testing instructions:
1. Install Jetpack, initialize the connection (free plan is fine).
2. Open the "Jetpack Settings -> Security": `/wp-admin/admin.php?page=jetpack#/settings` and turn off "_Brute force attack protection_"
3. Go to the WordPress Admin Dashboard and find the card "_Stats by Jetpack_": `/wp-admin/index.php`
4. Experiment with the window width and see that the button "_Activate brute force attack protection_" occasionally becomes too long and goes under the "_Anti-spam_" section.
Example width to reproduce (Firefox, new ephemeral website): `1900px`, `1550px`, `1000px`, anything under `570px`.

**The card with the issue present:**
<img width="409" alt="jetpack-brute-force-button" src="https://user-images.githubusercontent.com/1341249/77352735-a8aaf500-6d0d-11ea-9901-31f442f4ad1a.png">

**The card footer after the fix:**
<img width="409" alt="jetpack-brute-force-button-fixed" src="https://user-images.githubusercontent.com/1341249/77353144-7221aa00-6d0e-11ea-8d17-84c1dd00fb3d.png">

#### Proposed changelog entry for your changes:
No entry necessary.