### PR TITLE
Settings: add descriptive ID to each settings card

### DIFF
--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -321,17 +321,17 @@ export const SettingsCard = props => {
 		return null;
 	}
 
-	let moduleClassName = '';
+	let moduleId = '';
 	if ( props.feature ) {
-		moduleClassName = `jp-settings-${ props.feature }`;
+		moduleId = `jp-settings-${ props.feature }`;
 	} else if ( props.module ) {
-		moduleClassName = `jp-settings-${ props.module }`;
+		moduleId = `jp-settings-${ props.module }`;
 	}
 
 	return (
 		getModuleOverridenBanner() || (
 			<form
-				{ ...( moduleClassName ? { id: moduleClassName } : null ) }
+				{ ...( moduleId ? { id: moduleId } : null ) }
 				className={ `jp-form-settings-card` }
 				onSubmit={ ! isSaving ? props.onSubmit : undefined }
 			>

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -321,9 +321,19 @@ export const SettingsCard = props => {
 		return null;
 	}
 
+	let moduleClassName = '';
+	if ( props.feature ) {
+		moduleClassName = 'jp-settings-' + props.feature;
+	} else if ( props.module ) {
+		moduleClassName = 'jp-settings-' + props.module;
+	}
+
 	return (
 		getModuleOverridenBanner() || (
-			<form className="jp-form-settings-card" onSubmit={ ! isSaving ? props.onSubmit : undefined }>
+			<form
+				className={ `jp-form-settings-card ${ moduleClassName }` }
+				onSubmit={ ! isSaving ? props.onSubmit : undefined }
+			>
 				<SectionHeader label={ header }>
 					{ ! props.hideButton && (
 						<Button primary compact type="submit" disabled={ isSaving || ! props.isDirty() }>

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -323,15 +323,16 @@ export const SettingsCard = props => {
 
 	let moduleClassName = '';
 	if ( props.feature ) {
-		moduleClassName = 'jp-settings-' + props.feature;
+		moduleClassName = `jp-settings-${ props.feature }`;
 	} else if ( props.module ) {
-		moduleClassName = 'jp-settings-' + props.module;
+		moduleClassName = `jp-settings-${ props.module }`;
 	}
 
 	return (
 		getModuleOverridenBanner() || (
 			<form
-				className={ `jp-form-settings-card ${ moduleClassName }` }
+				{ ...( moduleClassName ? { id: moduleClassName } : null ) }
+				className={ `jp-form-settings-card` }
 				onSubmit={ ! isSaving ? props.onSubmit : undefined }
 			>
 				<SectionHeader label={ header }>

--- a/_inc/client/performance/speed-up-site.jsx
+++ b/_inc/client/performance/speed-up-site.jsx
@@ -219,7 +219,12 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 			}
 
 			return (
-				<SettingsCard { ...this.props } header={ __( 'Performance & speed' ) } hideButton>
+				<SettingsCard
+					{ ...this.props }
+					header={ __( 'Performance & speed' ) }
+					hideButton
+					module="performance-speed"
+				>
 					{ ( foundPhoton || foundAssetCdn ) && (
 						<SettingsGroup
 							hasChild

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -89,7 +89,7 @@ class ActiveCard extends Component {
 			devMode = this.props.devMode;
 
 		return (
-			<SettingsCard header={ m.name } action={ m.module } hideButton>
+			<SettingsCard module={ m.module } header={ m.name } action={ m.module } hideButton>
 				<SettingsGroup
 					disableInDevMode={ devMode }
 					module={ { module: m.module } }

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -122,10 +122,10 @@ export class Security extends Component {
 				{ foundBackups && backupsContent }
 				{ foundMonitor && <Monitor { ...commonProps } /> }
 				{ foundAkismet && (
-					<div>
+					<>
 						<Antispam { ...commonProps } />
 						<QueryAkismetKeyCheck />
-					</div>
+					</>
 				) }
 				{ ! isSearchTerm && <ManagePlugins { ...commonProps } /> }
 				{ foundProtect && <Protect { ...commonProps } /> }

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -172,6 +172,7 @@ class SiteStatsComponent extends React.Component {
 				{ ...this.props }
 				header={ __( 'Site stats', { context: 'Settings header' } ) }
 				hideButton
+				module="site-stats"
 			>
 				<FoldableCard
 					onOpen={ this.trackOpenCard }

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -124,6 +124,7 @@ class ThemeEnhancements extends React.Component {
 				{ ...this.props }
 				header={ __( 'Theme enhancements' ) }
 				hideButton={ ! foundInfiniteScroll || ! this.props.isInfiniteScrollSupported }
+				module="theme-enhancements"
 			>
 				{ infiniteScrollDisabledByOverride && (
 					<ModuleOverriddenBanner moduleName={ infScr.name } compact />

--- a/_inc/client/writing/writing-media.jsx
+++ b/_inc/client/writing/writing-media.jsx
@@ -59,6 +59,7 @@ class WritingMedia extends Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
+				module="media"
 				header={ __( 'Media' ) }
 				hideButton={ ! foundCarousel }
 				saveDisabled={ this.props.isSavingAnyOption( 'carousel_background_color' ) }


### PR DESCRIPTION
Fixes #15405
Fixes #5693 

#### Changes proposed in this Pull Request:

* adds a descriptive ID attribute to each settings card. IDs correspond first to the feature name assigned, and if it doesn't exist, to the module name.
* some cards don't match a module, like Performance & speed, so these have ad hoc class names. This is safe and it's something that was done before, see `_inc/client/writing/composing.jsx` because the `module` prop was only used to get the module name and use it as the card heading _if_ a `header`prop wasn't provided.
* removes an unnecessary `div` in Security tab for the Akismet card
* the IDs are also added to modules found when searching settings

The list of IDs is

Security

- `jp-settings-security-scanning-jetpack`
- `jp-settings-monitor`
- `jp-settings-spam-akismet-plus`
- `jp-settings-manage`
- `jp-settings-protect`
- `jp-settings-sso`

Performance

- `jp-settings-search-jetpack`
- `jp-settings-performance-speed`
- `jp-settings-video-hosting-jetpack`

Writing

- `jp-settings-media`
- `jp-settings-composing`
- `jp-settings-custom-content-types`
- `jp-settings-theme-enhancements`
- `jp-settings-widgets`
- `jp-settings-post-by-email`
- `jp-settings-masterbar`

Sharing

- `jp-settings-publicize`
- `jp-settings-sharing`
- `jp-settings-likes`

Discussion

- `jp-settings-comments`
- `jp-settings-subscriptions`

Traffic

- `jp-settings-wordads-jetpack`
- `jp-settings-related-posts`
- `jp-settings-seo-tools-jetpack`
- `jp-settings-google-analytics-jetpack`
- `jp-settings-site-stats`
- `jp-settings-shortlinks`
- `jp-settings-sitemaps`
- `jp-settings-verification-tools`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:

* Go to Settings
* check the `.jp-form-settings-card`
* confirm it has an ID relevant to the card

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Each card in Jetpack settings now has a descriptive ID attribute for easier selecting when styling.
