### PR TITLE
Fix missed instance of updating the namespace

### DIFF
--- a/extensions/blocks/rating-star/rating-star.php
+++ b/extensions/blocks/rating-star/rating-star.php
@@ -75,8 +75,8 @@ function render_block( $attributes ) {
  * This entire section can be removed once we're on version a newer version.
  * Confirmed that version 1.4.1 (or presumably newer) does not need this filter.
  */
-function jetpack_rating_star_amp_add_inline_css() {
+function amp_add_inline_css() {
 	echo '.wp-block-jetpack-rating-star span { display: none; }';
 }
-add_action( 'amp_post_template_css', 'jetpack_rating_star_amp_add_inline_css', 11 );
+add_action( 'amp_post_template_css', __NAMESPACE__ . '\amp_add_inline_css', 11 );
 


### PR DESCRIPTION
Catches an instance missed in #15088.

Resolves a `call_user_func_array() expects parameter 1 to be a valid callback, function 'jetpack_rating_star_amp_add_inline_css' not found or invalid function name` error.

#### Changes proposed in this Pull Request:
* Uses a namespace for an action hook.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add a rating star block. Load AMP view and verify no errors in the log.
*

#### Proposed changelog entry for your changes:
* n/a
