### PR TITLE
AMP compatibility fix for Internet Defense League widget

### DIFF
--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -86,6 +86,12 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 		if ( ! isset( $this->variants[ $this->variant ] ) ) {
 			$this->variant = $this->defaults['variant'];
 		}
+
+		// On AMP endpoints, prevent a validation error from the inline script.
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		?>
 		<script type="text/javascript">
 			window._idl = {};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevents outputting an inline `<script>` on AMP, to prevent a validation error


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* An AMP fix for an existing feature

#### Testing instructions:
1. Ensure the [AMP](https://wordpress.org/plugins/amp/) plugin is active
2. In AMP > Settings, select 'Transitional' mode
3. Open the Customizer
4. Add an 'Internet Defense League' widget
5. Save and exit the Customizer
6. In the admin bar, click 'Validate':

![validate-this](https://user-images.githubusercontent.com/4063887/79056880-8deae280-7c20-11ea-87f2-ac69fa82b6d5.png)

7. Expected: there's no validation error from the `<script>` from this widget. There might be other validation errors from Jetpack unrelated to this.
8. Go to the AMP URL
9. The widget looks the same in AMP as non-AMP:

![net-guel](https://user-images.githubusercontent.com/4063887/79056894-c8547f80-7c20-11ea-8edc-90cb95c54909.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* AMP compatibility fix for Internet Defense League widget
