### PR TITLE
Blocks: Add No Post Editor entry point

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -29,7 +29,7 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "instagram-gallery", "podcast-player" ],
+	"beta": [ "amazon", "instagram-gallery" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [
 		"business-hours",

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -31,4 +31,31 @@
 	],
 	"beta": [ "amazon", "instagram-gallery" ],
 	"experimental": [ "seo" ]
+	"beta": [ "amazon", "instagram-gallery", "podcast-player" ],
+	"experimental": [ "seo" ],
+	"p2tenberg": [
+		"business-hours",
+		"calendly",
+		"contact-form",
+		"contact-info",
+		"eventbrite",
+		"gif",
+		"google-calendar",
+		"mailchimp",
+		"map",
+		"markdown",
+		"opentable",
+		"pinterest",
+		"rating-star",
+		"recurring-payments",
+		"related-posts",
+		"repeat-visitor",
+		"revue",
+		"simple-payments",
+		"slideshow",
+		"subscriptions",
+		"tiled-gallery",
+		"videopress",
+		"wordads"
+	]
 }

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -33,7 +33,7 @@
 	"experimental": [ "seo" ]
 	"beta": [ "amazon", "instagram-gallery", "podcast-player" ],
 	"experimental": [ "seo" ],
-	"p2tenberg": [
+	"no-post-editor": [
 		"business-hours",
 		"calendly",
 		"contact-form",

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -29,8 +29,6 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "instagram-gallery" ],
-	"experimental": [ "seo" ]
 	"beta": [ "amazon", "instagram-gallery", "podcast-player" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -34,6 +34,8 @@ function blockScripts( type, inputDir, presetBlocks ) {
 const presetPath = path.join( __dirname, 'extensions', 'index.json' );
 const presetIndex = require( presetPath );
 const presetProductionBlocks = _.get( presetIndex, [ 'production' ], [] );
+const presetP2tenbergBlocks = _.get( presetIndex, [ 'p2tenberg' ], [] );
+
 const presetExperimentalBlocks = [
 	...presetProductionBlocks,
 	..._.get( presetIndex, [ 'experimental' ], [] ),
@@ -68,6 +70,11 @@ const editorBetaScript = [
 	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetBetaBlocks ),
 ];
 
+const editorP2tenbergScript = [
+	editorSetup,
+	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetP2tenbergBlocks ),
+];
+
 const extensionsWebpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
@@ -75,6 +82,7 @@ const extensionsWebpackConfig = getBaseWebpackConfig(
 			editor: editorScript,
 			'editor-experimental': editorExperimentalScript,
 			'editor-beta': editorBetaScript,
+			'editor-p2tenberg': editorP2tenbergScript,
 			...viewBlocksScripts,
 		},
 		'output-chunk-filename': '[name].[chunkhash].js',

--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -34,7 +34,7 @@ function blockScripts( type, inputDir, presetBlocks ) {
 const presetPath = path.join( __dirname, 'extensions', 'index.json' );
 const presetIndex = require( presetPath );
 const presetProductionBlocks = _.get( presetIndex, [ 'production' ], [] );
-const presetP2tenbergBlocks = _.get( presetIndex, [ 'p2tenberg' ], [] );
+const presetNoPostEditorBlocks = _.get( presetIndex, [ 'no-post-editor' ], [] );
 
 const presetExperimentalBlocks = [
 	...presetProductionBlocks,
@@ -70,9 +70,9 @@ const editorBetaScript = [
 	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetBetaBlocks ),
 ];
 
-const editorP2tenbergScript = [
+const editorNoPostEditorScript = [
 	editorSetup,
-	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetP2tenbergBlocks ),
+	...blockScripts( 'editor', path.join( __dirname, 'extensions' ), presetNoPostEditorBlocks ),
 ];
 
 const extensionsWebpackConfig = getBaseWebpackConfig(
@@ -82,7 +82,7 @@ const extensionsWebpackConfig = getBaseWebpackConfig(
 			editor: editorScript,
 			'editor-experimental': editorExperimentalScript,
 			'editor-beta': editorBetaScript,
-			'editor-p2tenberg': editorP2tenbergScript,
+			'editor-no-post-editor': editorNoPostEditorScript,
 			...viewBlocksScripts,
 		},
 		'output-chunk-filename': '[name].[chunkhash].js',


### PR DESCRIPTION
List of blocks that don't use the "post sidebar", no `wp-edit-post` dependency.
Useful for when using Gutenberg outside of wp-admin, frontend, comments, you name it.

Test:

* run `yarn build-extensions`
* confirm `_inc/blocks/editor-no-post-editor.asset.php` doesn't contain `wp-edit-post`
