### PR TITLE
Plans: Fix plans link to send users to jetpack-monthly

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -241,7 +241,7 @@ class PlanGrid extends React.Component {
 	 * @return {ReactElement} <td>s with buttons
 	 */
 	renderTopButtons() {
-		const { planDuration } = this.props.planDuration;
+		const { planDuration } = this.props;
 		return map( this.getPlans(), ( plan, planType ) => {
 			const { siteRawUrl, plansUpgradeUrl, sitePlan } = this.props;
 			const isActivePlan = this.isCurrentPlanType( planType );


### PR DESCRIPTION
Currently when you toggle the monthly/yearly views you are always take to the the yearly checkout. Instead of the expected Monthly one.  

This PR fixed the type that introduced that in Jetpack 8.4.0. (https://github.com/Automattic/jetpack/pull/15193/files#diff-ae220df8872f453d2658e4d2e6d5adbeR244)

#### Changes proposed in this Pull Request:
* Make sure that we are accessing the planDuration correctly. 

#### Testing instructions:
* Build this PR with `yarn build` 
* Go to the plans page. 
* Try to any of the buy the monthly plans. Notice that it works as expected! 

#### Proposed changelog entry for your changes:
Fixes bug in the plans page that prevents users from buying the monthly plan.