### PR TITLE
Block: Revue - Remove width setting on block inputs

### DIFF
--- a/extensions/blocks/revue/edit.js
+++ b/extensions/blocks/revue/edit.js
@@ -28,6 +28,7 @@ import icon from './icon';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import './editor.scss';
+import './view.scss';
 
 export default function RevueEdit( props ) {
 	const { attributes, className, setAttributes } = props;

--- a/extensions/blocks/revue/editor.scss
+++ b/extensions/blocks/revue/editor.scss
@@ -14,10 +14,4 @@
 	.components-text-control__input {
 		color: #72777c;
 	}
-
-	input {
-		@media screen and ( min-width: 600px ) {
-			max-width: 300px;
-		}
-	}
 }

--- a/extensions/blocks/revue/editor.scss
+++ b/extensions/blocks/revue/editor.scss
@@ -14,4 +14,10 @@
 	.components-text-control__input {
 		color: #72777c;
 	}
+
+	input {
+		@media screen and ( min-width: 600px ) {
+			max-width: 300px;
+		}
+	}
 }

--- a/extensions/blocks/revue/view.scss
+++ b/extensions/blocks/revue/view.scss
@@ -16,6 +16,9 @@
 		display: block;
 		margin-top: 0.25em;
 		width: 100%;
+		@media screen and ( min-width: 600px ) {
+			max-width: 250px;
+		}
 	}
 
 	label {

--- a/extensions/blocks/revue/view.scss
+++ b/extensions/blocks/revue/view.scss
@@ -7,7 +7,9 @@
 	> div {
 		margin-bottom: 0.75em;
 	}
+}
 
+.wp-block-jetpack-revue {
 	.wp-block-button {
 		margin-top: 0;
 	}

--- a/extensions/blocks/revue/view.scss
+++ b/extensions/blocks/revue/view.scss
@@ -17,7 +17,7 @@
 		margin-top: 0.25em;
 		width: 100%;
 		@media screen and ( min-width: 600px ) {
-			max-width: 250px;
+			max-width: 300px;
 		}
 	}
 

--- a/extensions/blocks/revue/view.scss
+++ b/extensions/blocks/revue/view.scss
@@ -16,9 +16,6 @@
 		display: block;
 		margin-top: 0.25em;
 		width: 100%;
-		@media screen and ( min-width: 600px ) {
-			width: 50%;
-		}
 	}
 
 	label {


### PR DESCRIPTION
Fixes #15269

#### Changes proposed in this Pull Request:
* Changes the 50% width setting on inputs on front-end large viewports to a max-width setting, as this only works reliably if the block is in the body, eg. in a column block the inputs end up truncated as set to 50% of parent column width.

#### Testing instructions:
* Apply to PR to local Jetpack dev environment
* Add a Revue block to post body and also nested within a column block
* Ensure that the block inputs display correctly on the front end in both placements

**Before:**
<img width="773" alt="Screen Shot 2020-04-14 at 4 02 18 PM" src="https://user-images.githubusercontent.com/3629020/79184823-5c188c80-7e69-11ea-81ed-845488e0bcd9.png">

**After:** 
<img width="1038" alt="Screen Shot 2020-04-14 at 4 13 36 PM" src="https://user-images.githubusercontent.com/3629020/79185431-ef9e8d00-7e6a-11ea-8066-a58927d7d6ed.png">

#### Proposed changelog entry for your changes:
* No changelog entry needed
