### PR TITLE
Podcast Player: Improve themes compatibility

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -112,6 +112,7 @@ $player-background: transparent;
 		display: flex;
 		flex-direction: column;
 		margin: 0;
+		padding: 0;
 		overflow: hidden;
 		letter-spacing: 0; // Fixes Twenty Twenty compressed text.
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -73,11 +73,13 @@ $player-background: transparent;
 		a {
 			box-shadow: none;
 			text-decoration: none;
+			border: none;
 	
 			&:hover,
 			&:focus {
 				box-shadow: none;
 				text-decoration: none;
+				border: none;
 			}
 		}
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -66,6 +66,20 @@ $player-background: transparent;
 		--jetpack-podcast-player-primary: #{$jetpack-podcast-player-primary};
 		--jetpack-podcast-player-secondary: #{$jetpack-podcast-player-secondary};
 		--jetpack-podcast-player-background: #{$jetpack-podcast-player-background};
+
+		/**
+		 * Override to address themes using text-decoration or box-shadow underlines on links.
+		 */
+		a {
+			box-shadow: none;
+			text-decoration: none;
+	
+			&:hover,
+			&:focus {
+				box-shadow: none;
+				text-decoration: none;
+			}
+		}
 	}
 
 	/**
@@ -124,7 +138,6 @@ $player-background: transparent;
 	}
 
 	a.jetpack-podcast-player__podcast-title {
-		text-decoration: none;
 
 		&:hover,
 		&:focus {
@@ -229,16 +242,6 @@ $player-background: transparent;
 		&:hover,
 		&:focus {
 			color: inherit;
-		}
-	}
-
-	// The tag name increases specificity to override some themes/editor styles.
-	a.jetpack-podcast-player__track-link {
-		text-decoration: none;
-
-		&:hover,
-		&:focus {
-			text-decoration: none;
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -105,6 +105,9 @@ $player-background: transparent;
 	.jetpack-podcast-player__cover-image {
 		width: $cover-image-size;
 		height: $cover-image-size;
+		padding: 0;
+		border: 0;
+		max-width: 100%;
 	}
 
 	// The tag name increases specificity to override some themes/editor styles.
@@ -240,6 +243,7 @@ $player-background: transparent;
 		transition: none;
 		color: inherit;
 
+		&:visited,
 		&:hover,
 		&:focus {
 			color: inherit;
@@ -345,7 +349,8 @@ $player-background: transparent;
 	.mejs-container,
 	.mejs-embed,
 	.mejs-embed body,
-	.mejs-container .mejs-controls {
+	.mejs-container .mejs-controls,
+	.mejs-mediaelement {
 		background-color: $player-background;
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -40,7 +40,6 @@ $player-background: transparent;
 	border: 1px solid $block-border-color;
 	background-color: $block-bg-color;
 	overflow: hidden;
-	font-family: $default-font;
 
 	/**
 	 * Player's state classes added to this element:
@@ -187,7 +186,6 @@ $player-background: transparent;
 
 	.jetpack-podcast-player__track {
 		margin: 0;
-		font-family: $default-font;
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 
@@ -280,7 +278,6 @@ $player-background: transparent;
 		margin-left: ($player-grid-spacing - 2px) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
 		margin-bottom: $track-h-padding;
 		color: $alert-red;
-		font-family: $default-font;
 		font-size: 0.8em;
 		font-weight: normal;
 
@@ -316,7 +313,6 @@ $player-background: transparent;
 		padding: $player-grid-spacing;
 		margin: 0;
 		color: $alert-red;
-		font-family: $default-font;
 		font-size: 0.8em;
 		font-weight: normal;
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -74,7 +74,7 @@ $player-background: transparent;
 			box-shadow: none;
 			text-decoration: none;
 			border: none;
-	
+
 			&:hover,
 			&:focus {
 				box-shadow: none;
@@ -144,6 +144,11 @@ $player-background: transparent;
 	}
 
 	a.jetpack-podcast-player__podcast-title {
+		&,
+		&:active,
+		&:visited {
+			color: $text-color;
+		}
 
 		&:hover,
 		&:focus {
@@ -155,6 +160,16 @@ $player-background: transparent;
 	.has-secondary {
 		.jetpack-podcast-player__podcast-title {
 			color: currentColor;
+		}
+
+		a.jetpack-podcast-player__podcast-title {
+			&,
+			&:hover,
+			&:focus,
+			&:active,
+			&:visited {
+				color: currentColor;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/15469
Fixes https://github.com/Automattic/jetpack/issues/15478

Except for:
- Twenty Thirteen editor mejs background. Front-end is fine.
- Twenty Fourteen mejs player which includes a lot of customizations to the mejs player. We'd have to bump the specificity a bit and add quite a few overrides. Maybe it's best not to touch that one unless there's strong data to suggest fixing it.

We've decided not to fix the Twenty Thirteen or Twenty Fourteen mejs player issues: https://github.com/Automattic/jetpack/issues/15478#issuecomment-617384963



**Global Styles in action**
![podcast-player-global-styles](https://user-images.githubusercontent.com/967608/79872553-8c9d8080-83ab-11ea-88af-f1bf02eee6a7.gif)

**Twenty Fifteen (and others) that used `text-decoration` or `box-shadow` or `border-bottom` styles on links**
| before  | after |
| ------------- | ------------- |
| <img width="722" alt="Screen Shot 2020-04-21 at 2 09 35 PM" src="https://user-images.githubusercontent.com/967608/79905610-20874080-83dc-11ea-8f96-42f63cb0033b.png"> | <img width="720" alt="Screen Shot 2020-04-21 at 2 15 18 PM" src="https://user-images.githubusercontent.com/967608/79905550-0b121680-83dc-11ea-8530-04258c7cfb76.png">|






#### Changes proposed in this Pull Request:
* Removes `font-family` declarations from the CSS so that the theme's (and hopefully global styles) fonts will be applied.
* Adds minor CSS overrides for consistency. These are added into this PR to make it easier overall for testing, as they are minor and require a large amount of themes to test against. Hopefully this will save us time overall.
  * Sets a visited link color
  * Makes sure the podcast title inherits secondary color
  * Adds another mejs classname to the background color styling
  * Removes borders, text-decoration, and box-shadows on links
  * Removes padding on h2
  * Removes padding and border, and sets a max-width on the image

#### Testing instructions:
* Add a podcast block to your site
* Check that the podcast player looks correct in the frontend and editor canvas and that it utilizes the theme's fonts for the Podcast Player block.

#### Themes tested:
- [x] Twenty Eleven
- [x] Twenty Twelve
- [x] Twenty Thirteen (known that editor background color on mejs player is not applied)
- [x] Twenty Fourteen (known that it does not look right. Can be addressed in follow-up PR if necessary).
- [x] Twenty Fifteen
- [x] Twenty Sixteen
- [x] Twenty Seventeen
- [x] Twenty Nineteen 
- [x] Twenty Twenty
- [x] Varia
- [x] Maywood
- [x] Barnsbury
- [x] Dalston
- [x] Rivington
- [x] Mayland
- [x] Balasana
- [x] Shawburn
- [ ] Alvez (didn't test due to missing stylesheet error)
- [x] Exford
- [x] Rockfield
- [x] Stratford
- [x] Coutoire
- [x] Morden
- [x] Stow
- [x] Leven
- [ ] Bromton (didn't test due to missing stylesheet error)
- [x] Redhill

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Use the theme's fonts in the Podcast Player
* Improves styling consistency amongst themes
