### PR TITLE
Podcast Player: fix Calypso preview compatibility

### DIFF
--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -180,6 +180,8 @@ export class PodcastPlayer extends Component {
 				aria-describedby={
 					track && track.description ? `${ playerId }__track-description` : undefined
 				}
+				// The following line ensures compatibility with Calypso previews (jetpack-iframe-embed.js).
+				data-jetpack-iframe-ignore
 			>
 				<Header
 					playerId={ playerId }


### PR DESCRIPTION
Fixes #15047

#### Changes proposed in this Pull Request:
* adds a data attribute to the wrapper of the dynamic part of the podcast player so jetpack-iframe-embed.js knows to leave link handling alone (and allows our React component to handle them)

#### Testing instructions:
* this is only testable on a sandboxed wpcom simple site
* sandbox the site and apply this PR together with D41067-code
* from Calypso, make a new page on your sandboxed site, add the Podcast Player block and click the Preview button
* as opposed to wp-admin, the preview doesn't open a new tab but rather loads the preview in a modal window
* inside the window, try to click a podcast episode link — it should start playing instead of opening a new tab

### Proposed changelog entry for your changes:
* none