### PR TITLE
Adds check for Scan to scan header in dash

### DIFF
--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -85,13 +85,7 @@ class AtAGlance extends Component {
 		// Status can be unavailable, active, provisioning, awaiting_credentials
 		const rewindStatus = get( this.props.rewindStatus, [ 'state' ], '' );
 		const securityCards = [];
-		securityCards.push(
-			<DashScan
-				{ ...settingsProps }
-				siteRawUrl={ this.props.siteRawUrl }
-				rewindStatus={ rewindStatus }
-			/>
-		);
+		securityCards.push( <DashScan { ...settingsProps } siteRawUrl={ this.props.siteRawUrl } /> );
 		if ( ! this.props.multisite ) {
 			securityCards.push(
 				<DashBackups

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
-import { getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 import getRedirectUrl from 'lib/jp-redirect';
 
 /**
@@ -14,7 +13,7 @@ import getRedirectUrl from 'lib/jp-redirect';
 import Card from 'components/card';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import QueryScanStatus from 'components/data/query-scan-status';
-import { getSitePlan, isFetchingSiteData } from 'state/site';
+import { getSitePlan, isFetchingSiteData, getSitePurchases } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressScanThreatCount, getVaultPressData } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
@@ -22,6 +21,7 @@ import DashItem from 'components/dash-item';
 import { get, isArray } from 'lodash';
 import { getUpgradeUrl, showBackups } from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
+import { isJetpackScan, getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Displays a card for Security Scan based on the props given.
@@ -259,10 +259,15 @@ class DashScan extends Component {
 			} );
 		}
 
+		const scanPurchase = this.props.purchases.find( purchase =>
+			isJetpackScan( purchase.product_slug )
+		);
+
 		// If the plan class does not support Scan, prompt an upgrade
 		// Otherwise, use either VaultPress or Rewind to determine what to show
 		let content;
 		if (
+			! scanPurchase &&
 			[
 				'is-free-plan',
 				'is-personal-plan',
@@ -300,5 +305,6 @@ export default connect( state => {
 		fetchingSiteData: isFetchingSiteData( state ),
 		showBackups: showBackups( state ),
 		upgradeUrl: getUpgradeUrl( state, 'aag-scan' ),
+		purchases: getSitePurchases( state ),
 	};
 } )( DashScan );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -13,7 +13,7 @@ import Card from 'components/card';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import QueryScanStatus from 'components/data/query-scan-status';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
-import { getScanStatus } from 'state/scan';
+import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressScanThreatCount, getVaultPressData } from 'state/at-a-glance';
 import { isDevMode } from 'state/connection';
@@ -199,7 +199,7 @@ class DashScan extends Component {
 				content: message,
 			} );
 
-		if ( scanStatus.credentials.length === 0 ) {
+		if ( scanStatus.credentials && scanStatus.credentials.length === 0 ) {
 			return (
 				<React.Fragment>
 					{ buildCard( __( "You need to enter your server's credentials to finish the setup." ) ) }
@@ -260,17 +260,13 @@ class DashScan extends Component {
 
 		// Show loading while we're getting props.
 		// Once we get them, test the Scan system and then VaultPress in order.
-		const { scanStatus, vaultPressData } = this.props;
+		const { scanStatus, vaultPressData, fetchingScanStatus } = this.props;
 		let content = renderCard( { content: __( 'Loading…' ) } );
-		if ( scanStatus.state && 'unavailable' !== scanStatus.state ) {
+		if ( ! fetchingScanStatus && scanStatus.state && 'unavailable' !== scanStatus.state ) {
 			content = <div className="jp-dash-item">{ this.getRewindContent() }</div>;
 		} else if ( get( vaultPressData, [ 'data', 'features', 'security' ], false ) ) {
 			content = this.getVPContent();
-		} else if (
-			'N/A' === vaultPressData &&
-			scanStatus.state &&
-			'unavailable' === scanStatus.state
-		) {
+		} else if ( 'N/A' === vaultPressData && ! fetchingScanStatus ) {
 			content = this.getUpgradeContent();
 		}
 
@@ -289,6 +285,7 @@ export default connect( state => {
 
 	return {
 		scanStatus: getScanStatus( state ),
+		fetchingScanStatus: isFetchingScanStatus( state ),
 		vaultPressData: getVaultPressData( state ),
 		scanThreats: getVaultPressScanThreatCount( state ),
 		sitePlan,

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { numberFormat, translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
 
 /**
  * Internal dependencies
@@ -22,6 +21,7 @@ import { get, isArray } from 'lodash';
 import { getUpgradeUrl, showBackups } from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
 import { isJetpackScan, getPlanClass, PLAN_JETPACK_PREMIUM } from 'lib/plans/constants';
+import getRedirectUrl from 'lib/jp-redirect';
 
 /**
  * Displays a card for Security Scan based on the props given.

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -195,7 +195,6 @@ class DashScan extends Component {
 			renderCard( {
 				className: 'jp-dash-item__is-active',
 				status: 'is-working',
-				feature: 'rewind',
 				content: message,
 			} );
 

--- a/_inc/client/components/dev-card/index.jsx
+++ b/_inc/client/components/dev-card/index.jsx
@@ -405,16 +405,29 @@ export class DevCard extends React.Component {
 						</label>
 					</li>
 					<li>
-						<label htmlFor="scanActive">
+						<label htmlFor="scanIdle">
 							<input
 								type="radio"
-								id="scanActive"
-								value="active"
-								name="active"
-								checked={ 'active' === scanState }
+								id="scanIdle"
+								value="idle"
+								name="idle"
+								checked={ 'idle' === scanState }
 								onChange={ this.onScanStatusChange }
 							/>
-							Active
+							Idle
+						</label>
+					</li>
+					<li>
+						<label htmlFor="scanScanning">
+							<input
+								type="radio"
+								id="scanScanning"
+								value="scanning"
+								name="scanning"
+								checked={ 'scanning' === scanState }
+								onChange={ this.onScanStatusChange }
+							/>
+							Scanning
 						</label>
 					</li>
 				</ul>

--- a/_inc/client/state/scan/reducer.js
+++ b/_inc/client/state/scan/reducer.js
@@ -19,7 +19,12 @@ export const data = ( state = {}, action ) => {
 		case SCAN_STATUS_FETCH_RECEIVE:
 			return assign( {}, state, { status: action.status } );
 		case MOCK_SWITCH_SCAN_STATE:
-			return assign( {}, state, { status: action.scanState } );
+			return {
+				status: {
+					...state.status,
+					...action.scanState,
+				},
+			};
 		default:
 			return state;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a check for a scan purchase when determining whether to show an upgrade prompt.
* Fixes minor state issue with dev card.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Ticket here: 1151678672052943-as-1169237957358338.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a Jetpack site.
* Visit the Jetpack admin dashboard.
* See what the scan dash says (expected upgrade prompt).
* Using dev tools, set the scan state to provisioning and look at dash (expected provisioning text).
* Set scan state to idle or scanning and observe change.
* Add a plan with VaultPress and refresh admin dashboard. Scan should be current behavior for VaultPress information.

**NOTE** that as of now there's a known issue with the Scan endpoint with permissions. See: 1165179288312705-as-1165179288312714.

<img width="543" alt="Screen Shot 2020-04-03 at 12 01 36 PM" src="https://user-images.githubusercontent.com/1760168/78381287-250dc580-75a3-11ea-9087-5570bed8dcd0.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A, rolls up into Scan changelog.
