### PR TITLE
oEmbeds: move extra oEmbeds to their own file

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -660,8 +660,6 @@ class Jetpack {
 
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 
-		add_action( 'plugins_loaded', array( $this, 'extra_oembed_providers' ), 100 );
-
 		/**
 		 * These actions run checks to load additional files.
 		 * They check for external files or plugins, so they need to run as late as possible.
@@ -1863,20 +1861,6 @@ class Jetpack {
 		}
 
 		return ! empty( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : '';
-	}
-
-	/**
-	 * Add any extra oEmbed providers that we know about and use on wpcom for feature parity.
-	 */
-	function extra_oembed_providers() {
-		// Cloudup: https://dev.cloudup.com/#oembed
-		wp_oembed_add_provider( 'https://cloudup.com/*', 'https://cloudup.com/oembed' );
-		wp_oembed_add_provider( 'https://me.sh/*', 'https://me.sh/oembed?format=json' );
-		wp_oembed_add_provider( '#https?://(www\.)?gfycat\.com/.*#i', 'https://api.gfycat.com/v1/oembed', true );
-		wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
-		wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
-		wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
-		wp_oembed_add_provider( 'https://song.link/*', 'https://song.link/oembed', false );
 	}
 
 	/**

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -18,6 +18,8 @@ $tools = array(
 	'custom-post-types/testimonial.php',
 	'custom-post-types/nova.php',
 	'geo-location.php',
+	// Those oEmbed providers are always available.
+	'shortcodes/others.php',
 	'theme-tools.php',
 	'theme-tools/social-links.php',
 	'theme-tools/random-redirect.php',

--- a/modules/shortcodes/others.php
+++ b/modules/shortcodes/others.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Extra oEmbed providers that we know about and use on wpcom for feature parity.
+ *
+ * This file will be loaded even when you don't use the Shortcodes feature,
+ * as these embeds are considered safe to use on any site
+ * (and may end up embedded in Core in the future).
+ *
+ * @package Jetpack
+ */
+
+wp_oembed_add_provider( 'https://me.sh/*', 'https://me.sh/oembed?format=json' );
+wp_oembed_add_provider( '#https?://(www\.)?gfycat\.com/.*#i', 'https://api.gfycat.com/v1/oembed', true );
+wp_oembed_add_provider( '#https?://[^.]+\.(wistia\.com|wi\.st)/(medias|embed)/.*#', 'https://fast.wistia.com/oembed', true );
+wp_oembed_add_provider( '#https?://sketchfab\.com/.*#i', 'https://sketchfab.com/oembed', true );
+wp_oembed_add_provider( '#https?://(www\.)?icloud\.com/keynote/.*#i', 'https://iwmb.icloud.com/iwmb/oembed', true );
+wp_oembed_add_provider( 'https://song.link/*', 'https://song.link/oembed', false );

--- a/tests/php/modules/shortcodes/test-class.others.php
+++ b/tests/php/modules/shortcodes/test-class.others.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test Suite for extra oEmbed providers available in Jetpack.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Test Extra embeds available.
+ */
+class WP_Test_Jetpack_Shortcodes_Others extends WP_UnitTestCase {
+	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		wp_reset_postdata();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test a post including a song.link link.
+	 *
+	 * @since 8.4.0
+	 */
+	public function test_shortcodes_songlink() {
+		global $post;
+
+		$url  = 'https://song.link/hu/i/1051332387';
+		$post = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		setup_postdata( $post );
+
+		// Test HTML version.
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+
+		$this->assertContains(
+			sprintf(
+				'src="https://embed.song.link/?url=%s" frameborder="0" allowtransparency allowfullscreen sandbox="allow-same-origin allow-scripts allow-presentation allow-popups allow-popups-to-escape-sandbox"></iframe>',
+				rawurlencode( $url )
+			),
+			$actual
+		);
+	}
+}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Let's move those embeds out of the already too-crowded `class.jetpack.php` file, and move them in a place where one would expect to find them.

The file will be loaded when you use the Shortcodes module, but also if you don't, to stay consistent with how we've handled those in the past (loaded for everyone as soon as Jetpack is activated).

Internal reference: p1585061348130900-slack-jetpack-crew

This PR also introduces a basic test, to make it easier for folks new to Jetpack who may be interested in contributing tests in the future (e.g. #14998).

#### Testing instructions:

* Start from a site where shortcodes are disabled.
* In a new post, add a classic block, and paste this URL in: `https://song.link/hu/i/1051332387`
* View the post; the embed should work nicely.
* Now activate the Shortcodes module.
* The embed should continue to work

* Tests should pass.

#### Proposed changelog entry for your changes:

* N/A
