### PR TITLE
Extensions: Remove unnecessary Webpack resolution rules

### DIFF
--- a/webpack.config.extensions.js
+++ b/webpack.config.extensions.js
@@ -112,10 +112,6 @@ const componentsWebpackConfig = getBaseWebpackConfig(
 module.exports = [
 	{
 		...extensionsWebpackConfig,
-		resolve: {
-			...extensionsWebpackConfig.resolve,
-			modules: [ path.resolve( __dirname, '_inc/client' ), 'node_modules' ],
-		},
 		// The `module` override fixes https://github.com/Automattic/jetpack/issues/12511.
 		// @TODO Remove once there's a fix in `@automattic/calypso-build`
 		module: {
@@ -137,10 +133,6 @@ module.exports = [
 	},
 	{
 		...componentsWebpackConfig,
-		resolve: {
-			...componentsWebpackConfig.resolve,
-			modules: [ path.resolve( __dirname, '_inc/client' ), 'node_modules' ],
-		},
 		plugins: [
 			...componentsWebpackConfig.plugins,
 			new webpack.NormalModuleReplacementPlugin(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #15314

Requires #15482

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Stop resolving `_inc/client` in the extensions Webpack configuration.

In #15091 I've tried reusing the `PopupMonitor` library from `_inc/client` in the Instagram Gallery block. As it turns out this doesn't work on WPCOM.
The plan B has been to export the library from the Calypso monorepo, publish it on npm and use it in Jetpack as a normal external library.
Therefore, the [`_inc/client` resolution rules](https://github.com/Automattic/jetpack/pull/15091/commits/d50652291ca1e35bb28ae96f1e281f5833133028#diff-09575ea3a128e617b9c541a2b7262da5) I added are now unnecessary.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Wait for #15482 to merge!
* `yarn build-extensions`
* Open the editor and insert an Instagram Gallery block.
* Click on "Connect to Instagram".
* Make sure the popup opens correctly.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
