### PR TITLE
Instant Search: Make overlay trigger configurable

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -123,6 +123,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 				'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', false ),
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
 				'opacity'         => (int) get_option( $prefix . 'opacity', 97 ),
+				'overlayTrigger'  => get_option( $prefix . 'overlay_trigger', 'immediate' ),
 				'showPoweredBy'   => (bool) get_option( $prefix . 'show_powered_by', true ),
 			),
 

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -72,6 +72,29 @@ class Jetpack_Search_Customize {
 			)
 		);
 
+		$id = $setting_prefix . 'overlay_trigger';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default'   => 'immediate',
+				'transport' => 'postMessage',
+				'type'      => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'label'       => __( 'Overlay Trigger', 'jetpack' ),
+				'description' => __( 'Choose when the search overlay should appear.', 'jetpack' ),
+				'section'     => $section_id,
+				'type'        => 'select',
+				'choices'     => array(
+					'immediate' => __( 'Open immediately', 'jetpack' ),
+					'results'   => __( 'Open when results are available', 'jetpack' ),
+				),
+			)
+		);
+
 		$id = $setting_prefix . 'opacity';
 		$wp_customize->add_setting(
 			$id,
@@ -152,8 +175,6 @@ class Jetpack_Search_Customize {
 				'label'   => __( 'Display "Powered by Jetpack"', 'jetpack' ),
 			)
 		);
-
 	}
-
 }
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -287,6 +287,7 @@ class SearchApp extends Component {
 					isVisible={ this.state.showResults }
 					locale={ this.props.options.locale }
 					onLoadNextPage={ this.loadNextPage }
+					overlayTrigger={ this.state.overlayOptions.overlayTrigger }
 					postTypes={ this.props.options.postTypes }
 					query={ getSearchQuery() }
 					response={ this.state.response }

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -72,11 +72,7 @@ class SearchApp extends Component {
 		window.addEventListener( 'popstate', this.onPopstate );
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
-		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
-			input.form.addEventListener( 'submit', this.handleSubmit );
-			input.addEventListener( 'input', this.handleInput );
-		} );
-
+		this.updateEventListeners( this.state.overlayOptions.overlayTrigger );
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
 			select.addEventListener( 'change', this.handleSortChange );
 		} );
@@ -93,6 +89,7 @@ class SearchApp extends Component {
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
+			input.removeEventListener( 'focus', this.handleInputFocus );
 		} );
 
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
@@ -101,6 +98,25 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
+		} );
+	}
+
+	updateEventListeners( type ) {
+		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
+			if ( type === 'results' ) {
+				// Remove focus event listener
+				input.removeEventListener( 'focus', this.handleInputFocus );
+				// Add listeners for input and submit
+				input.form.addEventListener( 'submit', this.handleSubmit );
+				input.addEventListener( 'input', this.handleInput );
+			}
+			if ( type === 'immediate' ) {
+				// Remove listeners for input and submit
+				input.form.removeEventListener( 'submit', this.handleSubmit );
+				input.removeEventListener( 'input', this.handleInput );
+				// Add focus event listener
+				input.addEventListener( 'focus', this.handleInputFocus );
+			}
 		} );
 	}
 
