### PR TITLE
Instant Search: improve theme compatibility

### DIFF
--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -10,6 +10,7 @@
 	overflow-y: auto;
 	overflow-x: hidden;
 	transition: opacity 0.15s ease-in-out;
+	box-sizing: border-box;
 
 	&.is-hidden {
 		transform: translateX( 100vw );
@@ -21,6 +22,10 @@
 
 	&.jetpack-instant-search__overlay--dark {
 		background: #131313;
+	}
+
+	*, *:before, *:after {
+		box-sizing: inherit;
 	}
 }
 

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -30,14 +30,17 @@
 }
 
 .jetpack-instant-search__overlay-close {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	position: fixed;
-	top: 4px;
-	right: 4px;
+	top: 0;
+	right: 0;
 	z-index: 20;
-	width: 44px;
-	height: 44px;
+	width: 40px;
+	height: 40px;
 	margin: 0;
-	padding: 10px;
+	padding: 0;
 	line-height: 1;
 	cursor: pointer;
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -36,7 +36,7 @@ const SearchBox = props => {
 			<div className="jetpack-instant-search__box">
 				{ /* TODO: Add support for preserving label text */ }
 				<label className="jetpack-instant-search__box-label" htmlFor={ inputId }>
-					<span className="screen-reader-text">{ __( 'Site Search', 'jetpack' ) }</span>
+					<span className="screen-reader-text assistive-text">{ __( 'Site Search', 'jetpack' ) }</span>
 					<div className="jetpack-instant-search__box-gridicon">
 						<Gridicon icon="search" size={ 24 } />
 					</div>
@@ -50,7 +50,7 @@ const SearchBox = props => {
 						value={ props.query }
 					/>
 
-					<button className="screen-reader-text">{ __( 'Search', 'jetpack' ) }</button>
+					<button className="screen-reader-text assistive-text">{ __( 'Search', 'jetpack' ) }</button>
 				</label>
 			</div>
 
@@ -70,7 +70,7 @@ const SearchBox = props => {
 							alt="Show search filters"
 							aria-hidden="true"
 						/>
-						<span className="screen-reader-text">
+						<span className="screen-reader-text assistive-text">
 							{ props.showFilters
 								? __( 'Hide filters', 'jetpack' )
 								: __( 'Show filters', 'jetpack' ) }

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -157,6 +157,8 @@ input.jetpack-instant-search__box-input.search-field {
 	}
 
 	&.is-selected {
+		text-decoration: none;
+
 		.jetpack-instant-search__overlay--light & {
 			border-color: #000;
 		}

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -10,13 +10,13 @@
 }
 
 input.jetpack-instant-search__box-input.search-field {
+	margin: 0;
+	padding: 4px 14px;
+	font-size: 18px;
 	border-radius: 5px;
 	border-style: solid;
 	border-width: 2px;
-	font-size: 18px;
 	line-height: 1;
-	margin: 0;
-	padding: 4px 14px;
 	text-indent: 32px;
 	vertical-align: middle;
 	-webkit-appearance: none;

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -58,6 +58,7 @@ input.jetpack-instant-search__box-input.search-field {
 	position: absolute;
 	top: 15px;
 	left: 14px;
+	z-index: 1;
 
 	svg {
 		fill: #666666;

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -19,6 +19,7 @@ input.jetpack-instant-search__box-input.search-field {
 	padding: 4px 14px;
 	text-indent: 32px;
 	vertical-align: middle;
+	-webkit-appearance: none;
 
 	.jetpack-instant-search__overlay--light & {
 		color: #666666;

--- a/modules/search/instant-search/components/search-box.scss
+++ b/modules/search/instant-search/components/search-box.scss
@@ -1,12 +1,11 @@
 .jetpack-instant-search__box {
 	position: relative;
-	display: flex;
-	align-items: center;
-	flex: 0 0 100%;
 }
 
 .jetpack-instant-search__box-label {
-	width: 100%;
+	display: flex;
+	align-items: center;
+	flex: 0 0 100%;
 }
 
 input.jetpack-instant-search__box-input.search-field {
@@ -56,9 +55,12 @@ input.jetpack-instant-search__box-input.search-field {
 
 .jetpack-instant-search__box-gridicon {
 	position: absolute;
-	top: 15px;
+	top: 0;
 	left: 14px;
 	z-index: 1;
+	display: flex;
+	align-items: center;
+	height: 100%;
 
 	svg {
 		fill: #666666;

--- a/modules/search/instant-search/components/search-filters.scss
+++ b/modules/search/instant-search/components/search-filters.scss
@@ -20,5 +20,6 @@
 }
 
 .jetpack-instant-search__clear-filters-link {
+	display: block;
 	margin-bottom: 1em;
 }

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -4,7 +4,7 @@
 	z-index: 10;
 	max-width: 1080px;
 	margin: 0 auto;
-	padding: 0.125em 0.5em;
+	padding: 0.125em 0;
 	text-align: left;
 
 	mark {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/15304 and https://github.com/Automattic/jetpack/issues/14957

#### Changes proposed in this Pull Request:

* Forces border-box on all overlay elements to ensure consistency across all themes.
* Tweak padding for search results.
* Get rid of search input default appearance.
* Update close button size and position.
* Add `assistive-text` class to screen reader text.
* Fixes non-visible gridicon on search input.
* Removes text decoration from selected filter option.
* Center the gridicon on the search input no matter how tall it is.
* Ensures margin is being applied to clear filters link.

#### Notes:

> 2010: showing the sidebar

* This theme doesn't have a viewport meta definition (supposedly because it isn't responsive), so the overlay won't be either. This is not something we can change with CSS only.

> 2012: overlapping highlighting of matches

* This is weird one. There's no line-height defined on the `html` or `body`, so it's impossible to change it on the search results without a) adding an overriding value or b) returning a `line-height: initial` value. Either of these fix the issue for 2012, but break the layout for all other themes.

In sum: given the age of these two themes, I'd suggest we don't try to fix because it could lead to more issues for a much larger quantity of modern themes.

#### Before // After:

![jps-theme-compatibility](https://user-images.githubusercontent.com/390760/78554320-d6f6fd00-7802-11ea-921e-474c034c9d2a.png)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
* Fire up this PR.
* Enable Jetpack Instant Search on your site.
* Active the different themes, one at a time, and ensure they don't display the issues reported in https://github.com/Automattic/jetpack/issues/15304 and https://github.com/Automattic/jetpack/issues/14957

#### Proposed changelog entry for your changes:
* None.
