### PR TITLE
Instagram Gallery Block: Secondary users handling

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -141,6 +141,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __CLASS__ . '::build_connect_url',
 			'permission_callback' => __CLASS__ . '::connect_url_permission_callback',
+			'args'                => array(
+				'from'     => array( 'type' => 'string' ),
+				'redirect' => array( 'type' => 'string' ),
+			),
 		) );
 
 		// Get current user connection data
@@ -1241,8 +1245,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return string|WP_Error A raw URL if the connection URL could be built; error message otherwise.
 	 */
-	public static function build_connect_url() {
-		$url = Jetpack::init()->build_connect_url( true, false, false );
+	public static function build_connect_url( $request ) {
+		$from     = isset( $request['from'] ) ? $request['from'] : false;
+		$redirect = isset( $request['redirect'] ) ? $request['redirect'] : false;
+
+		$url = Jetpack::init()->build_connect_url( true, $redirect, $from );
 		if ( $url ) {
 			return rest_ensure_response( $url );
 		}

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram.php
@@ -98,10 +98,17 @@ class WPCOM_REST_API_V2_Endpoint_Instagram extends WP_REST_Controller {
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
-		$body        = json_decode( wp_remote_retrieve_body( $response ) );
-		$connect_url = $body->services->{'instagram-basic-display'}->connect_URL;
 
-		return $connect_url;
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! property_exists( $body, 'services' ) || ! property_exists( $body->services, 'instagram-basic-display' ) ) {
+			return new WP_Error(
+				'bad_request',
+				__( 'An error occurred. Please try again later.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return $body->services->{ 'instagram-basic-display' }->connect_URL;
 	}
 
 	/**

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -697,15 +697,17 @@ class Jetpack_Gutenberg {
 		);
 
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$user      = wp_get_current_user();
-			$user_data = array(
+			$user                      = wp_get_current_user();
+			$user_data                 = array(
 				'userid'   => $user->ID,
 				'username' => $user->user_login,
 			);
-			$blog_id   = get_current_blog_id();
+			$blog_id                   = get_current_blog_id();
+			$is_current_user_connected = true;
 		} else {
-			$user_data = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
-			$blog_id   = Jetpack_Options::get_option( 'id', 0 );
+			$user_data                 = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
+			$blog_id                   = Jetpack_Options::get_option( 'id', 0 );
+			$is_current_user_connected = Jetpack::is_user_connected();
 		}
 
 		wp_localize_script(
@@ -713,7 +715,10 @@ class Jetpack_Gutenberg {
 			'Jetpack_Editor_Initial_State',
 			array(
 				'available_blocks' => self::get_availability(),
-				'jetpack'          => array( 'is_active' => Jetpack::is_active() ),
+				'jetpack'          => array(
+					'is_active'                 => Jetpack::is_active(),
+					'is_current_user_connected' => $is_current_user_connected,
+				),
 				'siteFragment'     => $site_fragment,
 				'tracksUserData'   => $user_data,
 				'wpcomBlogId'      => $blog_id,

--- a/extensions/blocks/instagram-gallery/constants.js
+++ b/extensions/blocks/instagram-gallery/constants.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export const IS_CURRENT_USER_CONNECTED_TO_WPCOM = get( window.Jetpack_Editor_Initial_State, [
+	'jetpack',
+	'is_current_user_connected',
+] );
+
+export const MAX_IMAGE_COUNT = 30;

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -58,7 +58,8 @@ const InstagramGalleryEdit = props => {
 	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
 	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram(
 		setAttributes,
-		setImages
+		setImages,
+		noticeOperations
 	);
 	const [ wpcomConnectUrl, setWpcomConnectUrl ] = useState();
 	const [ isRequestingWpcomConnectUrl, setRequestingWpcomConnectUrl ] = useState( false );

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -20,8 +20,6 @@ import {
 	Spinner,
 	withNotices,
 } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -43,15 +41,7 @@ const isCurrentUserConnectedToWpcom = get( window.Jetpack_Editor_Initial_State, 
 const MAX_IMAGE_COUNT = 30;
 
 const InstagramGalleryEdit = props => {
-	const {
-		attributes,
-		canUserManageOptions,
-		className,
-		isSelected,
-		noticeOperations,
-		noticeUI,
-		setAttributes,
-	} = props;
+	const { attributes, className, isSelected, noticeOperations, noticeUI, setAttributes } = props;
 	const { accessToken, align, columns, count, instagramUser, spacing } = attributes;
 
 	const [ images, setImages ] = useState( [] );
@@ -74,12 +64,7 @@ const InstagramGalleryEdit = props => {
 	}, [ attributes, setAttributes ] );
 
 	useEffect( () => {
-		if (
-			! canUserManageOptions ||
-			isCurrentUserConnectedToWpcom ||
-			wpcomConnectUrl ||
-			isRequestingWpcomConnectUrl
-		) {
+		if ( isCurrentUserConnectedToWpcom || wpcomConnectUrl || isRequestingWpcomConnectUrl ) {
 			return;
 		}
 		setRequestingWpcomConnectUrl( true );
@@ -92,7 +77,7 @@ const InstagramGalleryEdit = props => {
 			setWpcomConnectUrl( connectUrl );
 			setRequestingWpcomConnectUrl( false );
 		} );
-	}, [ canUserManageOptions, isRequestingWpcomConnectUrl, wpcomConnectUrl ] );
+	}, [ isRequestingWpcomConnectUrl, wpcomConnectUrl ] );
 
 	useEffect( () => {
 		if ( ! accessToken ) {
@@ -126,14 +111,6 @@ const InstagramGalleryEdit = props => {
 	const showSidebar = ! showPlaceholder;
 	const showLoadingSpinner = accessToken && isLoadingGallery && isEmpty( images );
 	const showGallery = ! showPlaceholder && ! showLoadingSpinner;
-
-	// `canUserManageOptions` is undefined while loading
-	const isConnectToInstagramButtonDisabled =
-		true !== canUserManageOptions || ! isCurrentUserConnectedToWpcom || isConnecting;
-	const showLowerRolesNotice = false === canUserManageOptions;
-	const showUserNeedsConnectionToWpcomNotice =
-		canUserManageOptions && ! isCurrentUserConnectedToWpcom;
-	const showDisconnectFromInstagramButton = canUserManageOptions || isCurrentUserConnectedToWpcom;
 
 	const blockClasses = classnames( className, { [ `align${ align }` ]: align } );
 	const gridClasses = classnames(
@@ -195,7 +172,7 @@ const InstagramGalleryEdit = props => {
 					notices={ noticeUI }
 				>
 					<Button
-						disabled={ isConnectToInstagramButtonDisabled }
+						disabled={ ! isCurrentUserConnectedToWpcom || isConnecting }
 						isLarge
 						isPrimary
 						onClick={ connectToService }
@@ -205,13 +182,7 @@ const InstagramGalleryEdit = props => {
 							: __( 'Connect your Instagram account', 'jetpack' ) }
 					</Button>
 
-					{ showLowerRolesNotice && (
-						<Notice isDismissible={ false } status="info">
-							{ __( 'Only administrators can connect their accounts to Instagram.', 'jetpack' ) }
-						</Notice>
-					) }
-
-					{ showUserNeedsConnectionToWpcomNotice && (
+					{ ! isCurrentUserConnectedToWpcom && (
 						<Notice isDismissible={ false } status="info">
 							{ __(
 								'To connect your Instagram account, you need to link your account to WordPress.com.',
@@ -256,7 +227,7 @@ const InstagramGalleryEdit = props => {
 								@{ instagramUser }
 							</ExternalLink>
 						</PanelRow>
-						{ showDisconnectFromInstagramButton && (
+						{ isCurrentUserConnectedToWpcom && (
 							<PanelRow>
 								<Button
 									disabled={ isConnecting }
@@ -301,10 +272,4 @@ const InstagramGalleryEdit = props => {
 	);
 };
 
-export default compose(
-	withSelect( select => ( {
-		// canUser returns undefined while loading, then true or false
-		canUserManageOptions: select( 'core' ).canUser( 'update', 'settings' ),
-	} ) ),
-	withNotices
-)( InstagramGalleryEdit );
+export default withNotices( InstagramGalleryEdit );

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isEmpty, isEqual, times } from 'lodash';
+import { get, isEmpty, isEqual, times } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,6 +12,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
+	Notice,
 	PanelBody,
 	PanelRow,
 	Placeholder,
@@ -31,6 +32,11 @@ import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import useConnectInstagram from './use-connect-instagram';
 import ImageTransition from './image-transition';
 import './editor.scss';
+
+const isCurrentUserConnected = get( window.Jetpack_Editor_Initial_State, [
+	'jetpack',
+	'is_current_user_connected',
+] );
 
 const MAX_IMAGE_COUNT = 30;
 
@@ -116,7 +122,7 @@ const InstagramGalleryEdit = props => {
 				isDismissible: false,
 			} );
 		}
-	}, [ count, images ] );
+	}, [ count, images, noticeOperations, showSidebar ] );
 
 	const renderImage = index => {
 		if ( images[ index ] ) {
@@ -146,11 +152,27 @@ const InstagramGalleryEdit = props => {
 					label={ __( 'Instagram Gallery', 'jetpack' ) }
 					notices={ noticeUI }
 				>
-					<Button disabled={ isConnecting } isLarge isPrimary onClick={ connectToService }>
+					<Button
+						disabled={ ! isCurrentUserConnected || isConnecting }
+						isLarge
+						isPrimary
+						onClick={ connectToService }
+					>
 						{ isConnecting
 							? __( 'Connecting…', 'jetpack' )
 							: __( 'Connect your Instagram account', 'jetpack' ) }
 					</Button>
+
+					<Notice isDismissible={ false } status="info">
+						{ __(
+							'To connect your Instagram account, you need to link your account to WordPress.com.',
+							'jetpack'
+						) }
+						<br />
+						<Button href={ addQueryArgs( 'admin.php', { page: 'jetpack#/dashboard' } ) } isLink>
+							{ __( 'Open the Jetpack dashboard', 'jetpack' ) }
+						</Button>
+					</Notice>
 				</Placeholder>
 			) }
 
@@ -184,18 +206,20 @@ const InstagramGalleryEdit = props => {
 								@{ instagramUser }
 							</ExternalLink>
 						</PanelRow>
-						<PanelRow>
-							<Button
-								disabled={ isConnecting }
-								isDestructive
-								isLink
-								onClick={ () => disconnectFromService( accessToken ) }
-							>
-								{ isConnecting
-									? __( 'Disconnecting…', 'jetpack' )
-									: __( 'Disconnect your account', 'jetpack' ) }
-							</Button>
-						</PanelRow>
+						{ isCurrentUserConnected && (
+							<PanelRow>
+								<Button
+									disabled={ isConnecting }
+									isDestructive
+									isLink
+									onClick={ () => disconnectFromService( accessToken ) }
+								>
+									{ isConnecting
+										? __( 'Disconnecting…', 'jetpack' )
+										: __( 'Disconnect your account', 'jetpack' ) }
+								</Button>
+							</PanelRow>
+						) }
 					</PanelBody>
 					<PanelBody title={ __( 'Gallery Settings', 'jetpack' ) }>
 						<div className="wp-block-jetpack-instagram-gallery__count-notice">{ noticeUI }</div>

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -146,11 +146,9 @@ const InstagramGalleryEdit = props => {
 				<Placeholder
 					icon="instagram"
 					instructions={
-						! IS_CURRENT_USER_CONNECTED_TO_WPCOM &&
-						__(
-							'To connect your Instagram account, you need to link your account to WordPress.com.',
-							'jetpack'
-						)
+						! IS_CURRENT_USER_CONNECTED_TO_WPCOM
+							? __( "First, you'll need to connect to WordPress.com.", 'jetpack' )
+							: __( 'Connect to Instagram to start sharing your images.', 'jetpack' )
 					}
 					label={ __( 'Instagram Gallery', 'jetpack' ) }
 					notices={ noticeUI }
@@ -159,7 +157,7 @@ const InstagramGalleryEdit = props => {
 						<Button disabled={ isConnecting } isLarge isPrimary onClick={ connectToService }>
 							{ isConnecting
 								? __( 'Connecting…', 'jetpack' )
-								: __( 'Connect your Instagram account', 'jetpack' ) }
+								: __( 'Connect to Instagram', 'jetpack' ) }
 						</Button>
 					) : (
 						<Button
@@ -168,7 +166,7 @@ const InstagramGalleryEdit = props => {
 							isLarge
 							isPrimary
 						>
-							{ __( 'Link your account to WordPress.com', 'jetpack' ) }
+							{ __( 'Connect to WordPress.com', 'jetpack' ) }
 						</Button>
 					) }
 				</Placeholder>

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { get, isEmpty, isEqual, times } from 'lodash';
+import { isEmpty, isEqual, times } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,7 +12,6 @@ import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
-	Notice,
 	PanelBody,
 	PanelRow,
 	Placeholder,
@@ -146,35 +145,31 @@ const InstagramGalleryEdit = props => {
 			{ showPlaceholder && (
 				<Placeholder
 					icon="instagram"
+					instructions={
+						! IS_CURRENT_USER_CONNECTED_TO_WPCOM &&
+						__(
+							'To connect your Instagram account, you need to link your account to WordPress.com.',
+							'jetpack'
+						)
+					}
 					label={ __( 'Instagram Gallery', 'jetpack' ) }
 					notices={ noticeUI }
 				>
-					<Button
-						disabled={ ! IS_CURRENT_USER_CONNECTED_TO_WPCOM || isConnecting }
-						isLarge
-						isPrimary
-						onClick={ connectToService }
-					>
-						{ isConnecting
-							? __( 'Connecting…', 'jetpack' )
-							: __( 'Connect your Instagram account', 'jetpack' ) }
-					</Button>
-
-					{ ! IS_CURRENT_USER_CONNECTED_TO_WPCOM && (
-						<Notice isDismissible={ false } status="info">
-							{ __(
-								'To connect your Instagram account, you need to link your account to WordPress.com.',
-								'jetpack'
-							) }
-							<br />
-							<Button
-								disabled={ isRequestingWpcomConnectUrl || ! wpcomConnectUrl }
-								href={ wpcomConnectUrl }
-								isLink
-							>
-								{ __( 'Link your account to WordPress.com', 'jetpack' ) }
-							</Button>
-						</Notice>
+					{ IS_CURRENT_USER_CONNECTED_TO_WPCOM ? (
+						<Button disabled={ isConnecting } isLarge isPrimary onClick={ connectToService }>
+							{ isConnecting
+								? __( 'Connecting…', 'jetpack' )
+								: __( 'Connect your Instagram account', 'jetpack' ) }
+						</Button>
+					) : (
+						<Button
+							disabled={ isRequestingWpcomConnectUrl || ! wpcomConnectUrl }
+							href={ wpcomConnectUrl }
+							isLarge
+							isPrimary
+						>
+							{ __( 'Link your account to WordPress.com', 'jetpack' ) }
+						</Button>
 					) }
 				</Placeholder>
 			) }

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -1,38 +1,48 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import PopupMonitor from '@automattic/popup-monitor';
 
-export default function useConnectInstagram( setAttributes, setImages ) {
+export default function useConnectInstagram( setAttributes, setImages, noticeOperations ) {
 	const [ isConnecting, setIsConnecting ] = useState( false );
 
 	const connectToService = () => {
+		noticeOperations.removeAllNotices();
 		setIsConnecting( true );
-		apiFetch( { path: `/wpcom/v2/instagram/connect-url` } ).then( connectUrl => {
-			const popupMonitor = new PopupMonitor();
 
-			popupMonitor.open(
-				connectUrl,
-				`connect-to-instagram-popup`,
-				'toolbar=0,location=0,menubar=0,' + popupMonitor.getScreenCenterSpecs( 700, 700 )
-			);
+		apiFetch( { path: `/wpcom/v2/instagram/connect-url` } )
+			.then( connectUrl => {
+				const popupMonitor = new PopupMonitor();
 
-			popupMonitor.on( 'message', ( { keyring_id } ) => {
-				setIsConnecting( false );
-				if ( keyring_id ) {
-					setAttributes( { accessToken: keyring_id.toString() } );
-				}
-			} );
+				popupMonitor.open(
+					connectUrl,
+					`connect-to-instagram-popup`,
+					'toolbar=0,location=0,menubar=0,' + popupMonitor.getScreenCenterSpecs( 700, 700 )
+				);
 
-			popupMonitor.on( 'close', name => {
-				if ( `connect-to-instagram-popup` === name ) {
+				popupMonitor.on( 'message', ( { keyring_id } ) => {
 					setIsConnecting( false );
-				}
+					if ( keyring_id ) {
+						setAttributes( { accessToken: keyring_id.toString() } );
+					}
+				} );
+
+				popupMonitor.on( 'close', name => {
+					if ( `connect-to-instagram-popup` === name ) {
+						setIsConnecting( false );
+					}
+				} );
+			} )
+			.catch( () => {
+				noticeOperations.createErrorNotice(
+					__( 'An error occurred. Please try again later.', 'jetpack' )
+				);
+				setIsConnecting( false );
 			} );
-		} );
 	};
 
 	const disconnectFromService = accessToken => {

--- a/extensions/blocks/instagram-gallery/use-connect-wpcom.js
+++ b/extensions/blocks/instagram-gallery/use-connect-wpcom.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { IS_CURRENT_USER_CONNECTED_TO_WPCOM } from './constants';
+
+export default function useConnectWpcom() {
+	const { isAutoDraft } = useSelect( select => {
+		const { status } = select( 'core/editor' ).getCurrentPost();
+		return { isAutoDraft: 'auto-draft' === status };
+	} );
+
+	const { savePost } = useDispatch( 'core/editor' );
+
+	const [ wpcomConnectUrl, setWpcomConnectUrl ] = useState();
+	const [ isRequestingWpcomConnectUrl, setRequestingWpcomConnectUrl ] = useState( false );
+
+	useEffect( () => {
+		if ( IS_CURRENT_USER_CONNECTED_TO_WPCOM || wpcomConnectUrl || isRequestingWpcomConnectUrl ) {
+			return;
+		}
+
+		if ( isAutoDraft ) {
+			savePost();
+			return;
+		}
+
+		setRequestingWpcomConnectUrl( true );
+		apiFetch( {
+			path: addQueryArgs( '/jetpack/v4/connection/url', {
+				from: 'jetpack-block-editor',
+				redirect: window.location.href,
+			} ),
+		} ).then( connectUrl => {
+			setWpcomConnectUrl( connectUrl );
+			setRequestingWpcomConnectUrl( false );
+		} );
+	}, [ isAutoDraft, isRequestingWpcomConnectUrl, savePost, wpcomConnectUrl ] );
+
+	return { isRequestingWpcomConnectUrl, wpcomConnectUrl };
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #15276

~Requires https://github.com/Automattic/wp-calypso/pull/41334~
~Requires D42269-code~

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
To connect an Instagram Gallery block to Instagram, users need to be linked to WPCOM.

If a user is not linked to WPCOM:
- When adding a new block, disable the "Connect to Instagram" button, and show a notice prompting to link their account to WPCOM first.
- When editing an existing connected block, hide the "Disconnect from Instagram" button in the sidebar.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Connect a site to WPCOM, and test with two users (try with an author if possible).
* Main user (the owner of the WPCOM connection):
  - Insert an Instagram Gallery block.
  - Make sure you can connect it to Instagram without any notices.
  - Make sure the "Disconnect" link in the block sidebar is visible.
  - Save the post.
* Secondary user not linked to WPCOM:
  - Reload the post and select the connected Instagram Gallery block.
  - Make sure the "Disconnect" link in the block sidebar is hidden.
  - Insert a new Instagram Gallery block.
  - Make sure the "Connect to Instagram" button is disabled, and you can see a notice prompting to link the account to WPCOM.
    - Click the link. It will open a WPCOM sign up form.
    - Log in with a secondary WPCOM account, and authorize it (it will link the JP user with the WPCOM one).
    - Click the "return to site" button.
    - Make sure it returns to the post editor.
  - Make sure you are now able to connect it to Instagram.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
