### PR TITLE
Admin Page: update a few URLs to use jp-redirect

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -92,7 +92,7 @@ class DashBackups extends Component {
 							components: {
 								a: (
 									<a
-										href="https://dashboard.vaultpress.com"
+										href={ getRedirectUrl( 'vaultpress-dashboard' ) }
 										target="_blank"
 										rel="noopener noreferrer"
 									/>

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -201,7 +201,7 @@ export class Footer extends React.Component {
 					<li className="jp-footer__link-item">
 						<a
 							onClick={ this.trackVersionClick }
-							href="https://jetpack.com"
+							href={ getRedirectUrl( 'jetpack' ) }
 							target="_blank"
 							rel="noopener noreferrer"
 							className="jp-footer__link"


### PR DESCRIPTION
Fixes #15455 

#### Changes proposed in this Pull Request:
External URLs should be created using the jp-redirect library. Use the jp-redirect library to create:
* The `https://dashboard.vaultpress.com` URL in the AAG backups card.
* The `https://jetpack.com` URL in the dashboard footer.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:

##### Test Setup
* Jetpack must be activated and connected.
* VaultPress must be activated.

##### Test Steps
1. Run `yarn build` to build the new front-end files.
2. Navigate to the Jetpack dashboard. In the footer, check the **Jetpack version** link. It should be a redirect link: `https://jetpack.com/redirect/?source=jetpack`. Click the link and confirm that you’re directed to `jetpack.com`
3. While still on the Jetpack dashboard, check the **View backup details** link in the Backup card. It should be a redirect link: `https://jetpack.com/redirect/?source=vaultpress-dashboard`.  Click the link and confirm that you’re directed to `dashboard.vaultpress.com`.

#### Proposed changelog entry for your changes:
* n/a
