### PR TITLE
Update cache-busting parameter for gprofiles

### DIFF
--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -12,7 +12,7 @@
  * Additional Search Queries: gravatar, hovercards
  */
 
-define( 'GROFILES__CACHE_BUSTER', gmdate( 'YM' ) . '-2' ); // Break CDN cache, increment when gravatar.com/js/gprofiles.js changes.
+define( 'GROFILES__CACHE_BUSTER', gmdate( 'YM' ) . '-3' ); // Break CDN cache, increment when gravatar.com/js/gprofiles.js changes.
 
 function grofiles_hovercards_init() {
 	add_filter( 'get_avatar',          'grofiles_get_avatar', 10, 2 );

--- a/modules/gravatar-hovercards.php
+++ b/modules/gravatar-hovercards.php
@@ -12,7 +12,7 @@
  * Additional Search Queries: gravatar, hovercards
  */
 
-define( 'GROFILES__CACHE_BUSTER', gmdate( 'YM' ) . '-3' ); // Break CDN cache, increment when gravatar.com/js/gprofiles.js changes.
+define( 'GROFILES__CACHE_BUSTER', gmdate( 'YW' ) );
 
 function grofiles_hovercards_init() {
 	add_filter( 'get_avatar',          'grofiles_get_avatar', 10, 2 );


### PR DESCRIPTION
A new version of `gprofiles.js` was published, reinstating removed functionality that's in use by some plugins.

#### Changes proposed in this Pull Request:

* Update cache-busting parameter for Gravatar's `gprofiles.js`

#### Testing instructions:
* Open DevTools in your browser
* Open a website with Jetpack's `Enable pop-up business cards over commenters’ Gravatars` feature enabled, using a Jetpack install patched with this PR
* Ensure that `gprofiles.js` gets loaded, and that the retrieved file contains the string `hex_md5`.

#### Proposed changelog entry for your changes:

No changelog entry needed.
