### PR TITLE
Podcast Player: Surpress scripts & unused styles in AMP

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -154,7 +154,9 @@ function render_player( $player_data, $attributes ) {
 	/**
 	 * Enqueue necessary scripts and styles.
 	 */
-	wp_enqueue_style( 'mediaelement' );
+	if ( ! $is_amp ) {
+		wp_enqueue_style( 'mediaelement' );
+	}
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME, array( 'mediaelement' ) );
 
 	return ob_get_clean();

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -12,6 +12,7 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 use WP_Error;
 use Jetpack_Gutenberg;
 use Jetpack_Podcast_Helper;
+use Jetpack_AMP_Support;
 
 const FEATURE_NAME = 'podcast-player';
 const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
@@ -115,6 +116,7 @@ function render_player( $player_data, $attributes ) {
 	);
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
+	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
 
 	ob_start();
 	?>
@@ -135,8 +137,11 @@ function render_player( $player_data, $attributes ) {
 			</li>
 			<?php endforeach; ?>
 		</ol>
+		<?php if ( ! $is_amp ) : ?>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
+		<?php endif; ?>
 	</div>
+	<?php if ( ! $is_amp ) : ?>
 	<script>
 		( function( instanceId ) {
 			document.getElementById( instanceId ).classList.remove( 'is-default' );
@@ -144,6 +149,7 @@ function render_player( $player_data, $attributes ) {
 			window.jetpackPodcastPlayers.push( instanceId );
 		} )( <?php echo wp_json_encode( $instance_id ); ?> );
 	</script>
+	<?php endif; ?>
 	<?php
 	/**
 	 * Enqueue necessary scripts and styles.


### PR DESCRIPTION
This ensures a basic compatibility with AMP requests. Our block renders semantic and functional markup already and this only disables the output of our inline scripts and one unused style file.

`Jetpack_Gutenberg::load_assets_as_required` already handles AMP so there was no further change needed.

#### Changes proposed in this Pull Request:
* adds `$is_amp` in server side rendering and uses it to control the output

#### Testing instructions:
- install AMP https://wordpress.org/plugins/amp/ and set to Transitional mode
- add the Podcast Player into a post or page and open it
- in the admin bar, you should be able to run AMP > Validate
  - on master, it returns two error messages
  - on this branch, you should get no validation issues
- test the amp version of the page (append `?amp` in the page URL)
  - confirm you can see the basic markup (a list of external links with no audio UI)

#### Proposed changelog entry for your changes:
* n/a