### PR TITLE
Sharing: Verify IS_WPCOM before using WP.com function

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -3,7 +3,7 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Sync\Settings;
 
-include_once dirname( __FILE__ ) . '/sharing-sources.php';
+require_once dirname( __FILE__ ) . '/sharing-sources.php';
 
 define( 'WP_SHARING_PLUGIN_VERSION', JETPACK__VERSION );
 
@@ -74,6 +74,7 @@ class Sharing_Service {
 		 * Filters if Email Sharing is enabled.
 		 *
 		 * E-Mail sharing is often problematic due to spam concerns, so this filter enables it to be quickly and simply toggled.
+		 *
 		 * @module sharedaddy
 		 *
 		 * @since 5.1.0
@@ -132,7 +133,8 @@ class Sharing_Service {
 
 			// Create a custom service and set the options for it
 			$service = new Share_Custom(
-				$service_id, array(
+				$service_id,
+				array(
 					'name' => $label,
 					'url'  => $url,
 					'icon' => $icon,
@@ -192,7 +194,8 @@ class Sharing_Service {
 		 * }
 		 */
 		do_action(
-			'sharing_get_services_state', array(
+			'sharing_get_services_state',
+			array(
 				'services'          => $services,
 				'available'         => $available,
 				'hidden'            => $hidden,
@@ -202,7 +205,8 @@ class Sharing_Service {
 		);
 
 		return update_option(
-			'sharing-services', array(
+			'sharing-services',
+			array(
 				'visible' => $visible,
 				'hidden'  => $hidden,
 			)
@@ -217,6 +221,7 @@ class Sharing_Service {
 		/**
 		 * Check if options exist and are well formatted.
 		 * This avoids issues on sites with corrupted options.
+		 *
 		 * @see https://github.com/Automattic/jetpack/issues/6121
 		 */
 		if ( ! is_array( $options ) || ! isset( $options['button_style'], $options['global'] ) ) {
@@ -445,7 +450,8 @@ class Sharing_Service {
 		 * }
 		 */
 		do_action(
-			'sharing_get_button_state', array(
+			'sharing_get_button_state',
+			array(
 				'id'      => $id,
 				'options' => $options,
 				'service' => $service,

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -953,6 +953,11 @@ function sharing_display( $text = '', $echo = false ) {
 	}
 }
 
+/**
+ * Returns the language code for Recaptcha to use.
+ *
+ * @return string Language code, 'en' if none found.
+ */
 function get_base_recaptcha_lang_code() {
 
 	$base_recaptcha_lang_code_mapping = array(
@@ -970,12 +975,12 @@ function get_base_recaptcha_lang_code() {
 		'tr'    => 'tr',
 	);
 
-	$blog_lang_code = function_exists( 'get_blog_lang_code' ) ? get_blog_lang_code() : get_bloginfo( 'language' );
+	$blog_lang_code = ( defined( 'IS_WPCOM' ) && IS_WPCOM && function_exists( 'get_blog_lang_code' ) ) ? get_blog_lang_code() : get_bloginfo( 'language' );
 	if ( isset( $base_recaptcha_lang_code_mapping[ $blog_lang_code ] ) ) {
 		return $base_recaptcha_lang_code_mapping[ $blog_lang_code ];
 	}
 
-	// if no base mapping is found return default 'en'
+	// if no base mapping is found return default 'en'.
 	return 'en';
 }
 


### PR DESCRIPTION
Fixes #9767 

`get_blog_lang_code` is a WP.com function that we were simply checking it if exists before executing. On VIP Go, as a transition shim, it defines the function along with a deprecated call.

To assist transitioning VIPs, let's verify we're actually on WP.com.

#### Changes proposed in this Pull Request:
* Adds a `IS_WPCOM` check.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* On VIP Go, verify the warning in 9767 is not thrown.
*

#### Proposed changelog entry for your changes:
* None needed, but if really need one: "Sharing: adds checks before executing WP.com-based code."
