### PR TITLE
Search: Add explicit handling for Atomic sites

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -18,7 +18,7 @@ import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
 import { isDevMode } from 'state/connection';
 import { getSitePlan, hasActiveSearchPurchase, isFetchingSitePurchases } from 'state/site';
-import { getUpgradeUrl } from 'state/initial-state';
+import { getUpgradeUrl, isAtomicSite } from 'state/initial-state';
 
 /**
  * Displays a card for Search based on the props given.
@@ -73,6 +73,11 @@ class DashSearch extends Component {
 	};
 
 	render() {
+		// NOTE: Jetpack Search currently does not support atomic sites.
+		if ( this.props.isAtomicSite ) {
+			return null;
+		}
+
 		if ( this.props.isFetching ) {
 			return renderCard( {
 				status: '',
@@ -165,6 +170,7 @@ class DashSearch extends Component {
 
 export default connect( state => {
 	return {
+		isAtomicSite: isAtomicSite( state ),
 		isBusinessPlan: 'is-business-plan' === getPlanClass( getSitePlan( state ).product_slug ),
 		isDevMode: isDevMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -28,10 +28,11 @@ import {
 } from 'lib/plans/constants';
 
 import {
-	isMultisite,
 	getSiteAdminUrl,
-	userCanManageModules,
 	getUpgradeUrl,
+	isAtomicSite,
+	isMultisite,
+	userCanManageModules,
 } from 'state/initial-state';
 import { isAkismetKeyValid, isCheckingAkismetKey, getVaultPressData } from 'state/at-a-glance';
 import {
@@ -188,7 +189,8 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SEARCH_JETPACK:
-				if ( props.hasActiveSearchPurchase ) {
+				// NOTE: Jetpack Search currently does not support atomic sites.
+				if ( props.hasActiveSearchPurchase || props.isAtomicSite ) {
 					return '';
 				}
 
@@ -377,5 +379,6 @@ export default connect( state => {
 		spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
 		multisite: isMultisite( state ),
 		hasActiveSearchPurchase: hasActiveSearchPurchase( state ),
+		isAtomicSite: isAtomicSite( state ),
 	};
 } )( SettingsCard );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Disables showing the Search card in the At a Glance page for atomic sites (`/wp-admin/admin.php?page=jetpack#/dashboard`).
* Disables Search upgrade nudge for atomic sites in Performance Settings (`/wp-admin/admin.php?page=jetpack#/performance`).
* Hides the Instant Search toggle for atomic sites in Performance Settings (`/wp-admin/admin.php?page=jetpack#/performance`).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Apply these changes to your Atomic site.
* Navigate to the At a Glance dashboard and ensure that the Search card no longer renders.
* Navigate to the Performance Settings page and ensure that:
  1) There's no upgrade nudge for the Search card.
  2) There's no toggle for toggling Instant Search.

#### Proposed changelog entry for your changes:
* None.