### PR TITLE
Markdown Block: ensure the editor buttons look good everywhere

### DIFF
--- a/extensions/blocks/markdown/edit.js
+++ b/extensions/blocks/markdown/edit.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { BlockControls, PlainText } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
@@ -67,12 +68,13 @@ class MarkdownEdit extends Component {
 
 	renderToolbarButton( mode, label ) {
 		const { activePanel } = this.state;
+		const { className } = this.props;
+		const buttonClassnames = classnames( className, 'components-button components-tab-button', {
+			'is-pressed': activePanel === mode,
+		} );
 
 		return (
-			<button
-				className={ `components-tab-button ${ activePanel === mode ? 'is-active' : '' }` }
-				onClick={ this.toggleMode( mode ) }
-			>
+			<button className={ buttonClassnames } onClick={ this.toggleMode( mode ) }>
 				<span>{ label }</span>
 			</button>
 		);


### PR DESCRIPTION
Fixes #14978


#### Changes proposed in this Pull Request:

* This adds additional classes so the button can be properly styled by the editor.


**Before**

![image](https://user-images.githubusercontent.com/426388/78589926-4d1a5480-7841-11ea-9d93-006d1a31999e.png)

**After (WP 5.3.2)**

![image](https://user-images.githubusercontent.com/426388/78591293-83f16a00-7843-11ea-987d-b9875482afb3.png)


**After (WP 5.4)**

![image](https://user-images.githubusercontent.com/426388/78590721-8f906100-7842-11ea-9a87-e5c89a0104c3.png)

**After (WP 5.4 + Gutenberg / WordPress.com)**

![image](https://user-images.githubusercontent.com/426388/78589509-96b66f80-7840-11ea-8d32-0f7b2c38d5a1.png)


#### Testing instructions:

**This is worth trying in different environments: WP 5.3.2, WP 5.4, and WP 5.4 + Gutenberg**

* Start with a Jetpack site connected to WordPress.com.
* In the Block editor, add a new Markdown block.
* Check the block toolbar appearing above the block.

#### Proposed changelog entry for your changes:

* N/A
