### PR TITLE
Podcast Player: Break components into their own files

### DIFF
--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -7,37 +7,16 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { memo } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import TrackIcon from './track-icon';
+import TrackError from './track-error';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
 
 import { getColorClassName } from '../utils';
-
-const TrackError = memo( ( { link, title } ) => (
-	<div className="jetpack-podcast-player__track-error">
-		{ __( 'Episode unavailable. ', 'jetpack' ) }
-		{ link && (
-			<span>
-				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
-					<span className="jetpack-podcast-player--visually-hidden">
-						{ /* Intentional trailing space outside of the translated string. */ }
-						{ `${ sprintf(
-							/* translators: %s is the title of the track. This text is
-							visually hidden from the screen, but available to screen readers. */
-							__( '%s:', 'jetpack' ),
-							title
-						) } ` }
-					</span>
-					{ __( 'Open in a new tab', 'jetpack' ) }
-				</a>
-			</span>
-		) }
-	</div>
-) );
 
 const Track = memo(
 	( {

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -12,39 +12,8 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import * as trackIcons from '../icons/track-icons';
+import TrackIcon from './track-icon';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
-
-const TrackIcon = ( { isPlaying, isError, className } ) => {
-	let hiddenText, name;
-
-	if ( isError ) {
-		name = 'error';
-		/* translators: This is text to describe the current state. This will go
-		before the track title, such as "Error: [The title of the track]". */
-		hiddenText = __( 'Error:', 'jetpack' );
-	} else if ( isPlaying ) {
-		name = 'playing';
-		/* translators: Text to describe the current state. This will go before the
-		track title, such as "Playing: [The title of the track]". */
-		hiddenText = __( 'Playing:', 'jetpack' );
-	}
-
-	const icon = trackIcons[ name ];
-
-	if ( ! icon ) {
-		// Return empty element - we need it for layout purposes.
-		return <span className={ className } />;
-	}
-
-	return (
-		<span className={ `${ className } ${ className }--${ name }` }>
-			{ /* Intentional space left after hiddenText */ }
-			<span className="jetpack-podcast-player--visually-hidden">{ `${ hiddenText } ` }</span>
-			{ icon }
-		</span>
-	);
-};
 
 import { getColorClassName } from '../utils';
 

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -12,100 +11,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import TrackIcon from './track-icon';
-import TrackError from './track-error';
 import { STATE_ERROR, STATE_PLAYING } from '../constants';
-
-import { getColorClassName } from '../utils';
-
-const Track = memo(
-	( {
-		track,
-		isActive,
-		isPlaying,
-		isError,
-		selectTrack,
-		index,
-		colors = {
-			primary: {},
-			secondary: {},
-		},
-	} ) => {
-		// Set CSS classes string.
-		const primaryColorClass = getColorClassName( 'color', colors.primary.name );
-		const secondaryColorClass = getColorClassName( 'color', colors.secondary.name );
-		const trackClassName = classnames( 'jetpack-podcast-player__track', {
-			'is-active': isActive,
-			'has-primary': isActive && ( colors.primary.name || colors.primary.custom ),
-			[ primaryColorClass ]: isActive && !! primaryColorClass,
-			'has-secondary': ! isActive && ( colors.secondary.name || colors.secondary.custom ),
-			[ secondaryColorClass ]: ! isActive && !! secondaryColorClass,
-		} );
-
-		const inlineStyle = {};
-		if ( isActive && colors.primary.custom && ! primaryColorClass ) {
-			inlineStyle.color = colors.primary.custom;
-		} else if ( ! isActive && colors.secondary.custom && ! secondaryColorClass ) {
-			inlineStyle.color = colors.secondary.custom;
-		}
-
-		/* translators: This needs to be a single word with no spaces. It describes
-		the current item in the group. A screen reader will announce it as "[title],
-		current track". */
-		const ariaCurrent = isActive ? __( 'track', 'jetpack' ) : undefined;
-
-		return (
-			<li
-				className={ trackClassName }
-				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
-			>
-				<a
-					className="jetpack-podcast-player__track-link"
-					href={ track.link }
-					role="button"
-					aria-current={ ariaCurrent }
-					onClick={ e => {
-						// Prevent handling clicks if a modifier is in use.
-						if ( e.shiftKey || e.metaKey || e.altKey ) {
-							return;
-						}
-
-						// Prevent default behavior (opening a link).
-						e.preventDefault();
-
-						// Select track.
-						selectTrack( index );
-					} }
-					onKeyDown={ e => {
-						// Only handle the Space key.
-						if ( event.key !== ' ' ) {
-							return;
-						}
-
-						// Prevent default behavior (scrolling one page down).
-						e.preventDefault();
-
-						// Select track.
-						selectTrack( index );
-					} }
-				>
-					<TrackIcon
-						className="jetpack-podcast-player__track-status-icon"
-						isPlaying={ isPlaying }
-						isError={ isError }
-					/>
-					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
-					{ track.duration && (
-						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>
-							{ track.duration }
-						</time>
-					) }
-				</a>
-				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }
-			</li>
-		);
-	}
-);
+import Track from './track';
 
 const Playlist = memo( ( { playerId, tracks, selectTrack, currentTrack, playerState, colors } ) => {
 	return (

--- a/extensions/blocks/podcast-player/components/track-error.js
+++ b/extensions/blocks/podcast-player/components/track-error.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+const TrackError = memo( ( { link, title } ) => (
+	<div className="jetpack-podcast-player__track-error">
+		{ __( 'Episode unavailable. ', 'jetpack' ) }
+		{ link && (
+			<span>
+				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
+					<span className="jetpack-podcast-player--visually-hidden">
+						{ /* Intentional trailing space outside of the translated string. */ }
+						{ `${ sprintf(
+							/* translators: %s is the title of the track. This text is
+							visually hidden from the screen, but available to screen readers. */
+							__( '%s:', 'jetpack' ),
+							title
+						) } ` }
+					</span>
+					{ __( 'Open in a new tab', 'jetpack' ) }
+				</a>
+			</span>
+		) }
+	</div>
+) );
+
+export default TrackError;

--- a/extensions/blocks/podcast-player/components/track-icon.js
+++ b/extensions/blocks/podcast-player/components/track-icon.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import * as trackIcons from '../icons/track-icons';
+
+const TrackIcon = memo( ( { isPlaying, isError, className } ) => {
+	let hiddenText, name;
+
+	if ( isError ) {
+		name = 'error';
+		/* translators: This is text to describe the current state. This will go
+		before the track title, such as "Error: [The title of the track]". */
+		hiddenText = __( 'Error:', 'jetpack' );
+	} else if ( isPlaying ) {
+		name = 'playing';
+		/* translators: Text to describe the current state. This will go before the
+		track title, such as "Playing: [The title of the track]". */
+		hiddenText = __( 'Playing:', 'jetpack' );
+	}
+
+	const icon = trackIcons[ name ];
+
+	if ( ! icon ) {
+		// Return empty element - we need it for layout purposes.
+		return <span className={ className } />;
+	}
+
+	return (
+		<span className={ `${ className } ${ className }--${ name }` }>
+			{ /* Intentional space left after hiddenText */ }
+			<span className="jetpack-podcast-player--visually-hidden">{ `${ hiddenText } ` }</span>
+			{ icon }
+		</span>
+	);
+} );
+
+export default TrackIcon;

--- a/extensions/blocks/podcast-player/components/track.js
+++ b/extensions/blocks/podcast-player/components/track.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { memo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import TrackIcon from './track-icon';
+import TrackError from './track-error';
+
+import { getColorClassName } from '../utils';
+
+const Track = memo(
+	( {
+		track,
+		isActive,
+		isPlaying,
+		isError,
+		selectTrack,
+		index,
+		colors = {
+			primary: {},
+			secondary: {},
+		},
+	} ) => {
+		// Set CSS classes string.
+		const primaryColorClass = getColorClassName( 'color', colors.primary.name );
+		const secondaryColorClass = getColorClassName( 'color', colors.secondary.name );
+		const trackClassName = classnames( 'jetpack-podcast-player__track', {
+			'is-active': isActive,
+			'has-primary': isActive && ( colors.primary.name || colors.primary.custom ),
+			[ primaryColorClass ]: isActive && !! primaryColorClass,
+			'has-secondary': ! isActive && ( colors.secondary.name || colors.secondary.custom ),
+			[ secondaryColorClass ]: ! isActive && !! secondaryColorClass,
+		} );
+
+		const inlineStyle = {};
+		if ( isActive && colors.primary.custom && ! primaryColorClass ) {
+			inlineStyle.color = colors.primary.custom;
+		} else if ( ! isActive && colors.secondary.custom && ! secondaryColorClass ) {
+			inlineStyle.color = colors.secondary.custom;
+		}
+
+		/* translators: This needs to be a single word with no spaces. It describes
+		the current item in the group. A screen reader will announce it as "[title],
+		current track". */
+		const ariaCurrent = isActive ? __( 'track', 'jetpack' ) : undefined;
+
+		return (
+			<li
+				className={ trackClassName }
+				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
+			>
+				<a
+					className="jetpack-podcast-player__track-link"
+					href={ track.link }
+					role="button"
+					aria-current={ ariaCurrent }
+					onClick={ e => {
+						// Prevent handling clicks if a modifier is in use.
+						if ( e.shiftKey || e.metaKey || e.altKey ) {
+							return;
+						}
+
+						// Prevent default behavior (opening a link).
+						e.preventDefault();
+
+						// Select track.
+						selectTrack( index );
+					} }
+					onKeyDown={ e => {
+						// Only handle the Space key.
+						if ( event.key !== ' ' ) {
+							return;
+						}
+
+						// Prevent default behavior (scrolling one page down).
+						e.preventDefault();
+
+						// Select track.
+						selectTrack( index );
+					} }
+				>
+					<TrackIcon
+						className="jetpack-podcast-player__track-status-icon"
+						isPlaying={ isPlaying }
+						isError={ isError }
+					/>
+					<span className="jetpack-podcast-player__track-title">{ track.title }</span>
+					{ track.duration && (
+						<time className="jetpack-podcast-player__track-duration" dateTime={ track.duration }>
+							{ track.duration }
+						</time>
+					) }
+				</a>
+				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }
+			</li>
+		);
+	}
+);
+
+export default Track;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15271

#### Changes proposed in this Pull Request:
* moving components into their own files to make maintainability better
* adding `memo` around `TrackIcon` which didn't have it for some reason

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Podcast Player

#### Testing instructions:
* Basic smoke test of the player in editor and frontend

#### Proposed changelog entry for your changes:
* none