### PR TITLE
Force refetch of feed when identical URL is submitted #15213

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -136,10 +136,8 @@ const PodcastPlayerEdit = ( {
 			return;
 		}
 
-		// Setting HTML `inputmode` to "url" allows non-http URLs whilst still
-		// allowing the user to see the most suitable keyboard on their device
-		// for entering URLs. However, this means we need to manually prepend
-		// "http" to any entry before attempting validation.
+		// Ensure URL has `http` appended to it (if it doesn't already) before
+		// we accept it as the entered URL.
 		const prependedURL = prependHTTP( editedUrl );
 
 		if ( ! isURL( prependedURL ) ) {
@@ -149,23 +147,13 @@ const PodcastPlayerEdit = ( {
 			return;
 		}
 
-		// If the URL is the same then it's likely it's being resubmitted via
-		// the UI due to the first attempt to fetch the feed erroring (eg: due
-		// to a network issue). However as the "new" `url` value matches the
-		// existing `url` attribute the `useEffect` call with `url` as a
-		// dependency will not be retriggered. Therefore in the case the values
-		// match we need to force a refetch.
-		// Note we could reset the `url` attribute on fetch failure. However,
-		// if the initial request to fetch the feedb from the URL fails the
-		// `url` attribute still needs to retained. This because if a block is
-		// inserted which already has a `url` attribute and the fetch fails we
-		// don't want that attribute to be wiped.
+		/*
+		 * Short-circuit feed fetching if we tried before, use useEffect otherwise.
+		 * @see {@link https://github.com/Automattic/jetpack/pull/15213}
+		 */
 		if ( prependedURL === url ) {
-			fetchFeed( url ); // force attempt to re-fetch the existing URL
+			fetchFeed( url );
 		} else {
-			// Update the attribute as usual and allow `useEffect` to handle fetching.
-			// Ensure URL has `http` appended to it (if it doesn't already) before
-			// we accept it as the entered URL.
 			setAttributes( { url: prependedURL } );
 		}
 


### PR DESCRIPTION
Sometimes, upon the submission of a valid Podcast URL, the network request fails or errors. This throws the player into an error state but the `url` attribute is (correctly) persisted to the Block attributes.

However, when you then try to resubmit the same URL to re-trigger the network request the Block will not update (or rather it stays forever in a "loading" state). This is because the `useEffect` which triggers the `apiFetch()` only runs when the `url` attributes is updated. This attribute is only considered "changed" if on calling `setAttributes()` the value is _different_. As a result the fetch doesn't trigger when attempting to submit the same URL.

For more see the steps in https://github.com/Automattic/jetpack/issues/15150

Fixes https://github.com/Automattic/jetpack/issues/15150
Closes #15213.

## Changes proposed in this Pull Request:
* Move fetch call to a `useCallback`.
* Call the callback from the existing `useEffect` which is dependent on a change to the `url` attribute.
* Add logic to the form `onSubmit` handler to manually force an fetch if the new URL is the same as the existing `url` attribute. 

## Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fix to existing Podcast Player Block feature.

## Testing instructions:

#### On Master
* Insert an empty Podcast Player block into a new post
* Open the network tab in devtools and keep it opened on a side
* Disable all network requests
* Go back to the block, input a valid podcast URL and submit
* Observe an error (because we cannot contact the API)
* Re-enable network requests
* Hit the submit button _again_ in the block
* See infinite loading spinner - it never resolves. 

#### On this branch
* Insert an empty Podcast Player block into a new post
* Open the network tab in devtools and keep it opened on a side
* Disable all network requests
* Go back to the block, input a valid podcast URL and submit
* Observe an error (because we cannot contact the API)
* Re-enable network requests
* Hit the submit button _again_ in the block
* See feed fetched correctly and Block renders the Player.

Also check that it continues to work on the normal happy path as well:
* Insert an empty Podcast Player block into a new post.
* Insert valid Podcast URL.
* Submit.
* See feed fetched correctly and Block renders the Player.


#### Proposed changelog entry for your changes:
* Fix Podcast Player Block to allow resubmission of same feed URL upon initial feed request failure.
