### PR TITLE
Podcast Player: Fix Sound Icon Position... including IE

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -261,8 +261,9 @@ $player-background: transparent;
 		fill: var( --jetpack-podcast-player-primary );
 
 		svg {
-			position: absolute;
+			display: block;
 			width: $track-status-icon-size;
+			height: $track-status-icon-size;
 		}
 	}
 


### PR DESCRIPTION
The sound icon was slightly off in the editor (and in the frontend as well, but not sure when that was introduced).

Fixes https://github.com/Automattic/jetpack/issues/15284

#### Changes proposed in this Pull Request:
- Uses `display: block;` on the `svg` to remove the mystery extra height on the `<span>` wrapping the `<svg>`: https://codepen.io/beau/pen/EjBovR

| before | after |
| ------------- | ------------- |
| <img width="783" alt="Screen Shot 2020-04-07 at 9 57 20 AM" src="https://user-images.githubusercontent.com/967608/78690382-f94d5100-78bc-11ea-9b07-2ad6c7e0a914.png"> | <img width="797" alt="Screen Shot 2020-04-07 at 9 57 38 AM" src="https://user-images.githubusercontent.com/967608/78690532-2ac61c80-78bd-11ea-96cd-3ae8a78a29b3.png"> |

**All track list items should be the same height**: Some themes may vary the height based on the line-height though.
<img width="799" alt="Screen Shot 2020-04-07 at 9 52 22 AM" src="https://user-images.githubusercontent.com/967608/78690346-ee92bc00-78bc-11ea-9d39-1961c89bbdb5.png">

**Wrapped titles**
<img width="360" alt="Screen Shot 2020-04-07 at 9 56 08 AM" src="https://user-images.githubusercontent.com/967608/78690549-3285c100-78bd-11ea-8771-3ec06ae35698.png">

**IE11**: Close enough!
<img width="798" alt="Screen Shot 2020-04-08 at 8 37 33 AM" src="https://user-images.githubusercontent.com/967608/78790593-5f48df80-7974-11ea-9c1c-45b34d791974.png">

#### Testing instructions:

* Add a podcast player to a post
* Play a track in the editor
* The sound icon should look centered with the first line of the track
* Reduce the window size so the track titles wrap.
* The sound icon should still be centered with the first line of the track
* The sound icon being added should not increase the height of the track `<a>` element
* Repeat for the front-end

#### Proposed changelog entry for your changes:
* Podcast Player: Centers playing/sound icon on the first line of the track list title.
