### PR TITLE
SEO: make block experimental

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -28,5 +28,6 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "instagram-gallery", "podcast-player", "seo" ]
+	"beta": [ "amazon", "instagram-gallery", "podcast-player" ],
+	"experimental": [ "seo" ]
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* This will make the block available on Atomic sites as well. Until now, it was only available to WordPress.com Simple sites.

Related: https://github.com/Automattic/wp-calypso/issues/27692

#### Testing instructions:

* See 431-gh-wpcomsh

#### Proposed changelog entry for your changes:
* N/A
