### PR TITLE
Blacklisting Post Types from Sync

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -387,6 +387,7 @@ class Defaults {
 		'jp_sitemap_master',
 		'jp_vid_sitemap',
 		'jp_vid_sitemap_index',
+		'msm_sitemap', // Metro Sitemap Plugin.
 		'postman_sent_mail',
 		'rssap-feed',
 		'rssmi_feed_item',

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -372,6 +372,7 @@ class Defaults {
 	 * @var array Blacklisted post types.
 	 */
 	public static $blacklisted_post_types = array(
+		'ai_log', // Logger - https://github.com/alleyinteractive/logger.
 		'ai1ec_event',
 		'bwg_album',
 		'bwg_gallery',

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -396,6 +396,7 @@ class Defaults {
 		'snitch',
 		'vip-legacy-redirect',
 		'wp_automatic',
+		'wp_log', // WP Logging Plugin.
 		'wp-rest-api-log', // https://wordpress.org/plugins/wp-rest-api-log/.
 		'wpephpcompat_jobs',
 		'wprss_feed_item',


### PR DESCRIPTION
Update post_type blacklist with additional sitemap and logging plugins. The content should not be synced to WP.com as no additional processing/actions will be driven off them.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* ai_log, wp_log and msm_sitemap post-types will be blacklisted.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Updates the blacklist to include 3 new post_types

#### Testing instructions:

* Install https://github.com/alleyinteractive/logger , https://github.com/Automattic/msm-sitemap or https://pippinsplugins.com/wp-logging/
* Generate logs, sitemaps
* Verify that actions are not being sent to WP.com for these post_types

#### Proposed changelog entry for your changes:
* N/A : Performance Optimizations
