### PR TITLE
Comments: update default comment type

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -102,9 +102,14 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 	 */
 	function get_site_tree_total_count( $status, $type ) {
 		global $wpdb;
+
 		$db_status = $this->get_comment_db_status( $status );
-		$type = $this->get_sanitized_comment_type( $type );
-		// An empty value in the comments_type column denotes a regular comment.
+		$type      = $this->get_sanitized_comment_type( $type );
+
+		/*
+		 * An empty value in the comments_type column denotes a regular comment in WP 5.5-
+		 * @to-do: remove empty value logic when the minimum required WP is 5.5.
+		 */
 		$type = ( 'comment' === $type ) ? 'comment' : $type;
 
 		$result = $wpdb->get_var(
@@ -112,8 +117,10 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 				"SELECT COUNT(1) " .
 				"FROM $wpdb->comments AS comments " .
 				"INNER JOIN $wpdb->posts AS posts ON comments.comment_post_ID = posts.ID " .
-				"WHERE comment_type = %s AND ( %s = 'all' OR comment_approved = %s )",
-				$type, $db_status, $db_status
+				"WHERE comment_type %s AND ( %s = 'all' OR comment_approved = %s )",
+				( 'comment' === $type ? "in ( '', 'comment' )" : '= ' . $type ),
+				$db_status,
+				$db_status
 			)
 		);
 		return intval( $result );

--- a/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-comments-tree-endpoint.php
@@ -105,7 +105,7 @@ class WPCOM_JSON_API_Get_Comments_Tree_Endpoint extends WPCOM_JSON_API_Endpoint 
 		$db_status = $this->get_comment_db_status( $status );
 		$type = $this->get_sanitized_comment_type( $type );
 		// An empty value in the comments_type column denotes a regular comment.
-		$type = ( 'comment' === $type ) ? '' : $type;
+		$type = ( 'comment' === $type ) ? 'comment' : $type;
 
 		$result = $wpdb->get_var(
 			$wpdb->prepare(

--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -254,7 +254,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 			'comment_author_url'   => $user->user_url,
 			'comment_content'      => $input['content'],
 			'comment_parent'       => $comment_parent_id,
-			'comment_type'         => '',
+			'comment_type'         => 'comment',
 		);
 
 		if ( $comment_parent_id ) {

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -687,7 +687,7 @@ class Jetpack_Carousel {
 			'comment_author_email' => $email,
 			'comment_author_url'   => $url,
 			'comment_approved'     => 0,
-			'comment_type'         => '',
+			'comment_type'         => 'comment',
 		);
 
 		if ( ! empty( $user_id ) ) {

--- a/modules/sitemaps/sitemap-librarian.php
+++ b/modules/sitemaps/sitemap-librarian.php
@@ -306,7 +306,7 @@ class Jetpack_Sitemap_Librarian {
 			$wpdb->prepare(
 				"SELECT MAX(comment_date_gmt)
 					FROM $wpdb->comments
-					WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type=''",
+					WHERE comment_post_ID = %d AND comment_approved = '1' AND comment_type in ( '', 'comment' )",
 				$post_id
 			)
 		);

--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -174,7 +174,7 @@ class Comments extends Module {
 		 */
 		return apply_filters(
 			'jetpack_sync_whitelisted_comment_types',
-			array( '', 'trackback', 'pingback' )
+			array( '', 'comment', 'trackback', 'pingback' )
 		);
 	}
 

--- a/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
+++ b/tests/php/sync/server/class.jetpack-sync-test-object-factory.php
@@ -28,7 +28,7 @@ class JetpackSyncTestObjectFactory {
 		'comment_author_url'   => 'http://example.com',
 		'comment_content'      => 'Hi there!',
 		'comment_approved'     => '1',
-		'comment_type'         => '',
+		'comment_type'         => 'comment',
 		'comment_author_IP'    => '',
 		'comment_karma'        => '0',
 		'comment_agent'        => '',

--- a/tests/php/sync/test_class.jetpack-sync-woocommerce.php
+++ b/tests/php/sync/test_class.jetpack-sync-woocommerce.php
@@ -15,9 +15,9 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		parent::setUpBeforeClass();
 
 		if ( "1" != getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
-			return; 
-		} 
-		
+			return;
+		}
+
 		self::$woo_enabled = true;
 
 		$woo_tests_dir = dirname( __FILE__ ) . '/../../../../woocommerce/tests';
@@ -104,7 +104,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 
 		// pay
 		$order->payment_complete( '12345' );
-		
+
 		// just for fun
 		$this->assertEquals( 'completed', $order->get_status() );
 		$this->assertEquals( '12345', $order->get_transaction_id() );
@@ -125,7 +125,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$create_order_item_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_new_order_item' );
-		
+
 		$this->assertTrue( !! $create_order_item_event );
 		$this->assertEquals( $order_item->get_id(), $create_order_item_event->args[0] );
 		$this->assertHasOrderItemProperties( $create_order_item_event->args[1], $order_item );
@@ -144,7 +144,7 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$update_order_item_event = $this->server_event_storage->get_most_recent_event( 'woocommerce_update_order_item' );
-		
+
 		$this->assertTrue( !! $update_order_item_event );
 		$this->assertEquals( $order_item->get_id(), $update_order_item_event->args[0] );
 		$this->assertHasOrderItemProperties( $update_order_item_event->args[1], $order_item );
@@ -173,9 +173,16 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_approving_a_review_is_synced() {
-		$post_id = $this->factory->post->create();
-		$review_ids = $this->factory->comment->create_post_comments( $post_id, 1, array( 'comment_type' => 'review', 'comment_approved' => 0 ) );
-		$review = get_comment( $review_ids[0] );
+		$post_id    = $this->factory->post->create();
+		$review_ids = $this->factory->comment->create_post_comments(
+			$post_id,
+			1,
+			array(
+				'comment_type'     => 'review',
+				'comment_approved' => 0,
+			)
+		);
+		$review     = get_comment( $review_ids[0] );
 
 		$this->sender->do_sync();
 
@@ -273,8 +280,8 @@ class WP_Test_Jetpack_Sync_WooCommerce extends WP_Test_Jetpack_Sync_Base {
 		foreach( $synced_order_items as $synced_order_item ) {
 			if ( $order1_item->get_id() == $synced_order_item->order_item_id ) {
 				$this->assertHasOrderItemProperties( $synced_order_item, $order1_item );
-				$found_order_item_1 = true;	
-				continue;	
+				$found_order_item_1 = true;
+				continue;
 			}
 
 			if ( $order2_item->get_id() == $synced_order_item->order_item_id ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This is to bring us in line with recent core changes:

https://core.trac.wordpress.org/changeset/47597
https://core.trac.wordpress.org/ticket/49236

> Use `comment` instead of an empty string for the `comment_type` DB field value in comments table.

#### Testing instructions:

* Do the tests pass?
* Can you post comments on a Carousel modal? Are they saved in the db properly?

#### Proposed changelog entry for your changes:

* Comments: update how comment types are stored to be fully compatible with upcoming WordPress Core changes.
