### PR TITLE
Gutenberg: Add Schedule Content Block

### DIFF
--- a/extensions/blocks/schedule-content/edit.js
+++ b/extensions/blocks/schedule-content/edit.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import {
+	Button,
+	PanelBody,
+	Path,
+	Placeholder,
+	DateTimePicker,
+	RadioControl,
+} from '@wordpress/components';
+import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import renderMaterialIcon from '../../shared/render-material-icon';
+import './editor.scss';
+
+const RADIO_OPTIONS = [
+	{
+		value: 'displayBlock',
+		label: __( 'Display block at this time', 'jetpack' ),
+	},
+	{
+		value: 'hideBlock',
+		label: __( 'Hide block at this time', 'jetpack' ),
+	},
+];
+
+class ScheduleContentBlock extends Component {
+	onClick = event => {
+		this.props.setAttributes( { hasScheduledBlock: true } );
+	};
+
+	render() {
+		const { attributes, setAttributes } = this.props;
+		const { date, radioOption, hasScheduledBlock } = attributes;
+
+		const radioOnChange = radioOption => {
+			setAttributes( { radioOption } );
+		};
+		const onChangeDate = dateSelected => {
+			setAttributes( { date: new Date( dateSelected ).getTime() } );
+		};
+		return (
+			<Fragment>
+				{ hasScheduledBlock && (
+					<InspectorControls>
+						<PanelBody>
+							<p>{ __( 'Change the scheduled date of the content below.', 'jetpack' ) }</p>
+							<RadioControl
+								selected={ radioOption }
+								options={ RADIO_OPTIONS }
+								onChange={ radioOnChange }
+							/>
+							<DateTimePicker currentDate={ date } onChange={ onChangeDate } />
+						</PanelBody>
+					</InspectorControls>
+				) }
+				{ ! hasScheduledBlock && (
+					<Placeholder
+						label={ __( 'Schedule Content', 'jetpack' ) }
+						className="jetpack-schedule-content-block__settings"
+						icon={ renderMaterialIcon(
+							<Path d="M12.5 8H11v6l4.75 2.85.75-1.23-4-2.37zm4.837-6.19l4.607 3.845-1.28 1.535-4.61-3.843zm-10.674 0l1.282 1.536L3.337 7.19l-1.28-1.536zM12 4c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9-4.03-9-9-9zm0 16c-3.86 0-7-3.14-7-7s3.14-7 7-7 7 3.14 7 7-3.14 7-7 7z" />
+						) }
+						instructions={ __(
+							"Select the date and time of which you'd like your block to appear.",
+							'jetpack'
+						) }
+					>
+						<RadioControl
+							selected={ radioOption }
+							options={ RADIO_OPTIONS }
+							onChange={ radioOnChange }
+						/>
+						<DateTimePicker currentDate={ date } onChange={ onChangeDate } />
+						<Button onClick={ this.onClick } isSecondary isLarge>
+							{ __( 'Save settings', 'jetpack' ) }
+						</Button>
+					</Placeholder>
+				) }
+				{ hasScheduledBlock && (
+					<div>
+						<InnerBlocks templateLock={ false } />
+					</div>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+export default ScheduleContentBlock;

--- a/extensions/blocks/schedule-content/editor.js
+++ b/extensions/blocks/schedule-content/editor.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import registerJetpackBlock from '../../shared/register-jetpack-block';
+import { name, settings } from '.';
+
+registerJetpackBlock( name, settings );

--- a/extensions/blocks/schedule-content/editor.scss
+++ b/extensions/blocks/schedule-content/editor.scss
@@ -1,0 +1,33 @@
+.jetpack-schedule-content-block__settings {
+	.components-radio-control {
+		margin: auto;
+
+		.components-base-control__field {
+			display: flex;
+		}
+
+		input[type='radio'].components-radio-control__input {
+			margin-right: 6px;
+		}
+
+		.components-radio-control__option:first-of-type {
+			margin-right: 32px;
+		}
+	}
+
+	.components-datetime {
+		width: 100%;
+
+		.components-datetime__time {
+			display: flex;
+
+			fieldset {
+				margin: auto;
+			}
+		}
+
+		.DayPicker {
+			margin: auto;
+		}
+	}
+}

--- a/extensions/blocks/schedule-content/index.js
+++ b/extensions/blocks/schedule-content/index.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, Path } from '@wordpress/components';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import renderMaterialIcon from '../../shared/render-material-icon';
+import ScheduleContentBlock from './edit';
+import { supportsCollections } from '../../shared/block-category';
+
+/**
+ * Style dependencies
+ */
+import './editor.scss';
+
+const save = () => (
+	<div>
+		<InnerBlocks.Content />
+	</div>
+);
+
+export const name = 'schedule-content';
+export const title = __( 'Schedule Content', 'jetpack' );
+export const settings = {
+	title,
+
+	description: __(
+		'Allow content within your post to appear or disappear at a certain time.',
+		'jetpack'
+	),
+
+	icon: renderMaterialIcon(
+		<Path d="M12.5 8H11v6l4.75 2.85.75-1.23-4-2.37zm4.837-6.19l4.607 3.845-1.28 1.535-4.61-3.843zm-10.674 0l1.282 1.536L3.337 7.19l-1.28-1.536zM12 4c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9-4.03-9-9-9zm0 16c-3.86 0-7-3.14-7-7s3.14-7 7-7 7 3.14 7 7-3.14 7-7 7z" />
+	),
+
+	category: supportsCollections() ? 'widgets' : 'jetpack',
+
+	keywords: [ __( 'timer', 'jetpack' ), __( 'wait', 'jetpack' ), __( 'revisions', 'jetpack' ) ],
+	attributes: {
+		date: {
+			type: 'number',
+			default: new Date(),
+		},
+		radioOption: {
+			type: 'string',
+			default: 'displayBlock',
+		},
+		hasScheduledBlock: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+
+	supports: {
+		align: false,
+		alignWide: true,
+		anchor: false,
+		customClassName: true,
+		className: true,
+		html: false,
+		multiple: true,
+		reusable: true,
+	},
+
+	edit: props => <ScheduleContentBlock { ...props } />,
+
+	save,
+};

--- a/extensions/blocks/schedule-content/schedule-content.php
+++ b/extensions/blocks/schedule-content/schedule-content.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Schedule Content Block.
+ *
+ * @since 8.5
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Extensions\Schedule_Content;
+
+use Jetpack_Gutenberg;
+
+const FEATURE_NAME = 'schedule-content';
+const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+
+/**
+ * Registers the block for use in Gutenberg
+ * This is done via an action so that we can disable
+ * registration if we need to.
+ */
+function register_block() {
+	jetpack_register_block(
+		BLOCK_NAME,
+		array( 'render_callback' => __NAMESPACE__ . '\load_assets' )
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\register_block' );
+
+/**
+ * Schedule Content block registration/dependency declaration.
+ *
+ * @param array  $attr    Array containing the Schedule Content block attributes.
+ * @param string $content String containing the Schedule Content block content.
+ *
+ * @return string
+ */
+function load_assets( $attr, $content ) {
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+	$time   = $attr['date'] - ( strtotime( current_time( 'mysql' ) ) * 1000 );
+	$option = isset( $attr['radioOption'] ) ? $attr['radioOption'] : 'displayBlock';
+	if ( ( $time < 0 && $option === 'displayBlock' ) || ( $time > 0 && $option === 'hideBlock' ) ) {
+		return $content;
+	}
+}

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -29,7 +29,7 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "instagram-gallery" ],
+	"beta": [ "amazon", "instagram-gallery", "schedule-content" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [
 		"business-hours",
@@ -49,6 +49,7 @@
 		"related-posts",
 		"repeat-visitor",
 		"revue",
+		"schedule-content",
 		"simple-payments",
 		"slideshow",
 		"subscriptions",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

I've been contributing to Automattic products for a while now, but I'm unsure if it's possible to contribute an entire Gutenberg block. However, this is a feature I've been hoping for since I created my blog seven years ago. Each time I've sent in a suggestion, it's been [dismissed as close to impossible](https://twitter.com/wordpressdotcom/status/998416476070608896).  Gutenberg really changes all of that, so I was really disappointed to see that a method to "schedule content" wasn't introduced, and a similar feature was sort of ruled out from Core.

The problem is that no such a block exists on WordPress.com yet. Whilst [this shortcode](https://wordpress.org/plugins/timed-content/) exists, admittedly, I have a site on the Free Plan which prevents me from installing custom plugins, and besides, shortcodes are far more complicated and less fashionable! As such, I would love to see this feature in Jetpack. It is my first Gutenberg block so I'm hoping that I've done this correctly, but there are plenty of uses for it. 

Let me firstly explain what it is: this block would allow authors to choose a specific time when content appears or is hidden, based on their site timezone. Whereas authors currently can only currently schedule an entire post, this allows them to schedule content within their post too.

<img width="1655" alt="Screenshot 2020-04-27 at 10 30 36" src="https://user-images.githubusercontent.com/43215253/80361595-1f8d5d80-8879-11ea-845e-db6bdc37888d.png">

The usage of this is close to endless. Anecdotally, issues such as #14390 where I'd like to automatically close giveaways at a specific time would be resolved. There's also plenty of other cases where it'd benefit me, such as notices for events, which is why I've been so desperate to see it since 2013. But it wouldn't just benefit small bloggers such as myself; businesses can use it for displaying coupons that last a timed amount, announcing temporary sales or deals, and so much more. 

That's why I'm really hopeful this block will be accepted, as I know that many people including myself would find it incredibly useful. I can't really propose it elsewhere either, since I'd be using it on my WordPress.com site with a Free plan, but I hope that it'll be acceptable to Jetpack - I really think it will be beneficial, for both businesses and bloggers alike! :) 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* New feature (see above)

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable beta blocks
* Create your own Scheduled Block and set a date for it to appear within the next few hours
* Head to `/wp-admin/options-general.php` and change the timezone so that date passes

<img width="948" alt="Screenshot 2020-04-27 at 11 30 22" src="https://user-images.githubusercontent.com/43215253/80362404-7e070b80-887a-11ea-9b23-7a83a5dd46b6.png">

* Verify the block appears
* Repeat this with the hidden option, though the block should remain visible initially 

Once you've clicked the "Save settings" button on the Placeholder, you should still be able to make modifications from the block sidebar, so verify this works too.

<img width="280" alt="Screenshot 2020-04-27 at 11 31 36" src="https://user-images.githubusercontent.com/43215253/80362559-beff2000-887a-11ea-9e56-61219eb0a910.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Gutenberg: add Schedule Content block.


Thanks again - and I really can't stress my gratitude enough if this block is acceptable to Jetpack, since this is a feature I've sought for years. 