### PR TITLE
Iteration 7 Podcast Player

### DIFF
--- a/_inc/lib/class-jetpack-podcast-helper.php
+++ b/_inc/lib/class-jetpack-podcast-helper.php
@@ -95,11 +95,11 @@ class Jetpack_Podcast_Helper {
 			return '';
 		}
 
-		// Replace all entities with their characters, including all types of quotes.
-		$str = wp_specialchars_decode( $str, ENT_QUOTES );
-
 		// Make sure there are no tags.
 		$str = wp_strip_all_tags( $str );
+
+		// Replace all entities with their characters, including all types of quotes.
+		$str = html_entity_decode( $str, ENT_QUOTES );
 
 		return $str;
 	}

--- a/extensions/blocks/podcast-player/api.js
+++ b/extensions/blocks/podcast-player/api.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { PODCAST_FEED, EMBED_BLOCK } from './constants';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+export const fetchPodcastFeed = async url => {
+	// First try calling our endpoint for Podcast parsing.
+	let feedData, feedError;
+	try {
+		feedData = await apiFetch( {
+			path: addQueryArgs( '/wpcom/v2/podcast-player', { url } ),
+		} );
+	} catch ( err ) {
+		// We are not rethrowing the error just yet so we can try the embed too.
+		feedError = err;
+	}
+
+	// Return podcast feed data if we have any.
+	if ( feedData ) {
+		return {
+			type: PODCAST_FEED,
+			data: feedData,
+		};
+	}
+
+	// Try if we have another block that can embed this URL.
+	const externalEmbed = await apiFetch( {
+		path: addQueryArgs( '/oembed/1.0/proxy', { url } ),
+	} );
+
+	// We can use an embed block for this URL, unless API returned the fallback code.
+	const oEmbedLinkCheck = '<a href="' + url + '">' + url + '</a>';
+	if ( externalEmbed && externalEmbed.html !== oEmbedLinkCheck ) {
+		return {
+			type: EMBED_BLOCK,
+		};
+	}
+
+	// Nothing worked, show error.
+	throw feedError;
+};

--- a/extensions/blocks/podcast-player/attributes.js
+++ b/extensions/blocks/podcast-player/attributes.js
@@ -36,6 +36,10 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	hexPrimaryColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
 	secondaryColor: {
 		type: 'string',
 	},
@@ -43,10 +47,18 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	hexSecondaryColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
 	backgroundColor: {
 		type: 'string',
 	},
 	customBackgroundColor: {
+		type: 'string',
+		validator: colorValidator,
+	},
+	hexBackgroundColor: {
 		type: 'string',
 		validator: colorValidator,
 	},

--- a/extensions/blocks/podcast-player/components/audio-player.js
+++ b/extensions/blocks/podcast-player/components/audio-player.js
@@ -1,4 +1,5 @@
 /* global _wpmejsSettings, MediaElementPlayer */
+
 /**
  * External dependencies
  */
