### PR TITLE
Podcast Player: Add an error boundary

### DIFF
--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -18,8 +18,8 @@ import Playlist from './playlist';
 import AudioPlayer from './audio-player';
 import Header from './header';
 import { getColorsObject } from '../utils';
+import withErrorBoundary from './with-error-boundary';
 
-// const debug = debugFactory( 'jetpack:podcast-player' );
 const noop = () => {};
 
 export class PodcastPlayer extends Component {
@@ -292,4 +292,4 @@ PodcastPlayer.defaultProps = {
 	tracks: [],
 };
 
-export default PodcastPlayer;
+export default withErrorBoundary( PodcastPlayer );

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -26,7 +26,6 @@ export class PodcastPlayer extends Component {
 	state = {
 		playerState: STATE_PAUSED,
 		currentTrack: 0,
-		hasUserInteraction: false,
 	};
 
 	playerRef = player => {
@@ -35,17 +34,6 @@ export class PodcastPlayer extends Component {
 		this.pause = player ? player.pause : noop;
 		this.togglePlayPause = player ? player.togglePlayPause : noop;
 		this.setAudioSource = player ? player.setAudioSource : noop;
-	};
-
-	/**
-	 * Record the user has interacted with the player.
-	 *
-	 * @private
-	 */
-	recordUserInteraction = () => {
-		if ( ! this.state.hasUserInteraction ) {
-			this.setState( { hasUserInteraction: true } );
-		}
 	};
 
 	/**
@@ -59,7 +47,6 @@ export class PodcastPlayer extends Component {
 
 		// Current track already selected.
 		if ( currentTrack === track ) {
-			this.recordUserInteraction();
 			this.togglePlayPause();
 			return;
 		}
@@ -80,9 +67,6 @@ export class PodcastPlayer extends Component {
 	 * @param {number} track - The track number
 	 */
 	loadAndPlay = track => {
-		// Record that user has interacted.
-		this.recordUserInteraction();
-
 		const trackData = this.getTrack( track );
 		if ( ! trackData ) {
 			return;
@@ -121,17 +105,9 @@ export class PodcastPlayer extends Component {
 	 *
 	 * @private
 	 */
-	handleError = error => {
-		// If an error happens before any user interaction, our player is broken beyond repair.
-		if ( ! this.state.hasUserInteraction ) {
-			// setState wrapper makes sure our ErrorBoundary handles the error.
-			this.setState( () => {
-				throw new Error( error );
-			} );
-		}
-
-		// Otherwise, let's just mark the episode as broken.
+	handleError = () => {
 		this.setState( { playerState: STATE_ERROR } );
+
 		speak( `${ __( 'Error: Episode unavailable - Open in a new tab', 'jetpack' ) }`, 'assertive' );
 	};
 
@@ -143,7 +119,6 @@ export class PodcastPlayer extends Component {
 	handlePlay = () => {
 		this.setState( {
 			playerState: STATE_PLAYING,
-			hasUserInteraction: true,
 		} );
 	};
 

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -26,6 +26,7 @@ export class PodcastPlayer extends Component {
 	state = {
 		playerState: STATE_PAUSED,
 		currentTrack: 0,
+		hasUserInteraction: false,
 	};
 
 	playerRef = player => {
@@ -34,6 +35,17 @@ export class PodcastPlayer extends Component {
 		this.pause = player ? player.pause : noop;
 		this.togglePlayPause = player ? player.togglePlayPause : noop;
 		this.setAudioSource = player ? player.setAudioSource : noop;
+	};
+
+	/**
+	 * Record the user has interacted with the player.
+	 *
+	 * @private
+	 */
+	recordUserInteraction = () => {
+		if ( ! this.state.hasUserInteraction ) {
+			this.setState( { hasUserInteraction: true } );
+		}
 	};
 
 	/**
@@ -47,6 +59,7 @@ export class PodcastPlayer extends Component {
 
 		// Current track already selected.
 		if ( currentTrack === track ) {
+			this.recordUserInteraction();
 			this.togglePlayPause();
 			return;
 		}
@@ -67,6 +80,9 @@ export class PodcastPlayer extends Component {
 	 * @param {number} track - The track number
 	 */
 	loadAndPlay = track => {
+		// Record that user has interacted.
+		this.recordUserInteraction();
+
 		const trackData = this.getTrack( track );
 		if ( ! trackData ) {
 			return;
@@ -105,9 +121,17 @@ export class PodcastPlayer extends Component {
 	 *
 	 * @private
 	 */
-	handleError = () => {
-		this.setState( { playerState: STATE_ERROR } );
+	handleError = error => {
+		// If an error happens before any user interaction, our player is broken beyond repair.
+		if ( ! this.state.hasUserInteraction ) {
+			// setState wrapper makes sure our ErrorBoundary handles the error.
+			this.setState( () => {
+				throw new Error( error );
+			} );
+		}
 
+		// Otherwise, let's just mark the episode as broken.
+		this.setState( { playerState: STATE_ERROR } );
 		speak( `${ __( 'Error: Episode unavailable - Open in a new tab', 'jetpack' ) }`, 'assertive' );
 	};
 
@@ -119,6 +143,7 @@ export class PodcastPlayer extends Component {
 	handlePlay = () => {
 		this.setState( {
 			playerState: STATE_PLAYING,
+			hasUserInteraction: true,
 		} );
 	};
 

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+export default function withErrorBoundary( WrappedComponent ) {
+	class ErrorBoundary extends Component {
+		state = {
+			didError: false,
+		};
+
+		componentDidCatch = ( error, errorInfo ) => {
+			// This needs to be delayed in order for React to finish its error handling.
+			setTimeout( () => {
+				this.props.onError( error, errorInfo );
+			} );
+		};
+
+		static getDerivedStateFromError = () => {
+			return { didError: true };
+		};
+
+		render() {
+			if ( this.state.didError ) {
+				return (
+					<section className="jetpack-podcast-player">
+						<p className="jetpack-podcast-player__error">
+							{ __(
+								'An unexpected error occured within the Podcast Player. Please reload the page.',
+								'jetpack'
+							) }
+						</p>
+					</section>
+				);
+			}
+
+			return <WrappedComponent { ...this.props } />;
+		}
+	}
+
+	ErrorBoundary.defaultProps = {
+		onError: () => {},
+	};
+
+	return ErrorBoundary;
+}

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -28,7 +28,7 @@ export default function withErrorBoundary( WrappedComponent ) {
 					<section className="jetpack-podcast-player">
 						<p className="jetpack-podcast-player__error">
 							{ __(
-								'An unexpected error occured within the Podcast Player. Please reload the page.',
+								'An unexpected error occured within the Podcast Player. Reloading this page might fix the problem.',
 								'jetpack'
 							) }
 						</p>

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -15,10 +15,7 @@ export default function withErrorBoundary( WrappedComponent ) {
 		};
 
 		componentDidCatch = ( error, errorInfo ) => {
-			// This needs to be delayed in order for React to finish its error handling.
-			setTimeout( () => {
-				this.props.onError( error, errorInfo );
-			} );
+			this.props.onError( error, errorInfo );
 		};
 
 		static getDerivedStateFromError = () => {

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -15,7 +15,10 @@ export default function withErrorBoundary( WrappedComponent ) {
 		};
 
 		componentDidCatch = ( error, errorInfo ) => {
-			this.props.onError( error, errorInfo );
+			// This needs to be delayed in order for React to finish its error handling.
+			setTimeout( () => {
+				this.props.onError( error, errorInfo );
+			} );
 		};
 
 		static getDerivedStateFromError = () => {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -292,6 +292,18 @@ $player-background: transparent;
 	}
 
 	/**
+	 * Global errro element, replaces the whole block with the error message.
+	 */
+	.jetpack-podcast-player__error {
+		padding: $player-grid-spacing;
+		margin: 0;
+		color: $alert-red;
+		font-family: $default-font;
+		font-size: 0.8em;
+		font-weight: normal;
+	}
+
+	/**
 	 * Style the block to hide dynamic UI and show just its default style.
 	 */
 	&.is-default {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -292,7 +292,7 @@ $player-background: transparent;
 	}
 
 	/**
-	 * Global errro element, replaces the whole block with the error message.
+	 * Global error element, replaces the whole block with the error message.
 	 */
 	.jetpack-podcast-player__error {
 		padding: $player-grid-spacing;


### PR DESCRIPTION
Helps #15188

#### Changes proposed in this Pull Request:
This PR introduces an error boundary - a concept that allows us to handle any error or an exception that happens inside our block. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Podcast Player

#### Testing instructions:

Expect plenty errors to be output in the console. That's how React handles them.

##### Error boundary in general (test in any browser)
* This boundary handles any uncaught exceptions caused by the Podcast Player
* Try adding `throw new Error( 'Test' )` somewhere in render functions of our components or inside functional components. For example, as the very first line in `render()` inside `audio-player.js`.
* Inside the editor, the player should be replaced by a simple error message like this:

<img width="599" alt="Screenshot 2020-04-08 at 13 15 07" src="https://user-images.githubusercontent.com/156676/78778113-050f4500-799b-11ea-8bae-0d6754c2a6e7.png">

* on the frontend, we have an additional handling that suppresses the error and instead unmounts the React component and brings back the static markup just like there never was any dynamic player:

<img width="563" alt="Screenshot 2020-04-08 at 13 16 44" src="https://user-images.githubusercontent.com/156676/78778233-3e47b500-799b-11ea-8e91-213c3f8ec718.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none
