### PR TITLE
E2E tests: Hide welcome guide in block editor

### DIFF
--- a/tests/e2e/lib/pages/wp-admin/block-editor.js
+++ b/tests/e2e/lib/pages/wp-admin/block-editor.js
@@ -16,12 +16,21 @@ export default class BlockEditorPage extends Page {
 		super( page, { expectedSelector, url } );
 	}
 
-	static async init( page, enableTips = false ) {
+	static async init( page, showWelcomeGuide = false ) {
 		const it = await super.init( page );
-		await page.evaluate( _enableTips => {
-			const action = _enableTips ? 'enableTips' : 'disableTips';
-			wp.data.dispatch( 'core/nux' )[ action ]();
-		}, enableTips );
+
+		const isWelcomeGuideActive = await page.evaluate( () =>
+			wp.data.select( 'core/edit-post' ).isFeatureActive( 'welcomeGuide' )
+		);
+
+		if ( showWelcomeGuide !== isWelcomeGuideActive ) {
+			await page.evaluate( () =>
+				wp.data.dispatch( 'core/edit-post' ).toggleFeature( 'welcomeGuide' )
+			);
+
+			await it.reload();
+		}
+
 		return it;
 	}
 


### PR DESCRIPTION
Updates E2E tests to work with latest 5.4 WP release

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* remove Welcome dialog in block editor

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Tests should be green
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