@@ -123,8 +139,6 @@ class SearchApp extends Component {
 	handleSubmit = event => {
 		event.preventDefault();
 		this.handleInput.flush();
-		setSearchQuery( event.target.elements.s.value );
-		this.showResults();
 	};
 
 	handleInput = debounce( event => {
@@ -134,6 +148,8 @@ class SearchApp extends Component {
 		}
 		setSearchQuery( event.target.value );
 	}, 200 );
+
+	handleInputFocus = () => this.showResults();
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
@@ -154,8 +170,11 @@ class SearchApp extends Component {
 
 	handleOverlayOptionsUpdate = newOverlayOptions => {
 		this.setState(
-			{ overlayOptions: { ...this.state.overlayOptions, ...newOverlayOptions } },
-			this.showResults
+			state => ( { overlayOptions: { ...state.overlayOptions, ...newOverlayOptions } } ),
+			() => {
+				this.updateEventListeners( this.state.overlayOptions.overlayTrigger );
+				this.showResults();
+			}
 		);
 	};
 

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -28,8 +28,12 @@ const SearchBox = props => {
 	const inputRef = useRef( null );
 
 	useEffect( () => {
-		props.isVisible ? stealFocusWithInput( inputRef.current )() : restoreFocus();
-	}, [ props.isVisible ] );
+		if ( props.isVisible ) {
+			stealFocusWithInput( inputRef.current )();
+		} else if ( props.shouldRestoreFocus ) {
+			restoreFocus();
+		}
+	}, [ props.isVisible, props.shouldRestoreFocus ] );
 
 	return (
 		<Fragment>

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -58,6 +58,7 @@ class SearchForm extends Component {
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }
+						shouldRestoreFocus={ this.props.overlayTrigger !== 'immediate' }
 						showFilters={ this.state.showFilters }
 						toggleFilters={ this.toggleFilters }
 						widget={ this.props.widget }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -73,6 +73,7 @@ class SearchResults extends Component {
 					isVisible={ this.props.isVisible }
 					locale={ this.props.locale }
 					postTypes={ this.props.postTypes }
+					overlayTrigger={ this.props.overlayTrigger }
 					response={ this.props.response }
 					widgets={ this.props.widgets }
 					widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -5,17 +5,19 @@ import { SERVER_OBJECT_NAME } from './constants';
 
 const CUSTOMIZE_SETTINGS = [
 	'jetpack_search_color_theme',
-	'jetpack_search_inf_scroll',
 	'jetpack_search_highlight_color',
+	'jetpack_search_inf_scroll',
 	'jetpack_search_opacity',
+	'jetpack_search_overlay_trigger',
 	'jetpack_search_show_powered_by',
 ];
 
 const SETTINGS_TO_STATE_MAP = new Map( [
 	[ 'jetpack_search_color_theme', 'colorTheme' ],
-	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
 	[ 'jetpack_search_highlight_color', 'highlightColor' ],
+	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
 	[ 'jetpack_search_opacity', 'opacity' ],
+	[ 'jetpack_search_overlay_trigger', 'overlayTrigger' ],
 	[ 'jetpack_search_show_powered_by', 'showPoweredBy' ],
 ] );
 

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -7,10 +7,10 @@ export function getCheckedInputNames( parentDom ) {
 export function getThemeOptions( searchOptions ) {
 	const options = {
 		searchInputSelector: [
-			'input[name="s"]',
-			'#searchform input.search-field',
+			'input[name="s"]:not(.jetpack-instant-search__box-input)',
+			'#searchform input.search-field:not(.jetpack-instant-search__box-input)',
 			'.search-form input.search-field:not(.jetpack-instant-search__box-input)',
-			'.searchform input.search-field',
+			'.searchform input.search-field:not(.jetpack-instant-search__box-input)',
 		].join( ', ' ),
 		searchSortSelector: [ '.jetpack-search-sort' ],
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],


### PR DESCRIPTION
Fixes #15404.

#### Changes proposed in this Pull Request:
* Adds a customizer value for configuring and changing the overlay trigger.
* Adds support for showing the overlay upon input focus (`Open immediately`).
* Preserves support for showing the overlay upon loading available results (`Open when results are available`).

<img width="297" alt="Screen Shot 2020-04-16 at 3 26 45 PM" src="https://user-images.githubusercontent.com/4044428/79508526-f3f7b100-7ff6-11ea-957e-c164925dcbcc.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, this adds a new customizer configuration value for Jetpack Search.

#### Testing instructions:
* Apply this patch to your Jetpack installation.
* Go to the Jetpack Search section of your customizer. Ensure that the new Overlay Trigger setting is available for configuration. Also ensure that the `Open immediately` is selected as the default.
* Try changing the trigger setting to "Open when results are available." Ensure that the overlay is automatically triggered (see #15245). Close the overlay and try triggering the overlay by typing into the search input.
* Try changing the trigger setting to "Open immediately." Ensure that the overlay is automatically triggered; close the overlay. Try triggering the overlay by focusing on the search input either by clicking or tabbing. 

#### Proposed changelog entry for your changes:
* Made Jetpack Search overlay trigger configurable.
