### PR TITLE
Feature: Podcast Player

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -18,6 +18,9 @@
 		<properties>
 			<property name="allowWordPressPassByRefFunctions" value="true" />
 		</properties>
+
+		<!-- Template files use extracted variables. -->
+		<exclude-pattern>/extensions/blocks/podcast-player/templates/*</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">

--- a/extensions/blocks/podcast-player/components/audio-player.js
+++ b/extensions/blocks/podcast-player/components/audio-player.js
@@ -7,6 +7,8 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -52,6 +54,7 @@ class AudioPlayer extends Component {
 	 */
 	pause = () => {
 		this.audio.pause();
+		speak( __( 'Paused', 'jetpack' ), 'assertive' );
 	};
 
 	/**

--- a/extensions/blocks/podcast-player/components/audio-player.js
+++ b/extensions/blocks/podcast-player/components/audio-player.js
@@ -17,17 +17,20 @@ class AudioPlayer extends Component {
 	audioRef = el => {
 		if ( el ) {
 			// Construct audio element.
-			this.audio = document.createElement( 'audio' );
-			this.audio.src = this.props.initialTrackSource;
+			const audio = document.createElement( 'audio' );
+			audio.src = this.props.initialTrackSource;
+
+			// Insert player into the DOM.
+			el.appendChild( audio );
+
+			// Initialize MediaElement.js.
+			this.mediaElement = new MediaElementPlayer( audio, meJsSettings );
+
+			// Save audio reference from the MediaElement.js instance.
+			this.audio = this.mediaElement.domNode;
 			this.audio.addEventListener( 'play', this.props.handlePlay );
 			this.audio.addEventListener( 'pause', this.props.handlePause );
 			this.audio.addEventListener( 'error', this.props.handleError );
-
-			// Insert player into the DOM.
-			el.appendChild( this.audio );
-
-			// Initialize MediaElement.js
-			this.mediaElement = new MediaElementPlayer( this.audio, meJsSettings );
 		} else {
 			// Cleanup.
 			this.mediaElement.remove();

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -6,7 +6,7 @@ import { memo } from '@wordpress/element';
 const Header = memo(
 	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
 		<div className="jetpack-podcast-player__header">
-			<div className="jetpack-podcast-player__current-track-info" aria-live="polite">
+			<div className="jetpack-podcast-player__current-track-info">
 				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__cover">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -5,31 +5,29 @@ import { memo } from '@wordpress/element';
 
 const Header = memo(
 	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
-		<div className="jetpack-podcast-player__header-wrapper">
-			<div className="jetpack-podcast-player__header" aria-live="polite">
-				{ showCoverArt && cover ? (
-					<div className="jetpack-podcast-player__track-image-wrapper">
+		<div className="jetpack-podcast-player__header">
+			<div className="jetpack-podcast-player__current-track-info" aria-live="polite">
+				{ showCoverArt && cover && (
+					<div className="jetpack-podcast-player__cover">
 						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
-						<img className="jetpack-podcast-player__track-image" src={ cover } alt="" />
+						<img className="jetpack-podcast-player__cover-image" src={ cover } alt="" />
 					</div>
-				) : null }
+				) }
 
-				{ title || ( track && track.title ) ? (
-					<div className="jetpack-podcast-player__titles">
-						<Title playerId={ playerId } title={ title } link={ link } track={ track } />
-					</div>
-				) : null }
+				{ !! ( title || ( track && track.title ) ) && (
+					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
+				) }
 			</div>
 
 			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
-			{ showEpisodeDescription && track && track.description ? (
+			{ !! ( showEpisodeDescription && track && track.description ) && (
 				<div
 					id={ `${ playerId }__track-description` }
 					className="jetpack-podcast-player__track-description"
 				>
 					{ track.description }
 				</div>
-			) : null }
+			) }
 
 			{ /* children contains the audio player */ }
 			{ children }
@@ -38,30 +36,32 @@ const Header = memo(
 );
 
 const Title = memo( ( { playerId, title, link, track } ) => (
-	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__titles">
-		{ track && track.title ? (
-			<span className="jetpack-podcast-player__track-title">{ track.title }</span>
-		) : null }
+	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
+		{ !! ( track && track.title ) && (
+			<span className="jetpack-podcast-player__current-track-title">{ track.title }</span>
+		) }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
-		{ track && track.title && title ? (
+		{ !! ( track && track.title && title ) && (
 			<span className="jetpack-podcast-player--visually-hidden"> - </span>
-		) : null }
+		) }
 
-		{ title ? <PodcastTitle title={ title } link={ link } /> : null }
+		{ !! title && <PodcastTitle title={ title } link={ link } /> }
 	</h2>
 ) );
 
