### PR TITLE
Sync Health Delay and Error UIs in Site Health

### DIFF
--- a/_inc/lib/debugger/0-load.php
+++ b/_inc/lib/debugger/0-load.php
@@ -21,3 +21,4 @@ add_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' );
 add_action( 'wp_ajax_health-check-jetpack-local_testing_suite', 'jetpack_debugger_ajax_local_testing_suite' );
 add_action( 'admin_enqueue_scripts', 'jetpack_debugger_enqueue_site_health_scripts' );
 add_action( 'wp_ajax_jetpack_sync_progress_check', 'jetpack_debugger_sync_progress_ajax' );
+add_action( 'wp_ajax_jetpack_debugger_full_sync_start', 'jetpack_debugger_full_sync_start' );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -560,11 +560,13 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 						'action_label'      => __( 'Contact Jetpack Support', 'jetpack' ),
 						'short_description' => __( 'Jetpack has detected an error syncing your site.', 'jetpack' ),
 						'long_description'  => sprintf(
-							'<p>%1$s</p><p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
+							'<p>%1$s</p><p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s <a id="full_sync_request_link" href="#">%5$s</a> %6$s</strong></p>',
 							__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
 							__( 'Error', 'jetpack' ),
 							__( 'Jetpack has detected an error while syncing your site', 'jetpack' ), /* translators: screen reader text indicating a test failed */
-							__( 'We recommend a full sync to align Jetpack with your site data.', 'jetpack' )
+							__( 'We recommend', 'jetpack' ),
+							__( 'full sync', 'jetpack' ),
+							__( 'to align Jetpack with your site data.', 'jetpack' )
 						),
 					)
 				);

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -113,6 +113,9 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
 	$full_sync_module = Modules::get_module( 'full-sync' );
 	$progress_percent = $full_sync_module ? $full_sync_module->get_sync_progress_percentage() : false;
+
+	$ajax_nonce = wp_create_nonce( 'jetpack-site-health' );
+
 	if ( 'site-health.php' === $hook ) {
 		$wp_scripts = wp_scripts();
 		wp_enqueue_script( 'jquery-ui-progressbar' );
@@ -145,6 +148,7 @@ function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
 				'ajaxUrl'             => admin_url( 'admin-ajax.php' ),
 				'syncProgressHeading' => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
 				'progressPercent'     => $progress_percent,
+				'fullSyncNonce'       => $ajax_nonce,
 			)
 		);
 	}
@@ -161,5 +165,16 @@ function jetpack_debugger_sync_progress_ajax() {
 		wp_die();
 	}
 	echo intval( $progress_percent );
+	wp_die();
+}
+
+/**
+ * Responds to ajax calls from the site health page. Triggers a Full Sync
+ */
+function jetpack_debugger_full_sync_start() {
+	check_ajax_referer( 'jetpack-site-health', 'site-health-nonce' );
+	$full_sync_module = Modules::get_module( 'full-sync' );
+	$full_sync_module->start();
+	echo 'requested';
 	wp_die();
 }

--- a/_inc/lib/debugger/jetpack-debugger-site-health.js
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.js
@@ -65,4 +65,14 @@ jQuery( document ).ready( function( $ ) {
 	if ( jetpackSiteHealth.progressPercent ) {
 		JetpackSync.init();
 	}
+
+	$( 'body' ).on( 'click', '#full_sync_request_link', function() {
+		var data = {
+			action: 'jetpack_debugger_full_sync_start',
+			'site-health-nonce': jetpackSiteHealth.fullSyncNonce,
+		};
+		$.post( jetpackSiteHealth.ajaxUrl, data, function( response ) {
+			window.location.reload( true );
+		} );
+	} );
 } );


### PR DESCRIPTION
Jetpack Sync tests added for Sync Delays exceeding 5 minutes and when data loss was experienced.

#### Changes proposed in this Pull Request:
* Extends the Sync Health test so that it now displays a recommendation when the sync lag exceeds 5 minutes or when the health state has experienced data loss (lag > 15 && actions over 1000).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.
Extends the existing Sync Site Health Test.

#### Testing instructions:

* Enable Jetpack and Sync Module
* Go to the SIte Health Admin Page `/wp-admin/site-health.php`
* Under Passed Tests you should not see any Jetpack Sync warnings in critical or recommended
* Update the Sync Health to Out of Sync  `Sync_Health::update_status( Sync_Health::STATUS_OUT_OF_SYNC )` dropped into the wp.config.php or the functions theme file or etc.
* Refresh the Site Health Admin Page
* Verify that under critical issues the Jetpack Sync info displays and aligns with the designs https://wp.me/p6TEKc-3uv

* Reset the Sync Health to In Sync `Sync_Health::update_status( Sync_Health::STATUS_IN_SYNC )`
* Point your Jetpack Connection to a bad address  `define( 'JETPACK__SANDBOX_DOMAIN', 'badbadbad23434.example.com' );`
* Update or Create a new Post.
* Verify sync health is not displayed in recommendations
* Wait 5-10 minutes.
* Refresh the Site Health Admin Page
* Verify that under recommended issues the Jetpack Sync delayed test displays and aligns with the designs https://wp.me/p6TEKc-3uv. Check that the X minutes updates as time goes on.

* Remove the Jetpack Connection sandbox
* refresh the admin a few times (clear the queue )
* Refresh the Site Health Admin Page
* Verify sync health is not displayed in recommendations

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Enhance Jetpack Site Health Tests to display Sync health to users.
