### PR TITLE
Remove the rest of the Skyword library.

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -150,10 +150,6 @@ abstract class SAL_Site {
 	}
 
 	public function get_post_by_id( $post_id, $context ) {
-		// Remove the skyword tracking shortcode for posts returned via the API.
-		remove_shortcode( 'skyword-tracking' );
-		add_shortcode( 'skyword-tracking', '__return_empty_string' );
-
 		$post = get_post( $post_id, OBJECT, $context );
 
 		if ( ! $post ) {


### PR DESCRIPTION
Differential Revision: D40227-code

This commit syncs r205531-wpcom.

#### Changes proposed in this Pull Request:

Following D40154-code and D40226-code, there should be no longer any reference to this Skyword library.

#### Testing instructions:

Sandboxing a site, visit it and make sure there is no errors popping up in the error log.

#### Proposed changelog entry for your changes:

* N/A
