### PR TITLE
My Plan: Adds a card for Jetpack Scan to My Plans

### DIFF
--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -30,6 +30,8 @@ export const PLAN_JETPACK_BACKUP_REALTIME = 'jetpack_backup_realtime';
 export const PLAN_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';
 export const PLAN_JETPACK_SEARCH = 'jetpack_search';
 export const PLAN_JETPACK_SEARCH_MONTHLY = 'jetpack_search_monthly';
+export const PLAN_JETPACK_SCAN = 'jetpack_scan';
+export const PLAN_JETPACK_SCAN_MONTHLY = 'jetpack_scan_monthly';
 export const PLAN_HOST_BUNDLE = 'host-bundle';
 export const PLAN_WPCOM_ENTERPRISE = 'wpcom-enterprise';
 export const PLAN_VIP = 'vip';
@@ -51,6 +53,8 @@ export const JETPACK_BACKUP_PRODUCTS = [
 ];
 
 export const JETPACK_SEARCH_PRODUCTS = [ PLAN_JETPACK_SEARCH, PLAN_JETPACK_SEARCH_MONTHLY ];
+
+export const JETPACK_SCAN_PRODUCTS = [ PLAN_JETPACK_SCAN, PLAN_JETPACK_SCAN_MONTHLY ];
 
 export const PLAN_MONTHLY_PERIOD = 31;
 export const PLAN_ANNUAL_PERIOD = 365;
@@ -146,8 +150,12 @@ export function isJetpackSearch( product ) {
 	return includes( JETPACK_SEARCH_PRODUCTS, product );
 }
 
+export function isJetpackScan( product ) {
+	return JETPACK_SCAN_PRODUCTS.includes( product );
+}
+
 export function isJetpackProduct( product ) {
-	return isJetpackBackup( product ) || isJetpackSearch( product );
+	return isJetpackBackup( product ) || isJetpackSearch( product ) || isJetpackScan( product );
 }
 
 export function getPlanClass( plan ) {
@@ -186,6 +194,9 @@ export function getPlanClass( plan ) {
 		case PLAN_JETPACK_SEARCH:
 		case PLAN_JETPACK_SEARCH_MONTHLY:
 			return 'is-search-plan';
+		case PLAN_JETPACK_SCAN:
+		case PLAN_JETPACK_SCAN_MONTHLY:
+			return 'is-scan-plan';
 		default:
 			return '';
 	}

--- a/_inc/client/my-plan/my-plan-card/index.jsx
+++ b/_inc/client/my-plan/my-plan-card/index.jsx
@@ -18,7 +18,7 @@ const MyPlanCard = ( { action, isError, isPlaceholder, details, icon, tagLine, t
 	const detailsClassNames = classNames( 'my-plan-card__details', { 'is-error': isError } );
 
 	return (
-		<div className={ cardClassNames } compact>
+		<div className={ cardClassNames }>
 			<div className="my-plan-card__primary">
 				<div className="my-plan-card__icon">{ icon && <img src={ icon } alt={ title } /> }</div>
 				<div className="my-plan-card__header">
@@ -40,7 +40,7 @@ MyPlanCard.propTypes = {
 	action: PropTypes.oneOfType( [ PropTypes.node, PropTypes.element ] ),
 	isError: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
-	details: PropTypes.string,
+	details: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
 	icon: PropTypes.string,
 	tagLine: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),
 	title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node, PropTypes.element ] ),

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -129,6 +129,16 @@ class MyPlanHeader extends React.Component {
 					} ),
 				};
 
+			case 'is-scan-plan':
+				return {
+					details: expiration,
+					icon: `${ imagePath }/products/product-jetpack-scan.svg`,
+					tagLine: __(
+						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+					),
+					title: __( 'Jetpack Scan' ),
+				};
+
 			default:
 				return {
 					isPlaceholder: true,

--- a/images/products/product-jetpack-scan.svg
+++ b/images/products/product-jetpack-scan.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72 72"><circle cx="36" cy="36" r="36" fill="#2fb41f"/><path d="M19.2 23l17.1-7.6L53.4 23v11.4c0 10.5-7.3 20.4-17.1 22.8-9.8-2.4-17.1-12.2-17.1-22.8V23zm30.4 13.2H36.3V19.5L23 25.4v10.8h13.3v17c7-2.2 12.2-9.1 13.3-17z" fill-rule="evenodd" clip-rule="evenodd" fill="#fff"/></svg>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This updated the My Plan cards to show the scan product, if purchased.
* Fixed extra prop added to `div` that was causing errors in React.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Ticket: 1151678672052943-as1139925594085620.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Jetpack Dashboard -> My Plan in site with Scan plan purchased.
* View listings under My Products.

<img width="1069" alt="Screen Shot 2020-04-01 at 2 11 12 PM" src="https://user-images.githubusercontent.com/1760168/78172042-62e3e000-7423-11ea-969b-c322de44460a.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Shouldn't be needed, will roll up into wider Scan changelog.
