### PR TITLE
Minor CSS fix to the email input box in email subscription widget

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -326,7 +326,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						echo wpautop( sprintf( _n( 'Join %s other follower', 'Join %s other followers', $subscribers_total ), number_format_i18n( $subscribers_total ) ) );
 					}
 					?>
-                    <p><input type="text" name="email" style="width: 95%; padding: 1px 2px"
+                    <p><input type="text" name="email" style="width: 95%; padding: 1px 10px"
                               placeholder="<?php esc_attr_e( 'Enter your email address' ); ?>" value=""
                               id="subscribe-field<?php if ( Jetpack_Subscriptions_Widget::$instance_count > 1 ) {
 						          echo '-' . Jetpack_Subscriptions_Widget::$instance_count;


### PR DESCRIPTION
Summary:

This PR is to keep in sync the changes committed in D40953-code.

Fixes the padding element to the input box.

**Before**

<img width="554" alt="Screenshot_2020-04-02_at_10 35 29_AM" src="https://user-images.githubusercontent.com/1269602/78326375-d73f9000-7597-11ea-8bee-93f3cc7b5a0a.png">

**After**

<img width="558" alt="Screenshot_2020-04-02_at_10 34 52_AM" src="https://user-images.githubusercontent.com/1269602/78326382-deff3480-7597-11ea-8e85-ab5b3081a672.png">
