### PR TITLE
Podcast Player: memoize colors object

### DIFF
--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -17,7 +17,7 @@ import { STATE_PLAYING, STATE_ERROR, STATE_PAUSED } from '../constants';
 import Playlist from './playlist';
 import AudioPlayer from './audio-player';
 import Header from './header';
-import { getColorClassName } from '../utils';
+import { getColorsObject } from '../utils';
 
 // const debug = debugFactory( 'jetpack:podcast-player' );
 const noop = () => {};
@@ -171,37 +171,14 @@ export class PodcastPlayer extends Component {
 		const tracksToDisplay = tracks.slice( 0, itemsToShow );
 		const track = this.getTrack( currentTrack );
 
-		// Set CSS classes string.
-		const primaryColorClass = getColorClassName( 'color', primaryColor );
-		const secondaryColorClass = getColorClassName( 'color', secondaryColor );
-		const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
-
-		const colors = {
-			primary: {
-				name: primaryColor,
-				custom: customPrimaryColor,
-				classes: classnames( {
-					'has-primary': primaryColorClass || customPrimaryColor,
-					[ primaryColorClass ]: primaryColorClass,
-				} ),
-			},
-			secondary: {
-				name: secondaryColor,
-				custom: customSecondaryColor,
-				classes: classnames( {
-					'has-secondary': secondaryColorClass || customSecondaryColor,
-					[ secondaryColorClass ]: secondaryColorClass,
-				} ),
-			},
-			background: {
-				name: backgroundColor,
-				custom: customBackgroundColor,
-				classes: classnames( {
-					'has-background': backgroundColorClass || customBackgroundColor,
-					[ backgroundColorClass ]: backgroundColorClass,
-				} ),
-			},
-		};
+		const colors = getColorsObject( {
+			primaryColor,
+			customPrimaryColor,
+			secondaryColor,
+			customSecondaryColor,
+			backgroundColor,
+			customBackgroundColor,
+		} );
 
 		/*
 		 * Set colors through inline styles.

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -185,9 +185,8 @@ export class PodcastPlayer extends Component {
 		 * Also, add CSS variables.
 		 */
 		const inlineStyle = {
-			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
-			backgroundColor:
-				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
+			color: customSecondaryColor,
+			backgroundColor: customBackgroundColor,
 			'--jetpack-podcast-player-primary': hexPrimaryColor,
 			'--jetpack-podcast-player-secondary': hexSecondaryColor,
 			'--jetpack-podcast-player-background': hexBackgroundColor,
@@ -203,7 +202,7 @@ export class PodcastPlayer extends Component {
 		return (
 			<section
 				className={ cssClassesName }
-				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
+				style={ inlineStyle }
 				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
 				aria-describedby={
 					track && track.description ? `${ playerId }__track-description` : undefined

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { memoize } from 'lodash';
+
+/**
  * Returns a class based on the context a color is being used and its slug.
  * Note: This helper function was copied from core @wordpress/block-editor lib,
  * in order to avoid requiring not-needed dependencies to reduce the size
@@ -46,3 +52,66 @@ export function makeCancellable( promise ) {
 		},
 	};
 }
+
+/**
+ * Returns object with detailed color settings computed from the basic configuration.
+ *
+ * @example
+ * const colors = generateColorsObject( {
+ *   primaryColor: '…',
+ *   customPrimaryColor: '…',
+ *   …
+ * } );
+ * @param Object config with all color-related block attributes.
+ * @returns Object with color details.
+ */
+const generateColorsObject = ( {
+	primaryColor,
+	customPrimaryColor,
+	secondaryColor,
+	customSecondaryColor,
+	backgroundColor,
+	customBackgroundColor,
+} ) => {
+	// Set CSS classes string.
+	const primaryColorClass = getColorClassName( 'color', primaryColor );
+	const secondaryColorClass = getColorClassName( 'color', secondaryColor );
+	const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
+
+	// Generate colors object.
+	return {
+		primary: {
+			name: primaryColor,
+			custom: customPrimaryColor,
+			classes: classnames( {
+				'has-primary': primaryColorClass || customPrimaryColor,
+				[ primaryColorClass ]: primaryColorClass,
+			} ),
+		},
+		secondary: {
+			name: secondaryColor,
+			custom: customSecondaryColor,
+			classes: classnames( {
+				'has-secondary': secondaryColorClass || customSecondaryColor,
+				[ secondaryColorClass ]: secondaryColorClass,
+			} ),
+		},
+		background: {
+			name: backgroundColor,
+			custom: customBackgroundColor,
+			classes: classnames( {
+				'has-background': backgroundColorClass || customBackgroundColor,
+				[ backgroundColorClass ]: backgroundColorClass,
+			} ),
+		},
+	};
+};
+
+/**
+ * Memoized version of generateColorsObject.
+ * @see {@link generateColorsObject} for params and return type.
+ */
+export const getColorsObject = memoize( generateColorsObject, config => {
+	// Cache key is a string with all arguments joined into one string.
+	return Object.values( config ).join();
+} );


### PR DESCRIPTION
This brings back our React optimizations which were broken since introducing the colors object. `React.memo` wasn't able to cache anything because the `colors` object was changing on each render. 

#### Changes proposed in this Pull Request:

This PR extracts the code that generates `colors` into a memoized function, thus the object doesn't change until any color configuration does.

I have also removed unnecessary checks from the code to make it more readable:
- Checking `Object.keys` on inline styles - useless because we always have things there and in any way, React can handle an empty objects without trouble
- Only applying custom colors when there are no named colors set - this is already handled inside `withColors`. Let's not duplicate the work.

Fixes #15272 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Podcast Player

#### Testing instructions:
* test block in both the editor and the frontend, confirm it works - mainly setting colors

#### Testing instructions for nerds:
If you want to drill into React Profiler, that is a good way to confirm our renders are optimized again

* load the block (on the frontend is the easiest, since Gutenberg renders won't mess with your profiling)
* In the React Profiler, go to its settings and enable "Record why each component rendered while profiling."
* start recording in the profiler
* in the block, click a different track to select it
* stop recording

On **master** (or the feature branch) you will get something like this:

<img width="989" alt="Screenshot 2020-04-07 at 11 29 12" src="https://user-images.githubusercontent.com/156676/78667189-ca44d880-78d8-11ea-85d1-34fd40da8036.png">

Notice how inside the `ol` element, all child components had to render. When you hover them, it shows that the reason is the `color` prop has changed. 

On **this branch**:

<img width="708" alt="Screenshot 2020-04-07 at 12 34 24" src="https://user-images.githubusercontent.com/156676/78667286-f82a1d00-78d8-11ea-8a55-c8c136a29ba5.png">

Notice how only two items in `ol` have rendered. Both were rendered because of the `isActive` prop (one track became active, one inactive). All other items didn't need to render as no prop has changed for them.

This confirms the `colors` object is no longer being regenerated on each render.

#### Proposed changelog entry for your changes:
* none
