### PR TITLE
Instant Search: Add support for whitelisting postTypes

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -133,8 +133,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'siteId'                => Jetpack::get_option( 'id' ),
 
 			// filtering.
-			'postTypeFilters'       => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
 			'postTypes'             => $post_type_labels,
+			'postTypesWhitelist'    => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
 			'sort'                  => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
 			'widgets'               => array_values( $widgets ),
 			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -219,6 +219,7 @@ class SearchApp extends Component {
 			siteId: this.props.options.siteId,
 			sort,
 			postsPerPage: this.props.options.postsPerPage,
+			postTypesWhitelist: this.props.options.postTypesWhitelist,
 		} )
 			.then( newResponse => {
 				if ( this.state.requestId === requestId ) {

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -103,7 +103,7 @@ const filterKeyToEsFilter = new Map( [
 	],
 ] );
 
-function buildFilterObject( filterQuery ) {
+function buildFilterObject( filterQuery, postTypesWhitelist ) {
 	if ( ! filterQuery ) {
 		return {};
 	}
@@ -121,6 +121,16 @@ function buildFilterObject( filterQuery ) {
 				}
 			} );
 		} );
+
+	// Handle post types whitelist defined in PHP
+	postTypesWhitelist.length > 0 &&
+		filter.bool.must.push( {
+			bool: {
+				should: postTypesWhitelist.map( postType =>
+					filterKeyToEsFilter.get( 'post_types' )( postType )
+				),
+			},
+		} );
 	return filter;
 }
 
@@ -133,6 +143,7 @@ export function search( {
 	siteId,
 	sort,
 	postsPerPage = 10,
+	postTypesWhitelist,
 } ) {
 	const key = stringify( Array.from( arguments ) );
 
@@ -171,7 +182,7 @@ export function search( {
 			aggregations,
 			fields,
 			highlight_fields: highlightFields,
-			filter: buildFilterObject( filter ),
+			filter: buildFilterObject( filter, postTypesWhitelist ),
 			query: encodeURIComponent( query ),
 			sort,
 			page_handle: pageHandle,


### PR DESCRIPTION
Fixes #13927.

#### Changes proposed in this Pull Request:
* Post types whitelisting from the customizer works as intended for the first Jetpack Search widget. Settings from any additional Jetpack Search widgets do not work as expected.
* Enables site owners to override post type whitelisting via the `jetpack_instant_search_options` filter.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, it adds partial support for handling post types whitelisting.

#### Testing instructions:
1. Apply this change.
2. Navigate to the customizer and change the post types whitelist settings for a Jetpack Search widget.
<img width="296" alt="Screen Shot 2020-04-22 at 3 59 35 PM" src="https://user-images.githubusercontent.com/4044428/80038184-50a11300-84b2-11ea-9354-14118921705f.png">
3. Try searching your site. Ensure that the post types whitelist is respected.

#### Proposed changelog entry for your changes:
* None.
