### PR TITLE
Blocks: do not Jetpack collection on WordPress.com.

### DIFF
--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -8,23 +8,29 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import JetpackLogo from '../shared/jetpack-logo';
+import { isAtomicSite, isSimpleSite } from '../shared/site-type-utils';
 
 /**
  * Return bool depending on registerBlockCollection compatibility.
  *
  * @todo When Jetpack's minimum is WP 5.4. Remove this function and update all block categories.
  *
- * @return {boolean} Value to indicate function support.
+ * @returns {boolean} Value to indicate function support.
  */
 export const supportsCollections = () => {
 	return typeof registerBlockCollection === 'function';
 };
 
+const isWpcom = isSimpleSite() || isAtomicSite();
+
 if ( supportsCollections() ) {
-	registerBlockCollection( 'jetpack', {
-		title: 'Jetpack',
-		icon: <JetpackLogo />,
-	} );
+	// We do not want the Jetpack collection on WordPress.com (Simple or Atomic).
+	if ( ! isWpcom ) {
+		registerBlockCollection( 'jetpack', {
+			title: 'Jetpack',
+			icon: <JetpackLogo />,
+		} );
+	}
 } else {
 	// This can be removed once Jetpack's minimum is Core 5.4.
 	setCategories( [


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/14454#issuecomment-608547942

#### Changes proposed in this Pull Request:

* There is no need to display a custom "Jetpack" category in the block picker on WordPress.com Simple and Atomic sites:

![image](https://user-images.githubusercontent.com/426388/78564455-bdfb4580-781c-11ea-9648-ec78f1084054.png)

Those blocks are already all available in Core or custom Jetpack categories anyway.

#### Testing instructions:

* On a Jetpack site, it should continue to look like the above.
* On a WordPress.com Simple or an Atomic site, that last category should not be there.

#### Proposed changelog entry for your changes:

* N/A
