### PR TITLE
Update default zoom for multi-point maps

### DIFF
--- a/extensions/blocks/map/component.js
+++ b/extensions/blocks/map/component.js
@@ -250,10 +250,10 @@ export class Map extends Component {
 		if ( points.length > 1 ) {
 			map.fitBounds( bounds, {
 				padding: {
-					top: 40,
-					bottom: 40,
-					left: 20,
-					right: 20,
+					top: 80,
+					bottom: 80,
+					left: 40,
+					right: 40,
 				},
 			} );
 			this.setState( { boundsSetProgrammatically: true } );


### PR DESCRIPTION
While using the map block with multiple points, the zoom fit feels really tight.

This PR would increase the padding around the points, giving users more context to what's immediately surrounding their points.

### Before
<img width="609" alt="Screen Shot 2020-03-25 at 6 18 35 PM" src="https://user-images.githubusercontent.com/2522431/77591420-4cd79c00-6ec6-11ea-87c5-8f001e93e86d.png">

### After
<img width="601" alt="Screen Shot 2020-03-25 at 6 18 54 PM" src="https://user-images.githubusercontent.com/2522431/77591427-4fd28c80-6ec6-11ea-97d9-6f40820a989f.png">

#### Testing Instructions
* Insert a map block on a page with 2 or more points.
* Check the padding around these points.

#### Proposed changelog entry for your changes:
* Slightly decreases the automatic zoom on multi-point map blocks.