### PR TITLE
Podcast Player: Show static markup and swap for React asynchronously

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -137,7 +137,13 @@ function render_player( $player_data, $attributes ) {
 		</ol>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
 	</div>
-	<script>window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);window.jetpackPodcastPlayers.push( <?php echo wp_json_encode( $instance_id ); ?> );</script>
+	<script>
+		( function( instanceId ) {
+			document.getElementById( instanceId ).classList.remove( 'no-js' );
+			window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);
+			window.jetpackPodcastPlayers.push( instanceId );
+		} )( <?php echo wp_json_encode( $instance_id ); ?> );
+	</script>
 	<?php
 	/**
 	 * Enqueue necessary scripts and styles.

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -114,11 +114,11 @@ function render_player( $player_data, $attributes ) {
 		$player_data
 	);
 
-	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
+	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( $block_classname ); ?> is-default" id="<?php echo esc_attr( $instance_id ); ?>">
+	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<ol class="jetpack-podcast-player__episodes">
 			<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 			<li class="jetpack-podcast-player__episode">

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -12,6 +12,7 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 use WP_Error;
 use Jetpack_Gutenberg;
 use Jetpack_Podcast_Helper;
+use Jetpack_AMP_Support;
 
 const FEATURE_NAME = 'podcast-player';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -115,6 +116,7 @@ function render_player( $player_data, $attributes ) {
 	);
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
+	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
 
 	ob_start();
 	?>
@@ -135,8 +137,11 @@ function render_player( $player_data, $attributes ) {
 			</li>
 			<?php endforeach; ?>
 		</ol>
+		<?php if ( ! $is_amp ) : ?>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
+		<?php endif; ?>
 	</div>
+	<?php if ( ! $is_amp ) : ?>
 	<script>
 		( function( instanceId ) {
 			document.getElementById( instanceId ).classList.remove( 'is-default' );
@@ -144,11 +149,14 @@ function render_player( $player_data, $attributes ) {
 			window.jetpackPodcastPlayers.push( instanceId );
 		} )( <?php echo wp_json_encode( $instance_id ); ?> );
 	</script>
+	<?php endif; ?>
 	<?php
 	/**
 	 * Enqueue necessary scripts and styles.
 	 */
-	wp_enqueue_style( 'mediaelement' );
+	if ( ! $is_amp ) {
+		wp_enqueue_style( 'mediaelement' );
+	}
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME, array( 'mediaelement' ) );
 
 	return ob_get_clean();

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -118,7 +118,7 @@ function render_player( $player_data, $attributes ) {
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( $block_classname ); ?> no-js" id="<?php echo esc_attr( $instance_id ); ?>">
+	<div class="<?php echo esc_attr( $block_classname ); ?> is-default" id="<?php echo esc_attr( $instance_id ); ?>">
 		<ol class="jetpack-podcast-player__episodes">
 			<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 			<li class="jetpack-podcast-player__episode">
@@ -139,7 +139,7 @@ function render_player( $player_data, $attributes ) {
 	</div>
 	<script>
 		( function( instanceId ) {
-			document.getElementById( instanceId ).classList.remove( 'no-js' );
+			document.getElementById( instanceId ).classList.remove( 'is-default' );
 			window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);
 			window.jetpackPodcastPlayers.push( instanceId );
 		} )( <?php echo wp_json_encode( $instance_id ); ?> );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -118,25 +118,23 @@ function render_player( $player_data, $attributes ) {
 
 	ob_start();
 	?>
-	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
-		<noscript>
-			<ol class="jetpack-podcast-player__episodes">
-				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
-				<li class="jetpack-podcast-player__episode">
-					<a
-						class="jetpack-podcast-player__episode-link"
-						href="<?php echo esc_url( $attachment['link'] ); ?>"
-						role="button"
-						aria-pressed="false"
-					>
-						<span class="jetpack-podcast-player__episode-status-icon"></span>
-						<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
-					</a>
-				</li>
-				<?php endforeach; ?>
-			</ol>
-		</noscript>
+	<div class="<?php echo esc_attr( $block_classname ); ?> no-js" id="<?php echo esc_attr( $instance_id ); ?>">
+		<ol class="jetpack-podcast-player__episodes">
+			<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
+			<li class="jetpack-podcast-player__episode">
+				<a
+					class="jetpack-podcast-player__episode-link"
+					href="<?php echo esc_url( $attachment['link'] ); ?>"
+					role="button"
+					aria-pressed="false"
+				>
+					<span class="jetpack-podcast-player__episode-status-icon"></span>
+					<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+					<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+				</a>
+			</li>
+			<?php endforeach; ?>
+		</ol>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
 	</div>
 	<script>window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);window.jetpackPodcastPlayers.push( <?php echo wp_json_encode( $instance_id ); ?> );</script>

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -24,7 +24,7 @@ const playerInstances = {};
  * @param {Element} block The root element of the block.
  */
 const downgradeBlockToStatic = function( block ) {
-	block.classList.add( 'no-js' );
+	block.classList.add( 'is-default' );
 };
 
 /**


### PR DESCRIPTION
This PR improves the loading experience for our frontend UI. Instead of showing nothing until React and our component are fully loaded, this PR makes the fallback markup intentionally visible. Previously it was used only as `<noscript>` variant.

The backend markup and react frontend currently differ a lot but we have a plan to make them equal, with the exception of the actual audio player component. Once we work on this, the player would be very seamlessly initialized with no visual glitch or jump of the UI.

I'm also adding a `no-js` class directly on the block so we don't have to rely on themes having the class or potentially overriding them. The `no-js` has no styling now but we have a separate task with slight adjustments. The `no-js` mode will now also be activate if any error happens during the component initialization. 

#### Changes proposed in this Pull Request:
* remove noscript and make the output visible
* add `no-js` to the block container class, which will be removed immediately after element gets parsed
* guard errors in initialization so they downgrade the block back to `no-js` version
* swap static markup for react as soon as everything is loaded

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?


#### Testing instructions:
* Insert the Podcast Player, preview it on the frontend
* Observe the loading process - should go from backend markup into the react player instantly once our dependencies are loaded
* Simulate slower internet connection to make sure you can see the basic player right away before react

#### Proposed changelog entry for your changes:
* n/a