### PR TITLE
Podcast Player - make feed fetch call cancellable and cancel on Block removal.

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -96,6 +96,10 @@ const PodcastPlayerEdit = ( {
 
 			cancellableFetch.current.promise.then(
 				data => {
+					if ( data?.isCanceled ) {
+						debug( 'Block was unmounted during fetch', data );
+						return; // bail if canceled to avoid setting state
+					}
 					// Store feed data.
 					setFeedData( data );
 				},

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -100,7 +100,7 @@ const PodcastPlayerEdit = ( {
 					setFeedData( data );
 				},
 				error => {
-					if ( error && error.isCanceled ) {
+					if ( error?.isCanceled ) {
 						debug( 'Block was unmounted during fetch', error );
 						return; // bail if canceled to avoid setting state
 					}
@@ -118,9 +118,7 @@ const PodcastPlayerEdit = ( {
 
 	useEffect( () => {
 		return () => {
-			if ( cancellableFetch && cancellableFetch.current && cancellableFetch.current.cancel ) {
-				cancellableFetch.current.cancel();
-			}
+			cancellableFetch?.current?.cancel?.();
 		};
 	}, [] );
 

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -6,7 +6,7 @@ import debugFactory from 'debug';
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
 	ExternalLink,
@@ -42,6 +42,7 @@ import { queueMusic } from './icons/';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import attributesValidation from './attributes';
 import PodcastPlayer from './components/podcast-player';
+import { makeCancellable } from './utils';
 import { applyFallbackStyles } from '../../shared/apply-fallback-styles';
 
 const DEFAULT_MIN_ITEMS = 1;
@@ -81,21 +82,30 @@ const PodcastPlayerEdit = ( {
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ feedData, setFeedData ] = useState( {} );
+	const cancellableFetch = useRef();
 
 	const fetchFeed = useCallback(
 		urlToFetch => {
 			const encodedURL = encodeURIComponent( urlToFetch );
 
-			apiFetch( {
-				path: '/wpcom/v2/podcast-player?url=' + encodedURL,
-			} ).then(
+			cancellableFetch.current = makeCancellable(
+				apiFetch( {
+					path: '/wpcom/v2/podcast-player?url=' + encodedURL,
+				} )
+			);
+
+			cancellableFetch.current.promise.then(
 				data => {
 					// Store feed data.
 					setFeedData( data );
 				},
-				err => {
+				error => {
+					if ( error && error.isCanceled ) {
+						debug( 'Block was unmounted during fetch', error );
+						return; // bail if canceled to avoid setting state
+					}
 					// Show error and allow to edit URL.
-					debug( 'feed error', err );
+					debug( 'feed error', error );
 					createErrorNotice(
 						__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
 					);
@@ -105,6 +115,14 @@ const PodcastPlayerEdit = ( {
 		},
 		[ createErrorNotice ]
 	);
+
+	useEffect( () => {
+		return () => {
+			if ( cancellableFetch && cancellableFetch.current && cancellableFetch.current.cancel ) {
+				cancellableFetch.current.cancel();
+			}
+		};
+	}, [] );
 
 	// Load RSS feed.
 	useEffect( () => {

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -5,13 +5,11 @@
  * of compiled files used in the front-end.
  *
  * @example
- *     const className = getColorClassName( 'color', canvasPrimaryColor );
- *
- * @param {string} colorContextName Context/place where color is being used e.g: background, text etc...
- * @param {string} colorSlug        Slug of the color.
- *
- * @return {?string} String with the class corresponding to the color in the provided context.
- *                   Returns undefined if either colorContextName or colorSlug are not provided.
+ * const className = getColorClassName( 'color', canvasPrimaryColor );
+ * @param colorContextName - Context/place where color is being used e.g: background, text etc...
+ * @param colorSlug -        Slug of the color.
+ * @returns String with the class corresponding to the color in the provided context.
+ * Returns undefined if either colorContextName or colorSlug are not provided.
  */
 export function getColorClassName( colorContextName, colorSlug ) {
 	if ( ! colorContextName || ! colorSlug ) {
@@ -19,4 +17,32 @@ export function getColorClassName( colorContextName, colorSlug ) {
 	}
 
 	return `has-${ colorSlug }-${ colorContextName }`;
+}
+
+/**
+ * Creates a wrapper around a promise which allows it to be programmatically
+ * cancelled. See: https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+ *
+ * @example
+ * const somePromise = makeCancellable( fetch('http://wordpress.org') );
+ * somePromise.promise.then()
+ * @param promise - the Promise to make cancelable
+ * @returns Object containing original promise object and cancel method.
+ */
+export function makeCancellable( promise ) {
+	let hasCanceled_ = false;
+
+	const wrappedPromise = new Promise( ( resolve, reject ) => {
+		promise.then(
+			val => ( hasCanceled_ ? reject( { isCanceled: true } ) : resolve( val ) ),
+			error => ( hasCanceled_ ? reject( { isCanceled: true } ) : reject( error ) )
+		);
+	} );
+
+	return {
+		promise: wrappedPromise,
+		cancel() {
+			hasCanceled_ = true;
+		},
+	};
 }


### PR DESCRIPTION
Currently the Podcast Player Block uses apiFetch to trigger a Ajax request for the feed data. Once it [the fetch promise] resolves then state and attributes updates are triggered.

If, whilst the network request is in progress, the Block is "unmounted" then the console will show an error along the lines of

> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

This is because the .then handler on the fetch still triggers even though the Block no longer exists. As the handler updates state and attributes the console triggers the above error regarding state updates on unmounted components.

To fix this we make the `apiFetch` call cancell-able (via a wrapper util) and then ensure we cancel and do not update state if the Block has been unmounted.

Fixes https://github.com/Automattic/jetpack/issues/15214

## Changes proposed in this Pull Request:
* Wrap `apiFetch` to make it possible to cancel it.
* Add ref to track cancellable promise instance.
* Add `useEffect` to `.cancel()` the fetch promise if the Block unmounts.
* Add conditional to the `.catch()` handler to check for `.isCancelled` and terminate handler execution early to avoid state updates.

## Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes existing bug in Podcast Player Block

## Testing instructions:

Annoyingly there seems to be a bug in Gutenberg with the Popover component. Therefore when "removing" the BLock below you will need to click to place the cursor in the editor immediate following the Block and then hit the `BACKSPACE` key to remove the block. Removing using the dropdown many on the Block itself will trigger a warning which is **unrelated to this Block**.

#### On Feature Branch

* Insert Podcast Block.
* In Network Tools switch to "Slow 3G mode".
* Add a valid feed URL and submit.
* Immediately (before the fetch request resolves) delete the Block (see notes above).
* See error in console relating to state updates on unmounted component.

#### On This Branch

* Insert Podcast Block.
* In Network Tools switch to "Slow 3G mode".
* Add a valid feed URL and submit.
* Immediately (before the fetch request resolves) delete the Block (see notes above).
* See no errors.

If you enable `debug` mode you will also see a notice informing you that:

> Block was unmounted during fetch

 

#### Proposed changelog entry for your changes:
* Fix React error regarding state updates on unmounted component if Block is removed during the fetching of the Podcast feed.
