### PR TITLE
General: Retire legacy deprecated hook code

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6430,72 +6430,251 @@ endif;
 
 		/*
 		 * Format:
-		 * deprecated_filter_name => replacement_name
+		 * deprecated_filter_name => array( 'alt' => replacement_name, 'version' = 'Jetpack x.x.x' )
 		 *
 		 * If there is no replacement, use null for replacement_name
 		 */
 		$deprecated_list = array(
-			'jetpack_bail_on_shortcode'                    => 'jetpack_shortcodes_to_include',
-			'wpl_sharing_2014_1'                           => null,
-			'jetpack-tools-to-include'                     => 'jetpack_tools_to_include',
-			'jetpack_identity_crisis_options_to_check'     => null,
-			'update_option_jetpack_single_user_site'       => null,
-			'audio_player_default_colors'                  => null,
-			'add_option_jetpack_featured_images_enabled'   => null,
-			'add_option_jetpack_update_details'            => null,
-			'add_option_jetpack_updates'                   => null,
-			'add_option_jetpack_network_name'              => null,
-			'add_option_jetpack_network_allow_new_registrations' => null,
-			'add_option_jetpack_network_add_new_users'     => null,
-			'add_option_jetpack_network_site_upload_space' => null,
-			'add_option_jetpack_network_upload_file_types' => null,
-			'add_option_jetpack_network_enable_administration_menus' => null,
-			'add_option_jetpack_is_multi_site'             => null,
-			'add_option_jetpack_is_main_network'           => null,
-			'add_option_jetpack_main_network_site'         => null,
-			'jetpack_sync_all_registered_options'          => null,
-			'jetpack_has_identity_crisis'                  => 'jetpack_sync_error_idc_validation',
-			'jetpack_is_post_mailable'                     => null,
-			'jetpack_seo_site_host'                        => null,
-			'jetpack_installed_plugin'                     => 'jetpack_plugin_installed',
-			'jetpack_holiday_snow_option_name'             => null,
-			'jetpack_holiday_chance_of_snow'               => null,
-			'jetpack_holiday_snow_js_url'                  => null,
-			'jetpack_is_holiday_snow_season'               => null,
-			'jetpack_holiday_snow_option_updated'          => null,
-			'jetpack_holiday_snowing'                      => null,
-			'jetpack_sso_auth_cookie_expirtation'          => 'jetpack_sso_auth_cookie_expiration',
-			'jetpack_cache_plans'                          => null,
-			'jetpack_updated_theme'                        => 'jetpack_updated_themes',
-			'jetpack_lazy_images_skip_image_with_atttributes' => 'jetpack_lazy_images_skip_image_with_attributes',
-			'jetpack_enable_site_verification'             => null,
+			'jetpack_bail_on_shortcode'                    => array(
+				'alt' => 'jetpack_shortcodes_to_include',
+				'ver' => null,
+			),
+			'wpl_sharing_2014_1'                           => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack-tools-to-include'                     => array(
+				'alt' => 'jetpack_tools_to_include',
+				'ver' => null,
+			),
+			'jetpack_identity_crisis_options_to_check'     => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'update_option_jetpack_single_user_site'       => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'audio_player_default_colors'                  => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_featured_images_enabled'   => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_update_details'            => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_updates'                   => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_network_name'              => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_network_allow_new_registrations' => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_network_add_new_users'     => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_network_site_upload_space' => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_network_upload_file_types' => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_network_enable_administration_menus' => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_is_multi_site'             => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_is_main_network'           => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'add_option_jetpack_main_network_site'         => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_sync_all_registered_options'          => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_has_identity_crisis'                  => array(
+				'alt' => 'jetpack_sync_error_idc_validation',
+				'ver' => null,
+			),
+			'jetpack_is_post_mailable'                     => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_seo_site_host'                        => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_installed_plugin'                     => array(
+				'alt' => 'jetpack_plugin_installed',
+				'ver' => null,
+			),
+			'jetpack_holiday_snow_option_name'             => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_holiday_chance_of_snow'               => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_holiday_snow_js_url'                  => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_is_holiday_snow_season'               => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_holiday_snow_option_updated'          => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_holiday_snowing'                      => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_sso_auth_cookie_expirtation'          => array(
+				'alt' => 'jetpack_sso_auth_cookie_expiration',
+				'ver' => null,
+			),
+			'jetpack_cache_plans'                          => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'jetpack_updated_theme'                        => array(
+				'alt' => 'jetpack_updated_themes',
+				'ver' => null,
+			),
+			'jetpack_lazy_images_skip_image_with_atttributes' => array(
+				'alt' => 'jetpack_lazy_images_skip_image_with_attributes',
+				'ver' => null,
+			),
+			'jetpack_enable_site_verification'             => array(
+				'alt' => null,
+				'ver' => null,
+			),
+			'can_display_jetpack_manage_notice'            => array(
+				'alt' => null,
+				'ver' => null,
+			),
 			// Removed in Jetpack 7.3.0
