### PR TITLE
Restore the `ab_connect_banner_green_bar` option to the valid options…

### DIFF
--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -64,6 +64,7 @@ class Jetpack_Options {
 					'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 					'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
 					'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
+					'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
 					'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 					'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.
 					'static_asset_cdn_files',      // (array) An nested array of files that we can swap out for cdn versions.


### PR DESCRIPTION
In PR #14969 the `ab_connect_banner_green_bar` variable was removed from the list of valid option names as a part of a cleanup. 

This clashes with the upgrade code which checks for the option's existence when Jetpack is upgraded in order to remove it.

Since the option is not on the list of valid options, a PHP warning will be triggered.

Fixes #15067 

#### Changes proposed in this Pull Request:

This PR restores the `ab_connect_banner_green_bar` option to the valid options list to allow safe removal when upgrading to Jetpack 8.4.

#### Testing instructions:

0. Make sure you're testing on a new site as the code path won't run if the connected/installed Jetpack version is the same as the one you're working with. I.e. you need to make it think it's "upgrading" from an older Jetpack version.
1. Enable debugging output
2. Go to `/wp-admin/admin.php?page=jetpack#/`
3. Try connect (make sure in-place connection is used)
4. Make sure no error is triggered

#### Proposed changelog entry for your changes:

* No changelog entry for this specific change as it's partial reversal of #14969 and should be under the same group.