### PR TITLE
Podcast Player - allow for valid URLs without http based protocol 

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -31,7 +31,7 @@ import {
 } from '@wordpress/block-editor';
 
 import apiFetch from '@wordpress/api-fetch';
-import { isURL } from '@wordpress/url';
+import { isURL, prependHTTP } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -128,7 +128,12 @@ const PodcastPlayerEdit = ( {
 			return;
 		}
 
-		const isValidURL = isURL( editedUrl );
+		// Setting HTML `inputmode` to "url" allows non-http URLs whilst still
+		// allowing the user to see the most suitable keyboard on their device
+		// for entering URLs. However, this means we need to manually prepend
+		// "http" to any entry before attempting validation.
+		const isValidURL = isURL( prependHTTP( editedUrl ) );
+
 		if ( ! isValidURL ) {
 			createErrorNotice(
 				! isValidURL
@@ -138,7 +143,9 @@ const PodcastPlayerEdit = ( {
 			return;
 		}
 
-		setAttributes( { url: editedUrl } );
+		// Ensure URL has `http` appended to it (if it doesn't already) before
+		// we accept it as the entered URL.
+		setAttributes( { url: prependHTTP( editedUrl ) } );
 		setIsEditing( false );
 	} );
 
@@ -152,7 +159,8 @@ const PodcastPlayerEdit = ( {
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
 					<TextControl
-						type="url"
+						type="text"
+						inputMode="url"
 						placeholder={ __( 'Enter URL here…', 'jetpack' ) }
 						value={ editedUrl || '' }
 						className={ 'components-placeholder__input' }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -110,7 +110,7 @@ const PodcastPlayerEdit = ( {
 				setIsEditing( true );
 			}
 		);
-	}, [ url ] );
+	}, [ createErrorNotice, removeAllNotices, url ] );
 
 	/**
 	 * Check if the current URL of the Podcast RSS feed
@@ -118,7 +118,7 @@ const PodcastPlayerEdit = ( {
 	 * the edition mode.
 	 * This function is bound to the onSubmit event for the form.
 	 *
-	 * @param {object} event Form on submit event object.
+	 * @param {object} event - Form on submit event object.
 	 */
 	const checkPodcastLink = useCallback( event => {
 		event.preventDefault();
@@ -132,7 +132,9 @@ const PodcastPlayerEdit = ( {
 		// allowing the user to see the most suitable keyboard on their device
 		// for entering URLs. However, this means we need to manually prepend
 		// "http" to any entry before attempting validation.
-		const isValidURL = isURL( prependHTTP( editedUrl ) );
+		const prependedURL = prependHTTP( editedUrl );
+
+		const isValidURL = isURL( prependedURL );
 
 		if ( ! isValidURL ) {
 			createErrorNotice(
@@ -145,7 +147,12 @@ const PodcastPlayerEdit = ( {
 
 		// Ensure URL has `http` appended to it (if it doesn't already) before
 		// we accept it as the entered URL.
-		setAttributes( { url: prependHTTP( editedUrl ) } );
+		setAttributes( { url: prependedURL } );
+
+		// Also update the temporary `input` value in order that clicking
+		// `Replace` in the UI will show the "corrected" version of the URL
+		// (ie: with `http` prepended if it wasn't originally present).
+		setEditedUrl( prependedURL );
 		setIsEditing( false );
 	} );
 


### PR DESCRIPTION
Currently the podcast feed URL has some pretty strict client side validation courtesy of the HTML `type` attribute on the `<input>` being set to `url`. 

`type="url"` is great for UX as it provides the correct keyboard entry mode on many devices. However, it also forces validation on the input which forces the user to use a valid protocol. It's entirely possible users will paste a link which is otherwise an entirely valid feed but neglect to provide the protocol and thus it will be invalid. The validation problem is obvious to anyone with a technical background but to many folks this could be baffling.

What we need is

* correct keyboard mode
* soft validation

The solution may be to use `inputmode` set to "url" and set `type` to "text" which doesn't have strict validation. Then we can manually prepend the protocol to any URL before we validate using JS and submit.

## Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Switch `<input>` to use [`inputmode`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) set to `url` to provide the correct keyboard mode.
* Switch `<input>` to use `type` text - remove requirement for protocol.
* Prepend protocol to all incoming URLs which don't already have it.

## Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhances the existing Podcast Player Block

## Testing instructions:

### On Master

* Insert Podcast Block
* Attempt to embed a feed using a URL without a protocol (eg: `anchor.fm/dissect`).
* See browser validation warning appear requiring you to enter a "valid url".
* Add `http` to your feed URL and verify the URL is accepted as "valid".

### On This Branch

* Insert Podcast Block
* Attempt to embed a feed using a URL without a protocol (eg: `anchor.fm/dissect`).
* See no browser validation warning.
* See your URL accepted as "valid".
* See the Podcast embedded correctly.
* Click "Replace" - see URL field prepopulated with original URL but now with `http` prepended to it. 

#### Bonus Points
* Repeat but this time manually add `http` to the URL to ensure it still works when you _already_ have the protocol in place.

### Proposed changelog entry for your changes:
* Relax feed URL validation requirements on Podcast Player Block to accept URLs without protocol.