-			'jetpack_widget_authors_exclude'               => 'jetpack_widget_authors_params',
+			'atd_load_scripts'                             => array(
+				'alt' => null,
+				'ver' => 'Jetpack 7.3',
+			),
+			'atd_http_post_timeout'                        => array(
+				'alt' => null,
+				'ver' => 'Jetpack 7.3',
+			),
+			'atd_http_post_error'                          => array(
+				'alt' => null,
+				'ver' => 'Jetpack 7.3',
+			),
+			'atd_service_domain'                           => array(
+				'alt' => null,
+				'ver' => 'Jetpack 7.3',
+			),
+			'jetpack_widget_authors_exclude'               => array(
+				'alt' => 'jetpack_widget_authors_params',
+				'ver' => 'Jetpack 8.3',
+			),
 			// Removed in Jetpack 7.9.0
-			'jetpack_pwa_manifest'                         => null,
-			'jetpack_pwa_background_color'                 => null,
+			'jetpack_pwa_manifest'                         => array(
+				'alt' => null,
+				'ver' => 'Jetpack 7.9',
+			),
+			'jetpack_pwa_background_color'                 => array(
+				'alt' => null,
+				'ver' => 'Jetpack 7.9',
+			),
 			// Removed in Jetpack 8.3.0.
-			'jetpack_check_mobile'                         => null,
-			'jetpack_mobile_stylesheet'                    => null,
-			'jetpack_mobile_template'                      => null,
-			'mobile_reject_mobile'                         => null,
-			'mobile_force_mobile'                          => null,
-			'mobile_app_promo_download'                    => null,
-			'mobile_setup'                                 => null,
-			'jetpack_mobile_footer_before'                 => null,
-			'wp_mobile_theme_footer'                       => null,
-			'minileven_credits'                            => null,
-			'jetpack_mobile_header_before'                 => null,
-			'jetpack_mobile_header_after'                  => null,
-			'jetpack_mobile_theme_menu'                    => null,
-			'minileven_show_featured_images'               => null,
-			'minileven_attachment_size'                    => null,
+			'jetpack_check_mobile'                         => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'jetpack_mobile_stylesheet'                    => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'jetpack_mobile_template'                      => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'mobile_reject_mobile'                         => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'mobile_force_mobile'                          => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'mobile_app_promo_download'                    => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'mobile_setup'                                 => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'jetpack_mobile_footer_before'                 => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'wp_mobile_theme_footer'                       => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'minileven_credits'                            => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'jetpack_mobile_header_before'                 => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'jetpack_mobile_header_after'                  => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'jetpack_mobile_theme_menu'                    => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'minileven_show_featured_images'               => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
+			'minileven_attachment_size'                    => array(
+				'alt' => null,
+				'ver' => 'Jetpack 8.3',
+			),
 			// Removed in Jetpack 9.1.0.
-			'instagram_cache_oembed_api_response_body'     => null,
+			'instagram_cache_oembed_api_response_body'     => array(
+				'alt' => null,
+				'ver' => 'Jetpack 9.1',
+			)
 		);
 
 		// This is a silly loop depth. Better way?
