### PR TITLE
Crowsignal shortcode: Always attempt to embed survey iframe. Refs D42082

### DIFF
--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -527,16 +527,6 @@ if (
 
 					$settings = array();
 
-					// Do we want a full embed code or a link?
-					if (
-						$no_script
-						|| $inline
-						|| $infinite_scroll
-						|| ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() )
-					) {
-						return $survey_link;
-					}
-
 					if ( 'iframe' === $attributes['type'] ) {
 						if ( 'auto' !== $attributes['height'] ) {
 							if (

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -150,22 +150,6 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 			$shortcode_content
 		);
 		$this->assertTrue( wp_script_is( 'crowdsignal-survey', 'enqueued' ) );
-
-		// Test AMP version. On AMP views, we only show a link.
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			self::markTestSkipped( 'WordPress.com does not run the latest version of the AMP plugin yet.' );
-			return;
-		}
-
-		add_filter( 'jetpack_is_amp_request', '__return_true' );
-		$shortcode_content = do_shortcode( $content );
-		$this->assertEquals(
-			sprintf(
-				'<a href="https://survey.fm/%1$s" target="_blank" rel="noopener noreferrer">Take Our Survey</a>',
-				$id
-			),
-			$shortcode_content
-		);
 	}
 
 	/**


### PR DESCRIPTION
This commit syncs r206118-wpcom. Crowdsignal survey iframes are always loaded, and fallback to a plain link if the load didn't succeed. I removed the `AMP` specific test since the change now outputs the same link with or without `AMP` running.

**Testing instructions:**
 * You'll need a Crowdsignal shortcode to add to a post or two. Here's one `[crowdsignal type="iframe" survey="D29C2F3267E6A603" height="auto" domain="7iger" id="a-phone-number-test"]`
 * Add the shortcode to a post, and view it in the main posts page for a site. The survey should be visible: 

<img width="862" alt="Screen Shot 2020-04-24 at 10 15 39 AM" src="https://user-images.githubusercontent.com/789137/80236019-beb31a80-8617-11ea-8fd5-4e6a81445433.png">

* View the `/amp` version of the post, it should show a simple `Take Our Survey` link:

<img width="837" alt="Screen Shot 2020-04-24 at 10 15 30 AM" src="https://user-images.githubusercontent.com/789137/80236051-d1c5ea80-8617-11ea-95b6-6994a13b54f0.png">

* Enable infinite scroll for a theme that supports it. Depending on how the theme processes shortcodes for asynchronously loaded posts, it will either display the survey (O2/breathe does this), or will show the `Take Our Survey` link.

<img width="831" alt="Screen Shot 2020-04-24 at 10 41 11 AM" src="https://user-images.githubusercontent.com/789137/80236266-25383880-8618-11ea-938a-f3db9634404e.png">


