### PR TITLE
Travis CI: Remove unneeded logging in push artifacts script

### DIFF
--- a/tests/e2e/bin/push-allure-artifacts.sh
+++ b/tests/e2e/bin/push-allure-artifacts.sh
@@ -54,9 +54,8 @@ fi
 cd $REPO_DIR
 
 # Push the changes
-git status
 git add .
-git commit --message "Build for $ARTIFACT. Travis build# $TRAVIS_BUILD_NUMBER."
+git commit -q --message "Build for $ARTIFACT. Travis build# $TRAVIS_BUILD_NUMBER."
 git push
 
 # TODO move it before push, once it we can confirm it's doing the right thing


### PR DESCRIPTION
It seems that the script is failing now due to too much logging. I removed unneeded logging since it's work fine right now. 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check E2E build log. make sure the `after_script` section is finished successfully

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
