### PR TITLE
Podcast Player: Theme Compatibility Fixes

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -110,6 +110,11 @@ $player-background: transparent;
 		flex-direction: column;
 		margin: 0;
 		overflow: hidden;
+
+		&:before,
+		&:after {
+			display: none;
+		}
 	}
 
 	.jetpack-podcast-player__current-track-title {
@@ -222,14 +227,20 @@ $player-background: transparent;
 		flex-flow: row nowrap;
 		justify-content: space-between;
 		padding: $track-h-padding $track-v-padding;
-		text-decoration: none;
 		transition: none;
 		color: inherit;
+
+		
 
 		&:hover,
 		&:focus {
 			color: inherit;
 		}
+	}
+
+	// needs slightly higher specificity to override some theme's link styles
+	a.jetpack-podcast-player__track-link {
+		text-decoration: none;
 	}
 
 	// Make space for the error element that will be appended.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -106,7 +106,7 @@ $player-background: transparent;
 		height: $cover-image-size;
 	}
 
-	// Increasing specificity on the header titles and links for more consistency across themes and editor canvas
+	// Increasing specificity on the header titles and links for more consistency across themes and editor canvas.
 	.jetpack-podcast-player__header {
 		
 		.jetpack-podcast-player__title {
@@ -114,7 +114,7 @@ $player-background: transparent;
 			flex-direction: column;
 			margin: 0;
 			overflow: hidden;
-			letter-spacing: 0; // Fixes 2020 compressed text
+			letter-spacing: 0; // Fixes Twenty Twenty compressed text.
 			
 			&:before,
 			&:after {
@@ -243,7 +243,7 @@ $player-background: transparent;
 		}
 	}
 
-	// needs slightly higher specificity to override some theme's link styles
+	// Needs slightly higher specificity to override some theme's link styles.
 	a.jetpack-podcast-player__track-link {
 		text-decoration: none;
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -132,9 +132,6 @@ $player-background: transparent;
 			font-size: $podcast-title-font-size;
 			color: $text-color;
 			margin: 0;
-		}
-	
-		.jetpack-podcast-player__podcast-title {
 			text-decoration: none;
 	
 			&:hover,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -244,6 +244,11 @@ $player-background: transparent;
 	// Needs slightly higher specificity to override some theme's link styles.
 	a.jetpack-podcast-player__track-link {
 		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: none;
+		}
 	}
 
 	// Make space for the error element that will be appended.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -22,7 +22,7 @@ $text-color-active: $text-color-hover;
 $text-color-error: $alert-red;
 $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
-$player-title-color: $black;
+$current-track-title-color: $black;
 $player-background: transparent;
 
 .jetpack-podcast-player--visually-hidden {
@@ -123,7 +123,7 @@ $player-background: transparent;
 		}
 	
 		.jetpack-podcast-player__current-track-title {
-			color: $player-title-color;
+			color: $current-track-title-color;
 			font-size: $track-title-font-size;
 			margin: 0 0 $track-title-b-margin;
 		}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -107,37 +107,38 @@ $player-background: transparent;
 	}
 
 	// Increasing specificity on the header titles and links for more consistency across themes and editor canvas.
