### PR TITLE
Podcast Player: AMP support

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -125,6 +125,10 @@ function render_player( $player_data, $attributes ) {
 	$instance_id             = wp_unique_id( 'jetpack-podcast-player-block-' . get_the_ID() . '-' );
 	$player_data['playerId'] = $instance_id;
 
+	// Check if we are in AMP mode.
+	$is_amp                = Blocks::is_amp_request();
+	$player_data['is_amp'] = $is_amp;
+
 	// Generate object to be used as props for PodcastPlayer.
 	$player_props = array_merge(
 		// Add all attributes.
@@ -141,8 +145,11 @@ function render_player( $player_data, $attributes ) {
 	$player_inline_style  = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
 	$player_inline_style .= get_css_vars( $attributes );
 
-	$block_classname = Blocks::classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
-	$is_amp          = Blocks::is_amp_request();
+	$extra_classes = array( 'is-default' );
+	if ( $is_amp ) {
+		$extra_classes[] = 'is-amp';
+	}
+	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $extra_classes );
 
 	ob_start();
 	?>
@@ -163,26 +170,45 @@ function render_player( $player_data, $attributes ) {
 				)
 			);
 			?>
-			<?php if ( count( $player_data['tracks'] ) > 1 ) : ?>
+			<?php if ( $is_amp ) : ?>
+			<amp-selector
+				layout="container"
+				keyboard-select-mode="select"
+				class="jetpack-podcast-player__tracks"
+				on="select: AMP.setState({
+					currentTrack: event.targetOption,
+				})"
+			>
+			<?php else : ?>
 			<ol class="jetpack-podcast-player__tracks">
+			<?php endif; ?>
 				<?php foreach ( $player_data['tracks'] as $track_index => $attachment ) : ?>
 					<?php
 					render(
 						'playlist-track',
 						array(
+							'index'            => $track_index,
 							'is_active'        => 0 === $track_index,
 							'attachment'       => $attachment,
 							'primary_colors'   => $primary_colors,
 							'secondary_colors' => $secondary_colors,
+							'is_amp'           => $is_amp,
 						)
 					);
 					?>
 				<?php endforeach; ?>
+			<?php if ( $is_amp ) : ?>
+			</amp-selector>
+			<?php else : ?>
 			</ol>
 			<?php endif; ?>
 		</section>
-		<?php if ( ! $is_amp ) : ?>
+		<?php if ( $is_amp ) : ?>
+		<amp-state id="podcastPlayer">
+		<?php endif; ?>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
+		<?php if ( $is_amp ) : ?>
+		</amp-state>
 		<?php endif; ?>
 	</div>
 	<?php

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -89,6 +89,7 @@ $jetpack-podcast-player-error: $alert-red;
 			@include focus-outline();
 		}
 
