### PR TITLE
Podcast Player: change error notice text when user is trying to embed a Spotify hosted podcast

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -110,11 +110,20 @@ const PodcastPlayerEdit = ( {
 						debug( 'Block was unmounted during fetch', error );
 						return; // bail if canceled to avoid setting state
 					}
-					// Show error and allow to edit URL.
-					debug( 'feed error', error );
-					createErrorNotice(
-						__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
-					);
+					if ( /\bspotify\b/i.test( encodedURL ) ) {
+						createErrorNotice(
+							__(
+								"It looks like you're trying to embed a podcast hosted on Spotify. Please use the Spotify block instead.",
+								'jetpack'
+							)
+						);
+					} else {
+						// Show error and allow to edit URL.
+						debug( 'feed error', error );
+						createErrorNotice(
+							__( "Your podcast couldn't be embedded. Please double check your URL.", 'jetpack' )
+						);
+					}
 					setIsEditing( true );
 				}
 			);
@@ -147,7 +156,7 @@ const PodcastPlayerEdit = ( {
 		if ( ! isSelected && isInteractive ) {
 			setIsInteractive( false );
 		}
-	}, [ isSelected ] );
+	}, [ isInteractive, isSelected ] );
 
 	/**
 	 * Check if the current URL of the Podcast RSS feed

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -156,7 +156,8 @@ const PodcastPlayerEdit = ( {
 		if ( ! isSelected && isInteractive ) {
 			setIsInteractive( false );
 		}
-	}, [ isInteractive, isSelected ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isSelected ] );
 
 	/**
 	 * Check if the current URL of the Podcast RSS feed


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR is an intermediary step to addressing feedback from Aadil to suggest using the Spotify embed block when trying to add a Spotify hosted podcast.

As a quick fix, this PR changes the error notice to suggest the Spotify block when a Spotify URL is detected upon error:

<img width="825" alt="Screenshot 2020-04-02 at 11 07 10" src="https://user-images.githubusercontent.com/1562646/78230801-2622f200-74d2-11ea-9d91-7106bff0451f.png">

Note: this should be thought of as an intermediary step. We're planning to build upon this by offering a one-click way to use the Spotify block. This will be worked on in a separate future PR.


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and add the Podcast Player (Beta) block
* Enter a Spotify podcast URL e.g. [this one](https://open.SpOtify.com/show/4XPl3uEEL9hvqMkoZrzbx5?si=8noFQsHjTpCMjtA-djqmMg)
* Confirm that you see the Spotify related error message
* Change URL to a different non-Spotify and non-RSS URL
* Confirm you're still seeing the generic error message