### PR TITLE
Podcast Player Header Markup and Styles

### DIFF
--- a/extensions/blocks/podcast-player/components/audio-player.js
+++ b/extensions/blocks/podcast-player/components/audio-player.js
@@ -65,7 +65,7 @@ class AudioPlayer extends Component {
 	};
 
 	render() {
-		return <div ref={ this.audioRef }></div>;
+		return <div ref={ this.audioRef } className="jetpack-podcast-player__audio-player"></div>;
 	}
 }
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -45,8 +45,7 @@ const Header = memo( ( { playerId, title, cover, link, track, children } ) => (
 				id={ `${ playerId }__track-description` }
 				className="jetpack-podcast-player__track-description"
 			>
-				This is the track description that will need to be escaped and rendered via HTML or the
-				like, since that's how the RSS feed delivers it.
+				{ track.description }
 			</div>
 		) : null }
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -13,30 +13,11 @@ const Header = memo( ( { playerId, title, cover, link, track, children } ) => (
 				</div>
 			) : null }
 
-			<div className="jetpack-podcast-player__titles">
-				{ /* The track title and player title are bundled together here in one <h3> so that it looks like "Track title - Podcast Title" for the aria-labelledby and screen reader headings */ }
-				{ title || ( track && track.title ) ? (
-					<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
-						{ track && track.title ? (
-							<span className="jetpack-podcast-player__track-title">{ track.title }</span>
-						) : null }
-
-						{ /* Adds a visually hidden - when both a track and title are present */ }
-						{ track && track.title && title ? (
-							<span className="jetpack-podcast-player--visually-hidden"> - </span>
-						) : null }
-						{ title && link ? (
-							<span className="jetpack-podcast-player__title">
-								<a className="jetpack-podcast-player__title-link" href={ link }>
-									{ title }
-								</a>
-							</span>
-						) : (
-							<span className="jetpack-podcast-player__title">{ title }</span>
-						) }
-					</h2>
-				) : null }
-			</div>
+			{ title || ( track && track.title ) ? (
+				<div className="jetpack-podcast-player__titles">
+					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
+				</div>
+			) : null }
 		</div>
 
 		{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
@@ -53,5 +34,36 @@ const Header = memo( ( { playerId, title, cover, link, track, children } ) => (
 		{ children }
 	</div>
 ) );
+
+const Title = ( { playerId, title, link, track } ) => {
+	return (
+		<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
+			{ track && track.title ? (
+				<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+			) : null }
+
+			{ /* Adds a visually hidden - when both a track and title are present */ }
+			{ track && track.title && title ? (
+				<span className="jetpack-podcast-player--visually-hidden"> - </span>
+			) : null }
+
+			{ title ? <PodcastTitle title={ title } link={ link } /> : null }
+		</h2>
+	);
+};
+
+const PodcastTitle = ( { title, link } ) => {
+	return (
+		<span className="jetpack-podcast-player__title">
+			{ link ? (
+				<a className="jetpack-podcast-player__title-link" href={ link }>
+					{ title }
+				</a>
+			) : (
+				title
+			) }
+		</span>
+	);
+};
 
 export default Header;

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -35,35 +35,31 @@ const Header = memo( ( { playerId, title, cover, link, track, children } ) => (
 	</div>
 ) );
 
-const Title = ( { playerId, title, link, track } ) => {
-	return (
-		<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
-			{ track && track.title ? (
-				<span className="jetpack-podcast-player__track-title">{ track.title }</span>
-			) : null }
+const Title = memo( ( { playerId, title, link, track } ) => (
+	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
+		{ track && track.title ? (
+			<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+		) : null }
 
-			{ /* Adds a visually hidden - when both a track and title are present */ }
-			{ track && track.title && title ? (
-				<span className="jetpack-podcast-player--visually-hidden"> - </span>
-			) : null }
+		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
+		{ track && track.title && title ? (
+			<span className="jetpack-podcast-player--visually-hidden"> - </span>
+		) : null }
 
-			{ title ? <PodcastTitle title={ title } link={ link } /> : null }
-		</h2>
-	);
-};
+		{ title ? <PodcastTitle title={ title } link={ link } /> : null }
+	</h2>
+) );
 
-const PodcastTitle = ( { title, link } ) => {
-	return (
-		<span className="jetpack-podcast-player__title">
-			{ link ? (
-				<a className="jetpack-podcast-player__title-link" href={ link }>
-					{ title }
-				</a>
-			) : (
-				title
-			) }
-		</span>
-	);
-};
+const PodcastTitle = memo( ( { title, link } ) => (
+	<span className="jetpack-podcast-player__title">
+		{ link ? (
+			<a className="jetpack-podcast-player__title-link" href={ link }>
+				{ title }
+			</a>
+		) : (
+			title
+		) }
+	</span>
+) );
 
 export default Header;

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -3,37 +3,39 @@
  */
 import { memo } from '@wordpress/element';
 
-const Header = memo( ( { playerId, title, cover, link, track, children } ) => (
-	<div className="jetpack-podcast-player__header-wrapper">
-		<div className="jetpack-podcast-player__header" aria-live="polite">
-			{ cover ? (
-				<div className="jetpack-podcast-player__track-image-wrapper">
-					{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
-					<img className="jetpack-podcast-player__track-image" src={ cover } alt="" />
-				</div>
-			) : null }
+const Header = memo(
+	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
+		<div className="jetpack-podcast-player__header-wrapper">
+			<div className="jetpack-podcast-player__header" aria-live="polite">
+				{ showCoverArt && cover ? (
+					<div className="jetpack-podcast-player__track-image-wrapper">
+						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
+						<img className="jetpack-podcast-player__track-image" src={ cover } alt="" />
+					</div>
+				) : null }
 
-			{ title || ( track && track.title ) ? (
-				<div className="jetpack-podcast-player__titles">
-					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
-				</div>
-			) : null }
-		</div>
-
-		{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
-		{ track && track.description ? (
-			<div
-				id={ `${ playerId }__track-description` }
-				className="jetpack-podcast-player__track-description"
-			>
-				{ track.description }
+				{ title || ( track && track.title ) ? (
+					<div className="jetpack-podcast-player__titles">
+						<Title playerId={ playerId } title={ title } link={ link } track={ track } />
+					</div>
+				) : null }
 			</div>
-		) : null }
 
-		{ /* children contains the audio player */ }
-		{ children }
-	</div>
-) );
+			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
+			{ showEpisodeDescription && track && track.description ? (
+				<div
+					id={ `${ playerId }__track-description` }
+					className="jetpack-podcast-player__track-description"
+				>
+					{ track.description }
+				</div>
+			) : null }
+
+			{ /* children contains the audio player */ }
+			{ children }
+		</div>
+	)
+);
 
 const Title = memo( ( { playerId, title, link, track } ) => (
 	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -3,11 +3,55 @@
  */
 import { memo } from '@wordpress/element';
 
-const Header = memo( ( { track, children } ) => (
-	<div>
-		{ /* TODO: display info based on `track` */ }
-		{ track ? <div>{ track.title }</div> : null }
-		<div>{ children }</div>
+const Header = memo( ( { playerId, title, cover, link, track, children } ) => (
+	<div className="jetpack-podcast-player__header-wrapper">
+		<div className="jetpack-podcast-player__header" aria-live="polite">
+			{ cover ? (
+				<div className="jetpack-podcast-player__track-image-wrapper">
+					{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
+					<img className="jetpack-podcast-player__track-image" src={ cover } alt="" />
+				</div>
+			) : null }
+
+			<div className="jetpack-podcast-player__titles">
+				{ /* The track title and player title are bundled together here in one <h3> so that it looks like "Track title - Podcast Title" for the aria-labelledby and screen reader headings */ }
+				{ title || ( track && track.title ) ? (
+					<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
+						{ track && track.title ? (
+							<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+						) : null }
+
+						{ /* Adds a visually hidden - when both a track and title are present */ }
+						{ track && track.title && title ? (
+							<span className="jetpack-podcast-player--visually-hidden"> - </span>
+						) : null }
+						{ title && link ? (
+							<span className="jetpack-podcast-player__title">
+								<a className="jetpack-podcast-player__title-link" href={ link }>
+									{ title }
+								</a>
+							</span>
+						) : (
+							<span className="jetpack-podcast-player__title">{ title }</span>
+						) }
+					</h2>
+				) : null }
+			</div>
+		</div>
+
+		{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
+		{ track && track.description ? (
+			<div
+				id={ `${ playerId }__track-description` }
+				className="jetpack-podcast-player__track-description"
+			>
+				This is the track description that will need to be escaped and rendered via HTML or the
+				like, since that's how the RSS feed delivers it.
+			</div>
+		) : null }
+
+		{ /* children contains the audio player */ }
+		{ children }
 	</div>
 ) );
 

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -132,14 +132,27 @@ export class PodcastPlayer extends Component {
 	setAudioSource = noop;
 
 	render() {
-		const { tracks, itemsToShow } = this.props;
+		const { playerId, title, link, cover, tracks, itemsToShow } = this.props;
 		const { playerState, currentTrack } = this.state;
 
 		const tracksToDisplay = tracks.slice( 0, itemsToShow );
+		const track = this.getTrack( currentTrack );
 
 		return (
-			<div className={ playerState }>
-				<Header track={ this.getTrack( currentTrack ) }>
+			<section
+				className={ playerState }
+				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
+				aria-describedby={
+					track && track.description ? `${ playerId }__track-description` : undefined
+				}
+			>
+				<Header
+					playerId={ playerId }
+					title={ title }
+					link={ link }
+					cover={ cover }
+					track={ this.getTrack( currentTrack ) }
+				>
 					<AudioPlayer
 						initialTrackSource={ this.getTrack( 0 ).src }
 						handlePlay={ this.handlePlay }
@@ -154,12 +167,15 @@ export class PodcastPlayer extends Component {
 					tracks={ tracksToDisplay }
 					selectTrack={ this.selectTrack }
 				/>
-			</div>
+			</section>
 		);
 	}
 }
 
 PodcastPlayer.defaultProps = {
+	title: 'Podcast Title',
+	cover: 'https://placekitten.com/100/100',
+	link: '#',
 	tracks: [],
 	url: null,
 	itemsToShow: 5,

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -173,9 +173,9 @@ export class PodcastPlayer extends Component {
 }
 
 PodcastPlayer.defaultProps = {
-	title: 'Podcast Title',
-	cover: 'https://placekitten.com/100/100',
-	link: '#',
+	title: '',
+	cover: '',
+	link: '',
 	tracks: [],
 	url: null,
 	itemsToShow: 5,

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -132,7 +132,16 @@ export class PodcastPlayer extends Component {
 	setAudioSource = noop;
 
 	render() {
-		const { playerId, title, link, cover, tracks, itemsToShow } = this.props;
+		const {
+			playerId,
+			title,
+			link,
+			cover,
+			tracks,
+			itemsToShow,
+			showCoverArt,
+			showEpisodeDescription,
+		} = this.props;
 		const { playerState, currentTrack } = this.state;
 
 		const tracksToDisplay = tracks.slice( 0, itemsToShow );
@@ -152,6 +161,8 @@ export class PodcastPlayer extends Component {
 					link={ link }
 					cover={ cover }
 					track={ this.getTrack( currentTrack ) }
+					showCoverArt={ showCoverArt }
+					showEpisodeDescription={ showEpisodeDescription }
 				>
 					<AudioPlayer
 						initialTrackSource={ this.getTrack( 0 ).src }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -18,6 +18,7 @@ import {
 	ToggleControl,
 	Spinner,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, BlockIcon, InspectorControls } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
@@ -57,6 +58,7 @@ const PodcastPlayerEdit = ( {
 		attributesValidation,
 		attributes
 	);
+	const instanceId = `jetpack-podcast-player-block-${ useInstanceId( PodcastPlayerEdit ) }`;
 
 	// State.
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
@@ -204,8 +206,9 @@ const PodcastPlayerEdit = ( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div className={ className }>
+			<div id={ instanceId } className={ className }>
 				<PodcastPlayer
+					playerId={ instanceId }
 					tracks={ feedData.tracks }
 					cover={ feedData.cover }
 					title={ feedData.title }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -18,7 +18,7 @@ import {
 	ToggleControl,
 	Spinner,
 } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
+import { compose, withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, BlockIcon, InspectorControls } from '@wordpress/block-editor';
 import apiFetch from '@wordpress/api-fetch';
@@ -47,6 +47,7 @@ const supportUrl =
 		: 'https://jetpack.com/support/jetpack-blocks/podcast-player-block/';
 
 const PodcastPlayerEdit = ( {
+	instanceId,
 	className,
 	attributes,
 	setAttributes,
@@ -58,7 +59,8 @@ const PodcastPlayerEdit = ( {
 		attributesValidation,
 		attributes
 	);
-	const instanceId = `jetpack-podcast-player-block-${ useInstanceId( PodcastPlayerEdit ) }`;
+
+	const playerId = `jetpack-podcast-player-block-${ instanceId }`;
 
 	// State.
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
@@ -206,9 +208,9 @@ const PodcastPlayerEdit = ( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<div id={ instanceId } className={ className }>
+			<div id={ playerId } className={ className }>
 				<PodcastPlayer
-					playerId={ instanceId }
+					playerId={ playerId }
 					tracks={ feedData.tracks }
 					cover={ feedData.cover }
 					title={ feedData.title }
@@ -222,4 +224,4 @@ const PodcastPlayerEdit = ( {
 	);
 };
 
-export default withNotices( PodcastPlayerEdit );
+export default compose( [ withInstanceId, withNotices ] )( PodcastPlayerEdit );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -104,7 +104,8 @@ function render_player( $player_data, $attributes ) {
 
 	// Genereate a unique id for the block instance.
 	$instance_id = wp_unique_id( 'jetpack-podcast-player-block-' );
-
+	$player_data['playerId'] = $instance_id;
+	
 	// Generate object to be used as props for PodcastPlayer.
 	$player_props = array_merge(
 		// Make all attributes available.

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -103,9 +103,9 @@ function render_player( $player_data, $attributes ) {
 	);
 
 	// Genereate a unique id for the block instance.
-	$instance_id = wp_unique_id( 'jetpack-podcast-player-block-' );
+	$instance_id             = wp_unique_id( 'jetpack-podcast-player-block-' );
 	$player_data['playerId'] = $instance_id;
-	
+
 	// Generate object to be used as props for PodcastPlayer.
 	$player_props = array_merge(
 		// Make all attributes available.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -5,6 +5,7 @@
 
 $episode-v-padding: 15px;
 $episode-h-padding: 10px;
+$player-grid-spacing: 24px;
 $episode-status-icon-size: 22px;
 $text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
 $text-color-hover: $black;
@@ -13,6 +14,15 @@ $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
 
 
+.jetpack-podcast-player--visually-hidden {
+	position: absolute !important;
+	height: 1px; 
+	width: 1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	white-space: nowrap; /* added line */
+}
+
 /**
  * Player's (block) parent element.
  */
@@ -20,6 +30,7 @@ $block-border-color: $dark-gray-100;
 	border: 1px solid $block-border-color;
 	background-color: $block-bg-color;
 	overflow: hidden;
+	font-family: $default-font;
 
 	/**
 	 * Player's state classes added to this element:
@@ -31,6 +42,81 @@ $block-border-color: $dark-gray-100;
 	audio {
 		display: none;
 	}
+}
+
+/**
+ * Podcast Player Header
+ */
+.jetpack-podcast-player__header-wrapper {
+	display: flex;
+	flex-direction: column;
+	position: relative;
+
+	&:after {
+		content: '';
+		background: $light-gray-700;
+		position: absolute;
+		height: 2px;
+		bottom: 0;
+		left: $player-grid-spacing;
+		right: $player-grid-spacing;
+	}
+}
+
+.jetpack-podcast-player__track-description {
+	order: 99; // high number to make it always appear after the audio player
+	padding: 0 $player-grid-spacing;
+	margin-bottom: $player-grid-spacing;
+	color: $dark-gray-500;
+	font-size: 16px;
+	line-height: 1.6;
+}
+
+.jetpack-podcast-player__header {
+	display: flex;
+	padding: $player-grid-spacing;
+}
+
+.jetpack-podcast-player__track-image-wrapper {
+	width: 80px;
+	margin-right: $player-grid-spacing;
+	flex-shrink: 0;
+}
+
+.jetpack-podcast-player__track-image {
+	width: 80px;
+	height: 80px;
+}
+
+.jetpack-podcast-player__titles { 
+	display: flex;
+	flex-direction: column;
+	
+}
+
+.jetpack-podcast-player__track-title {
+	font-size: 24px;
+	margin: 0 0 10px;
+}
+
+.jetpack-podcast-player__title {
+	font-size: 16px;
+	color: $text-color;
+	margin: 0;
+}
+
+.jetpack-podcast-player__title-link {
+	text-decoration: none;
+	color: $text-color;
+
+	&:hover,
+	&:focus {
+		color: $text-color-hover;
+	}
+}
+
+.jetpack-podcast-player__audio-player {
+	margin-bottom: $player-grid-spacing;
 }
 
 .jetpack-podcast-player__episodes {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -6,6 +6,12 @@
 $episode-v-padding: 15px;
 $episode-h-padding: 10px;
 $player-grid-spacing: 24px;
+$cover-image-size: 80px;
+$track-title-font-size: 24px;
+$track-title-b-margin: 10px;
+$podcast-title-font-size: 16px;
+$description-font-size: 16px;
+$player-divider-height: 2px;
 $episode-status-icon-size: 22px;
 $text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
 $text-color-hover: $black;
@@ -80,7 +86,7 @@ $block-border-color: $dark-gray-100;
 		content: '';
 		background: $light-gray-700;
 		position: absolute;
-		height: 2px;
+		height: $player-divider-height;
 		bottom: 0;
 		left: $player-grid-spacing;
 		right: $player-grid-spacing;
@@ -92,7 +98,7 @@ $block-border-color: $dark-gray-100;
 	padding: 0 $player-grid-spacing;
 	margin-bottom: $player-grid-spacing;
 	color: $dark-gray-500;
-	font-size: 16px;
+	font-size: $description-font-size;
 	line-height: 1.6;
 }
 
@@ -102,23 +108,23 @@ $block-border-color: $dark-gray-100;
 }
 
 .jetpack-podcast-player__track-image-wrapper {
-	width: 80px;
+	width: $cover-image-size;
 	margin-right: $player-grid-spacing;
 	flex-shrink: 0;
 }
 
 .jetpack-podcast-player__track-image {
-	width: 80px;
-	height: 80px;
+	width: $cover-image-size;
+	height: $cover-image-size;
 }
 
 .jetpack-podcast-player__track-title {
-	font-size: 24px;
-	margin: 0 0 10px;
+	font-size: $track-title-font-size;
+	margin: 0 0 $track-title-b-margin;
 }
 
 .jetpack-podcast-player__title {
-	font-size: 16px;
+	font-size: $podcast-title-font-size;
 	color: $text-color;
 	margin: 0;
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -42,6 +42,30 @@ $block-border-color: $dark-gray-100;
 	audio {
 		display: none;
 	}
+
+	.jetpack-podcast-player__titles { 
+		display: flex;
+		flex-direction: column;
+		margin: 0;
+	}
+
+	.jetpack-podcast-player__title-link {
+		text-decoration: none;
+		color: $text-color;
+	
+		&:hover,
+		&:focus {
+			color: $text-color-hover;
+		}
+	}
+	
+	.jetpack-podcast-player__episodes {
+		list-style-type: none;
+		display: flex;
+		flex-direction: column;
+		margin: 0;
+		padding: $episode-v-padding 0;
+	}
 }
 
 /**
@@ -88,12 +112,6 @@ $block-border-color: $dark-gray-100;
 	height: 80px;
 }
 
-.jetpack-podcast-player__titles { 
-	display: flex;
-	flex-direction: column;
-	
-}
-
 .jetpack-podcast-player__track-title {
 	font-size: 24px;
 	margin: 0 0 10px;
@@ -105,26 +123,8 @@ $block-border-color: $dark-gray-100;
 	margin: 0;
 }
 
-.jetpack-podcast-player__title-link {
-	text-decoration: none;
-	color: $text-color;
-
-	&:hover,
-	&:focus {
-		color: $text-color-hover;
-	}
-}
-
 .jetpack-podcast-player__audio-player {
 	margin-bottom: $player-grid-spacing;
-}
-
-.jetpack-podcast-player__episodes {
-	list-style-type: none;
-	display: flex;
-	flex-direction: column;
-	margin: 0;
-	padding: $episode-v-padding 0;
 }
 
 .jetpack-podcast-player__episode {
@@ -147,23 +147,25 @@ $block-border-color: $dark-gray-100;
 		color: $text-color-hover;
 		font-weight: bold;
 	}
-}
 
-.jetpack-podcast-player__episode-link {
-	display: flex;
-	flex-flow: row nowrap;
-	justify-content: space-between;
-	padding: $episode-h-padding $episode-v-padding;
-	text-decoration: none;
-	color: inherit;
-	transition: none;
-
-	.jetpack-podcast-player__episode.is-active & {
-		.is-error & {
-			padding-bottom: 0; // Make space for the error element that will be appended.
+	.jetpack-podcast-player__episode-link {
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: space-between;
+		padding: $episode-h-padding $episode-v-padding;
+		text-decoration: none;
+		color: inherit;
+		transition: none;
+	
+		.jetpack-podcast-player__episode.is-active & {
+			.is-error & {
+				padding-bottom: 0; // Make space for the error element that will be appended.
+			}
 		}
 	}
 }
+
+
 
 /**
  * Fixes a Chrome bug where in TwentyTwenty and other themes that apply a


### PR DESCRIPTION
Adds markup and styles for the header of the podcast player.

**Design**
<img width="398" alt="Podcast Player design" src="https://user-images.githubusercontent.com/967608/77468674-e8d8a900-6ddb-11ea-8815-c14af84ad158.png">

**How it looks in this PR**
Site
<img width="630" alt="Screen Shot 2020-03-25 at 3 21 49 PM" src="https://user-images.githubusercontent.com/967608/77581801-5c49eb80-6eac-11ea-990d-26b9c16e548a.png">

Editor
<img width="813" alt="Screen Shot 2020-03-25 at 3 28 44 PM" src="https://user-images.githubusercontent.com/967608/77582427-5ef91080-6ead-11ea-82a6-6db49b8842ed.png">

#### Changes proposed in this Pull Request:
Adds header markup to the podcast player.
- Uses a `<section>` on the Podcast Player to add it as a landmark region
- Uses `aria-labelledby` and `aria-describedby` on the `<section>`
- Podcast Player title is marked up as a single `<h2>` with both the Track Title and Podcast Title so it can set the `aria-labelledby` description to be read as `{track.title} - {title}`
- Uses block attributes "Show cover art" and "Show episode description" (configurable in the sidebar) to control which things will show up in the header

#### Testing instructions:
- Add a Podcast Player block to a page or post (some RSS feeds to use: 
   - https://anchor.fm/damian/episodes/Blocks-introduce-new-Podcast-Episodes-block-ebdqg5/a-a1pvrl
    - http://feeds.99percentinvisible.org/99percentinvisible?format=xml 
- The player header (track title, podcast title, cover image, track description) should look the same in both the site front-end and editor-canvas.
- Try different combinations of "Show cover art" and "Show episode description" settings and confirm they look good in the editor and the frontend too
