### PR TITLE
E2E tests: fix reconnection logic

### DIFF
--- a/tests/e2e/bin/docker-e2e-cli.sh
+++ b/tests/e2e/bin/docker-e2e-cli.sh
@@ -9,6 +9,18 @@ set -e
 # Include useful functions
 . "$(dirname "$0")/includes.sh"
 
+function usage {
+	echo "usage: $0 command"
+	echo "  setup                        Setup the docker containers for E2E tests"
+	echo "  reset                        Reset the containers state"
+	echo "  stop                         Stops the containers"
+	echo "  db_reset                     Reset the site DB"
+	echo "  sh                           sh into the container"
+	echo "  cli \"subcommand\"             run a wp-cli command"
+	echo "  -h | usage                   output this message"
+	exit 1
+}
+
 FILES=${1-.}
 E2E_DEBUG=${2-true}
 WP_BASE_URL=${3-$(get_ngrok_url)}
@@ -29,6 +41,8 @@ elif [ "${1}" == "sh" ]; then
 	$DC exec $CONTAINER bash
 elif [ "${1}" == "cli" ]; then
 	$DC run --rm -u 33 $CLI ${2}
+elif [ "${1}" == "usage" ]; then
+	usage
 else
-	$DC ${1}
+	usage
 fi

--- a/tests/e2e/lib/pages/wpcom/authorize.js
+++ b/tests/e2e/lib/pages/wpcom/authorize.js
@@ -20,7 +20,7 @@ export default class AuthorizePage extends Page {
 			if ( repeat ) {
 				const message = 'Jetpack connection failed. Retrying once again.';
 				console.log( message );
-				await sendMessageToSlack( 'Jetpack connection failed. Retrying once again.' );
+				await sendMessageToSlack( message );
 
 				return await this.approve( false );
 			}
@@ -29,11 +29,14 @@ export default class AuthorizePage extends Page {
 	}
 
 	async waitToDisappear() {
-		await waitForSelector( this.page, '.jetpack-connect__logged-in-form-loading', {
-			hidden: true,
-		} );
+		await Promise.all( [
+			this.page.waitForNavigation(),
+			waitForSelector( this.page, '.jetpack-connect__logged-in-form-loading', {
+				hidden: true,
+			} ),
+		] );
 
-		return await waitForSelector( this.page, this.expectedSelector, {
+		return await waitForSelector( this.page, '.jetpack-connect__authorize-form button', {
 			hidden: true,
 		} );
 	}


### PR DESCRIPTION
In https://github.com/Automattic/jetpack/pull/15252 I added a connection retry logic. But since I wasn't able to properly test it I missed how the conditional work there. Turns out, re-connection attempt never happened since `waitToDisappear()` was always successful.

In this PR I updated the logic in `waitToDisappear()` to wait for a redirect first, and then assert that we are not on the `Approve` page anymore. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* fix connection retry logic

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Tests should be green

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a