### PR TITLE
Search: Fix search plan detection

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -16,7 +16,7 @@ import DashItem from 'components/dash-item';
 import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
 import { isDevMode } from 'state/connection';
-import { getSitePlan, hasSearchPurchase, isFetchingSitePurchases } from 'state/site';
+import { getSitePlan, hasActiveSearchPurchase, isFetchingSitePurchases } from 'state/site';
 import { getUpgradeUrl } from 'state/initial-state';
 
 /**
@@ -173,7 +173,7 @@ export default connect( state => {
 		isBusinessPlan: 'is-business-plan' === getPlanClass( getSitePlan( state ).product_slug ),
 		isDevMode: isDevMode( state ),
 		isFetching: isFetchingSitePurchases( state ),
-		hasSearchProduct: hasSearchPurchase( state ),
+		hasSearchProduct: hasActiveSearchPurchase( state ),
 		upgradeUrl: getUpgradeUrl( state, 'aag-search' ),
 	};
 } )( DashSearch );

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -16,7 +16,7 @@ import DashItem from 'components/dash-item';
 import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
 import { isDevMode } from 'state/connection';
-import { getSitePlan } from 'state/site';
+import { getSitePlan, hasSearchPurchase, isFetchingSitePurchases } from 'state/site';
 import { getUpgradeUrl } from 'state/initial-state';
 
 /**
@@ -69,11 +69,18 @@ class DashSearch extends Component {
 	activateSearch = () => {
 		this.props.updateOptions( {
 			search: true,
-			...( this.props.isSearchPlan ? { instant_search_enabled: true } : {} ),
+			...( this.props.hasSearchProduct ? { instant_search_enabled: true } : {} ),
 		} );
 	};
 
 	render() {
+		if ( this.props.isFetching ) {
+			return renderCard( {
+				status: '',
+				content: __( 'Loading…' ),
+			} );
+		}
+
 		if ( this.props.isDevMode ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
@@ -83,7 +90,7 @@ class DashSearch extends Component {
 			} );
 		}
 
-		if ( ! this.props.isBusinessPlan && ! this.props.isSearchPlan ) {
+		if ( ! this.props.isBusinessPlan && ! this.props.hasSearchProduct ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
@@ -125,7 +132,7 @@ class DashSearch extends Component {
 							{ __( 'Jetpack Search is powering search on your site.' ) }
 						</p>
 					</DashItem>
-					{ this.props.isSearchPlan ? (
+					{ this.props.hasSearchProduct ? (
 						<Card
 							compact
 							className="jp-search-config-aag"
@@ -162,11 +169,11 @@ class DashSearch extends Component {
 }
 
 export default connect( state => {
-	const planClass = getPlanClass( getSitePlan( state ).product_slug );
 	return {
-		isBusinessPlan: 'is-business-plan' === planClass,
+		isBusinessPlan: 'is-business-plan' === getPlanClass( getSitePlan( state ).product_slug ),
 		isDevMode: isDevMode( state ),
-		isSearchPlan: 'is-search-plan' === planClass,
+		isFetching: isFetchingSitePurchases( state ),
+		hasSearchProduct: hasSearchPurchase( state ),
 		upgradeUrl: getUpgradeUrl( state, 'aag-search' ),
 	};
 } )( DashSearch );

--- a/_inc/client/components/data/query-site-products/index.js
+++ b/_inc/client/components/data/query-site-products/index.js
@@ -10,7 +10,9 @@ import { connect } from 'react-redux';
 import { fetchSiteProducts, isFetchingSiteProducts } from 'state/site-products';
 
 export function QuerySiteProducts( props ) {
-	useEffect( () => ! props.isFetchingSiteProducts && props.fetchSiteProducts(), [] );
+	useEffect( () => {
+		! props.isFetchingSiteProducts && props.fetchSiteProducts();
+	}, [] );
 	return null;
 }
 

--- a/_inc/client/components/dev-card/index.jsx
+++ b/_inc/client/components/dev-card/index.jsx
@@ -228,19 +228,6 @@ export class DevCard extends React.Component {
 							Jetpack Backup Reatime
 						</label>
 					</li>
-					<li>
-						<label htmlFor="jetpack_search">
-							<input
-								type="radio"
-								id="jetpack_search"
-								value="jetpack_search"
-								name="jetpack_search"
-								checked={ 'is-search-plan' === planClass }
-								onChange={ this.onPlanChange }
-							/>
-							Search
-						</label>
-					</li>
 				</ul>
 				<hr />
 				<ul>

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -34,7 +34,12 @@ import {
 	getUpgradeUrl,
 } from 'state/initial-state';
 import { isAkismetKeyValid, isCheckingAkismetKey, getVaultPressData } from 'state/at-a-glance';
-import { getSitePlan, isFetchingSiteData, getActiveFeatures, hasSearchPurchase } from 'state/site';
+import {
+	getActiveFeatures,
+	getSitePlan,
+	hasActiveSearchPurchase,
+	isFetchingSiteData,
+} from 'state/site';
 import SectionHeader from 'components/section-header';
 import ProStatus from 'pro-status';
 import JetpackBanner from 'components/jetpack-banner';
@@ -183,7 +188,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SEARCH_JETPACK:
-				if ( props.hasSearchPurchase ) {
+				if ( props.hasActiveSearchPurchase ) {
 					return '';
 				}
 
@@ -371,6 +376,6 @@ export default connect( state => {
 		searchUpgradeUrl: getUpgradeUrl( state, 'jetpack-search' ),
 		spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
 		multisite: isMultisite( state ),
-		hasSearchPurchase: hasSearchPurchase( state ),
+		hasActiveSearchPurchase: hasActiveSearchPurchase( state ),
 	};
 } )( SettingsCard );

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -16,6 +16,7 @@ import {
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_SEARCH,
 	FEATURE_SECURITY_SCANNING_JETPACK,
 	FEATURE_SEO_TOOLS_JETPACK,
 	FEATURE_VIDEO_HOSTING_JETPACK,
@@ -33,7 +34,7 @@ import {
 	getUpgradeUrl,
 } from 'state/initial-state';
 import { isAkismetKeyValid, isCheckingAkismetKey, getVaultPressData } from 'state/at-a-glance';
-import { getSitePlan, isFetchingSiteData, getActiveFeatures } from 'state/site';
+import { getSitePlan, isFetchingSiteData, getActiveFeatures, hasSearchPurchase } from 'state/site';
 import SectionHeader from 'components/section-header';
 import ProStatus from 'pro-status';
 import JetpackBanner from 'components/jetpack-banner';
@@ -182,7 +183,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SEARCH_JETPACK:
-				if ( 'is-business-plan' === planClass ) {
+				if ( props.hasSearchPurchase ) {
 					return '';
 				}
 
@@ -190,9 +191,9 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Add faster, more advanced searching to your site with Jetpack Professional.'
+							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.'
 						) }
-						plan={ PLAN_JETPACK_BUSINESS }
+						plan={ PLAN_JETPACK_SEARCH }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
 						href={ props.searchUpgradeUrl }
@@ -367,8 +368,9 @@ export default connect( state => {
 		securityPremiumUpgradeUrl: getUpgradeUrl( state, 'settings-security-premium' ),
 		gaUpgradeUrl: getUpgradeUrl( state, 'settings-ga' ),
 		seoUpgradeUrl: getUpgradeUrl( state, 'settings-seo' ),
-		searchUpgradeUrl: getUpgradeUrl( state, 'settings-search' ),
+		searchUpgradeUrl: getUpgradeUrl( state, 'jetpack-search' ),
 		spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
 		multisite: isMultisite( state ),
+		hasSearchPurchase: hasSearchPurchase( state ),
 	};
 } )( SettingsCard );

--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -146,6 +146,10 @@ export function isJetpackSearch( product ) {
 	return includes( JETPACK_SEARCH_PRODUCTS, product );
 }
 
+export function isJetpackProduct( product ) {
+	return isJetpackBackup( product ) || isJetpackSearch( product );
+}
+
 export function getPlanClass( plan ) {
 	switch ( plan ) {
 		case PLAN_JETPACK_FREE:

--- a/_inc/client/my-plan/index.jsx
+++ b/_inc/client/my-plan/index.jsx
@@ -13,7 +13,7 @@ import {
 	getAvailableFeatures,
 	getSitePlan,
 	getSitePurchases,
-	hasSearchPurchase,
+	hasActiveSearchPurchase,
 } from 'state/site';
 import QuerySite from 'components/data/query-site';
 import { getSiteConnectionStatus } from 'state/connection';
@@ -43,7 +43,7 @@ export function MyPlan( props ) {
 			<MyPlanBody
 				activeFeatures={ activeFeatures }
 				availableFeatures={ availableFeatures }
-				hasSearchPurchase={ props.hasSearchPurchase }
+				hasActiveSearchPurchase={ props.hasActiveSearchPurchase }
 				plan={ sitePlan }
 				rewindStatus={ props.rewindStatus }
 				siteAdminUrl={ props.siteAdminUrl }
@@ -59,7 +59,7 @@ export default connect( state => {
 		activeProducts: getActiveProductPurchases( state ),
 		availableFeatures: getAvailableFeatures( state ),
 		getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
-		hasSearchPurchase: hasSearchPurchase( state ),
+		hasActiveSearchPurchase: hasActiveSearchPurchase( state ),
 		purchases: getSitePurchases( state ),
 		sitePlan: getSitePlan( state ),
 	};

--- a/_inc/client/my-plan/index.jsx
+++ b/_inc/client/my-plan/index.jsx
@@ -3,7 +3,6 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { find } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,15 +10,12 @@ import { find } from 'lodash';
 import { getSitePlan, getSitePurchases, getAvailableFeatures, getActiveFeatures } from 'state/site';
 import QuerySite from 'components/data/query-site';
 import { getSiteConnectionStatus } from 'state/connection';
-import { isJetpackSearch } from 'lib/plans/constants';
 
 import MyPlanHeader from './my-plan-header';
 import MyPlanBody from './my-plan-body';
+import { getActiveProductPurchases, hasSearchPurchase } from '../state/site/reducer';
 
 export function MyPlan( props ) {
-	const hasSearchProduct = !! find( props.purchases, purchase =>
-		isJetpackSearch( purchase.product_slug )
-	);
 	let sitePlan = props.sitePlan.product_slug || '',
 		availableFeatures = props.availableFeatures,
 		activeFeatures = props.activeFeatures;
@@ -33,6 +29,7 @@ export function MyPlan( props ) {
 		<React.Fragment>
 			<QuerySite />
 			<MyPlanHeader
+				activeProducts={ props.activeProducts }
 				plan={ sitePlan }
 				purchases={ props.purchases }
 				siteRawUrl={ props.siteRawUrl }
@@ -40,7 +37,7 @@ export function MyPlan( props ) {
 			<MyPlanBody
 				activeFeatures={ activeFeatures }
 				availableFeatures={ availableFeatures }
-				hasSearchProduct={ hasSearchProduct }
+				hasSearchPurchase={ props.hasSearchPurchase }
 				plan={ sitePlan }
 				rewindStatus={ props.rewindStatus }
 				siteAdminUrl={ props.siteAdminUrl }
@@ -52,10 +49,12 @@ export function MyPlan( props ) {
 
 export default connect( state => {
 	return {
+		activeFeatures: getActiveFeatures( state ),
+		activeProducts: getActiveProductPurchases( state ),
+		availableFeatures: getAvailableFeatures( state ),
 		getSiteConnectionStatus: () => getSiteConnectionStatus( state ),
+		hasSearchPurchase: hasSearchPurchase( state ),
 		purchases: getSitePurchases( state ),
 		sitePlan: getSitePlan( state ),
-		availableFeatures: getAvailableFeatures( state ),
-		activeFeatures: getActiveFeatures( state ),
 	};
 } )( MyPlan );

--- a/_inc/client/my-plan/index.jsx
+++ b/_inc/client/my-plan/index.jsx
@@ -7,13 +7,19 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { getSitePlan, getSitePurchases, getAvailableFeatures, getActiveFeatures } from 'state/site';
+import {
+	getActiveFeatures,
+	getActiveProductPurchases,
+	getAvailableFeatures,
+	getSitePlan,
+	getSitePurchases,
+	hasSearchPurchase,
+} from 'state/site';
 import QuerySite from 'components/data/query-site';
 import { getSiteConnectionStatus } from 'state/connection';
 
 import MyPlanHeader from './my-plan-header';
 import MyPlanBody from './my-plan-body';
-import { getActiveProductPurchases, hasSearchPurchase } from '../state/site/reducer';
 
 export function MyPlan( props ) {
 	let sitePlan = props.sitePlan.product_slug || '',

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -263,7 +263,7 @@ class MyPlanBody extends React.Component {
 						{ 'is-personal-plan' === planClass && getRewindVaultPressCard() }
 						{ 'is-premium-plan' === planClass && getRewindVaultPressCard() }
 						{ 'is-business-plan' === planClass && getRewindVaultPressCard() }
-						{ this.props.hasSearchPurchase && getSearchCard() }
+						{ this.props.hasActiveSearchPurchase && getSearchCard() }
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-img">
 								<img
@@ -573,7 +573,7 @@ class MyPlanBody extends React.Component {
 				planCard = (
 					<div className="jp-landing__plan-features">
 						{ jetpackBackupCard }
-						{ this.props.hasSearchPurchase && getSearchCard() }
+						{ this.props.hasActiveSearchPurchase && getSearchCard() }
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-img">
 								<img

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -263,7 +263,7 @@ class MyPlanBody extends React.Component {
 						{ 'is-personal-plan' === planClass && getRewindVaultPressCard() }
 						{ 'is-premium-plan' === planClass && getRewindVaultPressCard() }
 						{ 'is-business-plan' === planClass && getRewindVaultPressCard() }
-						{ this.props.hasSearchProduct && getSearchCard() }
+						{ this.props.hasSearchPurchase && getSearchCard() }
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-img">
 								<img
@@ -573,7 +573,7 @@ class MyPlanBody extends React.Component {
 				planCard = (
 					<div className="jp-landing__plan-features">
 						{ jetpackBackupCard }
-						{ this.props.hasSearchProduct && getSearchCard() }
+						{ this.props.hasSearchPurchase && getSearchCard() }
 						<div className="jp-landing__plan-features-card">
 							<div className="jp-landing__plan-features-img">
 								<img

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -88,7 +88,7 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: imagePath + '/plans/plan-business.svg',
 					tagLine: __(
-						'Full security suite, marketing and revenue automation tools, unlimited video hosting, unlimited themes, enhanced search, and priority support.'
+						'Full security suite, marketing and revenue automation tools, unlimited video hosting, unlimited themes, and priority support.'
 					),
 					title: __( 'Jetpack Professional' ),
 				};

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { find, isEmpty } from 'lodash';
@@ -9,16 +10,15 @@ import { find, isEmpty } from 'lodash';
 /**
  * Internal dependencies
  */
