### PR TITLE
Search: Update copy for Pro Plan

### DIFF
--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -139,7 +139,7 @@ function jetpack_get_module_i18n( $key ) {
 
 			'search' => array(
 				'name' => _x( 'Search', 'Module Name', 'jetpack' ),
-				'description' => _x( 'Enhanced search, powered by Elasticsearch, a powerful replacement for WordPress search.', 'Module Description', 'jetpack' ),
+				'description' => _x( 'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.', 'Module Description', 'jetpack' ),
 			),
 
 			'seo-tools' => array(

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -812,7 +812,7 @@ add_action( 'jetpack_learn_more_button_search', 'jetpack_search_more_link' );
  */
 function jetpack_search_more_info() {
 	esc_html_e(
-		'Enhanced search, powered by Elasticsearch, a powerful replacement for WordPress search.',
+		'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
 		'jetpack'
 	);
 }

--- a/modules/search.php
+++ b/modules/search.php
@@ -2,7 +2,7 @@
 
 /**
  * Module Name: Search
- * Module Description: Enhanced search, powered by Elasticsearch, a powerful replacement for WordPress search.
+ * Module Description: Help visitors quickly find answers with highly relevant instant search results and powerful filtering.
  * First Introduced: 5.0
  * Sort Order: 34
  * Free: false

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -74,7 +74,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 			apply_filters( 'jetpack_widget_name', $name ),
 			array(
 				'classname'   => 'jetpack-filters widget_search',
-				'description' => __( 'Replaces the default search with an Elasticsearch-powered search interface and filters.', 'jetpack' ),
+				'description' => __( 'Instant search and filtering to help visitors quickly find relevant answers and explore your site.', 'jetpack' ),
 			)
 		);
 


### PR DESCRIPTION
A few updates to the copy for Search module to reflect instant search. Removing references to ES and using the new instant search and filtering language.

Some of these I am not even sure they still get displayed, but I did some searching in the repo to find them.

I've also fixed the plans grid which was coming from the wp.com api.
