### PR TITLE
Search: Clean up dashboard copy and upgrade messaging

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 import { noop } from 'lodash';
 import { getPlanClass, PLAN_JETPACK_SEARCH } from 'lib/plans/constants';
+import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
 
 /**
  * Internal dependencies
@@ -27,12 +28,10 @@ import { getUpgradeUrl } from 'state/initial-state';
  */
 const renderCard = props => (
 	<DashItem
-		label={ __( 'Jetpack Search' ) }
+		label={ __( 'Search' ) }
 		module="search"
 		support={ {
-			text: __(
-				'Jetpack Search is a powerful replacement for the search capability built into WordPress.'
-			),
+			text: SEARCH_SUPPORT,
 			link: 'https://jetpack.com/support/search/',
 		} }
 		className={ props.className }
@@ -98,9 +97,7 @@ class DashSearch extends Component {
 				overrideContent: (
 					<JetpackBanner
 						callToAction={ __( 'Upgrade' ) }
-						title={ __(
-							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.'
-						) }
+						title={ SEARCH_DESCRIPTION }
 						disableHref="false"
 						href={ this.props.upgradeUrl }
 						eventFeature="search"
@@ -119,9 +116,7 @@ class DashSearch extends Component {
 						label={ __( 'Search' ) }
 						module="search"
 						support={ {
-							text: __(
-								'Jetpack Search helps visitors quickly find answers with highly relevant instant search results and powerful filtering.'
-							),
+							text: SEARCH_SUPPORT,
 							link: 'https://jetpack.com/support/search/',
 						} }
 						className="jp-dash-item__is-active"
@@ -138,7 +133,7 @@ class DashSearch extends Component {
 							className="jp-search-config-aag"
 							href="customize.php?autofocus[section]=jetpack_search"
 						>
-							{ __( 'Customize' ) }
+							{ SEARCH_CUSTOMIZE_CTA }
 						</Card>
 					) : (
 						<Card

--- a/_inc/client/components/plans/plan-icon/index.jsx
+++ b/_inc/client/components/plans/plan-icon/index.jsx
@@ -156,7 +156,7 @@ export default class PlanIcon extends Component {
 				version="1.1"
 				x="0"
 				y="0"
-				viewBox="0 0 124 124"
+				viewBox="0 0 64 64"
 			>
 				<circle className="dops-plan-icon__search-0" cx="32" cy="32" r="32" fill="#2fb41f" />
 				<path

--- a/_inc/client/components/plans/plan-icon/index.jsx
+++ b/_inc/client/components/plans/plan-icon/index.jsx
@@ -24,6 +24,8 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_2_YEARS,
 	PLAN_VIP,
+	PLAN_JETPACK_SEARCH,
+	PLAN_JETPACK_SEARCH_MONTHLY,
 	getPlanClass,
 } from 'lib/plans/constants';
 
@@ -146,6 +148,26 @@ export default class PlanIcon extends Component {
 		);
 	}
 
+	getSearchIcon() {
+		return (
+			<svg
+				className={ this.getIconClassNames( 'dops-plan-icon__search' ) }
+				xmlns="http://www.w3.org/2000/svg"
+				version="1.1"
+				x="0"
+				y="0"
+				viewBox="0 0 124 124"
+			>
+				<circle className="dops-plan-icon__search-0" cx="32" cy="32" r="32" fill="#2fb41f" />
+				<path
+					className="dops-plan-icon__search-1"
+					d="M48 43.6L39.4 35c1.2-1.8 1.9-4 1.9-6.4 0-6.4-5.2-11.6-11.6-11.6S18 22.2 18 28.7s5.2 11.6 11.6 11.6c2.4 0 4.6-.7 6.4-1.9l8.6 8.6 3.4-3.4zM21.4 28.7c0-4.6 3.7-8.3 8.3-8.3s8.3 3.7 8.3 8.3-3.7 8.3-8.3 8.3-8.3-3.7-8.3-8.3z"
+					fill="#fff"
+				/>
+			</svg>
+		);
+	}
+
 	getDefaultIcon() {
 		return (
 			<svg
@@ -201,6 +223,9 @@ export default class PlanIcon extends Component {
 			case PLAN_JETPACK_BUSINESS_MONTHLY:
 			case PLAN_VIP:
 				return this.getBusinessIcon();
+			case PLAN_JETPACK_SEARCH:
+			case PLAN_JETPACK_SEARCH_MONTHLY:
+				return this.getSearchIcon();
 			default:
 				return this.getDefaultIcon();
 		}

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -10,6 +10,7 @@ import Card from 'components/card';
  * Internal dependencies
  */
 import { FEATURE_SEARCH_JETPACK, getPlanClass } from 'lib/plans/constants';
+import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
@@ -72,15 +73,11 @@ function Search( props ) {
 				hasChild
 				module={ { module: 'search' } }
 				support={ {
-					text: __( 'Jetpack Search supports many customizations.' ),
+					text: SEARCH_SUPPORT,
 					link: 'https://jetpack.com/support/search',
 				} }
 			>
-				<p>
-					{ __(
-						'Help visitors quickly find answers with highly relevant instant search results and powerful filtering. Powered by the WordPress.com cloud.'
-					) }{ ' ' }
-				</p>
+				<p>{ SEARCH_DESCRIPTION } </p>
 				{ props.isLoading && __( 'Loading…' ) }
 				{ ! props.isLoading && ( props.isBusinessPlan || props.hasActiveSearchPurchase ) && (
 					// TODO: There's a known bug preventing Jetpack Search from being enabled here for Search product purchases
@@ -92,7 +89,7 @@ function Search( props ) {
 							toggleModule={ toggleModule }
 							toggling={ props.isSavingAnyOption( 'search' ) }
 						>
-							{ __( 'Enable Jetpack Search' ) }
+							{ __( 'Enable Search' ) }
 						</ModuleToggle>
 						<FormFieldset>
 							<CompactFormToggle
@@ -133,7 +130,7 @@ function Search( props ) {
 					compact
 					href="customize.php?autofocus[section]=jetpack_search"
 				>
-					{ __( 'Configure your Jetpack Search experience in the customizer' ) }
+					{ SEARCH_CUSTOMIZE_CTA }
 				</Card>
 			) }
 		</SettingsCard>

--- a/_inc/client/plans/constants.js
+++ b/_inc/client/plans/constants.js
@@ -19,6 +19,7 @@ export const REALTIME_BACKUP_TITLE = __( 'Jetpack Backup {{em}}Real-Time{{/em}}'
 
 export const SEARCH_TITLE = __( 'Jetpack Search' );
 export const SEARCH_DESCRIPTION = __(
-	'Enhanced Search for more relevant results using modern ranking algorithms, ' +
-		'boosting of specific results, advanced filtering and faceting, and more. '
+	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
 );
+export const SEARCH_CUSTOMIZE_CTA = __( 'Customize your Search experience.' );
+export const SEARCH_SUPPORT = __( 'Search supports many customizations. ' );

--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -66,7 +66,7 @@ export function SingleProductSearchCard( props ) {
 			</div>
 			<div className="single-product__accented-card-body">
 				<p>
-					{ SEARCH_DESCRIPTION }
+					{ SEARCH_DESCRIPTION }{ ' ' }
 					<a href="https://jetpack.com/search" target="_blank" rel="noopener noreferrer">
 						{ __( 'Learn More' ) }
 					</a>


### PR DESCRIPTION
Fixes #15180 

Also:
- adds search icon instead of generic to the upgrade message
- cleans up some other copy I found and refactors to make it easily reusable
- uses the copy suggested in https://github.com/Automattic/wp-calypso/issues/40550#issuecomment-606023167

@keoshi I need some help with the search icon:

<img width="1069" alt="Screen Shot 2020-03-30 at 12 25 58 PM" src="https://user-images.githubusercontent.com/820871/77948060-0b5a3e80-7282-11ea-9006-abb8fc8e955a.png">

To test try the dashboard try it with:
- free plan
- pro plan
- search plan
