### PR TITLE
Jetpack: Move comment notification override to the constructor

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -695,19 +695,34 @@ class Jetpack {
 
 		add_filter( 'jetpack_just_in_time_msg_cache', '__return_true', 9 );
 
+		/*
+		 * If enabled, point edit post, page, and comment links to Calypso instead of WP-Admin.
+		 * We should make sure to only do this for front end links.
+		 */
+		if ( self::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
+			add_filter( 'get_edit_post_link', array( $this, 'point_edit_post_links_to_calypso' ), 1, 2 );
+			add_filter( 'get_edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1 );
+
+			/*
+			 * We'll override wp_notify_postauthor and wp_notify_moderator pluggable functions
+			 * so they point moderation links on emails to Calypso.
+			 */
+			jetpack_require_lib( 'functions.wp-notify' );
+		}
+
 		// Hide edit post link if mobile app.
 		if ( Jetpack_User_Agent_Info::is_mobile_app() ) {
 			add_filter( 'get_edit_post_link', '__return_empty_string' );
 		}
 
-		// Update the Jetpack plan from API on heartbeats
+		// Update the Jetpack plan from API on heartbeats.
 		add_action( 'jetpack_heartbeat', array( 'Jetpack_Plan', 'refresh_from_wpcom' ) );
 
 		/**
 		 * This is the hack to concatenate all css files into one.
-		 * For description and reasoning see the implode_frontend_css method
+		 * For description and reasoning see the implode_frontend_css method.
 		 *
-		 * Super late priority so we catch all the registered styles
+		 * Super late priority so we catch all the registered styles.
 		 */
 		if ( ! is_admin() ) {
 			add_action( 'wp_print_styles', array( $this, 'implode_frontend_css' ), -1 ); // Run first
@@ -801,22 +816,6 @@ class Jetpack {
 			require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.jetpack-keyring-service-helper.php';
 			add_action( 'init', array( 'Jetpack_Keyring_Service_Helper', 'init' ), 9, 0 );
 		}
-
-		/*
-		 * If enabled, point edit post, page, and comment links to Calypso instead of WP-Admin.
-		 * We should make sure to only do this for front end links.
-		 */
-		if ( self::get_option( 'edit_links_calypso_redirect' ) && ! is_admin() ) {
-			add_filter( 'get_edit_post_link', array( $this, 'point_edit_post_links_to_calypso' ), 1, 2 );
-			add_filter( 'get_edit_comment_link', array( $this, 'point_edit_comment_links_to_calypso' ), 1 );
-
-			/*
-			 * We'll override wp_notify_postauthor and wp_notify_moderator pluggable functions
-			 * so they point moderation links on emails to Calypso.
-			 */
-			jetpack_require_lib( 'functions.wp-notify' );
-		}
-
 	}
 
 	/**

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -146,6 +146,7 @@ if ( ! function_exists( __NAMESPACE__ . '\autoloader' ) ) {
 					$class_name,
 					array(
 						'Automattic\Jetpack\Connection\Manager',
+						'Jetpack_Options',
 					),
 					true
 				);


### PR DESCRIPTION
The code block that overrides comment notifications and points the notification
links to Calypso was [recently moved](https://github.com/Automattic/jetpack/pull/14402) to `Jetpack::configure()`, which is called during the `plugins_loaded` action. Unfortunately, this broke the override because this code block overrides
pluggable functions, and the pluggable functions are loaded just before `plugins_loaded` fires.

Fixes #15450

Props to @leogermani for finding this!

#### Changes proposed in this Pull Request:
* Move the comment notification override code block back to the Jetpack constructor.
* Add the `Jetpack_Options` class to the Autoloader's ignore list because this class is
loaded before `plugins_loaded`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
##### Test Environment
* Jetpack must be activated and connected to WordPress.com.
* Debug logging must be on.

##### Test Steps

1. Run the following command to set the `edit_links_calypso_redirect` option, which redirects the comment moderation links to Calypso:

   `wp jetpack options update edit_links_calypso_redirect true`
 
2. In Calypso, go to Settings > Discussion. In the **"Before a comment appears"** section, toggle on the **"Comment must be manually approved"** setting. This will force comment moderation.
 
3. In an incognito window, leave a comment.
 
4. Check the moderation email you received and verify that the moderation links point to Calypso.
 
5. Check debug.log and verify that no PHP notices, warning, or errors were generated.

#### Proposed changelog entry for your changes:
* General: fix comment notification overrides that direct moderation links to Calypso.
