### PR TITLE
Publicize block: Update wording on the publicize block placeholder message to reflect feature behavior

### DIFF
--- a/extensions/blocks/publicize/form-unwrapped.js
+++ b/extensions/blocks/publicize/form-unwrapped.js
@@ -91,7 +91,7 @@ class PublicizeFormUnwrapped extends Component {
 								disabled={ this.isDisabled() }
 								maxLength={ MAXIMUM_MESSAGE_LENGTH }
 								placeholder={ __(
-									"Write a message for your audience here. If you leave this blank, we'll use the post content as the message.",
+									"Write a message for your audience here. If you leave this blank, we'll use an excerpt of the post content as the message.",
 									'jetpack'
 								) }
 								rows={ 4 }

--- a/extensions/blocks/publicize/form-unwrapped.js
+++ b/extensions/blocks/publicize/form-unwrapped.js
@@ -91,7 +91,7 @@ class PublicizeFormUnwrapped extends Component {
 								disabled={ this.isDisabled() }
 								maxLength={ MAXIMUM_MESSAGE_LENGTH }
 								placeholder={ __(
-									"Write a message for your audience here. If you leave this blank, we'll use the post title as the message.",
+									"Write a message for your audience here. If you leave this blank, we'll use the post content as the message.",
 									'jetpack'
 								) }
 								rows={ 4 }


### PR DESCRIPTION
Fixes #15115

#### Changes proposed in this Pull Request:

This PR updates the wording in the Publicize block placeholder to reflect the actual behavior of the feature.

The old version said that it was only going to use the post title when generating the publicize message, while it is actually using the post content as the source for the snippet.

#### Testing instructions:

* Connect a social account
* Create a new post
* Click Publish
* In the confirmation popup click `Share this post` to expand the share form
* Remove the content of the message box
* Confirm the message was updated properly

#### Proposed changelog entry for your changes:

* Update wording on Publicize block to reflect the actual feature behavior.
