### PR TITLE
Search: Add adminQueryFilter support

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -132,10 +132,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'postsPerPage'          => get_option( 'posts_per_page' ),
 			'siteId'                => Jetpack::get_option( 'id' ),
 
-			// filtering.
-			'postTypeFilters'       => isset( $widget_options['post_types'] ) ? $widget_options['post_types'] : array(),
 			'postTypes'             => $post_type_labels,
-			'sort'                  => isset( $widget_options['sort'] ) ? $widget_options['sort'] : null,
 			'widgets'               => array_values( $widgets ),
 			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
 		);

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -219,6 +219,7 @@ class SearchApp extends Component {
 			siteId: this.props.options.siteId,
 			sort,
 			postsPerPage: this.props.options.postsPerPage,
+			adminQueryFilter: this.props.options.adminQueryFilter,
 		} )
 			.then( newResponse => {
 				if ( this.state.requestId === requestId ) {

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -103,9 +103,12 @@ const filterKeyToEsFilter = new Map( [
 	],
 ] );
 
-function buildFilterObject( filterQuery ) {
-	if ( ! filterQuery ) {
+function buildFilterObject( filterQuery, adminQueryFilter ) {
+	if ( ! filterQuery && ! adminQueryFilter ) {
 		return {};
+	}
+	if ( ! filterQuery ) {
+		return adminQueryFilter;
 	}
 
 	const filter = { bool: { must: [] } };
@@ -121,6 +124,10 @@ function buildFilterObject( filterQuery ) {
 				}
 			} );
 		} );
+
+	if ( adminQueryFilter ) {
+		filter.bool.must.push( adminQueryFilter );
+	}
 	return filter;
 }
 
@@ -133,6 +140,7 @@ export function search( {
 	siteId,
 	sort,
 	postsPerPage = 10,
+	adminQueryFilter,
 } ) {
 	const key = stringify( Array.from( arguments ) );
 
@@ -171,7 +179,7 @@ export function search( {
 			aggregations,
 			fields,
 			highlight_fields: highlightFields,
-			filter: buildFilterObject( filter ),
+			filter: buildFilterObject( filter, adminQueryFilter ),
 			query: encodeURIComponent( query ),
 			sort,
 			page_handle: pageHandle,


### PR DESCRIPTION
Allows the admin of the site to add a filter to all search queries. Addresses #13927 in a more generic way than #15526 

Should let us solve a lot of the cases we've been asked about in the past without adding any new UI: https://jetpack.com/support/search-old/customize-search/

To test, add a filter for the query and verify that it gets applied to all searches. Example:
```
function jp_filter_query( $options ) {
	$options['adminQueryFilter'] = array(
		'term' => array( 'tag.slug' => 'release' )
	);
	return $options;
}
add_filter( 'jetpack_instant_search_options', 'jp_filter_query' );
```
