### PR TITLE
Podcast player: instruct IE11 user on how to activate audio support

### DIFF
--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -26,6 +26,7 @@ export class PodcastPlayer extends Component {
 	state = {
 		playerState: STATE_PAUSED,
 		currentTrack: 0,
+		hasUserInteraction: false,
 	};
 
 	playerRef = player => {
@@ -34,6 +35,17 @@ export class PodcastPlayer extends Component {
 		this.pause = player ? player.pause : noop;
 		this.togglePlayPause = player ? player.togglePlayPause : noop;
 		this.setAudioSource = player ? player.setAudioSource : noop;
+	};
+
+	/**
+	 * Record the user has interacted with the player.
+	 *
+	 * @private
+	 */
+	recordUserInteraction = () => {
+		if ( ! this.state.hasUserInteraction ) {
+			this.setState( { hasUserInteraction: true } );
+		}
 	};
 
 	/**
@@ -47,6 +59,7 @@ export class PodcastPlayer extends Component {
 
 		// Current track already selected.
 		if ( currentTrack === track ) {
+			this.recordUserInteraction();
 			this.togglePlayPause();
 			return;
 		}
@@ -67,6 +80,9 @@ export class PodcastPlayer extends Component {
 	 * @param {number} track - The track number
 	 */
 	loadAndPlay = track => {
+		// Record that user has interacted.
+		this.recordUserInteraction();
+
 		const trackData = this.getTrack( track );
 		if ( ! trackData ) {
 			return;
@@ -104,10 +120,19 @@ export class PodcastPlayer extends Component {
 	 * Error handler for audio.
 	 *
 	 * @private
+	 * @param {object} error - The error object
 	 */
-	handleError = () => {
-		this.setState( { playerState: STATE_ERROR } );
+	handleError = error => {
+		// If an error happens before any user interaction, our player is broken beyond repair.
+		if ( ! this.state.hasUserInteraction ) {
+			// setState wrapper makes sure our ErrorBoundary handles the error.
+			this.setState( () => {
+				throw new Error( error );
+			} );
+		}
 
+		// Otherwise, let's just mark the episode as broken.
+		this.setState( { playerState: STATE_ERROR } );
 		speak( `${ __( 'Error: Episode unavailable - Open in a new tab', 'jetpack' ) }`, 'assertive' );
 	};
 
@@ -119,6 +144,7 @@ export class PodcastPlayer extends Component {
 	handlePlay = () => {
 		this.setState( {
 			playerState: STATE_PLAYING,
+			hasUserInteraction: true,
 		} );
 	};
 

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -125,9 +125,16 @@ export class PodcastPlayer extends Component {
 	handleError = error => {
 		// If an error happens before any user interaction, our player is broken beyond repair.
 		if ( ! this.state.hasUserInteraction ) {
+			// There is a known error where IE11 doesn't support the <audio> element by
+			// default but errors instead. If the user is using IE11 we thus provide
+			// additional instructions on how they can turn on <audio> support.
+			const isIE11 = window.navigator.userAgent.match( /Trident\/7\./ );
+			const playerError = isIE11
+				? 'IE11: Playing sounds in webpages setting is not checked'
+				: error;
 			// setState wrapper makes sure our ErrorBoundary handles the error.
 			this.setState( () => {
-				throw new Error( error );
+				throw new Error( playerError );
 			} );
 		}
 

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -129,6 +129,7 @@ export class PodcastPlayer extends Component {
 			// default but errors instead. If the user is using IE11 we thus provide
 			// additional instructions on how they can turn on <audio> support.
 			const isIE11 = window.navigator.userAgent.match( /Trident\/7\./ );
+			// Internal error message, no translation needed
 			const playerError = isIE11
 				? 'IE11: Playing sounds in webpages setting is not checked'
 				: error;

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -15,10 +15,7 @@ export default function withErrorBoundary( WrappedComponent ) {
 		};
 
 		componentDidCatch = ( error, errorInfo ) => {
-			// This needs to be delayed in order for React to finish its error handling.
-			setTimeout( () => {
-				this.props.onError( error, errorInfo );
-			} );
+			this.props.onError( error, errorInfo );
 		};
 
 		static getDerivedStateFromError = () => {
@@ -27,13 +24,22 @@ export default function withErrorBoundary( WrappedComponent ) {
 
 		render() {
 			if ( this.state.didError ) {
+				// There is a known error where IE11 doesn't support the <audio> element by
+				// default but errors instead. If the user is using IE11 we thus provide
+				// additional instructions on how they can turn on <audio> support.
+				const isIE11 = window.navigator.userAgent.match( /Trident\/7\./ );
 				return (
 					<section className="jetpack-podcast-player">
 						<p className="jetpack-podcast-player__error">
-							{ __(
-								'An unexpected error occured within the Podcast Player. Reloading this page might fix the problem.',
-								'jetpack'
-							) }
+							{ isIE11
+								? __(
+										'The podcast player cannot be displayed as your browser settings do not allow for sounds to be played in webpages. This can be changed in your browser’s "Internet options" settings. In the "Advanced" tab you will have to check the box next to "Play sounds in webpages" in the "Multimedia" section. Once you have confirmed that the box is checked, please press "Apply" and then reload this page.',
+										'jetpack'
+								  )
+								: __(
+										'An unexpected error occured within the Podcast Player. Reloading this page might fix the problem.',
+										'jetpack'
+								  ) }
 						</p>
 					</section>
 				);

--- a/extensions/blocks/podcast-player/components/with-error-boundary.js
+++ b/extensions/blocks/podcast-player/components/with-error-boundary.js
@@ -12,26 +12,27 @@ export default function withErrorBoundary( WrappedComponent ) {
 	class ErrorBoundary extends Component {
 		state = {
 			didError: false,
+			isIE11AudioIssue: false,
 		};
 
 		componentDidCatch = ( error, errorInfo ) => {
 			this.props.onError( error, errorInfo );
 		};
 
-		static getDerivedStateFromError = () => {
-			return { didError: true };
+		static getDerivedStateFromError = error => {
+			// There is a known error where IE11 doesn't support the <audio> element by
+			// default but errors instead. If the user is using IE11 we thus provide
+			// additional instructions on how they can turn on <audio> support.
+			return { didError: true, isIE11AudioIssue: error.message.match( /IE11/ ) ? true : false };
 		};
 
 		render() {
-			if ( this.state.didError ) {
-				// There is a known error where IE11 doesn't support the <audio> element by
-				// default but errors instead. If the user is using IE11 we thus provide
-				// additional instructions on how they can turn on <audio> support.
-				const isIE11 = window.navigator.userAgent.match( /Trident\/7\./ );
+			const { didError, isIE11AudioIssue } = this.state;
+			if ( didError ) {
 				return (
 					<section className="jetpack-podcast-player">
 						<p className="jetpack-podcast-player__error">
-							{ isIE11
+							{ isIE11AudioIssue
 								? __(
 										'The podcast player cannot be displayed as your browser settings do not allow for sounds to be played in webpages. This can be changed in your browser’s "Internet options" settings. In the "Advanced" tab you will have to check the box next to "Play sounds in webpages" in the "Multimedia" section. Once you have confirmed that the box is checked, please press "Apply" and then reload this page.',
 										'jetpack'


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR aims to resolve issue https://github.com/Automattic/jetpack/issues/15188. IE11 doesn't support `<audio>` unless the user enables the audio support for webpages. 

This PR suggests that when we [detect that this issue is present](https://github.com/Automattic/jetpack/commit/8eaf71fa2a639c357205ccbc462a46b1f028f2f0) and the user is using IE11, we show an error message in the editor that instructs them on how to activate audio support. This approach was suggested in  https://github.com/Automattic/jetpack/issues/15188#issuecomment-613977885.

Fixes https://github.com/Automattic/jetpack/issues/15188


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In IE 11:
* Create a new post and add the "Podcast Player (beta)" block
* Add a podcast URL
* Test both with the setting unchecked and checked
("This can be changed in your browser’s "Internet options" settings. In the "Advanced" tab you will have to check the box next to "Play sounds in webpages" in the "Multimedia" section. Once you have confirmed that the box is checked, please press "Apply" and then reload this page.")
* Observe whether what you see reflects the states displayed below

In other browsers:
* Test if the experience is still the same compared to master

**IE11: "Play sounds in webpages" unchecked**

| Editor  | Frontend |
| ------------- | ------------- |
| <img width="1448" alt="Screenshot 2020-04-15 at 15 05 52" src="https://user-images.githubusercontent.com/1562646/79342261-305eda80-7f2d-11ea-99df-4bdeedbf475c.png"> | <img width="1451" alt="Screenshot 2020-04-15 at 15 06 03" src="https://user-images.githubusercontent.com/1562646/79342321-42d91400-7f2d-11ea-909c-a9d403132390.png">  |

**IE11: "Play sounds in webpages" checked**

| Editor  | Frontend |
| ------------- | ------------- |
| <img width="1449" alt="Screenshot 2020-04-15 at 15 04 35" src="https://user-images.githubusercontent.com/1562646/79342448-72881c00-7f2d-11ea-9c04-858047a7079c.png">  | <img width="1449" alt="Screenshot 2020-04-15 at 15 04 53" src="https://user-images.githubusercontent.com/1562646/79342505-83d12880-7f2d-11ea-9eed-ebc0fb14ca3f.png"> |
