### PR TITLE
Top Posts Widget: provide defaults for newly added param.

### DIFF
--- a/modules/widgets/top-posts.php
+++ b/modules/widgets/top-posts.php
@@ -525,12 +525,15 @@ class Jetpack_Top_Posts_Widget extends WP_Widget {
 	/**
 	 * Get the top posts based on views
 	 *
+	 * @since 8.4.0 Added $types param
+	 *
 	 * @param int   $count The maximum number of posts to be returned.
 	 * @param array $args The widget arguments.
 	 * @param array $types The post types that should be returned.
-	 * @return array array of posts.
+	 *
+	 * @return array array of posts. Defaults to 'post' and 'page'.
 	 */
-	public function get_by_views( $count, $args, $types ) {
+	public function get_by_views( $count, $args, $types = array( 'post', 'page' ) ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			global $wpdb;
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* $types was added in 8.4, but we did not add a default value when it's not provided.

See #15109 for more details.

This was reported in 2860860-zen.

#### Testing instructions:

* In a third party plugin (functionality plugin, add a function that calls `Jetpack_Top_Posts_Widget::get_by_views` with 2 parameters instead of 3.
* No fatal error should occur.

#### Proposed changelog entry for your changes:

* Top Posts Widget: provide default for newly added parameter to avoid errors when using third-party plugins interacting with stats.
