### PR TITLE
Block: OpenTable: Add a warning if width is set to anything other than wide if style is wide

### DIFF
--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -61,11 +61,17 @@ function OpenTableEdit( {
 
 	useEffect( () => {
 		noticeOperations.removeAllNotices();
-		if ( ! isPlaceholder && ! __isBlockPreview && 'wide' === style && 'wide' !== align ) {
+		if (
+			! isPlaceholder &&
+			! __isBlockPreview &&
+			'wide' === style &&
+			'wide' !== align &&
+			'full' !== align
+		) {
 			const content = (
 				<>
 					{ __(
-						'With the OpenTable block you may encounter display issues if you use its "wide" style with anything other than "wide" alignment',
+						'With the OpenTable block you may encounter display issues if you use its "wide" style with anything other than "wide" or "full" alignment. The wide display style may also not work well on smaller screens.',
 						'jetpack'
 					) }
 				</>

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -56,18 +56,11 @@ function OpenTableEdit( {
 		setAttributes( validatedAttributes );
 	}
 
-	const { align, rid, style, iframe, domain, lang, newtab } = attributes;
+	const { align, rid, style, iframe, domain, lang, newtab, __isBlockPreview } = attributes;
 
-	// We only want to show the warning about wide display when alignment changes, not on every page load
-	// so below ref is set to indicate the initial component mount
-	const mount = useRef( true );
 	useEffect( () => {
-		if ( mount.current ) {
-			mount.current = false;
-			return;
-		}
 		noticeOperations.removeAllNotices();
-		if ( style === 'wide' && align && align !== 'wide' ) {
+		if ( ! isEmpty( rid ) && ! __isBlockPreview && 'wide' === style && 'wide' !== align ) {
 			const content = (
 				<>
 					{ __(
@@ -78,7 +71,7 @@ function OpenTableEdit( {
 			);
 			noticeOperations.createNotice( { status: 'warning', content } );
 		}
-	}, [ attributes ] );
+	}, [ __isBlockPreview, align, noticeOperations, rid, style ] );
 
 	const parseEmbedCode = embedCode => {
 		const newAttributes = getAttributesFromEmbedCode( embedCode );
@@ -227,11 +220,13 @@ function OpenTableEdit( {
 	} );
 
 	return (
-		<div className={ editClasses }>
+		<>
 			{ noticeUI }
-			{ ! isEmpty( rid ) && inspectorControls }
-			{ ! isEmpty( rid ) ? blockPreview() : blockPlaceholder }
-		</div>
+			<div className={ editClasses }>
+				{ ! isEmpty( rid ) && inspectorControls }
+				{ ! isEmpty( rid ) ? blockPreview() : blockPlaceholder }
+			</div>
+		</>
 	);
 }
 

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -19,6 +19,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,6 +57,28 @@ function OpenTableEdit( {
 	}
 
 	const { align, rid, style, iframe, domain, lang, newtab } = attributes;
+
+	// We only want to show the warning about wide display when alignment changes, not on every page load
+	// so below ref is set to indicate the initial component mount
+	const mount = useRef( true );
+	useEffect( () => {
+		if ( mount.current ) {
+			mount.current = false;
+			return;
+		}
+		noticeOperations.removeAllNotices();
+		if ( style === 'wide' && align && align !== 'wide' ) {
+			const content = (
+				<>
+					{ __(
+						'With the OpenTable block you may encounter display issues if you use its "wide" style with anything other than "wide" alignment',
+						'jetpack'
+					) }
+				</>
+			);
+			noticeOperations.createNotice( { status: 'warning', content } );
+		}
+	}, [ attributes ] );
 
 	const parseEmbedCode = embedCode => {
 		const newAttributes = getAttributesFromEmbedCode( embedCode );
@@ -205,6 +228,7 @@ function OpenTableEdit( {
 
 	return (
 		<div className={ editClasses }>
+			{ noticeUI }
 			{ ! isEmpty( rid ) && inspectorControls }
 			{ ! isEmpty( rid ) ? blockPreview() : blockPlaceholder }
 		</div>

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ function OpenTableEdit( {
 			);
 			noticeOperations.createNotice( { status: 'warning', content } );
 		}
-	}, [ __isBlockPreview, align, noticeOperations, rid, style ] );
+	}, [ __isBlockPreview, align, isPlaceholder, noticeOperations, rid, style ] );
 
 	const parseEmbedCode = embedCode => {
 		const newAttributes = getAttributesFromEmbedCode( embedCode );

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -57,10 +57,11 @@ function OpenTableEdit( {
 	}
 
 	const { align, rid, style, iframe, domain, lang, newtab, __isBlockPreview } = attributes;
+	const isPlaceholder = isEmpty( rid );
 
 	useEffect( () => {
 		noticeOperations.removeAllNotices();
-		if ( ! isEmpty( rid ) && ! __isBlockPreview && 'wide' === style && 'wide' !== align ) {
+		if ( ! isPlaceholder && ! __isBlockPreview && 'wide' === style && 'wide' !== align ) {
 			const content = (
 				<>
 					{ __(
@@ -213,8 +214,8 @@ function OpenTableEdit( {
 	);
 
 	const editClasses = classnames( className, {
-		[ `${ defaultClassName }-theme-${ style }` ]: ! isEmpty( rid ) && styleValues.includes( style ),
-		'is-placeholder': isEmpty( rid ),
+		[ `${ defaultClassName }-theme-${ style }` ]: ! isPlaceholder && styleValues.includes( style ),
+		'is-placeholder': isPlaceholder,
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
 		[ `align${ align }` ]: align,
 	} );
@@ -223,8 +224,8 @@ function OpenTableEdit( {
 		<>
 			{ noticeUI }
 			<div className={ editClasses }>
-				{ ! isEmpty( rid ) && inspectorControls }
-				{ ! isEmpty( rid ) ? blockPreview() : blockPlaceholder }
+				{ ! isPlaceholder && inspectorControls }
+				{ ! isPlaceholder ? blockPreview() : blockPlaceholder }
 			</div>
 		</>
 	);

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -107,6 +107,12 @@
 	}
 }
 
+.wp-block[data-type="jetpack/opentable"] {
+	.components-notice__content {
+		text-align: left;
+	}
+}
+
 .components-toggle-control.is-opentable {
 	padding-top: 6px;
 }


### PR DESCRIPTION
Fixes #14857

Currently the OpenTable `wide` style does not display well in themes if the block alignment is set to anything other than `wide` also. If a user selects the `wide` style the alignment is automatically set back to `wide`, but the user can change this using the block alignment toolbar option.

There is currently no way to disable particular options in the alignment toolbar on the fly, so this PR instead adds a warning notice to at least alert the user to the fact that their current style/align combination may cause display issues.

#### Changes proposed in this Pull Request:
* Adds a warning notice if a user selects a style/align combination that may cause display issues

#### Testing instructions:
Add this PR to your local Jetpack dev env
Add an OpenTable block
Try setting the block style to wide, and then set the block alignment to something other than wide
Make sure the warning notice appears and is dismissible
Make sure the notice doesn't appear on page reload of those alignment settings are saved
Make sure the notice disappears if the alignment is set back to wide

**Before:**

![open-table-before](https://user-images.githubusercontent.com/3629020/78613050-eb98cb00-78be-11ea-8b4a-ec559a14ba72.gif)

**After:**

![open-table-after](https://user-images.githubusercontent.com/3629020/78613056-ee93bb80-78be-11ea-97cd-eec6233d1c5a.gif)

#### Proposed changelog entry for your changes:
* Warning notice added to the OpenTable block to alert the user when their selected combination of style and align options may cause display issues
