### PR TITLE
Block Editor: Set width for vertically aligned column

### DIFF
--- a/extensions/shared/styles/gutenberg-base-styles.scss
+++ b/extensions/shared/styles/gutenberg-base-styles.scss
@@ -4,3 +4,21 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/animations';
+
+/**
+ * Following is a fix for column contents overflowing the parent container
+ * when vertically aligned. This has been taken from newer versions of
+ * Gutenberg and WP core to provide the fix for WP 5.3.
+ *
+ * Issue: https://github.com/Automattic/jetpack/issues/14524
+ *
+ * See: https://github.com/WordPress/gutenberg/commit/bef41793a12b76a5220d177a768f8fe56deb5eba
+ * See: https://github.com/WordPress/WordPress/commit/f616ffb9c1a0abcdbe3306fd9e695ef3173a18c6
+ */
+.wp-block-column {
+	&.is-vertically-aligned-top,
+	&.is-vertically-aligned-center,
+	&.is-vertically-aligned-bottom {
+		width: 100%;
+	}
+}

--- a/extensions/shared/styles/gutenberg-base-styles.scss
+++ b/extensions/shared/styles/gutenberg-base-styles.scss
@@ -10,6 +10,8 @@
  * when vertically aligned. This has been taken from newer versions of
  * Gutenberg and WP core to provide the fix for WP 5.3.
  *
+ * TO-DO: remove once the minimum WP version required by Jetpack is WP 5.4.
+ *
  * Issue: https://github.com/Automattic/jetpack/issues/14524
  *
  * See: https://github.com/WordPress/gutenberg/commit/bef41793a12b76a5220d177a768f8fe56deb5eba


### PR DESCRIPTION
Fixes #14524

#### Changes proposed in this Pull Request:
* Sets width of vertically aligned columns to properly constrain child blocks such as Slideshow in older versions of WordPress and Gutenberg.

_Without specifying the width, nested blocks such as slideshow, overflow the column. Setting the width to 100% constrains them as expected._

#### Testing instructions:

1. Start up version 5.3 of WP with this fix.
2. Edit a blog post or page with block editor.
3. Add a column block (2 columns of 50%)
4. In the first column add a slideshow block and add some images to it.
5. Add a paragraph of text into the second column.
6. Select the first column and set the vertical alignment to top.
7. Slideshow block should still be bound by the column it is in.

_You can see the original behaviour by inspecting the column via dev tools and toggling off the width CSS property within the style:  `.wp-block-column.is-vertically-aligned-top`_

Before:

![SlideshowOverflow](https://user-images.githubusercontent.com/60436221/80079721-0001e680-8594-11ea-924e-04adf11819ab.gif)

After:

![SlideshowFix](https://user-images.githubusercontent.com/60436221/80079743-06905e00-8594-11ea-9c68-cb013ee20698.gif)

#### Proposed changelog entry for your changes:
* Bug Fix (#14524): Add support for nesting Slideshow block in columns in older versions of Gutenberg
