### PR TITLE
Podcast player: apply color customization to error state

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -218,7 +218,7 @@ $player-background: transparent;
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		// Adjustments on left padding to account for SVG sound icon spacing 
+		// Adjustments on left padding to account for SVG sound icon spacing
 		padding: $track-h-padding $player-grid-spacing $track-h-padding $player-grid-spacing - 2px;
 		transition: none;
 		color: inherit;
@@ -326,7 +326,7 @@ $player-background: transparent;
 		* Magic numbers are due to needing to line-up the player spacing with buttons
 		* and fixed widths inside of the mediaplayer.
 		*/
-		padding: 0 ($player-grid-spacing - 6px) 0 ($player-grid-spacing - 9px);
+		padding: 0 ( $player-grid-spacing - 6px ) 0 ( $player-grid-spacing - 9px );
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -256,8 +256,6 @@ $player-background: transparent;
 		}
 	}
 
-	}
-
 	.jetpack-podcast-player__track-title {
 		flex-grow: 1;
 		padding: 0 $track-v-padding;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -256,8 +256,6 @@ $player-background: transparent;
 		}
 	}
 
-	.jetpack-podcast-player__track-status-icon--error {
-		fill: $text-color-error;
 	}
 
 	.jetpack-podcast-player__track-title {
@@ -289,6 +287,22 @@ $player-background: transparent;
 		& > span > a {
 			color: inherit;
 		}
+	}
+
+	.has-primary .jetpack-podcast-player__track-error {
+		color: currentColor;
+
+		& > span {
+			color: var( --jetpack-podcast-player-secondary );
+		}
+	}
+
+	.jetpack-podcast-player__track-status-icon--error {
+		fill: $text-color-error;
+	}
+
+	.has-primary .jetpack-podcast-player__track-status-icon--error {
+		fill: currentColor;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

In https://github.com/Automattic/jetpack/issues/15341 it was noted that the episode error state is not affected by color customization (making it almost invisible at times).

This PR aims to address that issue by setting the primary color for the icon and the episode unavailable text, and the secondary color for the Open in new tab link (as per https://github.com/Automattic/jetpack/issues/15341#issuecomment-610942159).

Fixes https://github.com/Automattic/jetpack/issues/15341

Before

<img width="609" alt="78688899-0a668400-78f6-11ea-91b9-654de394ecb9" src="https://user-images.githubusercontent.com/1562646/78905338-22690f80-7a7e-11ea-9ed4-36f864b1d330.png">


After

<img width="769" alt="Screenshot 2020-04-09 at 16 23 04" src="https://user-images.githubusercontent.com/1562646/78905525-6eb44f80-7a7e-11ea-8582-1a44f813fd1b.png">


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add the Podcast Player block to your page
2. Block a request / go offline to throw the episode error (or set isError to true in playlist.js)
3. In the editor, set primary/secondary/background colors and observe whether the error elements are now affected by color customization.
