### PR TITLE
Build: Improve Danger's whitelist message

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -1,4 +1,6 @@
 // If the file path starts with anything like in the array below, it should be linted.
+// New files must be added here when they're created.
+// If you are able to clear all errors from a file, please add it here.
 module.exports = [
 	'3rd-party/3rd-party.php',
 	'3rd-party/bbpress.php',

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -60,7 +60,7 @@ if ( newFiles.length > 0 ) {
 	if ( notWhitelistedFiles.length > 0 ) {
 		const stringifiedFilesList = '\n' + notWhitelistedFiles.join( '\n' );
 		fail(
-			'Please add these new PHP files to PHPCS whitelist for automatic linting:' +
+			'Please add these new PHP files to PHPCS whitelist in bin/phpcs-whitelist.js for automatic linting:' +
 				stringifiedFilesList
 		);
 	}


### PR DESCRIPTION
When adding a new PHP file, we ask folks add it to the bin/phpcs-whitelist.js file, but don't make that as clear as we could.

#### Changes proposed in this Pull Request:
* Improve messaging.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Add a new PHP file to this branch and push a new PR to see the error.

#### Proposed changelog entry for your changes:
* n/a
