### PR TITLE
Block: Instagram - Add a reset button to gallery settings

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -40,12 +40,6 @@ const InstagramGalleryEdit = props => {
 	const [ images, setImages ] = useState( [] );
 	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
 
-	const {
-		spacing: { default: defaultSpacing },
-		count: { default: defaultCount },
-		columns: { default: defaultColumns },
-	} = defaultAttributes;
-
 	useEffect( () => {
 		const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
 		if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -124,7 +118,7 @@ const InstagramGalleryEdit = props => {
 	};
 
 	const debouncedSetNumberOfPosts = debounce( value => {
-		if ( value < images.length ) {
+		if ( value && value < images.length ) {
 			setImages( take( images, value ) );
 		}
 		setAttributes( { count: value } );
@@ -135,10 +129,11 @@ const InstagramGalleryEdit = props => {
 	const showLoadingSpinner = accessToken && isLoadingGallery && isEmpty( images );
 	const showGallery = ! showPlaceholder && ! showLoadingSpinner;
 
+	const numberOfColumns = columns ? columns : defaultAttributes.columns.default;
 	const blockClasses = classnames( className, { [ `align${ align }` ]: align } );
 	const gridClasses = classnames(
 		'wp-block-jetpack-instagram-gallery__grid',
-		`wp-block-jetpack-instagram-gallery__grid-columns-${ columns }`
+		`wp-block-jetpack-instagram-gallery__grid-columns-${ numberOfColumns }`
 	);
 	const gridStyle = { gridGap: spacing };
 	const photoStyle = { padding: spacing };
@@ -228,41 +223,29 @@ const InstagramGalleryEdit = props => {
 							label={ __( 'Number of Posts', 'jetpack' ) }
 							value={ count }
 							onChange={ debouncedSetNumberOfPosts }
-							min={ 1 }
-							max={ 30 }
+							min={ defaultAttributes.count.min }
+							max={ defaultAttributes.count.max }
+							initialPosition={ defaultAttributes.count.default }
+							allowReset
 						/>
 						<RangeControl
 							label={ __( 'Number of Columns', 'jetpack' ) }
 							value={ columns }
 							onChange={ value => setAttributes( { columns: value } ) }
-							min={ 1 }
-							max={ 6 }
+							min={ defaultAttributes.columns.min }
+							max={ defaultAttributes.columns.max }
+							initialPosition={ defaultAttributes.columns.default }
+							allowReset
 						/>
 						<RangeControl
 							label={ __( 'Image Spacing (px)', 'jetpack' ) }
 							value={ spacing }
 							onChange={ value => setAttributes( { spacing: value } ) }
-							min={ 0 }
-							max={ 50 }
+							min={ defaultAttributes.spacing.min }
+							max={ defaultAttributes.spacing.max }
+							initialPosition={ defaultAttributes.spacing.default }
+							allowReset
 						/>
-						<div className="wp-block-jetpack-instagram-gallery__reset-button">
-							<Button
-								isSecondary
-								isSmall
-								disabled={
-									spacing === defaultSpacing && columns === defaultColumns && count === defaultCount
-								}
-								onClick={ () =>
-									setAttributes( {
-										spacing: defaultSpacing,
-										columns: defaultColumns,
-										count: defaultCount,
-									} )
-								}
-							>
-								{ __( 'Reset', 'jetpack' ) }
-							</Button>
-						</div>
 					</PanelBody>
 				</InspectorControls>
 			) }

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -40,6 +40,12 @@ const InstagramGalleryEdit = props => {
 	const [ images, setImages ] = useState( [] );
 	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
 
+	const {
+		spacing: { default: defaultSpacing },
+		count: { default: defaultCount },
+		columns: { default: defaultColumns },
+	} = defaultAttributes;
+
 	useEffect( () => {
 		const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
 		if ( ! isEqual( validatedAttributes, attributes ) ) {
@@ -239,6 +245,24 @@ const InstagramGalleryEdit = props => {
 							min={ 0 }
 							max={ 50 }
 						/>
+						<div className="wp-block-jetpack-instagram-gallery__reset-button">
+							<Button
+								isSecondary
+								isSmall
+								disabled={
+									spacing === defaultSpacing && columns === defaultColumns && count === defaultCount
+								}
+								onClick={ () =>
+									setAttributes( {
+										spacing: defaultSpacing,
+										columns: defaultColumns,
+										count: defaultCount,
+									} )
+								}
+							>
+								{ __( 'Reset', 'jetpack' ) }
+							</Button>
+						</div>
 					</PanelBody>
 				</InspectorControls>
 			) }

--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -16,6 +16,11 @@
 	}
 }
 
+.wp-block-jetpack-instagram-gallery__reset-button {
+	display: flex;
+	justify-content: flex-end;
+}
+
 @for $i from 1 through 6 {
 	.wp-block-jetpack-instagram-gallery__grid-columns-#{$i}
 		.wp-block-jetpack-instagram-gallery__grid-post {

--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -16,11 +16,6 @@
 	}
 }
 
-.wp-block-jetpack-instagram-gallery__reset-button {
-	display: flex;
-	justify-content: flex-end;
-}
-
 @for $i from 1 through 6 {
 	.wp-block-jetpack-instagram-gallery__grid-columns-#{$i}
 		.wp-block-jetpack-instagram-gallery__grid-post {


### PR DESCRIPTION
Part of #15277

#### Changes proposed in this Pull Request:
* Adds a reset button the Gallery Settings in the sidebar

#### Testing instructions:

* Apply patch to local Jetpack dev env with beta blocks enables
* Add an Instagram gallery block
* Change some settings, and make sure the Reset button becomes enabled, and that clicking it resets the defaults
* Check that Reset button is disabled again once block is back to default settings

![reset](https://user-images.githubusercontent.com/3629020/79182255-831f9000-7e62-11ea-8385-5c6e8d630914.gif)

#### Proposed changelog entry for your changes:
* No changelog  entry needed
