### PR TITLE
Podcast Player: Set colors to podcast title and description, in client-side

### DIFF
--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -1,10 +1,15 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
 import { memo } from '@wordpress/element';
 
 const Header = memo(
-	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription } ) => (
+	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription, colors } ) => (
 		<div className="jetpack-podcast-player__header">
 			<div className="jetpack-podcast-player__current-track-info">
 				{ showCoverArt && cover && (
@@ -15,7 +20,13 @@ const Header = memo(
 				) }
 
 				{ !! ( title || ( track && track.title ) ) && (
-					<Title playerId={ playerId } title={ title } link={ link } track={ track } />
+					<Title
+						playerId={ playerId }
+						title={ title }
+						link={ link }
+						track={ track }
+						colors={ colors }
+					/>
 				) }
 			</div>
 
@@ -35,10 +46,21 @@ const Header = memo(
 	)
 );
 
-const Title = memo( ( { playerId, title, link, track } ) => (
+const Title = memo( ( {
+	playerId,
+	title,
+	link,
+	track,
+	colors = { primary: { name: null, custom: null, classes: '' } }
+} ) => (
 	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
 		{ !! ( track && track.title ) && (
-			<span className="jetpack-podcast-player__current-track-title">{ track.title }</span>
+			<span
+				className={ classnames( 'jetpack-podcast-player__current-track-title', colors.primary.classes ) }
+				style={ { color: colors.primary.custom } }
+			>
+				{ track.title }
+			</span>
 		) }
 
 		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -68,16 +68,22 @@ const Title = memo( ( {
 			<span className="jetpack-podcast-player--visually-hidden"> - </span>
 		) }
 
-		{ !! title && <PodcastTitle title={ title } link={ link } /> }
+		{ !! title && <PodcastTitle title={ title } link={ link } colors={ colors } /> }
 	</h2>
 ) );
 
-const PodcastTitle = memo( ( { title, link } ) => {
-	const className = 'jetpack-podcast-player__podcast-title';
+const PodcastTitle = memo( ( { title, link, colors = { secondary: { name: null, custom: null, classes: '' } } } ) => {
+	const className = classnames( 'jetpack-podcast-player__podcast-title', colors.secondary.classes );
 
 	if ( link ) {
 		return (
-			<a className={ className } href={ link } target="_blank" rel="noopener noreferrer nofollow">
+			<a
+				className={ className }
+				style={ { color: colors.secondary.custom } }
+				href={ link }
+				target="_blank"
+				rel="noopener noreferrer nofollow"
+			>
 				{ title }
 			</a>
 		);

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -169,21 +169,48 @@ export class PodcastPlayer extends Component {
 		const track = this.getTrack( currentTrack );
 
 		// Set CSS classes string.
+		const primaryColorClass = getColorClassName( 'color', primaryColor );
 		const secondaryColorClass = getColorClassName( 'color', secondaryColor );
 		const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
 
-		const cssClassesName = classnames( playerState, {
-			'has-secondary': secondaryColor || customSecondaryColor,
-			[ secondaryColorClass ]: secondaryColorClass,
-			'has-background': backgroundColor || customBackgroundColor,
-			[ backgroundColorClass ]: backgroundColorClass,
-		} );
+		const colors = {
+			primary: {
+				name: primaryColor,
+				custom: customPrimaryColor,
+				classes: classnames( {
+					'has-primary': primaryColorClass || customPrimaryColor,
+					[ primaryColorClass ]: primaryColorClass,
+				} ),
+			},
+			secondary: {
+				name: secondaryColor,
+				custom: customSecondaryColor,
+				classes: classnames( {
+					'has-secondary': secondaryColorClass || customSecondaryColor,
+					[ secondaryColorClass ]: secondaryColorClass,
+				} ),
+			},
+			background: {
+				name: backgroundColor,
+				custom: customBackgroundColor,
+				classes: classnames( {
+					'has-background': backgroundColorClass || customBackgroundColor,
+					[ backgroundColorClass ]: backgroundColorClass,
+				} ),
+			},
+		};
 
 		const inlineStyle = {
 			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
 			backgroundColor:
 				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
 		};
+
+		const cssClassesName = classnames(
+			playerState,
+			colors.secondary.classes,
+			colors.background.classes
+		);
 
 		return (
 			<section
@@ -204,6 +231,7 @@ export class PodcastPlayer extends Component {
 					track={ this.getTrack( currentTrack ) }
 					showCoverArt={ showCoverArt }
 					showEpisodeDescription={ showEpisodeDescription }
+					colors={ colors }
 				>
 					<AudioPlayer
 						initialTrackSource={ this.getTrack( 0 ).src }
@@ -233,16 +261,7 @@ export class PodcastPlayer extends Component {
 					currentTrack={ currentTrack }
 					tracks={ tracksToDisplay }
 					selectTrack={ this.selectTrack }
-					colors={ {
-						primary: {
-							name: primaryColor,
-							custom: customPrimaryColor,
-						},
-						secondary: {
-							name: secondaryColor,
-							custom: customSecondaryColor,
-						},
-					} }
+					colors={ colors }
 				/>
 			</section>
 		);


### PR DESCRIPTION
This PR applies colores to the podcast player but on the client-side, complementing the server-side approach already merged in https://github.com/Automattic/jetpack/pull/15243.

![image](https://user-images.githubusercontent.com/77539/78180001-7ea5b100-7438-11ea-98f5-7867f5e0c5a4.png)


Fixes https://github.com/Automattic/jetpack/issues/15248

#### Testing instructions:

Apply colors to the podcast player. Test picking up colors from the palette and defining custom colors.

<img src="https://user-images.githubusercontent.com/77539/78193887-f7653700-7451-11ea-949e-fc8a31ae3524.png" width="300px" />

The colors should be propagated in a similar way how the picture shows below:

<img width="665" alt="Screen Shot 2020-04-01 at 4 48 06 PM" src="https://user-images.githubusercontent.com/77539/78180108-a9900500-7438-11ea-87b7-63f95a22647a.png">

`green`: primary colors
`yellow`: secondary colors.

#### Proposed changelog entry for your changes:

* Apply colors properly to the podcast player in the client-side

