### PR TITLE
Instant Search: Improve customizer integration

### DIFF
--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -45,7 +45,7 @@ class SearchApp extends Component {
 			overlayOptions: { ...this.props.initialOverlayOptions },
 			requestId: 0,
 			response: {},
-			showResults: false,
+			showResults: this.props.initialShowResults,
 		};
 		this.getResults = debounce( this.getResults, 200 );
 	}
@@ -152,8 +152,11 @@ class SearchApp extends Component {
 		this.showResults();
 	};
 
-	handleOverlayOptionsUpdate = ( { key, value } ) => {
-		this.setState( { overlayOptions: { ...this.state.overlayOptions, [ key ]: value } } );
+	handleOverlayOptionsUpdate = newOverlayOptions => {
+		this.setState(
+			{ overlayOptions: { ...this.state.overlayOptions, ...newOverlayOptions } },
+			this.showResults
+		);
 	};
 
 	showResults = () => {

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -5,6 +5,7 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { h, Component, Fragment } from 'preact';
+import { useMemo } from 'preact/hooks';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import ScrollButton from './scroll-button';
 import SearchForm from './search-form';
 import SearchResult from './search-result';
 import SearchSidebar from './search-sidebar';
+import { getConstrastingColor } from '../lib/colors';
 
 class SearchResults extends Component {
 	getSearchTitle() {
@@ -46,8 +48,9 @@ class SearchResults extends Component {
 	}
 
 	renderPrimarySection() {
-		const { query } = this.props;
+		const { highlightColor, query } = this.props;
 		const { results = [], total = 0, corrected_query = false } = this.props.response;
+		const textColor = useMemo( () => getConstrastingColor( highlightColor ), [ highlightColor ] );
 		const hasCorrectedQuery = corrected_query !== false;
 		const hasResults = total > 0;
 
@@ -58,7 +61,8 @@ class SearchResults extends Component {
 					dangerouslySetInnerHTML={ {
 						__html: `
 							.jetpack-instant-search__search-results .jetpack-instant-search__search-results-primary mark { 
-								background-color: ${ this.props.highlightColor };
+								color: ${ textColor };
+								background-color: ${ highlightColor };
 							}
 						`,
 					} }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -24,6 +24,8 @@ const injectSearchApp = () => {
 			] ) }
 			initialHref={ window.location.href }
 			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
+			// NOTE: initialShowResults is only used in the customizer. See lib/customize.js.
+			initialShowResults={ window[ SERVER_OBJECT_NAME ].showResults }
 			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }
 			isSearchPage={ getSearchQuery() !== '' }
 			options={ window[ SERVER_OBJECT_NAME ] }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -14,6 +14,7 @@ import { getThemeOptions } from './lib/dom';
 import { SERVER_OBJECT_NAME } from './lib/constants';
 import { initializeTracks, identifySite, resetTrackingCookies } from './lib/tracks';
 import { buildFilterAggregations } from './lib/api';
+import { bindCustomizerChanges } from './lib/customize';
 
 const injectSearchApp = () => {
 	render(
@@ -35,6 +36,9 @@ const injectSearchApp = () => {
 	);
 };
 
+if ( window[ SERVER_OBJECT_NAME ] ) {
+	bindCustomizerChanges();
+}
 document.addEventListener( 'DOMContentLoaded', function() {
 	if ( !! window[ SERVER_OBJECT_NAME ] && 'siteId' in window[ SERVER_OBJECT_NAME ] ) {
 		initializeTracks();

--- a/modules/search/instant-search/lib/colors.js
+++ b/modules/search/instant-search/lib/colors.js
@@ -1,0 +1,23 @@
+function extractHexCode( input ) {
+	let output;
+	if ( input[ 0 ] === '#' ) {
+		output = input.substring( 1 );
+	}
+	if ( output.length === 3 ) {
+		output = output
+			.split( '' )
+			.map( letter => `${ letter }${ letter }` )
+			.join( '' );
+	}
+	return output;
+}
+
+export function getConstrastingColor( input ) {
+	// https://gomakethings.com/dynamically-changing-the-text-color-based-on-background-color-contrast-with-vanilla-js/
+	const colorHex = extractHexCode( input );
+	const r = parseInt( colorHex.substr( 0, 2 ), 16 );
+	const g = parseInt( colorHex.substr( 2, 2 ), 16 );
+	const b = parseInt( colorHex.substr( 4, 2 ), 16 );
+	const yiq = ( r * 299 + g * 587 + b * 114 ) / 1000;
+	return yiq >= 128 ? 'black' : 'white';
+}

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -37,11 +37,17 @@ export function bindCustomizerChanges( callback ) {
 	CUSTOMIZE_SETTINGS.forEach( setting => {
 		window.wp.customize( setting, value => {
 			value.bind( function( newValue ) {
-				// If Instant Search hasn't been injected, set its initial overlay state via server server object.
+				const newOvelayOptions = { [ SETTINGS_TO_STATE_MAP.get( setting ) ]: newValue };
+
+				// If Instant Search hasn't been injected, update initial server object state
 				window[ SERVER_OBJECT_NAME ].showResults = true;
-				callback( {
-					[ SETTINGS_TO_STATE_MAP.get( setting ) ]: newValue,
-				} );
+				window[ SERVER_OBJECT_NAME ].overlayOptions = {
+					...window[ SERVER_OBJECT_NAME ].overlayOptions,
+					...newOvelayOptions,
+				};
+
+				// If callback is available, invoke it.
+				callback && callback( newOvelayOptions );
 			} );
 		} );
 	} );

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { SERVER_OBJECT_NAME } from './constants';
+
 const CUSTOMIZE_SETTINGS = [
 	'jetpack_search_color_theme',
 	'jetpack_search_inf_scroll',
@@ -32,9 +37,10 @@ export function bindCustomizerChanges( callback ) {
 	CUSTOMIZE_SETTINGS.forEach( setting => {
 		window.wp.customize( setting, value => {
 			value.bind( function( newValue ) {
+				// If Instant Search hasn't been injected, set its initial overlay state via server server object.
+				window[ SERVER_OBJECT_NAME ].showResults = true;
 				callback( {
-					key: SETTINGS_TO_STATE_MAP.get( setting ),
-					value: newValue,
+					[ SETTINGS_TO_STATE_MAP.get( setting ) ]: newValue,
 				} );
 			} );
 		} );


### PR DESCRIPTION
Fixes #14666.
Fixes #15179.
Fixes #15245.

#### Changes proposed in this Pull Request:
* Programmatically determine text color for highlighted search results.
* Open overlay when changing Jetpack Search settings in the customizer.
* React to Customizer changes as early as possible.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Apply these changes to your Jetpack installation.
* Purchase a Jetpack Search.
* Navigate to the customizer.
* Open the Jetpack Search section and change any of its settings. Ensure that the overlay opens without issue.
* Change the highlight color. Ensure that the text color remains readable no matter the highlight color.
* Change the infinite scroll setting. Ensure that the toggle works as expected.

#### Proposed changelog entry for your changes:
* None.
