### PR TITLE
Recipe shortcode: on AMP, change the Print link

### DIFF
--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -53,6 +53,11 @@ class Jetpack_Recipes {
 			$allowedtags[ $tag ]['datetime'] = array();
 		}
 
+		// In AMP, allow the handler <a on="">.
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			$allowedtags['a']['on'] = array();
+		}
+
 		// Allow itemscope and itemtype for divs.
 		if ( ! isset( $allowedtags['div'] ) ) {
 			$allowedtags['div'] = array();
@@ -103,6 +108,11 @@ class Jetpack_Recipes {
 
 		// add $themecolors-defined styles.
 		wp_add_inline_style( 'jetpack-recipes-style', self::themecolor_styles() );
+
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		wp_enqueue_script(
 			'jetpack-recipes-printthis',
 			Assets::get_file_url_for_environment( '_inc/build/shortcodes/js/recipes-printthis.min.js', 'modules/shortcodes/js/recipes-printthis.js' ),
@@ -254,9 +264,13 @@ class Jetpack_Recipes {
 			}
 
 			if ( 'false' !== $atts['print'] ) {
-				$html .= sprintf(
-					'<li class="jetpack-recipe-print"><a href="#">%1$s</a></li>',
-					esc_html_x( 'Print', 'recipe', 'jetpack' )
+				$is_amp       = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+				$print_action = $is_amp ? 'on="tap:AMP.print"' : '';
+				$print_text   = $is_amp ? esc_html_x( 'Print page', 'recipe', 'jetpack' ) : esc_html_x( 'Print', 'recipe', 'jetpack' );
+				$html        .= sprintf(
+					'<li class="jetpack-recipe-print"><a href="#" %1$s>%2$s</a></li>',
+					$print_action,
+					$print_text
 				);
 			}
 

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -53,10 +53,8 @@ class Jetpack_Recipes {
 			$allowedtags[ $tag ]['datetime'] = array();
 		}
 
-		// In AMP, allow the handler <a on="">.
-		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-			$allowedtags['a']['on'] = array();
-		}
+		// Allow the handler <a on=""> in AMP.
+		$allowedtags['a']['on'] = array();
 
 		// Allow itemscope and itemtype for divs.
 		if ( ! isset( $allowedtags['div'] ) ) {

--- a/modules/shortcodes/recipe.php
+++ b/modules/shortcodes/recipe.php
@@ -266,7 +266,7 @@ class Jetpack_Recipes {
 			if ( 'false' !== $atts['print'] ) {
 				$is_amp       = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
 				$print_action = $is_amp ? 'on="tap:AMP.print"' : '';
-				$print_text   = $is_amp ? esc_html_x( 'Print page', 'recipe', 'jetpack' ) : esc_html_x( 'Print', 'recipe', 'jetpack' );
+				$print_text   = $is_amp ? esc_html__( 'Print page', 'jetpack' ) : esc_html_x( 'Print', 'recipe', 'jetpack' );
 				$html        .= sprintf(
 					'<li class="jetpack-recipe-print"><a href="#" %1$s>%2$s</a></li>',
 					$print_action,

--- a/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/tests/php/modules/shortcodes/test-class.recipe.php
@@ -7,15 +7,19 @@
 class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 
 	/**
+	 * The tested instance.
+	 *
+	 * @var Jetpack_Recipes
+	 */
+	public $instance;
+
+	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
 	public function setUp() {
-		// Run hook to load shortcode.
-		do_action( 'init' );
-
-		// Reset data.
-		wp_reset_postdata();
-		parent::tearDown();
+		parent::setUp();
+		$this->instance = new Jetpack_Recipes();
+		$this->instance->action_init();
 	}
 
 	/**
@@ -36,9 +40,12 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 * @since 8.5.0
 	 */
 	public function test_add_scripts() {
-		$GLOBALS['posts'] = array( $this->factory()->post->create_and_get( array( 'post_content' => '[recipe]' ) ) );
-		$instance         = new Jetpack_Recipes();
-		$instance->add_scripts();
+		global $posts;
+
+		$post = new stdClass();
+		$post->post_content = '[recipe]';
+		$posts              = array( $post );
+		$this->instance->add_scripts();
 
 		$this->assertTrue( wp_style_is( 'jetpack-recipes-style' ) );
 		$this->assertTrue( wp_script_is( 'jetpack-recipes-printthis' ) );
@@ -51,10 +58,13 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 * @since 8.5.0
 	 */
 	public function test_add_scripts_amp() {
+		global $posts;
+
 		add_filter( 'jetpack_is_amp_request', '__return_true' );
-		$GLOBALS['posts'] = array( $this->factory()->post->create_and_get( array( 'post_content' => '[recipe]' ) ) );
-		$instance         = new Jetpack_Recipes();
-		$instance->add_scripts();
+		$post = new stdClass();
+		$post->post_content = '[recipe]';
+		$posts              = array( $post );
+		$this->instance->add_scripts();
 
 		$this->assertTrue( wp_style_is( 'jetpack-recipes-style' ) );
 		$this->assertFalse( wp_script_is( 'jetpack-recipes-printthis' ) );

--- a/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/tests/php/modules/shortcodes/test-class.recipe.php
@@ -14,7 +14,9 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	public $instance;
 
 	/**
-	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 * Set up each test.
+	 *
+	 * @inheritDoc
 	 */
 	public function setUp() {
 		parent::setUp();

--- a/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/tests/php/modules/shortcodes/test-class.recipe.php
@@ -30,7 +30,6 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 	 * @inheritDoc
 	 */
 	public function tearDown() {
-		wp_dequeue_style( 'jetpack-recipes-js' );
 		wp_dequeue_script( 'jetpack-recipes-js' );
 		wp_dequeue_script( 'jetpack-recipes-printthis' );
 		parent::tearDown();

--- a/tests/php/modules/shortcodes/test-class.recipe.php
+++ b/tests/php/modules/shortcodes/test-class.recipe.php
@@ -27,6 +27,7 @@ class WP_Test_Jetpack_Shortcodes_Recipe extends WP_UnitTestCase {
 		wp_dequeue_style( 'jetpack-recipes-js' );
 		wp_dequeue_script( 'jetpack-recipes-js' );
 		wp_dequeue_script( 'jetpack-recipes-printthis' );
+		parent::tearDown();
 	}
 
 	/**
@@ -408,7 +409,7 @@ EOT;
 	}
 
 	/**
-	 * Verify that the recipe shortcode allows needed content via KSES.
+	 * Test the [recipe] shortcode on an AMP endpoint.
 	 *
 	 * @dataProvider get_data_recipe_amp
 	 * @since 8.5.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* For the [Recipe shortcode](https://wordpress.com/support/recipes/) in AMP, changes the 'Print' link to 'Print page,' and it now prints the entire page 
* No intended change to non-AMP
* In AMP, it's not possible to only print only the recipe, like on non-AMP
* Printing only the recipe is [done with a jQuery plugin](https://href.li/?https://github.com/Automattic/jetpack/blob/feeadafa22309b7cf0d77077c0354d9df1f74eda/modules/shortcodes/js/recipes-printthis.js).
* Even `<amp-script>` doesn't look possible here, as it [doesn't allow](https://amp.dev/documentation/components/amp-script/#creating-amp-elements) creating an `<iframe>`


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This enhances an existing feature
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here:
pbIAo1-1m-p2

#### Testing instructions:
1. Ensure the [AMP plugin](https://wordpress.org/plugins/amp/) is active
2. In AMP > Settings, select Transitional mode
3. In Jetpack > Settings > Writing, ensure this is toggled on:

![settings-writing-sharing](https://user-images.githubusercontent.com/4063887/79644130-879ebe00-816c-11ea-9ae1-bbec1805c1f4.png)

4. Create a new post
5. Add a shortcode block with this, taken from the [documentation](https://wordpress.com/support/recipes/)
```html
[recipe title="Summer Pasta with Basil, Tomatoes and Cheese" servings="4-6" preptime="20 mins" cooktime="10 mins" difficulty="easy" rating="★★★★★" image="https://en-support.files.wordpress.com/2014/01/food-dinner-pasta-broccoli.jpg" description="A fresh, light, Italian-inspired pasta recipe perfect for a late summer dinner."]
[recipe-notes]
Credit: allrecipes.com
[/recipe-notes][recipe-ingredients]
– 2 pounds vine ripened tomatoes
– 3 cloves garlic
– 1/2 cup chopped fresh basil
[/recipe-ingredients][recipe-directions]
1. In a medium bowl, toss together tomatoes, garlic, basil, mint, salt and black pepper.
2. Cook and drain pasta.
3. Mix together.
[/recipe-directions][recipe-nutrition] Per Serving: 580 calories; 33 g fat; 50.6 g carbohydrates; 20.3 g protein; 50 mg cholesterol; 760 mg sodium. [/recipe-nutrition]
[/recipe]
```
6. Preview the non-AMP front-end
7. Preview the AMP front-end
8. Expected: the AMP front-end looks the same, except it has a 'Print page' link, not 'Print':

![recipe-in-amp](https://user-images.githubusercontent.com/4063887/79644234-33480e00-816d-11ea-8a3f-da2ce6bf299f.png)

9. Expected: clicking 'Print page' prints the entire page

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve AMP compatibility of Recipe shortcode
