### PR TITLE
Multisite: Check for the Beta Plugin managed version

### DIFF
--- a/class.jetpack-network-sites-list-table.php
+++ b/class.jetpack-network-sites-list-table.php
@@ -82,7 +82,8 @@ class Jetpack_Network_Sites_List_Table extends WP_List_Table {
 
 		switch_to_blog( $item->blog_id );
 
-		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
+		// Checks for both the stock version of Jetpack and the one managed by the Jetpack Beta Plugin.
+		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) && ! is_plugin_active( 'jetpack-dev/jetpack.php' ) ) {
 			$title  = __( 'Jetpack is not active on this site.', 'jetpack' );
 			$action = array(
 				'manage-plugins' => '<a href="' . get_admin_url( $item->blog_id, 'plugins.php', 'admin' ) . '">' . __( 'Manage Plugins', 'jetpack' ) . '</a>',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* For the Sites list table in Network Admin when Jetpack (beta version via the beta plugin) is network-activated, show all sites where either Jetpack stock or Jetpack beta is active.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Multisite with multiple subsites
* Network activate Jetpack
* Before PR, unable to manage subsites (see screeshot)
* After PR, able to manage subsites.

#### Proposed changelog entry for your changes:
* Beta: When using a beta version of Jetpack via the Jetpack Beta Plugin, allow subsite connections to be managed in Network Admin.

![2020-04-19 at 3 06 PM](https://user-images.githubusercontent.com/88897/79698688-25b78480-8250-11ea-96ac-ed2f6a2cc33f.png)

