### PR TITLE
Podcast Player: Add interaction overlay

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -71,6 +71,7 @@ const PodcastPlayerEdit = ( {
 	backgroundColor: backgroundColorProp,
 	setBackgroundColor,
 	fallbackBackgroundColor,
+	isSelected,
 } ) => {
 	// Validated attributes.
 	const validatedAttributes = getValidatedAttributes( attributesValidation, attributes );
@@ -83,6 +84,7 @@ const PodcastPlayerEdit = ( {
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ feedData, setFeedData ] = useState( {} );
 	const cancellableFetch = useRef();
+	const [ isInteractive, setIsInteractive ] = useState( false );
 
 	const fetchFeed = useCallback(
 		urlToFetch => {
@@ -139,6 +141,13 @@ const PodcastPlayerEdit = ( {
 
 		fetchFeed( url );
 	}, [ fetchFeed, removeAllNotices, url ] );
+
+	// Bring back the overlay after block gets deselected.
+	useEffect( () => {
+		if ( ! isSelected && isInteractive ) {
+			setIsInteractive( false );
+		}
+	}, [ isSelected ] );
 
 	/**
 	 * Check if the current URL of the Podcast RSS feed
@@ -304,6 +313,19 @@ const PodcastPlayerEdit = ( {
 					title={ feedData.title }
 					link={ feedData.link }
 				/>
+				{
+					// Disabled because the overlay div doesn't actually have a role or functionality
+					// as far as the user is concerned. We're just catching the first click so that
+					// the block can be selected without interacting with the embed preview that the overlay covers.
+					/* eslint-disable jsx-a11y/no-static-element-interactions */
+				 }
+				{ ! isInteractive && (
+					<div
+						className="jetpack-podcast-player__interactive-overlay"
+						onMouseUp={ () => setIsInteractive( true ) }
+					/>
+				) }
+				{ /* eslint-enable jsx-a11y/no-static-element-interactions */ }
 			</div>
 		</>
 	);

--- a/extensions/blocks/podcast-player/editor.scss
+++ b/extensions/blocks/podcast-player/editor.scss
@@ -10,3 +10,12 @@
 	width: auto;
 	padding: 0 1em;
 }
+
+.jetpack-podcast-player__interactive-overlay {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	right: 0px;
+	bottom: 0px;
+	opacity: 0;
+}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -254,6 +254,10 @@ $player-float-background: $light-gray-200;
 		background-color: $player-background;
 	}
 
+	.mejs-controls {
+		position: static;
+	}
+
 	.mejs-time,
 	.mejs-time-float {
 		color: $player-text-color;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* This overlay protects the player UI from receiving the first click. It prevents accidental triggering of audio when you just want to select the block. 

This is an exact copy of the interaction overlay from core embed block https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/embed/embed-preview.js

#### Testing instructions:
* In the editor, insert Podcast Player and give it a podcast URL
* Unselect the block and observe no UI should suggest interactivity (mouse cursor, hover states)
* Click the block to select it and only then you will be able to interact with the player.

#### Proposed changelog entry for your changes:
* none
