### PR TITLE
Podcast Player: Add cache to the API endpoint

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -73,7 +73,7 @@ function render_block( $attributes ) {
 	// Sanitize the URL.
 	$attributes['url'] = esc_url_raw( $attributes['url'] );
 
-	$player_data = Jetpack_Podcast_Helper::get_player_data( $attributes['url'], absint( $attributes['itemsToShow'] ) );
+	$player_data = Jetpack_Podcast_Helper::get_player_data( $attributes['url'] );
 
 	if ( is_wp_error( $player_data ) ) {
 		return '<p>' . esc_html( $player_data->get_error_message() ) . '</p>';
@@ -94,6 +94,15 @@ function render_player( $player_data, $attributes ) {
 	if ( empty( $player_data['tracks'] ) ) {
 		return '<p>' . esc_html__( 'No tracks available to play.', 'jetpack' ) . '</p>';
 	}
+
+	// Only use the amount of tracks requested.
+	$player_data['tracks'] = array_slice(
+		$player_data['tracks'],
+		0,
+		absint( $attributes['itemsToShow'] )
+	);
+
+	// Genereate a unique id for the block instance.
 	$instance_id = wp_unique_id( 'jetpack-podcast-player-block-' );
 
 	// Generate object to be used as props for PodcastPlayer.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds one hour caching for for RSS feed results for the Podcast Player.
* It does it on a level that both the API and the server side rendering use the same cache so you will never experience a difference where one might have updated and the other one still has old data cached.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
paYJgx-sH-p2

#### Testing instructions:
* Use player in both editor and on the frontend.
* Setting "items to show" in the block settings should be respected by both editor and the frontend
* If you really want to check the caching works, you can add a new value into `$player_data` just before it is stored in transient. For example `'cached' => time(),`
  * after that, you can observe that multiple requests to the API are coming back with equal `cache` value

#### Proposed changelog entry for your changes:
* none