### PR TITLE
Podcast Player: Add external embed detection

### DIFF
--- a/extensions/blocks/podcast-player/api.js
+++ b/extensions/blocks/podcast-player/api.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { PODCAST_FEED, EMBED_BLOCK } from './constants';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+export const fetchPodcastFeed = async url => {
+	// First try calling our endpoint for Podcast parsing.
+	let feedData, feedError;
+	try {
+		feedData = await apiFetch( {
+			path: addQueryArgs( '/wpcom/v2/podcast-player', { url } ),
+		} );
+	} catch ( err ) {
+		// We are not rethrowing the error just yet so we can try the embed too.
+		feedError = err;
+	}
+
+	// Return podcast feed data if we have any.
+	if ( feedData ) {
+		return {
+			type: PODCAST_FEED,
+			data: feedData,
+		};
+	}
+
+	// Try if we have another block that can embed this URL.
+	const externalEmbed = await apiFetch( {
+		path: addQueryArgs( '/oembed/1.0/proxy', { url } ),
+	} );
+
+	// We can use an embed block for this URL, unless API returned the fallback code.
+	const oEmbedLinkCheck = '<a href="' + url + '">' + url + '</a>';
+	if ( externalEmbed && externalEmbed.html !== oEmbedLinkCheck ) {
+		return {
+			type: EMBED_BLOCK,
+		};
+	}
+
+	// Nothing worked, show error.
+	throw feedError;
+};

--- a/extensions/blocks/podcast-player/constants.js
+++ b/extensions/blocks/podcast-player/constants.js
@@ -1,3 +1,6 @@
 export const STATE_PLAYING = 'is-playing';
 export const STATE_ERROR = 'is-error';
 export const STATE_PAUSED = 'is-paused';
+
+export const PODCAST_FEED = 'podcast-feed';
+export const EMBED_BLOCK = 'embed-block';

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -62,7 +62,7 @@ const PodcastPlayerEdit = ( {
 	className,
 	attributes,
 	setAttributes,
-	noticeOperations: { createErrorNotice, removeAllNotices, createNotice },
+	noticeOperations: { createErrorNotice, removeAllNotices },
 	noticeUI,
 	primaryColor: primaryColorProp,
 	setPrimaryColor,
@@ -133,7 +133,7 @@ const PodcastPlayerEdit = ( {
 				}
 			);
 		},
-		[ createErrorNotice, createNotice, replaceWithEmbedBlock ]
+		[ createErrorNotice, replaceWithEmbedBlock ]
 	);
 
 	useEffect( () => {

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -124,14 +124,3 @@ export const getColorsObject = memoize( generateColorsObject, config => {
 	// Cache key is a string with all arguments joined into one string.
 	return Object.values( config ).join();
 } );
-
-export const checkEmbedBlockCompatibility = url => {
-	// todo: implement proper detection
-	return true;
-
-	// if ( /\bspotify\b/i.test( url ) ) {
-	// 	return true;
-	// }
-	//
-	// return false;
-};

--- a/extensions/blocks/podcast-player/utils.js
+++ b/extensions/blocks/podcast-player/utils.js
@@ -124,3 +124,14 @@ export const getColorsObject = memoize( generateColorsObject, config => {
 	// Cache key is a string with all arguments joined into one string.
 	return Object.values( config ).join();
 } );
+
+export const checkEmbedBlockCompatibility = url => {
+	// todo: implement proper detection
+	return true;
+
+	// if ( /\bspotify\b/i.test( url ) ) {
+	// 	return true;
+	// }
+	//
+	// return false;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15275

#### Changes proposed in this Pull Request:
* when the user-provided URL is not a valid RSS but we know it can be embedded into the post using a different block, we will transform our block into the one capable of handling the link

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Podcast Player

#### Testing instructions:
- test with multiple URLs and confirm they all behave correctly. some examples:
  - http://example.com - should show error
  - https://distributed.blog/category/podcast/feed/ - direct RSS link, should use our player
  - https://anchor.fm/startapodcast/episodes/Whats-your-podcast-about-e17krq/a-a2q3ft - regular webpage with `<link>` to RSS, should also use our player
  - https://open.spotify.com/show/7gozmLqbcbr6PScMjc0Zl4, invalid RSS but valid oEmbed, should replace Podcast Player with the spotify block
  - https://www.youtube.com/watch?v=dQw4w9WgXcQ, again invalid as RSS but works as oEmbed, should replace our block with youtube block

Why do we do transformations from services unrelated to Podcasts? All core embed blocks are forgiving in this way too and automatically transform themselves. You can insert a Spotify block and put Youtube URL into it. It will automatically sort itself out and we are now doing the same with our block.

#### Proposed changelog entry for your changes:
* none

#### Todo:
- [x] properly detect providers before offering an embed block

#### Screencast:

![2020-04-15 19 24 33](https://user-images.githubusercontent.com/156676/79367900-e0910b00-7f4e-11ea-9f04-eb7bfd72a22a.gif)
