### PR TITLE
Comments: do not create comments with the comment type just yet

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -254,7 +254,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 			'comment_author_url'   => $user->user_url,
 			'comment_content'      => $input['content'],
 			'comment_parent'       => $comment_parent_id,
-			'comment_type'         => 'comment',
+			'comment_type'         => '',
 		);
 
 		if ( $comment_parent_id ) {


### PR DESCRIPTION
This is a follow-up on #15494.

#### Changes proposed in this Pull Request:

Let's not create "comment" type comments that are then displayed in areas handled by themes just yet. A lot of themes are not yet ready to handle comments that have a comment type other than an empty string.
We can apply this change once WordPress 5.5. ships, since there will then be a dev note published helping theme authors update their theme to take this into account.

Until then, let's only support the new comment type when pulling comments, and let's use the comment type in comments that are displayed via Jetpack, such as in the Carousel.

Internal reference: p2EDhh-14W-p2

#### Testing instructions:

There shouldn't be a lot to test, we're going back to the previous behaviour where comments created via the API (such as when replying to a comment via the Notifications panel or the Comments panel in Calypso) are created with an empty `comment_type`.

#### Proposed changelog entry for your changes:

* N/A
