### PR TITLE
Update the base styles package and the dependent variables

### DIFF
--- a/extensions/blocks/tiled-gallery/editor.scss
+++ b/extensions/blocks/tiled-gallery/editor.scss
@@ -73,13 +73,13 @@
 			@include reduce-motion("transition");
 
 			&:hover {
-				box-shadow: $shadow-toolbar;
+				box-shadow: $shadow-popover;
 			}
 
 			.components-button {
 				color: $dark-opacity-300;
 				padding: 2px;
-				height: $icon-button-size-small;
+				height: $button-size-small;
 
 				// Remove hover box shadows, since they clash with the container.
 				&:not(:disabled):not([aria-disabled="true"]):not(.is-secondary):hover {
@@ -135,7 +135,7 @@
 
 	.tiled-gallery__item__move-menu,
 	.tiled-gallery__item__inline-menu {
-		margin: $grid-size;
+		margin: $grid-unit-10;
 		display: inline-flex;
 		z-index: z-index(".block-library-gallery-item__inline-menu");
 
@@ -147,7 +147,7 @@
 			// Use smaller buttons to fit when there are many columns.
 			.columns-7 &,
 			.columns-8 & {
-				padding: $grid-size-small / 2;
+				padding: $grid-unit-05 / 2;
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		"@babel/core": "7.8.4",
 		"@babel/preset-env": "7.8.4",
 		"@babel/register": "7.7.7",
-		"@wordpress/base-styles": "1.4.0",
+		"@wordpress/base-styles": "1.5.0",
 		"@wordpress/browserslist-config": "2.6.0",
 		"@wordpress/compose": "3.11.0",
 		"@wordpress/data": "4.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2426,10 +2426,10 @@
   resolved "https://registry.yarnpkg.com/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.5.0.tgz#d140f902be16f9bef38abafd2a05e040e8aed29e"
   integrity sha512-fvb9+BBi5ns95pTKj2R/YoGbIbA2oBb2YNxRr0pSmeuURFqzeaQIzE+lFnkLCkWVp3DCkXQ1x92+5aWqOqfqzg==
 
-"@wordpress/base-styles@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@wordpress/base-styles/-/base-styles-1.4.0.tgz#5c7fd1f8c18803c8a57cf603f5fa30ebc457448b"
-  integrity sha512-yG2JsLxEpa5zqZc/H6CoB7qb22OJOiG0AQIyhkw8CgvFA0FxiiYIXObAe0yjh2T7EQQbsxq88vxR/cPnupqnEw==
+"@wordpress/base-styles@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/base-styles/-/base-styles-1.5.0.tgz#22395a641399df541ad572c6b9e869423247cab1"
+  integrity sha512-eCG7P3BtKfGiHatvqlJqCn3XdtTMnq4sxtQ/avQ+m40UXJ1mqiW2Ipcen2/MelFqsWVMb4ujjeZwWTsq+vncjg==
 
 "@wordpress/blob@^2.7.0":
   version "2.7.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

For https://github.com/Automattic/jetpack/pull/15051/files we need to update to the latest version of @wordpress/base-styles. When we do that we need to update some variables in the Tiled Gallery block.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This updates some deprecated variables in the Tiled Gallery block to use the new variables from G2. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Tiled Gallery block
* Check that the buttons to move the images around still look ok (they will be slightly different from before, to match G2 but not so that you'd notice probably!)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Upgrade @wordpress/base-styles to 1.5.0
