### PR TITLE
Podcast Player Accessibility and Interactions

### DIFF
--- a/extensions/blocks/podcast-player/components/audio-player.js
+++ b/extensions/blocks/podcast-player/components/audio-player.js
@@ -7,6 +7,8 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -49,6 +51,7 @@ class AudioPlayer extends Component {
 	 */
 	pause = () => {
 		this.audio.pause();
+		speak( __( 'Paused', 'jetpack' ), 'assertive' );
 	};
 
 	/**

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -6,7 +6,7 @@ import { memo } from '@wordpress/element';
 const Header = memo(
 	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
 		<div className="jetpack-podcast-player__header">
-			<div className="jetpack-podcast-player__current-track-info" aria-live="polite">
+			<div className="jetpack-podcast-player__current-track-info">
 				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__cover">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,10 +20,18 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 
 	if ( isError ) {
 		name = 'error';
-		hiddenText = __( 'Error:', 'jetpack' );
+		hiddenText = _x(
+			'Error: ',
+			'Text to describe the current state. This will go before the track title, such as "Error: The title of the track"',
+			'jetpack'
+		);
 	} else if ( isPlaying ) {
 		name = 'playing';
-		hiddenText = __( 'Playing: ', 'jetpack' );
+		hiddenText = _x(
+			'Playing: ',
+			'Text to describe the current state. This will go before the track title, such as "Playing: The title of the track"',
+			'jetpack'
+		);
 	}
 
 	const icon = trackIcons[ name ];
@@ -99,7 +107,15 @@ const Track = memo(
 					className="jetpack-podcast-player__track-link"
 					href={ track.link }
 					role="button"
-					aria-current={ isActive ? __( 'track' ) : undefined }
+					aria-current={
+						isActive
+							? _x(
+									'track',
+									'This needs to be a single word with no spaces. It describes the current item in the group. A screen reader will announce it as "[track title], current track"',
+									'jetpack'
+							  )
+							: undefined
+					}
 					onClick={ e => {
 						// Prevent handling clicks if a modifier is in use.
 						if ( e.shiftKey || e.metaKey || e.altKey ) {
@@ -132,7 +148,9 @@ const Track = memo(
 					/>
 					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
 					{ track.duration && (
-						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>{ track.duration }</time>
+						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>
+							{ track.duration }
+						</time>
 					) }
 				</a>
 				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -50,12 +50,13 @@ const TrackError = memo( ( { link, title } ) => (
 		{ __( 'Episode unavailable', 'jetpack' ) }{ ' ' }
 		{ link && (
 			<span>
-				{ '(' }
+				{ ' - ' }
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
-					<span class="jetpack-podcast-player--visually-hidden">{ title }: </span>
+					<span class="jetpack-podcast-player--visually-hidden">
+						{ sprintf( __( '%s: ', 'jetpack' ), title ) }
+					</span>
 					{ __( 'Open in a new tab', 'jetpack' ) }
 				</a>
-				{ ')' }
 			</span>
 		) }
 	</div>

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,18 +20,12 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 
 	if ( isError ) {
 		name = 'error';
-		hiddenText = _x(
-			'Error: ',
-			'Text to describe the current state. This will go before the track title, such as "Error: The title of the track"',
-			'jetpack'
-		);
+		/* translators: This is text to describe the current state. This will go before the track title, such as "Error: [The title of the track]" */
+		hiddenText = __( 'Error: ', 'jetpack' );
 	} else if ( isPlaying ) {
 		name = 'playing';
-		hiddenText = _x(
-			'Playing: ',
-			'Text to describe the current state. This will go before the track title, such as "Playing: The title of the track"',
-			'jetpack'
-		);
+		/* translators: Text to describe the current state. This will go before the track title, such as "Playing: [The title of the track]" */
+		hiddenText = __( 'Playing: ', 'jetpack' );
 	}
 
 	const icon = trackIcons[ name ];
@@ -98,6 +92,9 @@ const Track = memo(
 			inlineStyle.color = colors.secondary.custom;
 		}
 
