### PR TITLE
Set default values for getRewindMessage

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -90,6 +90,15 @@ class BackupsScanRewind extends Component {
 					),
 					url: 'https://wordpress.com/activity-log/' + siteRawUrl,
 				};
+			default:
+				return {
+					title: __( 'Oops!' ),
+					icon: 'info',
+					description: __(
+						'The Jetpack Backup and Scan status could not be retrieved at this time.'
+					),
+					url: '',
+				};
 		}
 	}
 
@@ -227,7 +236,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				this.props.vaultPressData !== 'N/A' &&
 				false !== get( this.props.vaultPressData, [ 'data' ], false );
 
-			if ( ! hasRewindData && ( this.props.vaultPressActive && ! hasVpData ) ) {
+			if ( ! hasRewindData && this.props.vaultPressActive && ! hasVpData ) {
 				return <LoadingCard />;
 			}
 

--- a/_inc/client/security/jetpack-backup.jsx
+++ b/_inc/client/security/jetpack-backup.jsx
@@ -70,6 +70,13 @@ export class JetpackBackup extends Component {
 					description: __( 'Your site is being backed up.' ),
 					url: 'https://wordpress.com/activity-log/' + siteRawUrl,
 				};
+			default:
+				return {
+					title: __( 'Oops!' ),
+					icon: 'info',
+					description: __( 'The Jetpack Backup status could not be retrieved at this time.' ),
+					url: '',
+				};
 		}
 	}
 


### PR DESCRIPTION
Attempts to fix error below by setting default values.

/wp-json/jetpack/v4/rewind?_cacheBuster=1585585696669:1 Failed to load resource: the server responded with a status of 400 ()
react-dom.min.js?ver=16.9.0:103 TypeError: Cannot read property 'title' of undefined
    at t.getRewindBanner (admin.js?ver=8.3:2)
    at t.value (admin.js?ver=8.3:2)
    at re (react-dom.min.js?ver=16.9.0:95)
    at Vg (react-dom.min.js?ver=16.9.0:95)
    at ph (react-dom.min.js?ver=16.9.0:217)
    at lh (react-dom.min.js?ver=16.9.0:126)
    at O (react-dom.min.js?ver=16.9.0:121)
    at ze (react-dom.min.js?ver=16.9.0:118)
    at react-dom.min.js?ver=16.9.0:53
    at unstable_runWithPriority (react.min.js?ver=16.9.0:26)
ve @ react-dom.min.js?ver=16.9.0:103

#### Changes proposed in this Pull Request:
* Sets default values.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* I need to figure out the best way to duplicate the original issue.
*

#### Proposed changelog entry for your changes:
* Admin Dashboard: Resolve an issue when Rewind status was not available.
