### PR TITLE
Update loading for Instagram

### DIFF
--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -41,3 +41,7 @@
 		}
 	}
 }
+
+.wp-block-jetpack-instagram-gallery__count-notice .components-notice {
+	margin: 0 0 15px 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15277
This is a different approach to #15329

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This tries to simplify the way we load images from the Instagram API and also improve the UX of selecting the number of images to show. Rather than load the images from the API every time we change the count, we can just load all 30 images on the initial load and simply show the number of images selected in the UI.  This means that the API is only called once, and we can show/hide the images immediately when the user changes the number of posts in the sidebar.

In addition, when connected to an account with less than the number of images selected, we display a notice in the sidebar, and placeholder images. This means that the user will have an idea of how big the block will be when they add more images to their instagram account. The downside is that the preview doesn't match the frontend of the site. To work around this we could only show the placeholders when the block is selected.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Update to an existing feature.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an Instagram gallery block to your site
* Connect to an account with more than 30 images
* Change the number of images in the sidebar
* Check that the images in the preview update synchronously

* Connect to an account with fewer than 30 images
* Change the number of images in the sidebar
* Check that a notice and placeholders show when you select more than the number of images you have for this account

#### Screencast
![Apr-13-2020 15-56-42](https://user-images.githubusercontent.com/275961/79130789-77b76080-7d9f-11ea-9e18-ec4e8562d6ad.gif)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
