### PR TITLE
Autoloader: remove file_exists() before loading the file

### DIFF
--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -28,10 +28,8 @@ function autoloader( $class_name ) {
 	global $jetpack_packages_classmap;
 
 	if ( isset( $jetpack_packages_classmap[ $class_name ] ) ) {
-		if ( file_exists( $jetpack_packages_classmap[ $class_name ]['path'] ) ) {
-			require_once $jetpack_packages_classmap[ $class_name ]['path'];
-			return true;
-		}
+		require_once $jetpack_packages_classmap[ $class_name ]['path'];
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
This PR basically reintroduces the change merged into `master` by PR #15118.

Before Jetpack Autoloader loads a file, it runs `file_exists()` before the actual `require_once`.
Checking the file for existence is excessive, because if the file is present in the class map, it must be available by the provided path.

If the file isn't there, the plugin will likely generate an error because it relies on that plugin, so it doesn't really matter if the error is generated by Autoloader or by the plugin when the class can't be found.

#### Changes proposed in this Pull Request:
* Remove excessive `file_exists()` call because [see above]

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the "New Autoloader" development.

#### Testing instructions:
* Switch to the branch `remove/autoloader_file_exists_new`
* Call `composer install` to regenerate the jetpack-autoloader files
* Open the file `vendor/autoload_functions.php` and find function `autoloader()`, make sure there aren't any any `file_exists()` calls in it.
* Load the website (both frontend and the admin area), make sure it still works
* Thanks 🙂

#### Proposed changelog entry for your changes:
* n/a