### PR TITLE
Podcast Player: Fix cropped description text & title wrapping

### DIFF
--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -135,6 +135,7 @@ $jetpack-podcast-player-error: $alert-red;
 	h2.jetpack-podcast-player__title {
 		display: flex;
 		flex-direction: column;
+		width: 100%; // Makes long titles wrap in IE11.
 		margin: 0;
 		padding: 0;
 		letter-spacing: 0; // Fixes Twenty Twenty compressed text.

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -180,13 +180,17 @@ $jetpack-podcast-player-error: $alert-red;
 		margin: 0 0 $gutter-l 0;
 		font-size: $editor-font-size;
 		line-height: $editor-line-height;
-		//crop the description if too long
-		display: -webkit-box;
-		-webkit-line-clamp: 4;
-		-webkit-box-orient: vertical;
-		overflow: hidden;
-		max-height: 105px; //IE11 fallback
 		color: inherit;
+		overflow: hidden;
+		max-height: 4em * $editor-line-height; // IE11 fallback for line-clamp
+
+		@supports ( display: -webkit-box ) {
+			//crop the description if too long
+			display: -webkit-box;
+			-webkit-box-orient: vertical;
+			-webkit-line-clamp: 4;
+			max-height: initial;
+		}
 	}
 
 	/**

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -183,10 +183,10 @@ $jetpack-podcast-player-error: $alert-red;
 		line-height: $editor-line-height;
 		color: inherit;
 		overflow: hidden;
-		max-height: 4em * $editor-line-height; // IE11 fallback for line-clamp
+		max-height: 4em * $editor-line-height; // IE11 fallback for line-clamp.
 
 		@supports ( display: -webkit-box ) {
-			//crop the description if too long
+			// Crop the description if too long.
 			display: -webkit-box;
 			-webkit-box-orient: vertical;
 			-webkit-line-clamp: 4;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -254,7 +254,7 @@ $jetpack-podcast-player-error: $alert-red;
 			display: block;
 			width: $track-status-icon-size;
 			height: $track-status-icon-size;
-			margin-top: 3px; // center vertically
+			margin-top: ( $editor-font-size * $editor-line-height - $track-status-icon-size ) / 2; // center vertically
 			fill: inherit;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fix the last line of the description text being cut off a few pixels from the bottom:

   | | Before  | After |
   | - | ------------- | ------------- |
   | `line-clamp` (modern browsers) | <img width="796" alt="Screenshot 2020-04-27 13 23 14" src="https://user-images.githubusercontent.com/1451471/80372092-422c7000-8893-11ea-8e89-7aeb70df088d.png"> | <img width="797" alt="Screenshot 2020-04-27 14 27 26" src="https://user-images.githubusercontent.com/1451471/80372123-4d7f9b80-8893-11ea-91ca-5c880b30c88b.png"> |
   | `max-height` (IE11) | <img width="779" alt="Screenshot 2020-04-27 14 46 03" src="https://user-images.githubusercontent.com/1451471/80374192-938a2e80-8896-11ea-8ab1-6b17517951b5.png"> | <img width="799" alt="Screenshot 2020-04-27 14 38 05" src="https://user-images.githubusercontent.com/1451471/80374184-8ff6a780-8896-11ea-8872-c78e4267e6d2.png"> |

* Fix long headings not being wrapped in IE11 (Flexbox specific bug):

   | Before  | After |
   | ------------- | ------------- |
   | <img width="797" alt="Screenshot 2020-04-27 14 28 38" src="https://user-images.githubusercontent.com/1451471/80372382-bebf4e80-8893-11ea-9d54-863c61485bff.png"> | <img width="800" alt="Screenshot 2020-04-27 14 30 56" src="https://user-images.githubusercontent.com/1451471/80372396-c252d580-8893-11ea-9048-d347bbccdfbf.png"> |

* Make the description height fallback and the icon center offset values to be derived from provided variables.


#### Testing instructions:
* Add the Podcast Player block (Use https://distributed.blog/category/podcast/feed/),
* Make sure the description text (when 4 lines are visible), has not cut off the last line (see screenshots above).
* Make sure the current episode title is being wrapped correctly in IE11 (see screenshot above).


#### Proposed changelog entry for your changes:
* N/A
