### PR TITLE
Search: Don't add widget to an empty sidebar-1 area

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -410,6 +410,10 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$sidebar_id            = false;
 		$sidebar_searchbox_idx = false;
 		if ( $has_sidebar ) {
+			if ( empty( $sidebars['sidebar-1'] ) ) {
+				// Adding to an empty sidebar is generally a bad idea.
+				$has_sidebar = false;
+			}
 			foreach ( (array) $sidebars['sidebar-1'] as $idx => $widget_id ) {
 				if ( 0 === strpos( $widget_id, 'search-' ) ) {
 					$sidebar_searchbox_idx = $idx;


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/15437

If the sidebar area is empty then we shouldn't add to it because it will likely make a major change to the users site and be confusing. Assume that they have some other search box on the site that will work for them.

To test:
- purchase search plan for a site both with and without widgets in the sidebar-1 area
- verify that either way the overlay sidebar gets configured but that the sidebar-1 area does not get added to