### PR TITLE
Onboarding: saving the site creation flow as a site option

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -142,7 +142,8 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'site_goals',
 		'site_segment',
 		'import_engine',
-		'is_wpforteams_site'
+		'is_wpforteams_site',
+		'site_creation_flow',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -611,6 +612,12 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'is_wpforteams_site':
 					$options[ $key ] = $site->is_wpforteams_site();
+					break;
+				case 'site_creation_flow':
+					$site_creation_flow = $site->get_site_creation_flow();
+					if ( $site_creation_flow ) {
+						$options[ $key ] = $site_creation_flow;
+					}
 					break;
 			}
 		}

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -658,4 +658,8 @@ abstract class SAL_Site {
 	function get_site_segment() {
 		return false;
 	}
+
+	function get_site_creation_flow() {
+		return get_option( 'site_creation_flow' );
+	}
 }


### PR DESCRIPTION

Differential Revision: D42191-code

This commit syncs r206374-wpcom.

#### Changes proposed in this Pull Request:

This patch saves the value of the `site_creation_flow` option as a site option.

We're doing this so we know which onboarding flow the user completed to create a particular site.

More specifically, we'd like to identify sites created in the Gutenboarding signup flow so we can customize the editor UI.

https://github.com/Automattic/wp-calypso/issues/41300#issuecomment-617065342

#### Testing instructions:

Run https://github.com/Automattic/wp-calypso/pull/41349

Create a site via `/new`.

When you finally land in the editor, filter the XHR network requests in your browser's console by `me/sites`

Check that the option is set.

#### Proposed changelog entry for your changes:

* N/A
