### PR TITLE
Podcast Player: Fix accidental scope for episode link class

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -1,7 +1,7 @@
 /**
  * Podcast Player block shared styles (editor & front-end).
  */
- @import '../../shared/styles/gutenberg-base-styles.scss';
+@import '../../shared/styles/gutenberg-base-styles.scss';
 
 $episode-v-padding: 15px;
 $episode-h-padding: 10px;
@@ -20,13 +20,12 @@ $text-color-error: $alert-red;
 $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
 
-
 .jetpack-podcast-player--visually-hidden {
 	position: absolute !important;
 	height: 1px;
 	width: 1px;
 	overflow: hidden;
-	clip: rect(1px, 1px, 1px, 1px);
+	clip: rect( 1px, 1px, 1px, 1px );
 	white-space: nowrap; /* added line */
 }
 
@@ -139,11 +138,6 @@ $block-border-color: $dark-gray-100;
 	font-family: $default-font;
 	font-size: $editor-font-size;
 
-	&:hover,
-	&:focus {
-		color: $text-color-hover;
-	}
-
 	/**
 	 * When episode "is-active", it means that it's been clicked by a user to
 	 * start playback. Combine this class with the Player's state classes (see
@@ -153,14 +147,17 @@ $block-border-color: $dark-gray-100;
 		font-weight: bold;
 	}
 
-	// Applies default color to:
-	// - the active podcast only if it doesn't have defined a custom color.
-	// - the other podcasts only if they don't have defined a custom color.
-	&.is-active:not(.has-primary),
-	&:not(.is-active):not(.has-secondary) {
+	/**
+	 * Applies default color to:
+	 * - The active podcast only if it doesn't have defined a custom color.
+	 * - The other podcasts only if they don't have defined a custom color.
+	 */
+	&.is-active:not( .has-primary ),
+	&:not( .is-active ):not( .has-secondary ) {
 		color: $text-color-hover;
 	}
 
+	// We need to scope this class to override editor link styles.
 	.jetpack-podcast-player__episode-link {
 		display: flex;
 		flex-flow: row nowrap;
@@ -169,19 +166,25 @@ $block-border-color: $dark-gray-100;
 		text-decoration: none;
 		transition: none;
 
-		.jetpack-podcast-player__episode.is-active & {
-			.is-error & {
-				padding-bottom: 0; // Make space for the error element that will be appended.
-			}
+		&:hover,
+		&:focus {
+			color: $text-color-hover;
 		}
 	}
 
-	// Inherits colors if:
-	// - active podcast has defined a custom color.
-	// - the other podcasts if they have defined a custom color.
+	/**
+	 * Inherits colors if:
+	 * - Active podcast has defined a custom color.
+	 * - The other podcasts if they have defined a custom color.
+	 */
 	&.is-active.has-primary .jetpack-podcast-player__episode-link,
 	&.has-secondary .jetpack-podcast-player__episode-link {
 		color: inherit;
+	}
+
+	// Make space for the error element that will be appended.
+	.is-error &.is-active .jetpack-podcast-player__episode-link {
+		padding-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Fixes styles for the link element caused by the accidental scope added [here](https://github.com/Automattic/jetpack/pull/15103/files#diff-23936c23c59259d544403d0cc941ea1dR157-R169).

#### Testing instructions:

The only visual regression caused by this was in the error state of an episode. When the error message is shown, the bottom padding for the episode link should be `0`:

| Before  | After |
| ------------- | ------------- |
| <img width="524" alt="Screenshot 2020-03-27 15 07 06" src="https://user-images.githubusercontent.com/1451471/77764437-efb22680-703c-11ea-9a5a-c249a05682f3.png">| <img width="525" alt="Screenshot 2020-03-27 15 06 35" src="https://user-images.githubusercontent.com/1451471/77764436-ee80f980-703c-11ea-86ec-d51a7e7fcfe3.png"> |

#### Proposed changelog entry for your changes:

* Podcast Player: Fix accidental scope for episode link class
