### PR TITLE
Add AMP support to shortcode `[archives option=format]`

### DIFF
--- a/modules/shortcodes/archives.php
+++ b/modules/shortcodes/archives.php
@@ -73,7 +73,9 @@ function archives_shortcode( $atts ) {
 	if ( empty( $archives ) ) {
 		$archives = '<p>' . __( 'Your blog does not currently have any published posts.', 'jetpack' ) . '</p>';
 	} elseif ( 'option' === $attr['format'] ) {
-		$archives = '<select name="archive-dropdown" onchange="document.location.href=this.options[this.selectedIndex].value;"><option value="' . get_permalink() . '">--</option>' . $archives . '</select>';
+		$is_amp           = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+		$change_attribute = $is_amp ? 'on="change:AMP.navigateTo(url=event.value)"' : 'onchange="document.location.href=this.options[this.selectedIndex].value;"';
+		$archives         = '<select name="archive-dropdown" ' . $change_attribute . '><option value="' . get_permalink() . '">--</option>' . $archives . '</select>';
 	} elseif ( 'html' === $attr['format'] ) {
 		$archives = '<ul>' . $archives . '</ul>';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In AMP, with a shortcode like:

```html
[archives format=option type=monthly limit=12 showcount=true]
```

...changing the <select> didn't change the `document.location`, like it does on non-AMP.


Now, on changing the `<select>`, it goes to the archive URL:

![select-ne](https://user-images.githubusercontent.com/4063887/79056608-ecfb2800-7c1d-11ea-97d9-3ba488ec33c9.gif)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* An enhancement to an existing feature

#### Testing instructions:

1. In Jetpack > Settings > Writing, ensure this is toggled on:

![writing-hj](https://user-images.githubusercontent.com/4063887/79056460-81fd2180-7c1c-11ea-8330-6096015796a3.png)

2. Ensure the [AMP plugin](https://wordpress.org/plugins/amp/) is active
3. Add a shortcode block with:
```html
[archives format=option type=monthly limit=12 showcount=true]
```
4. Go to the front-end AMP URL
5. Change the value of the `<select>`
6. Expected: the browser goes to the archive URL of the selection, as shown in the `.gif` above

##### Proposed changelog entry for your changes:
* Improve the Archives shortcode's AMP compatiblity