-		foreach ( $deprecated_list as $hook => $hook_alt ) {
+		foreach ( $deprecated_list as $hook => $hook_values ) {
 			if ( has_action( $hook ) ) {
 				foreach ( $wp_filter[ $hook ] as $func => $values ) {
 					foreach ( $values as $hooked ) {
@@ -6504,7 +6683,7 @@ endif;
 						} else {
 							$function_name = 'an anonymous function';
 						}
-						_deprecated_function( $hook . ' used for ' . $function_name, null, $hook_alt );
+						_deprecated_function( esc_html( $hook . ' used for ' . $function_name ), esc_html( $hook_values['ver'] ), esc_html( $hook_values['alt'] ) );
 					}
 				}
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6421,37 +6421,8 @@ endif;
 
 	/**
 	 * Throws warnings for deprecated hooks to be removed from Jetpack that cannot remain in the original place in the code.
-	 *
-	 * @todo Convert these to use apply_filters_deprecated and do_action_deprecated and remove custom code.
 	 */
 	public function deprecated_hooks() {
-		global $wp_filter;
-
-		/*
-		 * Format:
-		 * deprecated_filter_name => array( 'alt' => replacement_name, 'version' = 'Jetpack x.x.x' )
-		 *
-		 * If there is no replacement, use null for replacement_name
-		 */
-		$deprecated_list = array();
-
-		// This is a silly loop depth. Better way?
-		foreach ( $deprecated_list as $hook => $hook_values ) {
-			if ( has_action( $hook ) ) {
-				foreach ( $wp_filter[ $hook ] as $func => $values ) {
-					foreach ( $values as $hooked ) {
-						if ( is_callable( $hooked['function'] ) ) {
-							$function_name = $hooked['function'];
-						} else {
-							$function_name = 'an anonymous function';
-						}
-						$version = ( $hook_values['ver'] ) ? $hook_values['ver'] : 'Jetpack';
-						_deprecated_function( esc_html( $hook . ' used for ' . $function_name ), esc_html( $version ), esc_html( $hook_values['alt'] ) );
-					}
-				}
-			}
-		}
-
 		$filter_deprecated_list = array(
 			'jetpack_bail_on_shortcode'                    => array(
 				'replacement' => 'jetpack_shortcodes_to_include',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6683,7 +6683,8 @@ endif;
 						} else {
 							$function_name = 'an anonymous function';
 						}
-						_deprecated_function( esc_html( $hook . ' used for ' . $function_name ), esc_html( $hook_values['ver'] ), esc_html( $hook_values['alt'] ) );
+						$version = ( $hook_values['ver'] ) ? $hook_values['ver'] : 'Jetpack';
+						_deprecated_function( esc_html( $hook . ' used for ' . $function_name ), esc_html( $version ), esc_html( $hook_values['alt'] ) );
 					}
 				}
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6622,7 +6622,7 @@ endif;
 
 		foreach ( $filter_deprecated_list as $tag => $args ) {
 			if ( has_filter( $tag ) ) {
-				apply_filters_deprecated( $tag, array(), $args['version'], $args['replacement'] );
+				apply_filters_deprecated( $tag, array( null ), $args['version'], $args['replacement'] );
 			}
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6434,244 +6434,7 @@ endif;
 		 *
 		 * If there is no replacement, use null for replacement_name
 		 */
-		$deprecated_list = array(
-			'jetpack_bail_on_shortcode'                    => array(
-				'alt' => 'jetpack_shortcodes_to_include',
-				'ver' => null,
-			),
-			'wpl_sharing_2014_1'                           => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack-tools-to-include'                     => array(
-				'alt' => 'jetpack_tools_to_include',
-				'ver' => null,
-			),
-			'jetpack_identity_crisis_options_to_check'     => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'update_option_jetpack_single_user_site'       => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'audio_player_default_colors'                  => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_featured_images_enabled'   => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_update_details'            => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_updates'                   => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_network_name'              => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_network_allow_new_registrations' => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_network_add_new_users'     => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_network_site_upload_space' => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_network_upload_file_types' => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_network_enable_administration_menus' => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_is_multi_site'             => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_is_main_network'           => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'add_option_jetpack_main_network_site'         => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_sync_all_registered_options'          => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_has_identity_crisis'                  => array(
-				'alt' => 'jetpack_sync_error_idc_validation',
-				'ver' => null,
-			),
-			'jetpack_is_post_mailable'                     => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_seo_site_host'                        => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_installed_plugin'                     => array(
-				'alt' => 'jetpack_plugin_installed',
-				'ver' => null,
-			),
-			'jetpack_holiday_snow_option_name'             => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_holiday_chance_of_snow'               => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_holiday_snow_js_url'                  => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_is_holiday_snow_season'               => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_holiday_snow_option_updated'          => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_holiday_snowing'                      => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_sso_auth_cookie_expirtation'          => array(
-				'alt' => 'jetpack_sso_auth_cookie_expiration',
-				'ver' => null,
-			),
-			'jetpack_cache_plans'                          => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'jetpack_updated_theme'                        => array(
-				'alt' => 'jetpack_updated_themes',
-				'ver' => null,
-			),
-			'jetpack_lazy_images_skip_image_with_atttributes' => array(
-				'alt' => 'jetpack_lazy_images_skip_image_with_attributes',
-				'ver' => null,
-			),
-			'jetpack_enable_site_verification'             => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			'can_display_jetpack_manage_notice'            => array(
-				'alt' => null,
-				'ver' => null,
-			),
-			// Removed in Jetpack 7.3.0
-			'atd_load_scripts'                             => array(
-				'alt' => null,
-				'ver' => 'Jetpack 7.3',
-			),
-			'atd_http_post_timeout'                        => array(
-				'alt' => null,
-				'ver' => 'Jetpack 7.3',
-			),
-			'atd_http_post_error'                          => array(
-				'alt' => null,
-				'ver' => 'Jetpack 7.3',
-			),
-			'atd_service_domain'                           => array(
-				'alt' => null,
-				'ver' => 'Jetpack 7.3',
-			),
-			'jetpack_widget_authors_exclude'               => array(
-				'alt' => 'jetpack_widget_authors_params',
-				'ver' => 'Jetpack 8.3',
-			),
-			// Removed in Jetpack 7.9.0
-			'jetpack_pwa_manifest'                         => array(
-				'alt' => null,
-				'ver' => 'Jetpack 7.9',
-			),
-			'jetpack_pwa_background_color'                 => array(
-				'alt' => null,
-				'ver' => 'Jetpack 7.9',
-			),
-			// Removed in Jetpack 8.3.0.
-			'jetpack_check_mobile'                         => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'jetpack_mobile_stylesheet'                    => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'jetpack_mobile_template'                      => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'mobile_reject_mobile'                         => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'mobile_force_mobile'                          => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'mobile_app_promo_download'                    => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'mobile_setup'                                 => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'jetpack_mobile_footer_before'                 => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'wp_mobile_theme_footer'                       => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'minileven_credits'                            => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'jetpack_mobile_header_before'                 => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'jetpack_mobile_header_after'                  => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'jetpack_mobile_theme_menu'                    => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'minileven_show_featured_images'               => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			'minileven_attachment_size'                    => array(
-				'alt' => null,
-				'ver' => 'Jetpack 8.3',
-			),
-			// Removed in Jetpack 9.1.0.
-			'instagram_cache_oembed_api_response_body'     => array(
-				'alt' => null,
-				'ver' => 'Jetpack 9.1',
-			)
-		);
+		$deprecated_list = array();
 
 		// This is a silly loop depth. Better way?
 		foreach ( $deprecated_list as $hook => $hook_values ) {
@@ -6691,23 +6454,197 @@ endif;
 		}
 
 		$filter_deprecated_list = array(
-			'can_display_jetpack_manage_notice' => array(
+			'jetpack_bail_on_shortcode'                    => array(
+				'replacement' => 'jetpack_shortcodes_to_include',
+				'version'     => 'jetpack-3.1.0',
+			),
+			'wpl_sharing_2014_1'                           => array(
+				'replacement' => null,
+				'version'     => 'jetpack-3.6.0',
+			),
+			'jetpack-tools-to-include'                     => array(
+				'replacement' => 'jetpack_tools_to_include',
+				'version'     => 'jetpack-3.9.0',
+			),
+			'jetpack_identity_crisis_options_to_check'     => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.0.0',
+			),
+			'update_option_jetpack_single_user_site'       => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'audio_player_default_colors'                  => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_featured_images_enabled'   => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_update_details'            => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_updates'                   => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_network_name'              => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_network_allow_new_registrations' => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_network_add_new_users'     => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_network_site_upload_space' => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_network_upload_file_types' => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_network_enable_administration_menus' => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_is_multi_site'             => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_is_main_network'           => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'add_option_jetpack_main_network_site'         => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'jetpack_sync_all_registered_options'          => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.3.0',
+			),
+			'jetpack_has_identity_crisis'                  => array(
+				'replacement' => 'jetpack_sync_error_idc_validation',
+				'version'     => 'jetpack-4.4.0',
+			),
+			'jetpack_is_post_mailable'                     => array(
+				'replacement' => null,
+				'version'     => 'jetpack-4.4.0',
+			),
+			'jetpack_seo_site_host'                        => array(
+				'replacement' => null,
+				'version'     => 'jetpack-5.1.0',
+			),
+			'jetpack_installed_plugin'                     => array(
+				'replacement' => 'jetpack_plugin_installed',
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_holiday_snow_option_name'             => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_holiday_chance_of_snow'               => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_holiday_snow_js_url'                  => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_is_holiday_snow_season'               => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_holiday_snow_option_updated'          => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_holiday_snowing'                      => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.0.0',
+			),
+			'jetpack_sso_auth_cookie_expirtation'          => array(
+				'replacement' => 'jetpack_sso_auth_cookie_expiration',
+				'version'     => 'jetpack-6.1.0',
+			),
+			'jetpack_cache_plans'                          => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.1.0',
+			),
+
+			'jetpack_lazy_images_skip_image_with_atttributes' => array(
+				'replacement' => 'jetpack_lazy_images_skip_image_with_attributes',
+				'version'     => 'jetpack-6.5.0',
+			),
+			'jetpack_enable_site_verification'             => array(
+				'replacement' => null,
+				'version'     => 'jetpack-6.5.0',
+			),
+			'can_display_jetpack_manage_notice'            => array(
 				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
-			'atd_http_post_timeout'             => array(
+			'atd_http_post_timeout'                        => array(
 				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
-			'atd_service_domain'                => array(
+			'atd_service_domain'                           => array(
 				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
-			'atd_load_scripts'                  => array(
+			'atd_load_scripts'                             => array(
 				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
 			),
-			'jetpack_can_make_outbound_https'   => array(
+			'jetpack_widget_authors_exclude'               => array(
+				'replacement' => 'jetpack_widget_authors_params',
+				'version'     => 'jetpack-7.7.0',
+			),
+			// Removed in Jetpack 7.9.0
+			'jetpack_pwa_manifest'                         => array(
+				'replacement' => null,
+				'version'     => 'jetpack-7.9.0',
+			),
+			'jetpack_pwa_background_color'                 => array(
+				'replacement' => null,
+				'version'     => 'jetpack-7.9.0',
+			),
+			'jetpack_check_mobile'                         => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'jetpack_mobile_stylesheet'                    => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'jetpack_mobile_template'                      => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'jetpack_mobile_theme_menu'                    => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'minileven_show_featured_images'               => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'minileven_attachment_size'                    => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'instagram_cache_oembed_api_response_body'     => array(
+				'replacement' => null,
+				'version'     => 'jetpack-9.1.0',
+			),
+			'jetpack_can_make_outbound_https'              => array(
 				'replacement' => null,
 				'version'     => 'jetpack-9.1.0',
 			),
@@ -6720,9 +6657,49 @@ endif;
 		}
 
 		$action_deprecated_list = array(
-			'atd_http_post_error' => array(
+			'jetpack_updated_theme'        => array(
+				'replacement' => 'jetpack_updated_themes',
+				'version'     => 'jetpack-6.2.0',
+			),
+			'atd_http_post_error'          => array(
 				'replacement' => null,
 				'version'     => 'jetpack-7.3.0',
+			),
+			'mobile_reject_mobile'         => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'mobile_force_mobile'          => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'mobile_app_promo_download'    => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'mobile_setup'                 => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'jetpack_mobile_footer_before' => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'wp_mobile_theme_footer'       => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'minileven_credits'            => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'jetpack_mobile_header_before' => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
+			),
+			'jetpack_mobile_header_after'  => array(
+				'replacement' => null,
+				'version'     => 'jetpack-8.3.0',
 			),
 		);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4,12 +4,15 @@ use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 use Automattic\Jetpack\Licensing;
 use Automattic\Jetpack\Partner;
+use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Functions;
@@ -18,9 +21,6 @@ use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Sync\Users;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Plugin\Tracking as Plugin_Tracking;
-use Automattic\Jetpack\Redirect;
-use Automattic\Jetpack\Device_Detection\User_Agent_Info;
 
 /*
 Options:
@@ -741,7 +741,7 @@ class Jetpack {
 
 		add_action(
 			'plugins_loaded',
-			function() {
+			function () {
 				if ( User_Agent_Info::is_mobile_app() ) {
 					add_filter( 'get_edit_post_link', '__return_empty_string' );
 				}
@@ -1568,14 +1568,14 @@ class Jetpack {
 			)
 		);
 	}
-
+// phpcs:disable WordPress.WP.CapitalPDangit.Misspelled
 	/**
 	 * jetpack_updates is saved in the following schema:
 	 *
 	 * array (
 	 *      'plugins'                       => (int) Number of plugin updates available.
 	 *      'themes'                        => (int) Number of theme updates available.
-	 *      'wordpress'                     => (int) Number of WordPress core updates available. // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+	 *      'wordpress'                     => (int) Number of WordPress core updates available.
 	 *      'translations'                  => (int) Number of translation updates available.
 	 *      'total'                         => (int) Total of all available updates.
 	 *      'wp_update_version'             => (string) The latest available version of WordPress, only present if a WordPress update is needed.
@@ -1600,6 +1600,7 @@ class Jetpack {
 		}
 		return isset( $updates ) ? $updates : array();
 	}
+	// phpcs:enable
 
 	public static function get_update_details() {
 		$update_details = array(
@@ -2670,7 +2671,6 @@ class Jetpack {
 		return $data;
 	}
 
-
 	/**
 	 * Return translated module tag.
 	 *
@@ -3172,7 +3172,7 @@ p {
 		}
 
 		// For firing one-off events (notices) immediately after activation
-		set_transient( 'activated_jetpack', true, .1 * MINUTE_IN_SECONDS );
+		set_transient( 'activated_jetpack', true, 0.1 * MINUTE_IN_SECONDS );
 
 		update_option( 'jetpack_activation_source', self::get_activation_source( wp_get_referer() ) );
 
@@ -5916,7 +5916,6 @@ endif;
 		);
 	}
 
-
 	/**
 	 * Verifies the request by checking the signature
 	 *
@@ -6940,7 +6939,6 @@ endif;
 		return $filtered_data;
 	}
 
-
 	/*
 	 * This method is used to organize all options that can be reset
 	 * without disconnecting Jetpack.
@@ -7498,10 +7496,10 @@ endif;
 				'discount_percent'  => 30,
 				'options'           => array(
 					array(
-						'type'      => 'scan',
-						'slug'      => 'jetpack-scan',
-						'key'       => 'jetpack_scan',
-						'name'      => __( 'Daily Scan', 'jetpack' ),
+						'type' => 'scan',
+						'slug' => 'jetpack-scan',
+						'key'  => 'jetpack_scan',
+						'name' => __( 'Daily Scan', 'jetpack' ),
 					),
 				),
 				'default_option'    => 'scan',
@@ -7515,13 +7513,13 @@ endif;
 			'short_description' => __( 'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.', 'jetpack' ),
 			'learn_more'        => __( 'Learn More', 'jetpack' ),
 			'description'       => __( 'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.', 'jetpack' ),
-			'label_popup'  		=> __( 'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.' ),
+			'label_popup'       => __( 'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.', 'jetpack' ),
 			'options'           => array(
 				array(
-					'type'      => 'search',
-					'slug'      => 'jetpack-search',
-					'key'       => 'jetpack_search',
-					'name'      => __( 'Search', 'jetpack' ),
+					'type' => 'search',
+					'slug' => 'jetpack-search',
+					'key'  => 'jetpack_search',
+					'name' => __( 'Search', 'jetpack' ),
 				),
 			),
 			'tears'             => array(),
@@ -7538,10 +7536,10 @@ endif;
 			'description'       => __( 'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.', 'jetpack' ),
 			'options'           => array(
 				array(
-					'type'      => 'anti-spam',
-					'slug'      => 'jetpack-anti-spam',
-					'key'       => 'jetpack_anti_spam',
-					'name'      => __( 'Anti-Spam', 'jetpack' ),
+					'type' => 'anti-spam',
+					'slug' => 'jetpack-anti-spam',
+					'key'  => 'jetpack_anti_spam',
+					'name' => __( 'Anti-Spam', 'jetpack' ),
 				),
 			),
 			'default_option'    => 'anti-spam',

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1330,13 +1330,28 @@ EXPECTED;
 	}
 
 	/**
-	 * Testing that a deprecated filter triggers Jetpack functionality.
+	 * Testing that a deprecated action triggers Jetpack functionality.
 	 *
-	 * Using the `jetpack_updated_theme` filter for the sake of testing.
+	 * Using the `jetpack_updated_theme` action for the sake of testing.
+	 *
+	 * @expectedDeprecated jetpack_updated_theme
 	 */
 	public function test_deprecated_action_fires() {
 		add_action( 'jetpack_updated_theme', '__return_false' );
 		Jetpack::init()->deprecated_hooks();
-		$this->assertTrue( true );
+		remove_action( 'jetpack_updated_theme', '__return_false' );
+	}
+
+	/**
+	 * Testing that a deprecated filter triggers Jetpack functionality.
+	 *
+	 * Using the `jetpack_bail_on_shortcode` filter for the sake of testing.
+	 *
+	 * @expectedDeprecated jetpack_bail_on_shortcode
+	 */
+	public function test_deprecated_filter_fires() {
+		add_filter( 'jetpack_bail_on_shortcode', '__return_false' );
+		Jetpack::init()->deprecated_hooks();
+		remove_filter( 'jetpack_bail_on_shortcode', '__return_false' );
 	}
 } // end class

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1328,4 +1328,15 @@ EXPECTED;
 			array( 'message', null, true ),
 		);
 	}
+
+	/**
+	 * Testing that a deprecated filter triggers Jetpack functionality.
+	 *
+	 * Using the `jetpack_updated_theme` filter for the sake of testing.
+	 */
+	public function test_deprecated_action_fires() {
+		add_action( 'jetpack_updated_theme', '__return_false' );
+		Jetpack::init()->deprecated_hooks();
+		$this->assertTrue( true );
+	}
 } // end class


### PR DESCRIPTION
WordPress added `do_action_deprecated` and `apply_filters_deprecated`. We've implemented this in our `Jetpack::deprecated_hooks()` function; however, we left our pre-existing legacy custom implementation.

This PR refactors those existing deprecations to the new format.

Additionally, our original implementation returned a PHP notice for trying to access an invalid array offset. That's corrected in [`08d91eb` (#15342)](https://github.com/Automattic/jetpack/pull/15342/commits/08d91ebe63fea0d3a9596eb4de395ab9e484fa70). Please see that commit message for additional context.

#### Changes proposed in this Pull Request:
* Converts legacy deprecation code to use new WordPress-provided functionality.
* Adds tests.
* Resolves PHP array offset error discovered while adding tests.
* PHPCS class.jetpack.php (this was done previously, so this just catches up a few things that snuck in or new coding standards hadn't picked up yet).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add this code to your site, e.g. in debug.php in our docker mu-plugin folder:
```
add_filter( 'jetpack_check_mobile', 'foobug' );
function foobug() { }
```
* Check the error logs and see a deprecation notice.
* `yarn docker:phpunit --filter=test_deprecated

#### Proposed changelog entry for your changes:
* General: retire legacy implementation of throwing deprecation notices for old hooks.
