### PR TITLE
Remove unused styles configuration from Podcast Player Block

### DIFF
--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -25,12 +25,6 @@ export const settings = {
 	icon: queueMusic,
 	category: 'jetpack',
 	keywords: [],
-
-	styles: [
-		{ name: 'small', label: __( 'Small' ), isDefault: true },
-		{ name: 'large', label: __( 'Large' ) },
-	],
-
 	supports: {
 		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
 		align: false /* if set to true, the 'align' option below can be used*/,


### PR DESCRIPTION
The Podcast Player Block currently contains Block styles which don't do anything (ie: there are no CSS rules in place to change the layout/styling depending on the style that is active).

It has been decided by @lessbloat and @marekhrabe that we will not have "styles" for the beta version of the Block. They may be added in future in which case we can reinstate then. However, we shouldn't have functionality that doesn't work available in the UI.

## Changes proposed in this Pull Request:

* Remove the Block styles from the Podcast Player Block.

## Is this a new feature or does it add/remove features to an existing part of Jetpack?
This feature removes features (which didn't ever work!) from an existing part of Jetpack.

## Testing instructions:

The expected result is that there are no Block styles shown for the Block within the Editor.

### On Master

<img width="1278" alt="Screenshot 2020-03-24 at 15 47 11" src="https://user-images.githubusercontent.com/444434/77446859-dadc5580-6de6-11ea-9d34-90f3640e54b4.png">

* Insert Podcast Player Block
* Toggle Block settings to reveal sidebar.
* See two Block style variations in the sidebar for "Small" and "Large".

### On this branch

<img width="1278" alt="Screenshot 2020-03-24 at 15 46 54" src="https://user-images.githubusercontent.com/444434/77446842-d57f0b00-6de6-11ea-837a-41b7afdc48e3.png">

* Insert Podcast Player Block
* Toggle Block settings to reveal sidebar.
* You should not see any Block styles for the Block.


## Proposed changelog entry for your changes:

* Removes unused Block Styles from Podcast Player Block.
