### PR TITLE
add woo analytics event props for block/shortcode use in cart/checkout

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -82,12 +82,14 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * @return array Array of standard event props.
 	 */
 	public function get_common_properties() {
-		return array(
+		$site_info          = array(
 			'blog_id'     => Jetpack::get_option( 'id' ),
 			'ui'          => $this->get_user_id(),
 			'url'         => home_url(),
 			'woo_version' => WC()->version,
 		);
+		$cart_checkout_info = self::get_cart_checkout_info();
+		return array_merge( $site_info, $cart_checkout_info );
 	}
 
 	/**
@@ -416,4 +418,75 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		return $line;
 	}
 
+	/**
+	 * Search a specific post for text content.
+	 *
+	 * Note: similar code is in a WooCommerce core PR:
+	 * https://github.com/woocommerce/woocommerce/pull/25932
+	 *
+	 * @param integer $post_id The id of the post to search.
+	 * @param string  $text    The text to search for.
+	 * @return string 'Yes' if post contains $text (otherwise 'No').
+	 */
+	public static function post_contains_text( $post_id, $text ) {
+		global $wpdb;
+
+			// Search for the text anywhere in the post.
+		$wildcarded = "%{$text}%";
+
+		$result = $wpdb->get_var(
+			$wpdb->prepare(
+				"
+				SELECT COUNT( * ) FROM {$wpdb->prefix}posts
+				WHERE ID=%d
+				AND {$wpdb->prefix}posts.post_content LIKE %s
+				",
+				array( $post_id, $wildcarded )
+			)
+		);
+
+		return ( '0' !== $result ) ? 'Yes' : 'No';
+	}
+
+	/**
+	 * Get info about the cart & checkout pages, in particular
+	 * whether the store is using shortcodes or Gutenberg blocks.
+	 * This info is cached in a transient.
+	 *
+	 * Note: similar code is in a WooCommerce core PR:
+	 * https://github.com/woocommerce/woocommerce/pull/25932
+	 *
+	 * @return array
+	 */
+	public static function get_cart_checkout_info() {
+		$info = get_transient( 'jetpack-woocommerce-analytics-cart-checkout-info-cache' );
+
+		if ( false === $info ) {
+			$cart_page_id     = wc_get_page_id( 'cart' );
+			$checkout_page_id = wc_get_page_id( 'checkout' );
+
+			$info = array(
+				'cart_page_contains_cart_block'         => self::post_contains_text(
+					$cart_page_id,
+					'<!-- wp:woocommerce/cart'
+				),
+				'cart_page_contains_cart_shortcode'     => self::post_contains_text(
+					$cart_page_id,
+					'[woocommerce_cart]'
+				),
+				'checkout_page_contains_checkout_block' => self::post_contains_text(
+					$checkout_page_id,
+					'<!-- wp:woocommerce/checkout'
+				),
+				'checkout_page_contains_checkout_shortcode' => self::post_contains_text(
+					$checkout_page_id,
+					'[woocommerce_checkout]'
+				),
+			);
+
+			set_transient( 'jetpack-woocommerce-analytics-cart-checkout-info-cache', $info, DAY_IN_SECONDS );
+		}
+
+		return $info;
+	}
 }

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -459,8 +459,9 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * @return array
 	 */
 	public static function get_cart_checkout_info() {
-		$info = get_transient( 'jetpack_woocommerce_analytics_cart_checkout_info_cache' );
+		$transient_name = 'jetpack_woocommerce_analytics_cart_checkout_info_cache';
 
+		$info = get_transient( $transient_name );
 		if ( false === $info ) {
 			$cart_page_id     = wc_get_page_id( 'cart' );
 			$checkout_page_id = wc_get_page_id( 'checkout' );
@@ -484,7 +485,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 				),
 			);
 
-			set_transient( 'jetpack-woocommerce-analytics-cart-checkout-info-cache', $info, DAY_IN_SECONDS );
+			set_transient( $transient_name, $info, DAY_IN_SECONDS );
 		}
 
 		return $info;

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -426,7 +426,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 *
 	 * @param integer $post_id The id of the post to search.
 	 * @param string  $text    The text to search for.
-	 * @return string 'Yes' if post contains $text (otherwise 'No').
+	 * @return integer 1 if post contains $text (otherwise 0).
 	 */
 	public static function post_contains_text( $post_id, $text ) {
 		global $wpdb;
@@ -445,7 +445,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			)
 		);
 
