### PR TITLE
Instan Search: Stop spawning the overlay on popstate events

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -170,7 +170,6 @@ class SearchApp extends Component {
 	onChangeQuery = event => setSearchQuery( event.target.value );
 
 	onPopstate = () => {
-		this.showResults();
 		this.onChangeQueryString();
 	};
 


### PR DESCRIPTION
Fixes #15029.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Stops automatically opening the Instant Search overlay on popstate events. Now defaults to the logic within `onChangeQueryString` to determine if the overlay should be opened.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Apply these changes to your Jetpack installation. 
* Ensure that your site has an active Jetpack Search product purchase.
* Ensure that the Carousel feature has been activated at `/wp-admin/admin.php?page=jetpack#/writing`.
* Go to a page with a gallery and click on an image to spawn the carousel.
* Close the carousel. Ensure that the search overlay has not spawned.

#### Proposed changelog entry for your changes:
* None.
