### PR TITLE
Instant Search: Only show filters dropdown button in mobile if eligible

### DIFF
--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -58,8 +58,8 @@ const SearchBox = props => {
 				</label>
 			</div>
 
-			{ props.enableFilters && ! props.widget && (
-				<div className="jetpack-instant-search__box-filter-area">
+			<div className="jetpack-instant-search__box-filter-area">
+				{ props.enableFilters && (
 					<div
 						role="button"
 						onClick={ props.toggleFilters }
@@ -80,9 +80,9 @@ const SearchBox = props => {
 								: __( 'Show filters', 'jetpack' ) }
 						</span>
 					</div>
-					<SearchSort onChange={ props.onChangeSort } value={ getSortQuery() } />
-				</div>
-			) }
+				) }
+				<SearchSort onChange={ props.onChangeSort } value={ getSortQuery() } />
+			</div>
 		</Fragment>
 	);
 };

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -48,50 +48,53 @@ class SearchForm extends Component {
 		}
 	};
 
+	hasSelectableFilters = () =>
+		this.props.widgets.some( widget => Array( widget.filters ) && widget.filters.length > 0 );
+
+	hasPreselectedFilters = () =>
+		hasPreselectedFilters( this.props.widgets, this.props.widgetsOutsideOverlay );
+
 	render() {
 		return (
 			<form onSubmit={ noop } role="search" className={ this.props.className }>
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
-						enableFilters
+						enableFilters={ this.hasSelectableFilters() || this.hasPreselectedFilters() }
 						isVisible={ this.props.isVisible }
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }
 						showFilters={ this.state.showFilters }
 						toggleFilters={ this.toggleFilters }
-						widget={ this.props.widget }
 					/>
 				</div>
-				{ this.state.showFilters && (
-					<div className="jetpack-instant-search__search-form-filters">
-						<div className="jetpack-instant-search__search-form-filters-arrow" />
-						<PreselectedSearchFilters
-							loading={ this.props.isLoading }
-							locale={ this.props.locale }
-							postTypes={ this.props.postTypes }
-							results={ this.props.response }
-							widgets={ this.props.widgets }
-							widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
-						/>
-						{ this.props.widgets.map( ( widget, index ) => (
-							<SearchFilters
-								filters={ getFilterQuery() }
+				{ ( this.hasSelectableFilters() || this.hasPreselectedFilters() ) &&
+					this.state.showFilters && (
+						<div className="jetpack-instant-search__search-form-filters">
+							<div className="jetpack-instant-search__search-form-filters-arrow" />
+							<PreselectedSearchFilters
 								loading={ this.props.isLoading }
 								locale={ this.props.locale }
-								onChange={ this.hideFilters }
 								postTypes={ this.props.postTypes }
 								results={ this.props.response }
-								showClearFiltersButton={
-									! hasPreselectedFilters( this.props.widgets, this.props.widgetsOutsideOverlay ) &&
-									index === 0
-								}
-								widget={ widget }
+								widgets={ this.props.widgets }
+								widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 							/>
-						) ) }
-						<JetpackColophon locale={ this.props.locale } />
-					</div>
-				) }
+							{ this.props.widgets.map( ( widget, index ) => (
+								<SearchFilters
+									filters={ getFilterQuery() }
+									loading={ this.props.isLoading }
+									locale={ this.props.locale }
+									onChange={ this.hideFilters }
+									postTypes={ this.props.postTypes }
+									results={ this.props.response }
+									showClearFiltersButton={ ! this.hasPreselectedFilters() && index === 0 }
+									widget={ widget }
+								/>
+							) ) }
+							<JetpackColophon locale={ this.props.locale } />
+						</div>
+					) }
 			</form>
 		);
 	}


### PR DESCRIPTION
Fixes #15522.

#### Changes proposed in this Pull Request:
* Hides the Filters dropdown button below the overlay search input if there are no filters to show.

> Before:
> <img width="258" alt="Screen Shot 2020-04-23 at 4 57 29 PM" src="https://user-images.githubusercontent.com/4044428/80157491-8c57dd80-8583-11ea-91e1-e32f76abe9a9.png">

> After:
> <img width="258" alt="Screen Shot 2020-04-23 at 4 57 33 PM" src="https://user-images.githubusercontent.com/4044428/80157489-8a8e1a00-8583-11ea-9438-08eca8631a5b.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Testing instructions:
1) Apply this change to your local Jetpack installation.
2) Make sure that the Jetpack Search widget inside the overlay sidebar doesn't have any filters configured. Perform a search with a mobile viewport. Ensure that the Filters dropdown button doesn't appear.
3) Repeat the above step but spawn the overlay by clicking on a search filter defined by a Jetpack Search widget outside of the overlay sidebar (e.g. site footer or sidebar). Ensure that the Filters dropdown button appears in the mobile viewport.
4) Repeat (2) but ensure that there's a Jetpack Search widget inside the overlay sidebar with filters configured. Ensure that the Filters dropdown appears in the mobile viewport.

#### Proposed changelog entry for your changes:
* None.