+import { imagePath } from 'constants/urls';
 import Card from 'components/card';
+import ProductExpiration from 'components/product-expiration';
+import UpgradeLink from 'components/upgrade-link';
+import { getPlanClass } from 'lib/plans/constants';
+import { getUpgradeUrl, getSiteRawUrl, showBackups } from 'state/initial-state';
 import ChecklistCta from './checklist-cta';
 import ChecklistProgress from './checklist-progress-card';
 import MyPlanCard from '../my-plan-card';
-import UpgradeLink from 'components/upgrade-link';
-import ProductExpiration from 'components/product-expiration';
-import { getPlanClass } from 'lib/plans/constants';
-import { getUpgradeUrl, getSiteRawUrl, showBackups } from 'state/initial-state';
-import { imagePath } from 'constants/urls';
-import PropTypes from 'prop-types';
 
 class MyPlanHeader extends React.Component {
 	getProductProps( productSlug ) {

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { translate as __ } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { find, filter, isEmpty } from 'lodash';
+import { find, isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,7 +15,7 @@ import ChecklistProgress from './checklist-progress-card';
 import MyPlanCard from '../my-plan-card';
 import UpgradeLink from 'components/upgrade-link';
 import ProductExpiration from 'components/product-expiration';
-import { getPlanClass, isJetpackBackup, isJetpackSearch } from 'lib/plans/constants';
+import { getPlanClass } from 'lib/plans/constants';
 import { getUpgradeUrl, getSiteRawUrl, showBackups } from 'state/initial-state';
 import { imagePath } from 'constants/urls';
 import PropTypes from 'prop-types';
@@ -137,37 +137,25 @@ class MyPlanHeader extends React.Component {
 	}
 
 	renderPlan() {
-		const { plan } = this.props;
-		const planProps = this.getProductProps( plan );
-
 		return (
 			<Card compact>
 				{ this.renderHeader( __( 'My Plan' ) ) }
-				<MyPlanCard { ...planProps } />
+				<MyPlanCard { ...this.getProductProps( this.props.plan ) } />
 			</Card>
 		);
 	}
 
 	renderProducts() {
-		const { purchases } = this.props;
-		const products = filter(
-			purchases,
-			purchase =>
-				isJetpackBackup( purchase.product_slug ) || isJetpackSearch( purchase.product_slug )
-		);
-
-		if ( isEmpty( products ) ) {
+		if ( isEmpty( this.props.activeProducts ) ) {
 			return null;
 		}
 
 		return (
 			<Card compact>
 				{ this.renderHeader( __( 'My Products' ) ) }
-				{ products.map( ( { ID, product_slug } ) => {
-					const productProps = this.getProductProps( product_slug );
-
-					return <MyPlanCard key={ 'product-card-' + ID } { ...productProps } />;
-				} ) }
+				{ this.props.activeProducts.map( ( { ID, product_slug } ) => (
+					<MyPlanCard key={ 'product-card-' + ID } { ...this.getProductProps( product_slug ) } />
+				) ) }
 			</Card>
 		);
 	}

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -16,7 +16,7 @@ import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import {
 	getSitePlan,
-	hasSearchProducPurchase as selectHasSearchPurchase,
+	hasActiveSearchPurchase as selectHasActiveSearchPurchase,
 	isFetchingSitePurchases,
 } from 'state/site';
 import { FormFieldset } from 'components/forms';
@@ -24,21 +24,21 @@ import CompactFormToggle from 'components/form/form-toggle/compact';
 
 function toggleModuleFactory( {
 	getOptionValue,
-	hasSearchPurchase,
+	hasActiveSearchPurchase,
 	toggleModuleNow,
 	updateOptions,
 } ) {
 	return module => {
 		toggleModuleNow( module );
-		if ( hasSearchPurchase && getOptionValue( 'search' ) ) {
+		if ( hasActiveSearchPurchase && getOptionValue( 'search' ) ) {
 			updateOptions( { instant_search_enabled: true } );
 		}
 	};
 }
 
-function toggleInstantSearchFactory( { hasSearchPurchase, getOptionValue, updateOptions } ) {
+function toggleInstantSearchFactory( { hasActiveSearchPurchase, getOptionValue, updateOptions } ) {
 	return () => {
-		if ( hasSearchPurchase && getOptionValue( 'search' ) ) {
+		if ( hasActiveSearchPurchase && getOptionValue( 'search' ) ) {
 			updateOptions( {
 				instant_search_enabled: ! getOptionValue( 'instant_search_enabled', 'search' ),
 			} );
@@ -52,13 +52,13 @@ function Search( props ) {
 
 	const toggleModule = useMemo( () => toggleModuleFactory( props ), [
 		props.getOptionValue,
-		props.hasSearchPurchase,
+		props.hasActiveSearchPurchase,
 		props.toggleModuleNow,
 		props.updateOptions,
 	] );
 	const toggleInstantSearch = useMemo( () => toggleInstantSearchFactory( props ), [
 		props.getOptionValue,
-		props.hasSearchPurchase,
+		props.hasActiveSearchPurchase,
 		props.updateOptions,
 	] );
 
@@ -78,7 +78,7 @@ function Search( props ) {
 					) }{ ' ' }
 				</p>
 				{ props.isLoading && __( 'Loading…' ) }
-				{ ! props.isLoading && ( props.isBusinessPlan || props.hasSearchPurchase ) && (
+				{ ! props.isLoading && ( props.isBusinessPlan || props.hasActiveSearchPurchase ) && (
 					// TODO: There's a known bug preventing Jetpack Search from being enabled here for Search product purchases
 					<Fragment>
 						<ModuleToggle
@@ -93,7 +93,7 @@ function Search( props ) {
 						<FormFieldset>
 							<CompactFormToggle
 								checked={ isInstantSearchEnabled }
-								disabled={ ! props.hasSearchPurchase || ! isModuleEnabled }
+								disabled={ ! props.hasActiveSearchPurchase || ! isModuleEnabled }
 								onChange={ toggleInstantSearch }
 								toggling={ props.isSavingAnyOption( 'instant_search_enabled' ) }
 							>
@@ -112,7 +112,7 @@ function Search( props ) {
 				) }
 			</SettingsGroup>
 			{ ! props.isLoading &&
-				( props.isBusinessPlan || props.hasSearchPurchase ) &&
+				( props.isBusinessPlan || props.hasActiveSearchPurchase ) &&
 				isModuleEnabled &&
 				! isInstantSearchEnabled && (
 					<Card
@@ -123,7 +123,7 @@ function Search( props ) {
 						{ __( 'Add Jetpack Search Widget' ) }
 					</Card>
 				) }
-			{ props.hasSearchPurchase && isModuleEnabled && isInstantSearchEnabled && (
+			{ props.hasActiveSearchPurchase && isModuleEnabled && isInstantSearchEnabled && (
 				<Card
 					className="jp-settings-card__configure-link"
 					compact
@@ -140,7 +140,7 @@ export default connect( state => {
 	const planClass = getPlanClass( getSitePlan( state ).product_slug );
 	return {
 		isLoading: isFetchingSitePurchases( state ),
-		hasSearchPurchase: selectHasSearchPurchase( state ),
+		hasActiveSearchPurchase: selectHasActiveSearchPurchase( state ),
 		isBusinessPlan: 'is-business-plan' === planClass,
 	};
 } )( withModuleSettingsFormHelpers( Search ) );

--- a/_inc/client/plans/constants.js
+++ b/_inc/client/plans/constants.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+export const BACKUP_TITLE = __( 'Jetpack Backup' );
+export const BACKUP_DESCRIPTION = __( 'Always-on backups ensure you never lose your site.' );
+export const BACKUP_DESCRIPTION_REALTIME = __(
+	'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+);
+export const DAILY_BACKUP_TITLE = __( 'Jetpack Backup {{em}}Daily{{/em}}', {
+	components: { em: <em /> },
+} );
+
+export const REALTIME_BACKUP_TITLE = __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
+	components: { em: <em /> },
+} );
+
+export const SEARCH_TITLE = __( 'Jetpack Search' );
+export const SEARCH_DESCRIPTION = __(
+	'Enhanced Search for more relevant results using modern ranking algorithms, ' +
+		'boosting of specific results, advanced filtering and faceting, and more. '
+);

--- a/_inc/client/plans/index.jsx
+++ b/_inc/client/plans/index.jsx
@@ -6,24 +6,16 @@ import React, { Fragment } from 'react';
 /**
  * Internal dependencies
  */
-import QueryProducts from 'components/data/query-products';
-import QuerySiteProducts from 'components/data/query-site-products';
 import QuerySite from 'components/data/query-site';
 import PlanGrid from './plan-grid';
 import ProductSelector from './product-selector';
 
-export class Plans extends React.Component {
-	render() {
-		return (
-			<Fragment>
-				<QueryProducts />
-				<QuerySiteProducts />
-				<QuerySite />
-				<PlanGrid />
-				<ProductSelector />
-			</Fragment>
-		);
-	}
+export default function Plans() {
+	return (
+		<Fragment>
+			<QuerySite />
+			<PlanGrid />
+			<ProductSelector />
+		</Fragment>
+	);
 }
-
-export default Plans;

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -15,7 +15,6 @@ import ButtonGroup from 'components/button-group';
 import { getSiteRawUrl, getUpgradeUrl, getUserId, showBackups } from 'state/initial-state';
 import { getSitePlan, getAvailablePlans, isFetchingSiteData } from 'state/site/reducer';
 import { getPlanClass } from 'lib/plans/constants';
-import { isFetchingProducts } from '../state/products';
 import { translate as __ } from 'i18n-calypso';
 import TopButton from './top-button';
 import FeatureItem from './feture-item';
@@ -409,19 +408,16 @@ class PlanGrid extends React.Component {
 	}
 }
 
-export default connect(
-	state => {
-		const userId = getUserId( state );
-		return {
-			plans: getAvailablePlans( state ),
-			siteRawUrl: getSiteRawUrl( state ),
-			sitePlan: getSitePlan( state ),
-			userId,
-			showBackups: showBackups( state ),
-			plansUpgradeUrl: planType => getUpgradeUrl( state, `plans-${ planType }`, userId ),
-			plansLearnMoreUpgradeUrl: getUpgradeUrl( state, 'plans-learn-more', userId ),
-			isFetchingData: isFetchingSiteData( state ) || isFetchingProducts( state ),
-		};
-	},
-	null
-)( PlanGrid );
+export default connect( state => {
+	const userId = getUserId( state );
+	return {
+		plans: getAvailablePlans( state ),
+		siteRawUrl: getSiteRawUrl( state ),
+		sitePlan: getSitePlan( state ),
+		userId,
+		showBackups: showBackups( state ),
+		plansUpgradeUrl: planType => getUpgradeUrl( state, `plans-${ planType }`, userId ),
+		plansLearnMoreUpgradeUrl: getUpgradeUrl( state, 'plans-learn-more', userId ),
+		isFetchingData: isFetchingSiteData( state ),
+	};
+}, null )( PlanGrid );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -4,7 +4,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import classNames from 'classnames';
 import { get } from 'lodash';
 
 /**
@@ -189,13 +188,9 @@ class ProductSelector extends Component {
 
 	renderSingleProductContent() {
 		return (
-			<div
-				className={ classNames( 'plans-section__single-product', {
-					'plans-section__single-product--with-search': this.props.isInstantSearchEnabled,
-				} ) }
-			>
+			<div className="plans-section__single-product plans-section__single-product--with-search">
 				{ this.renderBackupProduct() }
-				{ this.props.isInstantSearchEnabled && this.renderSearchProduct() }
+				{ this.renderSearchProduct() }
 			</div>
 		);
 	}
@@ -265,6 +260,5 @@ export default connect( state => {
 			! getAvailablePlans( state ) ||
 			isFetchingSiteProducts( state ),
 		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ), // Redirect to https://jetpack.com/upgrade/backup/
-		isInstantSearchEnabled: !! get( state, 'jetpack.initialState.isInstantSearchEnabled', false ),
 	};
 } )( ProductSelector );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -154,14 +154,14 @@ export default connect( state => {
 	return {
 		activeSitePurchases: getActiveSitePurchases( state ),
 		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ), // Redirect to https://jetpack.com/upgrade/backup/
+		isFetchingData:
+			isFetchingSiteData( state ) ||
+			! getAvailablePlans( state ) ||
+			isFetchingSiteProducts( state ),
 		multisite: isMultisite( state ),
 		searchPurchase: getActiveSearchPurchase( state ),
 		sitePlan: getSitePlan( state ),
 		siteProducts: getSiteProducts( state ),
 		siteRawlUrl: getSiteRawUrl( state ),
-		isFetchingData:
-			isFetchingSiteData( state ) ||
-			! getAvailablePlans( state ) ||
-			isFetchingSiteProducts( state ),
 	};
 } )( ProductSelector );

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -9,23 +9,23 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import analytics from 'lib/analytics';
+import QuerySiteProducts from 'components/data/query-site-products';
 import ExternalLink from 'components/external-link';
 import ProductCard from 'components/product-card';
 import ProductExpiration from 'components/product-expiration';
-import SingleProductBackup from './single-product-backup';
-import SingleProductSearch from './single-product-search';
-import { getPlanClass } from '../lib/plans/constants';
+import analytics from 'lib/analytics';
+import { getPlanClass } from 'lib/plans/constants';
+import { getSiteRawUrl, getUpgradeUrl, isMultisite } from 'state/initial-state';
 import {
 	getActiveSitePurchases,
 	getAvailablePlans,
 	getSitePlan,
 	isFetchingSiteData,
-} from '../state/site';
-import { getSiteRawUrl, getUpgradeUrl, isMultisite } from '../state/initial-state';
-import { getProducts, isFetchingProducts } from '../state/products';
+} from 'state/site';
+import { isFetchingSiteProducts, getSiteProducts } from 'state/site-products';
+import SingleProductBackup from './single-product-backup';
+import SingleProductSearch from './single-product-search';
 import './single-products.scss';
-import { isFetchingSiteProducts, getSiteProducts } from '../state/site-products';
 
 class ProductSelector extends Component {
 	state = {
@@ -216,7 +216,7 @@ class ProductSelector extends Component {
 		return (
 			<SingleProductBackup
 				isFetching={ this.props.isFetchingData }
-				products={ this.props.products }
+				products={ this.props.siteProducts }
 				upgradeLinkDaily={ this.props.dailyBackupUpgradeUrl }
 				upgradeLinkRealtime={ this.props.realtimeBackupUpgradeUrl }
 				selectedBackupType={ this.state.selectedBackupType }
@@ -237,6 +237,7 @@ class ProductSelector extends Component {
 	render() {
 		return (
 			<Fragment>
+				<QuerySiteProducts />
 				{ this.renderTitleSection() }
 				{ this.renderSingleProductContent() }
 			</Fragment>
@@ -249,14 +250,12 @@ export default connect( state => {
 		activeSitePurchases: getActiveSitePurchases( state ),
 		dailyBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-daily' ),
 		multisite: isMultisite( state ),
-		products: getProducts( state ),
 		realtimeBackupUpgradeUrl: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
 		sitePlan: getSitePlan( state ),
 		siteProducts: getSiteProducts( state ),
 		siteRawlUrl: getSiteRawUrl( state ),
 		isFetchingData:
 			isFetchingSiteData( state ) ||
-			isFetchingProducts( state ) ||
 			! getAvailablePlans( state ) ||
 			isFetchingSiteProducts( state ),
 		backupInfoUrl: getUpgradeUrl( state, 'aag-backups' ), // Redirect to https://jetpack.com/upgrade/backup/

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -74,7 +74,7 @@ class ProductSelector extends Component {
 			<Fragment>
 				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
 				<h2 className="plans-section__subheader">
-					{ __( "Just looking for backups? We've got you covered." ) }
+					{ __( "Looking for specific features? We've got you covered." ) }
 					{ ! isFetchingData && ! this.findPrioritizedPurchaseForBackup() && (
 						<>
 							<br />

--- a/_inc/client/plans/single-product-backup/body.jsx
+++ b/_inc/client/plans/single-product-backup/body.jsx
@@ -10,6 +10,7 @@ import { withRouter } from 'react-router';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import { BACKUP_DESCRIPTION } from '../constants';
 import PlanRadioButton from '../single-product-components/plan-radio-button';
 import ProductSavings from '../single-product-components/product-savings';
 import UpgradeButton from '../single-product-components/upgrade-button';
@@ -44,7 +45,7 @@ class SingleProductBackupBody extends React.Component {
 
 		return (
 			<React.Fragment>
-				<p>{ __( 'Always-on backups ensure you never lose your site.' ) }</p>
+				<p>{ BACKUP_DESCRIPTION }</p>
 				<PromoNudge />
 				<h4 className="single-product-backup__options-header">
 					{ __( 'Select a backup option:' ) }

--- a/_inc/client/plans/single-product-backup/index.jsx
+++ b/_inc/client/plans/single-product-backup/index.jsx
@@ -2,12 +2,15 @@
  * External dependencies
  */
 import React, { useMemo } from 'react';
+import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import { getUpgradeUrl } from 'state/initial-state';
+import { BACKUP_TITLE } from '../constants';
 import SingleProductBackupBody from './body';
 
 function generateBackupOptions( { products, upgradeLinkDaily, upgradeLinkRealtime } ) {
@@ -42,7 +45,7 @@ function generateBackupOptions( { products, upgradeLinkDaily, upgradeLinkRealtim
 	];
 }
 
-export default function SingleProductBackupCard( props ) {
+function SingleProductBackupCard( props ) {
 	const {
 		products,
 		upgradeLinkDaily,
@@ -62,7 +65,7 @@ export default function SingleProductBackupCard( props ) {
 	) : (
 		<div className="single-product__accented-card dops-card">
 			<div className="single-product__accented-card-header">
-				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Backup' ) }</h3>
+				<h3 className="single-product-backup__header-title">{ BACKUP_TITLE }</h3>
 			</div>
 			<div className="single-product__accented-card-body">
 				<SingleProductBackupBody
@@ -76,3 +79,8 @@ export default function SingleProductBackupCard( props ) {
 		</div>
 	);
 }
+
+export default connect( state => ( {
+	upgradeLinkDaily: getUpgradeUrl( state, 'jetpack-backup-daily' ),
+	upgradeLinkRealtime: getUpgradeUrl( state, 'jetpack-backup-realtime' ),
+} ) )( SingleProductBackupCard );

--- a/_inc/client/plans/single-product-components/purchased-product-card.jsx
+++ b/_inc/client/plans/single-product-components/purchased-product-card.jsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { translate as __ } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ProductCard from 'components/product-card';
+import ProductExpiration from 'components/product-expiration';
+import { getPlanClass } from 'lib/plans/constants';
+import {
+	BACKUP_DESCRIPTION_REALTIME,
+	BACKUP_DESCRIPTION,
+	DAILY_BACKUP_TITLE,
+	REALTIME_BACKUP_TITLE,
+	SEARCH_DESCRIPTION,
+	SEARCH_TITLE,
+} from '../constants';
+
+export default function PurchasedProductCard( { purchase, siteRawlUrl } ) {
+	if ( ! purchase || ! siteRawlUrl ) {
+		return null;
+	}
+
+	const planClass = getPlanClass( purchase.product_slug );
+
+	const subtitle = (
+		<ProductExpiration
+			expiryDate={ purchase.expiry_date }
+			purchaseDate={ purchase.subscribed_date }
+			isRefundable={ purchase.is_refundable }
+		/>
+	);
+
+	const planLink = (
+		<a
+			href={ `https://wordpress.com/plans/my-plan/${ siteRawlUrl }` }
+			target="_blank"
+			rel="noopener noreferrer"
+		/>
+	);
+
+	let productCardProps = { purchase, isCurrent: true };
+	switch ( planClass ) {
+		case 'is-search-plan':
+			productCardProps = {
+				title: SEARCH_TITLE,
+				subtitle,
+				description: SEARCH_DESCRIPTION,
+				...productCardProps,
+			};
+		case 'is-daily-backup-plan':
+			productCardProps = {
+				title: DAILY_BACKUP_TITLE,
+				subtitle,
+				description: BACKUP_DESCRIPTION,
+				...productCardProps,
+			};
+		case 'is-realtime-backup-plan':
+			productCardProps = {
+				title: REALTIME_BACKUP_TITLE,
+				subtitle,
+				description: BACKUP_DESCRIPTION_REALTIME,
+				...productCardProps,
+			};
+		case 'is-personal-plan':
+			productCardProps = {
+				title: DAILY_BACKUP_TITLE,
+				subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
+					components: { planLink },
+				} ),
+				description: BACKUP_DESCRIPTION,
+				...productCardProps,
+			};
+		case 'is-premium-plan':
+			productCardProps = {
+				title: DAILY_BACKUP_TITLE,
+				subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
+					components: { planLink },
+				} ),
+				description: BACKUP_DESCRIPTION,
+				...productCardProps,
+			};
+		case 'is-business-plan':
+			productCardProps = {
+				title: REALTIME_BACKUP_TITLE,
+				subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
+					components: { planLink },
+				} ),
+				description: BACKUP_DESCRIPTION_REALTIME,
+				...productCardProps,
+			};
+	}
+
+	return <ProductCard { ...productCardProps } />;
+}

--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -10,8 +10,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import PlanRadioButton from '../single-product-components/plan-radio-button';
-import ProductSavings from '../single-product-components/product-savings';
 import {
 	JETPACK_SEARCH_TIER_UP_TO_100_RECORDS,
 	JETPACK_SEARCH_TIER_UP_TO_1K_RECORDS,
@@ -19,8 +17,11 @@ import {
 	JETPACK_SEARCH_TIER_UP_TO_100K_RECORDS,
 	JETPACK_SEARCH_TIER_UP_TO_1M_RECORDS,
 	JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS,
-} from '../../lib/plans/constants';
-import { getUpgradeUrl } from '../../state/initial-state';
+} from 'lib/plans/constants';
+import { getUpgradeUrl } from 'state/initial-state';
+import { SEARCH_DESCRIPTION, SEARCH_TITLE } from '../constants';
+import PlanRadioButton from '../single-product-components/plan-radio-button';
+import ProductSavings from '../single-product-components/product-savings';
 
 function getTierLabel( priceTierSlug, recordCount ) {
 	switch ( priceTierSlug ) {
@@ -61,14 +62,11 @@ export function SingleProductSearchCard( props ) {
 	) : (
 		<div className="single-product__accented-card dops-card">
 			<div className="single-product__accented-card-header">
-				<h3 className="single-product-backup__header-title">{ __( 'Jetpack Search' ) }</h3>
+				<h3 className="single-product-backup__header-title">{ SEARCH_TITLE }</h3>
 			</div>
 			<div className="single-product__accented-card-body">
 				<p>
-					{ __(
-						'Enhanced Search for your WordPress site that provides more relevant results using modern ' +
-							'ranking algorithms, boosting of specific results, advanced filtering and faceting, and more. '
-					) }
+					{ SEARCH_DESCRIPTION }
 					<a href="https://jetpack.com/search" target="_blank" rel="noopener noreferrer">
 						{ __( 'Learn More' ) }
 					</a>

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -205,7 +205,7 @@ export function getActiveSearchPurchase( state ) {
 	);
 }
 
-export function hasSearchPurchase( state ) {
+export function hasActiveSearchPurchase( state ) {
 	return !! getActiveSearchPurchase( state );
 }
 

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -199,10 +199,14 @@ export function getActiveProductPurchases( state ) {
 	);
 }
 
-export function hasSearchPurchase( state ) {
-	return !! find( getActiveProductPurchases( state ), product =>
+export function getActiveSearchPurchase( state ) {
+	return find( getActiveProductPurchases( state ), product =>
 		isJetpackSearch( product.product_slug )
 	);
+}
+
+export function hasSearchPurchase( state ) {
+	return !! getActiveSearchPurchase( state );
 }
 
 export function getSiteID( state ) {

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -7,6 +7,7 @@ import { assign, find, get, merge } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isJetpackProduct, isJetpackSearch } from 'lib/plans/constants';
 import {
 	JETPACK_SITE_DATA_FETCH,
 	JETPACK_SITE_DATA_FETCH_RECEIVE,
@@ -24,7 +25,6 @@ import {
 	JETPACK_SITE_PURCHASES_FETCH_RECEIVE,
 	JETPACK_SITE_PURCHASES_FETCH_FAIL,
 } from 'state/action-types';
-import { isJetpackProduct, isJetpackSearch } from 'lib/plans/constants';
 
 export const data = ( state = {}, action ) => {
 	switch ( action.type ) {

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { combineReducers } from 'redux';
-import { assign, get, merge } from 'lodash';
+import { assign, find, get, merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ import {
 	JETPACK_SITE_PURCHASES_FETCH_RECEIVE,
 	JETPACK_SITE_PURCHASES_FETCH_FAIL,
 } from 'state/action-types';
+import { isJetpackProduct, isJetpackSearch } from 'lib/plans/constants';
 
 export const data = ( state = {}, action ) => {
 	switch ( action.type ) {
@@ -190,6 +191,18 @@ export function getSitePurchases( state ) {
  */
 export function getActiveSitePurchases( state ) {
 	return getSitePurchases( state ).filter( purchase => '1' === purchase.active );
+}
+
+export function getActiveProductPurchases( state ) {
+	return getActiveSitePurchases( state ).filter( purchase =>
+		isJetpackProduct( purchase.product_slug )
+	);
+}
+
+export function hasSearchPurchase( state ) {
+	return !! find( getActiveProductPurchases( state ), product =>
+		isJetpackSearch( product.product_slug )
+	);
 }
 
 export function getSiteID( state ) {

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -306,7 +306,6 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'lastPostUrl'                 => esc_url( $last_post ),
 			'externalServicesConnectUrls' => $this->get_external_services_connect_urls(),
 			'calypsoEnv'                  => Jetpack::get_calypso_env(),
-			'isInstantSearchEnabled'      => (bool) Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' ),
 		);
 	}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2077,6 +2077,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'jp_group'          => 'search',
 			),
 
+			'has_jetpack_search_product'           => array(
+				'description'       => esc_html__( 'Has an active Jetpack Search product purchase', 'jetpack' ),
+				'type'              => 'boolean',
+				'default'           => 0,
+				'validate_callback' => __CLASS__ . '::validate_boolean',
+				'jp_group'          => 'search',
+			),
+
 			// Verification Tools
 			'google' => array(
 				'description'       => esc_html__( 'Google Search Console', 'jetpack' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -70,7 +70,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if ( ! Jetpack_Plan::supports( $module_slug ) || ( 'search' === $module_slug && get_option( 'has_jetpack_search_product' ) ) ) {
+		if ( ! ( Jetpack_Plan::supports( $module_slug ) || ( 'search' === $module_slug && get_option( 'has_jetpack_search_product' ) ) ) ) {
 			return new WP_Error(
 				'not_supported',
 				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -70,7 +70,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if ( ! Jetpack_Plan::supports( $module_slug ) ) {
+		if ( ! Jetpack_Plan::supports( $module_slug ) || ( 'search' === $module_slug && get_option( 'has_jetpack_search_product' ) ) ) {
 			return new WP_Error(
 				'not_supported',
 				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -70,7 +70,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if ( ! ( Jetpack_Plan::supports( $module_slug ) || ( 'search' === $module_slug && get_option( 'has_jetpack_search_product' ) ) ) ) {
+		if ( ! ( Jetpack_Plan::supports( $module_slug ) || ( 'search' === $module_slug && (bool) get_option( 'has_jetpack_search_product' ) ) ) ) {
 			return new WP_Error(
 				'not_supported',
 				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -70,7 +70,7 @@ class Jetpack_Core_API_Module_Toggle_Endpoint
 			);
 		}
 
-		if ( ! ( Jetpack_Plan::supports( $module_slug ) || ( 'search' === $module_slug && (bool) get_option( 'has_jetpack_search_product' ) ) ) ) {
+		if ( ! Jetpack_Plan::supports( $module_slug ) ) {
 			return new WP_Error(
 				'not_supported',
 				esc_html__( 'The requested Jetpack module is not supported by your plan.', 'jetpack' ),

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -205,6 +205,11 @@ class Jetpack_Plan {
 	 * @return bool True if plan supports feature, false if not
 	 */
 	public static function supports( $feature ) {
+		// Search product bypasses plan feature check.
+		if ( 'search' === $feature && (bool) get_option( 'has_jetpack_search_product' ) ) {
+			return true;
+		}
+
 		$plan = self::get();
 
 		// Manually mapping WordPress.com features to Jetpack module slugs.

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once dirname( __FILE__ ) . '/class.jetpack-search-options.php';
+require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
 
 /**
  * Class to customize search on the site.

--- a/modules/search/class-jetpack-search-options.php
+++ b/modules/search/class-jetpack-search-options.php
@@ -40,7 +40,7 @@ class Jetpack_Search_Options {
 	 * @return bool
 	 */
 	public static function is_instant_enabled() {
-		return true === get_option( 'instant_search_enabled' );
+		return true === (bool) get_option( 'instant_search_enabled' );
 	}
 
 

--- a/modules/search/class-jetpack-search-options.php
+++ b/modules/search/class-jetpack-search-options.php
@@ -40,7 +40,7 @@ class Jetpack_Search_Options {
 	 * @return bool
 	 */
 	public static function is_instant_enabled() {
-		return Constants::is_true( 'JETPACK_SEARCH_PROTOTYPE' );
+		return true === get_option( 'instant_search_enabled' );
 	}
 
 

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -9,7 +9,7 @@
 
 use Automattic\Jetpack\Constants;
 
-require_once dirname( __FILE__ ) . '/class.jetpack-search-options.php';
+require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
 
 /**
  * Various helper functions for reuse throughout the Jetpack Search code.

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -11,7 +11,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
 
-require_once dirname( __FILE__ ) . '/class.jetpack-search-options.php';
+require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
 
 /**
  * The main class for the Jetpack Search module.

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -21,7 +21,7 @@ function jetpack_search_widget_init() {
 	}
 
 	require_once JETPACK__PLUGIN_DIR . 'modules/search/class.jetpack-search-helpers.php';
-	require_once JETPACK__PLUGIN_DIR . 'modules/search/class.jetpack-search-options.php';
+	require_once JETPACK__PLUGIN_DIR . 'modules/search/class-jetpack-search-options.php';
 
 	register_widget( 'Jetpack_Search_Widget' );
 }

--- a/tests/php/modules/search/test-class.jetpack-search-helpers.php
+++ b/tests/php/modules/search/test-class.jetpack-search-helpers.php
@@ -8,7 +8,7 @@ use Automattic\Jetpack\Constants;
 
 require_jetpack_file( 'modules/search/class.jetpack-search.php' );
 require_jetpack_file( 'modules/search/class.jetpack-search-helpers.php' );
-require_jetpack_file( 'modules/search/class.jetpack-search-options.php' );
+require_jetpack_file( 'modules/search/class-jetpack-search-options.php' );
 
 class WP_Test_Jetpack_Search_Helpers_Customize {
 	public $previewing = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Check for Search product eligibility by checking the site's purchases instead of its plan.
* Removes Instant Search feature gate for Jetpacks' Plan page. 
* **Known issue**: Enabling the Jetpack Search module without a Professional Plan is currently not possible.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Apply this change to your Jetpack installation.
* Using a site without a Jetpack Search purchase, navigate to the following pages below. Ensure that each page works as expected (e.g. see upsells for Jetpack Search as necessary).
  1) The dashboard (/wp-admin/admin.php?page=jetpack#/dashboard)
  2) My Plan page (/wp-admin/admin.php?page=jetpack#/my-plan)
  3) Plans page (/wp-admin/admin.php?page=jetpack#/plans)
  4) Performance settings page (/wp-admin/admin.php?page=jetpack#/performance).
* Purchase a Jetpack Search product to your site and try the four pages listed above again. Ensure that each page works as expected.

#### Proposed changelog entry for your changes:
* None
