### PR TITLE
Fix/top posts widget

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -509,10 +509,11 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	 * @since 8.4.0 Added $types param
 	 *
 	 * @param int   $count The maximum number of posts to be returned.
-	 * @param array $types The post types that should be returned.
+	 * @param array $types The post types that should be returned. Optional. Defaults to 'post' and 'page'.
+	 *
 	 * @return array array of posts.
 	 */
-	public function get_by_likes( $count, $types ) {
+	public function get_by_likes( $count, $types = array( 'post', 'page' ) ) {
 		$post_likes = wpl_get_blogs_most_liked_posts();
 		if ( ! $post_likes ) {
 			return array();
@@ -581,8 +582,6 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	/**
 	 * Get some posts if no posts are found in the stats API
 	 *
-	 * @since 8.4.0 Added $count and $types parameters
-	 *
 	 * @param int   $count The maximum number of posts to be returned.
 	 * @param array $types The post types that should be returned.
 	 * @return array
@@ -618,12 +617,14 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	/**
 	 * Get posts from an array of IDs
 	 *
+	 * @since 8.4.0 Added $count and $types parameters
+	 *
 	 * @param array $post_ids The post IDs.
 	 * @param int   $count The maximum number of posts to return.
-	 * @param array $types The post types that should be returned.
+	 * @param array $types The post types that should be returned. Optional. Defaults to 'post', 'page'.
 	 * @return array
 	 */
-	public function get_posts( $post_ids, $count, $types ) {
+	public function get_posts( $post_ids, $count, $types = array( 'post', 'page' ) ) {
 		$counter = 0;
 
 		if ( ! is_array( $types ) || empty( $types ) ) {

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -619,7 +619,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	/**
 	 * Get posts from an array of IDs
 	 *
-	 * @since 8.4.0 Added $count and $types parameters
+	 * @since 8.4.0 Added $types parameters
 	 *
 	 * @param array $post_ids The post IDs.
 	 * @param int   $count The maximum number of posts to return.

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -506,6 +506,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	 *
 	 * ONLY TO BE USED IN WPCOM
 	 *
+	 * @since 8.4.0 Added $types param
+	 *
 	 * @param int   $count The maximum number of posts to be returned.
 	 * @param array $types The post types that should be returned.
 	 * @return array array of posts.
@@ -578,6 +580,8 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 
 	/**
 	 * Get some posts if no posts are found in the stats API
+	 *
+	 * @since 8.4.0 Added $count and $types parameters
 	 *
 	 * @param int   $count The maximum number of posts to be returned.
 	 * @param array $types The post types that should be returned.

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -290,7 +290,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 		}
 
 		if ( ! $posts ) {
-			$posts = $this->get_fallback_posts();
+			$posts = $this->get_fallback_posts( $count, $types );
 		}
 
 		echo $args['before_widget'];
@@ -579,21 +579,28 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	/**
 	 * Get some posts if no posts are found in the stats API
 	 *
+	 * @param int   $count The maximum number of posts to be returned.
+	 * @param array $types The post types that should be returned.
 	 * @return array
 	 */
-	public function get_fallback_posts() {
+	public function get_fallback_posts( $count, $types ) {
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			return array();
 		}
 
-		$post_query = new WP_Query;
+		$post_query = new WP_Query();
+
+		if ( ! is_array( $types ) || empty( $types ) ) {
+			$types = array( 'post', 'page' );
+		}
 
 		$posts = $post_query->query(
 			array(
-				'posts_per_page' => 1,
+				'posts_per_page' => $count,
 				'post_status'    => 'publish',
-				'post_type'      => array( 'post', 'page' ),
+				'post_type'      => $types,
 				'no_found_rows'  => true,
+				'fields'         => 'ids',
 			)
 		);
 
@@ -601,9 +608,7 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 			return array();
 		}
 
-		$post = array_pop( $posts );
-
-		return $this->get_posts( $post->ID, 1 );
+		return $this->get_posts( $posts, $count, $types );
 	}
 
 	/**

--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -582,11 +582,13 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	/**
 	 * Get some posts if no posts are found in the stats API
 	 *
+	 * @since 8.4.0 Added $count and $types
+	 *
 	 * @param int   $count The maximum number of posts to be returned.
 	 * @param array $types The post types that should be returned.
 	 * @return array
 	 */
-	public function get_fallback_posts( $count, $types ) {
+	public function get_fallback_posts( $count = 10, $types = array( 'post', 'page' ) ) {
 		if ( current_user_can( 'edit_theme_options' ) ) {
 			return array();
 		}


### PR DESCRIPTION
Fixes #15104, 
See #2369
Addresses 4794-jpop-issues, 4988-jpop-issues

#### Changes proposed in this Pull Request:

This PR improves the way the Top Posts & Pages Widget fetches posts to be displayed.

##### How it worked before this PR:

* Widget makes a request to the wp.com API to fetch the top posts (of all post types)
* Since it makes a request with `summarize=1`, it receives up to 500 posts in the response
* It filters out only the number of posts the widget is configured to be displayed
* From this few posts, it filters out only posts of the post types configured to be displayed
* If it results in zero posts, it falls back fetching only one post or page, no matter what the post types configured in the widget are

The problem here is that if there were 10 posts in the top 10 positions, and you queried for pages, you would get no results.

##### This PR proposes two changes:

1. It filters out the posts by post type at the same time it's iterating over all the posts returned by the API, till it reaches the number of posts configured in the widget. 
2. If no posts are found, it respects the post type and number of posts configurations

**Limitations:** This PR does not completely solve the problem. There is no way to query the wp.com API for post types filtering for a specific post type. So the same problem still persists, the only difference is that it now looks in all 500 retrieved posts, and not only on the first 10.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It fixes an existing feature

#### Testing instructions:

It's very difficult to test the edge cases that this PR fixes, but I'll give some basic testing instructions and describe the edge case afterward.

Run these tests both on a wp.com site and on a JP site. 

**On an existing site with some stats.**
2. in Jetpack settings, activate `Make extra widgets available for use on your site including subscription forms and Twitter streams`
3. Go to Appearance > Widgets and add two "Top Posts & Pages" Widget
4. Configure one of the widgets to display only posts, and the other one to display only pages
5. Visit the site both logged in and logged out and check if the widgets are working as expected

**On a brand new site**
1. Follow the same instructions, 1 to 4
2. Visit the site, logged in, and see the message "There are no posts to display"
3. Visit the site, logged out, and see that the posts displayed in both widget respect the configured post type and count.

**The Edge case**

The Edge case is a site that has many posts of a certain post type and, when you add a widget to display posts of another post type, this widget would not find any post.

* Considering a site that has many posts of the post type `post` as its top rankings posts, and few pages with few visits
1. Follow the same instructions 1 to 4
2. Check the site front end, bot logged in and logged out. Check that the widget that should display pages finds the most viewed pages.


#### Proposed changelog entry for your changes:

* Fixes Top Posts & Pages Widget handling with different post types
