### PR TITLE
Calypsoify: Support new Gutenberg back button

### DIFF
--- a/modules/calypsoify/mods-gutenberg.js
+++ b/modules/calypsoify/mods-gutenberg.js
@@ -12,13 +12,26 @@ jQuery( function( $ ) {
 	}
 
 	var editPostHeaderInception = setInterval( function() {
-		var $closeButton = $( '.edit-post-fullscreen-mode-close__toolbar a' );
-		if ( $closeButton.length < 1 ) {
+		// Legacy selector for Gutenberg plugin < v7.7
+		var legacyButton = $( '.edit-post-fullscreen-mode-close__toolbar a' );
+		// Updated selector for Gutenberg plugin => v7.7
+		var newButton = $( '.edit-post-header .edit-post-fullscreen-mode-close' );
+
+		// True if either close button exists.
+		var hasLegacyButton = legacyButton && legacyButton.length;
+		var hasNewButton = newButton && newButton.length;
+
+		// Keep trying until we find one of the close buttons.
+		if ( ! ( hasLegacyButton || hasNewButton ) ) {
 			return;
 		}
 		clearInterval( editPostHeaderInception );
 
-		$closeButton.attr( 'href', calypsoifyGutenberg.closeUrl );
+		var theButton = legacyButton;
+		if ( hasNewButton ) {
+			theButton = newButton;
+		}
+		theButton.attr( 'href', calypsoifyGutenberg.closeUrl );
 	} );
 
 	$( 'body.revision-php a' ).each( function() {

--- a/modules/calypsoify/mods-gutenberg.js
+++ b/modules/calypsoify/mods-gutenberg.js
@@ -17,7 +17,6 @@ jQuery( function( $ ) {
 		// Updated selector for Gutenberg plugin => v7.7
 		var newButton = $( '.edit-post-header .edit-post-fullscreen-mode-close' );
 
-		// True if either close button exists.
 		var hasLegacyButton = legacyButton && legacyButton.length;
 		var hasNewButton = newButton && newButton.length;
 


### PR DESCRIPTION
Adds support for the new Gutenberg back button format.

Fixes https://github.com/Automattic/wp-calypso/issues/40727

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In your Jetpack site
* Activate the latest version of the Gutenberg plugin
* Activate the elementor plugin. (doesn't play nice with gutenframe)
* Visit the editor from wp-calypso page list
* You should be redirected to wp-admin on your Jetpack site.
* When you click the new back button you should go back to wp-calypso.

The above steps should work if you do not activate the gutenberg plugin and instead use the version bundled with WordPress.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Support the new Gutenberg close button in Calypsoify.