+		/* translators: This needs to be a single word with no spaces. It describes the current item in the group. A screen reader will announce it as "[title], current track" */
+		const ariaCurrent = isActive ? __( 'track', 'jetpack' ) : undefined;
+
 		return (
 			<li
 				className={ trackClassName }
@@ -107,15 +104,7 @@ const Track = memo(
 					className="jetpack-podcast-player__track-link"
 					href={ track.link }
 					role="button"
-					aria-current={
-						isActive
-							? _x(
-									'track',
-									'This needs to be a single word with no spaces. It describes the current item in the group. A screen reader will announce it as "[track title], current track"',
-									'jetpack'
-							  )
-							: undefined
-					}
+					aria-current={ ariaCurrent }
 					onClick={ e => {
 						// Prevent handling clicks if a modifier is in use.
 						if ( e.shiftKey || e.metaKey || e.altKey ) {

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -53,6 +53,7 @@ const TrackError = memo( ( { link, title } ) => (
 				{ ' - ' }
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
 					<span class="jetpack-podcast-player--visually-hidden">
+						{ /* translators: %s is the title of the track. This text is visually hidden from the screen, but available to screen readers */ }
 						{ sprintf( __( '%s: ', 'jetpack' ), title ) }
 					</span>
 					{ __( 'Open in a new tab', 'jetpack' ) }

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -16,12 +16,14 @@ import * as trackIcons from '../icons/track-icons';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
 
 const TrackIcon = ( { isPlaying, isError, className } ) => {
-	let name;
+	let hiddenText, name;
 
 	if ( isError ) {
 		name = 'error';
+		hiddenText = __( 'Error:', 'jetpack' );
 	} else if ( isPlaying ) {
 		name = 'playing';
+		hiddenText = __( 'Playing: ', 'jetpack' );
 	}
 
 	const icon = trackIcons[ name ];
@@ -31,18 +33,24 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 		return <span className={ className } />;
 	}
 
-	return <span className={ `${ className } ${ className }--${ name }` }>{ icon }</span>;
+	return (
+		<span className={ `${ className } ${ className }--${ name }` }>
+			<span className="jetpack-podcast-player--visually-hidden">{ hiddenText }</span>
+			{ icon }
+		</span>
+	);
 };
 
 import { getColorClassName } from '../utils';
 
-const TrackError = memo( ( { link } ) => (
+const TrackError = memo( ( { link, title } ) => (
 	<div className="jetpack-podcast-player__track-error">
 		{ __( 'Episode unavailable', 'jetpack' ) }{ ' ' }
 		{ link && (
 			<span>
 				{ '(' }
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
+					<span class="jetpack-podcast-player--visually-hidden">{ title }: </span>
 					{ __( 'Open in a new tab', 'jetpack' ) }
 				</a>
 				{ ')' }
@@ -91,7 +99,7 @@ const Track = memo(
 					className="jetpack-podcast-player__track-link"
 					href={ track.link }
 					role="button"
-					aria-pressed="false"
+					aria-current={ isActive ? __( 'track' ) : undefined }
 					onClick={ e => {
 						// Prevent handling clicks if a modifier is in use.
 						if ( e.shiftKey || e.metaKey || e.altKey ) {
@@ -124,18 +132,22 @@ const Track = memo(
 					/>
 					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
 					{ track.duration && (
-						<time className="jetpack-podcast-player__track-duration">{ track.duration }</time>
+						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>{ track.duration }</time>
 					) }
 				</a>
-				{ isActive && isError && <TrackError link={ track.link } /> }
+				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }
 			</li>
 		);
 	}
 );
 
-const Playlist = memo( ( { tracks, selectTrack, currentTrack, playerState, colors } ) => {
+const Playlist = memo( ( { playerId, tracks, selectTrack, currentTrack, playerState, colors } ) => {
 	return (
-		<ol className="jetpack-podcast-player__tracks">
+		<ol
+			className="jetpack-podcast-player__tracks"
+			aria-labelledby={ `jetpack-podcast-player__tracklist-title--${ playerId }` }
+			aria-describedby={ `jetpack-podcast-player__tracklist-description--${ playerId }` }
+		>
 			{ tracks.map( ( track, index ) => {
 				const isActive = currentTrack === index;
 

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -21,11 +21,11 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 	if ( isError ) {
 		name = 'error';
 		/* translators: This is text to describe the current state. This will go before the track title, such as "Error: [The title of the track]" */
-		hiddenText = __( 'Error: ', 'jetpack' );
+		hiddenText = __( 'Error:', 'jetpack' );
 	} else if ( isPlaying ) {
 		name = 'playing';
 		/* translators: Text to describe the current state. This will go before the track title, such as "Playing: [The title of the track]" */
-		hiddenText = __( 'Playing: ', 'jetpack' );
+		hiddenText = __( 'Playing:', 'jetpack' );
 	}
 
 	const icon = trackIcons[ name ];
@@ -37,7 +37,8 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 
 	return (
 		<span className={ `${ className } ${ className }--${ name }` }>
-			<span className="jetpack-podcast-player--visually-hidden">{ hiddenText }</span>
+			{ /* Intentional space left after hiddenText */ }
+			<span className="jetpack-podcast-player--visually-hidden">{ `${ hiddenText } ` }</span>
 			{ icon }
 		</span>
 	);

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -48,14 +48,15 @@ import { getColorClassName } from '../utils';
 
 const TrackError = memo( ( { link, title } ) => (
 	<div className="jetpack-podcast-player__track-error">
-		{ __( 'Episode unavailable', 'jetpack' ) }{ ' ' }
+		{ __( 'Episode unavailable', 'jetpack' ) }
 		{ link && (
 			<span>
 				{ ' - ' }
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
 					<span class="jetpack-podcast-player--visually-hidden">
+						{ /* Intentional trailing space outside of the translated string */ }
 						{ /* translators: %s is the title of the track. This text is visually hidden from the screen, but available to screen readers */ }
-						{ sprintf( __( '%s: ', 'jetpack' ), title ) }
+						{ `${ sprintf( __( '%s:', 'jetpack' ), title ) } ` }
 					</span>
 					{ __( 'Open in a new tab', 'jetpack' ) }
 				</a>

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -215,14 +215,14 @@ export class PodcastPlayer extends Component {
 				</Header>
 
 				<h4
-					id={ 'jetpack-podcast-player__tracklist-title--' + playerId }
+					id={ `jetpack-podcast-player__tracklist-title--${ playerId }` }
 					className="jetpack-podcast-player--visually-hidden"
 				>
 					{ /* translators: %s is the track title. This describes what the playlist goes with, like "Playlist: [name of the podcast]" */ }
 					{ sprintf( __( 'Playlist: %s', 'jetpack' ), title ) }
 				</h4>
 				<p
-					id={ 'jetpack-podcast-player__tracklist-description--' + playerId }
+					id={ `jetpack-podcast-player__tracklist-description--${ playerId }` }
 					className="jetpack-podcast-player--visually-hidden"
 				>
 					{ __( 'Select an episode to play it in the audio player.', 'jetpack' ) }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -74,15 +74,9 @@ export class PodcastPlayer extends Component {
 		this.setAudioSource( trackData.src );
 
 		// Read that we're loading the track and its description. This is dismissible via ctrl on VoiceOver.
+		/* translators: %s is the track title. It describes the current state of the track as "Loading: [track title]" */
 		speak(
-			`${ sprintf(
-				_x(
-					'Loading: %s',
-					'Describes the current state of the track as "Loading: [track title]"',
-					'jetpack'
-				),
-				trackData.title
-			) } ${ trackData.description }`,
+			`${ sprintf( __( 'Loading: %s', 'jetpack' ), trackData.title ) } ${ trackData.description }`,
 			'assertive'
 		);
 
@@ -106,10 +100,7 @@ export class PodcastPlayer extends Component {
 	handleError = () => {
 		this.setState( { playerState: STATE_ERROR } );
 
-		speak(
-			`${ sprintf( __( 'Error: Episode unavailable. (Open in a new tab)', 'jetpack' ) ) }`,
-			'assertive'
-		);
+		speak( `${ __( 'Error: Episode unavailable. (Open in a new tab)', 'jetpack' ) }`, 'assertive' );
 	};
 
 	/**
@@ -227,14 +218,8 @@ export class PodcastPlayer extends Component {
 					id={ 'jetpack-podcast-player__tracklist-title--' + playerId }
 					className="jetpack-podcast-player--visually-hidden"
 				>
-					{ sprintf(
-						_x(
-							'Playlist: %s',
-							'Describes what the playlist goes with, like "Playlist: [name of the podcast]"',
-							'jetpack'
-						),
-						title
-					) }
+					{ /* translators: %s is the track title. This describes what the playlist goes with, like "Playlist: [name of the podcast]" */ }
+					{ sprintf( __( 'Playlist: %s', 'jetpack' ), title ) }
 				</h4>
 				<p
 					id={ 'jetpack-podcast-player__tracklist-description--' + playerId }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -75,7 +75,14 @@ export class PodcastPlayer extends Component {
 
 		// Read that we're loading the track and its description. This is dismissible via ctrl on VoiceOver.
 		speak(
-			`${ sprintf( __( 'Loading: %s', 'jetpack' ), trackData.title ) } ${ trackData.description }`,
+			`${ sprintf(
+				_x(
+					'Loading: %s',
+					'Describes the current state of the track as "Loading: [track title]"',
+					'jetpack'
+				),
+				trackData.title
+			) } ${ trackData.description }`,
 			'assertive'
 		);
 
@@ -220,7 +227,14 @@ export class PodcastPlayer extends Component {
 					id={ 'jetpack-podcast-player__tracklist-title--' + playerId }
 					className="jetpack-podcast-player--visually-hidden"
 				>
-					{ sprintf( __( 'Playlist: %s', 'jetpack' ), title ) }
+					{ sprintf(
+						_x(
+							'Playlist: %s',
+							'Describes what the playlist goes with, like "Playlist: [name of the podcast]"',
+							'jetpack'
+						),
+						title
+					) }
 				</h4>
 				<p
 					id={ 'jetpack-podcast-player__tracklist-description--' + playerId }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -7,6 +7,8 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -67,8 +69,16 @@ export class PodcastPlayer extends Component {
 		if ( ! trackData ) {
 			return;
 		}
+
 		this.setState( { currentTrack: track } );
 		this.setAudioSource( trackData.src );
+
+		// Read that we're loading the track and its description. This is dismissible via ctrl on VoiceOver.
+		speak(
+			`${ sprintf( __( 'Loading: %s', 'jetpack' ), trackData.title ) } ${ trackData.description }`,
+			'assertive'
+		);
+
 		this.play();
 	};
 
@@ -88,6 +98,11 @@ export class PodcastPlayer extends Component {
 	 */
 	handleError = () => {
 		this.setState( { playerState: STATE_ERROR } );
+
+		speak(
+			`${ sprintf( __( 'Error: Episode unavailable. (Open in a new tab)', 'jetpack' ) ) }`,
+			'assertive'
+		);
 	};
 
 	/**
@@ -176,9 +191,9 @@ export class PodcastPlayer extends Component {
 			<section
 				className={ cssClassesName }
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
-				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
+				aria-labelledby={ title || ( track && track.title ) ? playerId + '__title' : undefined }
 				aria-describedby={
-					track && track.description ? `${ playerId }__track-description` : undefined
+					track && track.description ? playerId + '__track-description' : undefined
 				}
 				// The following line ensures compatibility with Calypso previews (jetpack-iframe-embed.js).
 				data-jetpack-iframe-ignore
@@ -200,7 +215,21 @@ export class PodcastPlayer extends Component {
 						ref={ this.playerRef }
 					/>
 				</Header>
+
+				<h4
+					id={ 'jetpack-podcast-player__tracklist-title--' + playerId }
+					className="jetpack-podcast-player--visually-hidden"
+				>
+					{ sprintf( __( 'Playlist: %s', 'jetpack' ), title ) }
+				</h4>
+				<p
+					id={ 'jetpack-podcast-player__tracklist-description--' + playerId }
+					className="jetpack-podcast-player--visually-hidden"
+				>
+					{ __( 'Select an episode to play it in the audio player.', 'jetpack' ) }
+				</p>
 				<Playlist
+					playerId={ playerId }
 					playerState={ playerState }
 					currentTrack={ currentTrack }
 					tracks={ tracksToDisplay }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -100,7 +100,7 @@ export class PodcastPlayer extends Component {
 	handleError = () => {
 		this.setState( { playerState: STATE_ERROR } );
 
-		speak( `${ __( 'Error: Episode unavailable. (Open in a new tab)', 'jetpack' ) }`, 'assertive' );
+		speak( `${ __( 'Error: Episode unavailable - Open in a new tab', 'jetpack' ) }`, 'assertive' );
 	};
 
 	/**

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -189,9 +189,9 @@ export class PodcastPlayer extends Component {
 			<section
 				className={ cssClassesName }
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
-				aria-labelledby={ title || ( track && track.title ) ? playerId + '__title' : undefined }
+				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
 				aria-describedby={
-					track && track.description ? playerId + '__track-description' : undefined
+					track && track.description ? `${ playerId }__track-description` : undefined
 				}
 				// The following line ensures compatibility with Calypso previews (jetpack-iframe-embed.js).
 				data-jetpack-iframe-ignore

--- a/extensions/blocks/podcast-player/icons/track-icons.js
+++ b/extensions/blocks/podcast-player/icons/track-icons.js
@@ -4,34 +4,23 @@
 import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const TrackIcon = ( { name, title, children } ) => {
-	const id = `jetpack-podcast-player__${ name }-icon`;
-
+const TrackIcon = ( { name, children } ) => {
 	return (
-		<SVG
-			height="24"
-			viewBox="0 0 24 24"
-			width="24"
-			xmlns="http://www.w3.org/2000/svg"
-			role="img"
-			aria-labelledby={ id }
-			aria-hidden={ undefined }
-		>
-			<title id={ id }>{ title }</title>
+		<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
 			{ children }
 		</SVG>
 	);
 };
 
 export const playing = (
-	<TrackIcon name="playing" title={ __( 'Playing', 'jetpack' ) }>
+	<TrackIcon name="playing">
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z" />
 	</TrackIcon>
 );
 
 export const error = (
-	<TrackIcon name="error" title={ __( 'Error', 'jetpack' ) }>
+	<TrackIcon name="error">
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
 	</TrackIcon>


### PR DESCRIPTION
Adds improved `aria` states and interactions for screen readers. 

### Proposed changelog entry
The intention of this PR is to help indicate:
- What track is currently selected
- The track list is related to the player
- What happens after you click a track.

### How this is addressed / Testing instructions

- **What track is currently selected**: `aria-current="track"` in most screen readers will announce `[track title], currently track`. In Safari with VoiceOver, it announces `[track title], current item`. I wasn't sure about translating `track` as it needs to be a single word to be a valid value.
- After clicking a track list button, there can be a long delay between the button press and the actual track starting to play. In order to give confirmation that something is happening, it now announces `wp.a11y.speak('Loading: [Track title] [Track Description]', 'assertive')`. I initially wanted this to be 'polite' and had this as an `aria-live` region in the player header, but it was not being read at all or read multiple times in succession. Not a great experience.
- On a currently playing track, pressing the tracklist button will announce "Paused" as this track selection to start/stop a track is non-standard, so I think it's helpful to announce what happened.
- If there's an error, it should announce `'Error: Episode unavailable. (Open in a new window)'`.
- **The track list is related to the player**: I added a visually hidden title and description for the playlist and linked it to the `<ol>` tracklist via `aria-labelledby` and `aria-describedby`. This turns it into a "group" and announces the title and description of the group to make the connection of the playlist and audio player more apparent.
