### PR TITLE
Podcast Player: Improve MediaElement.js initialization

### DIFF
--- a/extensions/blocks/podcast-player/components/audio-player.js
+++ b/extensions/blocks/podcast-player/components/audio-player.js
@@ -17,17 +17,20 @@ class AudioPlayer extends Component {
 	audioRef = el => {
 		if ( el ) {
 			// Construct audio element.
-			this.audio = document.createElement( 'audio' );
-			this.audio.src = this.props.initialTrackSource;
+			const audio = document.createElement( 'audio' );
+			audio.src = this.props.initialTrackSource;
+
+			// Insert player into the DOM.
+			el.appendChild( audio );
+
+			// Initialize MediaElement.js.
+			this.mediaElement = new MediaElementPlayer( audio, meJsSettings );
+
+			// Save audio reference from the MediaElement.js instance.
+			this.audio = this.mediaElement.domNode;
 			this.audio.addEventListener( 'play', this.props.handlePlay );
 			this.audio.addEventListener( 'pause', this.props.handlePause );
 			this.audio.addEventListener( 'error', this.props.handleError );
-
-			// Insert player into the DOM.
-			el.appendChild( this.audio );
-
-			// Initialize MediaElement.js
-			this.mediaElement = new MediaElementPlayer( this.audio, meJsSettings );
 		} else {
 			// Cleanup.
 			this.mediaElement.remove();


### PR DESCRIPTION
Fixes #15202

#### Changes proposed in this Pull Request:
* Insead of using the audio element we create directly, ask the mediaelement library for it after it does its own initialization. That way things work well across browsers, specifically in Safari.

#### Testing instructions:
* In Safari, visit a page (frontend) with the podcast player block
* Try clicking the play button in the player
  - it should start loading (and eventually play) and the first episode should get the "playing" icon
* When the first episode audibly plays, select a different episode: 
  - the selection (bold text) and the playing icon should move over
  - the audio of the previous episode should get paused and the new episode should start loading & playing
- Confirm the behavior has not changed in other browsers

#### Proposed changelog entry for your changes:
* no
