### PR TITLE
Jetpack Sync: Split `jetpack_post_meta_batch_delete` in action to be called in chunks of 100 items

### DIFF
--- a/packages/sync/src/modules/class-posts.php
+++ b/packages/sync/src/modules/class-posts.php
@@ -142,17 +142,25 @@ class Posts extends Module {
 	 */
 	public function daily_akismet_meta_cleanup_before( $feedback_ids ) {
 		remove_action( 'deleted_post_meta', $this->action_handler );
-		/**
-		 * Used for syncing deletion of batch post meta
-		 *
-		 * @since 6.1.0
-		 *
-		 * @module sync
-		 *
-		 * @param array $feedback_ids feedback post IDs
-		 * @param string $meta_key to be deleted
-		 */
-		do_action( 'jetpack_post_meta_batch_delete', $feedback_ids, '_feedback_akismet_values' );
+
+		if ( ! is_array( $feedback_ids ) || count( $feedback_ids ) < 1 ) {
+			return;
+		}
+
+		$ids_chunks = array_chunk( $feedback_ids, 100, false );
+		foreach ( $ids_chunks as $chunk ) {
+			/**
+			 * Used for syncing deletion of batch post meta
+			 *
+			 * @since 6.1.0
+			 *
+			 * @module sync
+			 *
+			 * @param array $feedback_ids feedback post IDs
+			 * @param string $meta_key to be deleted
+			 */
+			do_action( 'jetpack_post_meta_batch_delete', $chunk, '_feedback_akismet_values' );
+		}
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1155,6 +1155,97 @@ That was a cool video.';
 		$this->assertEquals( $events[3]->action, 'jetpack_published_post' );
 	}
 
+	/**
+	 * Test if `Modules\Posts\daily_akismet_meta_cleanup_before` will properly chunk it's parameters in chunks of 100
+	 *
+	 * @throws ReflectionException Throw if Reflection fails to initialize.
+	 */
+	public function test_sync_jetpack_posts_akismet_post_meta_delete_is_chunked() {
+		$ids = array_fill( 0, 1450, 1234 );
+
+		$mocked = $this->getMockBuilder( stdClass::class )
+						->setMethods( array( 'chunked_call' ) )
+						->getMock();
+
+		$mocked->expects( $this->exactly( 15 ) )
+				->method( 'chunked_call' );
+
+		add_action( 'jetpack_post_meta_batch_delete', array( $mocked, 'chunked_call' ), 10, 2 );
+
+		/**
+		 * Override `action_handler` private property as it's used directly in the method and it's not initialized
+		 * to a function during method call, without calling `Modules\Posts\init_listeners()` to set it.
+		 */
+		$test_instance = new Modules\Posts();
+		$test_ref      = new ReflectionObject( $test_instance );
+		$property_ref  = $test_ref->getProperty( 'action_handler' );
+		$property_ref->setAccessible( true );
+		$property_ref->setValue( $test_instance, function () {} );
+
+		$test_instance->daily_akismet_meta_cleanup_before( $ids );
+	}
+
+	/**
+	 * Test if `Modules\Posts\daily_akismet_meta_cleanup_before` will properly return with invalid input
+	 *
+	 * @throws ReflectionException Throw if Reflection fails to initialize.
+	 */
+	public function test_sync_jetpack_posts_akismet_post_meta_delete_invalid_data() {
+		$ids = 'test_invalid_value';
+
+		$mocked = $this->getMockBuilder( stdClass::class )
+						->setMethods( array( 'chunked_call' ) )
+						->getMock();
+
+		$mocked->expects( $this->never() )
+				->method( 'chunked_call' );
+
+		add_action( 'jetpack_post_meta_batch_delete', array( $mocked, 'chunked_call' ), 10, 2 );
+
+		/**
+		 * Override `action_handler` private property as it's used directly in the method and it's not initialized
+		 * to a function during method call, without calling `Modules\Posts\init_listeners()` to set it.
+		 */
+		$test_instance = new Modules\Posts();
+		$test_ref      = new ReflectionObject( $test_instance );
+		$property_ref  = $test_ref->getProperty( 'action_handler' );
+		$property_ref->setAccessible( true );
+		$property_ref->setValue( $test_instance, function () {} );
+
+		$test_instance->daily_akismet_meta_cleanup_before( $ids );
+	}
+
+	/**
+	 * Test if `Modules\Posts\daily_akismet_meta_cleanup_before` will properly return with empty input
+	 *
+	 * @throws ReflectionException Throw if Reflection fails to initialize.
+	 */
+	public function test_sync_jetpack_posts_akismet_post_meta_delete_empty() {
+		$ids = array();
+
+		$mocked = $this->getMockBuilder( stdClass::class )
+						->setMethods( array( 'chunked_call' ) )
+						->getMock();
+
+		$mocked->expects( $this->never() )
+			->method( 'chunked_call' );
+
+		add_action( 'jetpack_post_meta_batch_delete', array( $mocked, 'chunked_call' ), 10, 2 );
+
+		/**
+		 * Override `action_handler` private property as it's used directly in the method and it's not initialized
+		 * to a function during method call, without calling `Modules\Posts\init_listeners()` to set it.
+		 */
+		$test_instance = new Modules\Posts();
+		$test_ref      = new ReflectionObject( $test_instance );
+		$property_ref  = $test_ref->getProperty( 'action_handler' );
+		$property_ref->setAccessible( true );
+		$property_ref->setValue( $test_instance, function () {} );
+
+		$test_instance->daily_akismet_meta_cleanup_before( $ids );
+	}
+
+
 	function add_a_hello_post_type() {
 		if ( ! $this->test_already  ) {
 			$this->test_already = true;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This PR updates the `daily_akismet_meta_cleanup_before` method to split calls to `jetpack_post_meta_batch_delete` action in chunks of 100 items.
* This way we're going to reduce the amount of time it takes for Jetpack Sync to process those items on WordPress.com and make the queue flow much better.

#### Testing instructions:

* Manually trigger the `jetpack_daily_akismet_meta_cleanup_before` (unsure exactly how at the moment).
* Make sure only 100 items are sent in each action.

* A functional test would be to run the included unit tests with `yarn docker:phpunit --filter test_sync_jetpack_posts_akismet_post_meta_delete_`

#### Proposed changelog entry for your changes:

* Jetpack Sync: Optimize `jetpack_post_meta_batch_delete` action to handle large volumes of Akismet feedback.
