### PR TITLE
Inline PDFs: better fallback link with more instructions

### DIFF
--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -30,8 +30,9 @@ function jetpack_inline_pdf_embed_handler( $matches, $attr, $url ) {
 	}
 	return sprintf(
 		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
-			<p><a href="%1$s">%1$s</a></p>
+			<p><a href="%1$s">%2$s</a></p>
 		</object>',
-		esc_attr( $url )
+		esc_attr( $url ),
+		esc_html__( 'Click to access PDF Document', 'jetpack' )
 	);
 }

--- a/modules/shortcodes/inline-pdfs.php
+++ b/modules/shortcodes/inline-pdfs.php
@@ -28,11 +28,19 @@ function jetpack_inline_pdf_embed_handler( $matches, $attr, $url ) {
 			esc_html__( 'PDF Document', 'jetpack' )
 		);
 	}
+
+	$filename      = basename( wp_parse_url( $url, PHP_URL_PATH ) );
+	$fallback_text = sprintf(
+		/* translators: Placeholder is a file name, for example "file.pdf" */
+		esc_html__( 'Click to access %1$s', 'jetpack' ),
+		$filename
+	);
+
 	return sprintf(
 		'<object data="%1$s" type="application/pdf" width="100%%" height="800">
 			<p><a href="%1$s">%2$s</a></p>
 		</object>',
 		esc_attr( $url ),
-		esc_html__( 'Click to access PDF Document', 'jetpack' )
+		$fallback_text
 	);
 }

--- a/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -37,7 +37,7 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 
 		$this->assertContains(
 			sprintf(
-				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">%1$s</a></p></object></p>' . "\n",
+				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">Click to access PDF Document</a></p></object></p>' . "\n",
 				$url
 			),
 			$actual

--- a/tests/php/modules/shortcodes/test-class.inline-pdf.php
+++ b/tests/php/modules/shortcodes/test-class.inline-pdf.php
@@ -25,8 +25,9 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 	public function test_shortcodes_inline_pdf() {
 		global $post;
 
-		$url  = 'https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf';
-		$post = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
+		$url      = 'https://jetpackme.files.wordpress.com/2017/08/jetpack-tips-for-hosts.pdf';
+		$filename = 'jetpack-tips-for-hosts.pdf';
+		$post     = $this->factory()->post->create_and_get( array( 'post_content' => $url ) );
 
 		setup_postdata( $post );
 
@@ -37,8 +38,9 @@ class WP_Test_Jetpack_Shortcodes_Inline_Pdfs extends WP_UnitTestCase {
 
 		$this->assertContains(
 			sprintf(
-				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">Click to access PDF Document</a></p></object></p>' . "\n",
-				$url
+				'<p><object data="%1$s" type="application/pdf" width="100%%" height="800"><p><a href="%1$s">Click to access %2$s</a></p></object></p>' . "\n",
+				$url,
+				$filename
 			),
 			$actual
 		);


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* `object` is not always supported in mobile browsers.
Instead of only displaying the file URL as a link, let's make that link more helpful with clear instructions ("click to access PDF document").

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Internal reference: p9F6qB-51M-p2#comment-28223

#### Testing instructions:

* On a site where the shortcodes module is active:
* Create a new post where you add a classic block
* In that classic block, paste a link to a PDF document
* Watch it transform into an embed.
* Publish your post.
* The embed should work well.
* Now open your browser dev tools and simulate a mobile browser
* Refresh; the embed should change into a link.

#### Proposed changelog entry for your changes:

* Inline PDFs: provide helpful feedback in mobile browsers.
