### PR TITLE
Podcast Player: Consistent gutter spacing

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -332,7 +332,11 @@ $player-background: transparent;
 
 	.mejs-controls {
 		position: static;
-		// Lines up the mejs player padding with our wrapper spacing
+		/**
+		* Lines up the mejs player padding with our wrapper spacing.
+		* Magic numbers are due to needing to line-up the player spacing with buttons
+		* and fixed widths inside of the mediaplayer.
+		*/
 		padding: 0 ($player-grid-spacing - 6px) 0 ($player-grid-spacing - 9px);
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -333,7 +333,7 @@ $player-background: transparent;
 	.mejs-controls {
 		position: static;
 		// Lines up the mejs player padding with our wrapper spacing
-		padding: 0 ($player-grid-spacing - 7px) 0 ($player-grid-spacing - 9px);
+		padding: 0 ($player-grid-spacing - 6px) 0 ($player-grid-spacing - 9px);
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -230,7 +230,8 @@ $player-background: transparent;
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		padding: $track-h-padding $track-v-padding;
+		// Adjustments on left padding to account for SVG sound icon spacing 
+		padding: $track-h-padding $player-grid-spacing $track-h-padding $player-grid-spacing - 2px;
 		transition: none;
 		color: inherit;
 
@@ -331,6 +332,8 @@ $player-background: transparent;
 
 	.mejs-controls {
 		position: static;
+		// Lines up the mejs player padding with our wrapper spacing
+		padding: 0 ($player-grid-spacing - 7px) 0 ($player-grid-spacing - 9px);
 	}
 
 	.mejs-time,


### PR DESCRIPTION
Brings a consistent side gutter spacing to the player

Fixes https://github.com/Automattic/jetpack/issues/15262

#### Changes proposed in this Pull Request:
* Tweaks spacing of mejs container and tracklist to be consistently spaced.
* The mejs player uses fixed widths for the play/pause button and volume track, making it impossible to _not use magic numbers_.
* The SVG playing/sound icon has a slight amount of padding on the left from being an SVG, so this is accounted for with a not-so-pretty `$player-grid-spacing - 2px` on the left padding.

**Screenshots**

**Playing**
| before  | after |
| ------------- | ------------- |
| <img width="602" alt="Screen Shot 2020-04-07 at 2 38 34 PM" src="https://user-images.githubusercontent.com/967608/78712012-8d2f1500-78dd-11ea-9992-7ea177d8c14c.png"> | <img width="599" alt="Screen Shot 2020-04-07 at 2 30 37 PM" src="https://user-images.githubusercontent.com/967608/78711763-23167000-78dd-11ea-9b29-1835d081684c.png"> |


**Paused**
| before  | after |
| ------------- | ------------- |
| <img width="607" alt="Screen Shot 2020-04-07 at 2 38 29 PM" src="https://user-images.githubusercontent.com/967608/78712097-b0f25b00-78dd-11ea-95c5-057f19ac589e.png"> | <img width="611" alt="Screen Shot 2020-04-07 at 2 30 31 PM" src="https://user-images.githubusercontent.com/967608/78711873-535e0e80-78dd-11ea-8f1b-efc8a6a5bc49.png"> |


Playing




#### Testing instructions:
* Add a podcast player
* Check gutter spacing in editor
* Check gutter spacing on frontend

#### Proposed changelog entry for your changes:
* No changelog needed
