### PR TITLE
Podcast Player: Clean-up styles & fix few remaining issues

### DIFF
--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -50,7 +50,11 @@ const Header = memo(
 			{ !! ( showEpisodeDescription && track && track.description ) && (
 				<div
 					id={ `${ playerId }__track-description` }
-					className="jetpack-podcast-player__track-description"
+					className={ classnames(
+						'jetpack-podcast-player__track-description',
+						colors.secondary.classes
+					) }
+					style={ { color: colors.secondary.custom } }
 				>
 					{ track.description }
 				</div>
@@ -103,21 +107,22 @@ const PodcastTitle = memo(
 			colors.secondary.classes
 		);
 
-		if ( link ) {
-			return (
-				<a
-					className={ className }
-					style={ { color: colors.secondary.custom } }
-					href={ link }
-					target="_blank"
-					rel="noopener noreferrer nofollow"
-				>
+		return (
+			<span className={ className } style={ { color: colors.secondary.custom } }>
+				{ link ? (
+					<a
+						className="jetpack-podcast-player__link"
+						href={ link }
+						target="_blank"
+						rel="noopener noreferrer nofollow"
+					>
+						{ title }
+					</a>
+				) : (
 					{ title }
-				</a>
-			);
-		}
-
-		return <span className={ className }>{ title }</span>;
+				) }
+			</span>
+		);
 	}
 );
 

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -50,11 +50,7 @@ const Header = memo(
 			{ !! ( showEpisodeDescription && track && track.description ) && (
 				<div
 					id={ `${ playerId }__track-description` }
-					className={ classnames(
-						'jetpack-podcast-player__track-description',
-						colors.secondary.classes
-					) }
-					style={ { color: colors.secondary.custom } }
+					className="jetpack-podcast-player__track-description"
 				>
 					{ track.description }
 				</div>
@@ -100,30 +96,21 @@ const Title = memo(
 	)
 );
 
-const PodcastTitle = memo(
-	( { title, link, colors = { secondary: { name: null, custom: null, classes: '' } } } ) => {
-		const className = classnames(
-			'jetpack-podcast-player__podcast-title',
-			colors.secondary.classes
-		);
-
-		return (
-			<span className={ className } style={ { color: colors.secondary.custom } }>
-				{ link ? (
-					<a
-						className="jetpack-podcast-player__link"
-						href={ link }
-						target="_blank"
-						rel="noopener noreferrer nofollow"
-					>
-						{ title }
-					</a>
-				) : (
-					{ title }
-				) }
-			</span>
-		);
-	}
-);
+const PodcastTitle = memo( ( { title, link } ) => (
+	<span className="jetpack-podcast-player__podcast-title">
+		{ link ? (
+			<a
+				className="jetpack-podcast-player__link"
+				href={ link }
+				target="_blank"
+				rel="noopener noreferrer nofollow"
+			>
+				{ title }
+			</a>
+		) : (
+			{ title }
+		) }
+	</span>
+) );
 
 export default Header;

--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -48,12 +48,12 @@ const Header = memo(
 			 * readers, then visually switching it with the audio player via flex.
 			 */ }
 			{ !! ( showEpisodeDescription && track && track.description ) && (
-				<div
+				<p
 					id={ `${ playerId }__track-description` }
 					className="jetpack-podcast-player__track-description"
 				>
 					{ track.description }
-				</div>
+				</p>
 			) }
 
 			{ /* children contains the audio player */ }

--- a/extensions/blocks/podcast-player/components/track-error.js
+++ b/extensions/blocks/podcast-player/components/track-error.js
@@ -8,12 +8,17 @@
 import { memo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
-const TrackError = memo( ( { link, title } ) => (
+const TrackError = memo( ( { link, title, colors } ) => (
 	<div className="jetpack-podcast-player__track-error">
 		{ __( 'Episode unavailable. ', 'jetpack' ) }
 		{ link && (
-			<span>
-				<a href={ link } rel="noopener noreferrer nofollow" target="_blank">
+			<span className={ colors.secondary.classes } style={ { color: colors.secondary.custom } }>
+				<a
+					className="jetpack-podcast-player__link"
+					href={ link }
+					rel="noopener noreferrer nofollow"
+					target="_blank"
+				>
 					<span className="jetpack-podcast-player--visually-hidden">
 						{ /* Intentional trailing space outside of the translated string. */ }
 						{ `${ sprintf(

--- a/extensions/blocks/podcast-player/components/track.js
+++ b/extensions/blocks/podcast-player/components/track.js
@@ -59,7 +59,7 @@ const Track = memo(
 				style={ Object.keys( inlineStyle ).length ? inlineStyle : null }
 			>
 				<a
-					className="jetpack-podcast-player__track-link"
+					className="jetpack-podcast-player__link jetpack-podcast-player__track-link"
 					href={ track.link }
 					role="button"
 					aria-current={ ariaCurrent }
@@ -100,7 +100,9 @@ const Track = memo(
 						</time>
 					) }
 				</a>
-				{ isActive && isError && <TrackError link={ track.link } title={ track.title } /> }
+				{ isActive && isError && (
+					<TrackError link={ track.link } title={ track.title } colors={ colors } />
+				) }
 			</li>
 		);
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -63,7 +63,8 @@ $jetpack-podcast-player-background: $white;
 		 */
 
 		/**
-		 * Override to address themes using text-decoration or box-shadow underlines on links.
+		 * Override to address themes using text-decoration or box-shadow underlines
+		 * on links.
 		 */
 		a {
 			box-shadow: none;
@@ -77,19 +78,19 @@ $jetpack-podcast-player-background: $white;
 				border: none;
 			}
 		}
-	}
 
-	a.jetpack-podcast-player__link {
-		&,
-		&:active,
-		&:visited {
-			color: inherit;
-		}
+		a.jetpack-podcast-player__link {
+			&,
+			&:active,
+			&:visited {
+				color: inherit;
+			}
 
-		&:hover,
-		&:focus {
-			color: inherit;
-			color: var( --jetpack-podcast-player-primary );
+			&:hover,
+			&:focus {
+				color: inherit;
+				color: var( --jetpack-podcast-player-primary );
+			}
 		}
 	}
 

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -9,8 +9,6 @@ $player-grid-spacing: 24px;
 $cover-image-size: 80px;
 $track-title-font-size: 24px;
 $track-title-b-margin: 10px;
-$podcast-title-font-size: 16px;
-$description-font-size: 16px;
 $track-status-icon-size: 22px;
 $block-border-color: $dark-gray-100;
 $jetpack-podcast-player-primary: $black;
@@ -131,7 +129,7 @@ $jetpack-podcast-player-background: $white;
 	}
 
 	.jetpack-podcast-player__podcast-title {
-		font-size: $podcast-title-font-size;
+		font-size: $editor-font-size;
 		color: $jetpack-podcast-player-secondary;
 		margin: 0;
 	}
@@ -181,7 +179,7 @@ $jetpack-podcast-player-background: $white;
 		order: 99; // high number to make it always appear after the audio player
 		padding: 0 $player-grid-spacing;
 		margin-bottom: $player-grid-spacing;
-		font-size: $description-font-size;
+		font-size: $editor-font-size;
 		line-height: 1.6;
 		color: $dark-gray-500;
 		//crop the description if too long

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -4,7 +4,6 @@
 @import '../../shared/styles/gutenberg-base-styles.scss';
 
 $block-grid-gutter: 24px;
-$block-border-color: $dark-gray-100;
 $cover-image-size: 80px;
 $current-track-title-font-size: 24px;
 $current-track-title-bottom-margin: 10px;
@@ -28,7 +27,6 @@ $jetpack-podcast-player-background: $white;
  * Player's (block) parent element.
  */
 .wp-block-jetpack-podcast-player {
-	border: 1px solid $block-border-color;
 	overflow: hidden;
 
 	audio {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -51,7 +51,7 @@ $jetpack-podcast-player-background: $white;
 		padding-bottom: 0;
 		background-color: var( --jetpack-podcast-player-background );
 
-		&:not(.has-background) {
+		&:not( .has-background ) {
 			background-color: $jetpack-podcast-player-background;
 		}
 
@@ -76,6 +76,20 @@ $jetpack-podcast-player-background: $white;
 				text-decoration: none;
 				border: none;
 			}
+		}
+	}
+
+	a.jetpack-podcast-player__link {
+		&,
+		&:active,
+		&:visited {
+			color: inherit;
+		}
+
+		&:hover,
+		&:focus {
+			color: inherit;
+			color: var( --jetpack-podcast-player-primary );
 		}
 	}
 
@@ -125,46 +139,21 @@ $jetpack-podcast-player-background: $white;
 	.jetpack-podcast-player__current-track-title {
 		font-size: $current-track-title-font-size;
 		margin: 0 0 $current-track-title-bottom-margin;
+		color: var( --jetpack-podcast-player-primary );
 
 		// Apply default color if custom primary has not been set
-		&:not(.has-primary) {
+		&:not( .has-primary ) {
 			color: $jetpack-podcast-player-primary;
 		}
 	}
 
 	.jetpack-podcast-player__podcast-title {
 		font-size: $editor-font-size;
-		color: $jetpack-podcast-player-secondary;
 		margin: 0;
-	}
+		color: var( --jetpack-podcast-player-secondary );
 
-	a.jetpack-podcast-player__podcast-title {
-		&,
-		&:active,
-		&:visited {
+		&:not( .has-secondary ) {
 			color: $jetpack-podcast-player-secondary;
-		}
-
-		&:hover,
-		&:focus {
-			color: $jetpack-podcast-player-primary;
-		}
-	}
-
-	// Apply `secondary` color to the podcast title.
-	.has-secondary {
-		.jetpack-podcast-player__podcast-title {
-			color: currentColor;
-		}
-
-		a.jetpack-podcast-player__podcast-title {
-			&,
-			&:hover,
-			&:focus,
-			&:active,
-			&:visited {
-				color: currentColor;
-			}
 		}
 	}
 
@@ -185,19 +174,16 @@ $jetpack-podcast-player-background: $white;
 		margin-bottom: $block-grid-gutter;
 		font-size: $editor-font-size;
 		line-height: 1.6;
-		color: $dark-gray-500;
 		//crop the description if too long
 		display: -webkit-box;
 		-webkit-line-clamp: 4;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 		max-height: 105px; //IE11 fallback
-	}
+		color: var( --jetpack-podcast-player-secondary );
 
-	// Apply `secondary` color to the track description.
-	.has-secondary {
-		.jetpack-podcast-player__track-description {
-			color: currentColor;
+		&:not( .has-secondary ) {
+			color: $jetpack-podcast-player-secondary;
 		}
 	}
 
@@ -217,6 +203,11 @@ $jetpack-podcast-player-background: $white;
 		margin: 0;
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
+		color: var( --jetpack-podcast-player-secondary );
+
+		&:not( .is-active ):not( .has-secondary ) {
+			color: $jetpack-podcast-player-secondary;
+		}
 
 		/**
 		 * When track "is-active", it means that it's been clicked by a user to
@@ -225,22 +216,9 @@ $jetpack-podcast-player-background: $white;
 		 */
 		&.is-active {
 			font-weight: bold;
-		}
+			color: var( --jetpack-podcast-player-primary );
 
-		// Apply default colors only if custom ones are not defined.
-		&:not( .is-active ):not( .has-secondary ) {
-			color: $jetpack-podcast-player-secondary;
-
-			&:hover,
-			&:focus {
-				color: $jetpack-podcast-player-primary;
-			}
-		}
-		&.is-active:not( .has-primary ) {
-			color: $jetpack-podcast-player-primary;
-
-			&:hover,
-			&:focus {
+			&:not( .has-primary ) {
 				color: $jetpack-podcast-player-primary;
 			}
 		}
@@ -253,13 +231,6 @@ $jetpack-podcast-player-background: $white;
 		// Adjustments on left padding to account for SVG sound icon spacing
 		padding: $track-h-padding $block-grid-gutter $track-h-padding $block-grid-gutter - 2px;
 		transition: none;
-		color: inherit;
-
-		&:visited,
-		&:hover,
-		&:focus {
-			color: inherit;
-		}
 	}
 
 	// Make space for the error element that will be appended.
@@ -269,15 +240,24 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__track-status-icon {
 		flex: $track-status-icon-size 0 0;
-		fill: $jetpack-podcast-player-primary;
-		fill: var( --jetpack-podcast-player-primary );
+		fill: currentColor;
 
 		svg {
 			display: block;
 			width: $track-status-icon-size;
 			height: $track-status-icon-size;
 			margin-top: 3px; // center vertically
+			fill: inherit;
 		}
+	}
+
+	.jetpack-podcast-player__track-status-icon--error {
+		fill: $alert-red;
+	}
+
+	// Use primary color to prevent visual conflicts (i.e. with red bg color)
+	.jetpack-podcast-player__track.has-primary .jetpack-podcast-player__track-status-icon--error  {
+		fill: currentColor;
 	}
 
 	.jetpack-podcast-player__track-title {
@@ -297,33 +277,22 @@ $jetpack-podcast-player-background: $white;
 		display: block;
 		margin-left: ($block-grid-gutter - 2px) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
 		margin-bottom: $track-h-padding;
-		color: $alert-red;
 		font-size: 0.8em;
 		font-weight: normal;
-
-		& > span {
-			color: $jetpack-podcast-player-secondary;
-		}
-
-		& > span > a {
-			color: inherit;
-		}
-	}
-
-	.has-primary .jetpack-podcast-player__track-error {
-		color: currentColor;
+		color: $alert-red;
 
 		& > span {
 			color: var( --jetpack-podcast-player-secondary );
+
+			&:not( .has-secondary ) {
+				color: $jetpack-podcast-player-secondary;
+			}
 		}
 	}
 
-	.jetpack-podcast-player__track-status-icon--error {
-		fill: $alert-red;
-	}
-
-	.has-primary .jetpack-podcast-player__track-status-icon--error {
-		fill: currentColor;
+	// Use primary color to prevent visual conflicts (i.e. red background)
+	.jetpack-podcast-player__track.has-primary .jetpack-podcast-player__track-error {
+		color: inherit;
 	}
 
 	/**

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -330,9 +330,9 @@ $jetpack-podcast-player-background: $white;
 	 * Style player by overriding mejs default styles
 	 */
 	.mejs-container,
+	.mejs-container .mejs-controls,
 	.mejs-embed,
 	.mejs-embed body,
-	.mejs-container .mejs-controls,
 	.mejs-mediaelement {
 		background-color: transparent;
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -12,11 +12,10 @@ $track-title-b-margin: 10px;
 $podcast-title-font-size: 16px;
 $description-font-size: 16px;
 $track-status-icon-size: 22px;
+$block-border-color: $dark-gray-100;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
 $jetpack-podcast-player-background: $white;
-$block-border-color: $dark-gray-100;
-$player-background: transparent;
 
 .jetpack-podcast-player--visually-hidden {
 	position: absolute !important;
@@ -362,7 +361,7 @@ $player-background: transparent;
 	.mejs-embed body,
 	.mejs-container .mejs-controls,
 	.mejs-mediaelement {
-		background-color: $player-background;
+		background-color: transparent;
 	}
 
 	.mejs-controls {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -32,13 +32,6 @@ $jetpack-podcast-player-background: $white;
 	background-color: $jetpack-podcast-player-background;
 	overflow: hidden;
 
-	/**
-	 * Player's state classes added to this element:
-	 * &.is-playing {} // When audio starts playing.
-	 * &.is-paused {}  // When audio is paused.
-	 * &.is-error {}   // When playback error occured.
-	 */
-
 	audio {
 		display: none;
 	}
@@ -50,6 +43,13 @@ $jetpack-podcast-player-background: $white;
 	.jetpack-podcast-player {
 		padding-top: 0;
 		padding-bottom: 0;
+
+		/**
+		 * Player's state classes added to this element:
+		 * &.is-playing {} // When audio starts playing.
+	 	 * &.is-paused {}  // When audio is paused.
+		 * &.is-error {}   // When playback error occured.
+		 */
 
 		/**
 		* Set default values for our CSS variables.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -29,7 +29,6 @@ $jetpack-podcast-player-background: $white;
  */
 .wp-block-jetpack-podcast-player {
 	border: 1px solid $block-border-color;
-	background-color: $jetpack-podcast-player-background;
 	overflow: hidden;
 
 	audio {
@@ -41,8 +40,20 @@ $jetpack-podcast-player-background: $white;
 	 * For instance, Twenty-Twenty sets `padding: 8rem 0`.
 	 */
 	.jetpack-podcast-player {
+		/**
+		 * Set default values for our CSS variables.
+		 */
+		--jetpack-podcast-player-primary: #{$jetpack-podcast-player-primary};
+		--jetpack-podcast-player-secondary: #{$jetpack-podcast-player-secondary};
+		--jetpack-podcast-player-background: #{$jetpack-podcast-player-background};
+
 		padding-top: 0;
 		padding-bottom: 0;
+		background-color: var( --jetpack-podcast-player-background );
+
+		&:not(.has-background) {
+			background-color: $jetpack-podcast-player-background;
+		}
 
 		/**
 		 * Player's state classes added to this element:
@@ -50,13 +61,6 @@ $jetpack-podcast-player-background: $white;
 	 	 * &.is-paused {}  // When audio is paused.
 		 * &.is-error {}   // When playback error occured.
 		 */
-
-		/**
-		* Set default values for our CSS variables.
-		*/
-		--jetpack-podcast-player-primary: #{$jetpack-podcast-player-primary};
-		--jetpack-podcast-player-secondary: #{$jetpack-podcast-player-secondary};
-		--jetpack-podcast-player-background: #{$jetpack-podcast-player-background};
 
 		/**
 		 * Override to address themes using text-decoration or box-shadow underlines on links.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -35,10 +35,6 @@ $jetpack-podcast-player-background: $white;
 		display: none;
 	}
 
-	/**
-	 * Reset vertical padding for <section /> elements.
-	 * For instance, Twenty-Twenty sets `padding: 8rem 0`.
-	 */
 	.jetpack-podcast-player {
 		/**
 		 * Set default values for our CSS variables.
@@ -47,6 +43,10 @@ $jetpack-podcast-player-background: $white;
 		--jetpack-podcast-player-secondary: #{$jetpack-podcast-player-secondary};
 		--jetpack-podcast-player-background: #{$jetpack-podcast-player-background};
 
+		/**
+		 * Reset vertical padding for <section /> elements.
+		 * For instance, Twenty-Twenty sets `padding: 8rem 0`.
+		 */
 		padding-top: 0;
 		padding-bottom: 0;
 		background-color: var( --jetpack-podcast-player-background );

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -3,14 +3,14 @@
  */
 @import '../../shared/styles/gutenberg-base-styles.scss';
 
+$block-grid-gutter: 24px;
+$block-border-color: $dark-gray-100;
+$cover-image-size: 80px;
+$current-track-title-font-size: 24px;
+$current-track-title-bottom-margin: 10px;
 $track-v-padding: 15px;
 $track-h-padding: 10px;
-$player-grid-spacing: 24px;
-$cover-image-size: 80px;
-$track-title-font-size: 24px;
-$track-title-b-margin: 10px;
 $track-status-icon-size: 22px;
-$block-border-color: $dark-gray-100;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
 $jetpack-podcast-player-background: $white;
@@ -86,12 +86,12 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__current-track-info {
 		display: flex;
-		padding: $player-grid-spacing;
+		padding: $block-grid-gutter;
 	}
 
 	.jetpack-podcast-player__cover {
 		width: $cover-image-size;
-		margin-right: $player-grid-spacing;
+		margin-right: $block-grid-gutter;
 		flex-shrink: 0;
 	}
 
@@ -119,8 +119,8 @@ $jetpack-podcast-player-background: $white;
 	}
 
 	.jetpack-podcast-player__current-track-title {
-		font-size: $track-title-font-size;
-		margin: 0 0 $track-title-b-margin;
+		font-size: $current-track-title-font-size;
+		margin: 0 0 $current-track-title-bottom-margin;
 
 		// Apply default color if custom primary has not been set
 		&:not(.has-primary) {
@@ -166,19 +166,19 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__audio-player {
 		height: 40px; // mirroring .mejs-container
-		margin-bottom: $player-grid-spacing;
+		margin-bottom: $block-grid-gutter;
 	}
 
 	.jetpack-podcast-player--audio-player-loading {
 		height: 10px; // mirroring .mejs-time-total
 		background: $jetpack-podcast-player-secondary;
-		margin: 15px $player-grid-spacing; // simulating spacing of .mejs-container
+		margin: 15px $block-grid-gutter; // simulating spacing of .mejs-container
 	}
 
 	.jetpack-podcast-player__track-description {
 		order: 99; // high number to make it always appear after the audio player
-		padding: 0 $player-grid-spacing;
-		margin-bottom: $player-grid-spacing;
+		padding: 0 $block-grid-gutter;
+		margin-bottom: $block-grid-gutter;
 		font-size: $editor-font-size;
 		line-height: 1.6;
 		color: $dark-gray-500;
@@ -247,7 +247,7 @@ $jetpack-podcast-player-background: $white;
 		flex-flow: row nowrap;
 		justify-content: space-between;
 		// Adjustments on left padding to account for SVG sound icon spacing
-		padding: $track-h-padding $player-grid-spacing $track-h-padding $player-grid-spacing - 2px;
+		padding: $track-h-padding $block-grid-gutter $track-h-padding $block-grid-gutter - 2px;
 		transition: none;
 		color: inherit;
 
@@ -291,7 +291,7 @@ $jetpack-podcast-player-background: $white;
 	 */
 	.jetpack-podcast-player__track-error {
 		display: block;
-		margin-left: ($player-grid-spacing - 2px) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
+		margin-left: ($block-grid-gutter - 2px) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
 		margin-bottom: $track-h-padding;
 		color: $alert-red;
 		font-size: 0.8em;
@@ -326,7 +326,7 @@ $jetpack-podcast-player-background: $white;
 	 * Global error element, replaces the whole block with the error message.
 	 */
 	.jetpack-podcast-player__error {
-		padding: $player-grid-spacing;
+		padding: $block-grid-gutter;
 		margin: 0;
 		color: $alert-red;
 		font-size: 0.8em;
@@ -339,7 +339,7 @@ $jetpack-podcast-player-background: $white;
 	&.is-default {
 		.jetpack-podcast-player__track-title {
 			// Change padding to account for missing space for status-icon.
-			padding-left: $player-grid-spacing - $track-v-padding;
+			padding-left: $block-grid-gutter - $track-v-padding;
 		}
 
 		.jetpack-podcast-player__audio-player {
@@ -369,7 +369,7 @@ $jetpack-podcast-player-background: $white;
 		* Magic numbers are due to needing to line-up the player spacing with buttons
 		* and fixed widths inside of the mediaplayer.
 		*/
-		padding: 0 ( $player-grid-spacing - 6px ) 0 ( $player-grid-spacing - 9px );
+		padding: 0 ( $block-grid-gutter - 6px ) 0 ( $block-grid-gutter - 9px );
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -15,13 +15,7 @@ $track-status-icon-size: 22px;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
 $jetpack-podcast-player-background: $white;
-$text-color: $dark-gray-300; // Lightest gray that can be used for AA text contrast.
-$text-color-hover: $black;
-$text-color-active: $text-color-hover;
-$text-color-error: $alert-red;
-$block-bg-color: $white;
 $block-border-color: $dark-gray-100;
-$current-track-title-color: $black;
 $player-background: transparent;
 
 .jetpack-podcast-player--visually-hidden {
@@ -38,7 +32,7 @@ $player-background: transparent;
  */
 .wp-block-jetpack-podcast-player {
 	border: 1px solid $block-border-color;
-	background-color: $block-bg-color;
+	background-color: $jetpack-podcast-player-background;
 	overflow: hidden;
 
 	/**
@@ -133,13 +127,13 @@ $player-background: transparent;
 
 		// Apply default color if custom primary has not been set
 		&:not(.has-primary) {
-			color: $current-track-title-color;
+			color: $jetpack-podcast-player-primary;
 		}
 	}
 
 	.jetpack-podcast-player__podcast-title {
 		font-size: $podcast-title-font-size;
-		color: $text-color;
+		color: $jetpack-podcast-player-secondary;
 		margin: 0;
 	}
 
@@ -147,12 +141,12 @@ $player-background: transparent;
 		&,
 		&:active,
 		&:visited {
-			color: $text-color;
+			color: $jetpack-podcast-player-secondary;
 		}
 
 		&:hover,
 		&:focus {
-			color: $text-color-hover;
+			color: $jetpack-podcast-player-primary;
 		}
 	}
 
@@ -234,19 +228,19 @@ $player-background: transparent;
 
 		// Apply default colors only if custom ones are not defined.
 		&:not( .is-active ):not( .has-secondary ) {
-			color: $text-color;
+			color: $jetpack-podcast-player-secondary;
 
 			&:hover,
 			&:focus {
-				color: $text-color-hover;
+				color: $jetpack-podcast-player-primary;
 			}
 		}
 		&.is-active:not( .has-primary ) {
-			color: $text-color-active;
+			color: $jetpack-podcast-player-primary;
 
 			&:hover,
 			&:focus {
-				color: $text-color-active;
+				color: $jetpack-podcast-player-primary;
 			}
 		}
 	}
@@ -307,7 +301,7 @@ $player-background: transparent;
 		font-weight: normal;
 
 		& > span {
-			color: $text-color;
+			color: $jetpack-podcast-player-secondary;
 		}
 
 		& > span > a {
@@ -324,7 +318,7 @@ $player-background: transparent;
 	}
 
 	.jetpack-podcast-player__track-status-icon--error {
-		fill: $text-color-error;
+		fill: $alert-red;
 	}
 
 	.has-primary .jetpack-podcast-player__track-status-icon--error {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -228,8 +228,10 @@ $jetpack-podcast-player-background: $white;
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		// Adjustments on left padding to account for SVG sound icon spacing
-		padding: $track-h-padding $block-grid-gutter $track-h-padding $block-grid-gutter - 2px;
+		padding-top: $track-h-padding;
+		padding-bottom: $track-h-padding;
+		padding-left: $block-grid-gutter - 2px; // Adjustments on left padding to account for SVG sound icon spacing
+		padding-right: $block-grid-gutter;
 		transition: none;
 	}
 
@@ -256,7 +258,7 @@ $jetpack-podcast-player-background: $white;
 	}
 
 	// Use primary color to prevent visual conflicts (i.e. with red bg color)
-	.jetpack-podcast-player__track.has-primary .jetpack-podcast-player__track-status-icon--error  {
+	.jetpack-podcast-player__track.has-primary .jetpack-podcast-player__track-status-icon--error {
 		fill: currentColor;
 	}
 
@@ -275,7 +277,7 @@ $jetpack-podcast-player-background: $white;
 	 */
 	.jetpack-podcast-player__track-error {
 		display: block;
-		margin-left: ($block-grid-gutter - 2px) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
+		margin-left: ( $block-grid-gutter - 2px ) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
 		margin-bottom: $track-h-padding;
 		font-size: 0.8em;
 		font-weight: normal;
@@ -337,12 +339,15 @@ $jetpack-podcast-player-background: $white;
 
 	.mejs-controls {
 		position: static;
+		padding-top: 0;
+		padding-bottom: 0;
 		/**
 		* Lines up the mejs player padding with our wrapper spacing.
 		* Magic numbers are due to needing to line-up the player spacing with buttons
 		* and fixed widths inside of the mediaplayer.
 		*/
-		padding: 0 ( $block-grid-gutter - 6px ) 0 ( $block-grid-gutter - 9px );
+		padding-left: $block-grid-gutter - 9px;
+		padding-right: $block-grid-gutter - 6px;
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -329,7 +329,11 @@ $jetpack-podcast-player-error: $alert-red;
 		padding-right: $gutter-l - 6px;
 	}
 
-	.mejs-time,
+	.mejs-time {
+		color: $jetpack-podcast-player-secondary;
+		color: var( --jetpack-podcast-player-secondary );
+	}
+
 	.mejs-time-float {
 		color: $jetpack-podcast-player-background;
 		color: var( --jetpack-podcast-player-background );

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -166,7 +166,7 @@ $jetpack-podcast-player-error: $alert-red;
 	.jetpack-podcast-player--audio-player-loading {
 		height: 10px; // mirroring .mejs-time-total
 		background: $jetpack-podcast-player-secondary;
-		margin: 15px $gutter-l; // simulating spacing of .mejs-container
+		margin: $gutter-m $gutter-l; // simulating spacing of .mejs-container
 	}
 
 	.jetpack-podcast-player__track-description {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -193,7 +193,7 @@ $jetpack-podcast-player-error: $alert-red;
 		display: flex;
 		flex-direction: column;
 		margin: 0;
-		padding: $gutter-m 0;
+		padding: 0 0 $gutter-m 0;
 	}
 
 	.jetpack-podcast-player__track {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -3,12 +3,11 @@
  */
 @import '../../shared/styles/gutenberg-base-styles.scss';
 
-$block-grid-gutter: 24px;
+$gutter-s: 10px;
+$gutter-m: 15px;
+$gutter-l: 24px;
 $cover-image-size: 80px;
 $current-track-title-font-size: 24px;
-$current-track-title-bottom-margin: 10px;
-$track-v-padding: 15px;
-$track-h-padding: 10px;
 $track-status-icon-size: 22px;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
@@ -108,12 +107,12 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__current-track-info {
 		display: flex;
-		padding: $block-grid-gutter;
+		padding: $gutter-l;
 	}
 
 	.jetpack-podcast-player__cover {
 		width: $cover-image-size;
-		margin-right: $block-grid-gutter;
+		margin-right: $gutter-l;
 		flex-shrink: 0;
 	}
 
@@ -143,7 +142,7 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__current-track-title {
 		font-size: $current-track-title-font-size;
-		margin: 0 0 $current-track-title-bottom-margin;
+		margin: 0 0 $gutter-s;
 		color: var( --jetpack-podcast-player-primary );
 
 		// Apply default color if custom primary has not been set
@@ -160,19 +159,19 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__audio-player {
 		height: 40px; // mirroring .mejs-container
-		margin-bottom: $block-grid-gutter;
+		margin-bottom: $gutter-l;
 	}
 
 	.jetpack-podcast-player--audio-player-loading {
 		height: 10px; // mirroring .mejs-time-total
 		background: $jetpack-podcast-player-secondary;
-		margin: 15px $block-grid-gutter; // simulating spacing of .mejs-container
+		margin: 15px $gutter-l; // simulating spacing of .mejs-container
 	}
 
 	.jetpack-podcast-player__track-description {
 		order: 99; // high number to make it always appear after the audio player
-		padding: 0 $block-grid-gutter;
-		margin-bottom: $block-grid-gutter;
+		padding: 0 $gutter-l;
+		margin-bottom: $gutter-l;
 		font-size: $editor-font-size;
 		line-height: 1.6;
 		//crop the description if too long
@@ -193,7 +192,7 @@ $jetpack-podcast-player-background: $white;
 		display: flex;
 		flex-direction: column;
 		margin: 0;
-		padding: $track-v-padding 0;
+		padding: $gutter-m 0;
 	}
 
 	.jetpack-podcast-player__track {
@@ -225,10 +224,10 @@ $jetpack-podcast-player-background: $white;
 		display: flex;
 		flex-flow: row nowrap;
 		justify-content: space-between;
-		padding-top: $track-h-padding;
-		padding-bottom: $track-h-padding;
-		padding-left: $block-grid-gutter - 2px; // Adjustments on left padding to account for SVG sound icon spacing
-		padding-right: $block-grid-gutter;
+		padding-top: $gutter-s;
+		padding-bottom: $gutter-s;
+		padding-left: $gutter-l - 2px; // Adjustments on left padding to account for SVG sound icon spacing
+		padding-right: $gutter-l;
 		transition: none;
 	}
 
@@ -261,7 +260,7 @@ $jetpack-podcast-player-background: $white;
 
 	.jetpack-podcast-player__track-title {
 		flex-grow: 1;
-		padding: 0 $track-v-padding;
+		padding: 0 $gutter-m;
 	}
 
 	.jetpack-podcast-player__track-duration {
@@ -274,8 +273,8 @@ $jetpack-podcast-player-background: $white;
 	 */
 	.jetpack-podcast-player__track-error {
 		display: block;
-		margin-left: ( $block-grid-gutter - 2px ) + $track-status-icon-size + $track-v-padding; // has to be aligned with the track title
-		margin-bottom: $track-h-padding;
+		margin-left: ( $gutter-l - 2px ) + $track-status-icon-size + $gutter-m; // has to be aligned with the track title
+		margin-bottom: $gutter-s;
 		font-size: 0.8em;
 		font-weight: normal;
 		color: $alert-red;
@@ -298,7 +297,7 @@ $jetpack-podcast-player-background: $white;
 	 * Global error element, replaces the whole block with the error message.
 	 */
 	.jetpack-podcast-player__error {
-		padding: $block-grid-gutter;
+		padding: $gutter-l;
 		margin: 0;
 		color: $alert-red;
 		font-size: 0.8em;
@@ -325,8 +324,8 @@ $jetpack-podcast-player-background: $white;
 		* Magic numbers are due to needing to line-up the player spacing with buttons
 		* and fixed widths inside of the mediaplayer.
 		*/
-		padding-left: $block-grid-gutter - 9px;
-		padding-right: $block-grid-gutter - 6px;
+		padding-left: $gutter-l - 9px;
+		padding-right: $gutter-l - 6px;
 	}
 
 	.mejs-time,

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -306,12 +306,11 @@ $jetpack-podcast-player-background: $white;
 	}
 
 	/**
-	 * Style the block to hide dynamic UI and show just its default style.
+	 * Style the block to hide dynamic UI and show just its default style (no-js).
 	 */
 	&.is-default {
 		.jetpack-podcast-player__track-title {
-			// Change padding to account for missing space for status-icon.
-			padding-left: $block-grid-gutter - $track-v-padding;
+			padding-left: 0; // Account for missing space for status-icon.
 		}
 
 		.jetpack-podcast-player__audio-player {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -174,7 +174,7 @@ $jetpack-podcast-player-error: $alert-red;
 		padding: 0 $gutter-l;
 		margin-bottom: $gutter-l;
 		font-size: $editor-font-size;
-		line-height: 1.6;
+		line-height: $editor-line-height;
 		//crop the description if too long
 		display: -webkit-box;
 		-webkit-line-clamp: 4;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -47,7 +47,12 @@ $jetpack-podcast-player-background: $white;
 		 */
 		padding-top: 0;
 		padding-bottom: 0;
+		color: var( --jetpack-podcast-player-secondary );
 		background-color: var( --jetpack-podcast-player-background );
+
+		&:not( .has-secondary ) {
+			color: $jetpack-podcast-player-secondary;
+		}
 
 		&:not( .has-background ) {
 			background-color: $jetpack-podcast-player-background;
@@ -128,6 +133,7 @@ $jetpack-podcast-player-background: $white;
 		padding: 0;
 		overflow: hidden;
 		letter-spacing: 0; // Fixes Twenty Twenty compressed text.
+		color: inherit;
 
 		&:before,
 		&:after {
@@ -149,11 +155,7 @@ $jetpack-podcast-player-background: $white;
 	.jetpack-podcast-player__podcast-title {
 		font-size: $editor-font-size;
 		margin: 0;
-		color: var( --jetpack-podcast-player-secondary );
-
-		&:not( .has-secondary ) {
-			color: $jetpack-podcast-player-secondary;
-		}
+		color: inherit;
 	}
 
 	.jetpack-podcast-player__audio-player {
@@ -179,11 +181,7 @@ $jetpack-podcast-player-background: $white;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 		max-height: 105px; //IE11 fallback
-		color: var( --jetpack-podcast-player-secondary );
-
-		&:not( .has-secondary ) {
-			color: $jetpack-podcast-player-secondary;
-		}
+		color: inherit;
 	}
 
 	/**

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -12,6 +12,7 @@ $track-status-icon-size: 22px;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
 $jetpack-podcast-player-background: $white;
+$jetpack-podcast-player-error: $alert-red;
 
 .jetpack-podcast-player--visually-hidden {
 	position: absolute !important;
@@ -250,7 +251,7 @@ $jetpack-podcast-player-background: $white;
 	}
 
 	.jetpack-podcast-player__track-status-icon--error {
-		fill: $alert-red;
+		fill: $jetpack-podcast-player-error;
 	}
 
 	// Use primary color to prevent visual conflicts (i.e. with red bg color)
@@ -277,7 +278,7 @@ $jetpack-podcast-player-background: $white;
 		margin-bottom: $gutter-s;
 		font-size: 0.8em;
 		font-weight: normal;
-		color: $alert-red;
+		color: $jetpack-podcast-player-error;
 
 		& > span {
 			color: var( --jetpack-podcast-player-secondary );
@@ -299,7 +300,7 @@ $jetpack-podcast-player-background: $white;
 	.jetpack-podcast-player__error {
 		padding: $gutter-l;
 		margin: 0;
-		color: $alert-red;
+		color: $jetpack-podcast-player-error;
 		font-size: 0.8em;
 		font-weight: normal;
 	}

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -172,7 +172,7 @@ $jetpack-podcast-player-error: $alert-red;
 	.jetpack-podcast-player__track-description {
 		order: 99; // high number to make it always appear after the audio player
 		padding: 0 $gutter-l;
-		margin-bottom: $gutter-l;
+		margin: 0 0 $gutter-l 0;
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
 		//crop the description if too long

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -331,8 +331,8 @@ $jetpack-podcast-player-background: $white;
 
 	.mejs-time,
 	.mejs-time-float {
-		color: $jetpack-podcast-player-secondary;
-		color: var( --jetpack-podcast-player-secondary );
+		color: $jetpack-podcast-player-background;
+		color: var( --jetpack-podcast-player-background );
 	}
 
 	.mejs-time-float {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -306,23 +306,6 @@ $jetpack-podcast-player-background: $white;
 	}
 
 	/**
-	 * Style the block to hide dynamic UI and show just its default style (no-js).
-	 */
-	&.is-default {
-		.jetpack-podcast-player__track-title {
-			padding-left: 0; // Account for missing space for status-icon.
-		}
-
-		.jetpack-podcast-player__audio-player {
-			display: none;
-		}
-
-		&.is-default .jetpack-podcast-player__track-status-icon {
-			display: none;
-		}
-	}
-
-	/**
 	 * Style player by overriding mejs default styles
 	 */
 	.mejs-container,
@@ -453,6 +436,20 @@ $jetpack-podcast-player-background: $white;
 				*/
 				visibility: hidden;
 			}
+		}
+	}
+
+	/**
+	 * Style the block to hide dynamic UI and show just its default style (no-js).
+	 */
+	&.is-default {
+		.jetpack-podcast-player__track-title {
+			padding-left: 0; // Account for missing space for status-icon.
+		}
+
+		.jetpack-podcast-player__audio-player,
+		.jetpack-podcast-player__track-status-icon {
+			display: none;
 		}
 	}
 }

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -33,7 +33,7 @@ if ( $is_active ) {
 	style="<?php echo esc_attr( $style ); ?>"
 >
 	<a
-		class="jetpack-podcast-player__track-link"
+		class="jetpack-podcast-player__track-link jetpack-podcast-player__link"
 		href="<?php echo esc_url( $attachment['link'] ); ?>"
 		role="button"
 		<?php echo $is_active ? 'aria-current="track"' : ''; ?>

--- a/extensions/blocks/podcast-player/templates/podcast-header.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header.php
@@ -30,7 +30,7 @@ $track  = ( is_array( $tracks ) && ! empty( $tracks ) ) ? $tracks[0] : array();
 ?>
 
 <div class="jetpack-podcast-player__header">
-	<div class="jetpack-podcast-player__current-track-info" aria-live="polite">
+	<div class="jetpack-podcast-player__current-track-info">
 		<?php if ( $show_cover_art && isset( $cover ) ) : ?>
 			<div class="jetpack-podcast-player__cover">
 				<img class="jetpack-podcast-player__cover-image" src="<?php echo esc_url( $cover ); ?>" alt="" />

--- a/extensions/blocks/podcast-player/templates/podcast-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-title.php
@@ -18,19 +18,22 @@ if ( empty( $title ) ) {
 	return;
 }
 
-if ( ! empty( $link ) ) :
-	?>
-	<a
-		class="jetpack-podcast-player__podcast-title"
-		href="<?php echo esc_url( $link ); ?>"
-		target="_blank"
-		rel="noopener noreferrer nofollow"
-	>
-		<?php echo esc_html( $title ); ?>
-	</a>
-<?php else : ?>
-	<span class="jetpack-podcast-player__podcast-title">
-		<?php echo esc_html( $title ); ?>
-	</span>;
+?>
+<span class="jetpack-podcast-player__podcast-title">
 	<?php
-endif;
+	if ( ! empty( $link ) ) :
+		?>
+		<a
+			class="jetpack-podcast-player__link"
+			href="<?php echo esc_url( $link ); ?>"
+			target="_blank"
+			rel="noopener noreferrer nofollow"
+		>
+			<?php echo esc_html( $title ); ?>
+		</a>
+		<?php
+	else :
+		echo esc_html( $title );
+	endif;
+	?>
+</span>


### PR DESCRIPTION
Built on top of #15504 as a part of completing the remaining Podcast Player improvements. My main goal was to go through styles.scss and clean it up a bit to minimize technical debt. On the way, I found a few small bugs and decided not to create separate issues for them as they kind of fixed themselves while cleaning up the code :)

#### Changes proposed in this Pull Request:

Maintenance:

- Removed duplicated SCSS variables,
- Renamed some SCSS variables for clarity,
- Used available SCSS variables for hardcoded values where possible,
- Unified gutter and some paddings into simple `$gutter-s/m/l` vars,
- Cleaned up and made colors styles more consistent and easy to follow,
- Cleaned up a few misplaced comments.

Bugfixes:

- Made links styling consistent (Podcast title, Track title, Error message)
   Links have the Secondary color initially and Primary when hovered (except for an active Track, which has Primary color at all times). Previously that was true only when default colors were applied. Now it's true also for any custom colors thanks to progressive enhancement with the CSS vars. Note that therefore hover colors are not supported in, i.e. IE11.
- Fixed error message link ("Open in a new tab") to which custom colors weren't applied in browsers that don't support CSS vars (IE11).
- Used correct default, `$dark-gray-300` (Secondary) color for episode description text instead of `$dark-gray-500`.
- Made the ME.js progress bar tooltip's text color the same as the background for proper contrast.

One _enhancement_:

- Removed block border (p1587552447434800-slack-ajax)

#### Testing instructions:

- Add the Podcast Player block (use e.g. this URL https://anchor.fm/s/9400d7c/podcast/rss),
- Make sure that podcast title, inactive track and the "Open in a new tab" track error links have all correct colors - Secondary initially and Primary on hover (hover colors applied only for browsers that support CSS variables),
- Make sure that episode description's default color is correct (`#6c7781`),
- Make sure the block has no border,
- Make sure the ME.js progress bar tooltip's text color is the same as the background,
- All of the above should be true when switching themes and global styles.

Demo GIF:
- Colors: custom
- Theme: Varia
- Global styles: "System Font & Libre Baskerville"

![Apr-22-2020 16-00-44](https://user-images.githubusercontent.com/1451471/79991786-fbb1cc80-84b2-11ea-8aa6-75feac1d15c8.gif)

IE11 screenshots (same for editor and front-end):

| playback | track error |
| ------------- | ------------- |
|<img width="598" alt="Screenshot 2020-04-23 13 14 00" src="https://user-images.githubusercontent.com/1451471/80093462-d2ea0f80-8564-11ea-99e0-24ebc6f59923.png">| <img width="598" alt="Screenshot 2020-04-23 13 15 34" src="https://user-images.githubusercontent.com/1451471/80093470-d67d9680-8564-11ea-9590-27a9588bfd34.png">|


No-JS screenshot (front-end):
- Colors: custom
- Theme: Varia

<img width="604" alt="Screenshot 2020-04-23 12 53 25" src="https://user-images.githubusercontent.com/1451471/80091610-b39db300-8561-11ea-93b6-99afd8285011.png">



#### Proposed changelog entry for your changes:
* none
