### PR TITLE
Podcast Player: Add loading and default states

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -133,6 +133,13 @@ $player-float-background: $light-gray-200;
 		display: none;
 	}
 
+	.jetpack-podcast-player--audio-player-loading {
+		width: 100%;
+		height: 10px;
+		background: $player-slider-background;
+		margin: 15px $player-grid-spacing;
+	}
+
 	.jetpack-podcast-player__track-description {
 		order: 99; // high number to make it always appear after the audio player
 		padding: 0 $player-grid-spacing;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -125,14 +125,14 @@ $player-float-background: $light-gray-200;
 	}
 
 	.jetpack-podcast-player__audio-player {
-		height: 40px; /* the same as .mejs-container */
+		height: 40px; // mirroring .mejs-container
 		margin-bottom: $player-grid-spacing;
 	}
 
 	.jetpack-podcast-player--audio-player-loading {
-		height: 10px;
+		height: 10px; // mirroring .mejs-time-total
 		background: $player-slider-background;
-		margin: 15px $player-grid-spacing;
+		margin: 15px $player-grid-spacing; // simulating spacing of .mejs-container
 	}
 
 	.jetpack-podcast-player__track-description {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -129,10 +129,6 @@ $player-float-background: $light-gray-200;
 		margin-bottom: $player-grid-spacing;
 	}
 
-	&.is-default .jetpack-podcast-player__audio-player {
-		display: none;
-	}
-
 	.jetpack-podcast-player--audio-player-loading {
 		height: 10px;
 		background: $player-slider-background;
@@ -238,10 +234,6 @@ $player-float-background: $light-gray-200;
 		}
 	}
 
-	&.is-default .jetpack-podcast-player__track-status-icon {
-		display: none;
-	}
-
 	.jetpack-podcast-player__track-status-icon--error {
 		fill: $text-color-error;
 	}
@@ -249,11 +241,6 @@ $player-float-background: $light-gray-200;
 	.jetpack-podcast-player__track-title {
 		flex-grow: 1;
 		padding: 0 $track-v-padding;
-	}
-
-	&.is-default .jetpack-podcast-player__track-title {
-		// Change padding to account for missing space for status-icon.
-		padding-left: $player-grid-spacing - $track-v-padding;
 	}
 
 	.jetpack-podcast-player__track-duration {
@@ -279,6 +266,24 @@ $player-float-background: $light-gray-200;
 
 		& > span > a {
 			color: inherit;
+		}
+	}
+
+	/**
+	 * Style the block to hide dynamic UI and show just its default style.
+	 */
+	&.is-default {
+		.jetpack-podcast-player__track-title {
+			// Change padding to account for missing space for status-icon.
+			padding-left: $player-grid-spacing - $track-v-padding;
+		}
+
+		.jetpack-podcast-player__audio-player {
+			display: none;
+		}
+
+		&.is-default .jetpack-podcast-player__track-status-icon {
+			display: none;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -134,7 +134,6 @@ $player-float-background: $light-gray-200;
 	}
 
 	.jetpack-podcast-player--audio-player-loading {
-		width: 100%;
 		height: 10px;
 		background: $player-slider-background;
 		margin: 15px $player-grid-spacing;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -125,7 +125,12 @@ $player-float-background: $light-gray-200;
 	}
 
 	.jetpack-podcast-player__audio-player {
+		height: 40px; /* the same as .mejs-container */
 		margin-bottom: $player-grid-spacing;
+	}
+
+	&.is-default .jetpack-podcast-player__audio-player {
+		display: none;
 	}
 
 	.jetpack-podcast-player__track-description {
@@ -227,6 +232,10 @@ $player-float-background: $light-gray-200;
 		}
 	}
 
+	&.is-default .jetpack-podcast-player__track-status-icon {
+		display: none;
+	}
+
 	.jetpack-podcast-player__track-status-icon--error {
 		fill: $text-color-error;
 	}
@@ -234,6 +243,11 @@ $player-float-background: $light-gray-200;
 	.jetpack-podcast-player__track-title {
 		flex-grow: 1;
 		padding: 0 $track-v-padding;
+	}
+
+	&.is-default .jetpack-podcast-player__track-title {
+		// Change padding to account for missing space for status-icon.
+		padding-left: $player-grid-spacing - $track-v-padding;
 	}
 
 	.jetpack-podcast-player__track-duration {

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -60,4 +60,8 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 		<?php echo esc_attr( $track['description'] ); ?>
 	</div>
 	<?php endif; ?>
+
+	<div class="jetpack-podcast-player__audio-player">
+		<div class="jetpack-podcast-player--audio-player-loading"></div>
+	</div>
 </div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* This adds styles for the default and loading states.

| Default State | Loading/Dynamic State |
| --- | --- |
| <img width="567" alt="Screenshot 2020-04-01 at 17 46 14" src="https://user-images.githubusercontent.com/156676/78160625-8703e900-7444-11ea-987a-2e9af22438ef.png"> | <img width="567" src="https://user-images.githubusercontent.com/156676/78162814-ba944280-7447-11ea-8308-d5711b302aec.gif" />


**Default state**:  that's the one that shows when you have disabled JavaScript. Shows very simple list of links, without any dynamic parts (like the audio player and a blank space for track state icon).

**Loading state**: is what shows when you have JavaScript enabled but our React frontend has not loaded. It matches the sizing and style of fully loaded player and adds a placeholder for the audio player. That way, once the component gets initialized, there should be no size jump in the UI and things should get replaced perfectly. We have a few things to further improve but the key thing is there is no vertical jump so we won't be affecting everything below our player by resizing.

**Dynamic state**: when our audio player fully loads and is interactive.

#### Testing instructions:
* Test on the frontend with Podcast Player block present
* Disable JavaScript in your browser and reload
* You should see very basic podcast player interface sans any interactive controls (as described above)
* To check the loading state, in devtools, remove class `is-default` from the block

Alternative way to test the loading state:
* In `podcast-player.php`, around line 164, comment out the line with `window.jetpackPodcastPlayers.push( …` call
* With JavaScript enabled, reload the frontend
* You should be looking at the loading state indefinitely
* When you are done inspecting it, you can run the initialization yourself in devtools:

```
window.jetpackPodcastPlayers.push( 'put block id here' );
// the block id can be found in the html markup, find the element with class wp-block-jetpack-podcast-player and use its id
```

This way is how I have recorded the gif for Loading/Dynamic state above.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none
