### PR TITLE
add support to direct url to Redirects::get_url

### DIFF
--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -35,9 +35,13 @@ class Redirect {
 	/**
 	 * Builds and returns an URL using the jetpack.com/redirect service
 	 *
-	 * Note to WP.com: Changes to this method must be synced to wpcom
+	 * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
 	 *
-	 * @param string       $source The URL handler registered in the server.
+	 * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
+	 *
+	 * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
+	 *
+	 * @param string       $source The URL handler registered in the server or the full destination URL (starting with https://).
 	 * @param array|string $args {
 	 *    Optional. Additional arguments to build the url.
 	 *
@@ -55,8 +59,18 @@ class Redirect {
 		$args          = wp_parse_args( $args, array( 'site' => self::build_raw_urls( get_home_url() ) ) );
 		$accepted_args = array( 'site', 'path', 'query', 'anchor' );
 
+		$source_key = 'source';
+
+		if ( 0 === strpos( $source, 'https://' ) ) {
+			$source_key = 'url';
+			$source_url = \wp_parse_url( $source );
+
+			// discard any query and fragments.
+			$source = $source_url['scheme'] . '://' . $source_url['host'] . ( isset( $source_url['path'] ) ? $source_url['path'] : '' );
+		}
+
 		$to_be_added = array(
-			'source' => rawurlencode( $source ),
+			$source_key => rawurlencode( $source ),
 		);
 
 		foreach ( $args as $arg_name => $arg_value ) {

--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -66,7 +66,7 @@ class Redirect {
 			$source_url = \wp_parse_url( $source );
 
 			// discard any query and fragments.
-			$source = $source_url['scheme'] . '://' . $source_url['host'] . ( isset( $source_url['path'] ) ? $source_url['path'] : '' );
+			$source = 'https://' . $source_url['host'] . ( isset( $source_url['path'] ) ? $source_url['path'] : '' );
 		}
 
 		$to_be_added = array(

--- a/packages/redirect/tests/php/bootstrap.php
+++ b/packages/redirect/tests/php/bootstrap.php
@@ -10,6 +10,10 @@ function get_home_url() {
 	return 'http://example.org';
 }
 
+function wp_parse_url( $url ) {
+	return parse_url( $url );
+}
+
 function wp_parse_args( $args, $defaults = '' ) {
 	if ( is_object( $args ) ) {
 		$parsed_args = get_object_vars( $args );

--- a/packages/redirect/tests/php/test_Redirect.php
+++ b/packages/redirect/tests/php/test_Redirect.php
@@ -48,6 +48,23 @@ class RedirectTest extends TestCase {
 		$v   = rawurlencode( 'key=value&key2=value2' );
 		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&anchor=' . $v, $url );
 
+		// Test informing URL.
+		$url = Redirect::get_url( 'https://wordpress.com/support' );
+		$v   = rawurlencode( 'https://wordpress.com/support' );
+		$this->assertEquals( 'https://jetpack.com/redirect?url=' . $v . '&site=example.org', $url );
+
+		// Test URL and query.
+		$url   = Redirect::get_url( 'https://wordpress.com/support', array( 'query' => 'key=value&key2=value2' ) );
+		$v     = rawurlencode( 'key=value&key2=value2' );
+		$v_url = rawurlencode( 'https://wordpress.com/support' );
+		$this->assertEquals( 'https://jetpack.com/redirect?url=' . $v_url . '&site=example.org&query=' . $v, $url );
+
+		// Test URL and query, discarding info from url.
+		$url   = Redirect::get_url( 'https://wordpress.com/support?this=that#super', array( 'query' => 'key=value&key2=value2' ) );
+		$v     = rawurlencode( 'key=value&key2=value2' );
+		$v_url = rawurlencode( 'https://wordpress.com/support' );
+		$this->assertEquals( 'https://jetpack.com/redirect?url=' . $v_url . '&site=example.org&query=' . $v, $url );
+
 	}
 
 }


### PR DESCRIPTION
After D42161-code, our redirect service also accetps a `url` parameter that will redirect the visitor to this URL without the need of registering this url in our backend beforehand. This will only work for a few Automattic domains.

This PR adds the possibility of creating such links using the `Redirects` package.

#### Testing instructions:
* Run the package unit tests:

```
cd packages/redirects
composer run phpunit
```

* Create some output to test links:

```PHP
use Automattic\Jetpack\Redirect;
// ...
?>

Check if this links creates an URL pointing to jetpack.com/redirect?url=https%3A%2F%2Fwordpress.com%2Fsupport
Click on it and see if it works.
<a href="<?php echo Redirect::get_url( 'https://wordpress.com/support' ); ?>">Link</a>
```
```PHP
use Automattic\Jetpack\Redirect;
// ...
?>

Check if this links creates an URL pointing to jetpack.com/redirect?source=jetpack-support
Click on it and see if it works. (should go to jetpack.com/support)
<a href="<?php echo Redirect::get_url( 'jetpack-support' ); ?>">Link</a>
```
```PHP
use Automattic\Jetpack\Redirect;
// ...
?>

Check if this links creates an URL pointing to jetpack.com/redirect?url=https%3A%2F%2Fwaltdisneyworld.com
Click on it and see if it works. (it should go to jetpack.com homepage, since this domain is not whitelsted)
<a href="<?php echo Redirect::get_url( 'https://waltdisneyworld.com ); ?>">Link</a>
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add support to inform the direct URL in Redirect package get_url method
