### PR TITLE
Debugger: Various Improvements

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1046,7 +1046,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		if (
 			! function_exists( 'openssl_verify' )
-			|| ! openssl_verify(
+			|| 1 !== openssl_verify(
 				$signature_data,
 				$signature,
 				JETPACK__DEBUGGER_PUBLIC_KEY

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1096,7 +1096,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				}
 			}
 
-			$result = $errors[0];
+			$result = ( ! empty( $errors ) ) ? $errors[0] : null;
 			if ( count( $errors ) > 1 ) {
 				// Remove the primary error.
 				array_shift( $errors );

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -247,7 +247,6 @@ class Jetpack_Cxn_Test_Base {
 	 * Possible Args:
 	 * - name: string The raw method name that runs the test. Default 'unnamed_test'.
 	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
-	 * - pass: bool|string True if the test passed. Default true.
 	 * - short_description: bool|string A brief, non-html description that will appear in CLI results. Default 'Test passed!'.
 	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
 	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
@@ -260,12 +259,11 @@ class Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	public static function passing_test( $args ) {
-		return wp_parse_args(
+		$args = wp_parse_args(
 			$args,
 			array(
 				'name'                => 'unnamed_test',
 				'label'               => false,
-				'pass'                => true,
 				'short_description'   => __( 'Test passed!', 'jetpack' ),
 				'long_description'    => false,
 				'severity'            => false,
@@ -274,6 +272,10 @@ class Jetpack_Cxn_Test_Base {
 				'show_in_site_health' => true,
 			)
 		);
+
+		$args['pass'] = true;
+
+		return $args;
 	}
 
 	/**
@@ -281,7 +283,6 @@ class Jetpack_Cxn_Test_Base {
 	 * Possible Args:
 	 * - name: string The raw method name that runs the test. Default unnamed_test.
 	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
-	 * - pass: bool|string True if the test passed. Default 'skipped'.
 	 * - short_description: bool|string A brief, non-html description that will appear in CLI results, and as headings in admin UIs. Default false.
 	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
 	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
@@ -294,12 +295,11 @@ class Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	public static function skipped_test( $args = array() ) {
-		return wp_parse_args(
+		$args = wp_parse_args(
 			$args,
 			array(
 				'name'                => 'unnamed_test',
 				'label'               => false,
-				'pass'                => 'skipped',
 				'short_description'   => false,
 				'long_description'    => false,
 				'severity'            => false,
@@ -308,6 +308,10 @@ class Jetpack_Cxn_Test_Base {
 				'show_in_site_health' => true,
 			)
 		);
+
+		$args['pass'] = 'skipped';
+
+		return $args;
 	}
 
 	/**
@@ -315,7 +319,6 @@ class Jetpack_Cxn_Test_Base {
 	 * Possible Args:
 	 * - name: string The raw method name that runs the test. Default unnamed_test.
 	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
-	 * - pass: bool|string True if the test passed. Default false.
 	 * - short_description: bool|string A brief, non-html description that will appear in CLI results, and as headings in admin UIs. Default 'Test failed!'.
 	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
 	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: 'critical'.
@@ -330,12 +333,11 @@ class Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	public static function failing_test( $args ) {
-		return wp_parse_args(
+		$args = wp_parse_args(
 			$args,
 			array(
 				'name'                => 'unnamed_test',
 				'label'               => false,
-				'pass'                => false,
 				'short_description'   => __( 'Test failed!', 'jetpack' ),
 				'long_description'    => false,
 				'severity'            => 'critical',
@@ -344,6 +346,10 @@ class Jetpack_Cxn_Test_Base {
 				'show_in_site_health' => true,
 			)
 		);
+
+		$args['pass'] = false;
+
+		return $args;
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -234,7 +234,7 @@ class Jetpack_Cxn_Test_Base {
 
 		foreach ( $results as $test => $result ) {
 			// We do not want tests that passed or ones that are misconfigured (no pass status or no failure message).
-			if ( ! isset( $result['pass'] ) || false !== $result['pass'] || ! isset( $result['message'] ) ) {
+			if ( ! isset( $result['pass'] ) || false !== $result['pass'] || ! isset( $result['short_description'] ) ) {
 				unset( $results[ $test ] );
 			}
 		}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -315,6 +315,42 @@ class Jetpack_Cxn_Test_Base {
 	}
 
 	/**
+	 * Helper function to return consistent responses for an informational test.
+	 * Possible Args:
+	 * - name: string The raw method name that runs the test. Default unnamed_test.
+	 * - label: bool|string If false, tests will be labeled with their `name`. You can pass a string to override this behavior. Default false.
+	 * - short_description: bool|string A brief, non-html description that will appear in CLI results, and as headings in admin UIs. Default false.
+	 * - long_description: bool|string An html description that will appear in the site health page. Default false.
+	 * - severity: bool|string 'critical', 'recommended', or 'good'. Default: false.
+	 * - action: bool|string A URL for the recommended action. Default: false
+	 * - action_label: bool|string The label for the recommended action. Default: false
+	 * - show_in_site_health: bool True if the test should be shown on the Site Health page. Default: true
+	 *
+	 * @param array $args Arguments to override defaults.
+	 *
+	 * @return array Test results.
+	 */
+	public static function informational_test( $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'name'                => 'unnamed_test',
+				'label'               => false,
+				'short_description'   => false,
+				'long_description'    => false,
+				'severity'            => false,
+				'action'              => false,
+				'action_label'        => false,
+				'show_in_site_health' => true,
+			)
+		);
+
+		$args['pass'] = 'informational';
+
+		return $args;
+	}
+
+	/**
 	 * Helper function to return consistent responses for a failing test.
 	 * Possible Args:
 	 * - name: string The raw method name that runs the test. Default unnamed_test.
@@ -373,6 +409,11 @@ class Jetpack_Cxn_Test_Base {
 					WP_CLI::log( WP_CLI::colorize( '%gPassed:%n  ' . $test['name'] ) );
 				} elseif ( 'skipped' === $test['pass'] ) {
 					WP_CLI::log( WP_CLI::colorize( '%ySkipped:%n ' . $test['name'] ) );
+					if ( $test['short_description'] ) {
+						WP_CLI::log( '         ' . $test['short_description'] ); // Number of spaces to "tab indent" the reason.
+					}
+				} elseif ( 'informational' === $test['pass'] ) {
+					WP_CLI::log( WP_CLI::colorize( '%yInfo:%n    ' . $test['name'] ) );
 					if ( $test['short_description'] ) {
 						WP_CLI::log( '         ' . $test['short_description'] ); // Number of spaces to "tab indent" the reason.
 					}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -259,19 +259,10 @@ class Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	public static function passing_test( $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'name'                => 'unnamed_test',
-				'label'               => false,
-				'short_description'   => __( 'Test passed!', 'jetpack' ),
-				'long_description'    => false,
-				'severity'            => false,
-				'action'              => false,
-				'action_label'        => false,
-				'show_in_site_health' => true,
-			)
-		);
+		$defaults                      = self::test_result_defaults();
+		$defaults['short_description'] = __( 'Test passed!', 'jetpack' );
+
+		$args = wp_parse_args( $args, $defaults );
 
 		$args['pass'] = true;
 
@@ -297,16 +288,7 @@ class Jetpack_Cxn_Test_Base {
 	public static function skipped_test( $args = array() ) {
 		$args = wp_parse_args(
 			$args,
-			array(
-				'name'                => 'unnamed_test',
-				'label'               => false,
-				'short_description'   => false,
-				'long_description'    => false,
-				'severity'            => false,
-				'action'              => false,
-				'action_label'        => false,
-				'show_in_site_health' => true,
-			)
+			self::test_result_defaults()
 		);
 
 		$args['pass'] = 'skipped';
@@ -333,16 +315,7 @@ class Jetpack_Cxn_Test_Base {
 	public static function informational_test( $args = array() ) {
 		$args = wp_parse_args(
 			$args,
-			array(
-				'name'                => 'unnamed_test',
-				'label'               => false,
-				'short_description'   => false,
-				'long_description'    => false,
-				'severity'            => false,
-				'action'              => false,
-				'action_label'        => false,
-				'show_in_site_health' => true,
-			)
+			self::test_result_defaults()
 		);
 
 		$args['pass'] = 'informational';
@@ -369,23 +342,35 @@ class Jetpack_Cxn_Test_Base {
 	 * @return array Test results.
 	 */
 	public static function failing_test( $args ) {
-		$args = wp_parse_args(
-			$args,
-			array(
-				'name'                => 'unnamed_test',
-				'label'               => false,
-				'short_description'   => __( 'Test failed!', 'jetpack' ),
-				'long_description'    => false,
-				'severity'            => 'critical',
-				'action'              => false,
-				'action_label'        => false,
-				'show_in_site_health' => true,
-			)
-		);
+		$defaults                      = self::test_result_defaults();
+		$defaults['short_description'] = __( 'Test failed!', 'jetpack' );
+		$defaults['severity']          = 'critical';
+
+		$args = wp_parse_args( $args, $defaults );
 
 		$args['pass'] = false;
 
 		return $args;
+	}
+
+	/**
+	 * Provides defaults for test arguments.
+	 *
+	 * @since 8.5.0
+	 *
+	 * @return array Result defaults.
+	 */
+	private static function test_result_defaults() {
+		return array(
+			'name'                => 'unnamed_test',
+			'label'               => false,
+			'short_description'   => false,
+			'long_description'    => false,
+			'severity'            => false,
+			'action'              => false,
+			'action_label'        => false,
+			'show_in_site_health' => true,
+		);
 	}
 
 	/**

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -696,11 +696,12 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		$testsite_url = Connection_Utils::fix_url_for_bad_hosts( JETPACK__API_BASE . 'testsite/1/?url=' );
 
-		add_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ) );
+		// Using PHP_INT_MAX - 1 so that there is still a way to override this if needed and since it only impacts this one call.
+		add_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ), PHP_INT_MAX - 1 );
 
 		$response = wp_remote_get( $testsite_url . $self_xml_rpc_url );
 
-		remove_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ) );
+		remove_filter( 'http_request_timeout', array( 'Jetpack_Cxn_Tests', 'increase_timeout' ), PHP_INT_MAX - 1 );
 
 		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
 			return self::passing_test( array( 'name' => $name ) );

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -529,13 +529,13 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			// Full Sync in Progress.
 			if ( $progress_percent ) {
 
-				return self::skipped_test(
+				return self::informational_test(
 					array(
 						'name'              => $name,
 						'label'             => __( 'Jetpack is performing a full sync of your site', 'jetpack' ),
 						'severity'          => 'recommended',
 						/* translators: placeholder is a percentage number. */
-						'short_description' => sprintf( __( 'Jetpack is performing a full sync of your site. Current Progress: %1$d %', 'jetpack' ), $progress_percent ),
+						'short_description' => sprintf( __( 'Jetpack is performing a full sync of your site. Current Progress: %1$d %%', 'jetpack' ), $progress_percent ),
 						'long_description'  => sprintf(
 							'<p>%1$s</p><p><span class="dashicons dashicons-update"><span class="screen-reader-text">%2$s</span></span> %3$s</p><div class="jetpack-sync-progress-ui"><div class="jetpack-sync-progress-label"></div><div class="jetpack-sync-progress-bar"></div></div>',
 							__( 'The information synced by Jetpack ensures that Jetpack Search, Related Posts and other features are aligned with your site’s current content.', 'jetpack' ), /* translators: screen reader text indicating data is updating. */
@@ -618,7 +618,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				);
 				$description .= '</p>';
 
-				return self::skipped_test(
+				return self::failing_test(
 					array(
 						'name'              => $name,
 						'label'             => __( 'Jetpack has detected an error syncing your site.', 'jetpack' ),
@@ -662,7 +662,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 					);
 					$description .= '</p>';
 
-					return self::skipped_test(
+					return self::informational_test(
 						array(
 							'name'              => $name,
 							'label'             => __( 'Jetpack is experiencing a delay syncing your site.', 'jetpack' ),

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -530,7 +530,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			// Full Sync in Progress.
 			if ( $progress_percent ) {
 
-				return self::failing_test(
+				return self::skipped_test(
 					array(
 						'name'              => $name,
 						'label'             => __( 'Jetpack is performing a sync of your site', 'jetpack' ),
@@ -632,7 +632,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 				} else {
 
 					// Sync is Healthy.
-					return self::skipped_test( array( 'name' => $name ) );
+					return self::passing_test( array( 'name' => $name ) );
 
 				}
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -501,10 +501,9 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	/**
 	 * Full Sync Health Test.
 	 *
-	 * Disabled: Results in a skipped test (recommended)
-	 * In Progress: Results in failing test (recommended)
-	 * Delayed: Results in failing test (recommended)
-	 * Error: Results in failing test (critical)
+	 * Sync Disabled: Results in a skipped test
+	 * Not In Progress : Results in a skipped test
+	 * In Progress: Results in skipped test w/ status in CLI
 	 */
 	protected function test__full_sync_health() {
 

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -283,7 +283,7 @@ class Jetpack_Debug_Data {
 			foreach ( $sync_statuses as $sync_status => $sync_status_value ) {
 				$human_readable_sync_status[ $sync_status ] =
 					in_array( $sync_status, array( 'started', 'queue_finished', 'send_started', 'finished' ), true )
-						? date( 'r', $sync_status_value ) : $sync_status_value;
+						? gmdate( 'r', $sync_status_value ) : $sync_status_value;
 			}
 			$debug_info['full_sync'] = array(
 				'label'   => 'Full Sync Status',

--- a/_inc/lib/debugger/jetpack-debugger-site-health.js
+++ b/_inc/lib/debugger/jetpack-debugger-site-health.js
@@ -5,7 +5,7 @@
 
 jQuery( document ).ready( function( $ ) {
 	var JetpackSync = {
-		inProgress: false,
+		inProgress: true,
 		progressPercent: 0,
 		interval: false,
 		init: function() {
@@ -14,12 +14,12 @@ jQuery( document ).ready( function( $ ) {
 			JetpackSync.interval = setInterval( JetpackSync.checkProgress, 3000 );
 			$( 'body' ).on(
 				'click',
-				'[aria-controls=health-check-accordion-block-jetpack_test__sync_health]',
+				'[aria-controls=health-check-accordion-block-jetpack_test__full_sync_health]',
 				JetpackSync.setProgress
 			);
 		},
 		accordionButton: function() {
-			return $( '[aria-controls=health-check-accordion-block-jetpack_test__sync_health]' );
+			return $( '[aria-controls=health-check-accordion-block-jetpack_test__full_sync_health]' );
 		},
 		accordionIsOpen: function() {
 			return JetpackSync.accordionButton().attr( 'aria-expanded' );
@@ -63,7 +63,9 @@ jQuery( document ).ready( function( $ ) {
 	};
 
 	if ( jetpackSiteHealth.progressPercent ) {
-		JetpackSync.init();
+		setTimeout( function() {
+			JetpackSync.init();
+		}, 5000 );
 	}
 
 	$( 'body' ).on( 'click', '#full_sync_request_link', function() {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -63,7 +63,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 			$cxntests->output_results_for_cli();
 
-			WP_CLI::error( __( 'Jetpack connection is broken.', 'jetpack' ) ); // Exit CLI.
+			WP_CLI::error( __( 'One or more tests did not pass. Please investigate!', 'jetpack' ) ); // Exit CLI.
 		}
 
 		/* translators: %s is current version of Jetpack, for example 7.3 */


### PR DESCRIPTION
Fixes p9F6qB-56a-p2

While working through a master issue of unexpected debugging reports, spotted a few tweaks that could help improve the readability of the debugger results and reduce false fails.

#### Changes proposed in this Pull Request:
* Increase the priority for the http_timeout override to PHP_INT_MAX - 1 to reduce potential conflict from other plugins (setting the timeout later than us, but at a shorter value).
* Remove the "broken" language in the CLI results. A failed test, now that we have sync health, may not indicate a "broken connection".
* Moved Full Sync output to its own test__full_sync_health
* Modified CLI output for Full Sync to display current progress %
* Modified Sync output to "skipped" for all cases
* Modified CLI output suggesting performing a Full Sync when Sync Health is out of sync.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Jetpack + Connected Site
* Add a mu-plugin with `add_filter( 'http_request_timeout', function() { return 1;}, 11 );
* Run `wp jetpack status` 
* Before this PR, the wpcom_connection_test will likely fail with a timeout.
* Before this PR, the CLI will report that the Jetpack connection is broken.
* After this PR, WP.com should return an expected value (fail/pass based on the jetpack.com debugger).
* After this PR, the CLI will report that "1 or more tests have failed."

#### Proposed changelog entry for your changes:
* Debugger: Reduce false failures.
