### PR TITLE
Podcast Player: Make current track title inherit primary color

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -109,9 +109,13 @@ $player-background: transparent;
 	}
 
 	.jetpack-podcast-player__current-track-title {
-		color: $current-track-title-color;
 		font-size: $track-title-font-size;
 		margin: 0 0 $track-title-b-margin;
+
+		// Apply default color if custom primary has not been set
+		&:not(.has-primary) {
+			color: $current-track-title-color;
+		}
 	}
 
 	.jetpack-podcast-player__podcast-title {


### PR DESCRIPTION
Fixes #15443 

#### Testing instructions:
* Insert Podcast Player block
* Make sure there are no custom colors set
* Current track title should be black (the big one at the top of the Player's header)
* Set custom primary color
* The current track title should inherit the primary color

#### Screenshots:

| With default color  | With primary color  |
| ------------- | ------------- |
| <img width="775" alt="Screenshot 2020-04-16 14 32 30" src="https://user-images.githubusercontent.com/1451471/79456698-3d440280-7fef-11ea-9cdd-33922728c859.png">|<img width="774" alt="Screenshot 2020-04-16 14 32 51" src="https://user-images.githubusercontent.com/1451471/79456702-3f0dc600-7fef-11ea-8241-569d8ccaf978.png">|


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none
