### PR TITLE
Inline PDFs: add support for AMP views

### DIFF
--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -21,10 +21,18 @@ function jetpack_inline_pdf_embed_handler( $matches, $attr, $url ) {
 	/** This action is documented in modules/widgets/social-media-icons.php */
 	do_action( 'jetpack_bump_stats_extras', 'embeds', 'inline-pdf' );
 
-	return sprintf(
-		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
-		  <p><a href="%1$s">%1$s</a></p>
-		</object>',
-		esc_attr( $url )
-	);
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		return sprintf(
+			'<p><a href="%1$s">%2$s</a></p>',
+			esc_url( $url ),
+			esc_html__( 'PDF Document', 'jetpack' )
+		);
+	} else {
+		return sprintf(
+			'<object data="%1$s" type="application/pdf" width="100%%" height="800">
+				<p><a href="%1$s">%1$s</a></p>
+			</object>',
+			esc_attr( $url )
+		);
+	}
 }

--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -27,12 +27,11 @@ function jetpack_inline_pdf_embed_handler( $matches, $attr, $url ) {
 			esc_url( $url ),
 			esc_html__( 'PDF Document', 'jetpack' )
 		);
-	} else {
-		return sprintf(
-			'<object data="%1$s" type="application/pdf" width="100%%" height="800">
-				<p><a href="%1$s">%1$s</a></p>
-			</object>',
-			esc_attr( $url )
-		);
 	}
+	return sprintf(
+		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
+			<p><a href="%1$s">%1$s</a></p>
+		</object>',
+		esc_attr( $url )
+	);
 }

--- a/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -8,11 +8,19 @@
 class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 
 	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		wp_reset_postdata();
+		parent::tearDown();
+	}
+
+	/**
 	 * Unit test for Inline PDF embeds.
 	 *
 	 * @author lancewillett
 	 * @covers ::jetpack_inline_pdf_embed_handler
-	 * @since  8.4
+	 * @since  8.4.0
 	 */
 	public function test_shortcodes_inline_pdf() {
 		global $post;
@@ -27,11 +35,38 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 		the_content();
 		$actual = ob_get_clean();
 
-		wp_reset_postdata();
-
 		$this->assertContains(
 			sprintf(
 				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">%1$s</a></p></object></p>' . "\n",
+				$url
+			),
+			$actual
+		);
+	}
+
+	/**
+	 * Test Inline PDFs on AMP views.
+	 *
+	 * @covers ::jetpack_inline_pdf_embed_handler
+	 * @since 8.4.0
+	 */
+	public function test_shortcodes_inline_pdf_amp() {
+		global $post;
+
+		$url  = 'https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf';
+		$post = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+
+		setup_postdata( $post );
+
+		// Test AMP version.
+		add_filter( 'jetpack_is_amp_request', '__return_true' );
+		ob_start();
+		the_content();
+		$actual = ob_get_clean();
+
+		$this->assertContains(
+			sprintf(
+				'<p><a href="%1$s">PDF Document</a></p>',
 				$url
 			),
 			$actual


### PR DESCRIPTION


Fixes #15192

#### Changes proposed in this Pull Request:

* This PR adds a fallback element when adding PDFs links to a post.

#### Testing instructions:

* Start with a site the Shortcode module active.
* Install and activate the AMP plugin.
* In a new post, insert a classic block.
* In that block, paste a URL to a PDF, e.g. `https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf`
* Publish your post. 
* View in your browser; you should see a PDF embed on the page.
* Add `?amp` to the end of the URL; you should see a link to that PDF.
* Tests should pass.

#### Proposed changelog entry for your changes:

* N/A
