### PR TITLE
Sync Health Tests: make messages easier to translate

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -605,8 +605,8 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 						sprintf(
 							/* translators: placeholder is a number of minutes. */
 							_n(
-								'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site. <strong>We’re seeing a current delay of %1$d minute</strong>',
-								'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site. <strong>We’re seeing a current delay of %1$d minutes</strong>',
+								'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site. <strong>We’re seeing a current delay of %1$d minute.</strong>',
+								'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site. <strong>We’re seeing a current delay of %1$d minutes.</strong>',
 								intval( $sync_queue->lag() / MINUTE_IN_SECONDS ),
 								'jetpack'
 							),

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -548,8 +548,29 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				);
 
 			} elseif ( Sync_Health::get_status() === Sync_Health::STATUS_OUT_OF_SYNC ) {
+				/*
+				 * Sync has experienced Data Loss.
+				 */
 
-				// Sync has experienced Data Loss.
+				$description  = '<p>';
+				$description .= esc_html__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' );
+				$description .= '</p>';
+				$description .= '<p>';
+				$description .= sprintf(
+					'<span class="dashicons fail"><span class="screen-reader-text">%1$s</span></span> ',
+					esc_html__( 'Error', 'jetpack' )
+				);
+				$description .= wp_kses(
+					__( 'Jetpack has detected an error while syncing your site. <strong>We recommend <a id="full_sync_request_link" href="#">a full sync</a> to align Jetpack with your site data.</strong>', 'jetpack' ),
+					array(
+						'a'      => array(
+							'id'   => array(),
+							'href' => array(),
+						),
+						'strong' => array(),
+					)
+				);
+				$description .= '</p>';
 
 				return self::failing_test(
 					array(
@@ -559,26 +580,41 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 						'action'            => 'https://jetpack.com/contact-support/',
 						'action_label'      => __( 'Contact Jetpack Support', 'jetpack' ),
 						'short_description' => __( 'Jetpack has detected an error syncing your site.', 'jetpack' ),
-						'long_description'  => sprintf(
-							'<p>%1$s</p><p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s <a id="full_sync_request_link" href="#">%5$s</a> %6$s</strong></p>',
-							__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
-							__( 'Error', 'jetpack' ),
-							__( 'Jetpack has detected an error while syncing your site', 'jetpack' ), /* translators: screen reader text indicating a test failed */
-							__( 'We recommend', 'jetpack' ),
-							__( 'full sync', 'jetpack' ),
-							__( 'to align Jetpack with your site data.', 'jetpack' )
-						),
+						'long_description'  => $description,
 					)
 				);
 
 			} else {
-
 				// Get the Sync Queue.
 				$sender     = Sync_Sender::get_instance();
 				$sync_queue = $sender->get_sync_queue();
 
 				// lag exceeds 5 minutes.
 				if ( $sync_queue->lag() > 5 * MINUTE_IN_SECONDS ) {
+
+					$description  = '<p>';
+					$description .= esc_html__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' );
+					$description .= '</p>';
+					$description .= '<p>';
+					$description .= sprintf(
+						'<span class="dashicons dashicons-clock" style="color: orange;"><span class="screen-reader-text">%1$s</span></span> ',
+						/* translators: name, used to describe a clock icon. */
+						esc_html__( 'Clock', 'jetpack' )
+					);
+					$description .= wp_kses(
+						sprintf(
+							/* translators: placeholder is a number of minutes. */
+							_n(
+								'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site. <strong>We’re seeing a current delay of %1$d minute</strong>',
+								'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site. <strong>We’re seeing a current delay of %1$d minutes</strong>',
+								intval( $sync_queue->lag() / MINUTE_IN_SECONDS ),
+								'jetpack'
+							),
+							number_format_i18n( $sync_queue->lag() / MINUTE_IN_SECONDS )
+						),
+						array( 'strong' => array() )
+					);
+					$description .= '</p>';
 
 					return self::failing_test(
 						array(
@@ -588,15 +624,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 							'action'            => null,
 							'action_label'      => null,
 							'short_description' => __( 'Jetpack is experiencing a delay syncing your site.', 'jetpack' ),
-							'long_description'  => sprintf(
-								'<p>%1$s</p><p><span class="dashicons dashicons-clock" style="color: orange;"><span class="screen-reader-text">%2$s</span></span> %3$s <strong>%4$s %5$d %6$s</strong></p>',
-								__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
-								__( 'Clock', 'jetpack' ),
-								__( 'Jetpack has identified a delay while syncing individual content updates. Certain features might be slower than usual, but this is only temporary while sync catches up with recent changes to your site.', 'jetpack' ), /* translators: screen reader text indicating a test failed */
-								__( 'We’re seeing a current delay of', 'jetpack' ),
-								intval( $sync_queue->lag() / MINUTE_IN_SECONDS ),
-								__( 'minutes.', 'jetpack' )
-							),
+							'long_description'  => $description,
 						)
 					);
 
@@ -608,8 +636,27 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				}
 			}
 		} else {
+			/*
+			 * Sync is disabled.
+			 */
 
-			// Sync is disabled.
+			$description  = '<p>';
+			$description .= esc_html__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' );
+			$description .= '</p>';
+			$description .= '<p>';
+			$description .= __( 'Developers may enable / disable syncing using the Sync Settings API.', 'jetpack' );
+			$description .= '</p>';
+			$description .= '<p>';
+			$description .= sprintf(
+				'<span class="dashicons fail"><span class="screen-reader-text">%1$s</span></span> ',
+				esc_html__( 'Error', 'jetpack' )
+			);
+			$description .= wp_kses(
+				__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work. <strong>We recommend enabling Sync.</strong>', 'jetpack' ),
+				array( 'strong' => array() )
+			);
+			$description .= '</p>';
+
 			return self::failing_test(
 				array(
 					'name'              => $name,
@@ -618,17 +665,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 					'action'            => 'https://github.com/Automattic/jetpack/blob/master/packages/sync/src/class-settings.php',
 					'action_label'      => __( 'See Github for more on Sync Settings', 'jetpack' ),
 					'short_description' => __( 'Jetpack Sync has been disabled on your site.', 'jetpack' ),
-					'long_description'  => sprintf(
-						'<p>%1$s</p><p>%2$s</p><p><span class="dashicons fail"><span class="screen-reader-text">%3$s</span></span> %4$s<strong> %5$s</strong></p>',
-						__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
-						__( 'Developers may enable / disable syncing using the Sync Settings API.', 'jetpack' ), /* translators: screen reader text indicating a test failed */
-						__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ),
-						__( 'Developers may enable / disable syncing using the Sync Settings API.', 'jetpack' ),
-						/* translators: screen reader text indicating a test failed */
-						__( 'Error', 'jetpack' ),
-						__( 'Jetpack Sync has been disabled on your site. Without it, certain Jetpack features will not work.', 'jetpack' ),
-						__( 'We recommend enabling Sync.', 'jetpack' )
-					),
+					'long_description'  => $description,
 				)
 			);
 


