### PR TITLE
Store Product List: Stop setting attributes on the Store_Product class object to fill in data for the API responses

### DIFF
--- a/_inc/lib/plans.php
+++ b/_inc/lib/plans.php
@@ -23,7 +23,7 @@ class Jetpack_Plans {
 				require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
 			}
 
-			return Store_Product_List::get_active_plans_v1_5();
+			return Store_Product_List::api_only_get_active_plans_v1_4();
 		}
 
 		// We're on Jetpack, so it's safe to use this namespace.


### PR DESCRIPTION

Differential Revision: D41787-code

This commit syncs r206104-wpcom.

#### Changes proposed in this Pull Request:

This makes updates to the methods in Store_Product_List that were previously setting different attributes on the Store_Product to generate responses for the API endpoints.
Instead, this is now generating generic objects to be used as DTO's for the purpose of the API.

This did require updating some methods outside of the Store_Product_List to make sure they were using the methods that returned Store_Products[] vs the DTO's where necessary.

#### Testing instructions:

Built in tests.

I also applied D41723-code, which can be used to generate JSON output from the API endpoints that use the Store_Product_List and can be compared before and after applying this patch.

#### Proposed changelog entry for your changes:

* N/A
