### PR TITLE
Podcast Player: format active track in SS

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -133,11 +133,12 @@ function render_player( $player_data, $attributes ) {
 		>
 			<?php render( 'podcast-header', $player_props ); ?>
 			<ol class="jetpack-podcast-player__tracks">
-				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
+				<?php foreach ( $player_data['tracks'] as $track_index => $attachment ) : ?>
 					<?php
 					render(
 						'playlist-track',
 						array(
+							'is_active'        => 0 === $track_index,
 							'attachment'       => $attachment,
 							'secondary_colors' => $secondary_colors,
 						)

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -134,21 +134,15 @@ function render_player( $player_data, $attributes ) {
 			<?php render( 'podcast-header', $player_props ); ?>
 			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $attachment ) : ?>
-				<li
-					class="jetpack-podcast-player__track <?php echo esc_attr( $secondary_colors['class'] ); ?>"
-					style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
-				>
-					<a
-						class="jetpack-podcast-player__track-link"
-						href="<?php echo esc_url( $attachment['link'] ); ?>"
-						role="button"
-						aria-pressed="false"
-					>
-						<span class="jetpack-podcast-player__track-status-icon"></span>
-						<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-						<time class="jetpack-podcast-player__track-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
-					</a>
-				</li>
+					<?php
+					render(
+						'playlist-track',
+						array(
+							'attachment'       => $attachment,
+							'secondary_colors' => $secondary_colors,
+						)
+					);
+					?>
 				<?php endforeach; ?>
 			</ol>
 		</section>

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -115,6 +115,7 @@ function render_player( $player_data, $attributes ) {
 		$player_data
 	);
 
+	$primary_colors    = get_colors( 'primary', $attributes, 'color' );
 	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
@@ -140,6 +141,7 @@ function render_player( $player_data, $attributes ) {
 						array(
 							'is_active'        => 0 === $track_index,
 							'attachment'       => $attachment,
+							'primary_colors'   => $primary_colors,
 							'secondary_colors' => $secondary_colors,
 						)
 					);

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -16,7 +16,7 @@ if ( $is_active ) {
 
 	$style = $primary_colors['style'];
 } else {
-	$class .= " is-active {$secondary_colors['class']}";
+	$class .= " {$secondary_colors['class']}";
 
 	$style = $secondary_colors['style'];
 }

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -29,7 +29,7 @@ if ( $is_active ) {
 		class="jetpack-podcast-player__track-link"
 		href="<?php echo esc_url( $attachment['link'] ); ?>"
 		role="button"
-		aria-pressed="false"
+		<?php echo $is_active ? 'aria-current="track"' : ''; ?>
 	>
 		<span class="jetpack-podcast-player__track-status-icon"></span>
 		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $track_title ); ?></span>

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -8,16 +8,23 @@
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+$class = 'jetpack-podcast-player__track';
+$style = '';
 
-$css_classes = "jetpack-podcast-player__track {$secondary_colors['class']}";
 if ( $is_active ) {
-	$css_classes .= ' is-active';
+	$class .= " is-active {$primary_colors['class']}";
+
+	$style = $primary_colors['style'];
+} else {
+	$class .= " is-active {$secondary_colors['class']}";
+
+	$style = $secondary_colors['style'];
 }
 ?>
 
 <li
-	class="<?php echo esc_attr( $css_classes ); ?>"
-	style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
+	class="<?php echo esc_attr( $class ); ?>"
+	style="<?php echo esc_attr( $style ); ?>"
 >
 	<a
 		class="jetpack-podcast-player__track-link"

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -8,10 +8,15 @@
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$css_classes = "jetpack-podcast-player__track {$secondary_colors['class']}";
+if ( $is_active ) {
+	$css_classes .= ' is-active';
+}
 ?>
 
 <li
-	class="jetpack-podcast-player__track <?php echo esc_attr( $secondary_colors['class'] ); ?>"
+	class="<?php echo esc_attr( $css_classes ); ?>"
 	style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
 >
 	<a

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -12,17 +12,13 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 $track_title    = $attachment['title'];
 $track_duration = ! empty( $attachment['duration'] ) ? $attachment['duration'] : '';
 
-$class = 'jetpack-podcast-player__track';
-
+$class = 'jetpack-podcast-player__track ' . $secondary_colors['class'];
+$style = $secondary_colors['style'];
 if ( $is_active ) {
-	$class .= " is-active {$primary_colors['class']}";
-
+	$class = 'jetpack-podcast-player__track is-active ' . $primary_colors['class'];
 	$style = $primary_colors['style'];
-} else {
-	$class .= " {$secondary_colors['class']}";
-
-	$style = $secondary_colors['style'];
 }
+
 ?>
 
 <li

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -13,7 +13,6 @@ $track_title    = $attachment['title'];
 $track_duration = ! empty( $attachment['duration'] ) ? $attachment['duration'] : '';
 
 $class = 'jetpack-podcast-player__track';
-$style = '';
 
 if ( $is_active ) {
 	$class .= " is-active {$primary_colors['class']}";

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -8,6 +8,10 @@
 namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+$track_title    = $attachment['title'];
+$track_duration = ! empty( $attachment['duration'] ) ? $attachment['duration'] : '';
+
 $class = 'jetpack-podcast-player__track';
 $style = '';
 
@@ -33,8 +37,8 @@ if ( $is_active ) {
 		aria-pressed="false"
 	>
 		<span class="jetpack-podcast-player__track-status-icon"></span>
-		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $attachment['title'] ); ?></span>
-		<time class="jetpack-podcast-player__track-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $track_title ); ?></span>
+		<time class="jetpack-podcast-player__track-duration"><?php echo esc_attr( $track_duration ); ?></time>
 	</a>
 </li>
 

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Podcast Title template.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+?>
+
+<li
+	class="jetpack-podcast-player__track <?php echo esc_attr( $secondary_colors['class'] ); ?>"
+	style="<?php echo esc_attr( $secondary_colors['style'] ); ?>"
+>
+	<a
+		class="jetpack-podcast-player__track-link"
+		href="<?php echo esc_url( $attachment['link'] ); ?>"
+		role="button"
+		aria-pressed="false"
+	>
+		<span class="jetpack-podcast-player__track-status-icon"></span>
+		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $attachment['title'] ); ?></span>
+		<time class="jetpack-podcast-player__track-duration"><?php echo ( ! empty( $attachment['duration'] ) ? esc_html( $attachment['duration'] ) : '' ); ?></time>
+	</a>
+</li>
+
+<?php
+// phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -25,7 +25,7 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
 		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
 			<div class="jetpack-podcast-player__cover">
-				<img class="jetpack-podcast-player__cover-image" src=<?php echo esc_url( $cover ); ?>alt="" />
+				<img class="jetpack-podcast-player__cover-image" src="<?php echo esc_url( $cover ); ?>" alt="" />
 			</div>
 
 			<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds the format to the active track in the server-side, adding CSS class and inline style to the markup.

Fixes #

#### Changes proposed in this Pull Request:
* Add a new playlist-track template
* Pass is-active value to the template
* Add CSS classes and inline styles accordingly 

#### Testing instructions:

In the editor-canvas, set the primary and secondary colors to the podcast player block. Something like the following pic.
![image](https://user-images.githubusercontent.com/77539/78152224-e4ca0e00-740f-11ea-8061-d3af637039bf.png)


In the front-end disable javascript. For this:

a) Open Chrome DevTools.
b) Press Control+Shift+P or Command+Shift+P (Mac) to open the Command Menu.
c) Start typing javascript, select Disable JavaScript, and then press Enter to run the command. JavaScript is now disabled.
![image](https://user-images.githubusercontent.com/77539/77923313-a817de80-7278-11ea-875c-247050ac1915.png)

Hard refresh
Confirm that the first track sets as the current one. Pink square in the screenshot below:
<img width="655" alt="Screen Shot 2020-04-01 at 11 57 48 AM" src="https://user-images.githubusercontent.com/77539/78152379-180c9d00-7410-11ea-98ff-4b9e75be2bee.png">


#### Proposed changelog entry for your changes:

* Add format to active track in server-side
