### PR TITLE
Podcast Player: Center track icon vertically

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -185,6 +185,7 @@ $player-background: transparent;
 		margin: 0;
 		font-family: $default-font;
 		font-size: $editor-font-size;
+		line-height: $editor-line-height;
 
 		/**
 		 * When track "is-active", it means that it's been clicked by a user to
@@ -253,6 +254,7 @@ $player-background: transparent;
 			display: block;
 			width: $track-status-icon-size;
 			height: $track-status-icon-size;
+			margin-top: 3px; // center vertically
 		}
 	}
 


### PR DESCRIPTION
We need an explicit line-height to be sure that the track icon doesn't go off middle in themes that override the default line-height.

Context: https://github.com/Automattic/jetpack/issues/15373#issuecomment-613977242

#### Testing instructions:
* Insert Podcast Player block
* Click on a track to start playback
* Playing icon should be in the middle vertically
* Go offline
* Click one of the episodes to see the error
* Error icon should be in the middle vertically
* All of the above should be true for any theme in both, editor and front-end

#### Screenshots:

| Before  | After |
| ------------- | ------------- |
| <img width="359" alt="Screenshot 2020-04-16 15 05 03" src="https://user-images.githubusercontent.com/1451471/79459868-408dbd00-7ff4-11ea-8056-0566957bbf06.png">|<img width="343" alt="Screenshot 2020-04-16 15 04 12" src="https://user-images.githubusercontent.com/1451471/79459866-3f5c9000-7ff4-11ea-93f6-a140db0dbb70.png">|


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none
