### PR TITLE
 Search: Define number of records in the purchase product card.

### DIFF
--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -95,15 +95,10 @@ export function SingleProductSearchCard( props ) {
 						{ args: numberFormat( recordCount ), count: recordCount }
 					) }
 					<InfoPopover position="right">
-						{
-							'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search.'
-						}
+						{ __(
+							'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.'
+						) }
 					</InfoPopover>
-				</h4>
-				<h4 className="single-product-backup__options-header">
-					{ __(
-						'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search.'
-					) }
 				</h4>
 				<div className="single-product-search__radio-buttons-container">
 					<PlanRadioButton

--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -23,6 +23,7 @@ import {
 import { getPlanDuration } from 'state/plans/reducer';
 import { getUpgradeUrl } from 'state/initial-state';
 import { SEARCH_DESCRIPTION, SEARCH_TITLE } from '../constants';
+import InfoPopover from 'components/info-popover';
 import PlanRadioButton from '../single-product-components/plan-radio-button';
 import ProductSavings from '../single-product-components/product-savings';
 
@@ -93,6 +94,11 @@ export function SingleProductSearchCard( props ) {
 						'Your current site record size: %s records',
 						{ args: numberFormat( recordCount ), count: recordCount }
 					) }
+					<InfoPopover position="right">
+						{
+							'Records are all posts, pages, custom post types and other types of content indexed by Jetpack Search.'
+						}
+					</InfoPopover>
 				</h4>
 				<h4 className="single-product-backup__options-header">
 					{ __(
@@ -112,6 +118,7 @@ export function SingleProductSearchCard( props ) {
 						radioValue={ planDuration }
 					/>
 				</div>
+
 				<ProductSavings
 					billingTimeframe={ planDuration }
 					currencyCode={ currencyCode }

--- a/_inc/client/plans/single-products.scss
+++ b/_inc/client/plans/single-products.scss
@@ -24,6 +24,11 @@
 	color: $gray-text-min;
 	text-align: center;
 	margin-top: 30px;
+
+	.dops-info-popover {
+		margin-left: 4px;
+		vertical-align: middle;
+	}
 }
 
 // Plans section


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Sequel to https://github.com/Automattic/jetpack/pull/15552 with a modified design. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move the text explaining record meaning to a popover component

* Go to `wp-admin/admin.php?page=jetpack#/plans` for a site with no Search plan
* verify the description is visible in the icon:
![pop](https://user-images.githubusercontent.com/13561163/80259014-e7bdc480-8684-11ea-9367-115d071f56e9.png)

