### PR TITLE
Adds a Linter to check for URLs that should be added using Redirect

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,6 +8,7 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 	<rule ref="VariableAnalysis" />
+	<rule ref="bin/PHPCSSniffs" />
 
 	<!-- Elevate undefined variables to an Error instead of a Warning. -->
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">

--- a/bin/PHPCSSniffs/Sniffs/RedirectLinksSniff.php
+++ b/bin/PHPCSSniffs/Sniffs/RedirectLinksSniff.php
@@ -1,0 +1,61 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Sniffer that looks for links to a8c domains and throw a warning if they are not being added using a redirect url
+ */
+class Jetpack_Sniffs_RedirectLinksSniff implements PHP_CodeSniffer_Sniff {
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return array( T_CONSTANT_ENCAPSED_STRING, T_DOUBLE_QUOTED_STRING, T_INLINE_HTML );
+	}
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file where the token was found.
+	 * @param int                  $stack_ptr The position in the stack where the token was found.
+	 */
+	public function process( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+
+		$tokens = $phpcs_file->getTokens();
+
+		$blacklist = array(
+			'([^ ]*\.)?wordpress.com',
+			'([^ ]*\.)?jetpack.com',
+			'([^ ]*\.)?vaultpress.com',
+			'([^ ]*\.)?akismet.com',
+			'([^ ]*\.)?tumblr.com',
+			'([^ ]*\.)?videopress.com',
+			'([^ ]*\.)?wordpress.org',
+		);
+
+		$pattern = '/https?:\/\/(' . implode( '|', $blacklist ) . ')/';
+
+		if ( preg_match( $pattern, $tokens[ $stack_ptr ]['content'] ) ) {
+
+			// if string is inside a parenthesis.
+			if ( isset( $tokens[ $stack_ptr ]['nested_parenthesis'] ) ) {
+				// Gets the position of the most nested opening parenthesis (array_key_last).
+				$open_parenthesis_positions = array_keys( $tokens[ $stack_ptr ]['nested_parenthesis'] );
+				$open_parenthesis_position  = $open_parenthesis_positions[ count( $open_parenthesis_positions ) - 1 ];
+
+				// gets the first T_STING before the open parenthesis, which should be the function call.
+				$function_call = $tokens[ $phpcs_file->findPrevious( T_STRING, $open_parenthesis_position ) ];
+
+				// if function call is get_url, we are fine, don't trigger the Warning.
+				if ( 'get_url' === $function_call['content'] ) {
+					return;
+				}
+			}
+
+			$phpcs_file->addWarning(
+				'Links must be added using the Jetpack redirect service. See Automattic\Jetpack\Redirects::get_url()',
+				$stack_ptr,
+				'UrlFoundWithoutRedirect'
+			);
+		}
+	}
+}

--- a/bin/PHPCSSniffs/ruleset.xml
+++ b/bin/PHPCSSniffs/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset name="Jetpack">
+	<description>Jetpack Specific lint rules.</description>
+</ruleset>

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -54,4 +54,5 @@ module.exports = [
 	'modules/wpcom-tos/wpcom-tos.php',
 	'packages',
 	'tests/e2e/plugins/e2e-plan-data-interceptor.php',
+	'bin/PHPCSSniffs',
 ];


### PR DESCRIPTION
After we deployed the "Redirect Everything" project on https://github.com/Automattic/jetpack/pull/15140, we want to make sure that future links are added using our Redirect service.

This PR adds a new sniffer to phpcs that will look for strings containing URLs to some automattic domains and throw a warning if they are  not being added using the redirect function.

### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It adds a sniffer to our phpcs rules

### Testing instructions:

This is going to be easier if you try it on a single file. So choose a PHP file to work with and run `phpcs` against it:

```
yarn php:lint myfile.php
```
See the `$blacklist` variable

Now test it with different situations:

```PHP
use Automattic\Jetpack\Redirect;
// ...

$x = 'https://wordpress.com/any'; // should throw warning

$x = Redirect::get_url( 'https://wordpress.com/any' ); // should NOT throw warning

$var = array(
	'whatever',
	__( 'anything', 'jetpack' ),
	'https://subdomain.vaultpress.com', // should throw warning
);

?>
	<a href="http://akismet.com">Link</a> <!-- should throw warning -->
<?php

if ( true ) {
	foreach ( $var as $v ) {
		echo esc_url( 'http://super.videopress.com' ); // should throw warning
		echo esc_url( Redirect::get_url( 'http://super.videopress.com' ) ); // should NOT throw warning
	}

	$multi_line = Redirect::get_url(
		'https://support.jetpack.com', // should NOT throw warning
		array( 'site' => 'example.org )
	);
}
```
#### Feedback wanted

* Is `bin` folder a good place for it?
* Run it in random files to have a feel of how many false positives it triggers

Note: I couldn't figure out an easy way to run only this sniffer in the whole code. In theory, you can call `vendor/bin/phpcs` passing the `--sniffs` parameter, but it didn't work for me. If you know how to do this, please share

(what I did was temporarily delete all rules from `.phpcs.xml.dist` (except `PHPCompatibilityWP`) and then run `yarn php:compatibility`)