### PR TITLE
Scribd shortcode AMP compatibility: allow external links

### DIFF
--- a/modules/shortcodes/scribd.php
+++ b/modules/shortcodes/scribd.php
@@ -50,8 +50,9 @@ function scribd_shortcode_handler( $atts ) {
  * @param array $atts Shortcode attributes.
  */
 function scribd_shortcode_markup( $atts ) {
-	$markup = <<<EOD
-<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/$atts[id]/content?start_page=1&view_mode=$atts[mode]&access_key=$atts[key]" data-auto-height="true" scrolling="no" id="scribd_$atts[id]" width="100%" height="500" frameborder="0"></iframe>
+	$sandbox = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ? 'sandbox="allow-popups allow-scripts allow-same-origin"' : '';
+	$markup  = <<<EOD
+<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/$atts[id]/content?start_page=1&view_mode=$atts[mode]&access_key=$atts[key]" $sandbox data-auto-height="true" scrolling="no" id="scribd_$atts[id]" width="100%" height="500" frameborder="0"></iframe>
 <div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/$atts[id]" target="_blank">View this document on Scribd</a></div>
 EOD;
 

--- a/modules/shortcodes/scribd.php
+++ b/modules/shortcodes/scribd.php
@@ -48,15 +48,35 @@ function scribd_shortcode_handler( $atts ) {
  * Display the shortcode.
  *
  * @param array $atts Shortcode attributes.
+ * @return string The rendered shortcode.
  */
 function scribd_shortcode_markup( $atts ) {
-	$sandbox = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ? 'sandbox="allow-popups allow-scripts allow-same-origin"' : '';
-	$markup  = <<<EOD
-<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/$atts[id]/content?start_page=1&view_mode=$atts[mode]&access_key=$atts[key]" $sandbox data-auto-height="true" scrolling="no" id="scribd_$atts[id]" width="100%" height="500" frameborder="0"></iframe>
-<div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/$atts[id]" target="_blank">View this document on Scribd</a></div>
-EOD;
+	$sandbox = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request()
+		? 'sandbox="allow-popups allow-scripts allow-same-origin"'
+		: '';
 
-	return $markup;
+	$url = add_query_arg(
+		array(
+			'start_page' => '1',
+			'view_mode'  => esc_attr( $atts['mode'] ),
+			'access_key' => esc_attr( $atts['key'] ),
+		),
+		esc_url(
+			sprintf(
+				'https://www.scribd.com/embeds/%1$d/content',
+				absint( $atts['id'] )
+			)
+		)
+	);
+
+	return sprintf(
+		'<iframe class="scribd_iframe_embed" src="%1$s" %2$s data-auto-height="true" scrolling="no" id="scribd_%3$d" width="100%%" height="500" frameborder="0"></iframe>
+		<div style="font-size:10px;text-align:center;width:100%%"><a href="https://www.scribd.com/doc/%3$d" rel="noopener noreferrer" target="_blank">%4$s</a></div>',
+		$url,
+		$sandbox,
+		absint( $atts['id'] ),
+		esc_html__( 'View this document on Scribd', 'jetpack' )
+	);
 }
 add_shortcode( 'scribd', 'scribd_shortcode_handler' );
 

--- a/tests/php/modules/shortcodes/test-class.scribd.php
+++ b/tests/php/modules/shortcodes/test-class.scribd.php
@@ -21,12 +21,12 @@ class WP_Test_Jetpack_Shortcodes_Scribd extends WP_UnitTestCase {
 			'non_amp' => array(
 				'[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]',
 				false,
-				'<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw"  data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe>' . PHP_EOL . '<div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" target="_blank">View this document on Scribd</a></div>',
+				'<iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe><div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" rel="noopener noreferrer" target="_blank">View this document on Scribd</a></div>',
 			),
 			'amp'     => array(
 				'[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]',
 				true,
-				'<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" sandbox="allow-popups allow-scripts allow-same-origin" data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe>' . PHP_EOL . '<div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" target="_blank">View this document on Scribd</a></div>',
+				'<iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" sandbox="allow-popups allow-scripts allow-same-origin" data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe><div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" rel="noopener noreferrer" target="_blank">View this document on Scribd</a></div>',
 			),
 		);
 	}
@@ -48,7 +48,10 @@ class WP_Test_Jetpack_Shortcodes_Scribd extends WP_UnitTestCase {
 			add_filter( 'jetpack_is_amp_request', '__return_true' );
 		}
 
-		$this->assertEquals( $expected, do_shortcode( $shortcode ) );
+		$actual = preg_replace( '/\s+/', ' ', do_shortcode( $shortcode ) );
+		$actual = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+
+		$this->assertEquals( $expected, $actual );
 	}
 
 }

