### PR TITLE
Fix: When footer is not enabled, avoid JS errors

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -202,6 +202,10 @@
 		var blog = document.getElementById( 'infinity-blog-title' );
 		var self = this;
 
+		if ( ! blog ) {
+			return;
+		}
+
 		blog.setAttribute( 'title', totop );
 		blog.addEventListener( 'click', function( e ) {
 			var sourceScroll = self.window.pageYOffset;
@@ -223,7 +227,12 @@
 			footerContainer,
 			width,
 			sourceBottom,
-			targetBottom;
+			targetBottom,
+			footerEnabled = this.footer && this.footer.el;
+
+		if ( ! footerEnabled ) {
+			return;
+		}
 
 		// Check if we have an id for the page wrapper
 		if ( 'string' === typeof this.footer.wrap ) {


### PR DESCRIPTION
Fixes #15348

#### Changes proposed in this Pull Request:
* Makes explicit checks for the existence of footer and the blog title element within in order to not initialize any logic that depend on footer being present on the page.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a fix that applies to the Infinite Scroll module.

#### Testing instructions:
* Follow the steps outlined in #15348
* Observe no JS errors being reported.
* Observe a working IS.

#### Proposed changelog entry for your changes:
* Fixes an Infinite Scroll bug that prevented its functionality on themes without footers.
