### PR TITLE
Podcast Player: Simplify isUrl check

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -134,13 +134,9 @@ const PodcastPlayerEdit = ( {
 		// "http" to any entry before attempting validation.
 		const prependedURL = prependHTTP( editedUrl );
 
-		const isValidURL = isURL( prependedURL );
-
-		if ( ! isValidURL ) {
+		if ( ! isURL( prependedURL ) ) {
 			createErrorNotice(
-				! isValidURL
-					? __( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
-					: ''
+				__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
 			);
 			return;
 		}


### PR DESCRIPTION
Simplifies the logic a little bit. 

`isValidURL` is not re-used after this check, and can not be truth after it's been falsy.