### PR TITLE
Podcast Player: introduce CSS vars for colors

### DIFF
--- a/extensions/blocks/podcast-player/attributes.js
+++ b/extensions/blocks/podcast-player/attributes.js
@@ -36,6 +36,10 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	hexPrimaryColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
 	secondaryColor: {
 		type: 'string',
 	},
@@ -43,10 +47,18 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	hexSecondaryColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
 	backgroundColor: {
 		type: 'string',
 	},
 	customBackgroundColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
+	hexBackgroundColor: {
 		type: 'string',
 		validator: colorValidator,
 	},

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -209,9 +209,9 @@ export class PodcastPlayer extends Component {
 			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
 			backgroundColor:
 				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
-			'--color-primary': hexPrimaryColor,
-			'--color-secondary': hexSecondaryColor,
-			'--color-background': hexBackgroundColor,
+			'--jetpack-podcast-player-primary': hexPrimaryColor,
+			'--jetpack-podcast-player-secondary': hexSecondaryColor,
+			'--jetpack-podcast-player-background': hexBackgroundColor,
 		};
 
 		const cssClassesName = classnames(

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -203,8 +203,10 @@ export class PodcastPlayer extends Component {
 			},
 		};
 
-		// Set colors through inline styles.
-		// Also, add CSS variables.
+		/*
+		 * Set colors through inline styles.
+		 * Also, add CSS variables.
+		 */
 		const inlineStyle = {
 			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
 			backgroundColor:

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -156,10 +156,13 @@ export class PodcastPlayer extends Component {
 			itemsToShow,
 			primaryColor,
 			customPrimaryColor,
+			hexPrimaryColor,
 			secondaryColor,
 			customSecondaryColor,
+			hexSecondaryColor,
 			backgroundColor,
 			customBackgroundColor,
+			hexBackgroundColor,
 			showCoverArt,
 			showEpisodeDescription,
 		} = attributes;
@@ -200,10 +203,15 @@ export class PodcastPlayer extends Component {
 			},
 		};
 
