### PR TITLE
Block: Instagram Replace loading placeholders with loading indicator in the sidebar

### DIFF
--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -1,3 +1,22 @@
+.wp-block-jetpack-instagram-gallery__gallery-loading {
+	position: absolute;
+	right: 24px;
+}
+.wp-block-jetpack-instagram-gallery__count-notice {
+	.components-notice__content {
+		margin: 0;
+		line-height: inherit;
+		padding-right: 0;
+	}
+	.components-notice.is-dismissible {
+		padding-right: 12px;
+	}
+	.components-button.has-icon {
+		padding: 0;
+		min-width: 24px;
+		height: 24px;
+	}
+}
 .wp-block-jetpack-instagram-gallery__grid {
 	align-content: stretch;
 	display: flex;


### PR DESCRIPTION
Relates to: #15277

#### Changes proposed in this Pull Request:

* Replaces the skeleton loading placeholders with a loading spinner in sidebar, along with a note about mismatch in post count.

#### Testing instructions:

**Before:**
![pr-before](https://user-images.githubusercontent.com/3629020/78848284-66034f80-7a65-11ea-82d7-9e66a6fd5365.gif)

**After:**
![prafter](https://user-images.githubusercontent.com/3629020/78848304-75829880-7a65-11ea-85ae-67ed879c8dd0.gif)






#### Proposed changelog entry for your changes:
* No changelog entry needed
