### PR TITLE
Podcast Block: create new shared utility to massage podcast data

### DIFF
--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Helper to massage Podcast data to be used in the Podcast block.
+ *
+ * @package jetpack
+ */
+
+/**
+ * Class Jetpack_Podcast_Helper
+ */
+class Jetpack_Podcast_Helper {
+	/**
+	 * Gets a list of tracks for the supplied RSS feed. This function is used
+	 * in both server-side block rendering and in API `WPCOM_REST_API_V2_Endpoint_Podcast_Player`.
+	 *
+	 * @param string $feed     The RSS feed to load and list tracks for.
+	 * @param int    $quantity Optional. The number of tracks to return.
+	 * @return array|WP_Error The feed's tracks or a error object.
+	 */
+	public static function get_track_list( $feed, $quantity = 10 ) {
+		$rss = fetch_feed( $feed );
+
+		if ( is_wp_error( $rss ) ) {
+			return new WP_Error( 'invalid_url', __( 'Your podcast couldn\'t be embedded. Please double check your URL.', 'jetpack' ) );
+		}
+
+		if ( ! $rss->get_item_quantity() ) {
+			return new WP_Error( 'no_tracks', __( 'Podcast audio RSS feed has no tracks.', 'jetpack' ) );
+		}
+
+		$track_list = array_map( array( __CLASS__, 'setup_tracks_callback' ), $rss->get_items( 0, $quantity ) );
+
+		// Remove empty tracks.
+		return array_filter( $track_list );
+	}
+
+	/**
+	 * Prepares Episode data to be used with MediaElement.js.
+	 *
+	 * @param SimplePie_Item $episode SimplePie_Item object, representing a podcast episode.
+	 * @return array
+	 */
+	private static function setup_tracks_callback( SimplePie_Item $episode ) {
+		$enclosure = self::get_audio_enclosure( $episode );
+
+		// If there is no link return an empty array. We will filter out later.
+		if ( empty( $enclosure->link ) ) {
+			return array();
+		}
+
+		// Build track data.
+		$track = array(
+			'id'          => wp_unique_id( 'podcast-track-' ),
+			'link'        => esc_url( $episode->get_link() ),
+			'src'         => esc_url( $enclosure->link ),
+			'type'        => esc_attr( $enclosure->type ),
+			'description' => wp_kses_post( $episode->get_description() ),
+			'title'       => esc_html( trim( wp_strip_all_tags( $episode->get_title() ) ) ),
+		);
+
+		if ( empty( $track['title'] ) ) {
+			$track['title'] = esc_html__( '(no title)', 'jetpack' );
+		}
+
+		if ( ! empty( $enclosure->duration ) ) {
+			$track['duration'] = self::format_track_duration( $enclosure->duration );
+		}
+
+		return $track;
+	}
+
+	/**
+	 * Retrieves an audio enclosure.
+	 *
+	 * @param SimplePie_Item $episode SimplePie_Item object, representing a podcast episode.
+	 * @return SimplePie_Enclosure|null
+	 */
+	private static function get_audio_enclosure( SimplePie_Item $episode ) {
+		foreach ( (array) $episode->get_enclosures() as $enclosure ) {
+			if ( 0 === strpos( $enclosure->type, 'audio/' ) ) {
+				return $enclosure;
+			}
+		}
+
+		// Default to empty SimplePie_Enclosure object.
+		return $episode->get_enclosure();
+	}
+
+	/**
+	 * Returns the track duration as a formatted string.
+	 *
+	 * @param number $duration of the track in seconds.
+	 * @return string
+	 */
+	private static function format_track_duration( $duration ) {
+		$format = $duration > HOUR_IN_SECONDS ? 'H:i:s' : 'i:s';
+
+		return date_i18n( $format, $duration );
+	}
+}

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -56,13 +56,16 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 	 * @return WP_REST_Response The REST API response.
 	 */
 	public function get_player_data( $request ) {
+		if ( ! class_exists( 'Jetpack_Podcast_Helper' ) ) {
+			jetpack_require_lib( 'class-jetpack-podcast-helper' );
+		}
+
 		return rest_ensure_response(
 			array(
-				'tracks' => \Automattic\Jetpack\Extensions\Podcast_Player\get_track_list( $request['url'] ),
+				'tracks' => Jetpack_Podcast_Helper::get_track_list( $request['url'] ),
 				'cover'  => '', // TODO: parse podcast cover image.
 			)
 		);
 	}
 }
-
 wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Podcast_Player' );

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -12,6 +12,7 @@ module.exports = [
 	'functions.opengraph.php',
 	'_inc/lib/admin-pages/class-jetpack-about-page.php',
 	'_inc/lib/class-jetpack-mapbox-helper.php',
+	'_inc/lib/class-jetpack-podcast-helper.php',
 	'_inc/lib/class.jetpack-password-checker.php',
 	'_inc/lib/components.php',
 	'_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is a follow-up to #15072 (see https://github.com/Automattic/jetpack/pull/15072#issuecomment-603417915)

It should address this:
https://github.com/Automattic/jetpack/blob/d1f825c3941dba2f49122a12f886647facf010c5/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php#L61

We currently cannot reliably call functions declared in the block registration file in `extensions/blocks/podcast-player/podcast-player.php` from the API endpoint in `_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php`; in the WordPress.com environment the API endpoint loads too early for that: there the endpoints are loaded in an mu-plugin while in Jetpack they're loaded on `plugins_loaded`:
https://github.com/Automattic/jetpack/blob/e83d91e577af1dd45fe25cb313cc2ebb17811bff/_inc/lib/core-api/load-wpcom-endpoints.php#L42-L45

Instead, let's introduce a new class, `Jetpack_Podcast_Helper`, that will be available in both environments so that both the block's PHP and the API endpoint can use it.

#### Testing instructions:

* Start from a site where Beta blocks are enabled with `define( 'JETPACK_BETA_BLOCKS', true );`
* In a new post, add a Podcast player
* Add a feed URL such as `http://feeds.feedburner.com/lerendezvousjeux`
* The block should display nicely in the editor and on the frontend.

#### Proposed changelog entry for your changes:

* N/A
