### PR TITLE
Instagram Gallery Block: Reuse the Instagram token if already stored

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -126,13 +126,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	public function get_instagram_access_token() {
-		$site_id = Jetpack_Instagram_Gallery_Helper::get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return $site_id;
-		}
-
-		$path     = sprintf( '/sites/%d/external-services/connections', $site_id );
-		$response = Client::wpcom_json_api_request_as_user( $path );
+		$response = Client::wpcom_json_api_request_as_user( '/me/connections' );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -40,11 +40,12 @@ const InstagramGalleryEdit = props => {
 
 	const [ images, setImages ] = useState( [] );
 	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
-	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram(
+	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram( {
+		accessToken,
+		noticeOperations,
 		setAttributes,
 		setImages,
-		noticeOperations
-	);
+	} );
 	const { isRequestingWpcomConnectUrl, wpcomConnectUrl } = useConnectWpcom();
 
 	const unselectedCount = count > images.length ? images.length : count;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #15276

~Requires D42457-code~

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* When the Instagram Gallery block is inserted, checks if the user has already an Instagram access token stored, and use it automatically instead of asking them to connect to Instagram every time.

![Apr-24-2020 12-54-59](https://user-images.githubusercontent.com/2070010/80210092-0ee7a800-862b-11ea-961f-55b9a0a32220.gif)

Note: this needs to be synced in D42516-code

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* ~Apply D42457-code and sandbox the API.~
* On a site connected to WPCOM, open the editor and insert an Instagram Gallery block.
* If your user has already an Instagram token stored, the block should (eventually) directly embed the gallery.
* Otherwise, it should show a "Connect to Instagram" button.
* When the block is connected to Instagram, open its sidebar and click on "Disconnect your account".
* Make sure the block is reverted to placeholder state.

Note: this doesn't work across different blocks.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
