### PR TITLE
Podcast Player: Show header template even if no cover art is available

### DIFF
--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -35,8 +35,9 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 			<div class="jetpack-podcast-player__cover">
 				<img class="jetpack-podcast-player__cover-image" src="<?php echo esc_url( $cover ); ?>" alt="" />
 			</div>
+		<?php endif; ?>
 
-			<?php
+		<?php
 			render(
 				'podcast-header-title',
 				array(
@@ -48,7 +49,6 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 				)
 			);
 			?>
-		<?php endif; ?>
 	</div>
 
 	<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves the `podcast-header-title` template rendering outside of the `$show_cover_art` `if` statement so that the title will show even if no cover art is available.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

| before  | after |
| ------------- | ------------- |
|<img width="781" alt="Screen Shot 2020-04-21 at 8 58 52 AM" src="https://user-images.githubusercontent.com/967608/79875192-e6537a00-83ae-11ea-89b1-33fcd6657338.png">| <img width="777" alt="Screen Shot 2020-04-21 at 8 58 35 AM" src="https://user-images.githubusercontent.com/967608/79875199-e9e70100-83ae-11ea-8257-1f75647fc30f.png">|


* Create a podcast player block and set the Show Cover Art option to false.
* Publish
* Go to the front-end.
* Turn off JavaScript so you only see the PHP server-side rendered template
* You should see the podcast player titles, but no image. (previously the entire header would be blank)

