### PR TITLE
Search: format the number of records displayed on plan page

### DIFF
--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -81,7 +81,7 @@ export function SingleProductSearchCard( props ) {
 					{ __(
 						'Your current site record size: %s record',
 						'Your current site record size: %s records',
-						{ args: recordCount, count: recordCount }
+						{ args: numberFormat( recordCount ), count: recordCount }
 					) }
 				</h4>
 				<div className="single-product-search__radio-buttons-container">


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Update the number of records displayed on the Plans page to use commas when necessary.

**Before**

![image](https://user-images.githubusercontent.com/426388/78172653-bb80a080-7456-11ea-8c18-c25172319acc.png)

**After**

![image](https://user-images.githubusercontent.com/426388/78172806-f4207a00-7456-11ea-87c5-a8fe5d2e0e0e.png)

#### Testing instructions:

* Go to Jetpack > Dashboard > Plans on a site with a lot of records and no Search plan.
* Check that the number of records is nicely displayed.

#### Proposed changelog entry for your changes:

* N/A
