### PR TITLE
Podcast Player - disallow feeds containing invalid audio types as track data.

### DIFF
--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -26,7 +26,7 @@ class Jetpack_Podcast_Helper {
 		$player_data   = get_transient( $transient_key );
 
 		// Fetch data if we don't have any cached.
-		if ( false === $player_data ) {
+		if ( false === $player_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
 			// Load feed.
 			$rss = self::load_feed( $feed );
 			if ( is_wp_error( $rss ) ) {
@@ -70,8 +70,15 @@ class Jetpack_Podcast_Helper {
 		// Get first ten items and format them.
 		$track_list = array_map( array( __CLASS__, 'setup_tracks_callback' ), $rss->get_items( 0, 10 ) );
 
+		$audio_extensions = wp_get_audio_extensions();
+
 		// Remove empty tracks.
-		return array_filter( $track_list );
+		return array_filter(
+			$track_list,
+			function( $track ) use ( $audio_extensions ) {
+				return ! empty( $track['url'] ) && in_array( wp_check_filetype( $track['url'] ), $audio_extensions, true );
+			}
+		);
 	}
 
 	/**

--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -179,7 +179,7 @@ class Jetpack_Podcast_Helper {
 			}
 		}
 
-		return new \WP_Error( 'invalid_audio', 'Podcast audio is an invalid type.' );
+		return new WP_Error( 'invalid_audio', __( 'Podcast audio is an invalid type.', 'jetpack' ) );
 	}
 
 	/**

--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -133,6 +133,9 @@ class Jetpack_Podcast_Helper {
 	private static function setup_tracks_callback( SimplePie_Item $episode ) {
 		$enclosure = self::get_audio_enclosure( $episode );
 
+		// If the audio enclosure is empty then it is not playable.
+		// We therefore return an empty array for this track.
+		// It will be filtered out later.
 		if ( is_wp_error( $enclosure ) ) {
 			return array();
 		}


### PR DESCRIPTION
> With the Podcast Player Block trying to embed https://distributed.blog/podcast/ will cause the block to render but the tracks will be invalid and result in an error when trying to play.

The reason for the above error is that the tracks SimplePie parses from the feed end up containing image data. This is not valid audio and therefore causes the player to error.

This PR resolves this by only allow tracks from the feed which contain valid a type which is valid audio. Anything else is filtered out.

Moreover, if there are no tracks _at all_, then the Podcast is considered invalid for embedding.

Fixes https://github.com/Automattic/jetpack/issues/15134

## Changes proposed in this Pull Request:
* Check each feed track enclosure and only allow those with valid audio.
* Error if there are no valid tracks or the tracks are empty.
* Skip caching of feed if `WP_DEBUG` constant is set.
### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes existing feature.

## Testing instructions:

### On Master

* Insert Podcast Block
* Paste in `https://distributed.blog/podcast/`.
* See feed render in Block.
* Click on episodes - see that they error and cannot play.
* Inspect Network requests for REST API call - see JSON response contains tracks whose URL contains image data not audio data.

### On This Branch

* Insert Podcast Block
* Paste in `https://distributed.blog/podcast/`.
* See feed render in Block but only with items that are playable without erroring.
* Click on episodes - see that they do not error and are all playable.
* Inspect Network requests for REST API call - see JSON response contains tracks whose URL contains only audio data.

* Insert another Podcast Block.
* Insert a valid RSS feed URL such as `https://feeds.megaphone.fm/darknetdiaries`.
* See that tracks data still renders correctly for these, is playable and doesn't error.

* Insert any random URL (like `http://simplepie.org/wiki/reference/simplepie_caption/get_type`).
* See that this is still rejected as an invalid URL type.

## Proposed changelog entry for your changes:

* Fix Podcast Block to only display tracks for valid audio data.
* Skip caching of Podcast Feed on Podcast Block if `WP_DEBUG` constant is set.
