### PR TITLE
Featured Content: allow case of Posts page not on home

### DIFF
--- a/modules/theme-tools/featured-content.php
+++ b/modules/theme-tools/featured-content.php
@@ -315,8 +315,8 @@ if ( ! class_exists( 'Featured_Content' ) && isset( $GLOBALS['pagenow'] ) && 'pl
 				return;
 			}
 
-			// Bail if the blog page is not the front page.
-			if ( 'posts' !== get_option( 'show_on_front' ) ) {
+			// Bail if not on a blog page (posts list).
+			if ( ! is_front_page() && ! $query->is_posts_page ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes #3650

#### Changes proposed in this Pull Request:

Currently the featured content is only filtered on the home page with `is_home()`.

This change allows a site to set home to a static page, and display posts on a Posts page instead, and still benefit from receiving the filtered content.

Related WP Calypso issue: https://github.com/Automattic/wp-calypso/issues/28957

#### Testing instructions:

* Activate the free Canard theme
* In Customizer, change Homepage settings to a static page for Home, and a static page for Posts list.
* Edit 2 or 3 posts to add the featured tag, and add the featured tag to Customizer in "Featured Content" settings
* Make sure `Also display tagged posts outside the Featured Content area.` is unchecked in Customizer "Featured Content" settings
* Verify that when viewing the Posts page display, it shows the featured content above the rest of the page, and does not duplicate the featured posts in the list below.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Theme Tools: allow filtering featured content when using a Posts page for blog list (not home).
