### PR TITLE
WP for Teams: add is_wpforteams_site option to sites endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -602,6 +602,10 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'import_engine':
 					$options[ $key ] = $site->get_import_engine();
 					break;
+
+				case 'is_wpforteams_site':
+					$options[ $key ] = $site->is_wpforteams_site();
+					break;
 			}
 		}
 

--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -140,6 +140,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_goals',
 		'site_segment',
 		'import_engine',
+		'is_wpforteams_site'
 	);
 
 	protected static $jetpack_response_field_additions = array(

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -135,6 +135,8 @@ abstract class SAL_Site {
 		);
 	}
 
+	abstract protected function is_wpforteams_site();
+
 	public function is_wpcom_atomic() {
 		return false;
 	}

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -155,7 +155,7 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	function is_coming_soon() {
 		return $this->is_private() && (int) $this->get_atomic_cloud_site_option( 'wpcom_coming_soon' ) === 1;
 	}
-	
+
 	/**
 	 * Return site's launch status.
 	 *
@@ -227,6 +227,10 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 
 	function is_connected_site() {
 		return true;
+	}
+
+	function is_wpforteams_site() {
+		return false;
 	}
 
 	function current_user_can( $role ) {


### PR DESCRIPTION
Summary: In this patch, we add an option `is_wpforteams_site` to all `sites/` REST API endpoints. We need that so we can distinguish between standard WP.com sites and WP for Teams sites in Calypso and other places.

Test Plan: Apply the patch. Open Calypso and inspect the `sites/` endpoint response. It should contain the `options` field with `is_wpforteams_site` option either `true` or `false` depending on whether the site was created with the `start/wp-for-teams` signup flow or not.
