### PR TITLE
Add eslint rule for jetpack redirects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
 			version: 'detect', // React version. "detect" automatically picks the version you have installed.
 		},
 	},
-	plugins: [ 'jsx-a11y', 'lodash', 'jsdoc' ],
+	plugins: [ 'jsx-a11y', 'lodash', 'jsdoc', 'jetpack' ],
 	rules: {
 		// REST API objects include underscores
 		camelcase: 0,
@@ -137,6 +137,9 @@ module.exports = {
 		'no-case-declarations': 1,
 		'no-class-assign': 1,
 		'no-redeclare': 1,
+
+		// Jetpack custom rules
+		'jetpack/jetpack-redirects': 1,
 
 		// Workaround for ESLint failing to parse files with template literals
 		// with this error: "TypeError: Cannot read property 'range' of null"

--- a/bin/ESLintCustomRules/index.js
+++ b/bin/ESLintCustomRules/index.js
@@ -1,0 +1,48 @@
+function getBlacklistUrlsPattern() {
+	const blackList = [
+		'([^ ]*\.)?wordpress.com',
+		'([^ ]*\.)?jetpack.com',
+		'([^ ]*\.)?vaultpress.com',
+		'([^ ]*\.)?akismet.com',
+		'([^ ]*\.)?tumblr.com',
+		'([^ ]*\.)?videopress.com',
+		'([^ ]*\.)?wordpress.org',
+	];
+
+	const domains = blackList.join( '|' );
+
+	return new RegExp( `https?:\/\/(${ domains })` );
+
+}
+
+module.exports.rules = {
+	"jetpack-redirects": context => (
+		{
+			TemplateLiteral: (node) => {
+
+				node.quasis.forEach( element => {
+					if ( 'string' === typeof( element.value.raw ) && element.value.raw.length && element.value.raw.search( getBlacklistUrlsPattern() ) >= 0 ) {
+						const parent = node.parent;
+						if ( 'CallExpression' === parent.type && parent.callee && parent.callee.name && 'getRedirectUrl' === parent.callee.name ) {
+							return;
+						}
+						context.report(node, 'Links to a8c domains must be added using the jetpack redirects package');
+					}
+				} );
+
+			},
+
+			Literal: (node) => {
+
+				if ( 'string' === typeof( node.value ) && node.value.length && node.value.search( getBlacklistUrlsPattern() ) >= 0 ) {
+					const parent = node.parent;
+					if ( 'CallExpression' === parent.type && parent.callee && parent.callee.name && 'getRedirectUrl' === parent.callee.name ) {
+						return;
+					}
+					context.report(node, 'Links to a8c domains must be added using the jetpack redirects package');
+				}
+
+			}
+		}
+	)
+};

--- a/bin/ESLintCustomRules/package.json
+++ b/bin/ESLintCustomRules/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "eslint-plugin-jetpack",
+		"version": "0.0.1",
+	"main": "index.js",
+	"devDependencies": {
+			"eslint": "6.8.0"
+	},
+	"engines": {
+		"node": ">=10"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
 		"debug": "4.1.1",
 		"del": "5.1.0",
 		"email-validator": "2.0.4",
+		"eslint-plugin-jetpack": "file:bin/ESLintCustomRules",
 		"fancy-log": "1.3.3",
 		"fast-json-stable-stringify": "2.1.0",
 		"focus-trap": "5.1.0",


### PR DESCRIPTION
After we deployed the "Redirect Everything" project on https://github.com/Automattic/jetpack/pull/15140, we want to make sure that future links are added using our Redirect service.

This PR adds a new sniffer to phpcs that will look for strings containing URLs to some automattic domains and throw a warning if they are  not being added using the redirect function.

### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It adds a sniffer to our phpcs rules

### Testing instructions:

Lint some files and check the results

```JS

const link = 'https://wordpress.com/bla'; // Warning
const link = 'http://wordpress.com/bla'; // Warning
const link = 'some string https://wordpress.com/bla'; // Warning

const link = `template literal ${ var } https://wordpress.com/asds`; // Warning

const obj = { 
	prop: 'foo', 
	link: 'https://subdomain.jetpack.com' // Warning
}

const link = 'http://somewhere.com'; // ok, domain not listed

const link = getRedirectUrl( 'https://wordpress.com' ) // ok, using the redirect function
```



#### Feedback wanted

* Is `bin` folder a good place for it?
* Run it in random files to have a feel of how many false positives it triggers
* Is the naming of the rule ok?
* Is the error message ok? Should we point it to more info? how? where? (there's a FG page)
