### PR TITLE
Adds way to redirect user for connect flow

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4054,7 +4054,7 @@ p {
 						'url'          => rawurlencode( get_site_url() ),
 					),
 					// @todo provide way to go to specific calypso env.
-					'https://wordpress.com/jetpack/connect'
+					self::get_calypso_host() . 'jetpack/connect'
 				)
 			);
 			exit;
@@ -7160,6 +7160,28 @@ endif;
 		}
 
 		return '';
+	}
+
+	/**
+	 * Returns the hostname with protocol for Calypso.
+	 * Used for developing Jetpack with Calypso.
+	 *
+	 * @since 8.4.0
+	 *
+	 * @return string Calypso host.
+	 */
+	public static function get_calypso_host() {
+		$calypso_env = self::get_calypso_env();
+		switch ( $calypso_env ) {
+			case 'development':
+				return 'http://calypso.localhost:3000/';
+			case 'wpcalypso':
+				return 'https://wpcalypso.wordpress.com/';
+			case 'horizon':
+				return 'https://horizon.wordpress.com/';
+			default:
+				return 'https://wordpress.com/';
+		}
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -384,7 +384,7 @@ class Jetpack {
 	 * @var string
 	 * @since 8.4.0
 	 */
-	protected static $jetpack_redirect_login = 'jetpack_connect_login_redirect';
+	public static $jetpack_redirect_login = 'jetpack_connect_login_redirect';
 
 	/**
 	 * Holds the singleton instance of this class

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -379,6 +379,14 @@ class Jetpack {
 	public static $plugin_upgrade_lock_key = 'jetpack_upgrade_lock';
 
 	/**
+	 * Constant for login redirect key.
+	 *
+	 * @var string
+	 * @since 8.4.0
+	 */
+	protected static $jetpack_redirect_login = 'jetpack_connect_login_redirect';
+
+	/**
 	 * Holds the singleton instance of this class
 	 *
 	 * @since 2.3.3
@@ -4032,8 +4040,8 @@ p {
 	 */
 	public function login_url( $login_url, $redirect ) {
 		parse_str( wp_parse_url( $redirect, PHP_URL_QUERY ), $redirect_parts );
-		if ( ! empty( $redirect_parts['connect_login_redirect'] ) ) {
-			$login_url = add_query_arg( 'connect_login_redirect', 'true', $login_url );
+		if ( ! empty( $redirect_parts[ self::$jetpack_redirect_login ] ) ) {
+			$login_url = add_query_arg( self::$jetpack_redirect_login, 'true', $login_url );
 		}
 		return $login_url;
 	}
@@ -4045,7 +4053,7 @@ p {
 	 */
 	public function login_init() {
 		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( ! empty( $_GET['connect_login_redirect'] ) ) {
+		if ( ! empty( $_GET[ self::$jetpack_redirect_login ] ) ) {
 			add_filter( 'allowed_redirect_hosts', array( &$this, 'allow_wpcom_environments' ) );
 			wp_safe_redirect(
 				add_query_arg(

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1216,7 +1216,7 @@ EXPECTED;
 	 */
 	public function test_login_url_add_redirect() {
 		$login_url = wp_login_url( '/wp-admin' );
-		$this->assertStringNotContainsString( $login_url, Jetpack::$jetpack_redirect_login );
+		$this->assertFalse( strpos( $login_url, Jetpack::$jetpack_redirect_login ) );
 
 		$login_url = wp_login_url( '/wp-admin?' . Jetpack::$jetpack_redirect_login . '=true' );
 		parse_str( wp_parse_url( $login_url, PHP_URL_QUERY ), $login_parts );


### PR DESCRIPTION
Redirects users back to Calypso if they aren't signed in to WordPress.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds a query param `connect_login_redirect` which redirects users that aren't logged in back to Calypso instead of displaying the wp-login screen.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updates features. See 1164141197617539-as-1164522491999689.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* On a site with Jetpack installed and active but not connected, log out.
* Go to wordpress.com/jetpack/connect and enter your site URL.
* Observe network traffic and verify you are redirected back to Calypso.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improves Jetpack connection flow issues.
