### PR TITLE
Simple Payments Block: Fix email field cut and paste bug

### DIFF
--- a/extensions/blocks/simple-payments/edit.js
+++ b/extensions/blocks/simple-payments/edit.js
@@ -524,7 +524,8 @@ class SimplePaymentsEdit extends Component {
 						onChange={ this.handleEmailChange }
 						placeholder={ __( 'Email', 'jetpack' ) }
 						required
-						type="email"
+						// TODO: switch this back to type="email" once Gutenberg paste handler ignores inputs of type email
+						type="text"
 						value={ email }
 					/>
 					<HelpMessage id={ `${ instanceId }-email-error` } isError>
@@ -573,7 +574,4 @@ const mapSelectToProps = withSelect( ( select, props ) => {
 	};
 } );
 
-export default compose(
-	mapSelectToProps,
-	withInstanceId
-)( SimplePaymentsEdit );
+export default compose( mapSelectToProps, withInstanceId )( SimplePaymentsEdit );


### PR DESCRIPTION
Currently the Gutenberg paste handler is bypassed for input fields of type text, but not of type email, which causes the block to be killed and replaced with a paragraph if text is pasted into the email field.

Fixes #15121
Fixes #11906

#### Changes proposed in this Pull Request:

* Temporarily change email field type to `text` to prevent gutenberg paste handler hijacking native copy/cut/past for the field.

#### Testing instructions:

- Add this patch to local jetpack text env, along with latest gutenberg plugin
- Add Simple Payments Block
- Try cutting and pasting in the email field - should work as expected
- Try removing focus from block and then selecting and cut/paste email field again
- Try loading a page with block saved and make sure no console errors

**before:**

![before](https://user-images.githubusercontent.com/3629020/77715814-79fc8980-7041-11ea-80da-b6ec173b7c65.gif)

**after:**

![after](https://user-images.githubusercontent.com/3629020/77715816-7f59d400-7041-11ea-8606-f555bb37d5e6.gif)

#### Proposed changelog entry for your changes:
* No entry needed
