### PR TITLE
Podcast player: Render podcast header markup by server-side

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -31,14 +31,14 @@ function register_block() {
 		BLOCK_NAME,
 		array(
 			'attributes'      => array(
-				'url'                  => array(
+				'url'                    => array(
 					'type' => 'url',
 				),
-				'itemsToShow'          => array(
+				'itemsToShow'            => array(
 					'type'    => 'integer',
 					'default' => 5,
 				),
-				'showCoverArt'         => array(
+				'showCoverArt'           => array(
 					'type'    => 'boolean',
 					'default' => true,
 				),
@@ -213,4 +213,33 @@ function get_colors( $name, $attrs, $property ) {
 	}
 
 	return $colors;
+}
+
+/**
+ * Render the given podcast template.
+ *
+ * @param string $name  Template name, available in `./templates` folder.
+ * @param array  $data   Template data. Optional.
+ * @param bool   $print   Render template. True as default.
+ * @return false|string HTML markup or false.
+ */
+function render( $name, $data = array(), $print = true ) {
+	if ( ! strpos( $name, '.php' ) ) {
+		$name = $name . '.php';
+	}
+
+	$template_path = dirname( __FILE__ ) . '/templates/' . $name;
+	if ( ! file_exists( $template_path ) ) {
+		return '';
+	}
+
+	ob_start();
+	include $template_path;
+	$markup = ob_get_contents();
+	ob_end_clean();
+
+	if ( $print ) {
+		echo esc_attr( $markup );
+	}
+	return $markup;
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -238,9 +238,7 @@ function render( $name, $data = array(), $print = true ) {
 	// Optionally provided an assoc array of data to pass to template
 	// and it will be extracted into variables.
 	if ( is_array( $data ) ) {
-		// phpcs:disable WordPress.PHP.DontExtract.extract_extract
-		extract( $data );
-		// phpcs:enable WordPress.PHP.DontExtract.extract_extract
+		extract( $data ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 	}
 
 	ob_start();

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -249,6 +249,11 @@ function render( $name, $data = array(), $print = true ) {
 	ob_end_clean();
 
 	if ( $print ) {
+		// it's disabled in order to allow to templates
+		// render their content without HTML entities issues.
+		// However, each template is going to be checked
+		// guaranteeing the correct escape for the markup.
+
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $markup;
 		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -217,7 +217,7 @@ function get_colors( $name, $attrs, $property ) {
 }
 
 /**
- * Render the given podcast template.
+ * Render the given template in server-side.
  *
  * @param string $name  Template name, available in `./templates` folder.
  * @param array  $data   Template data. Optional.
@@ -235,10 +235,12 @@ function render( $name, $data = array(), $print = true ) {
 		return '';
 	}
 
-	// Optionally provided an assoc array of data to pass to tempalte
-	// and it will be extracted into variables
+	// Optionally provided an assoc array of data to pass to template
+	// and it will be extracted into variables.
 	if ( is_array( $data ) ) {
+		// phpcs:disable WordPress.PHP.DontExtract.extract_extract
 		extract( $data );
+		// phpcs:enable WordPress.PHP.DontExtract.extract_extract
 	}
 
 	ob_start();
@@ -247,7 +249,9 @@ function render( $name, $data = array(), $print = true ) {
 	ob_end_clean();
 
 	if ( $print ) {
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $markup;
+		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 	return $markup;
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -131,6 +131,7 @@ function render_player( $player_data, $attributes ) {
 			class="<?php echo esc_attr( $player_classes_name ); ?>"
 			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
+			<?php render( 'podcast-header', $player_props ); ?>
 			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
 				<li
@@ -239,7 +240,7 @@ function render( $name, $data = array(), $print = true ) {
 	ob_end_clean();
 
 	if ( $print ) {
-		echo esc_attr( $markup );
+		echo $markup;
 	}
 	return $markup;
 }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -218,6 +218,11 @@ function get_colors( $name, $attrs, $property ) {
 
 /**
  * Render the given template in server-side.
+ * Important note:
+ *    The $template_props array will be extracted.
+ *    This means it will create a var for each array item.
+ *    Keep it mind when using this param to pass
+ *    properties to the template.
  *
  * @param string $name           Template name, available in `./templates` folder.
  * @param array  $template_props Template properties. Optional.
@@ -236,8 +241,10 @@ function render( $name, $template_props = array(), $print = true ) {
 	}
 
 	// Optionally provided an assoc array of data to pass to template
-	// and it will be extracted into variables.
+	// IMPORTANT: It will be extracted into variables.
 	if ( is_array( $template_props ) ) {
+		// It ignores the `discouraging` sniffer rule for extract,
+		// since it's needed to make the templating system works.
 		extract( $template_props ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 	}
 

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -230,8 +230,15 @@ function render( $name, $data = array(), $print = true ) {
 	}
 
 	$template_path = dirname( __FILE__ ) . '/templates/' . $name;
+
 	if ( ! file_exists( $template_path ) ) {
 		return '';
+	}
+
+	// Optionally provided an assoc array of data to pass to tempalte
+	// and it will be extracted into variables
+	if ( is_array( $data ) ) {
+		extract( $data );
 	}
 
 	ob_start();

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -219,12 +219,12 @@ function get_colors( $name, $attrs, $property ) {
 /**
  * Render the given template in server-side.
  *
- * @param string $name  Template name, available in `./templates` folder.
- * @param array  $data   Template data. Optional.
- * @param bool   $print   Render template. True as default.
- * @return false|string HTML markup or false.
+ * @param string $name           Template name, available in `./templates` folder.
+ * @param array  $template_props Template properties. Optional.
+ * @param bool   $print          Render template. True as default.
+ * @return false|string          HTML markup or false.
  */
-function render( $name, $data = array(), $print = true ) {
+function render( $name, $template_props = array(), $print = true ) {
 	if ( ! strpos( $name, '.php' ) ) {
 		$name = $name . '.php';
 	}
@@ -237,8 +237,8 @@ function render( $name, $data = array(), $print = true ) {
 
 	// Optionally provided an assoc array of data to pass to template
 	// and it will be extracted into variables.
-	if ( is_array( $data ) ) {
-		extract( $data ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
+	if ( is_array( $template_props ) ) {
+		extract( $template_props ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 	}
 
 	ob_start();
@@ -252,9 +252,7 @@ function render( $name, $data = array(), $print = true ) {
 		// However, each template is going to be checked
 		// guaranteeing the correct escape for the markup.
 
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo $markup;
-		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 	return $markup;
 }

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
+	return;
+}
+?>
+
+<h2 id=<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
+	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
+		<span class="jetpack-podcast-player__current-track-title">
+			<?php echo $track['title']; ?>
+		</span>
+	<?php endif; ?>
+
+	<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
+		<span class="jetpack-podcast-player--visually-hidden"> - </span>
+	<?php endif; ?>
+
+	<?php if ( isset( $title ) ) : ?>
+		<?php
+		render(
+			'podcast-title',
+			array(
+				'title' => $title,
+				'link'  => $link,
+			)
+		);
+		?>
+	<?php endif; ?>
+</h2>

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -1,16 +1,24 @@
 <?php
+/**
+ * Podcast Header Title template.
+ *
+ * @package Jetpack
+ */
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 	return;
 }
 ?>
 
-<h2 id=<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
+<h2 id=<?php echo esc_attr( $playerId ); ?>__title" class="jetpack-podcast-player__title">
 	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
 		<span class="jetpack-podcast-player__current-track-title">
-			<?php echo $track['title']; ?>
+			<?php echo esc_attr( $track['title'] ); ?>
 		</span>
 	<?php endif; ?>
 
@@ -30,3 +38,7 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 		?>
 	<?php endif; ?>
 </h2>
+
+<?php
+// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Podcast Header template.
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Block attributes
+ */
+
+$attributes = (array) $data['attributes'];
+
+/**
+ * Player data.
+ */
+
+$player_id                = (string) $data['playerId'];
+$cover                    = (string) $data['cover'];
+$link                     = (string) $data['link'];
+$track                    = ! empty( $data['tracks'] ) ? $data['tracks'][0] : array();
+$show_cover_art           = (bool) $attributes['showCoverArt'];
+$show_episode_description = (bool) $attributes['showEpisodeDescription'];
+?>
+
+<div class="jetpack-podcast-player__header">
+	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
+		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
+		<div class="jetpack-podcast-player__cover">
+			<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
+		</div>
+		<?php endif; ?>
+	</div>
+
+	<?php
+	if ( $show_episode_description && ! empty( $track ) && isset( $track['description'] ) ) :
+		?>
+
+	<div
+		id="<?php echo esc_attr( $player_id ); ?>__track-description"
+		class="jetpack-podcast-player__track-description"
+	>
+		<?php echo esc_attr( $track['description'] ); ?>
+	</div>
+	<?php endif; ?>
+</div>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -13,12 +13,12 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 /**
  * Block attributes
  */
-$attributes               = (array) $data['attributes'];
+$attributes               = (array) $template_props['attributes']; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 $show_cover_art           = (bool) $attributes['showCoverArt'];
 $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 
 // Current track.
-$track = ! empty( $data['tracks'] ) ? $data['tracks'][0] : array();
+$track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : array();
 ?>
 
 <div class="jetpack-podcast-player__header">

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -25,61 +25,24 @@ $show_cover_art           = (bool) $attributes['showCoverArt'];
 $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 ?>
 
-
-<?php
-function render_podcast_title( $title, $link ) {
-	if ( ! isset( $title ) ) {
-		return;
-	}
-	?>
-
-	<?php if ( isset( $link ) ) : ?>
-		<a
-			class="jetpack-podcast-player__podcast-title"
-			href="<?php echo esc_url( $link ); ?>"
-			target="_blank"
-			rel="noopener noreferrer nofollow"
-		>
-			<?php echo esc_attr( $title ); ?>
-		</a>
-	<?php else : ?>
-		<span class="jetpack-podcast-player__podcast-title">
-			<?php echo esc_attr( $title ); ?>
-		</span>;
-	<?php endif; ?>
-<?php } ?>
-
-<?php
-function render_title( $player_id, $title, $link, $track ) {
-	if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
-		return;
-	}
-	?>
-	<h2 id=<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
-		<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
-			<span class="jetpack-podcast-player__current-track-title">
-				<?php echo $track['title']; ?>
-			</span>
-		<?php endif; ?>
-
-		<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
-			<span class="jetpack-podcast-player--visually-hidden"> - </span>
-		<?php endif; ?>
-
-		<?php if ( isset( $title ) ) : ?>
-			<?php render_podcast_title( $title, $link ); ?>
-		<?php endif; ?>
-	</h2>
-<?php } ?>
-
 <div class="jetpack-podcast-player__header">
 	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
 		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
-		<div class="jetpack-podcast-player__cover">
-			<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
-		</div>
+			<div class="jetpack-podcast-player__cover">
+				<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
+			</div>
 
-			<?php render_title( $player_id, $title, $link, $track ); ?>
+			<?php
+			render(
+				'podcast-header-title',
+				array(
+					'player_id' => $player_id,
+					'title'     => $title,
+					'link'      => $link,
+					'track'     => $track,
+				)
+			);
+			?>
 		<?php endif; ?>
 	</div>
 

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -7,22 +7,18 @@
 
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
 /**
  * Block attributes
  */
-$attributes = (array) $data['attributes'];
-
-/**
- * Player data.
- */
-
-$player_id                = (string) $data['playerId'];
-$title                    = (string) $data['title'];
-$cover                    = (string) $data['cover'];
-$link                     = (string) $data['link'];
-$track                    = ! empty( $data['tracks'] ) ? $data['tracks'][0] : array();
+$attributes               = (array) $data['attributes'];
 $show_cover_art           = (bool) $attributes['showCoverArt'];
 $show_episode_description = (bool) $attributes['showEpisodeDescription'];
+
+// Current track.
+$track = ! empty( $data['tracks'] ) ? $data['tracks'][0] : array();
 ?>
 
 <div class="jetpack-podcast-player__header">
@@ -36,10 +32,10 @@ $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 			render(
 				'podcast-header-title',
 				array(
-					'player_id' => $player_id,
-					'title'     => $title,
-					'link'      => $link,
-					'track'     => $track,
+					'playerId' => $playerId,
+					'title'    => $title,
+					'link'     => $link,
+					'track'    => $track,
 				)
 			);
 			?>
@@ -50,10 +46,14 @@ $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 	if ( $show_episode_description && ! empty( $track ) && isset( $track['description'] ) ) :
 		?>
 	<div
-		id="<?php echo esc_attr( $player_id ); ?>__track-description"
+		id="<?php echo esc_attr( $playerId ); ?>__track-description"
 		class="jetpack-podcast-player__track-description"
 	>
 		<?php echo esc_attr( $track['description'] ); ?>
 	</div>
 	<?php endif; ?>
 </div>
+
+<?php
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -5,10 +5,11 @@
  * @package Jetpack
  */
 
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
 /**
  * Block attributes
  */
-
 $attributes = (array) $data['attributes'];
 
 /**
@@ -16,6 +17,7 @@ $attributes = (array) $data['attributes'];
  */
 
 $player_id                = (string) $data['playerId'];
+$title                    = (string) $data['title'];
 $cover                    = (string) $data['cover'];
 $link                     = (string) $data['link'];
 $track                    = ! empty( $data['tracks'] ) ? $data['tracks'][0] : array();
@@ -23,19 +25,67 @@ $show_cover_art           = (bool) $attributes['showCoverArt'];
 $show_episode_description = (bool) $attributes['showEpisodeDescription'];
 ?>
 
+
+<?php
+function render_podcast_title( $title, $link ) {
+	if ( ! isset( $title ) ) {
+		return;
+	}
+	?>
+
+	<?php if ( isset( $link ) ) : ?>
+		<a
+			class="jetpack-podcast-player__podcast-title"
+			href="<?php echo esc_url( $link ); ?>"
+			target="_blank"
+			rel="noopener noreferrer nofollow"
+		>
+			<?php echo esc_attr( $title ); ?>
+		</a>
+	<?php else : ?>
+		<span class="jetpack-podcast-player__podcast-title">
+			<?php echo esc_attr( $title ); ?>
+		</span>;
+	<?php endif; ?>
+<?php } ?>
+
+<?php
+function render_title( $player_id, $title, $link, $track ) {
+	if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
+		return;
+	}
+	?>
+	<h2 id=<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
+		<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
+			<span class="jetpack-podcast-player__current-track-title">
+				<?php echo $track['title']; ?>
+			</span>
+		<?php endif; ?>
+
+		<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
+			<span class="jetpack-podcast-player--visually-hidden"> - </span>
+		<?php endif; ?>
+
+		<?php if ( isset( $title ) ) : ?>
+			<?php render_podcast_title( $title, $link ); ?>
+		<?php endif; ?>
+	</h2>
+<?php } ?>
+
 <div class="jetpack-podcast-player__header">
 	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
 		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
 		<div class="jetpack-podcast-player__cover">
 			<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
 		</div>
+
+			<?php render_title( $player_id, $title, $link, $track ); ?>
 		<?php endif; ?>
 	</div>
 
 	<?php
 	if ( $show_episode_description && ! empty( $track ) && isset( $track['description'] ) ) :
 		?>
-
 	<div
 		id="<?php echo esc_attr( $player_id ); ?>__track-description"
 		class="jetpack-podcast-player__track-description"

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -1,0 +1,22 @@
+<?php
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+if ( ! isset( $title ) ) {
+	return;
+}
+?>
+
+<?php if ( isset( $link ) ) : ?>
+	<a
+		class="jetpack-podcast-player__podcast-title"
+		href="<?php echo esc_url( $link ); ?>"
+		target="_blank"
+		rel="noopener noreferrer nofollow"
+	>
+		<?php echo esc_attr( $title ); ?>
+	</a>
+<?php else : ?>
+	<span class="jetpack-podcast-player__podcast-title">
+		<?php echo esc_attr( $title ); ?>
+	</span>;
+<?php endif; ?>

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -1,5 +1,14 @@
 <?php
+/**
+ * Podcast Title template.
+ *
+ * @package Jetpack
+ */
+
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 if ( ! isset( $title ) ) {
 	return;
@@ -20,3 +29,7 @@ if ( ! isset( $title ) ) {
 		<?php echo esc_attr( $title ); ?>
 	</span>;
 <?php endif; ?>
+
+<?php
+// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable


### PR DESCRIPTION
This PR renders the podcast header on the server-side.

#### Changes proposed in this Pull Request:

It gets the podcast data from the Podcast RSS and renders the block HTML on the server-side, following the same structure which is applied by the client.
It adds a simple template system in order to isolate the process, suggested by @getdave [here](https://github.com/Automattic/jetpack/pull/15203#pullrequestreview-384557616).

#### Testing instructions:

In the front-end disable javascript. For this:

a) Open Chrome DevTools.
b) Press Control+Shift+P or Command+Shift+P (Mac) to open the Command Menu.
c) Start typing javascript, select Disable JavaScript, and then press Enter to run the command. JavaScript is now disabled.
![image](https://user-images.githubusercontent.com/77539/77923313-a817de80-7278-11ea-875c-247050ac1915.png)

Once it's disabled, do a hard-refresh. You should be able to still see the podcast header. Same HTML structure. Styles should be applied properly.

![image](https://user-images.githubusercontent.com/77539/77940181-af49e700-728e-11ea-85aa-192099a10e81.png)

![image](https://user-images.githubusercontent.com/77539/78074258-c238e600-7378-11ea-9e78-2e8ea74065b3.png)


#### Proposed changelog entry for your changes:
* Render Podcast header markup in the server-side
