### PR TITLE
Podcast Player: render headers in server-side

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -161,3 +161,93 @@ function render_player( $player_data, $attributes ) {
 
 	return ob_get_clean();
 }
+
+/**
+ * Helper function to render the podcast title.
+ *
+ * @param string $title Podcast title.
+ * @param string $link  Podcast link.
+ */
+function render_podcast_title( $title, $link ) {
+	?>
+	<span class="jetpack-podcast-player__title">
+		<?php if ( isset( $link ) ) : ?>
+			<a class="jetpack-podcast-player__title-link" href="<?php echo esc_url( $link ); ?>">
+				<?php echo esc_attr( $title ); ?>
+			</a>
+		<?php else : ?>
+			<?php echo esc_attr( $title ); ?>
+		<?php endif; ?>
+	</span>
+	<?php
+};
+
+/**
+ * Render the poscast title.
+ *
+ * @param string $player_id Podcast player instance ID.
+ * @param string $title     Podcast title.
+ * @param string $link      Podcast link.
+ * @param array  $track     Track array. Usually it expects the first one.
+ */
+function render_title( $player_id, $title, $link, $track ) {
+	?>
+	<h2 id="<?php echo esc_attr( "${player_id}__title" ); ?>" class="jetpack-podcast-player__titles">
+		<?php if ( isset( $track ) && isset( $track['title'] ) ) : ?>
+			<span class="jetpack-podcast-player__track-title">
+				<?php echo esc_attr( $track['title'] ); ?>
+			</span>
+		<?php endif; ?>
+
+
+		<?php if ( isset( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
+			<span class="jetpack-podcast-player--visually-hidden"> - </span>
+		<?php endif; ?>
+
+		<?php if ( isset( $title ) ) : ?>
+			<?php render_podcast_title( $title, $link ); ?>
+		<?php endif; ?>
+	</h2>
+	<?php
+};
+
+/**
+ * Render the podcast header.
+ *
+ * @param string $player_id    Podcast player instance ID.
+ * @param string $title        Podcast title.
+ * @param string $link         Podcast link.
+ * @param bool   $show_cover_art Attribute which defines if it should show the cover.
+ * @param string $cover        Podcast art cover.
+ * @param array  $track         Track array. Usually it expects the first one.
+ */
+function render_podcast_header( $player_id, $title, $link, $show_cover_art, $cover, $track ) {
+	?>
+	<div class="jetpack-podcast-player__header-wrapper">
+		<div class="jetpack-podcast-player__header" aria-live="polite">
+			<?php if ( isset( $show_cover_art ) && isset( $cover ) ) : ?>
+				<div class="jetpack-podcast-player__track-image-wrapper">
+					<img
+						class="jetpack-podcast-player__track-image"
+						src=<?php echo esc_attr( $cover ); ?>
+						alt=""
+					/>
+				</div>
+			<?php endif; ?>
+
+			<?php if ( isset( $title ) || ( isset( $track ) && isset( $track['title'] ) ) ) : ?>
+				<div class="jetpack-podcast-player__titles">
+					<?php render_title( $player_id, $title, $link, $track ); ?>
+				</div>
+			<?php endif; ?>
+		</div>
+
+		<div
+			id="<?php echo esc_attr( "${player_id}__track-description" ); ?>"
+			class="jetpack-podcast-player__track-description"
+		>
+			<?php echo esc_attr( $track['description'] ); ?>
+		</div>
+	</div>
+	<?php
+}

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -126,7 +126,7 @@ function render_player( $player_data, $attributes ) {
 			$instance_id,
 			$player_data['title'],
 			$player_data['link'],
-			$attributes['showCoverArt'],
+			(bool) $attributes['showCoverArt'],
 			$player_data['cover'],
 			$player_data['tracks'][0]
 		);
@@ -184,7 +184,7 @@ function render_podcast_title( $title, $link ) {
 	<span class="jetpack-podcast-player__title">
 		<?php if ( isset( $link ) ) : ?>
 			<a class="jetpack-podcast-player__title-link" href="<?php echo esc_url( $link ); ?>">
-				<?php echo esc_attr( $title ); ?>
+				<?php echo esc_html( $title ); ?>
 			</a>
 		<?php else : ?>
 			<?php echo esc_attr( $title ); ?>
@@ -194,7 +194,7 @@ function render_podcast_title( $title, $link ) {
 };
 
 /**
- * Render the poscast title.
+ * Render the podcast title.
  *
  * @param string $player_id Podcast player instance ID.
  * @param string $title     Podcast title.
@@ -204,14 +204,14 @@ function render_podcast_title( $title, $link ) {
 function render_title( $player_id, $title, $link, $track ) {
 	?>
 	<h2 id="<?php echo esc_attr( "${player_id}__title" ); ?>" class="jetpack-podcast-player__titles">
-		<?php if ( isset( $track ) && isset( $track['title'] ) ) : ?>
+		<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
 			<span class="jetpack-podcast-player__track-title">
 				<?php echo esc_attr( $track['title'] ); ?>
 			</span>
 		<?php endif; ?>
 
 
-		<?php if ( isset( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
+		<?php if ( ! empty( $track ) && isset( $track['title'] ) && ! isset( $title ) ) : ?>
 			<span class="jetpack-podcast-player--visually-hidden"> - </span>
 		<?php endif; ?>
 
@@ -225,28 +225,28 @@ function render_title( $player_id, $title, $link, $track ) {
 /**
  * Render the podcast header.
  *
- * @param string $player_id    Podcast player instance ID.
- * @param string $title        Podcast title.
- * @param string $link         Podcast link.
+ * @param string $player_id      Podcast player instance ID.
+ * @param string $title          Podcast title.
+ * @param string $link           Podcast link.
  * @param bool   $show_cover_art Attribute which defines if it should show the cover.
- * @param string $cover        Podcast art cover.
- * @param array  $track         Track array. Usually it expects the first one.
+ * @param string $cover          Podcast art cover.
+ * @param array  $track          Track array. Usually it expects the first one.
  */
 function render_podcast_header( $player_id, $title, $link, $show_cover_art, $cover, $track ) {
 	?>
 	<div class="jetpack-podcast-player__header-wrapper">
 		<div class="jetpack-podcast-player__header" aria-live="polite">
-			<?php if ( isset( $show_cover_art ) && isset( $cover ) ) : ?>
+			<?php if ( $show_cover_art && isset( $cover ) ) : ?>
 				<div class="jetpack-podcast-player__track-image-wrapper">
 					<img
 						class="jetpack-podcast-player__track-image"
-						src=<?php echo esc_attr( $cover ); ?>
+						src=<?php echo esc_url( $cover ); ?>
 						alt=""
 					/>
 				</div>
 			<?php endif; ?>
 
-			<?php if ( isset( $title ) || ( isset( $track ) && isset( $track['title'] ) ) ) : ?>
+			<?php if ( isset( $title ) || ( ! empty( $track ) && isset( $track['title'] ) ) ) : ?>
 				<div class="jetpack-podcast-player__titles">
 					<?php render_title( $player_id, $title, $link, $track ); ?>
 				</div>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -220,7 +220,8 @@ function render_title( $player_id, $title, $link, $track ) {
  * @param array $attributes Block attributes.
  */
 function render_podcast_header( $data, $attributes ) {
-	$show_cover_art = (bool) $attributes['showCoverArt'];
+	$show_cover_art   = (bool) $attributes['showCoverArt'];
+	$show_description = (bool) $attributes['showEpisodeDescription'];
 
 	$player_id = $data['playerId'];
 	$title     = $data['title'];
@@ -247,7 +248,7 @@ function render_podcast_header( $data, $attributes ) {
 			<?php endif; ?>
 		</div>
 
-		<?php if ( isset( $track['description'] ) ) : ?>
+		<?php if ( isset( $track['description'] ) && $show_description ) : ?>
 			<div
 				id="<?php echo esc_attr( "${player_id}__track-description" ); ?>"
 				class="jetpack-podcast-player__track-description"

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -121,16 +121,7 @@ function render_player( $player_data, $attributes ) {
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
-		<?php
-		render_podcast_header(
-			$instance_id,
-			$player_data['title'],
-			$player_data['link'],
-			(bool) $attributes['showCoverArt'],
-			$player_data['cover'],
-			$player_data['tracks'][0]
-		);
-		?>
+		<?php render_podcast_header( $player_data, $attributes ); ?>
 
 		<ol class="jetpack-podcast-player__episodes">
 			<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
@@ -182,7 +173,7 @@ function render_player( $player_data, $attributes ) {
 function render_podcast_title( $title, $link ) {
 	?>
 	<span class="jetpack-podcast-player__title">
-		<?php if ( isset( $link ) ) : ?>
+		<?php if ( $link ) : ?>
 			<a class="jetpack-podcast-player__title-link" href="<?php echo esc_url( $link ); ?>">
 				<?php echo esc_html( $title ); ?>
 			</a>
@@ -211,11 +202,11 @@ function render_title( $player_id, $title, $link, $track ) {
 		<?php endif; ?>
 
 
-		<?php if ( ! empty( $track ) && isset( $track['title'] ) && ! isset( $title ) ) : ?>
+		<?php if ( ! empty( $track ) && isset( $track['title'] ) && ! $title ) : ?>
 			<span class="jetpack-podcast-player--visually-hidden"> - </span>
 		<?php endif; ?>
 
-		<?php if ( isset( $title ) ) : ?>
+		<?php if ( $title ) : ?>
 			<?php render_podcast_title( $title, $link ); ?>
 		<?php endif; ?>
 	</h2>
@@ -225,18 +216,21 @@ function render_title( $player_id, $title, $link, $track ) {
 /**
  * Render the podcast header.
  *
- * @param string $player_id      Podcast player instance ID.
- * @param string $title          Podcast title.
- * @param string $link           Podcast link.
- * @param bool   $show_cover_art Attribute which defines if it should show the cover.
- * @param string $cover          Podcast art cover.
- * @param array  $track          Track array. Usually it expects the first one.
+ * @param array $data       Player data.
+ * @param array $attributes Block attributes.
  */
-function render_podcast_header( $player_id, $title, $link, $show_cover_art, $cover, $track ) {
+function render_podcast_header( $data, $attributes ) {
+	$show_cover_art = (bool) $attributes['showCoverArt'];
+
+	$player_id = $data['playerId'];
+	$title     = $data['title'];
+	$link      = $data['link'];
+	$cover     = $data['cover'];
+	$track     = $data['tracks'] && ! empty( $data['tracks'][0] ) ? $data['tracks'][0] : array();
 	?>
 	<div class="jetpack-podcast-player__header-wrapper">
 		<div class="jetpack-podcast-player__header" aria-live="polite">
-			<?php if ( $show_cover_art && isset( $cover ) ) : ?>
+			<?php if ( $show_cover_art && $cover ) : ?>
 				<div class="jetpack-podcast-player__track-image-wrapper">
 					<img
 						class="jetpack-podcast-player__track-image"
@@ -246,19 +240,21 @@ function render_podcast_header( $player_id, $title, $link, $show_cover_art, $cov
 				</div>
 			<?php endif; ?>
 
-			<?php if ( isset( $title ) || ( ! empty( $track ) && isset( $track['title'] ) ) ) : ?>
+			<?php if ( $title && ! empty( $track ) && isset( $track['title'] ) ) : ?>
 				<div class="jetpack-podcast-player__titles">
 					<?php render_title( $player_id, $title, $link, $track ); ?>
 				</div>
 			<?php endif; ?>
 		</div>
 
-		<div
-			id="<?php echo esc_attr( "${player_id}__track-description" ); ?>"
-			class="jetpack-podcast-player__track-description"
-		>
-			<?php echo esc_attr( $track['description'] ); ?>
-		</div>
+		<?php if ( isset( $track['description'] ) ) : ?>
+			<div
+				id="<?php echo esc_attr( "${player_id}__track-description" ); ?>"
+				class="jetpack-podcast-player__track-description"
+			>
+				<?php echo esc_attr( $track['description'] ); ?>
+			</div>
+		<?php endif; ?>
 	</div>
 	<?php
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -121,6 +121,17 @@ function render_player( $player_data, $attributes ) {
 	ob_start();
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
+		<?php
+		render_podcast_header(
+			$instance_id,
+			$player_data['title'],
+			$player_data['link'],
+			$attributes['showCoverArt'],
+			$player_data['cover'],
+			$player_data['tracks'][0]
+		);
+		?>
+
 		<ol class="jetpack-podcast-player__episodes">
 			<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 			<li class="jetpack-podcast-player__episode">

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -174,18 +174,20 @@ function render_podcast_title( $title, $link ) {
 	?>
 	<span class="jetpack-podcast-player__title">
 		<?php if ( $link ) : ?>
-			<a class="jetpack-podcast-player__title-link" href="<?php echo esc_url( $link ); ?>">
-				<?php echo esc_html( $title ); ?>
-			</a>
-		<?php else : ?>
-			<?php echo esc_attr( $title ); ?>
-		<?php endif; ?>
+		<a class="jetpack-podcast-player__title-link" href="<?php echo esc_url( $link ); ?>">
+			<?php echo esc_html( $title ); ?>
+		</a>
+			<?php
+		else :
+			echo esc_html( $title );
+		endif;
+		?>
 	</span>
 	<?php
 };
 
 /**
- * Render the podcast title.
+ * Renders the podcast title.
  *
  * @param string $player_id Podcast player instance ID.
  * @param string $title     Podcast title.
@@ -195,26 +197,27 @@ function render_podcast_title( $title, $link ) {
 function render_title( $player_id, $title, $link, $track ) {
 	?>
 	<h2 id="<?php echo esc_attr( "${player_id}__title" ); ?>" class="jetpack-podcast-player__titles">
-		<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
-			<span class="jetpack-podcast-player__track-title">
-				<?php echo esc_attr( $track['title'] ); ?>
-			</span>
-		<?php endif; ?>
+		<?php if ( ! empty( $track['title'] ) ) : ?>
+		<span class="jetpack-podcast-player__track-title">
+			<?php echo esc_html( $track['title'] ); ?>
+		</span>
 
+			<?php if ( ! $title ) : ?>
+			<span class="jetpack-podcast-player--visually-hidden"> &endash; </span>
+			<?php endif; ?>
+			<?php
+		endif;
 
-		<?php if ( ! empty( $track ) && isset( $track['title'] ) && ! $title ) : ?>
-			<span class="jetpack-podcast-player--visually-hidden"> - </span>
-		<?php endif; ?>
-
-		<?php if ( $title ) : ?>
-			<?php render_podcast_title( $title, $link ); ?>
-		<?php endif; ?>
+		if ( $title ) :
+			render_podcast_title( $title, $link );
+		endif;
+		?>
 	</h2>
 	<?php
 };
 
 /**
- * Render the podcast header.
+ * Renders the podcast header.
  *
  * @param array $data       Player data.
  * @param array $attributes Block attributes.
@@ -227,34 +230,30 @@ function render_podcast_header( $data, $attributes ) {
 	$title     = $data['title'];
 	$link      = $data['link'];
 	$cover     = $data['cover'];
-	$track     = $data['tracks'] && ! empty( $data['tracks'][0] ) ? $data['tracks'][0] : array();
+	$track     = ! empty( $data['tracks'][0] ) ? $data['tracks'][0] : array();
 	?>
 	<div class="jetpack-podcast-player__header-wrapper">
 		<div class="jetpack-podcast-player__header" aria-live="polite">
 			<?php if ( $show_cover_art && $cover ) : ?>
-				<div class="jetpack-podcast-player__track-image-wrapper">
-					<img
-						class="jetpack-podcast-player__track-image"
-						src=<?php echo esc_url( $cover ); ?>
-						alt=""
-					/>
-				</div>
+			<div class="jetpack-podcast-player__track-image-wrapper">
+				<img class="jetpack-podcast-player__track-image" src="<?php echo esc_url( $cover ); ?>" alt=""/>
+			</div>
 			<?php endif; ?>
 
-			<?php if ( $title && ! empty( $track ) && isset( $track['title'] ) ) : ?>
-				<div class="jetpack-podcast-player__titles">
-					<?php render_title( $player_id, $title, $link, $track ); ?>
-				</div>
+			<?php if ( $title && ! empty( $track['title'] ) ) : ?>
+			<div class="jetpack-podcast-player__titles">
+				<?php render_title( $player_id, $title, $link, $track ); ?>
+			</div>
 			<?php endif; ?>
 		</div>
 
-		<?php if ( isset( $track['description'] ) && $show_description ) : ?>
-			<div
-				id="<?php echo esc_attr( "${player_id}__track-description" ); ?>"
-				class="jetpack-podcast-player__track-description"
-			>
-				<?php echo esc_attr( $track['description'] ); ?>
-			</div>
+		<?php if ( $show_description && ! empty( $track['description'] ) ) : ?>
+		<div
+			id="<?php echo esc_attr( "${player_id}__track-description" ); ?>"
+			class="jetpack-podcast-player__track-description"
+		>
+			<?php echo esc_html( $track['description'] ); ?>
+		</div>
 		<?php endif; ?>
 	</div>
 	<?php


### PR DESCRIPTION
This PR renders the podcast header on the server-side.

#### Changes proposed in this Pull Request:

It gets the podcast data from the Podcast RSS and renders the block HTML on the server-side, following the same structure which is applied by the client.

#### Testing instructions:

In the front-end disable javascript. For this:

a) Open Chrome DevTools.
b) Press Control+Shift+P or Command+Shift+P (Mac) to open the Command Menu.
c) Start typing javascript, select Disable JavaScript, and then press Enter to run the command. JavaScript is now disabled.
![image](https://user-images.githubusercontent.com/77539/77923313-a817de80-7278-11ea-875c-247050ac1915.png)

Once it's disabled, do a hard-refresh. You should be able to still see the podcast header. Same HTML structure. Styles should be applied properly.

![image](https://user-images.githubusercontent.com/77539/77940181-af49e700-728e-11ea-85aa-192099a10e81.png)

![image](https://user-images.githubusercontent.com/77539/77940226-c25cb700-728e-11ea-8230-74d877cd1247.png)

#### Proposed changelog entry for your changes:
* Render Podcast header markup in the server-side