### PR DESCRIPTION
Fixes #15379

#### Changes proposed in this Pull Request:

This should make messages in the Site Health screen easier to translate, as per the feedback in #15379.

I've also taken the opportunity to make the message with a number translatable differently depending on the number.

#### Testing instructions:

* Enable Jetpack and Sync Module
* Go to the SIte Health Admin Page `/wp-admin/site-health.php`
* Under Passed Tests you should not see any Jetpack Sync warnings in critical or recommended
* Update the Sync Health to Out of Sync  `Sync_Health::update_status( Sync_Health::STATUS_OUT_OF_SYNC )` dropped into the wp.config.php or the functions theme file or etc.
* Refresh the Site Health Admin Page
* Verify that under critical issues the Jetpack Sync info displays and aligns with the designs p6TEKc-3uv-p2

![image](https://user-images.githubusercontent.com/426388/78921077-a75f2380-7a94-11ea-9351-fb31650a89b6.png)

* Reset the Sync Health to In Sync `Sync_Health::update_status( Sync_Health::STATUS_IN_SYNC )`
* Point your Jetpack Connection to a bad address  `define( 'JETPACK__SANDBOX_DOMAIN', 'badbadbad23434.example.com' );`
* Update or Create a new Post.
* Verify sync health is not displayed in recommendations
* Wait 5-10 minutes.
* Refresh the Site Health Admin Page
* Verify that under recommended issues the Jetpack Sync delayed test displays and aligns with the designs p6TEKc-3uv-p2. Check that the X minutes updates as time goes on.

![image](https://user-images.githubusercontent.com/426388/78922265-88619100-7a96-11ea-9e4e-b73cf9f0515f.png)

* Remove the Jetpack Connection sandbox
* refresh the admin a few times (clear the queue )
* Refresh the Site Health Admin Page
* Verify sync health is not displayed in recommendations

#### Proposed changelog entry for your changes:

* Site Health Tools: improve messaging to make translations easier.