-		return ( '0' !== $result ) ? 'Yes' : 'No';
+		return ( '0' !== $result ) ? 1 : 0;
 	}
 
 	/**

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -431,7 +431,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	public static function post_contains_text( $post_id, $text ) {
 		global $wpdb;
 
-			// Search for the text anywhere in the post.
+		// Search for the text anywhere in the post.
 		$wildcarded = "%{$text}%";
 
 		$result = $wpdb->get_var(
@@ -459,7 +459,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 	 * @return array
 	 */
 	public static function get_cart_checkout_info() {
-		$info = get_transient( 'jetpack-woocommerce-analytics-cart-checkout-info-cache' );
+		$info = get_transient( 'jetpack_woocommerce_analytics_cart_checkout_info_cache' );
 
 		if ( false === $info ) {
 			$cart_page_id     = wc_get_page_id( 'cart' );


### PR DESCRIPTION
This PR adds additional props to `woocommerceanalytics` events so we can filter based on how stores implement their cart & checkout pages.

New [cart](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1289) & [checkout](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1294) blocks are coming soon in the [WooCommerce Blocks plugin](https://github.com/woocommerce/woocommerce-gutenberg-products-block). We're planning to evaluate these blocks by measuring conversion rates from the existing `woocommerceanalytics` events, in particular `add_to_cart`, `product_checkout` and `product_purchase`. To compare traditional and block-based UX, we need to add these new props to the events.

The new props are as follows. Values are `0` or `1`, consistent with other boolean tracks props.

- `cart_page_contains_cart_block`
- `cart_page_contains_cart_shortcode`
- `checkout_page_contains_checkout_block`
- `checkout_page_contains_checkout_shortcode`

<img width="601" alt="Screen Shot 2020-03-26 at 1 02 11 PM" src="https://user-images.githubusercontent.com/4167300/77596960-4d257500-6f62-11ea-928d-e65fb195bfe1.png">

#### Changes proposed in this Pull Request:
* Utility functions for determining if a woo site is using shortcodes or blocks on the cart & checkout pages.
* Include this info as props on all `woocommerceanalytics` events.
* Cache this info in a transient (1-day life, `jetpack-woocommerce-analytics-cart-checkout-info-cache`).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This adds features to the existing [`woocommerce-analytics`](https://github.com/Automattic/jetpack/tree/master/modules/woocommerce-analytics) module.

#### Testing instructions:
* This requires WooCommerce to be installed and set up on the site, with some products. Recommend setting up `Cash on delivery` payment method for easy checkout.
* The events are disabled for development sites. Use an incognito window, or hack this by adding `return true;` at the start of [`Jetpack_WooCommerce_Analytics::shouldTrackStore()`](https://github.com/Automattic/jetpack/blob/master/modules/woocommerce-analytics/wp-woocommerce-analytics.php#L40).
- Open network tab in browser dev tools, search for `pixel.wp.com`.
- View a product on the front end of your site. You should see a request for `woocommerceanalytics_product_view` event. This should have new properties (parameters) as above. Check that the values are correct. You'll probably have `1` for shortcodes and `0` for blocks.

If you install the current `master` branch of WooCommerce Blocks, you can add the cart & checkout blocks to the cart & checkout pages and retest - the values should show the correct info. If don't have blocks plugin and want to hack some more, you can fake this by adding an [html comment that looks like the start of one of the blocks](https://github.com/Automattic/jetpack/pull/15127/files#diff-0ac5f90177967302e51546ed06d8cca6R471).

You can also test edge cases such as:

- Add the shortcodes and blocks to the pages, i.e. use both at the same time.
- Delete all content from the pages, or switch in some alternative cart or checkout solution (e.g. [One Page Checkout](https://woocommerce.com/products/woocommerce-one-page-checkout/)).
- Add cart/checkout shortcodes/blocks to other pages (not cart/checkout page).
- Break your woo setup or skip onboarding so there is no designated cart/checkout page.

Note that this is cached in a transient for a day, so if you change your setup, you'll need to wait a day to retest, or delete the transient:

`yarn docker:wp transient delete "jetpack-woocommerce-analytics-cart-checkout-info-cache"`

Note: right now, the events are not all consistently firing for block-based cart & checkout (e.g. https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2031). For example, `product_checkout` only works with shortcode checkout. This is a separate issue and will be fixed in a separate PR. Please be aware of this when testing with blocks :)

#### Proposed changelog entry for your changes:
* Added props to WooCommerce Analytics events indicating if store is using blocks or shortcodes on cart & checkout pages.
