### PR TITLE
add missing textdomain do gettext call

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -393,7 +393,7 @@ class The_Neverending_Home_Page {
 		$details = get_blog_details();
 		echo '<span>' . sprintf(
 			/* translators: Variables are the enclosing link to the settings page */
-			esc_html__( 'This option has moved. You can now manage it %1$shere%2$s.' ),
+			esc_html__( 'This option has moved. You can now manage it %1$shere%2$s.', 'jetpack' ),
 			'<a href="' . esc_url( 'https://wordpress.com/settings/writing/' . $details->domain ) . '">',
 			'</a>'
 		) . '</span>';


### PR DESCRIPTION
Adds a missing domain argument to a gettext function call

#### Testing instructions:

* Verify that the string is not present in WP core `.po` file
* Verify that the string IS present in jetpack's language package: https://translate.wordpress.org/projects/wp-plugins/jetpack/dev/en-gb/default/?filters%5Bterm%5D=This+option+has+moved.+You+can+now+manage+it&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc
