### PR TITLE
Podcast Player: Fix Sound Icon Position

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -243,10 +243,8 @@ $player-background: transparent;
 		fill: var(--jetpack-podcast-player-primary);
 
 		svg {
-			display: inline-block;
-			vertical-align: middle;
+			position: absolute;
 			width: $track-status-icon-size;
-			height: $track-status-icon-size;
 		}
 	}
 


### PR DESCRIPTION
The sound icon was slightly off in the editor (and in the frontend as well, but not sure when that was introduced).

Fixes https://github.com/Automattic/jetpack/issues/15284

#### Changes proposed in this Pull Request:
- Uses `position: absolute;` on the `svg` to prevent it from bumping down any titles when rendering and allows it be centered on the first line of the track title without any additional code. 

| before | after |
| ------------- | ------------- |
| <img width="783" alt="Screen Shot 2020-04-07 at 9 57 20 AM" src="https://user-images.githubusercontent.com/967608/78690382-f94d5100-78bc-11ea-9b07-2ad6c7e0a914.png"> | <img width="797" alt="Screen Shot 2020-04-07 at 9 57 38 AM" src="https://user-images.githubusercontent.com/967608/78690532-2ac61c80-78bd-11ea-96cd-3ae8a78a29b3.png"> |

**All track list items should be the same height**: Some themes may vary the height based on the line-height though.
<img width="799" alt="Screen Shot 2020-04-07 at 9 52 22 AM" src="https://user-images.githubusercontent.com/967608/78690346-ee92bc00-78bc-11ea-9d39-1961c89bbdb5.png">

**Wrapped titles**
<img width="360" alt="Screen Shot 2020-04-07 at 9 56 08 AM" src="https://user-images.githubusercontent.com/967608/78690549-3285c100-78bd-11ea-8771-3ec06ae35698.png">

#### Testing instructions:

* Add a podcast player to a post
* Play a track in the editor
* The sound icon should look centered with the first line of the track
* Reduce the window size so the track titles wrap.
* The sound icon should still be centered with the first line of the track
* The sound icon being added should not increase the height of the track `<a>` element
* Repeat for the front-end

#### Proposed changelog entry for your changes:
* Podcast Player: Centers playing/sound icon on the first line of the track list title.
