### PR TITLE
Podcast player: make speaker icons consistent

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -450,6 +450,7 @@ $player-background: transparent;
 		.jetpack-podcast-player__track-status-icon--playing {
 			mask-position: -60px 4px;
 			max-width: 20px;
+			max-height: 24px;
 			margin-right: 2px;
 			svg {
 				visibility: hidden;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -420,7 +420,8 @@ $player-background: transparent;
 	 * approach will allow us to customize colors via CSS variables.
 	 */
 	@supports ( mask-image: none ) or ( -webkit-mask-image: none ) {
-		.mejs-button > button {
+		.mejs-button > button,
+		.jetpack-podcast-player__track-status-icon--playing {
 			background-image: none;
 			background-color: var( --jetpack-podcast-player-primary );
 			mask: url( '/wp-includes/js/mediaelement/mejs-controls.svg' );
@@ -444,6 +445,15 @@ $player-background: transparent;
 
 		.mejs-unmute > button {
 			mask-position: -40px 0;
+		}
+
+		.jetpack-podcast-player__track-status-icon--playing {
+			mask-position: -60px 4px;
+			max-width: 20px;
+			margin-right: 2px;
+			svg {
+				visibility: hidden;
+			}
 		}
 	}
 }

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -453,6 +453,11 @@ $player-background: transparent;
 			max-width: 20px;
 			margin: 4px 2px 0 0;
 			svg {
+				/**
+				* To stay consistent with the mediaelement player icons, we're using the same
+				* icon sprite for the track list playing icon. As we still keep the SVG as a
+				* fallback when CSS masks are not supported, we have to hide it when they are.
+				*/
 				visibility: hidden;
 			}
 		}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -448,10 +448,10 @@ $player-background: transparent;
 		}
 
 		.jetpack-podcast-player__track-status-icon--playing {
-			mask-position: -60px 4px;
+			mask-position: -60px 0;
+			max-height: $track-status-icon-size;
 			max-width: 20px;
-			max-height: 24px;
-			margin-right: 2px;
+			margin: 4px 2px 0 0;
 			svg {
 				visibility: hidden;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

In https://github.com/Automattic/jetpack/issues/15337 it was reported that the icons for the mediaelement player sound bar as well as the playing icon in the podcast player list differ. This PR aims to make the icon use consistent in both places.

This PR keeps the original icon implementation in place so that in browsers not supporting masks we fall back to the original icon.

Fixes https://github.com/Automattic/jetpack/issues/15337

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a page and add the Podcast Player (Beta)
* Add a podcast
* Play a podcast and observe whether the icons are consistent now

| Before  | After |
| ------------- | ------------- |
|<img width="805" alt="Screenshot 2020-04-14 at 17 24 49" src="https://user-images.githubusercontent.com/1562646/79242657-e1ee0500-7e74-11ea-8238-b47d3c5641e6.png"> | <img width="810" alt="Screenshot 2020-04-14 at 17 22 05" src="https://user-images.githubusercontent.com/1562646/79242583-cf73cb80-7e74-11ea-9e4e-4bf560fe3064.png"> |