### PR TITLE
Podcast Player: Remove header divider

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -11,7 +11,6 @@ $track-title-font-size: 24px;
 $track-title-b-margin: 10px;
 $podcast-title-font-size: 16px;
 $description-font-size: 16px;
-$player-divider-height: 2px;
 $track-status-icon-size: 22px;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
@@ -77,17 +76,6 @@ $player-background: transparent;
 	.jetpack-podcast-player__header {
 		display: flex;
 		flex-direction: column;
-		position: relative;
-
-		&:after {
-			content: '';
-			background: $light-gray-700;
-			position: absolute;
-			height: $player-divider-height;
-			bottom: 0;
-			left: $player-grid-spacing;
-			right: $player-grid-spacing;
-		}
 	}
 
 	.jetpack-podcast-player__current-track-info {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes a request from @davemart-in to remove the dividing line on the podcast header to prevent custom color issues.

#### Changes proposed in this Pull Request:
* Removes the dividing line between the header and track list

**Screenshots**
| before  | after |
| ------------- | ------------- |
| <img width="594" alt="Screen Shot 2020-04-07 at 1 39 48 PM" src="https://user-images.githubusercontent.com/967608/78707071-b77cd480-78d5-11ea-8c3d-6d3472301739.png"> | <img width="596" alt="Screen Shot 2020-04-07 at 1 37 37 PM" src="https://user-images.githubusercontent.com/967608/78707063-b5b31100-78d5-11ea-821f-08f316a1b6cf.png"> |



#### Testing instructions:

* Add a podcast player
* See that the dividing line is gone

#### Proposed changelog entry for your changes:
* No changelog needed