--- a/tests/php/modules/shortcodes/test-class.scribd.php
+++ b/tests/php/modules/shortcodes/test-class.scribd.php
@@ -12,16 +12,43 @@ class WP_Test_Jetpack_Shortcodes_Scribd extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Gets the test data for test_shortcodes_scribd().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_data_shortcodes_scribd() {
+		return array(
+			'non_amp' => array(
+				'[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]',
+				false,
+				'<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw"  data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe>' . PHP_EOL . '<div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" target="_blank">View this document on Scribd</a></div>',
+			),
+			'amp'     => array(
+				'[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]',
+				true,
+				'<iframe class="scribd_iframe_embed" src="//www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" sandbox="allow-popups allow-scripts allow-same-origin" data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe>' . PHP_EOL . '<div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" target="_blank">View this document on Scribd</a></div>',
+			),
+		);
+	}
+
+	/**
+	 * Tests the [scribd] shortcode output.
+	 *
+	 * @dataProvider get_data_shortcodes_scribd
 	 * @author scotchfield
 	 * @covers ::scribd_shortcode_handler
 	 * @since 3.2
+	 *
+	 * @param string $shortcode The shortcode string.
+	 * @param bool   $is_amp    Whether this is an AMP endpoint.
+	 * @param string $expected  The expected return of the shortcode callback.
 	 */
-	public function test_shortcodes_scribd() {
-		$content = '[scribd]';
+	public function test_shortcodes_scribd( $shortcode, $is_amp, $expected ) {
+		if ( $is_amp ) {
+			add_filter( 'jetpack_is_amp_request', '__return_true' );
+		}
 
-		$shortcode_content = do_shortcode( $content );
-
-		$this->assertNotEquals( $content, $shortcode_content );
+		$this->assertEquals( $expected, do_shortcode( $shortcode ) );
 	}
 
 }


### PR DESCRIPTION


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In AMP, allow opening external links in the [scribd shortcode](https://wordpress.com/support/scribd/)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhances an existing feature

#### Testing instructions:
1. Ensure the [AMP plugin](https://wordpress.org/plugins/amp/) is activte
2. In AMP > Settings, select Transitional mode
3. In Jetpack >Settings > Writing, ensure this is toggled on:

![shortcode-toggle](https://user-images.githubusercontent.com/4063887/79085259-76cdf280-7cfd-11ea-80e5-d0605c47e685.png)

4. Create a new post
5. Add a shortcode block with this, taken from [scribd.php](https://github.com/Automattic/jetpack/blob/feeadafa22309b7cf0d77077c0354d9df1f74eda/modules/shortcodes/scribd.php#L10):

```html
[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]
```

6. Go to the front-end AMP URL:

![amp-view-pre](https://user-images.githubusercontent.com/4063887/79085374-ea6fff80-7cfd-11ea-995b-58b15f453b12.png)

7. In the Scribd shortcode, click an external link
8. Expected: the link opens:

![scribd-external-lnik](https://user-images.githubusercontent.com/4063887/79085540-9a456d00-7cfe-11ea-8590-2fac24078632.gif)

Before this PR, the link didn't open

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Scribd shortcode AMP compatibility improvement for external links
