### PR TITLE
OpenTable Block: fix possible warning when `rid` key is not defined

### DIFF
--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -94,7 +94,7 @@ function load_assets( $attributes ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	$classes = array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) );
-	if ( count( $attributes['rid'] ) > 1 ) {
+	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
 		$classes[] = 'is-multi';
 	}
 	$classes = Jetpack_Gutenberg::block_classes(

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -104,8 +104,8 @@
 		<testsuite name="deprecation">
 			<file>tests/php/test_deprecation.php</file>
 		</testsuite>
-		<testsuite name="blocks">
-			<directory prefix="test" suffix=".php">tests/php/extensions/blocks</directory>
+		<testsuite name="extensions">
+			<directory prefix="test" suffix=".php">tests/php/extensions</directory>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -104,6 +104,9 @@
 		<testsuite name="deprecation">
 			<file>tests/php/test_deprecation.php</file>
 		</testsuite>
+		<testsuite name="blocks">
+			<directory prefix="test" suffix=".php">tests/php/extensions/blocks</directory>
+		</testsuite>
 	</testsuites>
 	<groups>
 		<exclude>

--- a/tests/php/extensions/blocks/test-class.opentable.php
+++ b/tests/php/extensions/blocks/test-class.opentable.php
@@ -20,7 +20,7 @@ class WP_Test_OpenTable extends \WP_UnitTestCase {
 		$attributes = array();
 		$content    = OpenTable\load_assets( $attributes );
 
-		$this->assertIsString( $content );
+		$this->assertTrue( is_string( $content ) );
 	}
 
 	/**
@@ -30,7 +30,7 @@ class WP_Test_OpenTable extends \WP_UnitTestCase {
 		$attributes = array( 'rid' => null );
 		$content    = OpenTable\load_assets( $attributes );
 
-		$this->assertIsString( $content );
+		$this->assertTrue( is_string( $content ) );
 	}
 
 	/**
@@ -40,6 +40,6 @@ class WP_Test_OpenTable extends \WP_UnitTestCase {
 		$attributes = array( 'rid' => array() );
 		$content    = OpenTable\load_assets( $attributes );
 
-		$this->assertIsString( $content );
+		$this->assertTrue( is_string( $content ) );
 	}
 }

--- a/tests/php/extensions/blocks/test-class.opentable.php
+++ b/tests/php/extensions/blocks/test-class.opentable.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * OpenTable Block tests.
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Extensions\OpenTable;
+require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/opentable/opentable.php';
+
+/**
+ * OpenTable block tests
+ */
+class WP_Test_OpenTable extends \WP_UnitTestCase {
+
+	/**
+	 * `load_assets` with empty attributes
+	 */
+	public function test_load_assets_with_empty_attributes() {
+		$attributes = array();
+		$content    = OpenTable\load_assets( $attributes );
+
+		$this->assertIsString( $content );
+	}
+
+	/**
+	 * `load_assets` with `rid` attribute set to null
+	 */
+	public function test_load_assets_rid_not_valid() {
+		$attributes = array( 'rid' => null );
+		$content    = OpenTable\load_assets( $attributes );
+
+		$this->assertIsString( $content );
+	}
+
+	/**
+	 * `load_assets` with `rid` as array
+	 */
+	public function test_load_assets_rid_empty_array() {
+		$attributes = array( 'rid' => array() );
+		$content    = OpenTable\load_assets( $attributes );
+
+		$this->assertIsString( $content );
+	}
+}


### PR DESCRIPTION
Fixes #15129 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix possible notice and warning that is thrown when OpenTable block published unconfigured

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* bug fix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with connected Jetpack
* Add unconfigured OpenTable block, and publish the post
* Visit the post frontend. Make sure no errors or warnings were thrown in the error log

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* fix a warning thrown for empty OpenTable block
