### PR TITLE
WooCommerce Analytics: make it available as module

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -42,6 +42,7 @@ module.exports = [
 	'modules/verification-tools.php',
 	'modules/widgets/contact-info.php',
 	'modules/widgets/social-icons.php',
+	'modules/woocommerce-analytics.php',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'modules/wpcom-tos/wpcom-tos.php',
 	'packages',

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -191,6 +191,20 @@ class Jetpack_Admin {
 			return false;
 		}
 
+		/*
+		 * WooCommerce Analytics should only be available
+		 * when running WooCommerce 3+
+		 */
+		if (
+			'woocommerce-analytics' === $module['module']
+			&& (
+				! class_exists( 'WooCommerce' )
+				|| version_compare( WC_VERSION, '3.0', '<' )
+			)
+		) {
+			return false;
+		}
+
 		if ( ( new Status() )->is_development_mode() ) {
 			return ! ( $module['requires_connection'] );
 		} else {

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -46,7 +46,6 @@ $connected_tools = array(
 	'calypsoify/class.jetpack-calypsoify.php',
 	'plugin-search.php',
 	'simple-payments/simple-payments.php',
-	'woocommerce-analytics/wp-woocommerce-analytics.php',
 	'wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'wpcom-tos/wpcom-tos.php',
 );

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -212,6 +212,11 @@ function jetpack_get_module_i18n( $key ) {
 				'description' => _x( 'Provides additional widgets for use on your site.', 'Module Description', 'jetpack' ),
 			),
 
+			'woocommerce-analytics' => array(
+				'name' => _x( 'WooCommerce Analytics', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Enhanced analytics for WooCommerce and Jetpack users.', 'Module Description', 'jetpack' ),
+			),
+
 			'wordads' => array(
 				'name' => _x( 'Ads', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Earn income by allowing Jetpack to display high quality ads.', 'Module Description', 'jetpack' ),
@@ -234,6 +239,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 			// Modules with `Other` tag:
 			//  - modules/contact-form.php
 			//  - modules/notes.php
+			//  - modules/woocommerce-analytics.php
 			'Other' =>_x( 'Other', 'Module Tag', 'jetpack' ),
 
 			// Modules with `Photos and Videos` tag:
@@ -300,6 +306,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 			//  - modules/sharedaddy.php
 			//  - modules/sitemaps.php
 			//  - modules/stats.php
+			//  - modules/woocommerce-analytics.php
 			'Recommended' =>_x( 'Recommended', 'Module Tag', 'jetpack' ),
 
 			// Modules with `General` tag:

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -784,7 +784,7 @@ add_action( 'jetpack_module_more_info_google-analytics', 'jetpack_google_analyti
  * WooCommerce Analytics support link.
  */
 function jetpack_woocommerce_analytics_more_link() {
-	echo 'https://jetpack.com/support/';
+	echo 'https://jetpack.com/support/woocommerce-analytics/';
 }
 add_action( 'jetpack_learn_more_button_woocommerce-analytics', 'jetpack_woocommerce_analytics_more_link' );
 

--- a/modules/woocommerce-analytics.php
+++ b/modules/woocommerce-analytics.php
@@ -3,7 +3,7 @@
  * Module Name: WooCommerce Analytics
  * Module Description: Enhanced analytics for WooCommerce and Jetpack users.
  * Sort Order: 13
- * First Introduced: 5.9
+ * First Introduced: 8.4
  * Requires Connection: Yes
  * Auto Activate: Yes
  * Module Tags: Other, Recommended

--- a/modules/woocommerce-analytics.php
+++ b/modules/woocommerce-analytics.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Module Name: WooCommerce Analytics
+ * Module Description: Enhanced analytics for WooCommerce and Jetpack users.
+ * Sort Order: 13
+ * First Introduced: 5.9
+ * Requires Connection: Yes
+ * Auto Activate: Yes
+ * Module Tags: Other, Recommended
+ * Feature: Engagement
+ * Additional Search Queries: woocommerce, analytics, stats, statistics, tracking, analytics, views
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Load module functionality.
+ */
+function jetpack_load_woocommerce_analytics() {
+	require_once dirname( __FILE__ ) . '/woocommerce-analytics/wp-woocommerce-analytics.php';
+}
+jetpack_load_woocommerce_analytics();


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

WooCommerce Analytics was always enabled until now, and could not be disabled unless you were to hook into `jetpack_tools_to_include`. 

This PR makes the feature a proper module.
- The module is automatically enabled so should be automatically enabled on plugin update, unless folks turned that off with a filter like `jetpack_get_default_modules`.
- It will only appear as available in the full module list (at `wp-admin/admin.php?page=jetpack_modules`)
- It will be greyed out there if you do not use WooCommerce, or use an old version of WooCommerce:

![image](https://user-images.githubusercontent.com/426388/77895954-cdf0b380-7277-11ea-9ecb-a189ec3cddad.png)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* p7Ldg5-ru-p2

#### Testing instructions:

* On a site that does not run WooCommerce, go to `wp-admin/admin.php?page=jetpack_modules`; you should see the module greyed out.
* Activate WooCommerce. You should see the module available and active.
* Follow the instructions in #15127 to make sure the module still works.

#### Proposed changelog entry for your changes:

* N/A
