### PR TITLE
Podcast player: fix alignment issues in placeholder

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -215,6 +215,7 @@ const PodcastPlayerEdit = ( {
 				icon={ <BlockIcon icon={ queueMusic } /> }
 				label={ __( 'Podcast Player', 'jetpack' ) }
 				instructions={ __( 'Enter your podcast RSS feed URL.', 'jetpack' ) }
+				className={ 'jetpack-podcast-player__placeholder' }
 			>
 				<form onSubmit={ checkPodcastLink }>
 					{ noticeUI }
@@ -262,7 +263,7 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
-	const createColorChangeHandler = ( colorAttr, handler ) => ( color ) => {
+	const createColorChangeHandler = ( colorAttr, handler ) => color => {
 		setAttributes( { [ colorAttr ]: color } );
 		handler( color );
 	};

--- a/extensions/blocks/podcast-player/editor.scss
+++ b/extensions/blocks/podcast-player/editor.scss
@@ -20,3 +20,20 @@
 	bottom: 0;
 	opacity: 0;
 }
+
+// Placeholder styles
+.jetpack-podcast-player__placeholder {
+	.components-base-control,
+	.components-base-control__field {
+		display: flex;
+		flex-grow: 1;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+
+	.components-placeholder__learn-more {
+		margin-top: 1em;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR aims to fix alignment issues with the podcast player placeholder reported in https://github.com/Automattic/jetpack/issues/15263. Namely, it eliminates the height difference between the input field and button as well as balance the padding above/below the input field.

While we were using the same components as the RSS block and the link below the input from the core embed block, not all styles are shared. Both these blocks add custom styles that are specific to these blocks but affect the visual appearance of the placeholder. This PR extracts the minimal necessary styles from both blocks.

Fixes https://github.com/Automattic/jetpack/issues/15263

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the editor and add the Podcast Player (Beta) block
* Add the Youtube embed block and RSS block as well
* Compare the three blocks and check if they look consistent

#### Screenshots

**Chrome:** 

<img width="1429" alt="Screenshot 2020-04-08 at 19 41 12" src="https://user-images.githubusercontent.com/1562646/78817762-f2653200-79d3-11ea-82ff-9c7dbb9060e8.png">

**Firefox:**

<img width="1536" alt="Screenshot 2020-04-08 at 19 37 59" src="https://user-images.githubusercontent.com/1562646/78818024-4e2fbb00-79d4-11ea-9329-5a406c582156.png">

**IE11:**

<img width="1430" alt="Screenshot 2020-04-08 at 19 39 25" src="https://user-images.githubusercontent.com/1562646/78817850-14f74b00-79d4-11ea-8f3c-6ec6384fba08.png">
 


