### PR TITLE
E2E Tests: Add Connection mocking

### DIFF
--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -43,7 +43,7 @@ export async function connectThroughWPAdminIfNeeded( {
 	await loginToWpSite( mockPlanData );
 
 	if ( await isBlogTokenSet() ) {
-		return true;
+		return 'already_connected';
 	}
 
 	await ( await Sidebar.init( page ) ).selectJetpack();

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -38,27 +38,17 @@ export async function connectThroughWPAdminIfNeeded( {
 	plan = 'pro',
 	mockPlanData = false,
 } = {} ) {
-	// Logs in to WPCOM
-	const login = await LoginPage.visit( page );
-	if ( ! mockPlanData ) {
-		await login.setSandboxModeForPayments( cookie );
-	}
-	if ( ! ( await login.isLoggedIn() ) ) {
-		await login.login( wpcomUser );
-	}
+	await loginToWpcomIfNeeded( wpcomUser, mockPlanData );
 
-	const siteUrl = getNgrokSiteUrl();
-	const host = new URL( siteUrl ).host;
+	await loginToWpSite( mockPlanData );
 
-	await ( await WPLoginPage.visit( page, siteUrl + '/wp-login.php' ) ).login();
-
-	if ( ! mockPlanData ) {
-		await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, host );
+	if ( await isBlogTokenSet() ) {
+		return true;
 	}
 
 	await ( await Sidebar.init( page ) ).selectJetpack();
 
-	let jetpackPage = await JetpackPage.init( page );
+	const jetpackPage = await JetpackPage.init( page );
 	if ( await jetpackPage.isConnected() ) {
 		await jetpackPage.openMyPlan();
 		if ( await jetpackPage.isPlan( plan ) ) {
@@ -68,43 +58,76 @@ export async function connectThroughWPAdminIfNeeded( {
 		}
 	}
 
-	await jetpackPage.connect();
+	await doClassicConnection( plan, mockPlanData );
+	await syncJetpackPlanData( plan, mockPlanData );
+}
 
+async function doClassicConnection( plan, mockPlanData ) {
+	const jetpackPage = await JetpackPage.init( page );
+	await jetpackPage.connect();
 	// Go through Jetpack connect flow
 	await ( await AuthorizePage.init( page ) ).approve();
-
-	// These steps are disabled for now
-	// await ( await JetpackSiteTypePage.init( page ) ).selectSiteType( 'blog' );
-	// await ( await JetpackSiteTopicPage.init( page ) ).selectSiteTopic( 'test site' );
-	// await ( await JetpackUserTypePage.init( page ) ).selectUserType( 'creator' );
-
 	if ( mockPlanData ) {
-		const planType = plan === 'free' ? 'jetpack_free' : 'jetpack_business';
-		await persistPlanData( planType );
 		await ( await PickAPlanPage.init( page ) ).selectFreePlan();
 	} else {
 		await ( await PickAPlanPage.init( page ) ).selectBusinessPlan();
 		await ( await CheckoutPage.init( page ) ).processPurchase( cardCredentials );
 	}
-
 	await ( await ThankYouPage.init( page ) ).waitForSetupAndProceed();
 	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
+}
 
-	jetpackPage = await JetpackPage.init( page );
+export async function syncJetpackPlanData( plan, mockPlanData = true ) {
+	const planType = plan === 'free' ? 'jetpack_free' : 'jetpack_business';
+	await persistPlanData( planType );
+
+	const siteUrl = getNgrokSiteUrl();
+	const jetpackUrl = siteUrl + '/wp-admin/admin.php?page=jetpack#/dashboard';
+
+	const jetpackPage = await JetpackPage.visit( page, jetpackUrl );
+	await jetpackPage.openMyPlan();
+	await jetpackPage.reload( { waitFor: 'networkidle0' } );
+
 	if ( ! mockPlanData ) {
 		await jetpackPage.reload( { waitFor: 'networkidle0' } );
-
 		await page.waitForResponse(
 			response => response.url().match( /v4\/site[^\/]/ ) && response.status() === 200,
 			{ timeout: 60 * 1000 }
 		);
 		await execWpCommand( 'wp cron event run jetpack_v2_heartbeat' );
 	}
-
 	await syncPlanData( page );
-
 	if ( ! ( await jetpackPage.isPlan( plan ) ) ) {
 		throw new Error( `Site does not have ${ plan } plan` );
+	}
+}
+
+async function loginToWpSite( mockPlanData ) {
+	const siteUrl = getNgrokSiteUrl();
+	const host = new URL( siteUrl ).host;
+	await ( await WPLoginPage.visit( page, siteUrl + '/wp-login.php' ) ).login();
+	if ( ! mockPlanData ) {
+		await ( await DashboardPage.init( page ) ).setSandboxModeForPayments( cookie, host );
+	}
+}
+
+async function loginToWpcomIfNeeded( wpcomUser, mockPlanData ) {
+	// Logs in to WPCOM
+	const login = await LoginPage.visit( page );
+	if ( ! mockPlanData ) {
+		await login.setSandboxModeForPayments( cookie );
+	}
+	if ( ! ( await login.isLoggedIn() ) ) {
+		await login.login( wpcomUser );
+	}
+}
+
+async function isBlogTokenSet() {
+	const cliCmd = 'wp jetpack options get blog_token';
+	const result = await execWpCommand( cliCmd );
+
+	if ( typeof result === 'object' && result.code === 1 ) {
+		return false;
 	}
 
 	return true;

--- a/tests/e2e/lib/plan-helper.js
+++ b/tests/e2e/lib/plan-helper.js
@@ -16,7 +16,7 @@ export async function persistPlanData( planType = 'jetpack_business' ) {
 
 	fs.writeFileSync( 'plan-data.txt', JSON.stringify( planData ) );
 
-	const cmd = `wp option add ${ planDataOption }`;
+	const cmd = `wp option update ${ planDataOption }`;
 	await execWpCommand( cmd, ' < plan-data.txt' );
 }
 

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -130,13 +130,12 @@ catchBeforeAll( async () => {
 	await enablePageDialogAccept();
 	setupConsoleLogs();
 
-	const url = getNgrokSiteUrl();
-	console.log( 'NEW SITE URL: ' + url );
+	const status = await connectThroughWPAdminIfNeeded( { mockPlanData: true, plan: 'free' } );
 
-	await connectThroughWPAdminIfNeeded( { mockPlanData: true, plan: 'free' } );
-	const result = await execWpCommand( 'wp option get jetpack_private_options --format=json' );
-
-	fs.writeFileSync( 'jetpack_private_options.txt', result.trim() );
+	if ( status !== 'already_connected' ) {
+		const result = await execWpCommand( 'wp option get jetpack_private_options --format=json' );
+		fs.writeFileSync( 'jetpack_private_options.txt', result.trim() );
+	}
 } );
 
 afterEach( async () => {

--- a/tests/e2e/lib/setup-env.js
+++ b/tests/e2e/lib/setup-env.js
@@ -11,7 +11,7 @@ import { setBrowserViewport, enablePageDialogAccept } from '@wordpress/e2e-test-
 import { takeScreenshot } from './reporters/screenshot';
 import { logHTML, logDebugLog } from './page-helper';
 import logger from './logger';
-import { getNgrokSiteUrl, execWpCommand } from './utils-helper';
+import { execWpCommand } from './utils-helper';
 import { connectThroughWPAdminIfNeeded } from './flows/jetpack-connect';
 
 const { PUPPETEER_TIMEOUT, E2E_DEBUG, CI, E2E_LOG_HTML } = process.env;
@@ -117,7 +117,7 @@ jasmine.getEnv().addReporter( {
 		logger.info( `Spec name: ${ result.fullName }, description: ${ result.description }` );
 		jasmine.currentTest = result;
 	},
-	specDone: result => ( jasmine.currentTest = result ),
+	specDone: () => ( jasmine.currentTest = null ),
 } );
 
 // Before every test suite run, delete all content created by the test. This ensures

--- a/tests/e2e/specs/free-blocks.test.js
+++ b/tests/e2e/specs/free-blocks.test.js
@@ -3,20 +3,14 @@
  */
 import BlockEditorPage from '../lib/pages/wp-admin/block-editor';
 import PostFrontendPage from '../lib/pages/postFrontend';
-import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
-import { resetWordpressInstall, getNgrokSiteUrl } from '../lib/utils-helper';
+import { syncJetpackPlanData } from '../lib/flows/jetpack-connect';
 import PinterestBlock from '../lib/blocks/pinterest';
 import EventbriteBlock from '../lib/blocks/eventbrite';
 import { catchBeforeAll } from '../lib/setup-env';
-import logger from '../lib/logger';
 
 describe( 'Free blocks', () => {
 	catchBeforeAll( async () => {
-		await resetWordpressInstall();
-		const url = getNgrokSiteUrl();
-		logger.info( 'NEW SITE URL: ' + url );
-
-		await connectThroughWPAdminIfNeeded( { mockPlanData: true, plan: 'free' } );
+		await syncJetpackPlanData( 'free' );
 	} );
 
 	describe( 'Pinterest block', () => {

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -4,24 +4,23 @@
 import BlockEditorPage from '../lib/pages/wp-admin/block-editor';
 import PostFrontendPage from '../lib/pages/postFrontend';
 import MailchimpBlock from '../lib/blocks/mailchimp';
-import { connectThroughWPAdminIfNeeded } from '../lib/flows/jetpack-connect';
-import { resetWordpressInstall, getNgrokSiteUrl, activateModule } from '../lib/utils-helper';
+import { syncJetpackPlanData } from '../lib/flows/jetpack-connect';
+import { activateModule, execWpCommand } from '../lib/utils-helper';
 import SimplePaymentBlock from '../lib/blocks/simple-payments';
 import WordAdsBlock from '../lib/blocks/word-ads';
-
 import { catchBeforeAll } from '../lib/setup-env';
-import logger from '../lib/logger';
 
 describe( 'Paid blocks', () => {
 	catchBeforeAll( async () => {
-		await resetWordpressInstall();
-		const url = getNgrokSiteUrl();
-		logger.info( 'NEW SITE URL: ' + url );
-
-		await connectThroughWPAdminIfNeeded( { mockPlanData: true } );
+		await syncJetpackPlanData( 'pro' );
 
 		await activateModule( page, 'publicize' );
 		await activateModule( page, 'wordads' );
+	} );
+
+	afterAll( async () => {
+		await execWpCommand( 'wp jetpack module deactivate publicize' );
+		await execWpCommand( 'wp jetpack module deactivate wordads' );
 	} );
 
 	describe( 'Mailchimp Block', () => {


### PR DESCRIPTION
Before this PR, for every test suite, we would create a new site (actually reset the existing one, and generate new URL). This is quite time-consuming. In this PR I tried to reuse created site, and tweak its state by messing around with plan data and  `jetpack_private_options` option. Seems like it saves us around 80 sec comparing to `master` build. 

Thanks @dereksmart for the suggestion!

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* No functional changes were made. 
* Travis tests should be green

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
