### PR TITLE
Renovate: Remove history

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,6 @@
 		"gulp-sass": "4.0.2",
 		"gulp-sourcemaps": "2.6.5",
 		"gulp-tap": "2.0.0",
-		"history": "3.3.0",
 		"i18n-calypso": "4.0.0",
 		"i18n-calypso-cli": "1.0.0",
 		"jsdom": "15.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7856,7 +7856,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@3.3.0, history@^3.0.0:
+history@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
   integrity sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=


### PR DESCRIPTION
Closes #11261

I couldn't find a place we directly use history, but instead only use react-router.

#### Changes proposed in this Pull Request:
* Remove history as a dependency

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Verify the Dashboard works.
* Verify blocks work.

#### Proposed changelog entry for your changes:
* n/a
