### PR TITLE
Podcast Player: truncate podcast description if too long

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -135,6 +135,12 @@ $player-float-background: $light-gray-200;
 		font-size: $description-font-size;
 		line-height: 1.6;
 		color: $dark-gray-500;
+		//crop the description if too long
+		display: -webkit-box;
+		-webkit-line-clamp: 4;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+		max-height: 105px; //IE11 fallback
 	}
 
 	.has-secondary { // custom color.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Currently, podcast descriptions are being displayed in full. This leads to a negative visual experience as described in https://github.com/Automattic/jetpack/issues/15251. The goal of this PR is to truncate the podcast description to a reasonable length.

Fixes https://github.com/Automattic/jetpack/issues/15251

| Before  | After |
| ------------- | ------------- |
| <img width="566" alt="invest_like_the_best__d_a__wallach_e28093_investing_in_healthcare_-__invest_like_the_best__ep_166__on_apple_podcasts_and_add_new_post_e280b9_wide_gerenuk_e28094_wordpress" src="https://user-images.githubusercontent.com/1562646/78224133-46e64a00-74c8-11ea-8f32-5e51fe5b1635.png"> | <img width="804" alt="Screenshot 2020-04-02 at 09 35 02" src="https://user-images.githubusercontent.com/1562646/78224173-56659300-74c8-11ea-83cf-75adfcb180ec.png"> |

#### Context on solution proposed in this Pull Request:

The Editor's draft for CSS Overflow Module Level 3 defines `line-clamp`(https://drafts.csswg.org/css-overflow-3/#line-clamp) as a way to limit the visible lines i.e. multiline ellipsis.

Since Firefox added support in the form of `-webkit-line-clamp`, which is the vendor-prefixed version of the property that all major browsers support (see [ browser support matrix ](https://caniuse.com/#feat=css-line-clamp)), I suggest we use this to achieve the wanted effect using just CSS.

IMO we can regard this as a progressive enhancement and simply use a height-based cut off (without ellipsis) in browsers that don't support the property (namely IE 11).

#### Testing instructions:

* Go to the editor and select the Podcast Player (Beta) block
* Enter the following URL https://investlikethebest.libsyn.com/rss
* Observe whether the description is truncated as shown in the after state above

#### Screenshots

**Chrome:**
see above

**Firefox:**
<img width="797" alt="firefox" src="https://user-images.githubusercontent.com/1562646/78224003-13a3bb00-74c8-11ea-8031-233284ffd648.png">

**Safari:**
<img width="811" alt="Screenshot 2020-04-02 at 09 35 30" src="https://user-images.githubusercontent.com/1562646/78223966-0686cc00-74c8-11ea-96c0-e00cc0998427.png">

**IE11:**
<img width="1006" alt="Screenshot 2020-04-02 at 09 37 22" src="https://user-images.githubusercontent.com/1562646/78224035-1e5e5000-74c8-11ea-9bab-7de8cf98967b.png">