@@ -41,6 +42,7 @@ class AudioPlayer extends Component {
 
 	/**
 	 * Play current audio.
+	 *
 	 * @public
 	 */
 	play = () => {
@@ -50,6 +52,7 @@ class AudioPlayer extends Component {
 
 	/**
 	 * Pause current audio.
+	 *
 	 * @public
 	 */
 	pause = () => {
@@ -59,6 +62,7 @@ class AudioPlayer extends Component {
 
 	/**
 	 * Toggle playing state.
+	 *
 	 * @public
 	 */
 	togglePlayPause = () => {

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -9,12 +9,25 @@ import classnames from 'classnames';
 import { memo } from '@wordpress/element';
 
 const Header = memo(
-	( { playerId, title, cover, link, track, children, showCoverArt, showEpisodeDescription, colors } ) => (
+	( {
+		playerId,
+		title,
+		cover,
+		link,
+		track,
+		children,
+		showCoverArt,
+		showEpisodeDescription,
+		colors,
+	} ) => (
 		<div className="jetpack-podcast-player__header">
 			<div className="jetpack-podcast-player__current-track-info">
 				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__cover">
-						{ /* alt="" will prevent the src from being announced. Ideally we'd have a cover.alt, but we can't get that from the RSS */ }
+						{ /*
+						 * alt="" will prevent the src from being announced. Ideally we'd
+						 * have a cover.alt, but we can't get that from the RSS.
+						 */ }
 						<img className="jetpack-podcast-player__cover-image" src={ cover } alt="" />
 					</div>
 				) }
@@ -30,7 +43,10 @@ const Header = memo(
 				) }
 			</div>
 
-			{ /* putting this above the audio player for source order HTML with screen readers, then visually switching it with the audio player via flex */ }
+			{ /*
+			 * Putting this above the audio player for source order HTML with screen
+			 * readers, then visually switching it with the audio player via flex.
+			 */ }
 			{ !! ( showEpisodeDescription && track && track.description ) && (
 				<div
 					id={ `${ playerId }__track-description` }
@@ -46,50 +62,63 @@ const Header = memo(
 	)
 );
 
-const Title = memo( ( {
-	playerId,
-	title,
-	link,
-	track,
-	colors = { primary: { name: null, custom: null, classes: '' } }
-} ) => (
-	<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
-		{ !! ( track && track.title ) && (
-			<span
-				className={ classnames( 'jetpack-podcast-player__current-track-title', colors.primary.classes ) }
-				style={ { color: colors.primary.custom } }
-			>
-				{ track.title }
-			</span>
-		) }
+const Title = memo(
+	( {
+		playerId,
+		title,
+		link,
+		track,
+		colors = { primary: { name: null, custom: null, classes: '' } },
+	} ) => (
+		<h2 id={ `${ playerId }__title` } className="jetpack-podcast-player__title">
+			{ !! ( track && track.title ) && (
+				<span
+					className={ classnames(
+						'jetpack-podcast-player__current-track-title',
+						colors.primary.classes
+					) }
+					style={ { color: colors.primary.custom } }
+				>
+					{ track.title }
+				</span>
+			) }
 
-		{ /* Adds a visually hidden dash when both a track and a podcast titles are present */ }
-		{ !! ( track && track.title && title ) && (
-			<span className="jetpack-podcast-player--visually-hidden"> - </span>
-		) }
+			{ /*
+			 * Adds a visually hidden dash when both a track and a podcast titles are
+			 * present.
+			 */ }
+			{ !! ( track && track.title && title ) && (
+				<span className="jetpack-podcast-player--visually-hidden"> - </span>
+			) }
 
-		{ !! title && <PodcastTitle title={ title } link={ link } colors={ colors } /> }
-	</h2>
-) );
+			{ !! title && <PodcastTitle title={ title } link={ link } colors={ colors } /> }
+		</h2>
+	)
+);
 
-const PodcastTitle = memo( ( { title, link, colors = { secondary: { name: null, custom: null, classes: '' } } } ) => {
-	const className = classnames( 'jetpack-podcast-player__podcast-title', colors.secondary.classes );
-
-	if ( link ) {
-		return (
-			<a
-				className={ className }
-				style={ { color: colors.secondary.custom } }
-				href={ link }
-				target="_blank"
-				rel="noopener noreferrer nofollow"
-			>
-				{ title }
-			</a>
+const PodcastTitle = memo(
+	( { title, link, colors = { secondary: { name: null, custom: null, classes: '' } } } ) => {
+		const className = classnames(
+			'jetpack-podcast-player__podcast-title',
+			colors.secondary.classes
 		);
-	}
 
-	return <span className={ className }>{ title }</span>;
-} );
+		if ( link ) {
+			return (
+				<a
+					className={ className }
+					style={ { color: colors.secondary.custom } }
+					href={ link }
+					target="_blank"
+					rel="noopener noreferrer nofollow"
+				>
+					{ title }
+				</a>
+			);
+		}
+
+		return <span className={ className }>{ title }</span>;
+	}
+);
 
 export default Header;

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -25,8 +25,8 @@ const Header = memo(
 				{ showCoverArt && cover && (
 					<div className="jetpack-podcast-player__cover">
 						{ /*
-						 * alt="" will prevent the src from being announced. Ideally we'd
-						 * have a cover.alt, but we can't get that from the RSS.
+						 * alt="" will prevent the src from being announced by a screen reader.
+						 * Ideally we'd have a cover.alt, but we can't get that from the RSS.
 						 */ }
 						<img className="jetpack-podcast-player__cover-image" src={ cover } alt="" />
 					</div>

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -20,11 +20,13 @@ const TrackIcon = ( { isPlaying, isError, className } ) => {
 
 	if ( isError ) {
 		name = 'error';
-		/* translators: This is text to describe the current state. This will go before the track title, such as "Error: [The title of the track]" */
+		/* translators: This is text to describe the current state. This will go
+		before the track title, such as "Error: [The title of the track]". */
 		hiddenText = __( 'Error:', 'jetpack' );
 	} else if ( isPlaying ) {
 		name = 'playing';
-		/* translators: Text to describe the current state. This will go before the track title, such as "Playing: [The title of the track]" */
+		/* translators: Text to describe the current state. This will go before the
+		track title, such as "Playing: [The title of the track]". */
 		hiddenText = __( 'Playing:', 'jetpack' );
 	}
 
@@ -53,9 +55,13 @@ const TrackError = memo( ( { link, title } ) => (
 			<span>
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
 					<span class="jetpack-podcast-player--visually-hidden">
-						{ /* Intentional trailing space outside of the translated string */ }
-						{ /* translators: %s is the title of the track. This text is visually hidden from the screen, but available to screen readers */ }
-						{ `${ sprintf( __( '%s:', 'jetpack' ), title ) } ` }
+						{ /* Intentional trailing space outside of the translated string. */ }
+						{ `${ sprintf(
+							/* translators: %s is the title of the track. This text is
+							visually hidden from the screen, but available to screen readers. */
+							__( '%s:', 'jetpack' ),
+							title
+						) } ` }
 					</span>
 					{ __( 'Open in a new tab', 'jetpack' ) }
 				</a>
@@ -95,7 +101,9 @@ const Track = memo(
 			inlineStyle.color = colors.secondary.custom;
 		}
 
-		/* translators: This needs to be a single word with no spaces. It describes the current item in the group. A screen reader will announce it as "[title], current track" */
+		/* translators: This needs to be a single word with no spaces. It describes
+		the current item in the group. A screen reader will announce it as "[title],
+		current track". */
 		const ariaCurrent = isActive ? __( 'track', 'jetpack' ) : undefined;
 
 		return (

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -1,163 +1,18 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import * as trackIcons from '../icons/track-icons';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
-
-const TrackIcon = ( { isPlaying, isError, className } ) => {
-	let hiddenText, name;
-
-	if ( isError ) {
-		name = 'error';
-		/* translators: This is text to describe the current state. This will go
-		before the track title, such as "Error: [The title of the track]". */
-		hiddenText = __( 'Error:', 'jetpack' );
-	} else if ( isPlaying ) {
-		name = 'playing';
-		/* translators: Text to describe the current state. This will go before the
-		track title, such as "Playing: [The title of the track]". */
-		hiddenText = __( 'Playing:', 'jetpack' );
-	}
-
-	const icon = trackIcons[ name ];
-
-	if ( ! icon ) {
-		// Return empty element - we need it for layout purposes.
-		return <span className={ className } />;
-	}
-
-	return (
-		<span className={ `${ className } ${ className }--${ name }` }>
-			{ /* Intentional space left after hiddenText */ }
-			<span className="jetpack-podcast-player--visually-hidden">{ `${ hiddenText } ` }</span>
-			{ icon }
-		</span>
-	);
-};
-
-import { getColorClassName } from '../utils';
-
-const TrackError = memo( ( { link, title } ) => (
-	<div className="jetpack-podcast-player__track-error">
-		{ __( 'Episode unavailable. ', 'jetpack' ) }
-		{ link && (
-			<span>
-				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
-					<span className="jetpack-podcast-player--visually-hidden">
-						{ /* Intentional trailing space outside of the translated string. */ }
-						{ `${ sprintf(
-							/* translators: %s is the title of the track. This text is
-							visually hidden from the screen, but available to screen readers. */
-							__( '%s:', 'jetpack' ),
-							title
-						) } ` }
-					</span>
-					{ __( 'Open in a new tab', 'jetpack' ) }
-				</a>
-			</span>
-		) }
-	</div>
-) );
-
-const Track = memo(
-	( {
-		track,
-		isActive,
-		isPlaying,
-		isError,
-		selectTrack,
-		index,
-		colors = {
-			primary: {},
-			secondary: {},
-		},
-	} ) => {
-		// Set CSS classes string.
-		const primaryColorClass = getColorClassName( 'color', colors.primary.name );
-		const secondaryColorClass = getColorClassName( 'color', colors.secondary.name );
-		const trackClassName = classnames( 'jetpack-podcast-player__track', {
-			'is-active': isActive,
-			'has-primary': isActive && ( colors.primary.name || colors.primary.custom ),
-			[ primaryColorClass ]: isActive && !! primaryColorClass,
-			'has-secondary': ! isActive && ( colors.secondary.name || colors.secondary.custom ),
-			[ secondaryColorClass ]: ! isActive && !! secondaryColorClass,
-		} );
-
-		const inlineStyle = {};
-		if ( isActive && colors.primary.custom && ! primaryColorClass ) {
-			inlineStyle.color = colors.primary.custom;
-		} else if ( ! isActive && colors.secondary.custom && ! secondaryColorClass ) {
-			inlineStyle.color = colors.secondary.custom;
-		}
-
-		/* translators: This needs to be a single word with no spaces. It describes
-		the current item in the group. A screen reader will announce it as "[title],
-		current track". */
-		const ariaCurrent = isActive ? __( 'track', 'jetpack' ) : undefined;
-
-		return (
-			<li
-				className={ trackClassName }
-				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
-			>
-				<a
-					className="jetpack-podcast-player__track-link"
-					href={ track.link }
-					role="button"
-					aria-current={ ariaCurrent }
-					onClick={ e => {
-						// Prevent handling clicks if a modifier is in use.
-						if ( e.shiftKey || e.metaKey || e.altKey ) {
-							return;
-						}
-
-						// Prevent default behavior (opening a link).
-						e.preventDefault();
-
-						// Select track.
-						selectTrack( index );
-					} }
-					onKeyDown={ e => {
-						// Only handle the Space key.
-						if ( event.key !== ' ' ) {
-							return;
-						}
-
-						// Prevent default behavior (scrolling one page down).
-						e.preventDefault();
-
-						// Select track.
-						selectTrack( index );
-					} }
-				>
-					<TrackIcon
-						className="jetpack-podcast-player__track-status-icon"
-						isPlaying={ isPlaying }
-						isError={ isError }
-					/>
-					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
-					{ track.duration && (
-						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>
-							{ track.duration }
-						</time>
-					) }
-				</a>
-				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }
-			</li>
-		);
-	}
-);
+import Track from './track';
 
 const Playlist = memo( ( { playerId, tracks, selectTrack, currentTrack, playerState, colors } ) => {
 	return (

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -54,7 +54,7 @@ const TrackError = memo( ( { link, title } ) => (
 		{ link && (
 			<span>
 				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
-					<span class="jetpack-podcast-player--visually-hidden">
+					<span className="jetpack-podcast-player--visually-hidden">
 						{ /* Intentional trailing space outside of the translated string. */ }
 						{ `${ sprintf(
 							/* translators: %s is the title of the track. This text is

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -18,8 +18,8 @@ import Playlist from './playlist';
 import AudioPlayer from './audio-player';
 import Header from './header';
 import { getColorsObject } from '../utils';
+import withErrorBoundary from './with-error-boundary';
 
-// const debug = debugFactory( 'jetpack:podcast-player' );
 const noop = () => {};
 
 export class PodcastPlayer extends Component {
@@ -292,4 +292,4 @@ PodcastPlayer.defaultProps = {
 	tracks: [],
 };
 
-export default PodcastPlayer;
+export default withErrorBoundary( PodcastPlayer );

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -38,8 +38,9 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Select a track and play/pause, as needed.
+	 *
 	 * @public
-	 * @param {number} track The track number
+	 * @param {number} track - The track number
 	 */
 	selectTrack = track => {
 		const { currentTrack } = this.state;
@@ -61,8 +62,9 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Load audio from the track, start playing.
+	 *
 	 * @private
-	 * @param {number} track The track number
+	 * @param {number} track - The track number
 	 */
 	loadAndPlay = track => {
 		const trackData = this.getTrack( track );
@@ -73,9 +75,13 @@ export class PodcastPlayer extends Component {
 		this.setState( { currentTrack: track } );
 		this.setAudioSource( trackData.src );
 
-		// Read that we're loading the track and its description. This is dismissible via ctrl on VoiceOver.
-		/* translators: %s is the track title. It describes the current state of the track as "Loading: [track title]" */
+		/*
+		 * Read that we're loading the track and its description. This is
+		 * dismissible via ctrl on VoiceOver.
+		 */
 		speak(
+			/* translators: %s is the track title. It describes the current state of
+			the track as "Loading: [track title]". */
 			`${ sprintf( __( 'Loading: %s', 'jetpack' ), trackData.title ) } ${ trackData.description }`,
 			'assertive'
 		);
@@ -85,8 +91,9 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Get track data.
+	 *
 	 * @private
-	 * @param {number} track The track number
+	 * @param {number} track - The track number
 	 * @returns {object} Track object.
 	 */
 	getTrack = track => {
@@ -95,6 +102,7 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Error handler for audio.
+	 *
 	 * @private
 	 */
 	handleError = () => {
@@ -105,6 +113,7 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Play handler for audio.
+	 *
 	 * @private
 	 */
 	handlePlay = () => {
@@ -115,6 +124,7 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Pause handler for audio.
+	 *
 	 * @private
 	 */
 	handlePause = () => {
@@ -127,25 +137,29 @@ export class PodcastPlayer extends Component {
 
 	/**
 	 * Play current audio.
+	 *
 	 * @public
 	 */
 	play = noop;
 
 	/**
 	 * Pause current audio.
+	 *
 	 * @public
 	 */
 	pause = noop;
 
 	/**
 	 * Toggle playing state.
+	 *
 	 * @public
 	 */
 	togglePlayPause = noop;
 
 	/**
 	 * Set audio source.
-	 * @param {string} src The url of audio content.
+	 *
+	 * @param {string} src - The url of audio content.
 	 * @public
 	 */
 	setAudioSource = noop;
@@ -207,7 +221,10 @@ export class PodcastPlayer extends Component {
 				aria-describedby={
 					track && track.description ? `${ playerId }__track-description` : undefined
 				}
-				// The following line ensures compatibility with Calypso previews (jetpack-iframe-embed.js).
+				/*
+				 * The following line ensures compatibility with Calypso previews
+				 * (jetpack-iframe-embed.js).
+				 */
 				data-jetpack-iframe-ignore
 			>
 				<Header
@@ -233,8 +250,15 @@ export class PodcastPlayer extends Component {
 					id={ `jetpack-podcast-player__tracklist-title--${ playerId }` }
 					className="jetpack-podcast-player--visually-hidden"
 				>
-					{ /* translators: %s is the track title. This describes what the playlist goes with, like "Playlist: [name of the podcast]" */ }
-					{ sprintf( __( 'Playlist: %s', 'jetpack' ), title ) }
+					{ /*
+					 * This describes what the playlist goes with, like "Playlist: [name
+					 * of the podcast]".
+					 */ }
+					{ sprintf(
+						// translators: %s is the track title.
+						__( 'Playlist: %s', 'jetpack' ),
+						title
+					) }
 				</h4>
 				<p
 					id={ `jetpack-podcast-player__tracklist-description--${ playerId }` }

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -156,10 +156,13 @@ export class PodcastPlayer extends Component {
 			itemsToShow,
 			primaryColor,
 			customPrimaryColor,
+			hexPrimaryColor,
 			secondaryColor,
 			customSecondaryColor,
+			hexSecondaryColor,
 			backgroundColor,
 			customBackgroundColor,
+			hexBackgroundColor,
 			showCoverArt,
 			showEpisodeDescription,
 		} = attributes;
@@ -200,10 +203,17 @@ export class PodcastPlayer extends Component {
 			},
 		};
 
+		/*
+		 * Set colors through inline styles.
+		 * Also, add CSS variables.
+		 */
 		const inlineStyle = {
 			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
 			backgroundColor:
 				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
+			'--jetpack-podcast-player-primary': hexPrimaryColor,
+			'--jetpack-podcast-player-secondary': hexSecondaryColor,
+			'--jetpack-podcast-player-background': hexBackgroundColor,
 		};
 
 		const cssClassesName = classnames(

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -17,7 +17,7 @@ import { STATE_PLAYING, STATE_ERROR, STATE_PAUSED } from '../constants';
 import Playlist from './playlist';
 import AudioPlayer from './audio-player';
 import Header from './header';
-import { getColorClassName } from '../utils';
+import { getColorsObject } from '../utils';
 
 // const debug = debugFactory( 'jetpack:podcast-player' );
 const noop = () => {};
@@ -171,46 +171,22 @@ export class PodcastPlayer extends Component {
 		const tracksToDisplay = tracks.slice( 0, itemsToShow );
 		const track = this.getTrack( currentTrack );
 
-		// Set CSS classes string.
-		const primaryColorClass = getColorClassName( 'color', primaryColor );
-		const secondaryColorClass = getColorClassName( 'color', secondaryColor );
-		const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
-
-		const colors = {
-			primary: {
-				name: primaryColor,
-				custom: customPrimaryColor,
-				classes: classnames( {
-					'has-primary': primaryColorClass || customPrimaryColor,
-					[ primaryColorClass ]: primaryColorClass,
-				} ),
-			},
-			secondary: {
-				name: secondaryColor,
-				custom: customSecondaryColor,
-				classes: classnames( {
-					'has-secondary': secondaryColorClass || customSecondaryColor,
-					[ secondaryColorClass ]: secondaryColorClass,
-				} ),
-			},
-			background: {
-				name: backgroundColor,
-				custom: customBackgroundColor,
-				classes: classnames( {
-					'has-background': backgroundColorClass || customBackgroundColor,
-					[ backgroundColorClass ]: backgroundColorClass,
-				} ),
-			},
-		};
+		const colors = getColorsObject( {
+			primaryColor,
+			customPrimaryColor,
+			secondaryColor,
+			customSecondaryColor,
+			backgroundColor,
+			customBackgroundColor,
+		} );
 
 		/*
 		 * Set colors through inline styles.
 		 * Also, add CSS variables.
 		 */
 		const inlineStyle = {
-			color: customSecondaryColor && ! secondaryColorClass ? customSecondaryColor : null,
-			backgroundColor:
-				customBackgroundColor && ! backgroundColorClass ? customBackgroundColor : null,
+			color: customSecondaryColor,
+			backgroundColor: customBackgroundColor,
 			'--jetpack-podcast-player-primary': hexPrimaryColor,
 			'--jetpack-podcast-player-secondary': hexSecondaryColor,
 			'--jetpack-podcast-player-background': hexBackgroundColor,
@@ -226,7 +202,7 @@ export class PodcastPlayer extends Component {
 		return (
 			<section
 				className={ cssClassesName }
-				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
+				style={ inlineStyle }
 				aria-labelledby={ title || ( track && track.title ) ? `${ playerId }__title` : undefined }
 				aria-describedby={
 					track && track.description ? `${ playerId }__track-description` : undefined

--- a/extensions/blocks/podcast-player/components/track-error.js
+++ b/extensions/blocks/podcast-player/components/track-error.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+const TrackError = memo( ( { link, title } ) => (
+	<div className="jetpack-podcast-player__track-error">
+		{ __( 'Episode unavailable. ', 'jetpack' ) }
+		{ link && (
+			<span>
+				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
+					<span className="jetpack-podcast-player--visually-hidden">
+						{ /* Intentional trailing space outside of the translated string. */ }
+						{ `${ sprintf(
+							/* translators: %s is the title of the track. This text is
+							visually hidden from the screen, but available to screen readers. */
+							__( '%s:', 'jetpack' ),
+							title
+						) } ` }
+					</span>
+					{ __( 'Open in a new tab', 'jetpack' ) }
+				</a>
+			</span>
+		) }
+	</div>
+) );
+
+export default TrackError;

--- a/extensions/blocks/podcast-player/components/track-icon.js
+++ b/extensions/blocks/podcast-player/components/track-icon.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import * as trackIcons from '../icons/track-icons';
+
+const TrackIcon = memo( ( { isPlaying, isError, className } ) => {
+	let hiddenText, name;
+
+	if ( isError ) {
+		name = 'error';
+		/* translators: This is text to describe the current state. This will go
+		before the track title, such as "Error: [The title of the track]". */
+		hiddenText = __( 'Error:', 'jetpack' );
+	} else if ( isPlaying ) {
+		name = 'playing';
+		/* translators: Text to describe the current state. This will go before the
+		track title, such as "Playing: [The title of the track]". */
+		hiddenText = __( 'Playing:', 'jetpack' );
+	}
+
+	const icon = trackIcons[ name ];
+
+	if ( ! icon ) {
+		// Return empty element - we need it for layout purposes.
+		return <span className={ className } />;
+	}
+
+	return (
+		<span className={ `${ className } ${ className }--${ name }` }>
+			{ /* Intentional space left after hiddenText */ }
+			<span className="jetpack-podcast-player--visually-hidden">{ `${ hiddenText } ` }</span>
+			{ icon }
+		</span>
+	);
+} );
+
+export default TrackIcon;

--- a/extensions/blocks/podcast-player/components/track.js
+++ b/extensions/blocks/podcast-player/components/track.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import TrackIcon from './track-icon';
+import TrackError from './track-error';
+
+import { getColorClassName } from '../utils';
+
+const Track = memo(
+	( {
+		track,
+		isActive,
+		isPlaying,
+		isError,
+		selectTrack,
+		index,
+		colors = {
+			primary: {},
+			secondary: {},
+		},
+	} ) => {
+		// Set CSS classes string.
+		const primaryColorClass = getColorClassName( 'color', colors.primary.name );
+		const secondaryColorClass = getColorClassName( 'color', colors.secondary.name );
+		const trackClassName = classnames( 'jetpack-podcast-player__track', {
+			'is-active': isActive,
+			'has-primary': isActive && ( colors.primary.name || colors.primary.custom ),
+			[ primaryColorClass ]: isActive && !! primaryColorClass,
+			'has-secondary': ! isActive && ( colors.secondary.name || colors.secondary.custom ),
+			[ secondaryColorClass ]: ! isActive && !! secondaryColorClass,
+		} );
+
+		const inlineStyle = {};
+		if ( isActive && colors.primary.custom && ! primaryColorClass ) {
+			inlineStyle.color = colors.primary.custom;
+		} else if ( ! isActive && colors.secondary.custom && ! secondaryColorClass ) {
+			inlineStyle.color = colors.secondary.custom;
+		}
+
+		/* translators: This needs to be a single word with no spaces. It describes
+		the current item in the group. A screen reader will announce it as "[title],
+		current track". */
+		const ariaCurrent = isActive ? __( 'track', 'jetpack' ) : undefined;
+
+		return (
+			<li
+				className={ trackClassName }
+				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
+			>
+				<a
+					className="jetpack-podcast-player__track-link"
+					href={ track.link }
+					role="button"
+					aria-current={ ariaCurrent }
+					onClick={ e => {
+						// Prevent handling clicks if a modifier is in use.
+						if ( e.shiftKey || e.metaKey || e.altKey ) {
+							return;
+						}
+
+						// Prevent default behavior (opening a link).
+						e.preventDefault();
+
+						// Select track.
+						selectTrack( index );
+					} }
+					onKeyDown={ e => {
+						// Only handle the Space key.
+						if ( event.key !== ' ' ) {
+							return;
+						}
+
+						// Prevent default behavior (scrolling one page down).
+						e.preventDefault();
+
+						// Select track.
+						selectTrack( index );
+					} }
+				>
+					<TrackIcon
+						className="jetpack-podcast-player__track-status-icon"
+						isPlaying={ isPlaying }
+						isError={ isError }
+					/>
+					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+					{ track.duration && (
+						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>
+							{ track.duration }
+						</time>
+					) }
+				</a>
+				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }
+			</li>
+		);
+	}
+);
+
+export default Track;

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -12,28 +12,35 @@ export default function withErrorBoundary( WrappedComponent ) {
 	class ErrorBoundary extends Component {
 		state = {
 			didError: false,
+			isIE11AudioIssue: false,
 		};
 
 		componentDidCatch = ( error, errorInfo ) => {
-			// This needs to be delayed in order for React to finish its error handling.
-			setTimeout( () => {
-				this.props.onError( error, errorInfo );
-			} );
+			this.props.onError( error, errorInfo );
 		};
 
-		static getDerivedStateFromError = () => {
-			return { didError: true };
+		static getDerivedStateFromError = error => {
+			// There is a known error where IE11 doesn't support the <audio> element by
+			// default but errors instead. If the user is using IE11 we thus provide
+			// additional instructions on how they can turn on <audio> support.
+			return { didError: true, isIE11AudioIssue: error.message.match( /IE11/ ) ? true : false };
 		};
 
 		render() {
-			if ( this.state.didError ) {
+			const { didError, isIE11AudioIssue } = this.state;
+			if ( didError ) {
 				return (
 					<section className="jetpack-podcast-player">
 						<p className="jetpack-podcast-player__error">
-							{ __(
-								'An unexpected error occured within the Podcast Player. Reloading this page might fix the problem.',
-								'jetpack'
-							) }
+							{ isIE11AudioIssue
+								? __(
+										'The podcast player cannot be displayed as your browser settings do not allow for sounds to be played in webpages. This can be changed in your browser’s "Internet options" settings. In the "Advanced" tab you will have to check the box next to "Play sounds in webpages" in the "Multimedia" section. Once you have confirmed that the box is checked, please press "Apply" and then reload this page.',
+										'jetpack'
+								  )
+								: __(
+										'An unexpected error occured within the Podcast Player. Reloading this page might fix the problem.',
+										'jetpack'
+								  ) }
 						</p>
 					</section>
 				);

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export default function withErrorBoundary( WrappedComponent ) {
+	class ErrorBoundary extends Component {
+		state = {
+			didError: false,
+		};
+
+		componentDidCatch = ( error, errorInfo ) => {
+			// This needs to be delayed in order for React to finish its error handling.
+			setTimeout( () => {
+				this.props.onError( error, errorInfo );
+			} );
+		};
+
+		static getDerivedStateFromError = () => {
+			return { didError: true };
+		};
+
+		render() {
+			if ( this.state.didError ) {
+				return (
+					<section className="jetpack-podcast-player">
+						<p className="jetpack-podcast-player__error">
+							{ __(
+								'An unexpected error occured within the Podcast Player. Reloading this page might fix the problem.',
+								'jetpack'
+							) }
+						</p>
+					</section>
+				);
+			}
+
+			return <WrappedComponent { ...this.props } />;
+		}
+	}
+
+	ErrorBoundary.defaultProps = {
+		onError: () => {},
+	};
+
+	return ErrorBoundary;
+}

--- a/extensions/blocks/podcast-player/constants.js
+++ b/extensions/blocks/podcast-player/constants.js
@@ -1,3 +1,6 @@
 export const STATE_PLAYING = 'is-playing';
 export const STATE_ERROR = 'is-error';
 export const STATE_PAUSED = 'is-paused';
+
+export const PODCAST_FEED = 'podcast-feed';
+export const EMBED_BLOCK = 'embed-block';

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { startCase } from 'lodash';
-
 
 /**
  * WordPress dependencies
@@ -261,9 +259,8 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
-	const createColorChangeHandler = ( colorName, handler ) => ( color ) => {
-		const attr = `hex${ startCase( colorName ) }Color`;
-		setAttributes( { [ attr ]: color } );
+	const createColorChangeHandler = ( colorAttr, handler ) => ( color ) => {
+		setAttributes( { [ colorAttr ]: color } );
 		handler( color );
 	};
 
@@ -300,17 +297,17 @@ const PodcastPlayerEdit = ( {
 					colorSettings={ [
 						{
 							value: primaryColorProp.color,
-							onChange: createColorChangeHandler( 'primary', setPrimaryColor ),
+							onChange: createColorChangeHandler( 'hexPrimaryColor', setPrimaryColor ),
 							label: __( 'Primary Color', 'jetpack' ),
 						},
 						{
 							value: secondaryColorProp.color,
-							onChange: createColorChangeHandler( 'secondary', setSecondaryColor ),
+							onChange: createColorChangeHandler( 'hexSecondaryColor', setSecondaryColor ),
 							label: __( 'Secondary Color', 'jetpack' ),
 						},
 						{
 							value: backgroundColorProp.color,
-							onChange: createColorChangeHandler( 'background', setBackgroundColor ),
+							onChange: createColorChangeHandler( 'hexBackgroundColor', setBackgroundColor ),
 							label: __( 'Background Color', 'jetpack' ),
 						},
 					] }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -160,10 +160,9 @@ const PodcastPlayerEdit = ( {
 	}, [ isSelected ] );
 
 	/**
-	 * Check if the current URL of the Podcast RSS feed
-	 * is valid. If so, set the block attribute and changes
-	 * the edition mode.
-	 * This function is bound to the onSubmit event for the form.
+	 * Check if the current URL of the Podcast RSS feed is valid. If so, set the
+	 * block attribute and changes the edition mode. This function is bound to the
+	 * onSubmit event for the form.
 	 *
 	 * @param {object} event - Form on submit event object.
 	 */
@@ -176,8 +175,10 @@ const PodcastPlayerEdit = ( {
 				return;
 			}
 
-			// Ensure URL has `http` appended to it (if it doesn't already) before
-			// we accept it as the entered URL.
+			/*
+			 * Ensure URL has `http` appended to it (if it doesn't already) before we
+			 * accept it as the entered URL.
+			 */
 			const prependedURL = prependHTTP( editedUrl );
 
 			if ( ! isURL( prependedURL ) ) {
@@ -197,9 +198,11 @@ const PodcastPlayerEdit = ( {
 				setAttributes( { url: prependedURL } );
 			}
 
-			// Also update the temporary `input` value in order that clicking
-			// `Replace` in the UI will show the "corrected" version of the URL
-			// (ie: with `http` prepended if it wasn't originally present).
+			/*
+			 * Also update the temporary `input` value in order that clicking `Replace`
+			 * in the UI will show the "corrected" version of the URL (ie: with `http`
+			 * prepended if it wasn't originally present).
+			 */
 			setEditedUrl( prependedURL );
 			setIsEditing( false );
 		},
@@ -331,12 +334,13 @@ const PodcastPlayerEdit = ( {
 					title={ feedData.title }
 					link={ feedData.link }
 				/>
-				{
-					// Disabled because the overlay div doesn't actually have a role or functionality
-					// as far as the user is concerned. We're just catching the first click so that
-					// the block can be selected without interacting with the embed preview that the overlay covers.
-					/* eslint-disable jsx-a11y/no-static-element-interactions */
-				 }
+				{ /*
+				 * Disabled because the overlay div doesn't actually have a role or
+				 * functionality as far as the user is concerned. We're just catching
+				 * the first click so that the block can be selected without
+				 * interacting with the embed preview that the overlay covers.
+				 */ }
+				{ /* eslint-disable jsx-a11y/no-static-element-interactions */ }
 				{ ! isInteractive && (
 					<div
 						className="jetpack-podcast-player__interactive-overlay"

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import debugFactory from 'debug';
+import { startCase } from 'lodash';
+
 
 /**
  * WordPress dependencies
@@ -259,6 +261,12 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
+	const createColorChangeHandler = ( colorName, handler ) => ( color ) => {
+		const attr = `hex${ startCase( colorName ) }Color`;
+		setAttributes( { [ attr ]: color } );
+		handler( color );
+	};
+
 	return (
 		<>
 			<BlockControls>
@@ -292,17 +300,17 @@ const PodcastPlayerEdit = ( {
 					colorSettings={ [
 						{
 							value: primaryColorProp.color,
-							onChange: setPrimaryColor,
+							onChange: createColorChangeHandler( 'primary', setPrimaryColor ),
 							label: __( 'Primary Color', 'jetpack' ),
 						},
 						{
 							value: secondaryColorProp.color,
-							onChange: setSecondaryColor,
+							onChange: createColorChangeHandler( 'secondary', setSecondaryColor ),
 							label: __( 'Secondary Color', 'jetpack' ),
 						},
 						{
 							value: backgroundColorProp.color,
-							onChange: setBackgroundColor,
+							onChange: createColorChangeHandler( 'background', setBackgroundColor ),
 							label: __( 'Background Color', 'jetpack' ),
 						},
 					] }

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -215,6 +215,7 @@ const PodcastPlayerEdit = ( {
 				icon={ <BlockIcon icon={ queueMusic } /> }
 				label={ __( 'Podcast Player', 'jetpack' ) }
 				instructions={ __( 'Enter your podcast RSS feed URL.', 'jetpack' ) }
+				className={ 'jetpack-podcast-player__placeholder' }
 			>
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
@@ -262,7 +263,7 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
-	const createColorChangeHandler = ( colorAttr, handler ) => ( color ) => {
+	const createColorChangeHandler = ( colorAttr, handler ) => color => {
 		setAttributes( { [ colorAttr ]: color } );
 		handler( color );
 	};

--- a/extensions/blocks/podcast-player/editor.scss
+++ b/extensions/blocks/podcast-player/editor.scss
@@ -3,8 +3,11 @@
  */
 
 /* Back-compat for pre-G2 ToolbarButton elements containing text */
-.block-editor-block-contextual-toolbar[data-type="jetpack/podcast-player"] .components-toolbar__control,
-[data-type="jetpack/podcast-player"] .block-editor-block-contextual-toolbar .components-toolbar__control {
+.block-editor-block-contextual-toolbar[data-type='jetpack/podcast-player']
+	.components-toolbar__control,
+[data-type='jetpack/podcast-player']
+	.block-editor-block-contextual-toolbar
+	.components-toolbar__control {
 	width: auto;
 	padding: 0 1em;
 }

--- a/extensions/blocks/podcast-player/editor.scss
+++ b/extensions/blocks/podcast-player/editor.scss
@@ -20,3 +20,20 @@
 	bottom: 0;
 	opacity: 0;
 }
+
+// Placeholder styles
+.jetpack-podcast-player__placeholder {
+	.components-base-control,
+	.components-base-control__field {
+		display: flex;
+		flex-grow: 1;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+
+	.components-placeholder__learn-more {
+		margin-top: 1em;
+	}
+}

--- a/extensions/blocks/podcast-player/icons/track-icons.js
+++ b/extensions/blocks/podcast-player/icons/track-icons.js
@@ -2,26 +2,24 @@
  * External dependencies
  */
 import { Path, SVG } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
-const TrackIcon = ( { name, children } ) => {
-	return (
-		<SVG height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-			{ children }
-		</SVG>
-	);
+const sharedProps = {
+	height: '24',
+	viewBox: '0 0 24 24',
+	width: '24',
+	xmlns: 'http://www.w3.org/2000/svg',
 };
 
 export const playing = (
-	<TrackIcon name="playing">
+	<SVG { ...sharedProps }>
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M3 9v6h4l5 5V4L7 9H3zm7-.17v6.34L7.83 13H5v-2h2.83L10 8.83zM16.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77 0-4.28-2.99-7.86-7-8.77z" />
-	</TrackIcon>
+	</SVG>
 );
 
 export const error = (
-	<TrackIcon name="error">
+	<SVG { ...sharedProps }>
 		<Path d="M0 0h24v24H0V0z" fill="none" />
 		<Path d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z" />
-	</TrackIcon>
+	</SVG>
 );

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -34,25 +34,43 @@ export const settings = {
 		_x( 'embed', 'block search term', 'jetpack' ),
 	],
 	supports: {
-		// Support for block's alignment (left, center, right, wide, full). When true, it adds block controls to change block’s alignment.
-		align: false /* if set to true, the 'align' option below can be used*/,
-		// Pick which alignment options to display.
-		/*align: [ 'left', 'right', 'full' ],*/
-		// Support for wide alignment, that requires additional support in themes.
+		/*
+		 * Support for block's alignment (left, center, right, wide, full). When
+		 * true, it adds block controls to change block’s alignment.
+		 */
+		align: false, // [ 'left', 'right', 'full' ]
+		/*
+		 * Support for wide alignment, that requires additional support in themes.
+		 */
 		alignWide: true,
-		// When true, a new field in the block sidebar allows to define an id for the block and a button to copy the direct link.
+		/*
+		 * When true, a new field in the block sidebar allows to define an id for
+		 * the block and a button to copy the direct link.
+		 */
 		anchor: false,
-		// When true, a new field in the block sidebar allows to define a custom className for the block’s wrapper.
+		/*
+		 * When true, a new field in the block sidebar allows to define a custom
+		 * className for the block’s wrapper.
+		 */
 		customClassName: true,
-		// When false, Gutenberg won't add a class like .wp-block-your-block-name to the root element of your saved markup
+		/*
+		 * When false, Gutenberg won't add a class like .wp-block-your-block-name to
+		 * the root element of your saved markup.
+		 */
 		className: true,
-		// Setting this to false suppress the ability to edit a block’s markup individually. We often set this to false in Jetpack blocks.
+		/*
+		 * Setting this to false suppress the ability to edit a block’s markup
+		 * individually. We often set this to false in Jetpack blocks.
+		 */
 		html: false,
-		// Passing false hides this block in Gutenberg's visual inserter.
-		/*inserter: true,*/
-		// When false, user will only be able to insert the block once per post.
+		/*
+		 * When false, user will only be able to insert the block once per post.
+		 */
 		multiple: true,
-		// When false, the block won't be available to be converted into a reusable block.
+		/*
+		 * When false, the block won't be available to be converted into a reusable
+		 * block.
+		 */
 		reusable: true,
 	},
 	edit,

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -22,9 +22,8 @@ if ( ! class_exists( 'Jetpack_Podcast_Helper' ) ) {
 }
 
 /**
- * Registers the block for use in Gutenberg
- * This is done via an action so that we can disable
- * registration if we need to.
+ * Registers the block for use in Gutenberg. This is done via an action so that
+ * we can disable registration if we need to.
  */
 function register_block() {
 	jetpack_register_block(
@@ -269,11 +268,15 @@ function render( $name, $template_props = array(), $print = true ) {
 		return '';
 	}
 
-	// Optionally provided an assoc array of data to pass to template
-	// IMPORTANT: It will be extracted into variables.
+	/*
+	 * Optionally provided an assoc array of data to pass to template.
+	 * IMPORTANT: It will be extracted into variables.
+	 */
 	if ( is_array( $template_props ) ) {
-		// It ignores the `discouraging` sniffer rule for extract,
-		// since it's needed to make the templating system works.
+		/*
+		 * It ignores the `discouraging` sniffer rule for extract, since it's needed
+		 * to make the templating system works.
+		 */
 		extract( $template_props ); // phpcs:ignore WordPress.PHP.DontExtract.extract_extract
 	}
 

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -119,8 +119,9 @@ function render_player( $player_data, $attributes ) {
 	$secondary_colors  = get_colors( 'secondary', $attributes, 'color' );
 	$background_colors = get_colors( 'background', $attributes, 'background-color' );
 
-	$player_classes_name = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
-	$player_inline_style = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
+	$player_classes_name  = trim( "{$secondary_colors['class']} {$background_colors['class']}" );
+	$player_inline_style  = trim( "{$secondary_colors['style']} ${background_colors['style']}" );
+	$player_inline_style .= get_css_vars( $attributes );
 
 	$block_classname = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, array( 'is-default' ) );
 	$is_amp          = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
@@ -222,6 +223,26 @@ function get_colors( $name, $attrs, $property ) {
 	}
 
 	return $colors;
+}
+
+/**
+ * It generates a string with CSS variables according to the
+ * block colors, prefixing each one with `--jetpack-podcast-player'.
+ *
+ * @param array $attrs Podcast Block attributes object.
+ * @return string      CSS variables depending on block colors.
+ */
+function get_css_vars( $attrs ) {
+	$colors_name = array( 'primary', 'secondary', 'background' );
+
+	$inline_style = '';
+	foreach ( $colors_name as $color ) {
+		$hex_color = 'hex' . ucfirst( $color ) . 'Color';
+		if ( ! empty( $attrs[ $hex_color ] ) ) {
+			$inline_style .= " --jetpack-podcast-player-{$color}: {$attrs[ $hex_color ]};";
+		}
+	}
+	return $inline_style;
 }
 
 /**

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -339,8 +339,11 @@ $player-float-background: $light-gray-200;
 		background-color: $player-slider-foreground;
 	}
 
-	//Helper function that escapes the value of the color variable in the SVG.
-	//This way we can change the value in one place and easily add style variations.
+	/**
+	 * Helper function that escapes the value of the color variable in the SVG.
+	 * This way we can change the value in one place and easily add style
+	 * variations.
+	 */
 	@function encodecolor( $string ) {
 		@if type-of( $string ) == 'color' {
 			$hex: str-slice( ie-hex-str( $string ), 4 );
@@ -350,9 +353,47 @@ $player-float-background: $light-gray-200;
 		@return $string;
 	}
 
-	//For the buttons mejs is using an external SVG that's linked to via CSS.
-	//This is the same SVG but inlined in the CSS using a color variable.
+	/**
+	 * For the buttons mejs is using an external SVG that's linked to via CSS.
+	 * This is the same SVG but inlined in the CSS using a color variable. We're
+	 * using this as a fallback for IE11 where the mask property is not supported.
+	 */
 	.mejs-button > button {
 		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E" );
+	}
+
+	/**
+	 * Make the controls SVGs color customizable via the background-color property.
+	 * This is possible thanks to the mask property, which is now supported in all
+	 * major browsers. We're using the original sprite for creating the mask and
+	 * then define a background-color for the actual color of the icon. This
+	 * approach will allow us to customize colors via CSS variables.
+	 */
+	@supports (mask-image: none) or (-webkit-mask-image: none) {
+		.mejs-button > button {
+			background-image: none;
+			background-color: $player-button-color;
+			mask: url('/wp-includes/js/mediaelement/mejs-controls.svg');
+		}
+
+		.mejs-play > button {
+			mask-position: 0 0;
+		}
+
+		.mejs-pause > button {
+			mask-position: -20px 0;
+		}
+
+		.mejs-replay > button {
+			mask-position: -160px 0;
+		}
+
+		.mejs-mute > button {
+			mask-position: -60px 0;
+		}
+
+		.mejs-unmute > button {
+			mask-position: -40px 0;
+		}
 	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -109,9 +109,13 @@ $player-background: transparent;
 	}
 
 	.jetpack-podcast-player__current-track-title {
-		color: $current-track-title-color;
 		font-size: $track-title-font-size;
 		margin: 0 0 $track-title-b-margin;
+
+		// Apply default color if custom primary has not been set
+		&:not(.has-primary) {
+			color: $current-track-title-color;
+		}
 	}
 
 	.jetpack-podcast-player__podcast-title {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -13,18 +13,16 @@ $podcast-title-font-size: 16px;
 $description-font-size: 16px;
 $player-divider-height: 2px;
 $track-status-icon-size: 22px;
+$jetpack-podcast-player-primary: $black;
+$jetpack-podcast-player-secondary: $dark-gray-300;
+$jetpack-podcast-player-background: $white;
 $text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
 $text-color-hover: $black;
 $text-color-active: $text-color-hover;
 $text-color-error: $alert-red;
 $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
-$player-text-color: $text-color;
 $player-background: transparent;
-$player-slider-background: $light-gray-600;
-$player-slider-foreground: $dark-gray-100;
-$player-button-color: $dark-gray-100;
-$player-float-background: $light-gray-200;
 
 .jetpack-podcast-player--visually-hidden {
 	position: absolute !important;
@@ -62,6 +60,13 @@ $player-float-background: $light-gray-200;
 	.jetpack-podcast-player {
 		padding-top: 0;
 		padding-bottom: 0;
+
+		/**
+		* Set default values for our CSS variables.
+		*/
+		--jetpack-podcast-player-primary: #{$jetpack-podcast-player-primary};
+		--jetpack-podcast-player-secondary: #{$jetpack-podcast-player-secondary};
+		--jetpack-podcast-player-background: #{$jetpack-podcast-player-background};
 	}
 
 	/**
@@ -141,7 +146,7 @@ $player-float-background: $light-gray-200;
 
 	.jetpack-podcast-player--audio-player-loading {
 		height: 10px; // mirroring .mejs-time-total
-		background: $player-slider-background;
+		background: $jetpack-podcast-player-secondary;
 		margin: 15px $player-grid-spacing; // simulating spacing of .mejs-container
 	}
 
@@ -234,7 +239,8 @@ $player-float-background: $light-gray-200;
 
 	.jetpack-podcast-player__track-status-icon {
 		flex: $track-status-icon-size 0 0;
-		fill: $text-color-active;
+		fill: $jetpack-podcast-player-primary;
+		fill: var(--jetpack-podcast-player-primary);
 
 		svg {
 			display: inline-block;
@@ -313,30 +319,38 @@ $player-float-background: $light-gray-200;
 
 	.mejs-time,
 	.mejs-time-float {
-		color: $player-text-color;
+		color: $jetpack-podcast-player-secondary;
+		color: var( --jetpack-podcast-player-secondary );
 	}
 
 	.mejs-time-float {
-		background: $player-float-background;
-		border-color: $player-float-background;
+		background: $jetpack-podcast-player-primary;
+		background: var( --jetpack-podcast-player-primary );
+		border-color: $jetpack-podcast-player-primary;
+		border-color: var( --jetpack-podcast-player-primary );
 	}
 
 	.mejs-time-float-corner {
-		border-top-color: $player-float-background;
+		border-top-color: $jetpack-podcast-player-primary;
+		border-top-color: var( --jetpack-podcast-player-primary );
 	}
 
 	.mejs-controls .mejs-time-rail .mejs-time-total,
 	.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-total {
-		background-color: $player-slider-background;
+		background-color: $jetpack-podcast-player-secondary;
+		background-color: var( --jetpack-podcast-player-secondary );
 	}
 
 	.mejs-controls .mejs-time-rail .mejs-time-loaded {
-		background-color: lighten( $player-slider-foreground, 20% );
+		opacity: .5;
+		background-color: $jetpack-podcast-player-primary;
+		background-color: var( --jetpack-podcast-player-primary );
 	}
 
 	.mejs-controls .mejs-time-rail .mejs-time-current,
 	.mejs-controls .mejs-horizontal-volume-slider .mejs-horizontal-volume-current {
-		background-color: $player-slider-foreground;
+		background-color: $jetpack-podcast-player-primary;
+		background-color: var( --jetpack-podcast-player-primary );
 	}
 
 	/**
@@ -359,7 +373,7 @@ $player-float-background: $light-gray-200;
 	 * using this as a fallback for IE11 where the mask property is not supported.
 	 */
 	.mejs-button > button {
-		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($player-button-color)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($player-button-color)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($player-button-color)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($player-button-color)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($player-button-color)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E" );
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='120'%3E%3Cstyle%3E.st0%7Bfill:#{encodecolor($jetpack-podcast-player-primary)};width:16px;height:16px%7D.st1%7Bfill:none;stroke:#{encodecolor($jetpack-podcast-player-primary)};stroke-width:1.5;stroke-linecap:round%7D%3C/style%3E%3Cpath class='st0' d='M16.5 8.5c.3.1.4.5.2.8-.1.1-.1.2-.2.2l-11.4 7c-.5.3-.8.1-.8-.5V2c0-.5.4-.8.8-.5l11.4 7zM24 1h2.2c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1H24c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zm9.8 0H36c.6 0 1 .4 1 1v14c0 .6-.4 1-1 1h-2.2c-.6 0-1-.4-1-1V2c0-.5.4-1 1-1zM81 1.4c0-.6.4-1 1-1h5.4c.6 0 .7.3.3.7l-6 6c-.4.4-.7.3-.7-.3V1.4zm0 15.8c0 .6.4 1 1 1h5.4c.6 0 .7-.3.3-.7l-6-6c-.4-.4-.7-.3-.7.3v5.4zM98.8 1.4c0-.6-.4-1-1-1h-5.4c-.6 0-.7.3-.3.7l6 6c.4.4.7.3.7-.3V1.4zm0 15.8c0 .6-.4 1-1 1h-5.4c-.6 0-.7-.3-.3-.7l6-6c.4-.4.7-.3.7.3v5.4zM112.7 5c0 .6.4 1 1 1h4.1c.6 0 .7-.3.3-.7L113.4.6c-.4-.4-.7-.3-.7.3V5zm-7.1 1c.6 0 1-.4 1-1V.9c0-.6-.3-.7-.7-.3l-4.7 4.7c-.4.4-.3.7.3.7h4.1zm1 7.1c0-.6-.4-1-1-1h-4.1c-.6 0-.7.3-.3.7l4.7 4.7c.4.4.7.3.7-.3v-4.1zm7.1-1c-.6 0-1 .4-1 1v4.1c0 .5.3.7.7.3l4.7-4.7c.4-.4.3-.7-.3-.7h-4.1zM67 5.8c-.5.4-1.2.6-1.8.6H62c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L67 5.8z'/%3E%3Cpath class='st1' d='M73.9 2.5s3.9-.8 3.9 7.7-3.9 7.8-3.9 7.8'/%3E%3Cpath class='st1' d='M72.6 6.4s2.6-.4 2.6 3.8-2.6 3.9-2.6 3.9'/%3E%3Cpath class='st0' d='M47 5.8c-.5.4-1.2.6-1.8.6H42c-.6 0-1 .4-1 1v5.7c0 .6.4 1 1 1h4.2c.3.2.5.4.8.6l3.5 2.6c.4.3.8.1.8-.4V3.5c0-.5-.4-.7-.8-.4L47 5.8z'/%3E%3Cpath d='M52.8 7l5.4 5.4m-5.4 0L58.2 7' fill='none' stroke='#{encodecolor($jetpack-podcast-player-primary)}' stroke-width='2' stroke-linecap='round'/%3E%3Cpath d='M128.7 8.6c-6.2-4.2-6.5 7.8 0 3.9m6.5-3.9c-6.2-4.2-6.5 7.8 0 3.9' fill='none' stroke='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Cpath class='st0' d='M122.2 3.4h15.7v13.1h-15.7V3.4zM120.8 2v15.7h18.3V2h-18.3zM143.2 3h14c1.1 0 2 .9 2 2v10c0 1.1-.9 2-2 2h-14c-1.1 0-2-.9-2-2V5c0-1.1.9-2 2-2z'/%3E%3Cpath d='M146.4 13.8c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.6.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.7.5-1.6.7-2.5.8zm7.5 0c-.8 0-1.6-.4-2.1-1-1.1-1.4-1-3.4.1-4.8.5-.6 2-1.7 4.6.2l-.5.8c-1.4-1-2.6-1.1-3.3-.3-.8 1-.8 2.4-.1 3.5.7.9 1.9.8 3.4-.1l.5.9c-.8.5-1.7.7-2.6.8z' fill='%23231f20'/%3E%3Cpath class='st0' d='M60.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L30 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L60.3 77z'/%3E%3Cpath d='M2.5 79c0-20.7 16.8-37.5 37.5-37.5S77.5 58.3 77.5 79 60.7 116.5 40 116.5 2.5 99.7 2.5 79z' opacity='.75' fill='none' stroke='#{encodecolor($jetpack-podcast-player-primary)}' stroke-width='5'/%3E%3Cpath class='st0' d='M140.3 77c.6.2.8.8.6 1.4-.1.3-.3.5-.6.6L110 96.5c-1 .6-1.7.1-1.7-1v-35c0-1.1.8-1.5 1.7-1L140.3 77z'/%3E%3Cpath d='M82.5 79c0-20.7 16.8-37.5 37.5-37.5s37.5 16.8 37.5 37.5-16.8 37.5-37.5 37.5S82.5 99.7 82.5 79z' fill='none' stroke='#{encodecolor($jetpack-podcast-player-primary)}' stroke-width='5'/%3E%3Ccircle class='st0' cx='201.9' cy='47.1' r='8.1'/%3E%3Ccircle cx='233.9' cy='79' r='5' opacity='.4' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Ccircle cx='201.9' cy='110.9' r='6' opacity='.6' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Ccircle cx='170.1' cy='79' r='7' opacity='.8' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Ccircle cx='178.2' cy='56.3' r='7.5' opacity='.9' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Ccircle cx='226.3' cy='56.1' r='4.5' opacity='.3' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Ccircle cx='225.8' cy='102.8' r='5.5' opacity='.5' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Ccircle cx='178.2' cy='102.8' r='6.5' opacity='.7' fill='#{encodecolor($jetpack-podcast-player-primary)}'/%3E%3Cpath class='st0' d='M178 9.4c0 .4-.4.7-.9.7-.1 0-.2 0-.2-.1L172 8.2c-.5-.2-.6-.6-.1-.8l6.2-3.6c.5-.3.8-.1.7.5l-.8 5.1z'/%3E%3Cpath class='st0' d='M169.4 15.9c-1 0-2-.2-2.9-.7-2-1-3.2-3-3.2-5.2.1-3.4 2.9-6 6.3-6 2.5.1 4.8 1.7 5.6 4.1l.1-.1 2.1 1.1c-.6-4.4-4.7-7.5-9.1-6.9-3.9.6-6.9 3.9-7 7.9 0 2.9 1.7 5.6 4.3 7 1.2.6 2.5.9 3.8 1 2.6 0 5-1.2 6.6-3.3l-1.8-.9c-1.2 1.2-3 2-4.8 2zM183.4 3.2c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5zm-5.1 5c.8 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5-1.5-.7-1.5-1.5c0-.9.7-1.5 1.5-1.5zm5.1 0h8.5c.9 0 1.5.7 1.5 1.5s-.7 1.5-1.5 1.5h-8.5c-.9 0-1.5-.7-1.5-1.5-.1-.9.6-1.5 1.5-1.5z'/%3E%3C/svg%3E" );
 	}
 
 	/**
@@ -369,11 +383,11 @@ $player-float-background: $light-gray-200;
 	 * then define a background-color for the actual color of the icon. This
 	 * approach will allow us to customize colors via CSS variables.
 	 */
-	@supports (mask-image: none) or (-webkit-mask-image: none) {
+	@supports ( mask-image: none ) or ( -webkit-mask-image: none ) {
 		.mejs-button > button {
 			background-image: none;
-			background-color: $player-button-color;
-			mask: url('/wp-includes/js/mediaelement/mejs-controls.svg');
+			background-color: var( --jetpack-podcast-player-primary );
+			mask: url( '/wp-includes/js/mediaelement/mejs-controls.svg' );
 		}
 
 		.mejs-play > button {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -189,6 +189,7 @@ $player-background: transparent;
 		margin: 0;
 		font-family: $default-font;
 		font-size: $editor-font-size;
+		line-height: $editor-line-height;
 
 		/**
 		 * When track "is-active", it means that it's been clicked by a user to
@@ -257,6 +258,7 @@ $player-background: transparent;
 			display: block;
 			width: $track-status-icon-size;
 			height: $track-status-icon-size;
+			margin-top: 3px; // center vertically
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -143,7 +143,6 @@ $player-background: transparent;
 
 	// Apply `secondary` color to the podcast title.
 	.has-secondary {
-		// custom color.
 		.jetpack-podcast-player__podcast-title {
 			color: currentColor;
 		}
@@ -175,8 +174,8 @@ $player-background: transparent;
 		max-height: 105px; //IE11 fallback
 	}
 
+	// Apply `secondary` color to the track description.
 	.has-secondary {
-		// custom color.
 		.jetpack-podcast-player__track-description {
 			color: currentColor;
 		}
@@ -227,7 +226,6 @@ $player-background: transparent;
 		}
 	}
 
-	// We need to scope this class to override editor link styles.
 	.jetpack-podcast-player__track-link {
 		display: flex;
 		flex-flow: row nowrap;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -304,6 +304,18 @@ $player-background: transparent;
 	}
 
 	/**
+	 * Global error element, replaces the whole block with the error message.
+	 */
+	.jetpack-podcast-player__error {
+		padding: $player-grid-spacing;
+		margin: 0;
+		color: $alert-red;
+		font-family: $default-font;
+		font-size: 0.8em;
+		font-weight: normal;
+	}
+
+	/**
 	 * Style the block to hide dynamic UI and show just its default style.
 	 */
 	&.is-default {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -218,7 +218,8 @@ $player-background: transparent;
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		padding: $track-h-padding $track-v-padding;
+		// Adjustments on left padding to account for SVG sound icon spacing 
+		padding: $track-h-padding $player-grid-spacing $track-h-padding $player-grid-spacing - 2px;
 		transition: none;
 		color: inherit;
 
@@ -319,6 +320,12 @@ $player-background: transparent;
 
 	.mejs-controls {
 		position: static;
+		/**
+		* Lines up the mejs player padding with our wrapper spacing.
+		* Magic numbers are due to needing to line-up the player spacing with buttons
+		* and fixed widths inside of the mediaplayer.
+		*/
+		padding: 0 ($player-grid-spacing - 6px) 0 ($player-grid-spacing - 9px);
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -420,7 +420,8 @@ $player-background: transparent;
 	 * approach will allow us to customize colors via CSS variables.
 	 */
 	@supports ( mask-image: none ) or ( -webkit-mask-image: none ) {
-		.mejs-button > button {
+		.mejs-button > button,
+		.jetpack-podcast-player__track-status-icon--playing {
 			background-image: none;
 			background-color: var( --jetpack-podcast-player-primary );
 			mask: url( '/wp-includes/js/mediaelement/mejs-controls.svg' );
@@ -444,6 +445,21 @@ $player-background: transparent;
 
 		.mejs-unmute > button {
 			mask-position: -40px 0;
+		}
+
+		.jetpack-podcast-player__track-status-icon--playing {
+			mask-position: -60px 0;
+			max-height: $track-status-icon-size;
+			max-width: 20px;
+			margin: 4px 2px 0 0;
+			svg {
+				/**
+				* To stay consistent with the mediaelement player icons, we're using the same
+				* icon sprite for the track list playing icon. As we still keep the SVG as a
+				* fallback when CSS masks are not supported, we have to hide it when they are.
+				*/
+				visibility: hidden;
+			}
 		}
 	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -271,7 +271,7 @@ $player-background: transparent;
 	 */
 	.jetpack-podcast-player__track-error {
 		display: block;
-		margin-left: 2 * $track-v-padding + $track-status-icon-size;
+		margin-left: ($player-grid-spacing - 2px) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
 		margin-bottom: $track-h-padding;
 		color: $alert-red;
 		font-family: $default-font;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -22,6 +22,7 @@ $text-color-active: $text-color-hover;
 $text-color-error: $alert-red;
 $block-bg-color: $white;
 $block-border-color: $dark-gray-100;
+$current-track-title-color: $black;
 $player-background: transparent;
 
 .jetpack-podcast-player--visually-hidden {
@@ -105,14 +106,22 @@ $player-background: transparent;
 		height: $cover-image-size;
 	}
 
-	.jetpack-podcast-player__title {
+	// The tag name increases specificity to override some themes/editor styles.
+	h2.jetpack-podcast-player__title {
 		display: flex;
 		flex-direction: column;
 		margin: 0;
 		overflow: hidden;
+		letter-spacing: 0; // Fixes Twenty Twenty compressed text.
+
+		&:before,
+		&:after {
+			display: none;
+		}
 	}
 
 	.jetpack-podcast-player__current-track-title {
+		color: $current-track-title-color;
 		font-size: $track-title-font-size;
 		margin: 0 0 $track-title-b-margin;
 	}
@@ -133,7 +142,8 @@ $player-background: transparent;
 	}
 
 	// Apply `secondary` color to the podcast title.
-	.has-secondary { // custom color.
+	.has-secondary {
+		// custom color.
 		.jetpack-podcast-player__podcast-title {
 			color: currentColor;
 		}
@@ -165,7 +175,8 @@ $player-background: transparent;
 		max-height: 105px; //IE11 fallback
 	}
 
-	.has-secondary { // custom color.
+	.has-secondary {
+		// custom color.
 		.jetpack-podcast-player__track-description {
 			color: currentColor;
 		}
@@ -222,13 +233,22 @@ $player-background: transparent;
 		flex-flow: row nowrap;
 		justify-content: space-between;
 		padding: $track-h-padding $track-v-padding;
-		text-decoration: none;
 		transition: none;
 		color: inherit;
 
 		&:hover,
 		&:focus {
 			color: inherit;
+		}
+	}
+
+	// The tag name increases specificity to override some themes/editor styles.
+	a.jetpack-podcast-player__track-link {
+		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			text-decoration: none;
 		}
 	}
 
@@ -240,7 +260,7 @@ $player-background: transparent;
 	.jetpack-podcast-player__track-status-icon {
 		flex: $track-status-icon-size 0 0;
 		fill: $jetpack-podcast-player-primary;
-		fill: var(--jetpack-podcast-player-primary);
+		fill: var( --jetpack-podcast-player-primary );
 
 		svg {
 			display: inline-block;
@@ -342,7 +362,7 @@ $player-background: transparent;
 	}
 
 	.mejs-controls .mejs-time-rail .mejs-time-loaded {
-		opacity: .5;
+		opacity: 0.5;
 		background-color: $jetpack-podcast-player-primary;
 		background-color: var( --jetpack-podcast-player-primary );
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -218,7 +218,7 @@ $player-background: transparent;
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		// Adjustments on left padding to account for SVG sound icon spacing 
+		// Adjustments on left padding to account for SVG sound icon spacing
 		padding: $track-h-padding $player-grid-spacing $track-h-padding $player-grid-spacing - 2px;
 		transition: none;
 		color: inherit;
@@ -256,10 +256,6 @@ $player-background: transparent;
 		}
 	}
 
-	.jetpack-podcast-player__track-status-icon--error {
-		fill: $text-color-error;
-	}
-
 	.jetpack-podcast-player__track-title {
 		flex-grow: 1;
 		padding: 0 $track-v-padding;
@@ -289,6 +285,22 @@ $player-background: transparent;
 		& > span > a {
 			color: inherit;
 		}
+	}
+
+	.has-primary .jetpack-podcast-player__track-error {
+		color: currentColor;
+
+		& > span {
+			color: var( --jetpack-podcast-player-secondary );
+		}
+	}
+
+	.jetpack-podcast-player__track-status-icon--error {
+		fill: $text-color-error;
+	}
+
+	.has-primary .jetpack-podcast-player__track-status-icon--error {
+		fill: currentColor;
 	}
 
 	/**
@@ -326,7 +338,7 @@ $player-background: transparent;
 		* Magic numbers are due to needing to line-up the player spacing with buttons
 		* and fixed widths inside of the mediaplayer.
 		*/
-		padding: 0 ($player-grid-spacing - 6px) 0 ($player-grid-spacing - 9px);
+		padding: 0 ( $player-grid-spacing - 6px ) 0 ( $player-grid-spacing - 9px );
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -11,7 +11,6 @@ $track-title-font-size: 24px;
 $track-title-b-margin: 10px;
 $podcast-title-font-size: 16px;
 $description-font-size: 16px;
-$player-divider-height: 2px;
 $track-status-icon-size: 22px;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
@@ -77,17 +76,6 @@ $player-background: transparent;
 	.jetpack-podcast-player__header {
 		display: flex;
 		flex-direction: column;
-		position: relative;
-
-		&:after {
-			content: '';
-			background: $light-gray-700;
-			position: absolute;
-			height: $player-divider-height;
-			bottom: 0;
-			left: $player-grid-spacing;
-			right: $player-grid-spacing;
-		}
 	}
 
 	.jetpack-podcast-player__current-track-info {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -250,8 +250,9 @@ $player-background: transparent;
 		fill: var( --jetpack-podcast-player-primary );
 
 		svg {
-			position: absolute;
+			display: block;
 			width: $track-status-icon-size;
+			height: $track-status-icon-size;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -261,10 +261,8 @@ $player-background: transparent;
 		fill: var( --jetpack-podcast-player-primary );
 
 		svg {
-			display: inline-block;
-			vertical-align: middle;
+			position: absolute;
 			width: $track-status-icon-size;
-			height: $track-status-icon-size;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { memoize } from 'lodash';
+
+/**
  * Returns a class based on the context a color is being used and its slug.
  * Note: This helper function was copied from core @wordpress/block-editor lib,
  * in order to avoid requiring not-needed dependencies to reduce the size
@@ -46,3 +52,66 @@ export function makeCancellable( promise ) {
 		},
 	};
 }
+
+/**
+ * Returns object with detailed color settings computed from the basic configuration.
+ *
+ * @example
+ * const colors = generateColorsObject( {
+ *   primaryColor: '…',
+ *   customPrimaryColor: '…',
+ *   …
+ * } );
+ * @param Object config with all color-related block attributes.
+ * @returns Object with color details.
+ */
+const generateColorsObject = ( {
+	primaryColor,
+	customPrimaryColor,
+	secondaryColor,
+	customSecondaryColor,
+	backgroundColor,
+	customBackgroundColor,
+} ) => {
+	// Set CSS classes string.
+	const primaryColorClass = getColorClassName( 'color', primaryColor );
+	const secondaryColorClass = getColorClassName( 'color', secondaryColor );
+	const backgroundColorClass = getColorClassName( 'background-color', backgroundColor );
+
+	// Generate colors object.
+	return {
+		primary: {
+			name: primaryColor,
+			custom: customPrimaryColor,
+			classes: classnames( {
+				'has-primary': primaryColorClass || customPrimaryColor,
+				[ primaryColorClass ]: primaryColorClass,
+			} ),
+		},
+		secondary: {
+			name: secondaryColor,
+			custom: customSecondaryColor,
+			classes: classnames( {
+				'has-secondary': secondaryColorClass || customSecondaryColor,
+				[ secondaryColorClass ]: secondaryColorClass,
+			} ),
+		},
+		background: {
+			name: backgroundColor,
+			custom: customBackgroundColor,
+			classes: classnames( {
+				'has-background': backgroundColorClass || customBackgroundColor,
+				[ backgroundColorClass ]: backgroundColorClass,
+			} ),
+		},
+	};
+};
+
+/**
+ * Memoized version of generateColorsObject.
+ * @see {@link generateColorsObject} for params and return type.
+ */
+export const getColorsObject = memoize( generateColorsObject, config => {
+	// Cache key is a string with all arguments joined into one string.
+	return Object.values( config ).join();
+} );

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -7,15 +7,19 @@ import { memoize } from 'lodash';
 /**
  * Returns a class based on the context a color is being used and its slug.
  * Note: This helper function was copied from core @wordpress/block-editor lib,
- * in order to avoid requiring not-needed dependencies to reduce the size
- * of compiled files used in the front-end.
+ * in order to avoid requiring not-needed dependencies to reduce the size of
+ * compiled files used in the front-end.
  *
  * @example
  * const className = getColorClassName( 'color', canvasPrimaryColor );
- * @param colorContextName - Context/place where color is being used e.g: background, text etc...
- * @param colorSlug -        Slug of the color.
- * @returns String with the class corresponding to the color in the provided context.
- * Returns undefined if either colorContextName or colorSlug are not provided.
+ *
+ * @param {string} colorContextName - Context/place where color is being used
+ * e.g: background, text etc...
+ * @param {string} colorSlug - Slug of the color.
+ *
+ * @returns {string|undefined} String with the class corresponding to the color
+ * in the provided context. Undefined if either colorContextName or colorSlug
+ * are not provided.
  */
 export function getColorClassName( colorContextName, colorSlug ) {
 	if ( ! colorContextName || ! colorSlug ) {
@@ -27,13 +31,18 @@ export function getColorClassName( colorContextName, colorSlug ) {
 
 /**
  * Creates a wrapper around a promise which allows it to be programmatically
- * cancelled. See: https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+ * cancelled.
+ *
+ * @see {@link https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html}
  *
  * @example
- * const somePromise = makeCancellable( fetch('http://wordpress.org') );
- * somePromise.promise.then()
- * @param promise - the Promise to make cancelable
- * @returns Object containing original promise object and cancel method.
+ * const somePromise = makeCancellable( fetch( 'http://wordpress.org' ) );
+ * somePromise.promise.then();
+ *
+ * @param {Promise} promise - the Promise to make cancelable
+ *
+ * @returns {object} Object containing original promise object and cancel
+ * method.
  */
 export function makeCancellable( promise ) {
 	let hasCanceled_ = false;

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -1,4 +1,5 @@
 /* global jetpackPodcastPlayers */
+
 /**
  * External dependencies
  */
@@ -21,7 +22,8 @@ const playerInstances = {};
 
 /**
  * Downgrades the block to use the static markup as rendered on the server.
- * @param {Element} block The root element of the block.
+ *
+ * @param {Element} block - The root element of the block.
  */
 const downgradeBlockToStatic = function( block ) {
 	block.classList.add( 'is-default' );
@@ -29,7 +31,8 @@ const downgradeBlockToStatic = function( block ) {
 
 /**
  * Initialize player instance.
- * @param {string} id The id of the block element in document.
+ *
+ * @param {string} id - The id of the block element in document.
  */
 const initializeBlock = function( id ) {
 	// Find DOM node.


### PR DESCRIPTION
Remaining work on Podcast Player Block

#### Changes proposed in this Pull Request:
* Use CSS mask to color ME.js controls (#15257)
* Introduce CSS vars for colors (#15321)
* Enable mediaelement player color customization (#15332)
* Simplify creating color change handler (#15335)
* Memoize colors object (#15336)
* Theme Compatibility Fixes (#15320)
* Lint everything (#15281)
* Fix Sound Icon Position (#15343)
* Remove bottom border on podcast header (#15355)
* Decode all HTML entities (#15351) 
* Consistent gutter spacing (#15356)
* Fix Sound Icon Position... including IE (#15371)
* Fix alignment issues in placeholder (#15376)
* Apply color customization to error state (#15394)
* Add an error boundary (#15369)
* Break components into their own files (#15442)
* Make speaker icons consistent (#15445) 
* Instruct IE11 user on how to activate audio support (#15451)
* Add external embed detection (#15446)
* Fix error message alignment (#15462)
* Make current track title inherit primary color (#15463)
* Center track icon vertically (#15465)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Polishes Podcast Player block after CfT

#### Testing instructions:

_**NOTE: it should be tested in Simple sites**_

General URL for testing: https://anchor.fm/s/9400d7c/podcast/rss

* To test customization of controls colors (in modern browsers), go to the bottom of [`styles.css`](https://github.com/Automattic/jetpack/compare/feature/podcast-player...try/podcast-player-mejs-svg-colors?expand=1#diff-23936c23c59259d544403d0cc941ea1d) and set any color to the [background-color property of the ME.js button](https://github.com/Automattic/jetpack/compare/feature/podcast-player...try/podcast-player-mejs-svg-colors?expand=1#diff-23936c23c59259d544403d0cc941ea1dR340). Refresh the page and see if the color has been set. Play with the controls by clicking them - it should toggle colored `play`/`pause`, `mute`/`unmute` and `replay` SVGs.
* Play a track in the editor: The sound icon should look centered with the first line of the track
* Reduce the window size so the track titles wrap. The sound icon should still be centered with the first line of the track
* The sound icon being added should not increase the height of the track `<a>` element
* Test with one of these feeds and make sure there are no encoded html entities: https://whatsurfave.com/category/podcast/feed/, https://anchor.fm/s/9400d7c/podcast/rss
* Add the Podcast Player (Beta), Youtube embed, and RSS blocks. Compare the three blocks and check that input and button elements are aligned and that the blocks look consistent.
* Block a request / go offline to throw the episode error. In the editor, set primary/secondary/background colors and observe whether the error elements are now affected by color customization.
* Try adding `throw new Error( 'Test' )` somewhere in render functions of our components or inside functional components. For example, as the very first line in `render()` inside `audio-player.js`. Inside the editor, the player should be replaced by a simple error message. On the frontend, we have an additional handling that suppresses the error and instead unmounts the React component and brings back the static markup.
* In IE 11: Test both with the "audio support for webpages" setting unchecked and checked. Observe whether what you see reflects the states displayed in the #15451 issue description.
* Test with multiple URLs and confirm they all embed correctly. Some examples:
  - http://example.com - should show error
  - https://distributed.blog/category/podcast/feed/ - direct RSS link, should use our player
  - https://anchor.fm/startapodcast/episodes/Whats-your-podcast-about-e17krq/a-a2q3ft - regular webpage with `<link>` to RSS, should also use our player
  - https://open.spotify.com/show/7gozmLqbcbr6PScMjc0Zl4, invalid RSS but valid oEmbed, should replace Podcast Player with the spotify block
  - https://www.youtube.com/watch?v=dQw4w9WgXcQ, again invalid as RSS but works as oEmbed, should replace our block with youtube block


#### Proposed changelog entry for your changes:
* Not sure if needed at this time?

#### Follow-up issues
https://github.com/Automattic/jetpack/issues/15443, https://github.com/Automattic/jetpack/issues/15444, #15459