### PR TITLE
Podcast Player: handle dual-behaviour of render_callback fn

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -91,7 +91,7 @@ function render_block( $attributes ) {
 	if ( ! empty( $attributes->attributes ) ) {
 		$attributes = $attributes->attributes;
 	}
-	return render_player( $player_data, $block_attributes );
+	return render_player( $player_data, $attributes );
 }
 
 /**

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -88,9 +88,9 @@ function render_block( $attributes ) {
 	 * was recently introduced by this Pull Request:
 	 * https://github.com/WordPress/gutenberg/pull/21467
 	 */
-	$block_attributes = ! is_array( $attributes ) && isset( $attributes->attributes )
-		? $attributes->attributes
-		: $attributes;
+	if ( ! empty( $attributes->attributes ) ) {
+		$attributes = $attributes->attributes;
+	}
 	return render_player( $player_data, $block_attributes );
 }
 

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -55,7 +55,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 /**
  * Podcast Player block registration/dependency declaration.
  *
- * @param array $attributes Array containing the Podcast Player block attributes.
+ * @param array|object $attributes Podcast Player block attributes / WP_Block instance.
  * @return string
  */
 function render_block( $attributes ) {
@@ -79,7 +79,19 @@ function render_block( $attributes ) {
 		return '<p>' . esc_html( $player_data->get_error_message() ) . '</p>';
 	}
 
-	return render_player( $player_data, $attributes );
+	/*
+	 * Get the block attributes checking if `$attributes`
+	 * is an array and it has defined a property.
+	 *
+	 * It handles the dual-behavior of argument
+	 * of the callback_render() function, which
+	 * was recently introduced by this Pull Request:
+	 * https://github.com/WordPress/gutenberg/pull/21467
+	 */
+	$block_attributes = ! is_array( $attributes ) && isset( $attributes->attributes )
+		? $attributes->attributes
+		: $attributes;
+	return render_player( $player_data, $block_attributes );
 }
 
 /**

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -55,7 +55,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 /**
  * Podcast Player block registration/dependency declaration.
  *
- * @param array|object $attributes Podcast Player block attributes / WP_Block instance.
+ * @param array|WP_Block $attributes Podcast Player block attributes / WP_Block instance.
  * @return string
  */
 function render_block( $attributes ) {


### PR DESCRIPTION
This PR handles a bug that happens in `7.9.1` version of Gutenberg. These changes were [introduced in this PR](https://github.com/WordPress/gutenberg/pull/21467#discussion_r410004286).

In terms of the functionality and how it affects the Podcast Player, what the PR changed is the ~value~ behavior of the first argument the callback render function. Now it supports a dual-behavior which could be a `WP_Block` object instance, or simply the `$attributes` array.

It means that you can pick up the block name through of the object property, for instance:

```php
function render_block( $block ) {
  echo $block->name;
};
```
Or use this param as an array (block attributes):

```php
function render_block( $attributes ) {
  echo $attributes['showEpisodeDescription'];
};
```

It works as expected as long as the argument is treated explicitly as an array or as an object. The issue happens when we use this value expecting it acts as the attributes array (the current, and unique, the behavior of it so far) but it acts as a WP_Block object instance.

It happens in parts of our code. When [it encodes the data](https://github.com/Automattic/jetpack/blob/536848abd0652dd575c0496214e3745d73265bc3/extensions/blocks/podcast-player/podcast-player.php#L164) to be consumed bt the client, and when it [extracts the array items](https://github.com/Automattic/jetpack/blob/536848abd0652dd575c0496214e3745d73265bc3/extensions/blocks/podcast-player/podcast-player.php#L280) to be used in the server-side templates.

To deal with this, what I suggest is checking if the $attributes is in fact an array, and also checks if the `attributes` property is defined. Take a look at the code to get the idea:


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Deal with dual-behavior of render_callback function introduced in https://github.com/WordPress/gutenberg/pull/21467

#### Testing instructions:

1) activate Gutenberg `7.9.1` or later
2) Confirm that it doesn't generate a PHP notice when tries to pick up some block attributes. Without these changes, it should trigger something like the following:

```
[21-Apr-2020 16:28:07 UTC] PHP Notice:  Undefined index: showCoverArt in /var/www/html/wp-content/plugins/jetpack/extensions/blocks/podcast-player/templates/podcast-header.php on line 25
```

Also, you could print the `$attributes` on the server side for different versions of Gutenberg. It should shown something like the following:

```
Array
(
    [url] => https://distributed.blog/category/podcast/feed/
    [primaryColor] => accent
    [hexPrimaryColor] => #cd2653
    [customSecondaryColor] => #1b092e
    [hexSecondaryColor] => #1b092e
    [backgroundColor] => subtle-background
    [hexBackgroundColor] => #dcd7ca
    [itemsToShow] => 5
    [showCoverArt] => 1
    [showEpisodeDescription] => 1
)
```
