### PR TITLE
Search: Define number of records in the upgrade card

### DIFF
--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -94,6 +94,11 @@ export function SingleProductSearchCard( props ) {
 						{ args: numberFormat( recordCount ), count: recordCount }
 					) }
 				</h4>
+				<h4 className="single-product-backup__options-header">
+					{ __(
+						'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search.'
+					) }
+				</h4>
 				<div className="single-product-search__radio-buttons-container">
 					<PlanRadioButton
 						billingTimeFrame={ planDuration }


### PR DESCRIPTION
Fixes #15402

Before:

<img width="532" alt="Screen Shot 2020-04-24 at 9 57 27 AM" src="https://user-images.githubusercontent.com/820871/80235803-6e3bbd00-8617-11ea-8552-ef95c27e2013.png">

After:

<img width="529" alt="Screen Shot 2020-04-24 at 10 33 46 AM" src="https://user-images.githubusercontent.com/820871/80235828-7267da80-8617-11ea-808d-79d2b354e6ae.png">

On the wp-admin plans page when the site does not have a search plan.
