### PR TITLE
Autoloader: display an error when a non-default vendor directory is used

### DIFF
--- a/packages/autoloader/README.md
+++ b/packages/autoloader/README.md
@@ -42,3 +42,5 @@ Current Limitations
 -----
 
 We currently only support packages that autoload via psr-4 definition in their package.
+
+Your project must use the default composer vendor directory, `vendor`.

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -1,4 +1,4 @@
-<?php
+<?php //phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
 /**
  * Custom Autoloader Composer Plugin, hooks into composer events to generate the custom autoloader.
  *
@@ -71,11 +71,19 @@ class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterfac
 	 */
 	public function postAutoloadDump( Event $event ) {
 
+		$config = $this->composer->getConfig();
+
+		if ( 'vendor' !== $config->raw()['config']['vendor-dir'] ) {
+			$this->io->writeError( "\n<error>An error occurred while generating the autoloader files:", true );
+			$this->io->writeError( 'The project\'s composer.json or composer environment set a non-default vendor directory.', true );
+			$this->io->writeError( 'The default composer vendor directory must be used.</error>', true );
+			exit();
+		}
+
 		$installationManager = $this->composer->getInstallationManager();
 		$repoManager         = $this->composer->getRepositoryManager();
 		$localRepo           = $repoManager->getLocalRepository();
 		$package             = $this->composer->getPackage();
-		$config              = $this->composer->getConfig();
 		$optimize            = true;
 		$suffix              = $config->get( 'autoloader-suffix' )
 			? $config->get( 'autoloader-suffix' )


### PR DESCRIPTION
This PR will be merged into the `feature/update_autoloader` branch.

The autoloader package only supports the default composer vendor directory.  When a consuming plugin uses a non-default vendor directory, an error should be generated during `composer install`, `composer update`, and `composer dump-autoload`.

#### Changes proposed in this Pull Request:
* Display an error when a consuming plugin uses a non-default vendor directory.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
1. Verify that the autoloader files are generated when the default vendor directory is used:

   1. In the Jetpack directory, run `composer install`. You should see multiple messages for autoloader files that have been generated:

   > Generating autoload files
   > Generated /jetpack/vendor/composer/jetpack_autoload_classmap.php
   > Generated /jetpack/vendor/composer/jetpack_autoload_filemap.php
   > Generated /jetpack/vendor/autoload_packages.php
   > Generated /jetpack/vendor/autoload_functions.php
   > Generated /jetpack/vendor/class-autoloader-handler.php
   > Generated /jetpack/vendor/class-classes-handler.php
   > Generated /jetpack/vendor/class-files-handler.php
   > Generated /jetpack/vendor/class-plugins-handler.php
   > Generated /jetpack/vendor/class-version-selector.php
   > Generated autoload files containing 15 classes

2. Verify that the error message is generated when another installation directory is used:

   1. Add a different `vendor-dir` value to the config section in Jetpack’s `composer.json` file. For example:
   ```
   "config": {
           "sort-packages": true,
           "vendor-dir": "not-vendor"
   }
   ```
   2. In the Jetpack directory, run `composer install`. You should see the error message.

#### Proposed changelog entry for your changes:
* n/a
