### PR TITLE
Simple Payments Block: Fix email field cut and paste bug

### DIFF
--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -91,8 +91,10 @@ class SimplePaymentsEdit extends Component {
 		if ( this.emailInput.current ) {
 			this.emailInput.current.removeEventListener( 'paste', this.trapEmailFieldEvents );
 			this.emailInput.current.removeEventListener( 'cut', this.trapEmailFieldEvents );
+			this.emailInput.current.removeEventListener( 'copy', this.trapEmailFieldEvents );
 			this.emailInput.current.addEventListener( 'paste', this.trapEmailFieldEvents );
 			this.emailInput.current.addEventListener( 'cut', this.trapEmailFieldEvents );
+			this.emailInput.current.addEventListener( 'copy', this.trapEmailFieldEvents );
 		}
 	}
 

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -35,7 +35,6 @@ class SimplePaymentsEdit extends Component {
 
 	state = {
 		fieldEmailError: null,
-		fieldEmailPasteListenerAdded: false,
 		fieldPriceError: null,
 		fieldTitleError: null,
 		isSavingProduct: false,

--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -88,6 +88,7 @@ class SimplePaymentsEdit extends Component {
 
 		// currently the Gutenberg paste handler isn't bypassed for inputs with type="email" which breaks
 		// the block on cut or paste, so this prevents the cut and paste events bubbling up for now
+		// TODO: remove this and the related emailInput ref once email inputs are ignored by Gutenberg paste handler
 		if ( this.emailInput.current ) {
 			this.emailInput.current.removeEventListener( 'paste', this.trapEmailFieldEvents );
 			this.emailInput.current.removeEventListener( 'cut', this.trapEmailFieldEvents );


### PR DESCRIPTION
**N.B. - See https://github.com/Automattic/jetpack/pull/15145 for a much simpler alternative.**

Currently the Gutenberg paste handler is bypassed for input fields of type text, but not of type email, which causes the block to be killed and replaced with a paragraph if text is pasted into the email field.

Fixes #15121 & #11906

#### Changes proposed in this Pull Request:
* Add a temporary event handler to trap cut and paste events in the email field and stop them propogating.

#### Testing instructions:

- Add this patch to local jetpack text env, along with latest gutenberg plugin
- Add Simple Payments Block
- Try cutting and pasting in the email field - should work as expected
- Try removing focus from block and then selecting and cut/paste email field again
- Try loading a page with block saved and make sure no console errors

**before:**

![before](https://user-images.githubusercontent.com/3629020/77715814-79fc8980-7041-11ea-80da-b6ec173b7c65.gif)

after:

![after](https://user-images.githubusercontent.com/3629020/77715816-7f59d400-7041-11ea-8606-f555bb37d5e6.gif)

#### Proposed changelog entry for your changes:
* No entry needed
