### PR TITLE
Comments: change default comment type of comments created via API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-update-comment-endpoint.php
@@ -254,7 +254,7 @@ class WPCOM_JSON_API_Update_Comment_Endpoint extends WPCOM_JSON_API_Comment_Endp
 			'comment_author_url'   => $user->user_url,
 			'comment_content'      => $input['content'],
 			'comment_parent'       => $comment_parent_id,
-			'comment_type'         => '',
+			'comment_type'         => 'comment',
 		);
 
 		if ( $comment_parent_id ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This reverts commit 99ec0afb51d8b2e5e439e4e3451225d183b37abf.

Follow-up from #15494 and #15530

Internal reference: 94tqY-p2

#### Testing instructions:

* Comments created in Calypso or in Notifications should use the `comment` `comment_type`.

#### Proposed changelog entry for your changes:

* N/A