-	.jetpack-podcast-player__header {
+	h2.jetpack-podcast-player__title {
+		display: flex;
+		flex-direction: column;
+		margin: 0;
+		overflow: hidden;
+		letter-spacing: 0; // Fixes Twenty Twenty compressed text.
 		
-		.jetpack-podcast-player__title {
-			display: flex;
-			flex-direction: column;
-			margin: 0;
-			overflow: hidden;
-			letter-spacing: 0; // Fixes Twenty Twenty compressed text.
-			
-			&:before,
-			&:after {
-				display: none;
-			}
+		&:before,
+		&:after {
+			display: none;
 		}
+	}
+
+	.jetpack-podcast-player__current-track-title {
+		color: $current-track-title-color;
+		font-size: $track-title-font-size;
+		margin: 0 0 $track-title-b-margin;
+	}
 	
-		.jetpack-podcast-player__current-track-title {
-			color: $current-track-title-color;
-			font-size: $track-title-font-size;
-			margin: 0 0 $track-title-b-margin;
-		}
-	
-		.jetpack-podcast-player__podcast-title {
-			font-size: $podcast-title-font-size;
-			color: $text-color;
-			margin: 0;
-			text-decoration: none;
-	
-			&:hover,
-			&:focus {
-				color: $text-color-hover;
-			}
+
+	.jetpack-podcast-player__podcast-title {
+		font-size: $podcast-title-font-size;
+		color: $text-color;
+		margin: 0;
+	}
+
+	a.jetpack-podcast-player__podcast-title {
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			color: $text-color-hover;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -22,6 +22,7 @@ $text-color-active: $text-color-hover;
 $text-color-error: $alert-red;
 $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
+$player-title-color: $black;
 $player-background: transparent;
 
 .jetpack-podcast-player--visually-hidden {
@@ -122,6 +123,7 @@ $player-background: transparent;
 		}
 	
 		.jetpack-podcast-player__current-track-title {
+			color: $player-title-color;
 			font-size: $track-title-font-size;
 			margin: 0 0 $track-title-b-margin;
 		}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -110,7 +110,8 @@ $player-background: transparent;
 		flex-direction: column;
 		margin: 0;
 		overflow: hidden;
-
+		letter-spacing: 0; // Fixes 2020 compressed text
+		
 		&:before,
 		&:after {
 			display: none;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -106,14 +106,14 @@ $player-background: transparent;
 		height: $cover-image-size;
 	}
 
-	// Increasing specificity on the header titles and links for more consistency across themes and editor canvas.
+	// The tag name increases specificity to override some themes/editor styles.
 	h2.jetpack-podcast-player__title {
 		display: flex;
 		flex-direction: column;
 		margin: 0;
 		overflow: hidden;
 		letter-spacing: 0; // Fixes Twenty Twenty compressed text.
-		
+
 		&:before,
 		&:after {
 			display: none;
@@ -125,7 +125,6 @@ $player-background: transparent;
 		font-size: $track-title-font-size;
 		margin: 0 0 $track-title-b-margin;
 	}
-	
 
 	.jetpack-podcast-player__podcast-title {
 		font-size: $podcast-title-font-size;
@@ -143,7 +142,8 @@ $player-background: transparent;
 	}
 
 	// Apply `secondary` color to the podcast title.
-	.has-secondary { // custom color.
+	.has-secondary {
+		// custom color.
 		.jetpack-podcast-player__podcast-title {
 			color: currentColor;
 		}
@@ -175,7 +175,8 @@ $player-background: transparent;
 		max-height: 105px; //IE11 fallback
 	}
 
-	.has-secondary { // custom color.
+	.has-secondary {
+		// custom color.
 		.jetpack-podcast-player__track-description {
 			color: currentColor;
 		}
@@ -241,7 +242,7 @@ $player-background: transparent;
 		}
 	}
 
-	// Needs slightly higher specificity to override some theme's link styles.
+	// The tag name increases specificity to override some themes/editor styles.
 	a.jetpack-podcast-player__track-link {
 		text-decoration: none;
 
@@ -259,7 +260,7 @@ $player-background: transparent;
 	.jetpack-podcast-player__track-status-icon {
 		flex: $track-status-icon-size 0 0;
 		fill: $jetpack-podcast-player-primary;
-		fill: var(--jetpack-podcast-player-primary);
+		fill: var( --jetpack-podcast-player-primary );
 
 		svg {
 			display: inline-block;
@@ -361,7 +362,7 @@ $player-background: transparent;
 	}
 
 	.mejs-controls .mejs-time-rail .mejs-time-loaded {
-		opacity: .5;
+		opacity: 0.5;
 		background-color: $jetpack-podcast-player-primary;
 		background-color: var( --jetpack-podcast-player-primary );
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -105,36 +105,40 @@ $player-background: transparent;
 		height: $cover-image-size;
 	}
 
-	.jetpack-podcast-player__title {
-		display: flex;
-		flex-direction: column;
-		margin: 0;
-		overflow: hidden;
-		letter-spacing: 0; // Fixes 2020 compressed text
+	// Increasing specificity on the header titles and links for more consistency across themes and editor canvas
+	.jetpack-podcast-player__header {
 		
-		&:before,
-		&:after {
-			display: none;
+		.jetpack-podcast-player__title {
+			display: flex;
+			flex-direction: column;
+			margin: 0;
+			overflow: hidden;
+			letter-spacing: 0; // Fixes 2020 compressed text
+			
+			&:before,
+			&:after {
+				display: none;
+			}
 		}
-	}
-
-	.jetpack-podcast-player__current-track-title {
-		font-size: $track-title-font-size;
-		margin: 0 0 $track-title-b-margin;
-	}
-
-	.jetpack-podcast-player__podcast-title {
-		font-size: $podcast-title-font-size;
-		color: $text-color;
-		margin: 0;
-	}
-
-	a.jetpack-podcast-player__podcast-title {
-		text-decoration: none;
-
-		&:hover,
-		&:focus {
-			color: $text-color-hover;
+	
+		.jetpack-podcast-player__current-track-title {
+			font-size: $track-title-font-size;
+			margin: 0 0 $track-title-b-margin;
+		}
+	
+		.jetpack-podcast-player__podcast-title {
+			font-size: $podcast-title-font-size;
+			color: $text-color;
+			margin: 0;
+		}
+	
+		.jetpack-podcast-player__podcast-title {
+			text-decoration: none;
+	
+			&:hover,
+			&:focus {
+				color: $text-color-hover;
+			}
 		}
 	}
 
@@ -230,8 +234,6 @@ $player-background: transparent;
 		padding: $track-h-padding $track-v-padding;
 		transition: none;
 		color: inherit;
-
-		
 
 		&:hover,
 		&:focus {


### PR DESCRIPTION
Provides a baseline style for consistent podcast player styling in 2019, 2020, and all WPcom free themes.

Fixes https://github.com/Automattic/jetpack/issues/15132

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds minimum necessary CSS for style fixes across themes

### Themes that needed fixes
**Twenty Nineteen**
| Before  | After |
| ------------- | ------------- |
| <img width="732" alt="2019 Before Podcast Player" src="https://user-images.githubusercontent.com/967608/78599886-86d66580-7817-11ea-9cca-3e6484871da1.png"> | <img width="737" alt="Screen Shot 2020-04-06 at 2 50 32 PM" src="https://user-images.githubusercontent.com/967608/78600003-bf763f00-7817-11ea-9348-3d1aafef7438.png"> |


**Twenty Twenty**: The compressed letter spacing in the podcast title is the fix here (highlighted in Before image)
| Before  | After |
| ------------- | ------------- |
| <img width="604" alt="Screen Shot 2020-04-06 at 3 08 02 PM" src="https://user-images.githubusercontent.com/967608/78601299-239a0280-781a-11ea-96e6-f55dfa838f62.png"> | <img width="594" alt="Screen Shot 2020-04-06 at 3 09 18 PM" src="https://user-images.githubusercontent.com/967608/78601310-28f74d00-781a-11ea-848a-7ee78aadbd84.png"> |



**Twenty Twenty Editor Canvas**
| Before  | After |
| ------------- | ------------- |
| <img width="626" alt="Screen Shot 2020-04-06 at 3 10 54 PM" src="https://user-images.githubusercontent.com/967608/78601181-f0577380-7819-11ea-8e6b-50835f654ced.png"> | <img width="637" alt="Screen Shot 2020-04-06 at 3 14 31 PM" src="https://user-images.githubusercontent.com/967608/78601187-f3eafa80-7819-11ea-9fed-e7d707525b21.png"> |


**Rivington**: No title color (or default text color at all) is specified for the block. The current track title color was the only one missing, so I added that.
| Before  | After |
| ------------- | ------------- |
| <img width="780" alt="Screen Shot 2020-04-06 at 3 35 26 PM" src="https://user-images.githubusercontent.com/967608/78603904-855c6b80-781e-11ea-8687-257ffe241ff9.png"> | <img width="771" alt="Screen Shot 2020-04-06 at 3 43 00 PM" src="https://user-images.githubusercontent.com/967608/78603910-87bec580-781e-11ea-8732-1fdd86723b5c.png"> |

#### Testing instructions:
* Add a podcast block to your site
* Check that the podcast player looks correct in the frontend and editor canvas

#### Themes tested:
- [x] Twenty Nineteen 
- [x] Twenty Twenty
- [x] Varia
- [x] Maywood
- [x] Barnsbury
- [x] Dalston
- [x] Rivington
- [x] Mayland
- [x] Balasana
- [x] Shawburn
- [ ] Alvez (didn't test due to missing stylesheet error)
- [x] Exford
- [x] Rockfield
- [x] Stratford
- [x] Coutoire
- [x] Morden
- [x] Stow
- [x] Leven
- [ ] Bromton (didn't test due to missing stylesheet error)
- [x] Redhill
- [x] Twenty Twelve @obenland 😉

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* CSS Styles for Podcast Player consistency across base themes
