### PR TITLE
Podcast Player: API endpoint improvements

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -32,9 +32,12 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 			'/' . $this->rest_base,
 			array(
 				array(
-					'methods'  => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_player_data' ),
-					'args'     => array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_player_data' ),
+					'permission_callback' => function () {
+						return current_user_can( 'edit_posts' );
+					},
+					'args'                => array(
 						'url' => array(
 							'description'       => __( 'The Podcast RSS feed URL.', 'jetpack' ),
 							'type'              => 'string',

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php
@@ -60,12 +60,10 @@ class WPCOM_REST_API_V2_Endpoint_Podcast_Player extends WP_REST_Controller {
 			jetpack_require_lib( 'class-jetpack-podcast-helper' );
 		}
 
-		return rest_ensure_response(
-			array(
-				'tracks' => Jetpack_Podcast_Helper::get_track_list( $request['url'] ),
-				'cover'  => '', // TODO: parse podcast cover image.
-			)
-		);
+		$player_data = Jetpack_Podcast_Helper::get_player_data( $request['url'] );
+		// $player_data can be the actual data or WP_Error.
+		// rest_ensure_response handles both.
+		return rest_ensure_response( $player_data );
 	}
 }
 wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Podcast_Player' );

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -207,7 +207,9 @@ const PodcastPlayerEdit = ( {
 			<div className={ className }>
 				<PodcastPlayer
 					tracks={ feedData.tracks }
-					coverArt={ feedData.coverArt }
+					cover={ feedData.cover }
+					title={ feedData.title }
+					link={ feedData.link }
 					itemsToShow={ itemsToShow }
 					showEpisodeDescription={ showEpisodeDescription }
 					showCoverArt={ showCoverArt }


### PR DESCRIPTION
This updates the helper class to format all data needed, not just tracks. And data from this class is reused in both API and server-side rendering.

#### Changes proposed in this Pull Request:
* More universal helper function to get all player data at once
* Error passing from helper to API
* New data loaded from the RSS:
  - podcast title
  - podcast homepage
  - podcast cover image
* API only accessible for logged-in users, with `edit_posts` capability

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
paYJgx-sH-p2

#### Testing instructions:
- smoke test block in the editor
  - should load episodes of podcast and those will be playable
  - inspect the API request in devtools and check it comes back with these keys (might be empty for some podcasts): `tracks`, `title`, `link` and `cover`
- test block on the fronted. should work as expected
- try accessing the endpoint directly, like http://localhost/wp-json/wpcom/v2/podcast-player?url=https%3A%2F%2Fdistributed.blog%2Fcategory%2Fpodcast%2Ffeed%2F
  - should fail with `rest_forbidden` because you are not authorized without token/cookie

#### Proposed changelog entry for your changes:
* none
