### PR TITLE
Debugger: Add sync health progress bar

### DIFF
--- a/_inc/lib/debugger/0-load.php
+++ b/_inc/lib/debugger/0-load.php
@@ -19,3 +19,5 @@ require_once 'debug-functions.php';
 add_filter( 'debug_information', array( 'Jetpack_Debug_Data', 'core_debug_data' ) );
 add_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' );
 add_action( 'wp_ajax_health-check-jetpack-local_testing_suite', 'jetpack_debugger_ajax_local_testing_suite' );
+add_action( 'admin_enqueue_scripts', 'jetpack_debugger_enqueue_site_health_scripts' );
+add_action( 'wp_ajax_jetpack_sync_progress_check', 'jetpack_debugger_sync_progress_ajax' );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Settings as Sync_Settings;
 
 /**
@@ -510,30 +511,74 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = __FUNCTION__;
 		if ( ! $this->helper_is_jetpack_connected() ) {
 			// If the site is not connected, there is no point in testing Sync health.
-			return self::skipped_test( array( 'name' => $name, 'show_in_site_health' => false ) );
+			return self::skipped_test(
+				array(
+					'name'                => $name,
+					'show_in_site_health' => false,
+				)
+			);
 		}
-		if ( Sync_Settings::is_sync_enabled() ) {
-			return self::skipped_test( array( 'name' => $name ) );
+
+		if ( ! Sync_Settings::is_sync_enabled() ) {
+			// If sync is not enabled, show a warning in test results.
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					'label'             => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
+					'severity'          => 'recommended',
+					'action'            => 'https://github.com/Automattic/jetpack/blob/master/packages/sync/src/class-settings.php',
+					'action_label'      => __( 'See Github for more on Sync Settings', 'jetpack' ),
+					'short_description' => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
+					'long_description'  => sprintf(
+						'<p>%1$s</p>' .
+						'<p>%2$s</p>' .
+						'<p><span class="dashicons fail"><span class="screen-reader-text">%3$s</span></span> %4$s<strong> %5$s</strong></p>',
+						__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
+						__( 'Developers may enable / disable syncing using the Sync Settings API.', 'jetpack' ),
+						/* translators: screen reader text indicating a test failed */
+						__( 'Error', 'jetpack' ),
+						__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work.', 'jetpack' ),
+						__( 'We recommend enabling Sync.', 'jetpack' )
+					),
+				)
+			);
 		}
