### PR TITLE
WordAds - AMP Compatibility

### DIFF
--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -546,7 +546,7 @@ HTML;
 				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '5';
 				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, self::$SOLO_UNIT_CSS );
 			} elseif ( 'top_amp' === $spot ) {
-				// 300x250 unit which can safely be inserted below title, above content in a variety of themes.
+				// Ad unit which can safely be inserted below title, above content in a variety of themes.
 				$width   = $this->params->mobile_device ? 320 : 300;
 				$height  = $this->params->mobile_device ? 50 : 250;
 				$snippet = $this->get_ad_snippet( null, $height, $width );

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -546,9 +546,9 @@ HTML;
 				$section_id = 0 === $this->params->blog_id ? WORDADS_API_TEST_ID : $this->params->blog_id . '5';
 				$snippet    = $this->get_ad_snippet( $section_id, $height, $width, $spot, self::$SOLO_UNIT_CSS );
 			} elseif ( 'top_amp' === $spot ) {
-				// 320x50 unit which can safely be inserted below title, above content in a variety of themes.
-				$width   = 320;
-				$height  = 50;
+				// 300x250 unit which can safely be inserted below title, above content in a variety of themes.
+				$width   = $this->params->mobile_device ? 320 : 300;
+				$height  = $this->params->mobile_device ? 50 : 250;
 				$snippet = $this->get_ad_snippet( null, $height, $width );
 			}
 		} elseif ( 'house' == $type ) {


### PR DESCRIPTION
The "Standard" mode for the Google AMP plugin is AMP first. This means that when this mode is enabled, a user will see the AMP version of the website, regardless of device, the site being served from an AMP Cache or being viewed using a specific AMP endpoint. 

We should thus, render a larger Word Ads size when an AMP version of the website is being viewed on a desktop browser.

Fixes #15400

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This enhances and existing feature
* P2 shortlink: https://wp.me/pbIAo1-17

#### Testing instructions:

1. Ensure the AMP plugin is active
2. In AMP > Settings, select Standard mode
3. Enable Word Ads in Jetpack > Settings > Traffic > Ads
4. Visit a post on the front end on a desktop browser with ?amp appended to the URL, and make sure a 300*250 ad is showing above post content.
5. Visit a post on a mobile device with ?amp appended to the URL and make sure that a 320*50 ad is showing above the post content

Mobile Ad:
<img width="375" alt="Screen Shot 2020-04-24 at 4 46 53 PM" src="https://user-images.githubusercontent.com/49400/80225495-7281cd80-864b-11ea-9c6c-08da14a784eb.png">

Desktop Ad:
<img width="725" alt="Screen Shot 2020-04-24 at 4 48 11 PM" src="https://user-images.githubusercontent.com/49400/80225514-77df1800-864b-11ea-9581-904b752c68ad.png">
