### PR TITLE
Google Maps shortcode AMP compatibility fix: external links

### DIFF
--- a/modules/shortcodes/googlemaps.php
+++ b/modules/shortcodes/googlemaps.php
@@ -124,9 +124,20 @@ function jetpack_googlemaps_shortcode( $atts ) {
 			}
 		}
 
-		$sandbox = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ? 'sandbox="allow-popups allow-scripts allow-same-origin"' : '';
+		$sandbox = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request()
+			? 'sandbox="allow-popups allow-scripts allow-same-origin"'
+			: '';
 
-		return '<div class="' . esc_attr( $css_class ) . '"><iframe width="' . $width . '" height="' . $height . '" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="' . $url . '" ' . $sandbox . '></iframe></div>';
+		return sprintf(
+			'<div class="%1$s">
+				<iframe width="%2$d" height="%3$d" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" %5$s src="%4$s"></iframe>
+			</div>',
+			esc_attr( $css_class ),
+			absint( $width ),
+			absint( $height ),
+			esc_url( $url ),
+			$sandbox
+		);
 	}
 }
 add_shortcode( 'googlemaps', 'jetpack_googlemaps_shortcode' );

--- a/modules/shortcodes/googlemaps.php
+++ b/modules/shortcodes/googlemaps.php
@@ -124,7 +124,9 @@ function jetpack_googlemaps_shortcode( $atts ) {
 			}
 		}
 
-		return '<div class="' . esc_attr( $css_class ) . '"><iframe width="' . $width . '" height="' . $height . '" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="' . $url . '"></iframe></div>';
+		$sandbox = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ? 'sandbox="allow-popups allow-scripts allow-same-origin"' : '';
+
+		return '<div class="' . esc_attr( $css_class ) . '"><iframe width="' . $width . '" height="' . $height . '" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="' . $url . '" ' . $sandbox . '></iframe></div>';
 	}
 }
 add_shortcode( 'googlemaps', 'jetpack_googlemaps_shortcode' );

--- a/tests/php/modules/shortcodes/test-class.googlemaps.php
+++ b/tests/php/modules/shortcodes/test-class.googlemaps.php
@@ -21,17 +21,17 @@ class WP_Test_Jetpack_Shortcodes_Googlemaps extends WP_UnitTestCase {
 			'non_amp'         => array(
 				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA&amp;w=640&amp;h=480]',
 				true,
-				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA" sandbox="allow-popups allow-scripts allow-same-origin"></iframe></div>',
+				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" sandbox="allow-popups allow-scripts allow-same-origin" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
 			),
 			'amp'             => array(
 				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA&amp;w=640&amp;h=480]',
 				false,
-				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA" ></iframe></div>',
+				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
 			),
 			'align_attribute' => array(
 				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA align="center"]',
 				false,
-				'<div class="googlemaps aligncenter"><iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA" ></iframe></div>',
+				'<div class="googlemaps aligncenter"><iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
 			),
 		);
 	}
@@ -53,10 +53,10 @@ class WP_Test_Jetpack_Shortcodes_Googlemaps extends WP_UnitTestCase {
 			add_filter( 'jetpack_is_amp_request', '__return_true' );
 		}
 
-		$this->assertEquals(
-			$expected,
-			do_shortcode( $shortcode )
-		);
+		$actual = preg_replace( '/\s+/', ' ', do_shortcode( $shortcode ) );
+		$actual = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+
+		$this->assertEquals( $expected, $actual );
 	}
 
 }

--- a/tests/php/modules/shortcodes/test-class.googlemaps.php
+++ b/tests/php/modules/shortcodes/test-class.googlemaps.php
@@ -12,16 +12,51 @@ class WP_Test_Jetpack_Shortcodes_Googlemaps extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Gets the test data for test_shortcodes_googlemaps().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_shortcode_googlemaps_data() {
+		return array(
+			'non_amp'         => array(
+				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA&amp;w=640&amp;h=480]',
+				true,
+				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA" sandbox="allow-popups allow-scripts allow-same-origin"></iframe></div>',
+			),
+			'amp'             => array(
+				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA&amp;w=640&amp;h=480]',
+				false,
+				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA" ></iframe></div>',
+			),
+			'align_attribute' => array(
+				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA align="center"]',
+				false,
+				'<div class="googlemaps aligncenter"><iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA" ></iframe></div>',
+			),
+		);
+	}
+
+	/**
+	 * Test the shortcode output.
+	 *
+	 * @dataProvider get_shortcode_googlemaps_data
 	 * @author scotchfield
 	 * @covers ::jetpack_googlemaps_shortcode
 	 * @since 3.2
+	 *
+	 * @param string $shortcode The shortcode to render.
+	 * @param bool   $is_amp    Whether this is an AMP endpoint.
+	 * @param string $expected  The expected rendered shortcode.
 	 */
-	public function test_shortcodes_googlemaps() {
-		$content = '[googlemaps]';
+	public function test_shortcodes_googlemaps( $shortcode, $is_amp, $expected ) {
+		if ( $is_amp ) {
+			add_filter( 'jetpack_is_amp_request', '__return_true' );
+		}
 
-		$shortcode_content = do_shortcode( $content );
-
-		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals(
+			$expected,
+			do_shortcode( $shortcode )
+		);
 	}
 
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In the Google Maps shortcode, allow clicking external links on AMP endpoints

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds functionality to an existing feature 

#### Testing instructions:
1. Ensure the [AMP plugin](https://wordpress.org/plugins/amp/) is enabled
2. In AMP Settings, select 'Transitional' mode
3. In Jetpack > Settings, ensure 'Compose using shortcodes' is toggled on:


![compose-shortcodes](https://user-images.githubusercontent.com/4063887/78590154-fee85f80-7806-11ea-8291-b15b586a7ae3.png)

4. Add a Shortcode block with:
```html
[googlemaps https://maps.google.com/maps?f=q&amp;hl=en&amp;geocode=&amp;q=San+Francisco,+CA&amp;sll=43.469466,-83.998504&amp;sspn=0.01115,0.025942&amp;g=San+Francisco,+CA&amp;ie=UTF8&amp;z=12&amp;iwloc=addr&amp;ll=37.808156,-122.402458&amp;output=embed&amp;s=AARTsJp56EajYksz3JXgNCwT3LJnGsqqAQ&amp;w=425&amp;h=350]
```
(this was taken from [googlemaps.php](https://github.com/Automattic/jetpack/blob/30f4c13f59bfeae1eeb2d03e1ad3e81c90feeb54/modules/shortcodes/googlemaps.php#L7))
5. Preview the AMP front-end by clicking the AMP icon:

![amp-button](https://user-images.githubusercontent.com/4063887/78590589-aebdcd00-7807-11ea-843e-625fd0a5c00c.png)

6. Click an external link, like 'View larger map'
7. Expected: this opens a new tab or window:
![external-link](https://user-images.githubusercontent.com/4063887/78591253-c6e21c00-7808-11ea-9c61-935a8143aa1e.gif)


Before, clicking an external link did nothing.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve Google Maps shortcode AMP compatibility
