### PR TITLE
Filter out blacklisted post_types for deleted_post actions.

### DIFF
--- a/packages/sync/src/modules/class-posts.php
+++ b/packages/sync/src/modules/class-posts.php
@@ -570,10 +570,7 @@ class Posts extends Module {
 		do_action( 'jetpack_sync_save_post', $post_ID, $post, $update, $state );
 		unset( $this->previous_status[ $post_ID ] );
 
-		// Only Send Pulished Post event if post_type is not blacklisted.
-		if ( ! in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ), true ) ) {
-			$this->send_published( $post_ID, $post );
-		}
+		$this->send_published( $post_ID, $post );
 	}
 
 	/**
@@ -619,15 +616,18 @@ class Posts extends Module {
 		 */
 		$flags = apply_filters( 'jetpack_published_post_flags', $post_flags, $post );
 
-		/**
-		 * Action that gets synced when a post type gets published.
-		 *
-		 * @since 4.4.0
-		 *
-		 * @param int $post_ID
-		 * @param mixed array $flags post flags that are added to the post
-		 */
-		do_action( 'jetpack_published_post', $post_ID, $flags );
+		// Only Send Pulished Post event if post_type is not blacklisted.
+		if ( ! in_array( $post->post_type, Settings::get_setting( 'post_types_blacklist' ), true ) ) {
+			/**
+			 * Action that gets synced when a post type gets published.
+			 *
+			 * @since 4.4.0
+			 *
+			 * @param int $post_ID
+			 * @param mixed array $flags post flags that are added to the post
+			 */
+			do_action( 'jetpack_published_post', $post_ID, $flags );
+		}
 		unset( $this->just_published[ $post_ID ] );
 
 		/**

--- a/packages/sync/src/modules/class-posts.php
+++ b/packages/sync/src/modules/class-posts.php
@@ -286,7 +286,7 @@ class Posts extends Module {
 
 		// deleted_post is called after the SQL delete but before cache cleanup.
 		// There is the potential we can't detect post_type at this point.
-		if ( ! is_post_type_allowed( $args[0] ) ) {
+		if ( ! $this->is_post_type_allowed( $args[0] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
deleted_post and jetpack_published_post actions are enqueued even when the post_type has been blacklisted. This PR attempts to filter these actions from being enqueued, relies on object caching to work :)

#### Changes proposed in this Pull Request:
* Add filter to `jetpack_sync_before_enqueue_deleted_post` to exclude enqueuing `deleted_post` actions for blacklisted post-types.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Performance Enhancement

#### Testing instructions:

* Using the Jetpack Debugger blacklist the `post` post-type on a test site
* Create and then Delete a `post`
* Verify that no `deleted_post` or `jetpack_published_post` action is queued or sent to WP.com

#### Proposed changelog entry for your changes:
* N/A : Performance enhancement no change to functionality.
