### PR TITLE
require-lib: Update order to return out most likely valid option

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -305,10 +305,10 @@ class Jetpack_AMP_Support {
 	 * @return array Dimensions.
 	 */
 	private static function extract_image_dimensions_from_getimagesize( $dimensions ) {
-		if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'require_lib' ) ) ) {
+		if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'jetpack_require_lib' ) ) ) {
 			return $dimensions;
 		}
-		require_lib( 'wpcom/imagesize' );
+		jetpack_require_lib( 'wpcom/imagesize' );
 
 		foreach ( $dimensions as $url => $value ) {
 			if ( is_array( $value ) ) {

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -89,7 +89,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 */
 	public function create_product( $request ) {
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-			require_lib( 'memberships' );
+			jetpack_require_lib( 'memberships' );
 			$connected_destination_account_id = Jetpack_Memberships::get_connected_account_id();
 			if ( ! $connected_destination_account_id ) {
 				return new WP_Error( 'no-destination-account', __( 'Please set up a Stripe account for this site first', 'jetpack' ) );
@@ -147,7 +147,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 */
 	public function get_status() {
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-			require_lib( 'memberships' );
+			jetpack_require_lib( 'memberships' );
 			$blog_id = get_current_blog_id();
 			return (array) get_memberships_settings_for_site( $blog_id );
 		} else {

--- a/_inc/lib/debugger.php
+++ b/_inc/lib/debugger.php
@@ -6,15 +6,15 @@
  */
 
 /* Jetpack Connection Testing Framework */
-require_once 'class-jetpack-cxn-test-base.php';
+require_once 'debugger/class-jetpack-cxn-test-base.php';
 /* Jetpack Connection Tests */
-require_once 'class-jetpack-cxn-tests.php';
+require_once 'debugger/class-jetpack-cxn-tests.php';
 /* Jetpack Debug Data */
-require_once 'class-jetpack-debug-data.php';
+require_once 'debugger/class-jetpack-debug-data.php';
 /* The "In-Plugin Debugger" admin page. */
-require_once 'class-jetpack-debugger.php';
+require_once 'debugger/class-jetpack-debugger.php';
 /* General Debugging Functions */
-require_once 'debug-functions.php';
+require_once 'debugger/debug-functions.php';
 
 add_filter( 'debug_information', array( 'Jetpack_Debug_Data', 'core_debug_data' ) );
 add_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' );

--- a/extensions/blocks/map/map.php
+++ b/extensions/blocks/map/map.php
@@ -50,7 +50,7 @@ function wpcom_load_event( $access_token_source ) {
 
 	$event_name = 'map_block_mapbox_wpcom_key_load';
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		require_lib( 'tracks/client' );
+		jetpack_require_lib( 'tracks/client' );
 		tracks_record_event( wp_get_current_user(), $event_name );
 	} elseif ( jetpack_is_atomic_site() && Jetpack::is_active() ) {
 		$tracking = new Tracking();

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3588,7 +3588,7 @@ function jetpack_tracks_record_grunion_pre_message_sent( $post_id, $all_values, 
 			$event_user    = get_userdata( $event_user_id );
 		}
 
-		require_lib( 'tracks/client' );
+		jetpack_require_lib( 'tracks/client' );
 		tracks_record_event( $event_user, $event_name, $event_props );
 	} else {
 		// If the form was sent by a logged out visitor, record event with Jetpack master user.

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -442,7 +442,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 
 			// `bumps_stats_extra` only exists on .com
 			if ( function_exists( 'bump_stats_extras' ) ) {
-				require_lib( 'tracks/client' );
+				jetpack_require_lib( 'tracks/client' );
 				tracks_record_event( $current_user, 'simple_payments_button_' . $event_action, $event_properties );
 				/** This action is documented in modules/widgets/social-media-icons.php */
 				do_action( 'jetpack_bump_stats_extra', 'jetpack-simple_payments', $stat_name );

--- a/require-lib.php
+++ b/require-lib.php
@@ -21,10 +21,10 @@ function jetpack_require_lib( $slug ) {
 	 */
 	$lib_dir = apply_filters( 'jetpack_require_lib_dir', $lib_dir );
 	$choices = array(
-		JETPACK__PLUGIN_DIR . "vendor/automattic/jetpack-compat/lib/$slug.php",
 		"$lib_dir/$slug.php",
 		"$lib_dir/$slug/0-load.php",
 		"$lib_dir/$slug/$basename.php",
+		JETPACK__PLUGIN_DIR . "vendor/automattic/jetpack-compat/lib/$slug.php",
 	);
 	foreach( $choices as $file_name ) {
 		if ( is_readable( $file_name ) ) {

--- a/require-lib.php
+++ b/require-lib.php
@@ -24,8 +24,10 @@ function jetpack_require_lib( $slug ) {
 		"$lib_dir/$slug.php",
 		"$lib_dir/$slug/0-load.php",
 		"$lib_dir/$slug/$basename.php",
-		JETPACK__PLUGIN_DIR . "vendor/automattic/jetpack-compat/lib/$slug.php",
 	);
+	if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
+		$choices[] = JETPACK__PLUGIN_DIR . "vendor/automattic/jetpack-compat/lib/$slug.php";
+	}
 	foreach( $choices as $file_name ) {
 		if ( is_readable( $file_name ) ) {
 			require_once $file_name;

--- a/require-lib.php
+++ b/require-lib.php
@@ -25,9 +25,6 @@ function jetpack_require_lib( $slug ) {
 		"$lib_dir/$slug/0-load.php",
 		"$lib_dir/$slug/$basename.php",
 	);
-	if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
-		$choices[] = JETPACK__PLUGIN_DIR . "vendor/automattic/jetpack-compat/lib/$slug.php";
-	}
 	foreach( $choices as $file_name ) {
 		if ( is_readable( $file_name ) ) {
 			require_once $file_name;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* `JETPACK__PLUGIN_DIR . "vendor/automattic/jetpack-compat/lib/$slug.php",` is the least likely location for a file, but we're checking first. We can save file system checks by putting it in the end of the line.
* Move loader for the debugger library to the first location to improve load.
* Did not update the libraries that are shared with WP.com at this time.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a

#### Proposed changelog entry for your changes:
* None needed.
