### PR TITLE
Eventbrite, Pinterest Blocks: Use new shared function to test embeddable URLs

### DIFF
--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -69,6 +69,7 @@ class EventbriteEdit extends Component {
 					url: resolvedUrl,
 				} );
 				setAttributes( newValidatedAttributes );
+				this.setState( { editedUrl: resolvedUrl } );
 				noticeOperations.removeAllNotices();
 			} )
 			.catch( () => {

--- a/extensions/blocks/eventbrite/edit.js
+++ b/extensions/blocks/eventbrite/edit.js
@@ -11,10 +11,11 @@ import {
 	Toolbar,
 	Spinner,
 	ExternalLink,
+	withNotices,
 } from '@wordpress/components';
 import { BlockControls, BlockIcon } from '@wordpress/block-editor';
 import { withDispatch } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -22,11 +23,12 @@ import apiFetch from '@wordpress/api-fetch';
 import attributeDetails from './attributes';
 import { convertToLink, eventIdFromUrl } from './utils';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
-import { icon, URL_REGEX } from '.';
+import { icon, URL_REGEX, EVENTBRITE_EXAMPLE_URL } from '.';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import ModalButtonPreview from './modal-button-preview';
 import EventbriteInPageExample from './eventbrite-in-page-example.png';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
+import testEmbedUrl from '../../shared/test-embed-url';
 import './editor.scss';
 
 const MODAL_BUTTON_STYLES = [
@@ -38,79 +40,20 @@ class EventbriteEdit extends Component {
 	state = {
 		editedUrl: this.props.attributes.url || '',
 		editingUrl: false,
-		// Resolve the url on mount if we haven't already set an eventId,
-		// Such as when transforming from an Eventbrite link.
-		resolvingUrl: this.props.attributes.url && ! this.props.attributes.eventId,
-		resolvedStatusCode: null,
+		isResolvingUrl: false,
 	};
 
 	componentDidMount() {
-		const { resolvingUrl } = this.state;
-
-		// Check if we need to resolve an Eventbrite URL immediately.
-		if ( resolvingUrl ) {
-			this.resolveUrl();
-		}
-	}
-
-	componentDidUpdate( prevProps, prevState ) {
-		// Check if an Eventbrite URL has been entered, so we need to resolve it.
-		if ( ! prevState.resolvingUrl && this.state.resolvingUrl ) {
-			this.resolveUrl();
-		}
-	}
-
-	// TODO: figure out how to cancel request since apiFetch was updated to use Promises rather than XHR requests.
-	// componentWillUnmount() {}
-
-	resolveUrl = () => {
 		const { url } = this.props.attributes;
 
-		this.setState( { resolvedStatusCode: null } );
+		this.setUrl( url );
+	}
 
-		this.fetchRequest = apiFetch( {
-			path: `/wpcom/v2/resolve-redirect/${ url }`,
-		} );
+	setUrl = url => {
+		const { attributes, noticeOperations, setAttributes } = this.props;
+		const { style } = attributes;
 
-		this.fetchRequest.then(
-			response => {
-				// resolve
-				this.fetchRequest = null;
-				const resolvedUrl = response.url || url;
-				const resolvedStatusCode = response.status ? parseInt( response.status, 10 ) : null;
-
-				this.props.setAttributes( {
-					eventId: eventIdFromUrl( resolvedUrl ),
-					url: resolvedUrl,
-				} );
-				this.setState( {
-					resolvingUrl: false,
-					resolvedStatusCode,
-					editedUrl: resolvedUrl,
-				} );
-			},
-			xhr => {
-				// reject
-				if ( xhr.statusText === 'abort' ) {
-					return;
-				}
-				this.fetchRequest = null;
-				this.setState( {
-					resolvingUrl: false,
-					editingUrl: true,
-				} );
-			}
-		);
-	};
-
-	setUrl = event => {
-		if ( event ) {
-			event.preventDefault();
-		}
-
-		const { editedUrl: url } = this.state;
-
-		if ( ! url ) {
+		if ( ! url || EVENTBRITE_EXAMPLE_URL === url || 'modal' === style ) {
 			return;
 		}
 
@@ -118,26 +61,56 @@ class EventbriteEdit extends Component {
 			eventId: eventIdFromUrl( url ),
 			url,
 		};
-		const validatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
 
-		this.props.setAttributes( validatedAttributes );
+		testEmbedUrl( newAttributes.url, this.setIsResolvingUrl )
+			.then( resolvedUrl => {
+				const newValidatedAttributes = getValidatedAttributes( attributeDetails, {
+					...newAttributes,
+					url: resolvedUrl,
+				} );
+				setAttributes( newValidatedAttributes );
+				noticeOperations.removeAllNotices();
+			} )
+			.catch( () => {
+				setAttributes( { eventId: undefined, url: undefined } );
+				this.setErrorNotice();
+			} );
+	};
 
-		// Setting the `resolvingUrl` state here, then waiting for `componentDidUpdate()` to
-		// be called before actually resolving it ensures that the `editedUrl` state has also been
-		// updated before resolveUrl() is called.
-		this.setState( {
-			editingUrl: false,
-			resolvingUrl: true,
-		} );
+	setIsResolvingUrl = isResolvingUrl => this.setState( { isResolvingUrl } );
+
+	setErrorNotice = () => {
+		const { noticeOperations, onReplace } = this.props;
+		const { editedUrl } = this.state;
+
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice(
+			<>
+				{ __( 'Sorry, this content could not be embedded.', 'jetpack' ) }{ ' ' }
+				<Button isLink onClick={ () => convertToLink( editedUrl, onReplace ) }>
+					{ _x( 'Convert block to link', 'button label', 'jetpack' ) }
+				</Button>
+			</>
+		);
+	};
+
+	submitForm = event => {
+		if ( event ) {
+			event.preventDefault();
+		}
+
+		const { editedUrl } = this.state;
+
+		this.setUrl( editedUrl );
+
+		this.setState( { editingUrl: false } );
 	};
 
 	cannotEmbed = () => {
 		const { url } = this.props.attributes;
-		const { resolvedStatusCode } = this.state;
+		const { isResolvingUrl } = this.state;
 
-		return (
-			( url && ! URL_REGEX.test( url ) ) || ( resolvedStatusCode && resolvedStatusCode >= 400 )
-		);
+		return ! isResolvingUrl && url && ! URL_REGEX.test( url );
 	};
 
 	renderLoading() {
@@ -211,7 +184,7 @@ class EventbriteEdit extends Component {
 	// @todo Remove isDefault and isLarge from Button when the minimum WP version
 	// supported by JP uses Gutenberg > 7.2
 	renderEditEmbed() {
-		const { className } = this.props;
+		const { className, noticeUI } = this.props;
 		const { editedUrl } = this.state;
 		const supportLink =
 			isSimpleSite() || isAtomicSite()
@@ -227,8 +200,9 @@ class EventbriteEdit extends Component {
 						'jetpack'
 					) }
 					icon={ <BlockIcon icon={ icon } /> }
+					notices={ noticeUI }
 				>
-					<form onSubmit={ this.setUrl }>
+					<form onSubmit={ this.submitForm }>
 						<input
 							type="url"
 							value={ editedUrl }
@@ -240,15 +214,6 @@ class EventbriteEdit extends Component {
 						<Button isLarge isSecondary type="submit">
 							{ _x( 'Embed', 'submit button label', 'jetpack' ) }
 						</Button>
-						{ this.cannotEmbed() && (
-							<p className="components-placeholder__error">
-								{ __( 'Sorry, this content could not be embedded.', 'jetpack' ) }
-								<br />
-								<Button isLarge onClick={ () => convertToLink( editedUrl, this.props.onReplace ) }>
-									{ _x( 'Convert block to link', 'button label', 'jetpack' ) }
-								</Button>
-							</p>
-						) }
 					</form>
 
 					<div className="components-placeholder__learn-more">
@@ -310,11 +275,11 @@ class EventbriteEdit extends Component {
 	render() {
 		const { attributes, addModalButtonStyles, removeModalButtonStyles, isSelected } = this.props;
 		const { url, style } = attributes;
-		const { editingUrl, resolvingUrl } = this.state;
+		const { editingUrl, isResolvingUrl } = this.state;
 
 		let component;
 
-		if ( resolvingUrl ) {
+		if ( isResolvingUrl ) {
 			removeModalButtonStyles();
 			component = this.renderLoading();
 		} else if ( editingUrl || ! url || this.cannotEmbed() ) {
@@ -352,22 +317,25 @@ class EventbriteEdit extends Component {
 	}
 }
 
-export default withDispatch( ( dispatch, { name }, { select } ) => {
-	const { getBlockStyles } = select( 'core/blocks' );
-	const styles = getBlockStyles( name );
-	return {
-		addModalButtonStyles() {
-			if ( styles.length < 1 ) {
-				dispatch( 'core/blocks' ).addBlockStyles( name, MODAL_BUTTON_STYLES );
-			}
-		},
-		removeModalButtonStyles() {
-			if ( styles.length > 0 ) {
-				dispatch( 'core/blocks' ).removeBlockStyles(
-					name,
-					MODAL_BUTTON_STYLES.map( style => style.name )
-				);
-			}
-		},
-	};
-} )( EventbriteEdit );
+export default compose(
+	withDispatch( ( dispatch, { name }, { select } ) => {
+		const { getBlockStyles } = select( 'core/blocks' );
+		const styles = getBlockStyles( name );
+		return {
+			addModalButtonStyles() {
+				if ( styles.length < 1 ) {
+					dispatch( 'core/blocks' ).addBlockStyles( name, MODAL_BUTTON_STYLES );
+				}
+			},
+			removeModalButtonStyles() {
+				if ( styles.length > 0 ) {
+					dispatch( 'core/blocks' ).removeBlockStyles(
+						name,
+						MODAL_BUTTON_STYLES.map( style => style.name )
+					);
+				}
+			},
+		};
+	} ),
+	withNotices
+)( EventbriteEdit );

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -21,6 +21,8 @@ export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:eventbrite\.[a-z.]+)\/e\/[
 // Custom eventbrite urls use a subdomain of eventbrite.com
 export const CUSTOM_URL_REGEX = /^\s*https?:\/\/(?:.+\.)?(?:eventbrite\.[a-z.]+)\/?(?:\?[^\/]*)?\s*$/i;
 
+export const EVENTBRITE_EXAMPLE_URL = 'https://www.eventbrite.com/e/test-event-tickets-123456789';
+
 export const name = 'eventbrite';
 
 export const title = __( 'Eventbrite Checkout', 'jetpack' );
@@ -71,7 +73,7 @@ export const settings = {
 	// Make sure the example has `useModal` set to true.
 	example: {
 		attributes: {
-			url: 'https://www.eventbrite.com/e/test-event-tickets-123456789',
+			url: EVENTBRITE_EXAMPLE_URL,
 			eventId: 123456789,
 			style: 'modal',
 			text: _x( 'Register', 'verb: e.g. register for an event.', 'jetpack' ),

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -13,6 +13,8 @@ import { pinType } from './utils';
 
 export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^/]+)(\/[^/]+)?/i;
 
+export const PINTEREST_EXAMPLE_URL = 'https://pinterest.com/anapinskywalker/';
+
 export const name = 'pinterest';
 export const title = __( 'Pinterest', 'jetpack' );
 
@@ -85,7 +87,7 @@ export const settings = {
 
 	example: {
 		attributes: {
-			url: 'https://pinterest.com/anapinskywalker/',
+			url: PINTEREST_EXAMPLE_URL,
 		},
 	},
 };

--- a/extensions/shared/test-embed-url.js
+++ b/extensions/shared/test-embed-url.js
@@ -17,25 +17,28 @@ import apiFetch from '@wordpress/api-fetch';
  *   .then( () => setAttributes( url ) )
  *   .catch( () => setErrorNotice() );
  *
- * @param {String} url The URL to test.
- * @param {Function} [setIsResolvingUrl=noop] An optional function to track the resolving state. Typically used to update the calling component's state.
+ * @param {string} url - The URL to test.
+ * @param {Function} [setIsResolvingUrl=noop] - An optional function to track the resolving state. Typically used to update the calling component's state.
  * @returns {Promise} Resolve if the URL is valid, reject otherwise.
  */
 export default function testEmbedUrl( url, setIsResolvingUrl = noop ) {
 	setIsResolvingUrl( true );
-	return new Promise( async ( resolve, reject ) => {
-		try {
-			const response = await apiFetch( { path: `/wpcom/v2/resolve-redirect/${ url }` } );
-			setIsResolvingUrl( false );
-			const responseStatusCode = response.status ? parseInt( response.status, 10 ) : null;
-			if ( responseStatusCode && responseStatusCode >= 400 ) {
+
+	return new Promise( ( resolve, reject ) => {
+		apiFetch( { path: `/wpcom/v2/resolve-redirect/${ url }` } ).then(
+			response => {
+				setIsResolvingUrl( false );
+				const responseStatusCode = response.status ? parseInt( response.status, 10 ) : null;
+				if ( responseStatusCode && responseStatusCode >= 400 ) {
+					reject();
+				} else {
+					resolve( response.url || url );
+				}
+			},
+			() => {
+				setIsResolvingUrl( false );
 				reject();
-			} else {
-				resolve( response.url || url );
 			}
-		} catch ( error ) {
-			setIsResolvingUrl( false );
-			reject();
-		}
+		);
 	} );
 }

--- a/extensions/shared/test-embed-url.js
+++ b/extensions/shared/test-embed-url.js
@@ -31,7 +31,7 @@ export default function testEmbedUrl( url, setIsResolvingUrl = noop ) {
 			if ( responseStatusCode && responseStatusCode >= 400 ) {
 				reject();
 			} else {
-				resolve();
+				resolve( response.url || url );
 			}
 		} catch ( error ) {
 			setIsResolvingUrl( false );

--- a/tests/e2e/lib/blocks/eventbrite.js
+++ b/tests/e2e/lib/blocks/eventbrite.js
@@ -30,8 +30,8 @@ export default class EventbriteBlock {
 
 		await waitAndClick( this.page, inputSelector );
 		await waitAndType( this.page, inputSelector, this.embedUrl() );
-
 		await waitAndClick( this.page, descriptionSelector );
+		await waitForSelector( this.page, '.wp-block-jetpack-eventbrite .components-sandbox' );
 	}
 
 	getSelector( selector ) {

--- a/tests/e2e/lib/blocks/pinterest.js
+++ b/tests/e2e/lib/blocks/pinterest.js
@@ -4,11 +4,12 @@
 import { waitForSelector, waitAndClick, waitAndType } from '../page-helper';
 
 export default class PinterestBlock {
-	constructor( block, page ) {
+	constructor( block, page, pinId ) {
 		this.blockTitle = PinterestBlock.title();
 		this.block = block;
 		this.page = page;
 		this.blockSelector = '#block-' + block.clientId;
+		this.pinId = pinId;
 	}
 
 	static name() {
@@ -19,8 +20,8 @@ export default class PinterestBlock {
 		return 'Pinterest';
 	}
 
-	static embedUrl() {
-		return 'https://www.pinterest.com/pin/180003316347175596/';
+	embedUrl() {
+		return `https://www.pinterest.com/pin/${ this.pinId }/`;
 	}
 
 	async addEmbed() {
@@ -28,9 +29,9 @@ export default class PinterestBlock {
 		const descriptionSelector = this.getSelector( "button[type='submit']" );
 
 		await waitAndClick( this.page, inputSelector );
-		await waitAndType( this.page, inputSelector, PinterestBlock.embedUrl() );
-
+		await waitAndType( this.page, inputSelector, this.embedUrl() );
 		await waitAndClick( this.page, descriptionSelector );
+		await waitForSelector( this.page, '.wp-block-jetpack-pinterest .components-sandbox' );
 	}
 
 	getSelector( selector ) {
@@ -40,9 +41,10 @@ export default class PinterestBlock {
 	/**
 	 * Checks whether block is rendered on frontend
 	 * @param {Page} page Puppeteer page instance
+	 * @param {Object} args An object of any additional required instance values
 	 */
-	static async isRendered( page ) {
-		const containerSelector = `.entry-content a[data-pin-do='embedPin'][href='${ PinterestBlock.embedUrl() }']`;
+	static async isRendered( page, args ) {
+		const containerSelector = `.entry-content span[data-pin-id='${ args.pinId }']`;
 
 		await waitForSelector( page, containerSelector );
 	}

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -20,13 +20,14 @@ describe( 'Free blocks', () => {
 
 	describe( 'Pinterest block', () => {
 		it( 'Can publish a post with a Pinterest block', async () => {
+			const pinId = '180003316347175596';
 			const blockEditor = await BlockEditorPage.visit( page );
 			const blockInfo = await blockEditor.insertBlock(
 				PinterestBlock.name(),
 				PinterestBlock.title()
 			);
 
-			const pinterestBlock = new PinterestBlock( blockInfo, page );
+			const pinterestBlock = new PinterestBlock( blockInfo, page, pinId );
 			await pinterestBlock.addEmbed();
 
 			await blockEditor.focus();
@@ -34,7 +35,7 @@ describe( 'Free blocks', () => {
 			await blockEditor.viewPost();
 
 			const frontend = await PostFrontendPage.init( page );
-			await frontend.isRenderedBlockPresent( PinterestBlock );
+			await frontend.isRenderedBlockPresent( PinterestBlock, { pinId } );
 		} );
 	} );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14439
Fixes #14896

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the `testEmbedUrl` shared function on Eventbrite and Pinterest.
* Use `withNotices` to warn when the provided URL is not embeddable.

⚠️ **NOTE**: I've commited with `--no-verify` because of a current issue with ESLint, that throws an error when parsing template literals.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Eventbrite: 
- Correct: https://www.eventbrite.com/e/a8c-test-event-tickets-90126734489
- Wrong: https://www.eventbrite.com/e/a8c-test-event-tickets-90126734489000

Pinterest:
- Correct: https://www.pinterest.com/anapinskywalker/
- Wrong: https://www.pinterest.com/anapinskywalker000/

* Perform the same tests with the provided URLs for both the Eventbrite and Pinterest blocks.
* Add a block and try embedding the correct URL: make sure it's embedded correctly.
* Add a block and try embedding the wrong URL: make sure it reverts to placeholder, with a notice offering to convert the URL to a link. Also make sure the conversion to link works as expected.
* Try pasting the correct URL in the editor: make sure it's converted into its block, and successfully embedded.
* Try pasting the wrong URL: make sure it's converted into its block, but to placeholder state with the error notice.
* Only for Eventbrite:
  * Add two blocks, both with the correct URL. Turn one of the blocks into a normal button (embed style "modal").
  * Save and reload.
  * Make sure the "embedding" spinner only shows up for the actual embedded version of the block, while the button/modal version appears immediately without loading.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (mostly behind the scene changes)
