### PR TITLE
Instant Search: ensures all widgets have no background

### DIFF
--- a/modules/search/instant-search/components/search-sidebar.scss
+++ b/modules/search/instant-search/components/search-sidebar.scss
@@ -9,5 +9,6 @@
 	.jetpack-instant-search__widget-area .widget {
 		padding-left: 0;
 		padding-right: 0;
+		background: none;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/15247

#### Changes proposed in this Pull Request:

* Removes any existing background from widgets in the overlay sidebar.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:

* Fire up this PR.
* Install the [Ixion theme](https://wordpress.org/themes/ixion/) on your site.
* Set up Instant Search on your site and add widgets to your overlay sidebar.
* Trigger the JPS overlay by performing a search.
* Ensure the widgets in the overlay have no background.

#### Proposed changelog entry for your changes:
* None.


#### Before

![image](https://user-images.githubusercontent.com/390760/78373853-07505880-75c3-11ea-952b-5463fcc634e3.png)


#### After

![image](https://user-images.githubusercontent.com/390760/78373812-f869a600-75c2-11ea-902b-301e5b1183c3.png)
