### PR TITLE
ESLint: Don't require JSDoc on functions in JP Extensions

### DIFF
--- a/extensions/.eslintrc.js
+++ b/extensions/.eslintrc.js
@@ -26,5 +26,9 @@ module.exports = {
 		// eslint 6.x migration
 		'react-hooks/rules-of-hooks': 1,
 		'no-async-promise-executor': 1,
+
+		// Don't require JSDoc on functions.
+		// Jetpack Extensions are often self-explanatory functional React components.
+		'jsdoc/require-jsdoc': 0,
 	},
 };


### PR DESCRIPTION
#13944 added a few new ESLint rules, one of which is kinda bothering me a lot. 😅 

`jsdoc/require-jsdoc: 1` triggers a warning for all undocumented functions, which is a very appropriate thing to warn about.
Except... most often, functions in the Extensions folder are functional React components.
They are generally self-explanatory: expect props as param and return a React component.

Working with this warning led me to either `eslint-disable` it, or to convert functions into far arrow constants (`const foo = () => {}`).
Neither workaround is a valuable use of my time, imho. 😄 

This PR simply removes the warning in the `/extensions` folder.