-		return self::failing_test( array(
-			'name' => $name,
-			'label' => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
-			'severity' => 'recommended',
-			'action' => 'https://github.com/Automattic/jetpack/blob/master/packages/sync/src/class-settings.php',
-			'action_label' => __( 'See Github for more on Sync Settings', 'jetpack' ),
-			'short_description' => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
-			'long_description' => sprintf(
-				'<p>%1$s</p>' .
-				'<p>%2$s</p>' .
-				'<p><span class="dashicons fail"><span class="screen-reader-text">%3$s</span></span> %4$s<strong> %5$s</strong></p>',
-				__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
-				__( 'Developers may enable / disable syncing using the Sync Settings API.', 'jetpack' ),
-				/* translators: screen reader text indicating a test failed */
-				__( 'Error', 'jetpack' ),
-				__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work.', 'jetpack' ),
-				__( 'We recommend enabling Sync.', 'jetpack' )
+
+		$full_sync_module = Modules::get_module( 'full-sync' );
+		$progress_percent = $full_sync_module ? $full_sync_module->get_sync_progress_percentage() : null;
+		if ( $progress_percent ) {
+			return self::failing_test(
+				array(
+					'name'              => $name,
+					'label'             => __( 'Jetpack is performing a sync of your site', 'jetpack' ) . " - $progress_percent %",
+					'severity'          => 'recommended',
+					'short_description' => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
+					'long_description'  => sprintf(
+						'<p>%1$s</p>' .
+						'<p><span class="dashicons dashicons-update"><span class="screen-reader-text">%2$s</span></span> %3$s</p>' .
+						'<div class="jetpack-sync-progress"><span class="percent">%4$d%%</span><span class="progress-bar"></span></div>',
+						__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
+						/* translators: screen reader text indicating data is updating. */
+						__( 'Updating', 'jetpack' ),
+						__( 'Jetpack is currently performing a full sync of your site data.', 'jetpack' ),
+						$progress_percent
+					),
+				)
+			);
+		}
+
+		// If we've reached this point, we know that:
+		// 1) Sync is enabled
+		// 2) There is not a full sync in progress
+		// We cannot yet return a passing test. We'll still need to test for lag and data loss.
+		// We'll address those in future iterations, for now we'll just skip the test.
+		// See p6TEKc-3t2-p2 for more information.
+		return self::skipped_test(
+			array(
+				'name'                => $name,
+				'show_in_site_health' => false,
 			)
-		) );
+		);
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -550,15 +550,13 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			return self::failing_test(
 				array(
 					'name'              => $name,
-
-					/* translators: %d An integer indicating the progress of syncronation progress. */
-					'label'             => sprintf( __( 'Jetpack is performing a sync of your site - %d%%', 'jetpack' ), $progress_percent ),
+					'label'             => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
 					'severity'          => 'recommended',
 					'short_description' => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
 					'long_description'  => sprintf(
 						'<p>%1$s</p>' .
 						'<p><span class="dashicons dashicons-update"><span class="screen-reader-text">%2$s</span></span> %3$s</p>' .
-						'<div class="jetpack-sync-progress-bar"><div class="progress-label"></div></div>',
+						'<div class="jetpack-sync-progress-ui"><div class="jetpack-sync-progress-label"></div><div class="jetpack-sync-progress-bar"></div></div>',
 						__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
 						/* translators: screen reader text indicating data is updating. */
 						__( 'Updating', 'jetpack' ),

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -550,18 +550,19 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			return self::failing_test(
 				array(
 					'name'              => $name,
-					'label'             => __( 'Jetpack is performing a sync of your site', 'jetpack' ) . " - $progress_percent %",
+
+					/* translators: %d An integer indicating the progress of syncronation progress. */
+					'label'             => sprintf( __( 'Jetpack is performing a sync of your site - %d%%', 'jetpack' ), $progress_percent ),
 					'severity'          => 'recommended',
 					'short_description' => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
 					'long_description'  => sprintf(
 						'<p>%1$s</p>' .
 						'<p><span class="dashicons dashicons-update"><span class="screen-reader-text">%2$s</span></span> %3$s</p>' .
-						'<div class="jetpack-sync-progress"><span class="percent">%4$d%%</span><span class="progress-bar"></span></div>',
+						'<div class="jetpack-sync-progress-bar"><div class="progress-label"></div></div>',
 						__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
 						/* translators: screen reader text indicating data is updating. */
 						__( 'Updating', 'jetpack' ),
-						__( 'Jetpack is currently performing a full sync of your site data.', 'jetpack' ),
-						$progress_percent
+						__( 'Jetpack is currently performing a full sync of your site data.', 'jetpack' )
 					),
 				)
 			);

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -123,8 +123,16 @@ function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
 			JETPACK__VERSION,
 			false
 		);
+		/* WordPress is not bundled with jquery UI styles - we need to grab them from the Google API. */
 		wp_enqueue_style(
 			'plugin_name-admin-ui-css',
+			plugins_url( 'jetpack-debugger-site-health.css', __FILE__ ),
+			false,
+			JETPACK__VERSION,
+			false
+		);
+		wp_enqueue_style(
+			'jetpack_sync_site_health',
 			'http://ajax.googleapis.com/ajax/libs/jqueryui/' . $wp_scripts->registered['jquery-ui-core']->ver . '/themes/smoothness/jquery-ui.css',
 			false,
 			JETPACK__VERSION,

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -117,29 +117,29 @@ function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
 		$wp_scripts = wp_scripts();
 		wp_enqueue_script( 'jquery-ui-progressbar' );
 		wp_enqueue_script(
-			'jetpack_debug_site_health',
+			'jetpack_debug_site_health_script',
 			plugins_url( 'jetpack-debugger-site-health.js', __FILE__ ),
 			array( 'jquery-ui-progressbar' ),
 			JETPACK__VERSION,
 			false
 		);
-		/* WordPress is not bundled with jquery UI styles - we need to grab them from the Google API. */
 		wp_enqueue_style(
-			'plugin_name-admin-ui-css',
+			'jetpack_debug_site_health_styles',
 			plugins_url( 'jetpack-debugger-site-health.css', __FILE__ ),
 			false,
 			JETPACK__VERSION,
 			false
 		);
+		/* WordPress is not bundled with jquery UI styles - we need to grab them from the Google API. */
 		wp_enqueue_style(
-			'jetpack_sync_site_health',
-			'http://ajax.googleapis.com/ajax/libs/jqueryui/' . $wp_scripts->registered['jquery-ui-core']->ver . '/themes/smoothness/jquery-ui.css',
+			'jetpack-jquery-ui-styles',
+			'https://code.jquery.com/ui/' . $wp_scripts->registered['jquery-ui-core']->ver . '/themes/smoothness/jquery-ui.min.css',
 			false,
 			JETPACK__VERSION,
 			false
 		);
 		wp_localize_script(
-			'jetpack_debug_site_health',
+			'jetpack_debug_site_health_script',
 			'jetpackSiteHealth',
 			array(
 				'ajaxUrl'             => admin_url( 'admin-ajax.php' ),

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -111,13 +111,24 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
  * @param string $hook The current admin page hook.
  */
 function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
+	$full_sync_module = Modules::get_module( 'full-sync' );
+	$progress_percent = $full_sync_module ? $full_sync_module->get_sync_progress_percentage() : false;
 	if ( 'site-health.php' === $hook ) {
+		$wp_scripts = wp_scripts();
+		wp_enqueue_script( 'jquery-ui-progressbar' );
 		wp_enqueue_script(
 			'jetpack_debug_site_health',
 			plugins_url( 'jetpack-debugger-site-health.js', __FILE__ ),
 			array( 'jquery-ui-progressbar' ),
 			JETPACK__VERSION,
-			true
+			false
+		);
+		wp_enqueue_style(
+			'plugin_name-admin-ui-css',
+			'http://ajax.googleapis.com/ajax/libs/jqueryui/' . $wp_scripts->registered['jquery-ui-core']->ver . '/themes/smoothness/jquery-ui.css',
+			false,
+			JETPACK__VERSION,
+			false
 		);
 		wp_localize_script(
 			'jetpack_debug_site_health',
@@ -125,6 +136,7 @@ function jetpack_debugger_enqueue_site_health_scripts( $hook ) {
 			array(
 				'ajaxUrl'             => admin_url( 'admin-ajax.php' ),
 				'syncProgressHeading' => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
+				'progressPercent'     => $progress_percent,
 			)
 		);
 	}
@@ -138,6 +150,7 @@ function jetpack_debugger_sync_progress_ajax() {
 	$progress_percent = $full_sync_module ? $full_sync_module->get_sync_progress_percentage() : null;
 	if ( ! $progress_percent ) {
 		echo 'done';
+		wp_die();
 	}
 	echo intval( $progress_percent );
 	wp_die();

--- a/_inc/lib/debugger/jetpack-debugger-site-health.css
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.css
@@ -1,0 +1,13 @@
+.jetpack-sync-progress-bar{
+	margin-bottom:20px;
+}
+.ui-progressbar {
+	position: relative;
+}
+.progress-label {
+	color:#000;
+	font-weight: bold;
+	left: 50%;
+	position: absolute;
+	top: 4px;
+}

--- a/_inc/lib/debugger/jetpack-debugger-site-health.css
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.css
@@ -1,13 +1,21 @@
-.jetpack-sync-progress-bar{
-	margin-bottom:20px;
+.jetpack-sync-progress-ui {
+	display: flex;
+	align-items: baseline;
 }
-.ui-progressbar {
-	position: relative;
+
+.jetpack-sync-progress-label {
+	width: 5%;
+	margin-right: 1%;
+	font-weight: 600;
+	color: #036699;
 }
-.progress-label {
-	color:#000;
-	font-weight: bold;
-	left: 50%;
-	position: absolute;
-	top: 4px;
+
+.ui-progressbar.jetpack-sync-progress-bar {
+	width: 94%;
+	background: #bfe7f3;
+	height: 8px;
+}
+
+.jetpack-sync-progress-bar .ui-progressbar-value {
+	background: #036699;
 }

--- a/_inc/lib/debugger/jetpack-debugger-site-health.js
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.js
@@ -1,0 +1,53 @@
+/**
+ * This script runs on the site health page.
+ */
+jQuery( document ).ready( function( $ ) {
+	let fullSyncInProgress = false,
+		fullSyncPercent = 0;
+	const syncProgressInterval = setInterval( jetpackSyncProgressCheck, 3000 );
+	/**
+	 * Every 3 seconds, check for full sync progress. If a full sync is in progress,
+	 * we'll update the progress bar and text. If a full sync is not in progress we'll clear the timer.
+	 */
+	function jetpackSyncProgressCheck() {
+		jQuery.post( jetpackSiteHealth.ajaxUrl, { action: 'jetpack_sync_progress_check' }, function(
+			response
+		) {
+			if ( 'done' === response ) {
+				clearInterval( syncProgressInterval );
+				if ( fullSyncInProgress ) {
+					fullSyncPercent = 100;
+					jetpackSyncSetProgress();
+				}
+				fullSyncInProgress = false;
+				console.log( 'done' );
+				return;
+			}
+			/*if ( ! fullSyncInProgress ) {
+				accordionButton.on( "click", function() {
+					console.log( jetpackSyncIsAccordionOpen() );
+				} );
+			}*/
+			fullSyncInProgress = true;
+			fullSyncPercent = parseInt( response );
+			jetpackSyncSetProgress();
+		} );
+	}
+
+	function jetpackSyncSetProgress() {
+		const accordionButton = $(
+			'[aria-controls=health-check-accordion-block-jetpack_test__sync_health]'
+		);
+		const accordionIsOpen = accordionButton.attr( 'aria-expanded' );
+		console.log( accordionIsOpen );
+		if ( 'true' === accordionIsOpen ) {
+			$( '.jetpack-sync-progress' )
+				.find( '.progress' )
+				.text( fullSyncPercent + '%' );
+		} else {
+			accordionButton
+				.find( '.title' )
+				.text( jetpackSiteHealth.syncProgressHeading + ' - ' + fullSyncPercent + '%' );
+		}
+	}
+} );

--- a/_inc/lib/debugger/jetpack-debugger-site-health.js
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.js
@@ -9,8 +9,9 @@ jQuery( document ).ready( function( $ ) {
 		progressPercent: 0,
 		interval: false,
 		init: function() {
-			JetpackSync.interval = setInterval( JetpackSync.progressCheck, 3000 );
-			JetpackSync.progressPercent = jetpackSiteHealth.progressPercent;
+			JetpackSync.progressPercent = parseInt( jetpackSiteHealth.progressPercent );
+			JetpackSync.setProgress();
+			JetpackSync.interval = setInterval( JetpackSync.checkProgress, 3000 );
 			$( 'body' ).on(
 				'click',
 				'[aria-controls=health-check-accordion-block-jetpack_test__sync_health]',
@@ -23,7 +24,7 @@ jQuery( document ).ready( function( $ ) {
 		accordionIsOpen: function() {
 			return JetpackSync.accordionButton().attr( 'aria-expanded' );
 		},
-		progressCheck: function() {
+		checkProgress: function() {
 			$.post( jetpackSiteHealth.ajaxUrl, { action: 'jetpack_sync_progress_check' }, function(
 				response
 			) {
@@ -43,11 +44,15 @@ jQuery( document ).ready( function( $ ) {
 		},
 		setProgress: function() {
 			if ( 'true' === JetpackSync.accordionIsOpen() ) {
+				// When the accordion is open, we remove the progress percentage from the accordion heading,
+				// and show a progress bar in the accordion body.
 				$( '.jetpack-sync-progress-bar' ).progressbar( { value: JetpackSync.progressPercent } );
+				$( '.jetpack-sync-progress-label' ).text( JetpackSync.progressPercent + '%' );
 				JetpackSync.accordionButton()
 					.find( '.title' )
 					.text( jetpackSiteHealth.syncProgressHeading );
 			} else {
+				// When the accordion is closed, we show the progress percentage in the accordion heading.
 				JetpackSync.accordionButton()
 					.find( '.title' )
 					.text(

--- a/_inc/lib/debugger/jetpack-debugger-site-health.js
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.js
@@ -4,7 +4,7 @@
  */
 
 jQuery( document ).ready( function( $ ) {
-	const JetpackSync = {
+	var JetpackSync = {
 		inProgress: false,
 		progressPercent: 0,
 		interval: false,

--- a/_inc/lib/debugger/jetpack-debugger-site-health.js
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.js
@@ -1,53 +1,63 @@
+/* global jetpackSiteHealth */
 /**
  * This script runs on the site health page.
  */
-jQuery( document ).ready( function( $ ) {
-	let fullSyncInProgress = false,
-		fullSyncPercent = 0;
-	const syncProgressInterval = setInterval( jetpackSyncProgressCheck, 3000 );
-	/**
-	 * Every 3 seconds, check for full sync progress. If a full sync is in progress,
-	 * we'll update the progress bar and text. If a full sync is not in progress we'll clear the timer.
-	 */
-	function jetpackSyncProgressCheck() {
-		jQuery.post( jetpackSiteHealth.ajaxUrl, { action: 'jetpack_sync_progress_check' }, function(
-			response
-		) {
-			if ( 'done' === response ) {
-				clearInterval( syncProgressInterval );
-				if ( fullSyncInProgress ) {
-					fullSyncPercent = 100;
-					jetpackSyncSetProgress();
-				}
-				fullSyncInProgress = false;
-				console.log( 'done' );
-				return;
-			}
-			/*if ( ! fullSyncInProgress ) {
-				accordionButton.on( "click", function() {
-					console.log( jetpackSyncIsAccordionOpen() );
-				} );
-			}*/
-			fullSyncInProgress = true;
-			fullSyncPercent = parseInt( response );
-			jetpackSyncSetProgress();
-		} );
-	}
 
-	function jetpackSyncSetProgress() {
-		const accordionButton = $(
-			'[aria-controls=health-check-accordion-block-jetpack_test__sync_health]'
-		);
-		const accordionIsOpen = accordionButton.attr( 'aria-expanded' );
-		console.log( accordionIsOpen );
-		if ( 'true' === accordionIsOpen ) {
-			$( '.jetpack-sync-progress' )
-				.find( '.progress' )
-				.text( fullSyncPercent + '%' );
-		} else {
-			accordionButton
-				.find( '.title' )
-				.text( jetpackSiteHealth.syncProgressHeading + ' - ' + fullSyncPercent + '%' );
-		}
+jQuery( document ).ready( function( $ ) {
+	const JetpackSync = {
+		inProgress: false,
+		progressPercent: 0,
+		interval: false,
+		init: function() {
+			JetpackSync.interval = setInterval( JetpackSync.progressCheck, 3000 );
+			JetpackSync.progressPercent = jetpackSiteHealth.progressPercent;
+			$( 'body' ).on(
+				'click',
+				'[aria-controls=health-check-accordion-block-jetpack_test__sync_health]',
+				JetpackSync.setProgress
+			);
+		},
+		accordionButton: function() {
+			return $( '[aria-controls=health-check-accordion-block-jetpack_test__sync_health]' );
+		},
+		accordionIsOpen: function() {
+			return JetpackSync.accordionButton().attr( 'aria-expanded' );
+		},
+		progressCheck: function() {
+			$.post( jetpackSiteHealth.ajaxUrl, { action: 'jetpack_sync_progress_check' }, function(
+				response
+			) {
+				if ( 'done' === response ) {
+					clearInterval( JetpackSync.interval );
+					if ( JetpackSync.inProgress ) {
+						JetpackSync.progressPercent = 100;
+						JetpackSync.setProgress();
+					}
+					JetpackSync.inProgress = false;
+					return;
+				}
+				JetpackSync.inProgress = true;
+				JetpackSync.progressPercent = parseInt( response );
+				JetpackSync.setProgress();
+			} );
+		},
+		setProgress: function() {
+			if ( 'true' === JetpackSync.accordionIsOpen() ) {
+				$( '.jetpack-sync-progress-bar' ).progressbar( { value: JetpackSync.progressPercent } );
+				JetpackSync.accordionButton()
+					.find( '.title' )
+					.text( jetpackSiteHealth.syncProgressHeading );
+			} else {
+				JetpackSync.accordionButton()
+					.find( '.title' )
+					.text(
+						jetpackSiteHealth.syncProgressHeading + ' - ' + JetpackSync.progressPercent + '%'
+					);
+			}
+		},
+	};
+
+	if ( jetpackSiteHealth.progressPercent ) {
+		JetpackSync.init();
 	}
 } );

--- a/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/packages/sync/src/modules/class-full-sync-immediately.php
@@ -145,6 +145,38 @@ class Full_Sync_Immediately extends Module {
 	}
 
 	/**
+	 * Returns the progress percentage of a full sync.
+	 *
+	 * @access public
+	 *
+	 * @return int|null
+	 */
+	public function get_sync_progress_percentage() {
+		if ( ! $this->is_started() || $this->is_finished() ) {
+			return null;
+		}
+		$status = $this->get_status();
+		if ( empty( $status['progress'] ) ) {
+			return null;
+		}
+		$total_items = array_reduce(
+			array_values( $status['progress'] ),
+			function ( $sum, $sync_item ) {
+				return isset( $sync_item['total'] ) ? ( $sum + intval( $sync_item['total'] ) ) : $sum;
+			},
+			0
+		);
+		$total_sent  = array_reduce(
+			array_values( $status['progress'] ),
+			function ( $sum, $sync_item ) {
+				return isset( $sync_item['sent'] ) ? ( $sum + intval( $sync_item['sent'] ) ) : $sum;
+			},
+			0
+		);
+		return floor( ( $total_sent / $total_items ) * 100 );
+	}
+
+	/**
 	 * Whether full sync has finished.
 	 *
 	 * @access public

--- a/packages/sync/src/modules/class-full-sync.php
+++ b/packages/sync/src/modules/class-full-sync.php
@@ -407,6 +407,49 @@ class Full_Sync extends Module {
 	}
 
 	/**
+	 * Returns the progress percentage of a full sync.
+	 *
+	 * @access public
+	 *
+	 * @return int|null
+	 */
+	public function get_sync_progress_percentage() {
+		if ( ! $this->is_started() || $this->is_finished() ) {
+			return null;
+		}
+		$status = $this->get_status();
+		if ( ! $status['queue'] || ! $status['sent'] || ! $status['total'] ) {
+			return null;
+		}
+		$queued_multiplier = 0.1;
+		$sent_multiplier   = 0.9;
+		$count_queued      = array_reduce(
+			$status['queue'],
+			function ( $sum, $value ) {
+				return $sum + $value;
+			},
+			0
+		);
+		$count_sent        = array_reduce(
+			$status['sent'],
+			function ( $sum, $value ) {
+				return $sum + $value;
+			},
+			0
+		);
+		$count_total       = array_reduce(
+			$status['total'],
+			function ( $sum, $value ) {
+				return $sum + $value;
+			},
+			0
+		);
+		$percent_queued    = ( $count_queued / $count_total ) * $queued_multiplier * 100;
+		$percent_sent      = ( $count_sent / $count_total ) * $sent_multiplier * 100;
+		return ceil( $percent_queued + $percent_sent );
+	}
+
+	/**
 	 * Get the name of the action for an item in the sync queue.
 	 *
 	 * @access public


### PR DESCRIPTION
Allows people to see the status of data synchronization on the site health page.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new accordion card to the site health page when a full sync is in progress
* Shows a progress bar when the accordion is open

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is an enhancement to an existing feature. See: p1HpG7-8wB-p2

#### Testing instructions:

* Get this branch running on your local setup, or on jurasic.ninja
* Start a full sync on your site
* Visit the Tools -> Site Health page to see the sync progress card

![Screen Shot 2020-03-30 at 12 09 49 PM](https://user-images.githubusercontent.com/2694219/77936586-182a6280-7281-11ea-850b-731b8c1ecbde.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
