### PR TITLE
ensure woo analytics checkout event fires for checkout block

### DIFF
--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -42,8 +42,11 @@ class Jetpack_WooCommerce_Analytics_Universal {
 		add_action( 'wcct_before_cart_widget', array( $this, 'remove_from_cart' ) );
 		add_filter( 'woocommerce_cart_item_remove_link', array( $this, 'remove_from_cart_attributes' ), 10, 2 );
 
-		// cart checkout
+		// Checkout.
+		// Send events after checkout template (shortcode).
 		add_action( 'woocommerce_after_checkout_form', array( $this, 'checkout_process' ) );
+		// Send events after checkout block.
+		add_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after', array( $this, 'checkout_process' ) );
 
 		// order confirmed
 		add_action( 'woocommerce_thankyou', array( $this, 'order_process' ), 10, 1 );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2031

#### Changes proposed in this Pull Request:
* Hooks `checkout_process` to a new hook fired in WooCommerce Blocks - [`woocommerce_blocks_enqueue_checkout_block_scripts_after`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/BlockTypes/Checkout.php#L56).

This is currently hooked on [`woocommerce_after_checkout_form`](https://github.com/woocommerce/woocommerce/blob/master/templates/checkout/form-checkout.php#L66) from WoCommerce Core. Originally we planned to fire this hook from checkout block PHP `render()` (#2038 - reverted), but this is not appropriate as extensions will likely render content/markup directly to output from the hook.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
*p7Ldg5-ru-p2

#### Testing instructions:
##### setup
* This requires WooCommerce to be installed and set up on the site, with some products. Recommend setting up `Cash on delivery` payment method for easy checkout.
* Also requires [WooCommerce Blocks checkout block](https://github.com/woocommerce/woocommerce-gutenberg-products-block) – this is still in development, so you'll need to build the source
* The events are disabled for development sites. Use an incognito window, or hack this by adding `return true;` at the start of [`Jetpack_WooCommerce_Analytics::shouldTrackStore()`](https://github.com/Automattic/jetpack/blob/master/modules/woocommerce-analytics/wp-woocommerce-analytics.php#L40).

#### test
- Add the checkout block to a page or post.
- Open network tab in browser dev tools, search for `pixel.wp.com`.
- View a product on the front end of your site. 
- View a page/post containing checkout block. You should see a request for `woocommerceanalytics_product_view` event.

Optional:

- Test that shortcode / traditional checkout event still works correctly.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* WooCommerce Analytics: Ensure checkout event fires for checkout block (currently in development).
