### PR TITLE
Podcast Player: Rename "episode" to "track" for consistency

### DIFF
--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -6,7 +6,7 @@ import { memo } from '@wordpress/element';
 const Header = memo(
 	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
 		<div className="jetpack-podcast-player__header">
-			<div className="jetpack-podcast-player__cover-wrapper" aria-live="polite">
+			<div className="jetpack-podcast-player__current-track-info" aria-live="polite">
 				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__cover">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -50,16 +50,18 @@ const Title = memo( ( { playerId, title, link, track } ) => (
 	</h2>
 ) );
 
-const PodcastTitle = memo( ( { title, link } ) => (
-	<span className="jetpack-podcast-player__header-podcast-title">
-		{ link ? (
-			<a className="jetpack-podcast-player__header-podcast-title-link" href={ link }>
+const PodcastTitle = memo( ( { title, link } ) => {
+	const className = 'jetpack-podcast-player__header-podcast-title';
+
+	if ( link ) {
+		return (
+			<a className={ className } href={ link } target="_blank" rel="noopener noreferrer nofollow">
 				{ title }
 			</a>
-		) : (
-			title
-		) }
-	</span>
-) );
+		);
+	}
+
+	return <span className={ className }>{ title }</span>;
+} );
 
 export default Header;

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -7,27 +7,27 @@ const Header = memo(
 	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
 		<div className="jetpack-podcast-player__header-wrapper">
 			<div className="jetpack-podcast-player__header" aria-live="polite">
-				{ showCoverArt && cover ? (
+				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__header-image-wrapper">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
 						<img className="jetpack-podcast-player__header-image" src={ cover } alt="" />
 					</div>
-				) : null }
+				) }
 
-				{ title || ( track && track.title ) ? (
+				{ ( title || ( track && track.title ) ) && (
 					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
-				) : null }
+				) }
 			</div>
 
 			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
-			{ showEpisodeDescription && track && track.description ? (
+			{ showEpisodeDescription && track && track.description && (
 				<div
 					id={ `${ playerId }__header-track-description` }
 					className="jetpack-podcast-player__header-track-description"
 				>
 					{ track.description }
 				</div>
-			) : null }
+			) }
 
 			{ /* children contains the audio player */ }
 			{ children }
