### PR TITLE
Implemented /setup/questionnaire API endpoint for the new setup wizard

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -505,31 +505,29 @@ class Jetpack_Core_Json_Api_Endpoints {
 			)
 		);
 
-		// Update settings from the Jetpack wizard.
+		/*
+		 * Get and update settings from the Jetpack wizard.
+		 */
 		register_rest_route(
 			'jetpack/v4',
 			'/setup/questionnaire',
 			array(
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => __CLASS__ . '::update_setup_questionnaire',
-				'permission_callback' => __CLASS__ . '::update_settings_permission_check',
-				'args'                => array(
-					'option_values' => array(
-						'required' => true,
-						'type'     => 'object',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => __CLASS__ . '::get_setup_questionnaire',
+					'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => __CLASS__ . '::update_setup_questionnaire',
+					'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+					'args'                => array(
+						'option_values' => array(
+							'required' => true,
+							'type'     => 'object',
+						),
 					),
 				),
-			)
-		);
-
-		// Get settings for the Jetpack wizard.
-		register_rest_route(
-			'jetpack/v4',
-			'/setup/questionnaire',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => __CLASS__ . '::get_setup_questionnaire',
-				'permission_callback' => __CLASS__ . '::update_settings_permission_check',
 			)
 		);
 	}
@@ -542,8 +540,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool true.
 	 */
 	public static function update_setup_questionnaire( $request ) {
+		// TODO: add validation.
+
 		$option_values = $request['option_values'];
-		update_option( 'setup_questionnaire', $option_values );
+		Jetpack_Options::update_option( 'setup_questionnaire', $option_values );
 		return true;
 	}
 
@@ -555,13 +555,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array Questionnaire settings.
 	 */
 	public static function get_setup_questionnaire( $request ) {
-		$options_values = get_option( 'setup_questionnaire' );
+		$options_values = Jetpack_Options::get_option( 'setup_questionnaire' );
 		if ( $options_values ) {
-			$return = $options_values;
+			return $options_values;
 		} else {
-			$return = array();
+			return array();
 		}
-		return $return;
 	}
 
 	public static function get_plans( $request ) {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -542,7 +542,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function update_setup_questionnaire( $request ) {
 		// TODO: add validation.
 
-		$option_values = $request['option_values'];
+		$option_values = empty( $request['option_values'] ) ? array() : $request['option_values'];
 		Jetpack_Options::update_option( 'setup_questionnaire', $option_values );
 		return true;
 	}
@@ -550,17 +550,10 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Get the settings for the wizard questionnaire
 	 *
-	 * @param WP_REST_Request $request The request.
-	 *
 	 * @return array Questionnaire settings.
 	 */
-	public static function get_setup_questionnaire( $request ) {
-		$options_values = Jetpack_Options::get_option( 'setup_questionnaire' );
-		if ( $options_values ) {
-			return $options_values;
-		} else {
-			return array();
-		}
+	public static function get_setup_questionnaire() {
+		return Jetpack_Options::get_option( 'setup_questionnaire', array() );
 	}
 
 	public static function get_plans( $request ) {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -504,6 +504,64 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 			)
 		);
+
+		// Update settings from the Jetpack wizard.
+		register_rest_route(
+			'jetpack/v4',
+			'/setup/questionnaire',
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::update_setup_questionnaire',
+				'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+				'args'                => array(
+					'option_values' => array(
+						'required' => true,
+						'type'     => 'object',
+					),
+				),
+			)
+		);
+
+		// Get settings for the Jetpack wizard.
+		register_rest_route(
+			'jetpack/v4',
+			'/setup/questionnaire',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::get_setup_questionnaire',
+				'permission_callback' => __CLASS__ . '::update_settings_permission_check',
+			)
+		);
+	}
+
+	/**
+	 * Update the settings selected on the wizard questionnaire
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return bool true.
+	 */
+	public static function update_setup_questionnaire( $request ) {
+		$option_values = $request['option_values'];
+		update_option( 'setup_questionnaire', $option_values );
+		return true;
+	}
+
+	/**
+	 * Get the settings for the wizard questionnaire
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return array Questionnaire settings.
+	 */
+	public static function get_setup_questionnaire( $request ) {
+		$options_values = get_option( 'setup_questionnaire' );
+		if ( $options_values ) {
+			$return = $options_values;
+		} else {
+			$return = array();
+		}
+		return $return;
 	}
 
 	public static function get_plans( $request ) {

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -109,6 +109,7 @@ class Jetpack_Options {
 			'sso_first_login',              // (bool)   Is this the first time the user logins via SSO.
 			'dismissed_hints',              // (array)  Part of Plugin Search Hints. List of cards that have been dismissed.
 			'first_admin_view',             // (bool)   Set to true the first time the user views the admin. Usually after the initial connection.
+			'setup_questionnaire',           // (array)  List of user choices from the setup wizard.
 		);
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -966,5 +966,35 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		remove_filter( 'http_response', array( $this, 'mock_xmlrpc_success' ), 10 );
 	}
 
+	/**
+	 * Test saving and retrieving the Setup Wizard questionnaire responses.
+	 *
+	 * @since 4.4.0
+	 */
+	public function test_setup_wizard() {
+		// Create a user and set it up as current.
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		wp_set_current_user( $user->ID );
+
+		$test_data = array(
+			'param1' => 'val1',
+			'param2' => 'val2',
+		);
+
+		$response = $this->create_and_get_request(
+			'setup/questionnaire',
+			array(
+				'option_values' => $test_data,
+			),
+			'POST'
+		);
+		$this->assertResponseStatus( 200, $response );
+		$this->assertEquals( true, $response->get_data() );
+
+		$response = $this->create_and_get_request( 'setup/questionnaire', array(), 'GET' );
+		$this->assertResponseStatus( 200, $response );
+		$this->assertResponseData( $test_data, $response );
+	}
 
 } // class end


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR starts the work on the implementation of the /setup/questionnaire API endpoint for the new setup wizard (#15501 and related).
Data validation could be added in the future when the final schema is defined.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a new feature.
Project: p1HpG7-8BF-p2


#### Testing instructions:
You can use the unit test WP_Test_Jetpack_REST_API_endpoints->test_setup_wizard().

Alternatively:

Use Postman or similar request generator and call:

**GET** /setup/questionnaire : returns an array with saved questionnaire selections.
**POST** /setup/questionnaire : stores the questionnaire selections.
**Parameters format:** 
{
    "option_values": {
        "param1": "value",
        "param2": "value",
        ...
    }
}

Make sure you set your request body as raw, JSON, like:

<img width="1011" alt="Screen Shot 2020-04-28 at 17 21 17" src="https://user-images.githubusercontent.com/2166135/80541420-8302b280-8981-11ea-98b7-741e9fab2685.png">

If you use Postman, make sure you capture your session cookies using https://learning.postman.com/docs/postman/sending-api-requests/interceptor/

Other alternative: you can use the plugin  https://wordpress.org/plugins/rest-api-console/

<img width="1652" alt="Screen Shot 2020-04-28 at 17 20 37" src="https://user-images.githubusercontent.com/2166135/80541495-9ada3680-8981-11ea-902a-27a81b0d9f79.png">

Works perfectly for the GET request, but not for the POST, because there's no practical way to set the content-type to JSON.

#### Proposed changelog entry for your changes:
Implemented /setup/questionnaire endpoint for the new setup wizard.
