### PR TITLE
Podcast Player: Fix missing replace button

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -14,6 +14,7 @@ import {
 	Placeholder,
 	RangeControl,
 	TextControl,
+	Toolbar,
 	ToolbarGroup,
 	withNotices,
 	ToggleControl,
@@ -256,14 +257,29 @@ const PodcastPlayerEdit = ( {
 	return (
 		<>
 			<BlockControls>
-				<ToolbarGroup>
-					<Button
-						aria-label={ __( 'Edit Podcast Feed URL', 'jetpack' ) }
-						onClick={ () => setIsEditing( true ) }
-					>
-						{ __( 'Replace', 'jetpack' ) }
-					</Button>
-				</ToolbarGroup>
+				{ /* @todo Fallback can be removed when WP 5.4 is the minimum supported version. */ }
+				{ ToolbarGroup ? (
+					<ToolbarGroup>
+						<Button
+							aria-label={ __( 'Edit Podcast Feed URL', 'jetpack' ) }
+							onClick={ () => setIsEditing( true ) }
+						>
+							{ __( 'Replace', 'jetpack' ) }
+						</Button>
+					</ToolbarGroup>
+				) : (
+					<Toolbar
+						controls={ [
+							{
+								title: __( 'Edit Podcast Feed URL', 'jetpack' ),
+								onClick: () => setIsEditing( true ),
+								extraProps: {
+									children: __( 'Replace', 'jetpack' ),
+								},
+							},
+						] }
+					/>
+				) }
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -14,7 +14,7 @@ import {
 	Placeholder,
 	RangeControl,
 	TextControl,
-	Toolbar,
+	ToolbarGroup,
 	withNotices,
 	ToggleControl,
 	Spinner,
@@ -235,16 +235,6 @@ const PodcastPlayerEdit = ( {
 		);
 	}
 
-	const toolbarControls = [
-		{
-			title: __( 'Edit Podcast Feed URL', 'jetpack' ),
-			onClick: () => setIsEditing( true ),
-			extraProps: {
-				children: __( 'Replace', 'jetpack' ),
-			},
-		},
-	];
-
 	// Loading state for fetching the feed.
 	if ( ! feedData.tracks || ! feedData.tracks.length ) {
 		return (
@@ -266,7 +256,14 @@ const PodcastPlayerEdit = ( {
 	return (
 		<>
 			<BlockControls>
-				<Toolbar controls={ toolbarControls } />
+				<ToolbarGroup>
+					<Button
+						aria-label={ __( 'Edit Podcast Feed URL', 'jetpack' ) }
+						onClick={ () => setIsEditing( true ) }
+					>
+						{ __( 'Replace', 'jetpack' ) }
+					</Button>
+				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

As reported in https://github.com/Automattic/jetpack/issues/15459 with Gutenberg 7.9 the `Replace` button in the podcast player block is not visible anymore. The source of the change could be traced down to [this commit](https://github.com/WordPress/gutenberg/pull/21252/files#diff-79abb3d6d15fcdde19979cde85e9d2ac).

This PR suggests changing our implementation to be in line with how the same button is handled in `MediaReplaceFlow` which is used in the `image` block.

Fixes https://github.com/Automattic/jetpack/issues/15459

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post and add the `Podcast player (beta)` block
* Add a podcast URL
* See if the replace button is visible
* Try to replace the podcast URL

| Before  | After |
| ------------- | ------------- |
| <img width="113" alt="Screenshot 2020-04-21 at 15 58 00" src="https://user-images.githubusercontent.com/1562646/79874789-10299280-83e9-11ea-8165-2ff3d14cab7c.png"> | <img width="146" alt="Screenshot 2020-04-21 at 15 58 14" src="https://user-images.githubusercontent.com/1562646/79874809-161f7380-83e9-11ea-8b02-668b6db5e74e.png"> |