+
 		a.jetpack-podcast-player__link {
 			&,
 			&:active,
@@ -345,13 +346,19 @@ $jetpack-podcast-player-error: $alert-red;
 	/**
 	 * Style overrides for AMP version.
 	 */
-	&.is-amp {
+	&.is-amp, &.is-amp.is-default {
 		.jetpack-podcast-player__audio-player {
 			display: block;
-			padding: 0 $player-grid-spacing;
+			padding: 0 $gutter-l;
 		}
-		.jetpack-podcast-player__track[selected]:not(:focus) {
+		.jetpack-podcast-player__track[selected] {
 			outline: none;
+		}
+		.jetpack-podcast-player__track:focus {
+			@include focus-outline();
+		}
+		audio {
+			display: block;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -343,6 +343,16 @@ $jetpack-podcast-player-error: $alert-red;
 	}
 
 	/**
+	 * Style overrides for AMP version.
+	 */
+	&.is-amp {
+		.jetpack-podcast-player__audio-player {
+			display: block;
+			padding: 0 $player-grid-spacing;
+		}
+	}
+
+	/**
 	 * Style player by overriding mejs default styles
 	 */
 	.mejs-container,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -350,6 +350,9 @@ $jetpack-podcast-player-error: $alert-red;
 			display: block;
 			padding: 0 $player-grid-spacing;
 		}
+		.jetpack-podcast-player__track[selected]:not(:focus) {
+			outline: none;
+		}
 	}
 
 	/**

--- a/extensions/blocks/podcast-player/templates/amp-audio.php
+++ b/extensions/blocks/podcast-player/templates/amp-audio.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Podcast AMP Audio template.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Podcast_Player;
+
+/**
+ * Template variables.
+ *
+ * @var string $title
+ * @var string $cover
+ * @var array  $track
+ */
+?>
+
+<amp-audio
+	width="100%"
+	height="40"
+	artwork="<?php echo esc_url( $cover ); ?>"
+	artist="<?php echo esc_attr( $title ); ?>"
+	src="<?php echo esc_url( $track['src'] ); ?>"
+	title="<?php echo esc_attr( $track['title'] ); ?>"
+	[src]="podcastPlayer.tracks[currentTrack].src"
+	[title]="podcastPlayer.tracks[currentTrack].title"
+>
+	<p fallback>
+		<a [href]="podcastPlayer.tracks[currentTrack].link" href="<?php echo esc_url( $track['link'] ); ?>">
+			<?php esc_html_e( 'Open episode page', 'jetpack' ); ?>
+		</a>
+		<a download [href]="podcastPlayer.tracks[currentTrack].src" href="<?php echo esc_url( $track['src'] ); ?>">
+			<?php esc_html_e( 'Download audio', 'jetpack' ); ?>
+		</a>
+	</p>
+</amp-audio>

--- a/extensions/blocks/podcast-player/templates/amp-audio.php
+++ b/extensions/blocks/podcast-player/templates/amp-audio.php
@@ -17,8 +17,9 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 ?>
 
 <amp-audio
-	width="100%"
+	layout="fixed-height"
 	height="40"
+	controls
 	artwork="<?php echo esc_url( $cover ); ?>"
 	artist="<?php echo esc_attr( $title ); ?>"
 	src="<?php echo esc_url( $track['src'] ); ?>"

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -14,6 +14,8 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  * @var array $primary_colors
  * @var array $secondary_colors
  * @var bool  $is_active
+ * @var bool  $is_amp
+ * @var int   $index
  */
 
 $track_title    = $attachment['title'];
@@ -31,16 +33,29 @@ if ( $is_active ) {
 
 <li
 	class="<?php echo esc_attr( trim( $class ) ); ?>"
+	[class]="'<?php echo esc_attr( trim( 'jetpack-podcast-player__track ' . $secondary_colors['class'] ) ); ?> ' + (currentTrack == <?php echo esc_attr( $index ); ?> ? 'is-active' : '')"
 	style="<?php echo esc_attr( $style ); ?>"
+	option="<?php echo esc_attr( $index ); ?>"
+	<?php echo $is_active ? 'selected' : ''; ?>
 >
+	<?php if ( $is_amp ) : ?>
+	<div class="jetpack-podcast-player__track-link">
+	<?php else : ?>
 	<a
 		class="jetpack-podcast-player__track-link jetpack-podcast-player__link"
 		href="<?php echo esc_url( $track_link ); ?>"
 		role="button"
 		<?php echo $is_active ? 'aria-current="track"' : ''; ?>
+		role="button"
+		class="jetpack-podcast-player__track-link"
 	>
+	<?php endif; ?>
 		<span class="jetpack-podcast-player__track-status-icon"></span>
 		<span class="jetpack-podcast-player__track-title"><?php echo esc_html( $track_title ); ?></span>
 		<time class="jetpack-podcast-player__track-duration"><?php echo esc_html( $track_duration ); ?></time>
+	<?php if ( $is_amp ) : ?>
+	</div>
+	<?php else : ?>
 	</a>
+	<?php endif; ?>
 </li>

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -15,6 +15,7 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  * @var string $link
  * @var array  $track
  * @var array  $primary_colors
+ * @var bool   $is_amp
  */
 
 if ( ! isset( $title ) && empty( $track['title'] ) ) {
@@ -28,6 +29,7 @@ $track_link = empty( $track['link'] ) ? $track['src'] : $track['link'];
 	<span
 		class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
 		<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
+		<?php echo $is_amp ? '[text]="podcastPlayer.tracks[currentTrack].title"' : ''; ?>
 	>
 		<?php
 		echo esc_html( $track['title'] );

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -82,11 +82,11 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 				[title]="podcastPlayer.tracks[currentTrack].title"
 			>
 				<p fallback>
-					<a [href]="podcastPlayer.tracks[currentTrack].link" href="<?php esc_url( $track['link'] ); ?>">
-						<?php __( 'Open episode page', 'jetpack' ); ?>
+					<a [href]="podcastPlayer.tracks[currentTrack].link" href="<?php echo esc_url( $track['link'] ); ?>">
+						<?php esc_html_e( 'Open episode page', 'jetpack' ); ?>
 					</a>
-					<a download [href]="podcastPlayer.tracks[currentTrack].src" href="<?php esc_url( $track['src'] ); ?>">
-						<?php __( 'Download audio', 'jetpack' ); ?>
+					<a download [href]="podcastPlayer.tracks[currentTrack].src" href="<?php echo esc_url( $track['src'] ); ?>">
+						<?php esc_html_e( 'Download audio', 'jetpack' ); ?>
 					</a>
 				</p>
 			</amp-audio>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -71,25 +71,16 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 
 	<div class="jetpack-podcast-player__audio-player">
 		<?php if ( $is_amp ) : ?>
-			<amp-audio
-				width="100%"
-				height="40"
-				artwork="<?php echo esc_url( $cover ); ?>"
-				artist="<?php echo esc_attr( $title ); ?>"
-				src="<?php echo esc_url( $track['src'] ); ?>"
-				title="<?php echo esc_attr( $track['title'] ); ?>"
-				[src]="podcastPlayer.tracks[currentTrack].src"
-				[title]="podcastPlayer.tracks[currentTrack].title"
-			>
-				<p fallback>
-					<a [href]="podcastPlayer.tracks[currentTrack].link" href="<?php echo esc_url( $track['link'] ); ?>">
-						<?php esc_html_e( 'Open episode page', 'jetpack' ); ?>
-					</a>
-					<a download [href]="podcastPlayer.tracks[currentTrack].src" href="<?php echo esc_url( $track['src'] ); ?>">
-						<?php esc_html_e( 'Download audio', 'jetpack' ); ?>
-					</a>
-				</p>
-			</amp-audio>
+			<?php
+			render(
+				'amp-audio',
+				array(
+					'cover' => $cover,
+					'title' => $title,
+					'track' => $track,
+				)
+			);
+			?>
 		<?php else : ?>
 			<div class="jetpack-podcast-player--audio-player-loading"></div>
 		<?php endif; ?>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -15,6 +15,8 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  * @var string $title
  * @var string $link
  * @var array  $primary_colors
+ * @var bool   $is_amp
+ * @var string $cover
  */
 
 /**
@@ -48,6 +50,7 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 					'link'           => $link,
 					'track'          => $track,
 					'primary_colors' => $primary_colors,
+					'is_amp'         => $is_amp,
 				)
 			);
 		}
@@ -60,12 +63,35 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 	<div
 		id="<?php echo esc_attr( $player_id ); ?>__track-description"
 		class="jetpack-podcast-player__track-description"
+		<?php echo $is_amp ? '[text]="podcastPlayer.tracks[currentTrack].description"' : ''; ?>
 	>
 		<?php echo esc_html( $track['description'] ); ?>
 	</div>
 	<?php endif; ?>
 
 	<div class="jetpack-podcast-player__audio-player">
-		<div class="jetpack-podcast-player--audio-player-loading"></div>
+		<?php if ( $is_amp ) : ?>
+			<amp-audio
+				width="100%"
+				height="40"
+				artwork="<?php echo esc_url( $cover ); ?>"
+				artist="<?php echo esc_attr( $title ); ?>"
+				src="<?php echo esc_url( $track['src'] ); ?>"
+				title="<?php echo esc_attr( $track['title'] ); ?>"
+				[src]="podcastPlayer.tracks[currentTrack].src"
+				[title]="podcastPlayer.tracks[currentTrack].title"
+			>
+				<p fallback>
+					<a [href]="podcastPlayer.tracks[currentTrack].link" href="<?php esc_url( $track['link'] ); ?>">
+						<?php __( 'Open episode page', 'jetpack' ); ?>
+					</a>
+					<a download [href]="podcastPlayer.tracks[currentTrack].src" href="<?php esc_url( $track['src'] ); ?>">
+						<?php __( 'Download audio', 'jetpack' ); ?>
+					</a>
+				</p>
+			</amp-audio>
+		<?php else : ?>
+			<div class="jetpack-podcast-player--audio-player-loading"></div>
+		<?php endif; ?>
 	</div>
 </div>


### PR DESCRIPTION
Fixes #15771 

#### Changes proposed in this Pull Request:
* this experiments with AMP version of our player
* the block is visually the same to our full React version with the exception of:
  - the audio player which uses native `<audio>` controls
  - an extra border around selected episode (easily fixable via CSS)
  - inconsistent re-coloring for active tracks (also quite easily fixable in PHP template)

<img width="719" alt="Screenshot 2020-04-06 at 13 21 55" src="https://user-images.githubusercontent.com/156676/78553489-9ea6ed00-7809-11ea-8650-e1df0c725cd5.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
* Install [the AMP plugin](https://wordpress.org/plugins/amp/) and switch it to transitional mode on its settings screen
* Test with a post containing the podcast player and append `?amp` to its URL to see the AMP version

#### Proposed changelog entry for your changes:
* none