+		// Set colors through inline styles.
+		// Also, add CSS variables.
 		const inlineStyle = {
 			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
 			backgroundColor:
 				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
+			'--color-primary': hexPrimaryColor,
+			'--color-secondary': hexSecondaryColor,
+			'--color-background': hexBackgroundColor,
 		};
 
 		const cssClassesName = classnames(

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -261,7 +261,7 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
-	const updateColor = ( colorName, handler ) => ( color ) => {
+	const createColorChangeHandler = ( colorName, handler ) => ( color ) => {
 		const attr = `hex${ startCase( colorName ) }Color`;
 		setAttributes( { [ attr ]: color } );
 		handler( color );
@@ -300,17 +300,17 @@ const PodcastPlayerEdit = ( {
 					colorSettings={ [
 						{
 							value: primaryColorProp.color,
-							onChange: updateColor( 'primary', setPrimaryColor ),
+							onChange: createColorChangeHandler( 'primary', setPrimaryColor ),
 							label: __( 'Primary Color', 'jetpack' ),
 						},
 						{
 							value: secondaryColorProp.color,
-							onChange: updateColor( 'secondary', setSecondaryColor ),
+							onChange: createColorChangeHandler( 'secondary', setSecondaryColor ),
 							label: __( 'Secondary Color', 'jetpack' ),
 						},
 						{
 							value: backgroundColorProp.color,
-							onChange: updateColor( 'background', setBackgroundColor ),
+							onChange: createColorChangeHandler( 'background', setBackgroundColor ),
 							label: __( 'Background Color', 'jetpack' ),
 						},
 					] }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -8,7 +8,7 @@ import { startCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useEffect, useRef, memo } from '@wordpress/element';
+import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
 	ExternalLink,

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+import { startCase } from 'lodash';
+
 
 /**
  * WordPress dependencies
  */
-import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
+import { useState, useCallback, useEffect, useRef, memo } from '@wordpress/element';
 import {
 	Button,
 	ExternalLink,
@@ -259,6 +261,12 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
+	const updateColor = ( colorName, handler ) => ( color ) => {
+		const attr = `hex${ startCase( colorName ) }Color`;
+		setAttributes( { [ attr ]: color } );
+		handler( color );
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -292,17 +300,17 @@ const PodcastPlayerEdit = ( {
 					colorSettings={ [
 						{
 							value: primaryColorProp.color,
-							onChange: setPrimaryColor,
+							onChange: updateColor( 'primary', setPrimaryColor ),
 							label: __( 'Primary Color', 'jetpack' ),
 						},
 						{
 							value: secondaryColorProp.color,
-							onChange: setSecondaryColor,
+							onChange: updateColor( 'secondary', setSecondaryColor ),
 							label: __( 'Secondary Color', 'jetpack' ),
 						},
 						{
 							value: backgroundColorProp.color,
-							onChange: setBackgroundColor,
+							onChange: updateColor( 'background', setBackgroundColor ),
 							label: __( 'Background Color', 'jetpack' ),
 						},
 					] }

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -232,7 +232,7 @@ function get_css_vars( $attrs ) {
 	foreach ( $colors_name as $color ) {
 		$hex_color = 'hex' . ucfirst( $color ) . 'Color';
 		if ( isset( $attrs[ $hex_color ] ) ) {
-			$inline_style .= " --color-{$color}: {$attrs[ $hex_color ]};";
+			$inline_style .= " --jetpack-podcast-player-{$color}: {$attrs[ $hex_color ]};";
 		}
 	}
 	return $inline_style;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -119,8 +119,8 @@ function render_player( $player_data, $attributes ) {
 	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
-	$player_classes_name = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
-	$player_inline_style = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
+	$player_classes_name  = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
+	$player_inline_style  = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
 	$player_inline_style .= get_css_vars( $attributes );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
@@ -225,13 +225,20 @@ function get_colors( $name, $attrs, $property ) {
 	return $colors;
 }
 
+/**
+ * It generates a string with CSS variables according to the
+ * block colors, prefixing each one with `--jetpack-podcast-player'.
+ *
+ * @param array $attrs Podcast Block attributes object.
+ * @return string      CSS variables depending on block colors.
+ */
 function get_css_vars( $attrs ) {
 	$colors_name = array( 'primary', 'secondary', 'background' );
 
 	$inline_style = '';
 	foreach ( $colors_name as $color ) {
 		$hex_color = 'hex' . ucfirst( $color ) . 'Color';
-		if ( isset( $attrs[ $hex_color ] ) ) {
+		if ( ! empty( $attrs[ $hex_color ] ) ) {
 			$inline_style .= " --jetpack-podcast-player-{$color}: {$attrs[ $hex_color ]};";
 		}
 	}

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -121,6 +121,7 @@ function render_player( $player_data, $attributes ) {
 
 	$player_classes_name = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
 	$player_inline_style = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
+	$player_inline_style .= get_css_vars( $attributes );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
@@ -222,6 +223,19 @@ function get_colors( $name, $attrs, $property ) {
 	}
 
 	return $colors;
+}
+
+function get_css_vars( $attrs ) {
+	$colors_name = array( 'primary', 'secondary', 'background' );
+
+	$inline_style = '';
+	foreach ( $colors_name as $color ) {
+		$hex_color = 'hex' . ucfirst( $color ) . 'Color';
+		if ( isset( $attrs[ $hex_color ] ) ) {
+			$inline_style .= " --color-{$color}: {$attrs[ $hex_color ]};";
+		}
+	}
+	return $inline_style;
 }
 
 /**


### PR DESCRIPTION
This PR introduces CSS variables for colors, as a way to handle the colors setting section more effectively. The primary goal fo this implementation is to be able to apply color styles to the podcast player.

Related https://github.com/Automattic/jetpack/issues/15235#issuecomment-609884137

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add three new block attributes: `hexPrimaryColor`, `hexSecondaryColor` and `hexBackgroundColor`
* Add CSS vars through of inline styles 
* Apply these changes in both rendering systems: server-side and client-side

#### Testing instructions:
* Edit a Podcast Player block instance
* Set colors
* Confirm that:
  * it adds the CSS vars in the main wrapper element, editor-canvas 
  * it adds the CSS vars in the main wrapper element, front-end
  * it adds the CSS vars in the main wrapper element, by server-server (disable JS in front-end)

<img width="1652" alt="Screen Shot 2020-04-07 at 8 07 46 AM" src="https://user-images.githubusercontent.com/77539/78662567-06f7dc00-78a7-11ea-8469-a31a0bd8b92e.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Podcast Player: Add CSS color variables.
