### PR TITLE
Podcast Player: implement colors in server-side

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -103,7 +103,7 @@ function render_player( $player_data, $attributes ) {
 		absint( $attributes['itemsToShow'] )
 	);
 
-	// Genereate a unique id for the block instance.
+	// Generate a unique id for the block instance.
 	$instance_id             = wp_unique_id( 'jetpack-podcast-player-block-' );
 	$player_data['playerId'] = $instance_id;
 

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -126,8 +126,8 @@ function render_player( $player_data, $attributes ) {
 
 	$secondary_classes_name = '';
 	$secondary_inline_style = '';
-	if ( ! empty( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
-		$secondary_classes_name .= 'has-secondary ';
+	if ( isset( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
+		$secondary_classes_name .= ' has-secondary';
 		if ( isset( $secondary_color_class ) ) {
 			$secondary_classes_name .= $secondary_color_class;
 		} elseif ( isset( $custom_secondary_color ) ) {
@@ -138,7 +138,7 @@ function render_player( $player_data, $attributes ) {
 	$background_classes_name = '';
 	$background_inline_style = '';
 	if ( isset( $background_color_class ) || isset( $custom_background_color ) ) {
-		$background_classes_name .= 'has-background ';
+		$background_classes_name .= ' has-background';
 		if ( isset( $background_color_class ) ) {
 			$background_classes_name .= $background_color_class;
 		} elseif ( isset( $custom_background_color ) ) {
@@ -146,7 +146,7 @@ function render_player( $player_data, $attributes ) {
 		}
 	}
 
-	$podcast_player_classes_name = trim( $secondary_classes_name . ' ' . $background_classes_name );
+	$podcast_player_classes_name = trim( $secondary_classes_name . $background_classes_name );
 	$podcast_player_inline_style = trim( $secondary_inline_style . ' ' . $background_inline_style );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -124,20 +124,25 @@ function render_player( $player_data, $attributes ) {
 	$secondary_color_class  = get_color_class_name( 'color', $secondary_color );
 	$background_color_class = get_color_class_name( 'background-color', $background_color );
 
-	$podcast_player_classes_name = array();
+	$secondary_classes_name = array();
 	if ( isset( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
-		array_push( $podcast_player_classes_name, 'has-secondary' );
+		array_push( $secondary_classes_name, 'has-secondary' );
 		if ( isset( $secondary_color_class ) ) {
-			array_push( $podcast_player_classes_name, $secondary_color_class );
+			array_push( $secondary_classes_name, $secondary_color_class );
 		}
 	}
+	$secondary_classes_name = implode( ' ', $secondary_classes_name );
+
+	$background_classes_name = array();
 	if ( isset( $background_color_class ) || isset( $custom_background_color ) ) {
-		array_push( $podcast_player_classes_name, 'has-background' );
+		array_push( $background_classes_name, 'has-background' );
 		if ( isset( $background_color_class ) ) {
-			array_push( $podcast_player_classes_name, $background_color_class );
+			array_push( $background_classes_name, $background_color_class );
 		}
 	}
-	$podcast_player_classes_name = implode( ' ', $podcast_player_classes_name );
+	$background_classes_name = implode( ' ', $background_classes_name );
+
+	$podcast_player_classes_name = trim( $secondary_classes_name . ' ' . $background_classes_name );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
@@ -154,7 +159,7 @@ function render_player( $player_data, $attributes ) {
 		>
 			<ol class="jetpack-podcast-player__episodes">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
-				<li class="jetpack-podcast-player__episode">
+				<li class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_classes_name ); ?>">
 					<a
 						class="jetpack-podcast-player__episode-link"
 						href="<?php echo esc_url( $attachment['link'] ); ?>"

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -155,7 +155,7 @@ function render_player( $player_data, $attributes ) {
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
-		<div
+		<section
 			<?php
 			echo ! empty( $podcast_player_classes_name )
 				? ' class="' . esc_attr( $podcast_player_classes_name ) . '"'
@@ -189,7 +189,7 @@ function render_player( $player_data, $attributes ) {
 				</li>
 				<?php endforeach; ?>
 			</ol>
-		</div>
+		</section>
 		<?php if ( ! $is_amp ) : ?>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
 		<?php endif; ?>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -115,28 +115,60 @@ function render_player( $player_data, $attributes ) {
 		$player_data
 	);
 
+	// Set CSS classes for `secondary` and `background` colors.
+	$secondary_color         = isset( $attributes['secondaryColor'] ) ? $attributes['secondaryColor'] : null;
+	$custom_secondary_color  = isset( $attributes['customSecondaryColor'] ) ? $attributes['customSecondaryColor'] : null;
+	$background_color        = isset( $attributes['backgroundColor'] ) ? $attributes['backgroundColor'] : null;
+	$custom_background_color = isset( $attributes['customBackgroundColor'] ) ? $attributes['customBackgroundColor'] : null;
+
+	$secondary_color_class  = get_color_class_name( 'color', $secondary_color );
+	$background_color_class = get_color_class_name( 'background-color', $background_color );
+
+	$podcast_player_classes_name = array();
+	if ( isset( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
+		array_push( $podcast_player_classes_name, 'has-secondary' );
+		if ( isset( $secondary_color_class ) ) {
+			array_push( $podcast_player_classes_name, $secondary_color_class );
+		}
+	}
+	if ( isset( $background_color_class ) || isset( $custom_background_color ) ) {
+		array_push( $podcast_player_classes_name, 'has-background' );
+		if ( isset( $background_color_class ) ) {
+			array_push( $podcast_player_classes_name, $background_color_class );
+		}
+	}
+	$podcast_player_classes_name = implode( ' ', $podcast_player_classes_name );
+
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
 
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
-		<ol class="jetpack-podcast-player__episodes">
-			<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
-			<li class="jetpack-podcast-player__episode">
-				<a
-					class="jetpack-podcast-player__episode-link"
-					href="<?php echo esc_url( $attachment['link'] ); ?>"
-					role="button"
-					aria-pressed="false"
-				>
-					<span class="jetpack-podcast-player__episode-status-icon"></span>
-					<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-					<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
-				</a>
-			</li>
-			<?php endforeach; ?>
-		</ol>
+		<div
+			<?php
+			echo ! empty( $podcast_player_classes_name )
+				? ' class="' . esc_attr( $podcast_player_classes_name ) . '"'
+				: '';
+			?>
+		>
+			<ol class="jetpack-podcast-player__episodes">
+				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
+				<li class="jetpack-podcast-player__episode">
+					<a
+						class="jetpack-podcast-player__episode-link"
+						href="<?php echo esc_url( $attachment['link'] ); ?>"
+						role="button"
+						aria-pressed="false"
+					>
+						<span class="jetpack-podcast-player__episode-status-icon"></span>
+						<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+						<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+					</a>
+				</li>
+				<?php endforeach; ?>
+			</ol>
+		</div>
 		<?php if ( ! $is_amp ) : ?>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
 		<?php endif; ?>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -161,3 +161,19 @@ function render_player( $player_data, $attributes ) {
 
 	return ob_get_clean();
 }
+
+/**
+ * Returns a CSS class based on the context a color is being used and its slug.
+ *
+ * @param string $color_context_name Context/place where color is being used e.g: background, text etc...
+ * @param string $color_slug         Slug of the color.
+ *
+ * @return string String with the class corresponding to the color in the provided context.
+ */
+function get_color_class_name( $color_context_name, $color_slug ) {
+	if ( ! isset( $color_context_name ) || ! isset( $color_slug ) ) {
+		return '';
+	}
+
+	return "has-${color_slug}-${color_context_name}";
+}

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -115,33 +115,34 @@ function render_player( $player_data, $attributes ) {
 		$player_data
 	);
 
-	// Set CSS classes for `secondary` and `background` colors.
+	// Color attributes.
 	$secondary_color         = isset( $attributes['secondaryColor'] ) ? $attributes['secondaryColor'] : null;
 	$custom_secondary_color  = isset( $attributes['customSecondaryColor'] ) ? $attributes['customSecondaryColor'] : null;
 	$background_color        = isset( $attributes['backgroundColor'] ) ? $attributes['backgroundColor'] : null;
 	$custom_background_color = isset( $attributes['customBackgroundColor'] ) ? $attributes['customBackgroundColor'] : null;
 
-	$secondary_color_class  = get_color_class_name( 'color', $secondary_color );
-	$background_color_class = get_color_class_name( 'background-color', $background_color );
-
+	// `secondary` color.
 	$secondary_classes_name = '';
 	$secondary_inline_style = '';
-	if ( isset( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
+	$secondary_color_class  = get_color_class_name( 'color', $secondary_color );
+	if ( $secondary_color_class || $custom_secondary_color ) {
 		$secondary_classes_name .= ' has-secondary';
-		if ( isset( $secondary_color_class ) ) {
-			$secondary_classes_name .= $secondary_color_class;
-		} elseif ( isset( $custom_secondary_color ) ) {
+		if ( $secondary_color_class ) {
+			$secondary_classes_name .= " {$secondary_color_class}";
+		} elseif ( $custom_secondary_color ) {
 			$secondary_inline_style .= "color: $custom_secondary_color;";
 		}
 	}
 
+	// `background` color.
 	$background_classes_name = '';
 	$background_inline_style = '';
-	if ( isset( $background_color_class ) || isset( $custom_background_color ) ) {
+	$background_color_class  = get_color_class_name( 'background-color', $background_color );
+	if ( $background_color_class || $custom_background_color ) {
 		$background_classes_name .= ' has-background';
-		if ( isset( $background_color_class ) ) {
-			$background_classes_name .= $background_color_class;
-		} elseif ( isset( $custom_background_color ) ) {
+		if ( $background_color_class ) {
+			$background_classes_name .= " {$background_color_class}";
+		} elseif ( $custom_background_color ) {
 			$background_inline_style .= "background-color: $custom_background_color;";
 		}
 	}

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -115,40 +115,11 @@ function render_player( $player_data, $attributes ) {
 		$player_data
 	);
 
-	// Color attributes.
-	$secondary_color         = isset( $attributes['secondaryColor'] ) ? $attributes['secondaryColor'] : null;
-	$custom_secondary_color  = isset( $attributes['customSecondaryColor'] ) ? $attributes['customSecondaryColor'] : null;
-	$background_color        = isset( $attributes['backgroundColor'] ) ? $attributes['backgroundColor'] : null;
-	$custom_background_color = isset( $attributes['customBackgroundColor'] ) ? $attributes['customBackgroundColor'] : null;
+	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
+	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
-	// `secondary` color.
-	$secondary_classes_name = '';
-	$secondary_inline_style = '';
-	$secondary_color_class  = get_color_class_name( 'color', $secondary_color );
-	if ( $secondary_color_class || $custom_secondary_color ) {
-		$secondary_classes_name .= ' has-secondary';
-		if ( $secondary_color_class ) {
-			$secondary_classes_name .= " {$secondary_color_class}";
-		} elseif ( $custom_secondary_color ) {
-			$secondary_inline_style .= "color: $custom_secondary_color;";
-		}
-	}
-
-	// `background` color.
-	$background_classes_name = '';
-	$background_inline_style = '';
-	$background_color_class  = get_color_class_name( 'background-color', $background_color );
-	if ( $background_color_class || $custom_background_color ) {
-		$background_classes_name .= ' has-background';
-		if ( $background_color_class ) {
-			$background_classes_name .= " {$background_color_class}";
-		} elseif ( $custom_background_color ) {
-			$background_inline_style .= "background-color: $custom_background_color;";
-		}
-	}
-
-	$podcast_player_classes_name = trim( $secondary_classes_name . $background_classes_name );
-	$podcast_player_inline_style = trim( $secondary_inline_style . ' ' . $background_inline_style );
+	$player_classes_name = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
+	$player_inline_style = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
@@ -157,14 +128,14 @@ function render_player( $player_data, $attributes ) {
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<section
-			class="<?php echo esc_attr( $podcast_player_classes_name ); ?>"
-			style="<?php echo esc_attr( $podcast_player_inline_style ); ?>"
+			class="<?php echo esc_attr( $player_classes_name ); ?>"
+			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
 			<ol class="jetpack-podcast-player__episodes">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 				<li
-					class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_classes_name ); ?>"
-					style="<?php echo esc_attr( $secondary_inline_style ); ?>"
+					class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_colors['class'] ); ?>"
+					style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
 				>
 					<a
 						class="jetpack-podcast-player__episode-link"
@@ -219,4 +190,45 @@ function get_color_class_name( $color_context_name, $color_slug ) {
 	}
 
 	return "has-{$color_slug}-{$color_context_name}";
+}
+
+/**
+ * Given the color name, bock attributes and the CSS property,
+ * the function will return an array with the `class` and `style`
+ * HTML attributes to be used straight in the markup.
+ *
+ * @example
+ * $color = get_colors( 'secondary', $attributes, 'border-color'
+ *  => array( 'class' => 'has-secondary', 'style' => 'border-color: #333' )
+ *
+ * @param string $name     Color attribute name, for instance `primary`, `secondary`, ...
+ * @param array  $attrs     Block attributes.
+ * @param string $property Color CSS property, fo instance `color`, `background-color`, ...
+ * @return array           Colors array.
+ */
+function get_colors( $name, $attrs, $property ) {
+	$attr_color  = "{$name}Color";
+	$attr_custom = 'custom' . ucfirst( $attr_color );
+
+	$color        = isset( $attrs[ $attr_color ] ) ? $attrs[ $attr_color ] : null;
+	$custom_color = isset( $attrs[ $attr_custom ] ) ? $attrs[ $attr_custom ] : null;
+
+	// `secondary` color.
+	$colors = array(
+		'class' => '',
+		'style' => '',
+	);
+
+	if ( $color || $custom_color ) {
+		$colors['class'] .= " has-{$name}";
+
+		if ( $color ) {
+			$colors['class'] .= ' ' . get_color_class_name( $property, $color );
+		} elseif ( $custom_color ) {
+			$colors['style'] .= "{$property}: {$custom_color};";
+		}
+	}
+
+	$colors['class'] = trim( $colors['class'] );
+	return $colors;
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -177,7 +177,7 @@ function render_player( $player_data, $attributes ) {
 }
 
 /**
- * Given the color name, bock attributes and the CSS property,
+ * Given the color name, block attributes and the CSS property,
  * the function will return an array with the `class` and `style`
  * HTML attributes to be used straight in the markup.
  *
@@ -186,7 +186,7 @@ function render_player( $player_data, $attributes ) {
  *  => array( 'class' => 'has-secondary', 'style' => 'border-color: #333' )
  *
  * @param string $name     Color attribute name, for instance `primary`, `secondary`, ...
- * @param array  $attrs     Block attributes.
+ * @param array  $attrs    Block attributes.
  * @param string $property Color CSS property, fo instance `color`, `background-color`, ...
  * @return array           Colors array.
  */
@@ -206,12 +206,11 @@ function get_colors( $name, $attrs, $property ) {
 		$colors['class'] .= " has-{$name}";
 
 		if ( $color ) {
-			$colors['class'] .= ' ' . "has-{$property}-{$color}";
+			$colors['class'] .= " has-{$color}-{$property}";
 		} elseif ( $custom_color ) {
 			$colors['style'] .= "{$property}: {$custom_color};";
 		}
 	}
 
-	$colors['class'] = trim( $colors['class'] );
-	return $colors;
+	return array_map( 'trim', $colors );
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -156,25 +156,14 @@ function render_player( $player_data, $attributes ) {
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<section
-			<?php
-			echo ! empty( $podcast_player_classes_name )
-				? ' class="' . esc_attr( $podcast_player_classes_name ) . '"'
-				: '';
-
-			echo ! empty( $podcast_player_inline_style )
-				? ' style="' . esc_attr( $podcast_player_inline_style ) . '"'
-				: '';
-			?>
+			class="<?php echo esc_attr( $podcast_player_classes_name ); ?>"
+			style="<?php echo esc_attr( $podcast_player_inline_style ); ?>"
 		>
 			<ol class="jetpack-podcast-player__episodes">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 				<li
 					class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_classes_name ); ?>"
-					<?php
-					echo ! empty( $secondary_inline_style )
-						? ' style="' . esc_attr( $secondary_inline_style ) . '"'
-						: '';
-					?>
+					style="<?php echo esc_attr( $secondary_inline_style ); ?>"
 				>
 					<a
 						class="jetpack-podcast-player__episode-link"
@@ -228,5 +217,5 @@ function get_color_class_name( $color_context_name, $color_slug ) {
 		return null;
 	}
 
-	return "has-${color_slug}-${color_context_name}";
+	return "has-{$color_slug}-{$color_context_name}";
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -177,22 +177,6 @@ function render_player( $player_data, $attributes ) {
 }
 
 /**
- * Returns a CSS class based on the context a color is being used and its slug.
- *
- * @param string $color_context_name Context/place where color is being used e.g: background, text etc...
- * @param string $color_slug         Slug of the color.
- *
- * @return string String with the class corresponding to the color in the provided context.
- */
-function get_color_class_name( $color_context_name, $color_slug ) {
-	if ( ! isset( $color_context_name ) || ! isset( $color_slug ) ) {
-		return null;
-	}
-
-	return "has-{$color_slug}-{$color_context_name}";
-}
-
-/**
  * Given the color name, bock attributes and the CSS property,
  * the function will return an array with the `class` and `style`
  * HTML attributes to be used straight in the markup.
@@ -213,7 +197,6 @@ function get_colors( $name, $attrs, $property ) {
 	$color        = isset( $attrs[ $attr_color ] ) ? $attrs[ $attr_color ] : null;
 	$custom_color = isset( $attrs[ $attr_custom ] ) ? $attrs[ $attr_custom ] : null;
 
-	// `secondary` color.
 	$colors = array(
 		'class' => '',
 		'style' => '',
@@ -223,7 +206,7 @@ function get_colors( $name, $attrs, $property ) {
 		$colors['class'] .= " has-{$name}";
 
 		if ( $color ) {
-			$colors['class'] .= ' ' . get_color_class_name( $property, $color );
+			$colors['class'] .= ' ' . "has-{$property}-{$color}";
 		} elseif ( $custom_color ) {
 			$colors['style'] .= "{$property}: {$custom_color};";
 		}

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -203,7 +203,7 @@ function get_colors( $name, $attrs, $property ) {
 	);
 
 	if ( $color || $custom_color ) {
-		$colors['class'] .= " has-{$name}";
+		$colors['class'] .= "has-{$name}";
 
 		if ( $color ) {
 			$colors['class'] .= " has-{$color}-{$property}";
@@ -212,5 +212,5 @@ function get_colors( $name, $attrs, $property ) {
 		}
 	}
 
-	return array_map( 'trim', $colors );
+	return $colors;
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -124,25 +124,30 @@ function render_player( $player_data, $attributes ) {
 	$secondary_color_class  = get_color_class_name( 'color', $secondary_color );
 	$background_color_class = get_color_class_name( 'background-color', $background_color );
 
-	$secondary_classes_name = array();
-	if ( isset( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
-		array_push( $secondary_classes_name, 'has-secondary' );
+	$secondary_classes_name = '';
+	$secondary_inline_style = '';
+	if ( ! empty( $secondary_color_class ) || isset( $custom_secondary_color ) ) {
+		$secondary_classes_name .= 'has-secondary ';
 		if ( isset( $secondary_color_class ) ) {
-			array_push( $secondary_classes_name, $secondary_color_class );
+			$secondary_classes_name .= $secondary_color_class;
+		} elseif ( isset( $custom_secondary_color ) ) {
+			$secondary_inline_style .= "color: $custom_secondary_color;";
 		}
 	}
-	$secondary_classes_name = implode( ' ', $secondary_classes_name );
 
-	$background_classes_name = array();
+	$background_classes_name = '';
+	$background_inline_style = '';
 	if ( isset( $background_color_class ) || isset( $custom_background_color ) ) {
-		array_push( $background_classes_name, 'has-background' );
+		$background_classes_name .= 'has-background ';
 		if ( isset( $background_color_class ) ) {
-			array_push( $background_classes_name, $background_color_class );
+			$background_classes_name .= $background_color_class;
+		} elseif ( isset( $custom_background_color ) ) {
+			$background_inline_style .= "background-color: $custom_background_color;";
 		}
 	}
-	$background_classes_name = implode( ' ', $background_classes_name );
 
 	$podcast_player_classes_name = trim( $secondary_classes_name . ' ' . $background_classes_name );
+	$podcast_player_inline_style = trim( $secondary_inline_style . ' ' . $background_inline_style );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
@@ -155,11 +160,22 @@ function render_player( $player_data, $attributes ) {
 			echo ! empty( $podcast_player_classes_name )
 				? ' class="' . esc_attr( $podcast_player_classes_name ) . '"'
 				: '';
+
+			echo ! empty( $podcast_player_inline_style )
+				? ' style="' . esc_attr( $podcast_player_inline_style ) . '"'
+				: '';
 			?>
 		>
 			<ol class="jetpack-podcast-player__episodes">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
-				<li class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_classes_name ); ?>">
+				<li
+					class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_classes_name ); ?>"
+					<?php
+					echo ! empty( $secondary_inline_style )
+						? ' style="' . esc_attr( $secondary_inline_style ) . '"'
+						: '';
+					?>
+				>
 					<a
 						class="jetpack-podcast-player__episode-link"
 						href="<?php echo esc_url( $attachment['link'] ); ?>"
@@ -209,7 +225,7 @@ function render_player( $player_data, $attributes ) {
  */
 function get_color_class_name( $color_context_name, $color_slug ) {
 	if ( ! isset( $color_context_name ) || ! isset( $color_slug ) ) {
-		return '';
+		return null;
 	}
 
 	return "has-${color_slug}-${color_context_name}";


### PR DESCRIPTION
This PR implements colors in the server-side rendering by adding CSS classes and inline styles, depending on the settings.

Fixes https://github.com/Automattic/jetpack/issues/15194

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Build CSS classes and inline styles based on the block attributes.
* Apply these values straight to the markup built in the server-side

#### Testing instructions:

1) Edit/create a Podcast Player form the editor-canvas side.
2) Appy colors using the inspector controls (sidebar). Try to pick up colors from the palette as well as defining custom colors:

<img width="1133" alt="Screen Shot 2020-03-30 at 11 18 37 AM" src="https://user-images.githubusercontent.com/77539/77923130-5f602580-7278-11ea-9f19-a3594282d2cd.png">

3) Save the post

In the front-end, let's check how it renders disabling javascript. For this:

a) Open Chrome DevTools.
b) Press Control+Shift+P or Command+Shift+P (Mac) to open the Command Menu.
c) Start typing javascript, select Disable JavaScript, and then press Enter to run the command. JavaScript is now disabled.
![image](https://user-images.githubusercontent.com/77539/77923313-a817de80-7278-11ea-875c-247050ac1915.png)

4) Hard Refresh (always in the front-end). The player shouldn't work since JS has been disabled.
5) Check CSS classes and inline are applied, for instance:

![image](https://user-images.githubusercontent.com/77539/77926945-1f4f7180-727d-11ea-8f0c-b08ab62052b0.png)

![image](https://user-images.githubusercontent.com/77539/77927419-96850580-727d-11ea-8071-a561f70edf97.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Apply colors in markup server-side rendering
