### PR TITLE
Search: Fix php notice on autoconfig of search overlay

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -397,10 +397,12 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$sidebars = get_option( 'sidebars_widgets', array() );
 		$slug     = Jetpack_Search_Helpers::FILTER_WIDGET_BASE;
 
-		foreach ( (array) $sidebars['jetpack-instant-search-sidebar'] as $widget_id ) {
-			if ( 0 === strpos( $widget_id, $slug ) ) {
-				// Already configured.
-				return;
+		if ( isset( $sidebars['jetpack-instant-search-sidebar'] ) ) {
+			foreach ( (array) $sidebars['jetpack-instant-search-sidebar'] as $widget_id ) {
+				if ( 0 === strpos( $widget_id, $slug ) ) {
+					// Already configured.
+					return;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #15246

This should prevent any php notices from firing on a new site that has never had the widget in the config before. The notice was getting triggered after adding the Search Product to a site.

