### PR TITLE
Sharing Module: making unit tests independent from global environment.

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -11,6 +11,15 @@ class Sharing_Service {
 	private $global               = false;
 	public $default_sharing_label = '';
 
+	/**
+	 * Initialize the sharing service.
+	 * Only run this method once upon module loading.
+	 */
+	public static function init() {
+		add_filter( 'the_content', 'sharing_display', 19 );
+		add_filter( 'the_excerpt', 'sharing_display', 19 );
+	}
+
 	public function __construct() {
 		$this->default_sharing_label = __( 'Share this:', 'jetpack' );
 	}
@@ -944,8 +953,6 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 }
 
-add_filter( 'the_content', 'sharing_display', 19 );
-add_filter( 'the_excerpt', 'sharing_display', 19 );
 function get_base_recaptcha_lang_code() {
 
 	$base_recaptcha_lang_code_mapping = array(
@@ -971,3 +978,5 @@ function get_base_recaptcha_lang_code() {
 	// if no base mapping is found return default 'en'
 	return 'en';
 }
+
+Sharing_Service::init();

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -757,8 +757,12 @@ class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 		// this only applies to rendered content, which is off by default
 		Settings::update_settings( array( 'render_filtered_content' => 1 ) );
 
-		require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing.php';
-		require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php';
+		if ( class_exists( 'Sharing_Service' ) ) {
+			Sharing_Service::init();
+		} else {
+			require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing.php';
+			require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php';
+		}
 
 		set_current_screen( 'front' );
 		add_filter( 'sharing_show', '__return_true' );


### PR DESCRIPTION
The changes are necessary for unit tests to be isolated and independent on each other.

Including the `sharing-service.php` in any test currently leads to the failed assertions in `WP_Test_Jetpack_Sync_Post::test_remove_sharedaddy_from_filtered_content()`.

The minor refactoring suggested by the commit allows the unit test to run the module initialization again after it's been reset by previously run tests.

#### Changes proposed in this Pull Request:
* Minor refactoring of the sharing module.
* Adjustment of a unit test to make it independent from the environment.

#### Testing instructions:
Run the unit tests (e.g. `yarn docker:phpunit`). If everything goes well, we're fine.

There should be no need to test the UI as the changes are insignificant, but here are the instructions anyway:
1. Go to the "Jetpack -> Settings -> Sharing": `/wp-admin/admin.php?page=jetpack#/sharing`
2. Turn on the setting: "Add sharing buttons to your posts and pages"
3. Open any post and verify that the sharing buttons appear under the post content:
<img width="241" alt="Screen Shot 2020-03-25 at 9 46 04 AM" src="https://user-images.githubusercontent.com/1341249/77549145-7c15eb00-6e7d-11ea-8c69-edd654ead879.png">
4. Open the "Jetpack -> Settings -> Sharing" again and turn off the "Add sharing buttons to your posts and pages"
5. Verify that blog posts no longer display the sharing buttons

#### Proposed changelog entry for your changes:
No entry needed.