-const PodcastTitle = memo( ( { title, link } ) => (
-	<span className="jetpack-podcast-player__title">
-		{ link ? (
-			<a className="jetpack-podcast-player__title-link" href={ link }>
+const PodcastTitle = memo( ( { title, link } ) => {
+	const className = 'jetpack-podcast-player__podcast-title';
+
+	if ( link ) {
+		return (
+			<a className={ className } href={ link } target="_blank" rel="noopener noreferrer nofollow">
 				{ title }
 			</a>
-		) : (
-			title
-		) }
-	</span>
-) );
+		);
+	}
+
+	return <span className={ className }>{ title }</span>;
+} );
 
 export default Header;

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -1,10 +1,15 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
 import { memo } from '@wordpress/element';
 
 const Header = memo(
-	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
+	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription, colors } ) => (
 		<div className="jetpack-podcast-player__header">
 			<div className="jetpack-podcast-player__current-track-info">
 				{ showCoverArt && cover && (
@@ -15,7 +20,13 @@ const Header = memo(
 				) }
 
 				{ !! ( title || ( track && track.title ) ) && (
-					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
+					<Title
+						playerId={ playerId }
+						title={ title }
+						link={ link }
+						track={ track }
+						colors={ colors }
+					/>
 				) }
 			</div>
 
@@ -35,10 +46,21 @@ const Header = memo(
 	)
 );
 
-const Title = memo( ( { playerId, title, link, track } ) => (
+const Title = memo( ( {
+	playerId,
+	title,
+	link,
+	track,
+	colors = { primary: { name: null, custom: null, classes: '' } }
+} ) => (
 	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
 		{ !! ( track && track.title ) && (
-			<span className="jetpack-podcast-player__current-track-title">{ track.title }</span>
+			<span
+				className={ classnames( 'jetpack-podcast-player__current-track-title', colors.primary.classes ) }
+				style={ { color: colors.primary.custom } }
+			>
+				{ track.title }
+			</span>
 		) }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
@@ -46,16 +68,22 @@ const Title = memo( ( { playerId, title, link, track } ) => (
 			<span className="jetpack-podcast-player--visually-hidden"> - </span>
 		) }
 
-		{ !! title && <PodcastTitle title={ title } link={ link } /> }
+		{ !! title && <PodcastTitle title={ title } link={ link } colors={ colors } /> }
 	</h2>
 ) );
 
-const PodcastTitle = memo( ( { title, link } ) => {
-	const className = 'jetpack-podcast-player__podcast-title';
+const PodcastTitle = memo( ( { title, link, colors = { secondary: { name: null, custom: null, classes: '' } } } ) => {
+	const className = classnames( 'jetpack-podcast-player__podcast-title', colors.secondary.classes );
 
 	if ( link ) {
 		return (
-			<a className={ className } href={ link } target="_blank" rel="noopener noreferrer nofollow">
+			<a
+				className={ className }
+				style={ { color: colors.secondary.custom } }
+				href={ link }
+				target="_blank"
+				rel="noopener noreferrer nofollow"
+			>
 				{ title }
 			</a>
 		);

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import * as episodeIcons from '../icons/episode-icons';
+import * as trackIcons from '../icons/track-icons';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
 
 const TrackIcon = ( { isPlaying, isError, className } ) => {
@@ -24,7 +24,7 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 		name = 'playing';
 	}
 
-	const icon = episodeIcons[ name ];
+	const icon = trackIcons[ name ];
 
 	if ( ! icon ) {
 		// Return empty element - we need it for layout purposes.
@@ -37,7 +37,7 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 import { getColorClassName } from '../utils';
 
 const TrackError = memo( ( { link } ) => (
-	<div className="jetpack-podcast-player__episode-error">
+	<div className="jetpack-podcast-player__track-error">
 		{ __( 'Episode unavailable', 'jetpack' ) }{ ' ' }
 		{ link && (
 			<span>
@@ -67,7 +67,7 @@ const Track = memo(
 		// Set CSS classes string.
 		const primaryColorClass = getColorClassName( 'color', colors.primary.name );
 		const secondaryColorClass = getColorClassName( 'color', colors.secondary.name );
-		const trackClassName = classnames( 'jetpack-podcast-player__episode', {
+		const trackClassName = classnames( 'jetpack-podcast-player__track', {
 			'is-active': isActive,
 			'has-primary': isActive && ( colors.primary.name || colors.primary.custom ),
 			[ primaryColorClass ]: isActive && !! primaryColorClass,
@@ -88,7 +88,7 @@ const Track = memo(
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
 			>
 				<a
-					className="jetpack-podcast-player__episode-link"
+					className="jetpack-podcast-player__track-link"
 					href={ track.link }
 					role="button"
 					aria-pressed="false"
@@ -113,36 +113,30 @@ const Track = memo(
 						// Prevent default behavior (scrolling one page down).
 						e.preventDefault();
 
-					// Select track.
-					selectTrack( index );
-				} }
-			>
-				<TrackIcon
-					className="jetpack-podcast-player__episode-status-icon"
-					isPlaying={ isPlaying }
-					isError={ isError }
-				/>
-				<span className="jetpack-podcast-player__episode-title">{ track.title }</span>
-				{ track.duration && (
-					<time className="jetpack-podcast-player__episode-duration">{ track.duration }</time>
-				) }
-			</a>
-			{ isActive && isError && <TrackError link={ track.link } /> }
-		</li>
-	);
-} );
+						// Select track.
+						selectTrack( index );
+					} }
+				>
+					<TrackIcon
+						className="jetpack-podcast-player__track-status-icon"
+						isPlaying={ isPlaying }
+						isError={ isError }
+					/>
+					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+					{ track.duration && (
+						<time className="jetpack-podcast-player__track-duration">{ track.duration }</time>
+					) }
+				</a>
+				{ isActive && isError && <TrackError link={ track.link } /> }
+			</li>
+		);
+	}
+);
 
-const Playlist = memo(
-	( {
-		tracks,
-		selectTrack,
-		currentTrack,
-		playerState,
-		colors,
-	} ) => {
-		return (
-			<ol className="jetpack-podcast-player__episodes">
-				{ tracks.map( ( track, index ) => {
+const Playlist = memo( ( { tracks, selectTrack, currentTrack, playerState, colors } ) => {
+	return (
+		<ol className="jetpack-podcast-player__tracks">
+			{ tracks.map( ( track, index ) => {
 				const isActive = currentTrack === index;
 
 				return (

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -48,10 +48,9 @@ import { getColorClassName } from '../utils';
 
 const TrackError = memo( ( { link, title } ) => (
 	<div className="jetpack-podcast-player__track-error">
-		{ __( 'Episode unavailable', 'jetpack' ) }
+		{ __( 'Episode unavailable. ', 'jetpack' ) }
 		{ link && (
 			<span>
-				{ ' - ' }
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
 					<span class="jetpack-podcast-player--visually-hidden">
 						{ /* Intentional trailing space outside of the translated string */ }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -169,21 +169,48 @@ export class PodcastPlayer extends Component {
 		const track = this.getTrack( currentTrack );
 
 		// Set CSS classes string.
+		const primaryColorClass = getColorClassName( 'color', primaryColor );
 		const secondaryColorClass = getColorClassName( 'color', secondaryColor );
 		const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
 
-		const cssClassesName = classnames( playerState, {
-			'has-secondary': secondaryColor || customSecondaryColor,
-			[ secondaryColorClass ]: secondaryColorClass,
-			'has-background': backgroundColor || customBackgroundColor,
-			[ backgroundColorClass ]: backgroundColorClass,
-		} );
+		const colors = {
+			primary: {
+				name: primaryColor,
+				custom: customPrimaryColor,
+				classes: classnames( {
+					'has-primary': primaryColorClass || customPrimaryColor,
+					[ primaryColorClass ]: primaryColorClass,
+				} ),
+			},
+			secondary: {
+				name: secondaryColor,
+				custom: customSecondaryColor,
+				classes: classnames( {
+					'has-secondary': secondaryColorClass || customSecondaryColor,
+					[ secondaryColorClass ]: secondaryColorClass,
+				} ),
+			},
+			background: {
+				name: backgroundColor,
+				custom: customBackgroundColor,
+				classes: classnames( {
+					'has-background': backgroundColorClass || customBackgroundColor,
+					[ backgroundColorClass ]: backgroundColorClass,
+				} ),
+			},
+		};
 
 		const inlineStyle = {
 			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
 			backgroundColor:
 				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
 		};
+
+		const cssClassesName = classnames(
+			playerState,
+			colors.secondary.classes,
+			colors.background.classes
+		);
 
 		return (
 			<section
@@ -204,6 +231,7 @@ export class PodcastPlayer extends Component {
 					track={ this.getTrack( currentTrack ) }
 					showCoverArt={ showCoverArt }
 					showEpisodeDescription={ showEpisodeDescription }
+					colors={ colors }
 				>
 					<AudioPlayer
 						initialTrackSource={ this.getTrack( 0 ).src }
@@ -233,16 +261,7 @@ export class PodcastPlayer extends Component {
 					currentTrack={ currentTrack }
 					tracks={ tracksToDisplay }
 					selectTrack={ this.selectTrack }
-					colors={ {
-						primary: {
-							name: primaryColor,
-							custom: customPrimaryColor,
-						},
-						secondary: {
-							name: secondaryColor,
-							custom: customSecondaryColor,
-						},
-					} }
+					colors={ colors }
 				/>
 			</section>
 		);

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -207,6 +207,7 @@ export class PodcastPlayer extends Component {
 		};
 
 		const cssClassesName = classnames(
+			'jetpack-podcast-player',
 			playerState,
 			colors.secondary.classes,
 			colors.background.classes

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -7,6 +7,8 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -67,8 +69,17 @@ export class PodcastPlayer extends Component {
 		if ( ! trackData ) {
 			return;
 		}
+
 		this.setState( { currentTrack: track } );
 		this.setAudioSource( trackData.src );
+
+		// Read that we're loading the track and its description. This is dismissible via ctrl on VoiceOver.
+		/* translators: %s is the track title. It describes the current state of the track as "Loading: [track title]" */
+		speak(
+			`${ sprintf( __( 'Loading: %s', 'jetpack' ), trackData.title ) } ${ trackData.description }`,
+			'assertive'
+		);
+
 		this.play();
 	};
 
@@ -88,6 +99,8 @@ export class PodcastPlayer extends Component {
 	 */
 	handleError = () => {
 		this.setState( { playerState: STATE_ERROR } );
+
+		speak( `${ __( 'Error: Episode unavailable - Open in a new tab', 'jetpack' ) }`, 'assertive' );
 	};
 
 	/**
@@ -200,7 +213,22 @@ export class PodcastPlayer extends Component {
 						ref={ this.playerRef }
 					/>
 				</Header>
+
+				<h4
+					id={ `jetpack-podcast-player__tracklist-title--${ playerId }` }
+					className="jetpack-podcast-player--visually-hidden"
+				>
+					{ /* translators: %s is the track title. This describes what the playlist goes with, like "Playlist: [name of the podcast]" */ }
+					{ sprintf( __( 'Playlist: %s', 'jetpack' ), title ) }
+				</h4>
+				<p
+					id={ `jetpack-podcast-player__tracklist-description--${ playerId }` }
+					className="jetpack-podcast-player--visually-hidden"
+				>
+					{ __( 'Select an episode to play it in the audio player.', 'jetpack' ) }
+				</p>
 				<Playlist
+					playerId={ playerId }
 					playerState={ playerState }
 					currentTrack={ currentTrack }
 					tracks={ tracksToDisplay }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -167,41 +167,44 @@ const PodcastPlayerEdit = ( {
 	 *
 	 * @param {object} event - Form on submit event object.
 	 */
-	const checkPodcastLink = useCallback( event => {
-		event.preventDefault();
-		removeAllNotices();
+	const checkPodcastLink = useCallback(
+		event => {
+			event.preventDefault();
+			removeAllNotices();
 
-		if ( ! editedUrl ) {
-			return;
-		}
+			if ( ! editedUrl ) {
+				return;
+			}
 
-		// Ensure URL has `http` appended to it (if it doesn't already) before
-		// we accept it as the entered URL.
-		const prependedURL = prependHTTP( editedUrl );
+			// Ensure URL has `http` appended to it (if it doesn't already) before
+			// we accept it as the entered URL.
+			const prependedURL = prependHTTP( editedUrl );
 
-		if ( ! isURL( prependedURL ) ) {
-			createErrorNotice(
-				__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
-			);
-			return;
-		}
+			if ( ! isURL( prependedURL ) ) {
+				createErrorNotice(
+					__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
+				);
+				return;
+			}
 
-		/*
-		 * Short-circuit feed fetching if we tried before, use useEffect otherwise.
-		 * @see {@link https://github.com/Automattic/jetpack/pull/15213}
-		 */
-		if ( prependedURL === url ) {
-			fetchFeed( url );
-		} else {
-			setAttributes( { url: prependedURL } );
-		}
+			/*
+			 * Short-circuit feed fetching if we tried before, use useEffect otherwise.
+			 * @see {@link https://github.com/Automattic/jetpack/pull/15213}
+			 */
+			if ( prependedURL === url ) {
+				fetchFeed( url );
+			} else {
+				setAttributes( { url: prependedURL } );
+			}
 
-		// Also update the temporary `input` value in order that clicking
-		// `Replace` in the UI will show the "corrected" version of the URL
-		// (ie: with `http` prepended if it wasn't originally present).
-		setEditedUrl( prependedURL );
-		setIsEditing( false );
-	} );
+			// Also update the temporary `input` value in order that clicking
+			// `Replace` in the UI will show the "corrected" version of the URL
+			// (ie: with `http` prepended if it wasn't originally present).
+			setEditedUrl( prependedURL );
+			setIsEditing( false );
+		},
+		[ editedUrl, url, fetchFeed, createErrorNotice, removeAllNotices, setAttributes ]
+	);
 
 	if ( isEditing || ! url ) {
 		return (

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -71,6 +71,7 @@ const PodcastPlayerEdit = ( {
 	backgroundColor: backgroundColorProp,
 	setBackgroundColor,
 	fallbackBackgroundColor,
+	isSelected,
 } ) => {
 	// Validated attributes.
 	const validatedAttributes = getValidatedAttributes( attributesValidation, attributes );
@@ -83,6 +84,7 @@ const PodcastPlayerEdit = ( {
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ feedData, setFeedData ] = useState( {} );
 	const cancellableFetch = useRef();
+	const [ isInteractive, setIsInteractive ] = useState( false );
 
 	const fetchFeed = useCallback(
 		urlToFetch => {
@@ -139,6 +141,13 @@ const PodcastPlayerEdit = ( {
 
 		fetchFeed( url );
 	}, [ fetchFeed, removeAllNotices, url ] );
+
+	// Bring back the overlay after block gets deselected.
+	useEffect( () => {
+		if ( ! isSelected && isInteractive ) {
+			setIsInteractive( false );
+		}
+	}, [ isSelected ] );
 
 	/**
 	 * Check if the current URL of the Podcast RSS feed
@@ -304,6 +313,19 @@ const PodcastPlayerEdit = ( {
 					title={ feedData.title }
 					link={ feedData.link }
 				/>
+				{
+					// Disabled because the overlay div doesn't actually have a role or functionality
+					// as far as the user is concerned. We're just catching the first click so that
+					// the block can be selected without interacting with the embed preview that the overlay covers.
+					/* eslint-disable jsx-a11y/no-static-element-interactions */
+				 }
+				{ ! isInteractive && (
+					<div
+						className="jetpack-podcast-player__interactive-overlay"
+						onMouseUp={ () => setIsInteractive( true ) }
+					/>
+				) }
+				{ /* eslint-enable jsx-a11y/no-static-element-interactions */ }
 			</div>
 		</>
 	);

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -110,11 +110,20 @@ const PodcastPlayerEdit = ( {
 						debug( 'Block was unmounted during fetch', error );
 						return; // bail if canceled to avoid setting state
 					}
-					// Show error and allow to edit URL.
-					debug( 'feed error', error );
-					createErrorNotice(
-						__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
-					);
+					if ( /\bspotify\b/i.test( encodedURL ) ) {
+						createErrorNotice(
+							__(
+								"It looks like you're trying to embed a podcast hosted on Spotify. Please use the Spotify block instead.",
+								'jetpack'
+							)
+						);
+					} else {
+						// Show error and allow to edit URL.
+						debug( 'feed error', error );
+						createErrorNotice(
+							__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
+						);
+					}
 					setIsEditing( true );
 				}
 			);
@@ -147,6 +156,7 @@ const PodcastPlayerEdit = ( {
 		if ( ! isSelected && isInteractive ) {
 			setIsInteractive( false );
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isSelected ] );
 
 	/**

--- a/extensions/blocks/podcast-player/editor.scss
+++ b/extensions/blocks/podcast-player/editor.scss
@@ -10,3 +10,12 @@
 	width: auto;
 	padding: 0 1em;
 }
+
+.jetpack-podcast-player__interactive-overlay {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	right: 0px;
+	bottom: 0px;
+	opacity: 0;
+}

--- a/extensions/blocks/podcast-player/editor.scss
+++ b/extensions/blocks/podcast-player/editor.scss
@@ -2,8 +2,6 @@
  * Editor styles for Podcast Player
  */
 
-.wp-block-jetpack-podcast-player { }
-
 /* Back-compat for pre-G2 ToolbarButton elements containing text */
 .block-editor-block-contextual-toolbar[data-type="jetpack/podcast-player"] .components-toolbar__control,
 [data-type="jetpack/podcast-player"] .block-editor-block-contextual-toolbar .components-toolbar__control {
@@ -13,9 +11,9 @@
 
 .jetpack-podcast-player__interactive-overlay {
 	position: absolute;
-	top: 0px;
-	left: 0px;
-	right: 0px;
-	bottom: 0px;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
 	opacity: 0;
 }

--- a/extensions/blocks/podcast-player/icons/track-icons.js
+++ b/extensions/blocks/podcast-player/icons/track-icons.js
@@ -4,7 +4,7 @@
 import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const EpisodeIcon = ( { name, title, children } ) => {
+const TrackIcon = ( { name, title, children } ) => {
 	const id = `jetpack-podcast-player__${ name }-icon`;
 
 	return (
@@ -24,15 +24,15 @@ const EpisodeIcon = ( { name, title, children } ) => {
 };
 
 export const playing = (
-	<EpisodeIcon name="playing" title={ __( 'Playing', 'jetpack' ) }>
+	<TrackIcon name="playing" title={ __( 'Playing', 'jetpack' ) }>
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z" />
-	</EpisodeIcon>
+	</TrackIcon>
 );
 
 export const error = (
-	<EpisodeIcon name="error" title={ __( 'Error', 'jetpack' ) }>
+	<TrackIcon name="error" title={ __( 'Error', 'jetpack' ) }>
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
-	</EpisodeIcon>
+	</TrackIcon>
 );

--- a/extensions/blocks/podcast-player/icons/track-icons.js
+++ b/extensions/blocks/podcast-player/icons/track-icons.js
@@ -4,34 +4,23 @@
 import { Path, SVG } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-const TrackIcon = ( { name, title, children } ) => {
-	const id = `jetpack-podcast-player__${ name }-icon`;
-
+const TrackIcon = ( { name, children } ) => {
 	return (
-		<SVG
-			height="24"
-			viewBox="0 0 24 24"
-			width="24"
-			xmlns="http://www.w3.org/2000/svg"
-			role="img"
-			aria-labelledby={ id }
-			aria-hidden={ undefined }
-		>
-			<title id={ id }>{ title }</title>
+		<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
 			{ children }
 		</SVG>
 	);
 };
 
 export const playing = (
-	<TrackIcon name="playing" title={ __( 'Playing', 'jetpack' ) }>
+	<TrackIcon name="playing">
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z" />
 	</TrackIcon>
 );
 
 export const error = (
-	<TrackIcon name="error" title={ __( 'Error', 'jetpack' ) }>
+	<TrackIcon name="error">
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
 	</TrackIcon>

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,7 +28,10 @@ export const settings = {
 	description: __( 'Select and play episodes from a single podcast.', 'jetpack' ),
 	icon: queueMusic,
 	category: 'jetpack',
-	keywords: [],
+	keywords: [
+		_x( 'audio', 'block search term', 'jetpack' ),
+		_x( 'embed', 'block search term', 'jetpack' ),
+	],
 	supports: {
 		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
 		align: false /* if set to true, the 'align' option below can be used*/,

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -139,6 +139,7 @@ function render_player( $player_data, $attributes ) {
 					$player_props,
 					array(
 						'primary_colors' => $primary_colors,
+						'player_id'      => $player_data['playerId'],
 					)
 				)
 			);
@@ -255,18 +256,14 @@ function render( $name, $template_props = array(), $print = true ) {
 		extract( $template_props ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 	}
 
-	ob_start();
-	include $template_path;
-	$markup = ob_get_contents();
-	ob_end_clean();
-
 	if ( $print ) {
-		// it's disabled in order to allow to templates
-		// render their content without HTML entities issues.
-		// However, each template is going to be checked
-		// guaranteeing the correct escape for the markup.
+		include $template_path;
+	} else {
+		ob_start();
+		include $template_path;
+		$markup = ob_get_contents();
+		ob_end_clean();
 
-		echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		return $markup;
 	}
-	return $markup;
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -115,6 +115,7 @@ function render_player( $player_data, $attributes ) {
 		$player_data
 	);
 
+	$primary_colors    = get_colors( 'primary', $attributes, 'color' );
 	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
@@ -133,22 +134,18 @@ function render_player( $player_data, $attributes ) {
 		>
 			<?php render( 'podcast-header', $player_props ); ?>
 			<ol class="jetpack-podcast-player__tracks">
-				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
-				<li
-					class="jetpack-podcast-player__track <?php echo esc_attr( $secondary_colors['class'] ); ?>"
-					style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
-				>
-					<a
-						class="jetpack-podcast-player__track-link"
-						href="<?php echo esc_url( $attachment['link'] ); ?>"
-						role="button"
-						aria-pressed="false"
-					>
-						<span class="jetpack-podcast-player__track-status-icon"></span>
-						<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="jetpack-podcast-player__track-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
-					</a>
-				</li>
+				<?php foreach ( $player_data['tracks'] as $track_index => $attachment ) : ?>
+					<?php
+					render(
+						'playlist-track',
+						array(
+							'is_active'        => 0 === $track_index,
+							'attachment'       => $attachment,
+							'primary_colors'   => $primary_colors,
+							'secondary_colors' => $secondary_colors,
+						)
+					);
+					?>
 				<?php endforeach; ?>
 			</ol>
 		</section>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -129,7 +129,7 @@ function render_player( $player_data, $attributes ) {
 	?>
 	<div class="<?php echo esc_attr( $block_classname ); ?>" id="<?php echo esc_attr( $instance_id ); ?>">
 		<section
-			class="<?php echo esc_attr( $player_classes_name ); ?>"
+			class="jetpack-podcast-player <?php echo esc_attr( $player_classes_name ); ?>"
 			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
 			<?php

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -132,7 +132,17 @@ function render_player( $player_data, $attributes ) {
 			class="<?php echo esc_attr( $player_classes_name ); ?>"
 			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
-			<?php render( 'podcast-header', $player_props ); ?>
+			<?php
+			render(
+				'podcast-header',
+				array_merge(
+					$player_props,
+					array(
+						'primary_colors' => $primary_colors,
+					)
+				)
+			);
+			?>
 			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $track_index => $attachment ) : ?>
 					<?php

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -31,14 +31,14 @@ function register_block() {
 		BLOCK_NAME,
 		array(
 			'attributes'      => array(
-				'url'                    => array(
+				'url'                  => array(
 					'type' => 'url',
 				),
-				'itemsToShow'            => array(
+				'itemsToShow'          => array(
 					'type'    => 'integer',
 					'default' => 5,
 				),
-				'showCoverArt'           => array(
+				'showCoverArt'         => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),
@@ -131,21 +131,21 @@ function render_player( $player_data, $attributes ) {
 			class="<?php echo esc_attr( $player_classes_name ); ?>"
 			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
-			<ol class="jetpack-podcast-player__episodes">
+			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 				<li
-					class="jetpack-podcast-player__episode <?php echo esc_attr( $secondary_colors['class'] ); ?>"
+					class="jetpack-podcast-player__track <?php echo esc_attr( $secondary_colors['class'] ); ?>"
 					style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
 				>
 					<a
-						class="jetpack-podcast-player__episode-link"
+						class="jetpack-podcast-player__track-link"
 						href="<?php echo esc_url( $attachment['link'] ); ?>"
 						role="button"
 						aria-pressed="false"
 					>
-						<span class="jetpack-podcast-player__episode-status-icon"></span>
-						<span class="jetpack-podcast-player__episode-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="jetpack-podcast-player__episode-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+						<span class="jetpack-podcast-player__track-status-icon"></span>
+						<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+						<time class="jetpack-podcast-player__track-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
 					</a>
 				</li>
 				<?php endforeach; ?>

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -95,6 +95,7 @@ $player-float-background: $light-gray-200;
 		display: flex;
 		flex-direction: column;
 		margin: 0;
+		overflow: hidden;
 	}
 
 	.jetpack-podcast-player__current-track-title {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -254,6 +254,10 @@ $player-float-background: $light-gray-200;
 		background-color: $player-background;
 	}
 
+	.mejs-controls {
+		position: static;
+	}
+
 	.mejs-time,
 	.mejs-time-float {
 		color: $player-text-color;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -55,9 +55,56 @@ $player-float-background: $light-gray-200;
 		display: none;
 	}
 
+	/**
+	 * Header elements styles
+	 */
+
+	.jetpack-podcast-player__header {
+		display: flex;
+		flex-direction: column;
+		position: relative;
+
+		&:after {
+			content: '';
+			background: $light-gray-700;
+			position: absolute;
+			height: $player-divider-height;
+			bottom: 0;
+			left: $player-grid-spacing;
+			right: $player-grid-spacing;
+		}
+	}
+
+	.jetpack-podcast-player__current-track-info {
+		display: flex;
+		padding: $player-grid-spacing;
+	}
+
+	.jetpack-podcast-player__cover {
+		width: $cover-image-size;
+		margin-right: $player-grid-spacing;
+		flex-shrink: 0;
+	}
+
+	.jetpack-podcast-player__cover-image {
+		width: $cover-image-size;
+		height: $cover-image-size;
+	}
+
 	.jetpack-podcast-player__title {
 		display: flex;
 		flex-direction: column;
+		margin: 0;
+	}
+
+	.jetpack-podcast-player__current-track-title {
+		font-size: $track-title-font-size;
+		margin: 0 0 $track-title-b-margin;
+	}
+
+	.jetpack-podcast-player__podcast-title {
+		font-size: $podcast-title-font-size;
+		color: $text-color;
 		margin: 0;
 	}
 
@@ -71,6 +118,23 @@ $player-float-background: $light-gray-200;
 		}
 	}
 
+	.jetpack-podcast-player__audio-player {
+		margin-bottom: $player-grid-spacing;
+	}
+
+	.jetpack-podcast-player__track-description {
+		order: 99; // high number to make it always appear after the audio player
+		padding: 0 $player-grid-spacing;
+		margin-bottom: $player-grid-spacing;
+		color: $dark-gray-500;
+		font-size: $description-font-size;
+		line-height: 1.6;
+	}
+
+	/**
+	 * Playlist elements styles
+	 */
+
 	.jetpack-podcast-player__tracks {
 		list-style-type: none;
 		display: flex;
@@ -78,89 +142,38 @@ $player-float-background: $light-gray-200;
 		margin: 0;
 		padding: $track-v-padding 0;
 	}
-}
 
-/**
- * Podcast Player Header
- */
-.jetpack-podcast-player__header {
-	display: flex;
-	flex-direction: column;
-	position: relative;
+	.jetpack-podcast-player__track {
+		margin: 0;
+		font-family: $default-font;
+		font-size: $editor-font-size;
 
-	&:after {
-		content: '';
-		background: $light-gray-700;
-		position: absolute;
-		height: $player-divider-height;
-		bottom: 0;
-		left: $player-grid-spacing;
-		right: $player-grid-spacing;
-	}
-}
+		/**
+		 * When track "is-active", it means that it's been clicked by a user to
+		 * start playback. Combine this class with the Player's state classes (see
+		 * above) to apply styling for different scenarios.
+		 */
+		&.is-active {
+			font-weight: bold;
+		}
 
-.jetpack-podcast-player__track-description {
-	order: 99; // high number to make it always appear after the audio player
-	padding: 0 $player-grid-spacing;
-	margin-bottom: $player-grid-spacing;
-	color: $dark-gray-500;
-	font-size: $description-font-size;
-	line-height: 1.6;
-}
+		// Apply default colors only if custom ones are not defined.
+		&:not( .is-active ):not( .has-secondary ) {
+			color: $text-color;
 
-.jetpack-podcast-player__current-track-info {
-	display: flex;
-	padding: $player-grid-spacing;
-}
+			&:hover,
+			&:focus {
+				color: $text-color-hover;
+			}
+		}
+		&.is-active:not( .has-primary ) {
+			color: $text-color-active;
 
-.jetpack-podcast-player__cover {
-	width: $cover-image-size;
-	margin-right: $player-grid-spacing;
-	flex-shrink: 0;
-}
-
-.jetpack-podcast-player__cover-image {
-	width: $cover-image-size;
-	height: $cover-image-size;
-}
-
-.jetpack-podcast-player__current-track-title {
-	font-size: $track-title-font-size;
-	margin: 0 0 $track-title-b-margin;
-}
-
-.jetpack-podcast-player__podcast-title {
-	font-size: $podcast-title-font-size;
-	color: $text-color;
-	margin: 0;
-}
-
-.jetpack-podcast-player__audio-player {
-	margin-bottom: $player-grid-spacing;
-}
-
-.jetpack-podcast-player__track {
-	margin: 0;
-	font-family: $default-font;
-	font-size: $editor-font-size;
-
-	/**
-	 * When track "is-active", it means that it's been clicked by a user to
-	 * start playback. Combine this class with the Player's state classes (see
-	 * above) to apply styling for different scenarios.
-	 */
-	&.is-active {
-		font-weight: bold;
-	}
-
-	/**
-	 * Applies default color to:
-	 * - The active podcast only if it doesn't have defined a custom color.
-	 * - The other podcasts only if they don't have defined a custom color.
-	 */
-	&.is-active:not( .has-primary ),
-	&:not( .is-active ):not( .has-secondary ) {
-		color: $text-color-hover;
+			&:hover,
+			&:focus {
+				color: $text-color-active;
+			}
+		}
 	}
 
 	// We need to scope this class to override editor link styles.
@@ -171,33 +184,69 @@ $player-float-background: $light-gray-200;
 		padding: $track-h-padding $track-v-padding;
 		text-decoration: none;
 		transition: none;
+		color: inherit;
 
 		&:hover,
 		&:focus {
-			color: $text-color-hover;
+			color: inherit;
+		}
+	}
+
+	// Make space for the error element that will be appended.
+	.is-error .jetpack-podcast-player__track.is-active .jetpack-podcast-player__track-link {
+		padding-bottom: 0;
+	}
+
+	.jetpack-podcast-player__track-status-icon {
+		flex: $track-status-icon-size 0 0;
+		fill: $text-color-active;
+
+		svg {
+			display: inline-block;
+			vertical-align: middle;
+			width: $track-status-icon-size;
+			height: $track-status-icon-size;
+		}
+	}
+
+	.jetpack-podcast-player__track-status-icon--error {
+		fill: $text-color-error;
+	}
+
+	.jetpack-podcast-player__track-title {
+		flex-grow: 1;
+		padding: 0 $track-v-padding;
+	}
+
+	.jetpack-podcast-player__track-duration {
+		word-break: normal; // Prevents the time breaking into multiple lines.
+	}
+
+	/**
+	 * Error element, appended as the last child of the Episode element
+	 * (.jetpack-podcast-player__track) when Player's error has been caught.
+	 */
+	.jetpack-podcast-player__track-error {
+		display: block;
+		margin-left: 2 * $track-v-padding + $track-status-icon-size;
+		margin-bottom: $track-h-padding;
+		color: $alert-red;
+		font-family: $default-font;
+		font-size: 0.8em;
+		font-weight: normal;
+
+		& > span {
+			color: $text-color;
+		}
+
+		& > span > a {
+			color: inherit;
 		}
 	}
 
 	/**
-	 * Inherits colors if:
-	 * - Active podcast has defined a custom color.
-	 * - The other podcasts if they have defined a custom color.
+	 * Style player by overriding mejs default styles
 	 */
-	&.is-active.has-primary .jetpack-podcast-player__track-link,
-	&.has-secondary .jetpack-podcast-player__track-link {
-		color: inherit;
-	}
-
-	// Make space for the error element that will be appended.
-	.is-error &.is-active .jetpack-podcast-player__track-link {
-		padding-bottom: 0;
-	}
-}
-
-/**
- * Style player by overriding mejs default styles
- */
-.wp-block-jetpack-podcast-player {
 	.mejs-container,
 	.mejs-embed,
 	.mejs-embed body,
@@ -248,52 +297,5 @@ $player-float-background: $light-gray-200;
 	//This is the same SVG but inlined in the CSS using a color variable.
 	.mejs-button > button {
 		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E" );
-	}
-}
-
-.jetpack-podcast-player__track-status-icon {
-	flex: $track-status-icon-size 0 0;
-	fill: $text-color-active;
-
-	svg {
-		display: inline-block;
-		vertical-align: middle;
-		width: $track-status-icon-size;
-		height: $track-status-icon-size;
-	}
-}
-
-.jetpack-podcast-player__track-status-icon--error {
-	fill: $text-color-error;
-}
-
-.jetpack-podcast-player__track-title {
-	flex-grow: 1;
-	padding: 0 $track-v-padding;
-}
-
-.jetpack-podcast-player__track-duration {
-	word-break: normal; // Prevents the time breaking into multiple lines.
-}
-
-/**
- * Error element, appended as the last child of the Episode element
- * (.jetpack-podcast-player__track) when Player's error has been caught.
- */
-.jetpack-podcast-player__track-error {
-	display: block;
-	margin-left: 2 * $track-v-padding + $track-status-icon-size;
-	margin-bottom: $track-h-padding;
-	color: $alert-red;
-	font-family: $default-font;
-	font-size: 0.8em;
-	font-weight: normal;
-
-	& > span {
-		color: $text-color;
-	}
-
-	& > span > a {
-		color: inherit;
 	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -56,6 +56,15 @@ $player-float-background: $light-gray-200;
 	}
 
 	/**
+	 * Reset vertical padding for <section /> elements.
+	 * For instance, Twenty-Twenty sets `padding: 8rem 0`.
+	 */
+	.jetpack-podcast-player {
+		padding-top: 0;
+		padding-bottom: 0;
+	}
+
+	/**
 	 * Header elements styles
 	 */
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -135,6 +135,12 @@ $player-float-background: $light-gray-200;
 		font-size: $description-font-size;
 		line-height: 1.6;
 		color: $dark-gray-500;
+		//crop the description if too long
+		display: -webkit-box;
+		-webkit-line-clamp: 4;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+		max-height: 105px; //IE11 fallback
 	}
 
 	.has-secondary { // custom color.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -125,7 +125,14 @@ $player-float-background: $light-gray-200;
 	}
 
 	.jetpack-podcast-player__audio-player {
+		height: 40px; // mirroring .mejs-container
 		margin-bottom: $player-grid-spacing;
+	}
+
+	.jetpack-podcast-player--audio-player-loading {
+		height: 10px; // mirroring .mejs-time-total
+		background: $player-slider-background;
+		margin: 15px $player-grid-spacing; // simulating spacing of .mejs-container
 	}
 
 	.jetpack-podcast-player__track-description {
@@ -259,6 +266,24 @@ $player-float-background: $light-gray-200;
 
 		& > span > a {
 			color: inherit;
+		}
+	}
+
+	/**
+	 * Style the block to hide dynamic UI and show just its default style.
+	 */
+	&.is-default {
+		.jetpack-podcast-player__track-title {
+			// Change padding to account for missing space for status-icon.
+			padding-left: $player-grid-spacing - $track-v-padding;
+		}
+
+		.jetpack-podcast-player__audio-player {
+			display: none;
+		}
+
+		&.is-default .jetpack-podcast-player__track-status-icon {
+			display: none;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -110,11 +110,17 @@ $player-float-background: $light-gray-200;
 
 	a.jetpack-podcast-player__podcast-title {
 		text-decoration: none;
-		color: $text-color;
 
 		&:hover,
 		&:focus {
 			color: $text-color-hover;
+		}
+	}
+
+	// Apply `secondary` color to the podcast title.
+	.has-secondary { // custom color.
+		.jetpack-podcast-player__podcast-title {
+			color: currentColor;
 		}
 	}
 
@@ -126,9 +132,15 @@ $player-float-background: $light-gray-200;
 		order: 99; // high number to make it always appear after the audio player
 		padding: 0 $player-grid-spacing;
 		margin-bottom: $player-grid-spacing;
-		color: $dark-gray-500;
 		font-size: $description-font-size;
 		line-height: 1.6;
+		color: $dark-gray-500;
+	}
+
+	.has-secondary { // custom color.
+		.jetpack-podcast-player__track-description {
+			color: currentColor;
+		}
 	}
 
 	/**

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -3,8 +3,8 @@
  */
 @import '../../shared/styles/gutenberg-base-styles.scss';
 
-$episode-v-padding: 15px;
-$episode-h-padding: 10px;
+$track-v-padding: 15px;
+$track-h-padding: 10px;
 $player-grid-spacing: 24px;
 $cover-image-size: 80px;
 $track-title-font-size: 24px;
@@ -12,7 +12,7 @@ $track-title-b-margin: 10px;
 $podcast-title-font-size: 16px;
 $description-font-size: 16px;
 $player-divider-height: 2px;
-$episode-status-icon-size: 22px;
+$track-status-icon-size: 22px;
 $text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
 $text-color-hover: $black;
 $text-color-active: $text-color-hover;
@@ -21,7 +21,7 @@ $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
 $player-text-color: $text-color;
 $player-background: transparent;
-$player-slider-background: $light-gray-600; 
+$player-slider-background: $light-gray-600;
 $player-slider-foreground: $dark-gray-100;
 $player-button-color: $dark-gray-100;
 $player-float-background: $light-gray-200;
@@ -55,13 +55,13 @@ $player-float-background: $light-gray-200;
 		display: none;
 	}
 
-	.jetpack-podcast-player__titles {
+	.jetpack-podcast-player__title {
 		display: flex;
 		flex-direction: column;
 		margin: 0;
 	}
 
-	.jetpack-podcast-player__title-link {
+	a.jetpack-podcast-player__podcast-title {
 		text-decoration: none;
 		color: $text-color;
 
@@ -71,19 +71,19 @@ $player-float-background: $light-gray-200;
 		}
 	}
 
-	.jetpack-podcast-player__episodes {
+	.jetpack-podcast-player__tracks {
 		list-style-type: none;
 		display: flex;
 		flex-direction: column;
 		margin: 0;
-		padding: $episode-v-padding 0;
+		padding: $track-v-padding 0;
 	}
 }
 
 /**
  * Podcast Player Header
  */
-.jetpack-podcast-player__header-wrapper {
+.jetpack-podcast-player__header {
 	display: flex;
 	flex-direction: column;
 	position: relative;
@@ -108,28 +108,28 @@ $player-float-background: $light-gray-200;
 	line-height: 1.6;
 }
 
-.jetpack-podcast-player__header {
+.jetpack-podcast-player__current-track-info {
 	display: flex;
 	padding: $player-grid-spacing;
 }
 
-.jetpack-podcast-player__track-image-wrapper {
+.jetpack-podcast-player__cover {
 	width: $cover-image-size;
 	margin-right: $player-grid-spacing;
 	flex-shrink: 0;
 }
 
-.jetpack-podcast-player__track-image {
+.jetpack-podcast-player__cover-image {
 	width: $cover-image-size;
 	height: $cover-image-size;
 }
 
-.jetpack-podcast-player__track-title {
+.jetpack-podcast-player__current-track-title {
 	font-size: $track-title-font-size;
 	margin: 0 0 $track-title-b-margin;
 }
 
-.jetpack-podcast-player__title {
+.jetpack-podcast-player__podcast-title {
 	font-size: $podcast-title-font-size;
 	color: $text-color;
 	margin: 0;
@@ -139,13 +139,13 @@ $player-float-background: $light-gray-200;
 	margin-bottom: $player-grid-spacing;
 }
 
-.jetpack-podcast-player__episode {
+.jetpack-podcast-player__track {
 	margin: 0;
 	font-family: $default-font;
 	font-size: $editor-font-size;
 
 	/**
-	 * When episode "is-active", it means that it's been clicked by a user to
+	 * When track "is-active", it means that it's been clicked by a user to
 	 * start playback. Combine this class with the Player's state classes (see
 	 * above) to apply styling for different scenarios.
 	 */
@@ -164,11 +164,11 @@ $player-float-background: $light-gray-200;
 	}
 
 	// We need to scope this class to override editor link styles.
-	.jetpack-podcast-player__episode-link {
+	.jetpack-podcast-player__track-link {
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		padding: $episode-h-padding $episode-v-padding;
+		padding: $track-h-padding $track-v-padding;
 		text-decoration: none;
 		transition: none;
 
@@ -183,13 +183,13 @@ $player-float-background: $light-gray-200;
 	 * - Active podcast has defined a custom color.
 	 * - The other podcasts if they have defined a custom color.
 	 */
-	&.is-active.has-primary .jetpack-podcast-player__episode-link,
-	&.has-secondary .jetpack-podcast-player__episode-link {
+	&.is-active.has-primary .jetpack-podcast-player__track-link,
+	&.has-secondary .jetpack-podcast-player__track-link {
 		color: inherit;
 	}
 
 	// Make space for the error element that will be appended.
-	.is-error &.is-active .jetpack-podcast-player__episode-link {
+	.is-error &.is-active .jetpack-podcast-player__track-link {
 		padding-bottom: 0;
 	}
 }
@@ -197,12 +197,10 @@ $player-float-background: $light-gray-200;
 /**
  * Style player by overriding mejs default styles
  */
-
- .wp-block-jetpack-podcast-player {
-
-	.mejs-container, 
-	.mejs-embed, 
-	.mejs-embed body, 
+.wp-block-jetpack-podcast-player {
+	.mejs-container,
+	.mejs-embed,
+	.mejs-embed body,
 	.mejs-container .mejs-controls {
 		background-color: $player-background;
 	}
@@ -221,7 +219,7 @@ $player-float-background: $light-gray-200;
 		border-top-color: $player-float-background;
 	}
 
-	.mejs-controls .mejs-time-rail .mejs-time-total, 
+	.mejs-controls .mejs-time-rail .mejs-time-total,
 	.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
 		background-color: $player-slider-background;
 	}
@@ -237,10 +235,10 @@ $player-float-background: $light-gray-200;
 
 	//Helper function that escapes the value of the color variable in the SVG.
 	//This way we can change the value in one place and easily add style variations.
-	@function encodecolor($string) {
-		@if type-of($string) == 'color' {
-			$hex: str-slice(ie-hex-str($string), 4);
-			$string:unquote("#{$hex}");
+	@function encodecolor( $string ) {
+		@if type-of( $string ) == 'color' {
+			$hex: str-slice( ie-hex-str( $string ), 4 );
+			$string: unquote( '#{$hex}' );
 		}
 		$string: '%23' + $string;
 		@return $string;
@@ -249,43 +247,43 @@ $player-float-background: $light-gray-200;
 	//For the buttons mejs is using an external SVG that's linked to via CSS.
 	//This is the same SVG but inlined in the CSS using a color variable.
 	.mejs-button > button {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E");
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E" );
 	}
- }
+}
 
-.jetpack-podcast-player__episode-status-icon {
-	flex: $episode-status-icon-size 0 0;
+.jetpack-podcast-player__track-status-icon {
+	flex: $track-status-icon-size 0 0;
 	fill: $text-color-active;
 
 	svg {
 		display: inline-block;
 		vertical-align: middle;
-		width: $episode-status-icon-size;
-		height: $episode-status-icon-size;
+		width: $track-status-icon-size;
+		height: $track-status-icon-size;
 	}
 }
 
-.jetpack-podcast-player__episode-status-icon--error {
+.jetpack-podcast-player__track-status-icon--error {
 	fill: $text-color-error;
 }
 
-.jetpack-podcast-player__episode-title {
+.jetpack-podcast-player__track-title {
 	flex-grow: 1;
-	padding: 0 $episode-v-padding;
+	padding: 0 $track-v-padding;
 }
 
-.jetpack-podcast-player__episode-duration {
+.jetpack-podcast-player__track-duration {
 	word-break: normal; // Prevents the time breaking into multiple lines.
 }
 
 /**
  * Error element, appended as the last child of the Episode element
- * (.jetpack-podcast-player__episode) when Player's error has been caught.
+ * (.jetpack-podcast-player__track) when Player's error has been caught.
  */
-.jetpack-podcast-player__episode-error {
+.jetpack-podcast-player__track-error {
 	display: block;
-	margin-left: 2 * $episode-v-padding + $episode-status-icon-size;
-	margin-bottom: $episode-h-padding;
+	margin-left: 2 * $track-v-padding + $track-status-icon-size;
+	margin-bottom: $track-h-padding;
 	color: $alert-red;
 	font-family: $default-font;
 	font-size: 0.8em;

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Podcast Title template.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$track_title    = $attachment['title'];
+$track_duration = ! empty( $attachment['duration'] ) ? $attachment['duration'] : '';
+
+$class = 'jetpack-podcast-player__track ' . $secondary_colors['class'];
+$style = $secondary_colors['style'];
+if ( $is_active ) {
+	$class = 'jetpack-podcast-player__track is-active ' . $primary_colors['class'];
+	$style = $primary_colors['style'];
+}
+
+?>
+
+<li
+	class="<?php echo esc_attr( $class ); ?>"
+	style="<?php echo esc_attr( $style ); ?>"
+>
+	<a
+		class="jetpack-podcast-player__track-link"
+		href="<?php echo esc_url( $attachment['link'] ); ?>"
+		role="button"
+		<?php echo $is_active ? 'aria-current="track"' : ''; ?>
+	>
+		<span class="jetpack-podcast-player__track-status-icon"></span>
+		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $track_title ); ?></span>
+		<time class="jetpack-podcast-player__track-duration"><?php echo esc_attr( $track_duration ); ?></time>
+	</a>
+</li>
+
+<?php
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -7,7 +7,14 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+/**
+ * Template variables.
+ *
+ * @var array $attachment
+ * @var array $primary_colors
+ * @var array $secondary_colors
+ * @var bool  $is_active
+ */
 
 $track_title    = $attachment['title'];
 $track_duration = ! empty( $attachment['duration'] ) ? $attachment['duration'] : '';
@@ -22,7 +29,7 @@ if ( $is_active ) {
 ?>
 
 <li
-	class="<?php echo esc_attr( $class ); ?>"
+	class="<?php echo esc_attr( trim( $class ) ); ?>"
 	style="<?php echo esc_attr( $style ); ?>"
 >
 	<a
@@ -36,6 +43,3 @@ if ( $is_active ) {
 		<time class="jetpack-podcast-player__track-duration"><?php echo esc_attr( $track_duration ); ?></time>
 	</a>
 </li>
-
-<?php
-// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -40,6 +40,6 @@ if ( $is_active ) {
 	>
 		<span class="jetpack-podcast-player__track-status-icon"></span>
 		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $track_title ); ?></span>
-		<time class="jetpack-podcast-player__track-duration"><?php echo esc_attr( $track_duration ); ?></time>
+		<time class="jetpack-podcast-player__track-duration"><?php echo esc_html( $track_duration ); ?></time>
 	</a>
 </li>

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Podcast Header Title template.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
+	return;
+}
+?>
+
+<h2 id=<?php echo esc_attr( $playerId ); ?>__title" class="jetpack-podcast-player__title">
+	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
+		<span class="jetpack-podcast-player__current-track-title">
+			<?php echo esc_attr( $track['title'] ); ?>
+		</span>
+	<?php endif; ?>
+
+	<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
+		<span class="jetpack-podcast-player--visually-hidden"> - </span>
+	<?php endif; ?>
+
+	<?php if ( isset( $title ) ) : ?>
+		<?php
+		render(
+			'podcast-title',
+			array(
+				'title' => $title,
+				'link'  => $link,
+			)
+		);
+		?>
+	<?php endif; ?>
+</h2>
+
+<?php
+// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -17,7 +17,10 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 
 <h2 id=<?php echo esc_attr( $playerId ); ?>__title" class="jetpack-podcast-player__title">
 	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
-		<span class="jetpack-podcast-player__current-track-title">
+		<span
+			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
+			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
+		>
 			<?php echo esc_attr( $track['title'] ); ?>
 		</span>
 	<?php endif; ?>

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -7,15 +7,22 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+/**
+ * Template variables.
+ *
+ * @var string $player_id
+ * @var string $title
+ * @var string $link
+ * @var array  $track
+ * @var array  $primary_colors
+ */
 
 if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 	return;
 }
 ?>
 
-<h2 id=<?php echo esc_attr( $playerId ); ?>__title" class="jetpack-podcast-player__title">
+<h2 id=<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
 	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
 		<span
 			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
@@ -41,7 +48,3 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 		?>
 	<?php endif; ?>
 </h2>
-
-<?php
-// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -28,7 +28,7 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
 			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
 		>
-			<?php echo esc_attr( $track['title'] ); ?>
+			<?php echo esc_html( $track['title'] ); ?>
 		</span>
 	<?php endif; ?>
 

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -22,7 +22,7 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 }
 ?>
 
-<h2 id=<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
+<h2 id="<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
 	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
 		<span
 			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -32,10 +32,11 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 			render(
 				'podcast-header-title',
 				array(
-					'playerId' => $playerId,
-					'title'    => $title,
-					'link'     => $link,
-					'track'    => $track,
+					'playerId'       => $playerId,
+					'title'          => $title,
+					'link'           => $link,
+					'track'          => $track,
+					'primary_colors' => $primary_colors,
 				)
 			);
 			?>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -57,7 +57,7 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 		id="<?php echo esc_attr( $player_id ); ?>__track-description"
 		class="jetpack-podcast-player__track-description"
 	>
-		<?php echo esc_attr( $track['description'] ); ?>
+		<?php echo esc_html( $track['description'] ); ?>
 	</div>
 	<?php endif; ?>
 

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -25,7 +25,8 @@ $show_cover_art           = (bool) $attributes['showCoverArt'];
 $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 
 // Current track.
-$track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : array();
+$tracks = $template_props['tracks'];
+$track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 ?>
 
 <div class="jetpack-podcast-player__header">

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -60,4 +60,8 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 		<?php echo esc_attr( $track['description'] ); ?>
 	</div>
 	<?php endif; ?>
+
+	<div class="jetpack-podcast-player__audio-player">
+		<div class="jetpack-podcast-player--audio-player-loading"></div>
+	</div>
 </div>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -7,8 +7,15 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+/**
+ * Template variables.
+ *
+ * @var array  $template_props
+ * @var string $player_id
+ * @var string $title
+ * @var string $link
+ * @var array  $primary_colors
+ */
 
 /**
  * Block attributes
@@ -32,7 +39,7 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 			render(
 				'podcast-header-title',
 				array(
-					'playerId'       => $playerId,
+					'player_id'      => $player_id,
 					'title'          => $title,
 					'link'           => $link,
 					'track'          => $track,
@@ -47,14 +54,10 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 	if ( $show_episode_description && ! empty( $track ) && isset( $track['description'] ) ) :
 		?>
 	<div
-		id="<?php echo esc_attr( $playerId ); ?>__track-description"
+		id="<?php echo esc_attr( $player_id ); ?>__track-description"
 		class="jetpack-podcast-player__track-description"
 	>
 		<?php echo esc_attr( $track['description'] ); ?>
 	</div>
 	<?php endif; ?>
 </div>
-
-<?php
-// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Podcast Header template.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+/**
+ * Block attributes
+ */
+$attributes               = (array) $template_props['attributes']; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$show_cover_art           = (bool) $attributes['showCoverArt'];
+$show_episode_description = (bool) $attributes['showEpisodeDescription'];
+
+// Current track.
+$track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : array();
+?>
+
+<div class="jetpack-podcast-player__header">
+	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
+		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
+			<div class="jetpack-podcast-player__cover">
+				<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
+			</div>
+
+			<?php
+			render(
+				'podcast-header-title',
+				array(
+					'playerId' => $playerId,
+					'title'    => $title,
+					'link'     => $link,
+					'track'    => $track,
+				)
+			);
+			?>
+		<?php endif; ?>
+	</div>
+
+	<?php
+	if ( $show_episode_description && ! empty( $track ) && isset( $track['description'] ) ) :
+		?>
+	<div
+		id="<?php echo esc_attr( $playerId ); ?>__track-description"
+		class="jetpack-podcast-player__track-description"
+	>
+		<?php echo esc_attr( $track['description'] ); ?>
+	</div>
+	<?php endif; ?>
+</div>
+
+<?php
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -25,7 +25,7 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
 		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
 			<div class="jetpack-podcast-player__cover">
-				<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
+				<img class="jetpack-podcast-player__cover-image" src="<?php echo esc_url( $cover ); ?>" alt="" />
 			</div>
 
 			<?php

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -26,11 +26,11 @@ if ( isset( $link ) ) :
 		target="_blank"
 		rel="noopener noreferrer nofollow"
 	>
-		<?php echo esc_attr( $title ); ?>
+		<?php echo esc_html( $title ); ?>
 	</a>
 <?php else : ?>
 	<span class="jetpack-podcast-player__podcast-title">
-		<?php echo esc_attr( $title ); ?>
+		<?php echo esc_html( $title ); ?>
 	</span>;
 	<?php
 endif;

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -14,11 +14,11 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  * @var string $link
  */
 
-if ( ! isset( $title ) ) {
+if ( empty( $title ) ) {
 	return;
 }
 
-if ( isset( $link ) ) :
+if ( ! empty( $link ) ) :
 	?>
 	<a
 		class="jetpack-podcast-player__podcast-title"

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Podcast Title template.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+if ( ! isset( $title ) ) {
+	return;
+}
+?>
+
+<?php if ( isset( $link ) ) : ?>
+	<a
+		class="jetpack-podcast-player__podcast-title"
+		href="<?php echo esc_url( $link ); ?>"
+		target="_blank"
+		rel="noopener noreferrer nofollow"
+	>
+		<?php echo esc_attr( $title ); ?>
+	</a>
+<?php else : ?>
+	<span class="jetpack-podcast-player__podcast-title">
+		<?php echo esc_attr( $title ); ?>
+	</span>;
+<?php endif; ?>
+
+<?php
+// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -7,15 +7,19 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
-// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
-// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+/**
+ * Template variables.
+ *
+ * @var string $title
+ * @var string $link
+ */
 
 if ( ! isset( $title ) ) {
 	return;
 }
-?>
 
-<?php if ( isset( $link ) ) : ?>
+if ( isset( $link ) ) :
+	?>
 	<a
 		class="jetpack-podcast-player__podcast-title"
 		href="<?php echo esc_url( $link ); ?>"
@@ -28,8 +32,5 @@ if ( ! isset( $title ) ) {
 	<span class="jetpack-podcast-player__podcast-title">
 		<?php echo esc_attr( $title ); ?>
 	</span>;
-<?php endif; ?>
-
-<?php
-// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+	<?php
+endif;

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -5,13 +5,11 @@
  * of compiled files used in the front-end.
  *
  * @example
- *     const className = getColorClassName( 'color', canvasPrimaryColor );
- *
- * @param {string} colorContextName Context/place where color is being used e.g: background, text etc...
- * @param {string} colorSlug        Slug of the color.
- *
- * @return {?string} String with the class corresponding to the color in the provided context.
- *                   Returns undefined if either colorContextName or colorSlug are not provided.
+ * const className = getColorClassName( 'color', canvasPrimaryColor );
+ * @param colorContextName - Context/place where color is being used e.g: background, text etc...
+ * @param colorSlug -        Slug of the color.
+ * @returns String with the class corresponding to the color in the provided context.
+ * Returns undefined if either colorContextName or colorSlug are not provided.
  */
 export function getColorClassName( colorContextName, colorSlug ) {
 	if ( ! colorContextName || ! colorSlug ) {
@@ -19,4 +17,32 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	}
 
 	return `has-${ colorSlug }-${ colorContextName }`;
+}
+
+/**
+ * Creates a wrapper around a promise which allows it to be programmatically
+ * cancelled. See: https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+ *
+ * @example
+ * const somePromise = makeCancellable( fetch('http://wordpress.org') );
+ * somePromise.promise.then()
+ * @param promise - the Promise to make cancelable
+ * @returns Object containing original promise object and cancel method.
+ */
+export function makeCancellable( promise ) {
+	let hasCanceled_ = false;
+
+	const wrappedPromise = new Promise( ( resolve, reject ) => {
+		promise.then(
+			val => ( hasCanceled_ ? reject( { isCanceled: true } ) : resolve( val ) ),
+			error => ( hasCanceled_ ? reject( { isCanceled: true } ) : reject( error ) )
+		);
+	} );
+
+	return {
+		promise: wrappedPromise,
+		cancel() {
+			hasCanceled_ = true;
+		},
+	};
 }


### PR DESCRIPTION
Remaining work on Podcast Player Block

#### Changes proposed in this Pull Request:
* Renamed "episode" to "track" for consistency (#15211) 
* Forces refetch of feed when identical URL is submitted (#15213)
*  Use audio element from me.js rather than building our own (#15215)
* Scoped podcast player styles for consistency (#15201)
* Made feed fetch call cancellable and cancel on Block removal (#15228)
* Prevents accidental triggering of audio when selecting the block (#15226)
* Updated podcast header rendering of server-side  fallback (#15221)
* Improved accessibility and Interactions (#15207)
* Added block keywords 
* Now truncates podcast description if too long (#15253)
* Updated error notice text when user is trying to embed a Spotify podcast (#15254)
* Documented template variables (#15250)
* Updated podcast colors client side (#15249)
* Added loading and default states (#15234)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updates Podcast Player block to be ready for `experimental` status upgrade

#### Testing instructions:

_**NOTE: it should be tested in Simple sites**_

General URL for testing: https://anchor.fm/s/9400d7c/podcast/rss

- Submit the same feed URL after failed submit attempt, make sure it fetches again.
  _Tip: Can be tested via blocking request or going offline for the first request._
- Confirm there are no errors when the block is removed before the request has finished.
  _Tip: In the Network Tools switch to "Slow 3G mode" to make it easier to test._ 
- In the editor, make sure that the first click only selects the block rather than e.g. starting playback when the play button or track element is clicked.
- On the front-end, make sure the block renders correctly with JavaScript disabled:
  - Cover art, first episode title, podcast title, and description should be rendered within Player's header,
  - The audio element should not be rendered,
  - Episodes list should be a simple list of links,
  - Every color and other custom block settings should be respected.
- Make sure the Player's accessibility and interactions are correctly announced:
  - Clicking a track should announce `Loading: [Track title] [Track Description]`.
  - Current track (currently selected) in most screen readers will announce `[track title], currently track`. In Safari with VoiceOver, it announces `[track title], current item`.
  - Clicking a currently playing track should announce `Paused`.
  - The error should announce `Error: Episode unavailable. (Open in a new window)`.
    _Tip: You can simulate an error by going offline and trying to play an episode._
- Make sure track description doesn't exceed 4 lines and is truncated with an ellipsis.
  _Tip: Use this URL https://investlikethebest.libsyn.com/rss (it has looooong descriptions)._
- Make sure that, when trying to embed a Spotify podcast, correct error notice is shown:
  > It looks like you're trying to embed a podcast hosted on Spotify. Please use the Spotify block instead.

  _Tip: Here's a Spotify podcast URL for you https://open.spotify.com/show/4XPl3uEEL9hvqMkoZrzbx5?si=8noFQsHjTpCMjtA-djqmMg._
- Make sure the custom colors are being set in both editor and front-end.
- Make sure the loading state is applied correctly:
  - Test on the frontend with Podcast Player block present
  - Disable JavaScript in your browser and reload
  - You should see very basic podcast player interface sans any interactive controls (as described above)
  - To check the loading state, in dev tools, remove class is-default from the block
- Make sure that all variables used in files in templates directory are properly documented in their headers.
#### Proposed changelog entry for your changes:
* Not sure if needed at this time?

#### Follow-up issues
- #15271 Break components into their own files
- #15272 Fix React memo optimizations
- #15275 Improve non-compatible URL detection