### PR TITLE
Fix: Append all posts from IS response

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -151,11 +151,13 @@
 	 * Renders the results from a successful response.
 	 */
 	Scroller.prototype.render = function( response ) {
+		var childrenToAppend = Array.prototype.slice.call( response.fragment.childNodes );
 		this.body.classList.add( 'infinity-success' );
 
 		// Render the retrieved nodes.
-		for ( var i = 0; i < response.fragment.childNodes.length; i++ ) {
-			this.element.appendChild( response.fragment.childNodes[ i ] );
+		while ( childrenToAppend.length > 0 ) {
+			var currentNode = childrenToAppend.shift();
+			this.element.appendChild( currentNode );
 		}
 
 		this.trigger( this.body, 'is.post-load', {


### PR DESCRIPTION
Fixes #15352 

#### Changes proposed in this Pull Request:
* Avoid iterating over the `.length` property of a collection that's being altered in the loop.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is a bug fix related to the Infinite Scroll feature.

#### Testing instructions:
* Follow the steps under https://github.com/Automattic/jetpack/issues/15352
* Observe that all posts are loaded correctly.

#### Proposed changelog entry for your changes:
* Fixed a bug where some posts were omitted from infinite scroll.
