### PR TITLE
Block: Opentable - fix the required plan name so upgrade nudge shows correctly

### DIFF
--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -65,12 +65,12 @@ function set_availability() {
 			'missing_plan',
 			array(
 				'required_feature' => 'opentable',
-				'required_plan'    => 'premium-plan',
+				'required_plan'    => 'value_bundle',
 			)
 		);
 	}
 }
-add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\set_availability' );
+add_action( 'init', __NAMESPACE__ . '\set_availability' );
 
 /**
  * Adds an inline script which updates the block editor settings to


### PR DESCRIPTION
The required plan was not set correctly so the upgrade nudge message and upgrade button was not showing correctly.

Fixes #15021
#### Changes proposed in this Pull Request:

* Changes required bundle from premium-plan to value_bundle for Opentable block

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix for existing feature

#### Testing instructions:

* Add OpenTable block on free simple site and notice that specific plan to upgrade to is not displayed in nudge, and upgrade button is missing
* Apply this patch to sandbox, and sandbox free simple site, then add OpenTable block again and check nudge specifies that upgrade to 'Premium' plan is needed and that upgrade button shows.

**Before:**
<img width="658" alt="Screen Shot 2020-03-30 at 11 38 17 AM" src="https://user-images.githubusercontent.com/3629020/77863116-70129a80-727c-11ea-9127-0614572431d5.png">

**After:**

<img width="639" alt="Screen Shot 2020-03-30 at 11 39 05 AM" src="https://user-images.githubusercontent.com/3629020/77863117-73a62180-727c-11ea-9c05-652358922754.png">

#### Proposed changelog entry for your changes:
* WPcom specific bugfix so no entry needed
