### PR TITLE
Update Podcast player Block CSS attr to use `jetpack` namespace

### DIFF
--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { STATE_ERROR } from '../constants';
 
 const TrackError = memo( ( { link } ) => (
-	<div className="podcast-player__episode-error">
+	<div className="jetpack-podcast-player__episode-error">
 		{ __( 'Episode unavailable', 'jetpack' ) }{ ' ' }
 		{ link && (
 			<span>
@@ -28,12 +28,12 @@ const TrackError = memo( ( { link } ) => (
 const Track = memo( ( { track, isActive, isError, selectTrack, index } ) => {
 	return (
 		<li
-			className={ classnames( 'podcast-player__episode', {
+			className={ classnames( 'jetpack-podcast-player__episode', {
 				'is-active': isActive,
 			} ) }
 		>
 			<a
-				className="podcast-player__episode-link"
+				className="jetpack-podcast-player__episode-link"
 				href={ track.link }
 				role="button"
 				aria-pressed="false"
@@ -62,10 +62,10 @@ const Track = memo( ( { track, isActive, isError, selectTrack, index } ) => {
 					selectTrack( index );
 				} }
 			>
-				<span className="podcast-player__episode-status-icon"></span>
-				<span className="podcast-player__episode-title">{ track.title }</span>
+				<span className="jetpack-podcast-player__episode-status-icon"></span>
+				<span className="jetpack-podcast-player__episode-title">{ track.title }</span>
 				{ track.duration && (
-					<time className="podcast-player__episode-duration">{ track.duration }</time>
+					<time className="jetpack-podcast-player__episode-duration">{ track.duration }</time>
 				) }
 			</a>
 			{ isActive && isError && <TrackError link={ track.link } /> }
@@ -75,7 +75,7 @@ const Track = memo( ( { track, isActive, isError, selectTrack, index } ) => {
 
 const Playlist = memo( ( { tracks, selectTrack, currentTrack, playerState } ) => {
 	return (
-		<ol className="podcast-player__episodes">
+		<ol className="jetpack-podcast-player__episodes">
 			{ tracks.map( ( track, index ) => (
 				<Track
 					key={ track.id }

--- a/extensions/blocks/podcast-player/icons.js
+++ b/extensions/blocks/podcast-player/icons.js
@@ -5,22 +5,22 @@ import { __ } from '@wordpress/i18n';
 
 function createSVGs() {
 	// Prevent repeated initialization.
-	if ( document.getElementById( 'jetpack-player-podcast-icons' ) ) {
+	if ( document.getElementById( 'jetpack-podcast-player-icons' ) ) {
 		return;
 	}
 
 	const svgTemplate = document.createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
-	svgTemplate.id = 'jetpack-player-podcast-icons';
+	svgTemplate.id = 'jetpack-podcast-player-icons';
 	svgTemplate.setAttribute( 'style', 'position: absolute; width: 0; height: 0; overflow: hidden;' );
 	svgTemplate.setAttribute( 'version', '1.1' );
 	svgTemplate.setAttribute( 'xmlns', 'http://www.w3.org/2000/svg' );
 	svgTemplate.setAttribute( 'xmlns:xlink', 'http://www.w3.org/1999/xlink' );
 
-	const soundIcon = `<symbol id="podcast-player-icon__sound" viewBox="0 0 24 24"><title id="podcast-player-icon__sound-title">${ __(
+	const soundIcon = `<symbol id="jetpack-podcast-player-icon__sound" viewBox="0 0 24 24"><title id="jetpack-podcast-player-icon__sound-title">${ __(
 		'Playing',
 		'jetpack'
 	) }</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z"/></symbol>`;
-	const errorIcon = `<symbol id="podcast-player-icon__error" viewBox="0 0 24 24"><title id="podcast-player-icon__error-title">${ __(
+	const errorIcon = `<symbol id="jetpack-podcast-player-icon__error" viewBox="0 0 24 24"><title id="jetpack-podcast-player-icon__error-title">${ __(
 		'Error',
 		'jetpack'
 	) }</title><path d="M0 0h24v24H0V0z" fill="none"/><path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></symbol>`;
@@ -34,6 +34,6 @@ createSVGs();
 
 // Export individual icon references.
 export const soundIcon =
-	'<svg aria-labelledby="podcast-player-icon__sound-title"><use xlink:href="#podcast-player-icon__sound" /></svg>';
+	'<svg aria-labelledby="jetpack-podcast-player-icon__sound-title"><use xlink:href="#jetpack-podcast-player-icon__sound" /></svg>';
 export const errorIcon =
-	'<svg aria-labelledby="podcast-player-icon__error-title"><use xlink:href="#podcast-player-icon__error" /></svg>';
+	'<svg aria-labelledby="jetpack-podcast-player-icon__error-title"><use xlink:href="#jetpack-podcast-player-icon__error" /></svg>';

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -81,7 +81,6 @@ function render_block( $attributes ) {
 
 	return render_player( $track_list, $attributes );
 }
-
 /**
  * Renders the HTML for the Podcast player and tracklist.
  *
@@ -94,7 +93,7 @@ function render_player( $track_list, $attributes ) {
 	if ( empty( $track_list ) ) {
 		return '<p>' . esc_html__( 'No tracks available to play.', 'jetpack' ) . '</p>';
 	}
-	$instance_id = wp_unique_id( 'podcast-player-block-' );
+	$instance_id = wp_unique_id( 'jetpack-podcast-player-block-' );
 
 	// Generate object to be used as props for PodcastPlayer.
 	$player_data = array_merge(
@@ -113,18 +112,18 @@ function render_player( $track_list, $attributes ) {
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<noscript>
-			<ol class="podcast-player__episodes">
+			<ol class="jetpack-podcast-player__episodes">
 				<?php foreach ( $track_list as $attachment ) : ?>
-				<li class="podcast-player__episode">
+				<li class="jetpack-podcast-player__episode">
 					<a
-						class="podcast-player__episode-link"
+						class="jetpack-podcast-player__episode-link"
 						href="<?php echo esc_url( $attachment['link'] ); ?>"
 						role="button"
 						aria-pressed="false"
 					>
-						<span class="podcast-player__episode-status-icon"></span>
-						<span class="podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+						<span class="jetpack-podcast-player__episode-status-icon"></span>
+						<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+						<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
 					</a>
 				</li>
 				<?php endforeach; ?>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -81,6 +81,7 @@ function render_block( $attributes ) {
 
 	return render_player( $track_list, $attributes );
 }
+
 /**
  * Renders the HTML for the Podcast player and tracklist.
  *

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -33,7 +33,7 @@ $block-border-color: $dark-gray-100;
 	}
 }
 
-.podcast-player__episodes {
+.jetpack-podcast-player__episodes {
 	list-style-type: none;
 	display: flex;
 	flex-direction: column;
@@ -41,7 +41,7 @@ $block-border-color: $dark-gray-100;
 	padding: $episode-v-padding 0;
 }
 
-.podcast-player__episode {
+.jetpack-podcast-player__episode {
 	margin: 0;
 	color: $text-color;
 	font-family: $default-font;
@@ -63,7 +63,7 @@ $block-border-color: $dark-gray-100;
 	}
 }
 
-.podcast-player__episode-link {
+.jetpack-podcast-player__episode-link {
 	display: flex;
 	flex-flow: row nowrap;
 	justify-content: space-between;
@@ -72,7 +72,7 @@ $block-border-color: $dark-gray-100;
 	color: inherit;
 	transition: none;
 
-	.podcast-player__episode.is-active & {
+	.jetpack-podcast-player__episode.is-active & {
 		.is-error & {
 			padding-bottom: 0; // Make space for the error element that will be appended.
 		}
@@ -89,7 +89,7 @@ $block-border-color: $dark-gray-100;
 	transition: none;
 }
 
-.podcast-player__episode-status-icon {
+.jetpack-podcast-player__episode-status-icon {
 	flex: $episode-status-icon-size 0 0;
 
 	svg {
@@ -97,7 +97,7 @@ $block-border-color: $dark-gray-100;
 		height: $episode-status-icon-size;
 	}
 
-	.podcast-player__episode.is-active & {
+	.jetpack-podcast-player__episode.is-active & {
 		.is-paused & {
 			fill: none; // Currently there's no icon for paused state.
 		}
@@ -110,20 +110,20 @@ $block-border-color: $dark-gray-100;
 	}
 }
 
-.podcast-player__episode-title {
+.jetpack-podcast-player__episode-title {
 	flex-grow: 1;
 	padding: 0 $episode-v-padding;
 }
 
-.podcast-player__episode-duration {
+.jetpack-podcast-player__episode-duration {
 	word-break: normal; // Prevents the time breaking into multiple lines.
 }
 
 /**
  * Error element, appended as the last child of the Episode element
- * (.podcast-player__episode) when Player's error has been caught.
+ * (.jetpack-podcast-player__episode) when Player's error has been caught.
  */
-.podcast-player__episode-error {
+.jetpack-podcast-player__episode-error {
 	display: block;
 	margin-left: 2 * $episode-v-padding + $episode-status-icon-size;
 	margin-bottom: $episode-h-padding;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -85,7 +85,7 @@ $block-border-color: $dark-gray-100;
  * this definition gets applied to the symbol definitions and we can't override
  * them since we're applying via the shadow DOM.
  */
-#jetpack-player-podcast-icons path {
+#jetpack-podcast-player-icons path {
 	transition: none;
 }
 


### PR DESCRIPTION
Currently all CSS classes (and some other SVG attributes) used on the Block do not include a "namespace" which ties them to Jetpack. This makes them vulnerable to be overridden by / clashing with other Blocks by 3rd party vendors.

#### Changes proposed in this Pull Request:

This PR updates so that all CSS classes and SVG attributes contain the `jetpack-` prefix.

eg:

```css
.podcast-player__episode {}
``` 

becomes...

```css
.jetpack-podcast-player__episode {}
``` 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
It adds (updates) features to an existing part of Jetpack.

#### Testing instructions:

##### On Master

* Add the Podcast player Block - note the layout and styling of the Block on both Editor and Frontend (please take screenshots for your reference).
* Inspect the DOM - note:
  - CSS classes  do not contain `jetpack-` prefix (eg: `.podcast-player__episode`.
  - SVG attributes do not contain `jetpack-` prefix.

##### On this branch

* Add the Podcast player Block - compare the layout and styling of the Block. It should be identical to that of `master`. Please use screenshots to compare.
* Inspect the DOM - note:
  - CSS classes  should now contain the `jetpack-` prefix (eg: `.jetpack-podcast-player__episode`.
  - SVG attributes should now contain `jetpack-` prefix.


#### Proposed changelog entry for your changes:

* Update all classnames and SVG attributes to use the `jetpack` prefix.