### PR TITLE
Admin Page: place Photon section before VideoPress

### DIFF
--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -53,8 +53,8 @@ class Performance extends Component {
 					className="jp-settings-description"
 				/>
 				<Search { ...commonProps } />
-				<Media { ...commonProps } />
 				<SpeedUpSite { ...commonProps } />
+				<Media { ...commonProps } />
 			</div>
 		);
 	}


### PR DESCRIPTION
Follow-up from #15043.

#### Changes proposed in this Pull Request:

@jsnmoon @gibrown Could I have your opinion on this? This was changed in #15043, but it seems to me that Photon may be more valuable and important for most Jetpack site owners. Search can remain at the top of the section, which I think was the intended change, but do we need to change the order of the sections below?

#### Testing instructions:

* Go to Jetpack > Settings > Performance
* The cards should follow this order: 
    1. Search 
    2. Site Accelerator
    3. Videos
* They previously were set as Search - Videos - Site Accelerator

#### Proposed changelog entry for your changes:

* N/A
