### PR TITLE
ESLint: Workaround failure to parse files with template literals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -137,5 +137,9 @@ module.exports = {
 		'no-case-declarations': 1,
 		'no-class-assign': 1,
 		'no-redeclare': 1,
+
+		// Workaround for ESLint failing to parse files with template literals
+		// with this error: "TypeError: Cannot read property 'range' of null"
+		'template-curly-spacing': 'off',
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a workaround for ESLint failing to parse files containing template literals, throwing the following error: `TypeError: Cannot read property 'range' of null`.

This error has been reported several other times in the various ESLint repos:

https://github.com/babel/babel-eslint/issues/530 (I think `babel-eslint` is the origin of the problem, but don't quote me on this)
https://github.com/eslint/eslint/issues/9872
https://github.com/yannickcr/eslint-plugin-react/issues/2321
...and so on.

I've tried a few workarounds, but this is both the one that actually fixed the issue, and also the simplest one.

The [`template-curly-spacing`](https://eslint.org/docs/rules/template-curly-spacing) rule enforces our traditional spacing inside template literal variables (e.g. `${ foo }`).
Not only it's just a styling rule, but it's also one that is [automatically fixed by Prettier](https://github.com/Automattic/jetpack/blob/6ab48e5bbf6972ee03de44f73a10ad8c5cc49554/.prettierrc#L7).

Note: I've intentionally left the [original rule in the config file](https://github.com/Automattic/jetpack/blob/6ab48e5bbf6972ee03de44f73a10ad8c5cc49554/.eslintrc.js#L85). The workaround overrides it, and this way it would be easier to just remove the workaround whenever `babel-eslint` fixes this issue.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Before applying this PR, try opening a file containing template literals ([example](https://github.com/Automattic/jetpack/blob/master/extensions/blocks/opentable/index.js)).
* Open your editor and, while monitoring the ESLint log, try causing a parse error. For example, in VSCode, I did this:
  - Open the ESLint output log (typically by clicking on "ESLint" in the bottom toolbar).
  - The log should report this parsing error `Cannot read property 'range' of null Occurred while linting /path/to/file.js:123` whenever the file is parsed (in my case, it parses on type, so it happens very often; if you have set ESLint to only parse on save, please save the file every each step 😄). Note that the reported line is where the first template literal is (in the example it would be line 42).
  - In the file, try adding a space in the middle of a variable name.
E.g. `defaultAttributes` (at line 10 of the [example](https://github.com/Automattic/jetpack/blob/master/extensions/blocks/opentable/index.js)) -> `defa ultAttributes`.
  - Note that only the second half of the variable name is marked as error with the red wiggly line.
  - Delete the space (aka: remove the intentional error).
  - Now the entire variable is marked as error with the red line, and there's no way to "fix" it, except closing and reopening the file.
* Apply the PR. You might want to close and reopen VSCode just to be sure.
  - Notice that there are no parsing errors in the ESLint log.
  - Try causing a parse error again by adding a space in the variable name. Make sure the red line appears on the second half of the name.
  - Delete the space.
  - Now the error is cleared, and the ESLint log is clean.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