@@ -37,16 +37,16 @@ const Header = memo(
 
 const Title = memo( ( { playerId, title, link, track } ) => (
 	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__header-title">
-		{ track && track.title ? (
+		{ track && track.title && (
 			<span className="jetpack-podcast-player__header-track-title">{ track.title }</span>
-		) : null }
+		) }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
-		{ track && track.title && title ? (
+		{ track && track.title && title && (
 			<span className="jetpack-podcast-player--visually-hidden"> - </span>
-		) : null }
+		) }
 
-		{ title ? <PodcastTitle title={ title } link={ link } /> : null }
+		{ title && <PodcastTitle title={ title } link={ link } /> }
 	</h2>
 ) );
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -8,24 +8,22 @@ const Header = memo(
 		<div className="jetpack-podcast-player__header-wrapper">
 			<div className="jetpack-podcast-player__header" aria-live="polite">
 				{ showCoverArt && cover ? (
-					<div className="jetpack-podcast-player__track-image-wrapper">
+					<div className="jetpack-podcast-player__header-image-wrapper">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
-						<img className="jetpack-podcast-player__track-image" src={ cover } alt="" />
+						<img className="jetpack-podcast-player__header-image" src={ cover } alt="" />
 					</div>
 				) : null }
 
 				{ title || ( track && track.title ) ? (
-					<div className="jetpack-podcast-player__titles">
-						<Title playerId={ playerId } title={ title } link={ link } track={ track } />
-					</div>
+					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
 				) : null }
 			</div>
 
 			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
 			{ showEpisodeDescription && track && track.description ? (
 				<div
-					id={ `${ playerId }__track-description` }
-					className="jetpack-podcast-player__track-description"
+					id={ `${ playerId }__header-track-description` }
+					className="jetpack-podcast-player__header-track-description"
 				>
 					{ track.description }
 				</div>
@@ -38,9 +36,9 @@ const Header = memo(
 );
 
 const Title = memo( ( { playerId, title, link, track } ) => (
-	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
+	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__header-title">
 		{ track && track.title ? (
-			<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+			<span className="jetpack-podcast-player__header-track-title">{ track.title }</span>
 		) : null }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
@@ -53,9 +51,9 @@ const Title = memo( ( { playerId, title, link, track } ) => (
 ) );
 
 const PodcastTitle = memo( ( { title, link } ) => (
-	<span className="jetpack-podcast-player__title">
+	<span className="jetpack-podcast-player__header-podcast-title">
 		{ link ? (
-			<a className="jetpack-podcast-player__title-link" href={ link }>
+			<a className="jetpack-podcast-player__header-podcast-title-link" href={ link }>
 				{ title }
 			</a>
 		) : (

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -10,7 +10,7 @@ const Header = memo(
 				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__cover">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
-						<img src={ cover } alt="" />
+						<img className="jetpack-podcast-player__cover-image" src={ cover } alt="" />
 					</div>
 				) }
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -14,13 +14,13 @@ const Header = memo(
 					</div>
 				) }
 
-				{ ( title || ( track && track.title ) ) && (
+				{ !! ( title || ( track && track.title ) ) && (
 					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
 				) }
 			</div>
 
 			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
-			{ showEpisodeDescription && track && track.description && (
+			{ !! ( showEpisodeDescription && track && track.description ) && (
 				<div
 					id={ `${ playerId }__track-description` }
 					className="jetpack-podcast-player__track-description"
@@ -37,16 +37,16 @@ const Header = memo(
 
 const Title = memo( ( { playerId, title, link, track } ) => (
 	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
-		{ track && track.title && (
+		{ !! ( track && track.title ) && (
 			<span className="jetpack-podcast-player__current-track-title">{ track.title }</span>
 		) }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
-		{ track && track.title && title && (
+		{ !! ( track && track.title && title ) && (
 			<span className="jetpack-podcast-player--visually-hidden"> - </span>
 		) }
 
-		{ title && <PodcastTitle title={ title } link={ link } /> }
+		{ !! title && <PodcastTitle title={ title } link={ link } /> }
 	</h2>
 ) );
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -8,9 +8,9 @@ const Header = memo(
 		<div className="jetpack-podcast-player__header-wrapper">
 			<div className="jetpack-podcast-player__header" aria-live="polite">
 				{ showCoverArt && cover && (
-					<div className="jetpack-podcast-player__header-image-wrapper">
+					<div className="jetpack-podcast-player__header-image">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
-						<img className="jetpack-podcast-player__header-image" src={ cover } alt="" />
+						<img src={ cover } alt="" />
 					</div>
 				) }
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -5,10 +5,10 @@ import { memo } from '@wordpress/element';
 
 const Header = memo(
 	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
-		<div className="jetpack-podcast-player__header-wrapper">
-			<div className="jetpack-podcast-player__header" aria-live="polite">
+		<div className="jetpack-podcast-player__header">
+			<div className="jetpack-podcast-player__cover-wrapper" aria-live="polite">
 				{ showCoverArt && cover && (
-					<div className="jetpack-podcast-player__header-image">
+					<div className="jetpack-podcast-player__cover">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
 						<img src={ cover } alt="" />
 					</div>
@@ -22,8 +22,8 @@ const Header = memo(
 			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
 			{ showEpisodeDescription && track && track.description && (
 				<div
-					id={ `${ playerId }__header-track-description` }
-					className="jetpack-podcast-player__header-track-description"
+					id={ `${ playerId }__track-description` }
+					className="jetpack-podcast-player__track-description"
 				>
 					{ track.description }
 				</div>
@@ -36,9 +36,9 @@ const Header = memo(
 );
 
 const Title = memo( ( { playerId, title, link, track } ) => (
-	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__header-title">
+	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
 		{ track && track.title && (
-			<span className="jetpack-podcast-player__header-track-title">{ track.title }</span>
+			<span className="jetpack-podcast-player__current-track-title">{ track.title }</span>
 		) }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
@@ -51,7 +51,7 @@ const Title = memo( ( { playerId, title, link, track } ) => (
 ) );
 
 const PodcastTitle = memo( ( { title, link } ) => {
-	const className = 'jetpack-podcast-player__header-podcast-title';
+	const className = 'jetpack-podcast-player__podcast-title';
 
 	if ( link ) {
 		return (

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import * as episodeIcons from '../icons/episode-icons';
+import * as trackIcons from '../icons/track-icons';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
 
 const TrackIcon = ( { isPlaying, isError, className } ) => {
@@ -24,7 +24,7 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 		name = 'playing';
 	}
 
-	const icon = episodeIcons[ name ];
+	const icon = trackIcons[ name ];
 
 	if ( ! icon ) {
 		// Return empty element - we need it for layout purposes.
@@ -37,7 +37,7 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 import { getColorClassName } from '../utils';
 
 const TrackError = memo( ( { link } ) => (
-	<div className="jetpack-podcast-player__episode-error">
+	<div className="jetpack-podcast-player__track-error">
 		{ __( 'Episode unavailable', 'jetpack' ) }{ ' ' }
 		{ link && (
 			<span>
@@ -67,7 +67,7 @@ const Track = memo(
 		// Set CSS classes string.
 		const primaryColorClass = getColorClassName( 'color', colors.primary.name );
 		const secondaryColorClass = getColorClassName( 'color', colors.secondary.name );
-		const trackClassName = classnames( 'jetpack-podcast-player__episode', {
+		const trackClassName = classnames( 'jetpack-podcast-player__track', {
 			'is-active': isActive,
 			'has-primary': isActive && ( colors.primary.name || colors.primary.custom ),
 			[ primaryColorClass ]: isActive && !! primaryColorClass,
@@ -88,7 +88,7 @@ const Track = memo(
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
 			>
 				<a
-					className="jetpack-podcast-player__episode-link"
+					className="jetpack-podcast-player__track-link"
 					href={ track.link }
 					role="button"
 					aria-pressed="false"
@@ -113,36 +113,30 @@ const Track = memo(
 						// Prevent default behavior (scrolling one page down).
 						e.preventDefault();
 
-					// Select track.
-					selectTrack( index );
-				} }
-			>
-				<TrackIcon
-					className="jetpack-podcast-player__episode-status-icon"
-					isPlaying={ isPlaying }
-					isError={ isError }
-				/>
-				<span className="jetpack-podcast-player__episode-title">{ track.title }</span>
-				{ track.duration && (
-					<time className="jetpack-podcast-player__episode-duration">{ track.duration }</time>
-				) }
-			</a>
-			{ isActive && isError && <TrackError link={ track.link } /> }
-		</li>
-	);
-} );
+						// Select track.
+						selectTrack( index );
+					} }
+				>
+					<TrackIcon
+						className="jetpack-podcast-player__track-status-icon"
+						isPlaying={ isPlaying }
+						isError={ isError }
+					/>
+					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+					{ track.duration && (
+						<time className="jetpack-podcast-player__track-duration">{ track.duration }</time>
+					) }
+				</a>
+				{ isActive && isError && <TrackError link={ track.link } /> }
+			</li>
+		);
+	}
+);
 
-const Playlist = memo(
-	( {
-		tracks,
-		selectTrack,
-		currentTrack,
-		playerState,
-		colors,
-	} ) => {
-		return (
-			<ol className="jetpack-podcast-player__episodes">
-				{ tracks.map( ( track, index ) => {
+const Playlist = memo( ( { tracks, selectTrack, currentTrack, playerState, colors } ) => {
+	return (
+		<ol className="jetpack-podcast-player__tracks">
+			{ tracks.map( ( track, index ) => {
 				const isActive = currentTrack === index;
 
 				return (

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -178,7 +178,7 @@ export class PodcastPlayer extends Component {
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
 				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
 				aria-describedby={
-					track && track.description ? `${ playerId }__header-track-description` : undefined
+					track && track.description ? `${ playerId }__track-description` : undefined
 				}
 				// The following line ensures compatibility with Calypso previews (jetpack-iframe-embed.js).
 				data-jetpack-iframe-ignore

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -178,7 +178,7 @@ export class PodcastPlayer extends Component {
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
 				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
 				aria-describedby={
-					track && track.description ? `${ playerId }__track-description` : undefined
+					track && track.description ? `${ playerId }__header-track-description` : undefined
 				}
 				// The following line ensures compatibility with Calypso previews (jetpack-iframe-embed.js).
 				data-jetpack-iframe-ignore

--- a/extensions/blocks/podcast-player/icons/track-icons.js
+++ b/extensions/blocks/podcast-player/icons/track-icons.js
@@ -4,7 +4,7 @@
 import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const EpisodeIcon = ( { name, title, children } ) => {
+const TrackIcon = ( { name, title, children } ) => {
 	const id = `jetpack-podcast-player__${ name }-icon`;
 
 	return (
@@ -24,15 +24,15 @@ const EpisodeIcon = ( { name, title, children } ) => {
 };
 
 export const playing = (
-	<EpisodeIcon name="playing" title={ __( 'Playing', 'jetpack' ) }>
+	<TrackIcon name="playing" title={ __( 'Playing', 'jetpack' ) }>
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z" />
-	</EpisodeIcon>
+	</TrackIcon>
 );
 
 export const error = (
-	<EpisodeIcon name="error" title={ __( 'Error', 'jetpack' ) }>
+	<TrackIcon name="error" title={ __( 'Error', 'jetpack' ) }>
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
-	</EpisodeIcon>
+	</TrackIcon>
 );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -31,14 +31,14 @@ function register_block() {
 		BLOCK_NAME,
 		array(
 			'attributes'      => array(
-				'url'                    => array(
+				'url'                  => array(
 					'type' => 'url',
 				),
-				'itemsToShow'            => array(
+				'itemsToShow'          => array(
 					'type'    => 'integer',
 					'default' => 5,
 				),
-				'showCoverArt'           => array(
+				'showCoverArt'         => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),
@@ -131,21 +131,21 @@ function render_player( $player_data, $attributes ) {
 			class="<?php echo esc_attr( $player_classes_name ); ?>"
 			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
-			<ol class="jetpack-podcast-player__episodes">
+			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 				<li
-					class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_colors['class'] ); ?>"
+					class="jetpack-podcast-player__track <?php echo esc_attr( $secondary_colors['class'] ); ?>"
 					style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
 				>
 					<a
-						class="jetpack-podcast-player__episode-link"
+						class="jetpack-podcast-player__track-link"
 						href="<?php echo esc_url( $attachment['link'] ); ?>"
 						role="button"
 						aria-pressed="false"
 					>
-						<span class="jetpack-podcast-player__episode-status-icon"></span>
-						<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+						<span class="jetpack-podcast-player__track-status-icon"></span>
+						<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+						<time class="jetpack-podcast-player__track-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
 					</a>
 				</li>
 				<?php endforeach; ?>

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -113,15 +113,15 @@ $player-float-background: $light-gray-200;
 	padding: $player-grid-spacing;
 }
 
-.jetpack-podcast-player__header-image-wrapper {
+.jetpack-podcast-player__header-image {
 	width: $cover-image-size;
 	margin-right: $player-grid-spacing;
 	flex-shrink: 0;
-}
 
-.jetpack-podcast-player__header-image {
-	width: $cover-image-size;
-	height: $cover-image-size;
+	& > img {
+		width: $cover-image-size;
+		height: $cover-image-size;
+	}
 }
 
 .jetpack-podcast-player__header-track-title {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -3,8 +3,8 @@
  */
 @import '../../shared/styles/gutenberg-base-styles.scss';
 
-$episode-v-padding: 15px;
-$episode-h-padding: 10px;
+$track-v-padding: 15px;
+$track-h-padding: 10px;
 $player-grid-spacing: 24px;
 $cover-image-size: 80px;
 $track-title-font-size: 24px;
@@ -12,7 +12,7 @@ $track-title-b-margin: 10px;
 $podcast-title-font-size: 16px;
 $description-font-size: 16px;
 $player-divider-height: 2px;
-$episode-status-icon-size: 22px;
+$track-status-icon-size: 22px;
 $text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
 $text-color-hover: $black;
 $text-color-active: $text-color-hover;
@@ -21,7 +21,7 @@ $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
 $player-text-color: $text-color;
 $player-background: transparent;
-$player-slider-background: $light-gray-600; 
+$player-slider-background: $light-gray-600;
 $player-slider-foreground: $dark-gray-100;
 $player-button-color: $dark-gray-100;
 $player-float-background: $light-gray-200;
@@ -71,12 +71,12 @@ $player-float-background: $light-gray-200;
 		}
 	}
 
-	.jetpack-podcast-player__episodes {
+	.jetpack-podcast-player__tracks {
 		list-style-type: none;
 		display: flex;
 		flex-direction: column;
 		margin: 0;
-		padding: $episode-v-padding 0;
+		padding: $track-v-padding 0;
 	}
 }
 
@@ -139,13 +139,13 @@ $player-float-background: $light-gray-200;
 	margin-bottom: $player-grid-spacing;
 }
 
-.jetpack-podcast-player__episode {
+.jetpack-podcast-player__track {
 	margin: 0;
 	font-family: $default-font;
 	font-size: $editor-font-size;
 
 	/**
-	 * When episode "is-active", it means that it's been clicked by a user to
+	 * When track "is-active", it means that it's been clicked by a user to
 	 * start playback. Combine this class with the Player's state classes (see
 	 * above) to apply styling for different scenarios.
 	 */
@@ -164,11 +164,11 @@ $player-float-background: $light-gray-200;
 	}
 
 	// We need to scope this class to override editor link styles.
-	.jetpack-podcast-player__episode-link {
+	.jetpack-podcast-player__track-link {
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		padding: $episode-h-padding $episode-v-padding;
+		padding: $track-h-padding $track-v-padding;
 		text-decoration: none;
 		transition: none;
 
@@ -183,13 +183,13 @@ $player-float-background: $light-gray-200;
 	 * - Active podcast has defined a custom color.
 	 * - The other podcasts if they have defined a custom color.
 	 */
-	&.is-active.has-primary .jetpack-podcast-player__episode-link,
-	&.has-secondary .jetpack-podcast-player__episode-link {
+	&.is-active.has-primary .jetpack-podcast-player__track-link,
+	&.has-secondary .jetpack-podcast-player__track-link {
 		color: inherit;
 	}
 
 	// Make space for the error element that will be appended.
-	.is-error &.is-active .jetpack-podcast-player__episode-link {
+	.is-error &.is-active .jetpack-podcast-player__track-link {
 		padding-bottom: 0;
 	}
 }
@@ -197,12 +197,10 @@ $player-float-background: $light-gray-200;
 /**
  * Style player by overriding mejs default styles
  */
-
- .wp-block-jetpack-podcast-player {
-
-	.mejs-container, 
-	.mejs-embed, 
-	.mejs-embed body, 
+.wp-block-jetpack-podcast-player {
+	.mejs-container,
+	.mejs-embed,
+	.mejs-embed body,
 	.mejs-container .mejs-controls {
 		background-color: $player-background;
 	}
@@ -221,7 +219,7 @@ $player-float-background: $light-gray-200;
 		border-top-color: $player-float-background;
 	}
 
-	.mejs-controls .mejs-time-rail .mejs-time-total, 
+	.mejs-controls .mejs-time-rail .mejs-time-total,
 	.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
 		background-color: $player-slider-background;
 	}
@@ -237,10 +235,10 @@ $player-float-background: $light-gray-200;
 
 	//Helper function that escapes the value of the color variable in the SVG.
 	//This way we can change the value in one place and easily add style variations.
-	@function encodecolor($string) {
-		@if type-of($string) == 'color' {
-			$hex: str-slice(ie-hex-str($string), 4);
-			$string:unquote("#{$hex}");
+	@function encodecolor( $string ) {
+		@if type-of( $string ) == 'color' {
+			$hex: str-slice( ie-hex-str( $string ), 4 );
+			$string: unquote( '#{$hex}' );
 		}
 		$string: '%23' + $string;
 		@return $string;
@@ -249,43 +247,43 @@ $player-float-background: $light-gray-200;
 	//For the buttons mejs is using an external SVG that's linked to via CSS.
 	//This is the same SVG but inlined in the CSS using a color variable.
 	.mejs-button > button {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E");
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E" );
 	}
- }
+}
 
-.jetpack-podcast-player__episode-status-icon {
-	flex: $episode-status-icon-size 0 0;
+.jetpack-podcast-player__track-status-icon {
+	flex: $track-status-icon-size 0 0;
 	fill: $text-color-active;
 
 	svg {
 		display: inline-block;
 		vertical-align: middle;
-		width: $episode-status-icon-size;
-		height: $episode-status-icon-size;
+		width: $track-status-icon-size;
+		height: $track-status-icon-size;
 	}
 }
 
-.jetpack-podcast-player__episode-status-icon--error {
+.jetpack-podcast-player__track-status-icon--error {
 	fill: $text-color-error;
 }
 
-.jetpack-podcast-player__episode-title {
+.jetpack-podcast-player__track-title {
 	flex-grow: 1;
-	padding: 0 $episode-v-padding;
+	padding: 0 $track-v-padding;
 }
 
-.jetpack-podcast-player__episode-duration {
+.jetpack-podcast-player__track-duration {
 	word-break: normal; // Prevents the time breaking into multiple lines.
 }
 
 /**
  * Error element, appended as the last child of the Episode element
- * (.jetpack-podcast-player__episode) when Player's error has been caught.
+ * (.jetpack-podcast-player__track) when Player's error has been caught.
  */
-.jetpack-podcast-player__episode-error {
+.jetpack-podcast-player__track-error {
 	display: block;
-	margin-left: 2 * $episode-v-padding + $episode-status-icon-size;
-	margin-bottom: $episode-h-padding;
+	margin-left: 2 * $track-v-padding + $track-status-icon-size;
+	margin-bottom: $track-h-padding;
 	color: $alert-red;
 	font-family: $default-font;
 	font-size: 0.8em;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -55,13 +55,13 @@ $player-float-background: $light-gray-200;
 		display: none;
 	}
 
-	.jetpack-podcast-player__header-title {
+	.jetpack-podcast-player__title {
 		display: flex;
 		flex-direction: column;
 		margin: 0;
 	}
 
-	a.jetpack-podcast-player__header-podcast-title {
+	a.jetpack-podcast-player__podcast-title {
 		text-decoration: none;
 		color: $text-color;
 
@@ -83,7 +83,7 @@ $player-float-background: $light-gray-200;
 /**
  * Podcast Player Header
  */
-.jetpack-podcast-player__header-wrapper {
+.jetpack-podcast-player__header {
 	display: flex;
 	flex-direction: column;
 	position: relative;
@@ -99,7 +99,7 @@ $player-float-background: $light-gray-200;
 	}
 }
 
-.jetpack-podcast-player__header-track-description {
+.jetpack-podcast-player__track-description {
 	order: 99; // high number to make it always appear after the audio player
 	padding: 0 $player-grid-spacing;
 	margin-bottom: $player-grid-spacing;
@@ -108,12 +108,12 @@ $player-float-background: $light-gray-200;
 	line-height: 1.6;
 }
 
-.jetpack-podcast-player__header {
+.jetpack-podcast-player__cover-wrapper {
 	display: flex;
 	padding: $player-grid-spacing;
 }
 
-.jetpack-podcast-player__header-image {
+.jetpack-podcast-player__cover {
 	width: $cover-image-size;
 	margin-right: $player-grid-spacing;
 	flex-shrink: 0;
@@ -124,12 +124,12 @@ $player-float-background: $light-gray-200;
 	}
 }
 
-.jetpack-podcast-player__header-track-title {
+.jetpack-podcast-player__current-track-title {
 	font-size: $track-title-font-size;
 	margin: 0 0 $track-title-b-margin;
 }
 
-.jetpack-podcast-player__header-podcast-title {
+.jetpack-podcast-player__podcast-title {
 	font-size: $podcast-title-font-size;
 	color: $text-color;
 	margin: 0;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -108,7 +108,7 @@ $player-float-background: $light-gray-200;
 	line-height: 1.6;
 }
 
-.jetpack-podcast-player__cover-wrapper {
+.jetpack-podcast-player__current-track-info {
 	display: flex;
 	padding: $player-grid-spacing;
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -55,13 +55,13 @@ $player-float-background: $light-gray-200;
 		display: none;
 	}
 
-	.jetpack-podcast-player__titles {
+	.jetpack-podcast-player__header-title {
 		display: flex;
 		flex-direction: column;
 		margin: 0;
 	}
 
-	.jetpack-podcast-player__title-link {
+	.jetpack-podcast-player__header-podcast-title-link {
 		text-decoration: none;
 		color: $text-color;
 
@@ -99,7 +99,7 @@ $player-float-background: $light-gray-200;
 	}
 }
 
-.jetpack-podcast-player__track-description {
+.jetpack-podcast-player__header-track-description {
 	order: 99; // high number to make it always appear after the audio player
 	padding: 0 $player-grid-spacing;
 	margin-bottom: $player-grid-spacing;
@@ -113,23 +113,23 @@ $player-float-background: $light-gray-200;
 	padding: $player-grid-spacing;
 }
 
-.jetpack-podcast-player__track-image-wrapper {
+.jetpack-podcast-player__header-image-wrapper {
 	width: $cover-image-size;
 	margin-right: $player-grid-spacing;
 	flex-shrink: 0;
 }
 
-.jetpack-podcast-player__track-image {
+.jetpack-podcast-player__header-image {
 	width: $cover-image-size;
 	height: $cover-image-size;
 }
 
-.jetpack-podcast-player__track-title {
+.jetpack-podcast-player__header-track-title {
 	font-size: $track-title-font-size;
 	margin: 0 0 $track-title-b-margin;
 }
 
-.jetpack-podcast-player__title {
+.jetpack-podcast-player__header-podcast-title {
 	font-size: $podcast-title-font-size;
 	color: $text-color;
 	margin: 0;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -61,7 +61,7 @@ $player-float-background: $light-gray-200;
 		margin: 0;
 	}
 
-	.jetpack-podcast-player__header-podcast-title-link {
+	a.jetpack-podcast-player__header-podcast-title {
 		text-decoration: none;
 		color: $text-color;
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -117,11 +117,11 @@ $player-float-background: $light-gray-200;
 	width: $cover-image-size;
 	margin-right: $player-grid-spacing;
 	flex-shrink: 0;
+}
 
-	& > img {
-		width: $cover-image-size;
-		height: $cover-image-size;
-	}
+.jetpack-podcast-player__cover-image {
+	width: $cover-image-size;
+	height: $cover-image-size;
 }
 
 .jetpack-podcast-player__current-track-title {


### PR DESCRIPTION
In the Player code, we refer to the track elements as both `track` and `episode`. This PR attempts to make the naming consistent with `track` as the name of choice.

#### Changes proposed in this Pull Request:

* Rename "episode" to "track" for consistency
* ...and resolve conflicts where e.g. suddenly some class names become identical but refer to 2 different things. E.g. the `jetpack-podcast-player__track-title` became a selector for both track title in the Player header and the Playlist. This basically means just figuring out new names for a few CSS classes.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a refactor, so no changes in how things work and look should be noticed.

#### Testing instructions:
Compare the block with the one on the `master` branch - they should work and look the same.

#### Example screenshot (editor):
![image](https://user-images.githubusercontent.com/1451471/78019121-64dc6f00-734f-11ea-9fa3-adaab70672ea.png)


#### Proposed changelog entry for your changes:
* Podcast Player: Rename "episode" to "track" for consistency
