### PR TITLE
AMP: allow the display of the admin bar in AMP views.

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -53,18 +53,8 @@ class Jetpack_AMP_Support {
 		// Sync the amp-options.
 		add_filter( 'jetpack_options_whitelist', array( 'Jetpack_AMP_Support', 'filter_jetpack_options_whitelist' ) );
 
-		// Show admin bar.
-		add_filter( 'show_admin_bar', array( 'Jetpack_AMP_Support', 'show_admin_bar' ) );
+		// Disable Comment Likes.
 		add_filter( 'jetpack_comment_likes_enabled', array( 'Jetpack_AMP_Support', 'comment_likes_enabled' ) );
-	}
-
-	/**
-	 * Disable the admin bar on AMP views.
-	 *
-	 * @param Whether bool $show the admin bar should be shown. Default false.
-	 */
-	public static function show_admin_bar( $show ) {
-		return $show && ! self::is_amp_request();
 	}
 
 	/**

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -41,8 +41,14 @@ class Jetpack_AMP_Support {
 		// Post rendering changes for legacy AMP.
 		add_action( 'pre_amp_render_post', array( 'Jetpack_AMP_Support', 'amp_disable_the_content_filters' ) );
 
+		// Disable Comment Likes.
+		add_filter( 'jetpack_comment_likes_enabled', array( 'Jetpack_AMP_Support', 'comment_likes_enabled' ) );
+
 		// Transitional mode AMP should not have comment likes.
-		add_action( 'the_content', array( 'Jetpack_AMP_Support', 'disable_comment_likes_before_the_content' ) );
+		add_filter( 'the_content', array( 'Jetpack_AMP_Support', 'disable_comment_likes_before_the_content' ) );
+
+		// Remove the Likes button from the admin bar.
+		add_filter( 'jetpack_admin_bar_likes_enabled', array( 'Jetpack_AMP_Support', 'disable_likes_admin_bar' ) );
 
 		// Add post template metadata for legacy AMP.
 		add_filter( 'amp_post_template_metadata', array( 'Jetpack_AMP_Support', 'amp_post_template_metadata' ), 10, 2 );
@@ -52,9 +58,6 @@ class Jetpack_AMP_Support {
 
 		// Sync the amp-options.
 		add_filter( 'jetpack_options_whitelist', array( 'Jetpack_AMP_Support', 'filter_jetpack_options_whitelist' ) );
-
-		// Disable Comment Likes.
-		add_filter( 'jetpack_comment_likes_enabled', array( 'Jetpack_AMP_Support', 'comment_likes_enabled' ) );
 	}
 
 	/**
@@ -126,6 +129,18 @@ class Jetpack_AMP_Support {
 			remove_filter( 'comment_text', 'comment_like_button', 12, 2 );
 		}
 		return $content;
+	}
+
+	/**
+	 * Do not display the Likes' Admin bar on AMP requests.
+	 *
+	 * @param bool $is_admin_bar_button_visible Should the Like button be visible in the Admin bar. Default to true.
+	 */
+	public static function disable_likes_admin_bar( $is_admin_bar_button_visible ) {
+		if ( self::is_amp_request() ) {
+			return false;
+		}
+		return $is_admin_bar_button_visible;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #15353

#### Changes proposed in this Pull Request:

* The admin bar can be used in AMP views since AMP 1.3.1, thanks to AMP Dev mode. We consequently do not need to force-deactivate it.
* Since Likes aren't yet compatible with AMP yet (see #9555), let's remove the Likes iFrame from the admin bar.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Internal reference: p1586360434019800-slack-jetpack-plugin
* Follow-up to #14840. 

#### Testing instructions:

* On a brand new site running Twenty Twenty, this branch as well as the most recent of the AMP plugin, go to AMP > General and switch to the "Standard" option.
* Go to your site's frontend; you should still see the admin bar. You should also see no valdation errors linked to the Likes or Comment Likes module.

![image](https://user-images.githubusercontent.com/426388/78806089-862e0280-79c2-11ea-9cfb-757c6ae459ba.png)
* You should also not see any empty space in the admin bar, where the Likes button previously was.

* Alternatively, you can also try to activate and configure an ad on your site using the `advanced-ads` plugin, and make sure no warnings are generated in your error when viewing your site's frontend.

#### Proposed changelog entry for your changes:

* General: avoid conflicts with other plugins interacting with the AMP plugin and the admin bar.
