### PR TITLE
Add AMP compatibility to Carousel module

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -386,7 +386,7 @@ class Jetpack_Carousel {
 			class_exists( 'Jetpack_AMP_Support' )
 			&& Jetpack_AMP_Support::is_amp_request()
 		) {
-			return $content;
+			return $this->maybe_add_amp_lightbox( $content );
 		}
 
 		if ( ! preg_match_all( '/<img [^>]+>/', $content, $matches ) ) {
@@ -549,6 +549,43 @@ class Jetpack_Carousel {
 		}
 
 		return $html;
+	}
+
+	/**
+	 * Conditionally adds amp-lightbox to galleries and images.
+	 *
+	 * This applies to gallery blocks and shortcodes,
+	 * in addition to images that are wrapped in a link to the page.
+	 * Images wrapped in a link to the media file shouldn't get an amp-lightbox.
+	 *
+	 * @param string $content The content to possibly add amp-lightbox to.
+	 * @return string The content, with amp-lightbox possibly added.
+	 */
+	public function maybe_add_amp_lightbox( $content ) {
+		$content = preg_replace(
+			array(
+				'#(<figure)[^>]*(?=class=(["\']?)[^>]*wp-block-gallery[^>]*\2)#is', // Gallery block.
+				'#(\[gallery)(?=\s+)#', // Gallery shortcode.
+			),
+			array(
+				'\1 data-amp-lightbox="true" ', // https://github.com/ampproject/amp-wp/blob/1094ea03bd5dc92889405a47a8c41de1a88908de/includes/sanitizers/class-amp-gallery-block-sanitizer.php#L84.
+				'\1 amp-lightbox="true"', // https://github.com/ampproject/amp-wp/blob/1094ea03bd5dc92889405a47a8c41de1a88908de/includes/embeds/class-amp-gallery-embed.php#L64.
+			),
+			$content
+		);
+
+		return preg_replace_callback(
+			'#(<a[^>]* href=(["\']?)(\S+)\2>)\s*(<img[^>]*)(class=(["\']?)[^>]*wp-image-[0-9]+[^>]*\6.*>)\s*</a>#is',
+			static function( $matches ) {
+				if ( ! preg_match( '#\.\w+$#', $matches[3] ) ) {
+					// The a[href] doesn't end in a file extension like .jpeg, so this is not a link to the media file, and should get a lightbox.
+					return $matches[4] . ' data-amp-lightbox="true" lightbox="true" ' . $matches[5]; // https://github.com/ampproject/amp-wp/blob/1094ea03bd5dc92889405a47a8c41de1a88908de/includes/sanitizers/class-amp-img-sanitizer.php#L419.
+				}
+
+				return $matches[0];
+			},
+			$content
+		);
 	}
 
 	function get_attachment_comments() {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -92,6 +92,9 @@
 		<testsuite name="3rd-party">
 			<directory prefix="test_" suffix=".php">tests/php/3rd-party</directory>
 		</testsuite>
+		<testsuite name="carousel">
+			<directory prefix="test-" suffix=".php">tests/php/modules/carousel</directory>
+		</testsuite>
 		<testsuite name="lazy-images">
 			<directory prefix="test_" suffix=".php">tests/php/modules/lazy-images</directory>
 		</testsuite>

--- a/tests/php/modules/carousel/test-class.jetpack-carousel.php
+++ b/tests/php/modules/carousel/test-class.jetpack-carousel.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Class WP_Test_Jetpack_Carousel.
+ *
+ * @package Jetpack
+ */
+
+require_jetpack_file( 'modules/carousel/jetpack-carousel.php' );
+
+/**
+ * Class WP_Test_Jetpack_Carousel
+ */
+class WP_Test_Jetpack_Carousel extends WP_UnitTestCase {
+
+	/**
+	 * The tested instance.
+	 *
+	 * @var Jetpack_Carousel
+	 */
+	public $instance;
+
+	/**
+	 * Sets up each test.
+	 *
+	 * @inheritDoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->instance = new Jetpack_Carousel();
+	}
+
+	/**
+	 * Gets the test data for test_add_data_img_tags_and_enqueue_assets().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_data_img_tags() {
+		return array(
+			'amp_gallery_block'                          => array(
+				'<figure class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="8" data-full-url="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://example.com/?attachment_id=8" class="wp-image-8" srcset="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg 1000wj" sizes="(max-width: 1000px) 100vw, 1000px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg" alt="Image Alignment 1200x4002" data-id="1029" data-full-url="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg" data-link="https://example.com/?attachment_id=1029" class="wp-image-1029" srcset="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg 1024w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-300x100.jpg 300w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-768x256.jpg 768w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" data-id="10" data-full-url="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" data-link="https://example.com/?attachment_id=10" class="wp-image-10" srcset="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg 600w, https://example.com/wp-content/uploads/2020/01/858-600x400-1-300x200.jpg 300w" sizes="(max-width: 600px) 100vw, 600px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg" alt="" data-id="549" data-full-url="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1.jpg" data-link="https://example.com/?attachment_id=549" class="wp-image-549" srcset="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-300x225.jpg 300w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" alt="" data-id="571" data-full-url="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" data-link="https://example.com/?attachment_id=571" class="wp-image-571"/></figure></li></ul></figure>',
+				true,
+				'<figure data-amp-lightbox="true" class="wp-block-gallery columns-3 is-cropped"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="8" data-full-url="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://example.com/?attachment_id=8" class="wp-image-8" srcset="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg 1000wj" sizes="(max-width: 1000px) 100vw, 1000px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg" alt="Image Alignment 1200x4002" data-id="1029" data-full-url="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg" data-link="https://example.com/?attachment_id=1029" class="wp-image-1029" srcset="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg 1024w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-300x100.jpg 300w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-768x256.jpg 768w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" data-id="10" data-full-url="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" data-link="https://example.com/?attachment_id=10" class="wp-image-10" srcset="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg 600w, https://example.com/wp-content/uploads/2020/01/858-600x400-1-300x200.jpg 300w" sizes="(max-width: 600px) 100vw, 600px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg" alt="" data-id="549" data-full-url="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1.jpg" data-link="https://example.com/?attachment_id=549" class="wp-image-549" srcset="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-300x225.jpg 300w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" alt="" data-id="571" data-full-url="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" data-link="https://example.com/?attachment_id=571" class="wp-image-571"/></figure></li></ul></figure>',
+			),
+			'amp_gallery_block_class_preceded_by_other_classes' => array(
+				'<figure class="columns-3 is-cropped wp-block-gallery"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="8" data-full-url="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://example.com/?attachment_id=8" class="wp-image-8" srcset="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg 1000wj" sizes="(max-width: 1000px) 100vw, 1000px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg" alt="Image Alignment 1200x4002" data-id="1029" data-full-url="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg" data-link="https://example.com/?attachment_id=1029" class="wp-image-1029" srcset="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg 1024w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-300x100.jpg 300w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-768x256.jpg 768w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" data-id="10" data-full-url="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" data-link="https://example.com/?attachment_id=10" class="wp-image-10" srcset="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg 600w, https://example.com/wp-content/uploads/2020/01/858-600x400-1-300x200.jpg 300w" sizes="(max-width: 600px) 100vw, 600px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg" alt="" data-id="549" data-full-url="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1.jpg" data-link="https://example.com/?attachment_id=549" class="wp-image-549" srcset="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-300x225.jpg 300w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" alt="" data-id="571" data-full-url="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" data-link="https://example.com/?attachment_id=571" class="wp-image-571"/></figure></li></ul></figure>',
+				true,
+				'<figure data-amp-lightbox="true" class="columns-3 is-cropped wp-block-gallery"><ul class="blocks-gallery-grid"><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" alt="" data-id="8" data-full-url="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg" data-link="https://example.com/?attachment_id=8" class="wp-image-8" srcset="https://example.com/wp-content/uploads/2020/01/568-1000x1000-1.jpg 1000wj" sizes="(max-width: 1000px) 100vw, 1000px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg" alt="Image Alignment 1200x4002" data-id="1029" data-full-url="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg" data-link="https://example.com/?attachment_id=1029" class="wp-image-1029" srcset="https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-1024x341.jpg 1024w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-300x100.jpg 300w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1-768x256.jpg 768w, https://example.com/wp-content/uploads/2013/03/image-alignment-1200x4002-1.jpg 1200w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" alt="" data-id="10" data-full-url="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg" data-link="https://example.com/?attachment_id=10" class="wp-image-10" srcset="https://example.com/wp-content/uploads/2020/01/858-600x400-1.jpg 600w, https://example.com/wp-content/uploads/2020/01/858-600x400-1-300x200.jpg 300w" sizes="(max-width: 600px) 100vw, 600px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg" alt="" data-id="549" data-full-url="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1.jpg" data-link="https://example.com/?attachment_id=549" class="wp-image-549" srcset="https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-1024x768.jpg 1024w, https://example.com/wp-content/uploads/2020/03/448-1600x1200-1-300x225.jpg 300w" sizes="(max-width: 1024px) 100vw, 1024px" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" alt="" data-id="571" data-full-url="https://example.com/wp-content/uploads/2020/03/4-150x150-1.jpg" data-link="https://example.com/?attachment_id=571" class="wp-image-571"/></figure></li></ul></figure>',
+			),
+			'amp_gallery_shortcode'                      => array(
+				'[gallery ids=571,6]',
+				true,
+				'[gallery amp-lightbox="true" ids=571,6]',
+			),
+			'amp_gallery_shortcode_more_attributes'      => array(
+				'[gallery ids=571,6 icontag="div" captiontag="span"]',
+				true,
+				'[gallery amp-lightbox="true" ids=571,6 icontag="div" captiontag="span"]',
+			),
+			'amp_gallery_with_no_id'                     => array(
+				'[gallery]',
+				true,
+			),
+			'gallery_shortcode_non_amp_should_be_returned_unchanged' => array(
+				'[gallery ids=571,6]',
+			),
+			'amp_single_image_should_have_lightbox'      => array(
+				'<a href="https://example.com/726-300x300-2/"><img src="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg" alt="" class="wp-image-186" srcset="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg 300w, https://example.com/wp-content/uploads/2020/02/726-300x300-1-150x150.jpg 150w" sizes="(max-width: 300px) 100vw, 300px"></a>',
+				true,
+				'<img src="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg" alt=""  data-amp-lightbox="true" lightbox="true" class="wp-image-186" srcset="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg 300w, https://example.com/wp-content/uploads/2020/02/726-300x300-1-150x150.jpg 150w" sizes="(max-width: 300px) 100vw, 300px">',
+			),
+			'amp_single_image_should_not_have_lightbox_because_wrapped_in_link_to_media_file' => array(
+				'<a href="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg"><img src="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg" alt="" class="wp-image-186" srcset="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg 300w, https://example.com/wp-content/uploads/2020/02/726-300x300-1-150x150.jpg 150w" sizes="(max-width: 300px) 100vw, 300px"></a>',
+				true,
+			),
+			'amp_single_image_should_not_have_lightbox_because_not_wrapped_in_anchor' => array(
+				'<img src="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg" alt="" class="wp-image-186" srcset="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg 300w, https://example.com/wp-content/uploads/2020/02/726-300x300-1-150x150.jpg 150w" sizes="(max-width: 300px) 100vw, 300px">',
+				true,
+				'<img src="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg" alt="" class="wp-image-186" srcset="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg 300w, https://example.com/wp-content/uploads/2020/02/726-300x300-1-150x150.jpg 150w" sizes="(max-width: 300px) 100vw, 300px">',
+			),
+			'amp_non_image_not_have_amp_lightbox'        => array(
+				'<div class="entry-content"><p>This is some content</p><a href="https://example.com">Here is a link</a></div>',
+				true,
+			),
+			'image_non_amp_should_not_have_amp_lightbox' => array(
+				'<a href="https://example.com/726-300x300-2/"><img src="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg" alt="" class="wp-image-186" srcset="https://example.com/wp-content/uploads/2020/02/726-300x300-1.jpg 300w, https://example.com/wp-content/uploads/2020/02/726-300x300-1-150x150.jpg 150w" sizes="(max-width: 300px) 100vw, 300px"></a>',
+			),
+		);
+	}
+
+	/**
+	 * Test add_data_img_tags_and_enqueue_assets.
+	 *
+	 * @dataProvider get_data_img_tags
+	 * @covers Jetpack_Carousel::add_data_img_tags_and_enqueue_assets()
+	 * @covers Jetpack_Carousel::maybe_add_amp_lightbox()
+	 *
+	 * @param string      $content The initial content to be filtered.
+	 * @param bool        $is_amp Whether this is an AMP endpoint.
+	 * @param string|null $expected The filtered content.
+	 */
+	public function test_add_data_img_tags_and_enqueue_assets( $content, $is_amp = false, $expected = null ) {
+		if ( $is_amp ) {
+			add_filter( 'jetpack_is_amp_request', '__return_true' );
+		}
+
+		if ( null === $expected ) {
+			$expected = $content;
+		}
+
+		$this->assertEquals(
+			$expected,
+			$this->instance->add_data_img_tags_and_enqueue_assets( $content )
+		);
+
+		// The script should not be enqueued on AMP endpoints.
+		if ( $is_amp ) {
+			$this->assertFalse( wp_script_is( 'jetpack-carousel' ) );
+		}
+	}
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15397

#### Changes proposed in this Pull Request:
* In the [Carousel module](https://jetpack.com/support/carousel/), instead of [exiting](https://github.com/Automattic/jetpack/blob/feeadafa22309b7cf0d77077c0354d9df1f74eda/modules/carousel/jetpack-carousel.php#L517) on AMP endpoints, use [amp-lightbox](https://amp.dev/documentation/components/amp-lightbox/)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhances an existing feature

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure the [AMP plugin](https://wordpress.org/plugins/amp/) is active
2. In AMP Settings, select Transitional mode
3. In Jetpack > Settings, Writing, ensure this is toggled this on:

![jetpack-settings](https://user-images.githubusercontent.com/4063887/78948400-c8704600-7a8d-11ea-981b-8449ad55c74a.png)

4. Create a new post
5. Add a Gallery block, and select images
6. Add this to a shortcode block, but use IDs from your environment:

```html
[gallery ids="761,755,8"]
```
5. Preview the AMP front-end by clicking the AMP icon:

![amp-button](https://user-images.githubusercontent.com/4063887/78590589-aebdcd00-7807-11ea-843e-625fd0a5c00c.png)

6. Click an image in the Gallery block or shortcode

7. Expected: this opens a lightbox:
![gallery-lightbox](https://user-images.githubusercontent.com/4063887/78948907-80522300-7a8f-11ea-81b1-e59fcf5d728a.gif)

8. Go back to the editor
9. Add an image block, and add a link to an attachment page:

![image-link-attachment](https://user-images.githubusercontent.com/4063887/78948986-c6a78200-7a8f-11ea-8f57-ec058690db4b.png)

10. Preview the AMP front-end again
11. Click the image
12. Expected: a lightbox opens
13. Go back to the editor
14. Add another image block, with a link to the media file (not the attachment page)
15. Add another image block with no link at all
16. Go to the AMP front-end again
17. Click those 2 new image blocks
18. Expected: no lightbox opens



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add AMP compatibility to the Carousel module, using amp-lightbox
