### PR TITLE
Podcast Player: Set colors to podcast title and description, in server-side

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -119,7 +119,7 @@ function render_player( $player_data, $attributes ) {
 	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
-	$player_classes_name = trim( "jetpack-podcast-player__container {$secondary_colors['class']} {$background_colors['class']}" );
+	$player_classes_name = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
 	$player_inline_style = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -119,7 +119,7 @@ function render_player( $player_data, $attributes ) {
 	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
-	$player_classes_name = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
+	$player_classes_name = trim( "jetpack-podcast-player__container {$secondary_colors['class']} {$background_colors['class']}" );
 	$player_inline_style = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -132,7 +132,17 @@ function render_player( $player_data, $attributes ) {
 			class="<?php echo esc_attr( $player_classes_name ); ?>"
 			style="<?php echo esc_attr( $player_inline_style ); ?>"
 		>
-			<?php render( 'podcast-header', $player_props ); ?>
+			<?php
+			render(
+				'podcast-header',
+				array_merge(
+					$player_props,
+					array(
+						'primary_colors' => $primary_colors,
+					)
+				)
+			);
+			?>
 			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $track_index => $attachment ) : ?>
 					<?php

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -118,7 +118,7 @@ $player-float-background: $light-gray-200;
 	}
 
 	// Apply `secondary` color to the podcast title.
-	.jetpack-podcast-player__container.has-secondary { // custom color.
+	.has-secondary { // custom color.
 		.jetpack-podcast-player__podcast-title {
 			color: currentColor;
 		}
@@ -137,7 +137,7 @@ $player-float-background: $light-gray-200;
 		color: $dark-gray-500;
 	}
 
-	.jetpack-podcast-player__container.has-secondary { // custom color.
+	.has-secondary { // custom color.
 		.jetpack-podcast-player__track-description {
 			color: currentColor;
 		}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -121,8 +121,6 @@ $player-float-background: $light-gray-200;
 	// Apply `secondary` color to the podcast title.
 	.jetpack-podcast-player__container:not(.has-secondary) { // no custom -> default color.
 		a.jetpack-podcast-player__podcast-title {
-			font-size: $podcast-title-font-size;
-			color: $text-color;
 			margin: 0;
 		}
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -134,20 +134,14 @@ $player-float-background: $light-gray-200;
 		margin-bottom: $player-grid-spacing;
 		font-size: $description-font-size;
 		line-height: 1.6;
+		color: $dark-gray-500;
 	}
 
-	// Apply `secondary` color to the podcast title.
-	.jetpack-podcast-player__container:not(.has-secondary) { // no custom -> default color.
-		.jetpack-podcast-player__track-description {
-			color: $dark-gray-500;
-		}
-	}
 	.jetpack-podcast-player__container.has-secondary { // custom color.
 		.jetpack-podcast-player__track-description {
 			color: currentColor;
 		}
 	}
-
 
 	/**
 	 * Playlist elements styles

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -140,10 +140,22 @@ $player-float-background: $light-gray-200;
 		order: 99; // high number to make it always appear after the audio player
 		padding: 0 $player-grid-spacing;
 		margin-bottom: $player-grid-spacing;
-		color: $dark-gray-500;
 		font-size: $description-font-size;
 		line-height: 1.6;
 	}
+
+	// Apply `secondary` color to the podcast title.
+	.jetpack-podcast-player__container:not(.has-secondary) { // no custom -> default color.
+		.jetpack-podcast-player__track-description {
+			color: $dark-gray-500;
+		}
+	}
+	.jetpack-podcast-player__container.has-secondary { // custom color.
+		.jetpack-podcast-player__track-description {
+			color: currentColor;
+		}
+	}
+
 
 	/**
 	 * Playlist elements styles

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -110,7 +110,6 @@ $player-float-background: $light-gray-200;
 
 	a.jetpack-podcast-player__podcast-title {
 		text-decoration: none;
-		color: $text-color;
 
 		&:hover,
 		&:focus {
@@ -119,13 +118,8 @@ $player-float-background: $light-gray-200;
 	}
 
 	// Apply `secondary` color to the podcast title.
-	.jetpack-podcast-player__container:not(.has-secondary) { // no custom -> default color.
-		a.jetpack-podcast-player__podcast-title {
-			color: $text-color;
-		}
-	}
 	.jetpack-podcast-player__container.has-secondary { // custom color.
-		a.jetpack-podcast-player__podcast-title {
+		.jetpack-podcast-player__podcast-title {
 			color: currentColor;
 		}
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -118,6 +118,20 @@ $player-float-background: $light-gray-200;
 		}
 	}
 
+	// Apply `secondary` color to the podcast title.
+	.jetpack-podcast-player__container:not(.has-secondary) { // no custom -> default color.
+		a.jetpack-podcast-player__podcast-title {
+			font-size: $podcast-title-font-size;
+			color: $text-color;
+			margin: 0;
+		}
+	}
+	.jetpack-podcast-player__container.has-secondary { // custom color.
+		a.jetpack-podcast-player__podcast-title {
+			color: currentColor;
+		}
+	}
+
 	.jetpack-podcast-player__audio-player {
 		margin-bottom: $player-grid-spacing;
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -121,7 +121,7 @@ $player-float-background: $light-gray-200;
 	// Apply `secondary` color to the podcast title.
 	.jetpack-podcast-player__container:not(.has-secondary) { // no custom -> default color.
 		a.jetpack-podcast-player__podcast-title {
-			margin: 0;
+			color: $text-color;
 		}
 	}
 	.jetpack-podcast-player__container.has-secondary { // custom color.

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -17,7 +17,10 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 
 <h2 id=<?php echo esc_attr( $playerId ); ?>__title" class="jetpack-podcast-player__title">
 	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
-		<span class="jetpack-podcast-player__current-track-title">
+		<span
+			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
+			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
+		>
 			<?php echo esc_attr( $track['title'] ); ?>
 		</span>
 	<?php endif; ?>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -32,10 +32,11 @@ $track = ! empty( $template_props['tracks'] ) ? $template_props['tracks'][0] : a
 			render(
 				'podcast-header-title',
 				array(
-					'playerId' => $playerId,
-					'title'    => $title,
-					'link'     => $link,
-					'track'    => $track,
+					'playerId'       => $playerId,
+					'title'          => $title,
+					'link'           => $link,
+					'track'          => $track,
+					'primary_colors' => $primary_colors,
 				)
 			);
 			?>


### PR DESCRIPTION
This PR applies colors properly to the podcast title and podcast description, in the server-side rendering according to the following design:

![image](https://user-images.githubusercontent.com/77539/78180001-7ea5b100-7438-11ea-98f5-7867f5e0c5a4.png)


Fixes https://github.com/Automattic/jetpack/issues/15248

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*
#### Testing instructions:

1) Apply custom colors from the editor-canvas
2) Go to the front-end
3) Disable javascript
4) Hard refresh

Confirm the colors are properly applied to the podcast section.

<img width="665" alt="Screen Shot 2020-04-01 at 4 48 06 PM" src="https://user-images.githubusercontent.com/77539/78180108-a9900500-7438-11ea-87b7-63f95a22647a.png">



#### Proposed changelog entry for your changes:

* Apply colors properly to the podcast player in the server-side
