### PR TITLE
Recipes: show prep time before cook time when published

### DIFF
--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -202,7 +202,7 @@ class Jetpack_Recipes {
 				);
 			}
 
-			$time_types = array( 'cooktime', 'preptime', 'time' );
+			$time_types = array( 'preptime', 'cooktime', 'time' );
 			foreach ( $time_types as $time_type ) {
 				if ( '' === $atts[ $time_type ] ) {
 					continue;


### PR DESCRIPTION
Show prep time before cook time when published

<!--- Provide a general summary of your changes in the Title above -->

Fixes #15476

#### Changes proposed in this Pull Request:

* Swaps the order of prep time with the cook time (line numbers 205-211)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* This is a correction in the existing features. 

p1587098363018300-slack-jpop-support

#### Testing instructions:

* Create a post containing shortcode recipe e.g. [recipe title=" Oreo Blender Cheesecake " servings=" 4-6 " preptime=" 10 minutes " cooktime="overnight in fridge" difficulty=" Easy "]
* Publish the post containing this shortcode
* Check the published post. Prep time should appear before cook time.

#### Proposed changelog entry for your changes:

* No changelog entry required
