### PR TITLE
Fix for missing API key field issue

### DIFF
--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -259,7 +259,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>"><?php esc_html_e( 'Show map', 'jetpack' ); ?></label>
 			</p>
 
-			<?php if ( ! has_filter( 'jetpack_google_maps_api_key' ) ) { ?>
+			<?php if ( ! has_filter( 'jetpack_google_maps_api_key' ) || $apikey === $instance['apikey'] ) { ?>
 
 			<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<label for="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>">

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -285,6 +285,10 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				</label>
 			</p>
 
+			<?php } else { ?>
+
+			<input type="hidden" id="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'apikey' ) ); ?>" value="<?php echo esc_attr( $apikey ); ?>" />
+
 			<?php } // end if jetpack_google_maps_api_key check. ?>
 
 			<p class="jp-contact-info-admin-map jp-contact-info-embed-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">

--- a/modules/widgets/contact-info.php
+++ b/modules/widgets/contact-info.php
@@ -259,7 +259,7 @@ if ( ! class_exists( 'Jetpack_Contact_Info_Widget' ) ) {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'showmap' ) ); ?>"><?php esc_html_e( 'Show map', 'jetpack' ); ?></label>
 			</p>
 
-			<?php if ( ! has_filter( 'jetpack_google_maps_api_key' ) || $apikey === $instance['apikey'] ) { ?>
+			<?php if ( ! has_filter( 'jetpack_google_maps_api_key' ) || false === apply_filters( 'jetpack_google_maps_api_key', false ) ) { ?>
 
 			<p class="jp-contact-info-admin-map" style="<?php echo $instance['showmap'] ? '' : 'display: none;'; ?>">
 				<label for="<?php echo esc_attr( $this->get_field_id( 'apikey' ) ); ?>">

--- a/tests/php/modules/widgets/test_contact-info-widget.php
+++ b/tests/php/modules/widgets/test_contact-info-widget.php
@@ -1,0 +1,82 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+
+require_jetpack_file( 'modules/widgets/contact-info.php' );
+
+/**
+ * Test class for the Contact Info & Map Widget.
+ *
+ * @covers Jetpack_Contact_Info_Widget
+ */
+class WP_Test_Contact_Info_Widget extends WP_UnitTestCase {
+
+	const TEST_API_KEY = '12345abcde';
+
+	/**
+	 * This method is called before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		remove_all_filters( 'jetpack_google_maps_api_key' );
+		$this->contact_info_widget = new Jetpack_Contact_Info_Widget();
+	}
+
+	/**
+	 * No filter callback is set. The API key field should be displayed.
+	 *
+	 * @covers Jetpack_Contact_Info_Widget::form
+	 */
+	public function test_form_apikey_field_with_no_filter() {
+		ob_start();
+		$this->contact_info_widget->form( null );
+		$output_string = ob_get_clean();
+
+		$apikey_field_displayed = false === strpos( $output_string, '<input type="hidden" id="widget-widget_contact_info' );
+		$this->assertEquals( true, $apikey_field_displayed );
+	}
+
+	/**
+	 * The filter callback returns the same api key as $instance['apikey'].
+	 * The API key field should not be displayed.
+	 */
+	public function test_form_apikey_field_filter_with_instance_apikey() {
+		$instance           = array();
+		$instance['apikey'] = self::TEST_API_KEY;
+
+		add_filter(
+			'jetpack_google_maps_api_key',
+			function() {
+				return self::TEST_API_KEY;
+			}
+		);
+
+		ob_start();
+		$this->contact_info_widget->form( $instance );
+		$output_string = ob_get_clean();
+
+		$apikey_field_displayed = false === strpos( $output_string, '<input type="hidden" id="widget-widget_contact_info' );
+		$this->assertEquals( false, $apikey_field_displayed );
+	}
+
+	/**
+	 * The filter callback returns the input value. The API field should
+	 * be displayed.
+	 */
+	public function test_form_apikey_field_with_pass_through_filter() {
+		$instance           = array();
+		$instance['apikey'] = self::TEST_API_KEY;
+
+		add_filter(
+			'jetpack_google_maps_api_key',
+			function( $value ) {
+				return $value;
+			}
+		);
+
+		ob_start();
+		$this->contact_info_widget->form( $instance );
+		$output_string = ob_get_clean();
+
+		$apikey_field_displayed = false === strpos( $output_string, '<input type="hidden" id="widget-widget_contact_info' );
+		$this->assertEquals( true, $apikey_field_displayed );
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/15384

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

**Previous logic was:**
```
if filter is not applied:
	display field
else:
	don't display field
```

**New logic is:**
```
if (filter is not applied) OR (the applied filter makes no change):
	display field
else:
	don't display field
```

[Here's how](https://github.com/Automattic/jetpack/pull/13678#issuecomment-539066276) we can check whether the applied filter made any changes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to a WordPress.com site that has plugins installed (Atomic site)
2. Add the Contact Info & Map (Jetpack)
3. Save the widget without adding an API key
4. It returns an error **but this time we also see the API key field which was missing.** 

~Note: These tests are pending. I'll comment with an update as soon as I run these tests. I'm using [Jetpack Beta Plugin on Atomic site](https://jetpack.com/download-jetpack-beta/) to do so. I'm waiting for the branch to reflect in the beta plugin in order for me to test my changes.~

Tests complete on both Atomic and self-hosted site ✅

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes a minor issue with contact info widget for WordPress.com sites

#### Other:

- Thanks to @kbrown9 for her support and guidance.
- P2 reference: https://wp.me/p9F6qB-542