### PR TITLE
Update Sync limits based on analysis of data loss events.

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -1041,14 +1041,14 @@ class Defaults {
 	 *
 	 * @var int Number of queue items.
 	 */
-	public static $default_max_queue_size = 1000;
+	public static $default_max_queue_size = 5000;
 
 	/**
 	 * Default maximum lag allowed in the queue.
 	 *
 	 * @var int Number of seconds
 	 */
-	public static $default_max_queue_lag = 900; // 15 minutes.
+	public static $default_max_queue_lag = 7200; // 2 hours.
 
 	/**
 	 * Default for default writes per sec.


### PR DESCRIPTION
Update Sync Default settings that limit when actions can be added to the queue. 

#### Changes proposed in this Pull Request:
* queue_lag limit being increased from 15 minutes to 2 hours
* queue_size limit being increased from 1000 to 5000 entries

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* updates existing functionality. https://wp.me/p9dueE-1kC

#### Testing instructions:
* To test you will need to add 5000 items to the sync queue in short order.

1. Disable Sync `wp jetpack-sync disable --blog-id=12345`
1. Perform a Bulk Import, operations to have 5000 items in the queue
1. Wait 2 hours (twiddle thumbs)
1. Perform an update to a post
1. Verify new action was not added to queue
1. Enable Sync
1. perform several views/admin screen actions to move the queue
1. when siize is under 5000 perform an action and confirm it gets added.

#### Proposed changelog entry for your changes:
* N/A

As this is changing a default setting I don't think it needs a changelog entry. If we want one I'd lean on "Modified sync settings for stability."
