### PR TITLE
Podcast Player: fix setting CSS classes

### DIFF
--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -160,9 +160,9 @@ export class PodcastPlayer extends Component {
 		const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
 
 		const cssClassesName = classnames( playerState, {
-			'has-secondary': ! secondaryColorClass && ! customSecondaryColor,
+			'has-secondary': secondaryColor || customSecondaryColor,
 			[ secondaryColorClass ]: secondaryColorClass,
-			'has-background': backgroundColor && ! customBackgroundColor,
+			'has-background': backgroundColor || customBackgroundColor,
 			[ backgroundColorClass ]: backgroundColorClass,
 		} );
 


### PR DESCRIPTION
This PR fixes a bug when it sets the CSS classes to the main container of the block.

#### Changes proposed in this Pull Request:
* Apply properly the CSS classes according to the colors defined in the editor.


#### Testing instructions:
* Set colors in a Podcast Player block
* Confirm that when it sets a secondary and/ora blackground color, it adds the respective `has-secondary` and `has-background` classes to the markup.
* These changes should be reflected in both sides of the app.

<img width="1237" alt="Screen Shot 2020-03-30 at 12 20 37 PM" src="https://user-images.githubusercontent.com/77539/77930208-fa5cfd80-7280-11ea-85a0-b359f52c02e2.png">


#### Proposed changelog entry for your changes:
* Fix applying CSS classes
