### PR TITLE
Sync Comments apply whitelist to all actions

### DIFF
--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Settings;
+use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Class to handle sync for comments.
@@ -201,9 +202,17 @@ class Comments extends Module {
 	 * @return bool or array $args Arguments passed to wp_insert_comment, deleted_comment, spammed_comment, etc.
 	 */
 	public function only_allow_white_listed_comment_types( $args ) {
-		$comment = $args[1];
+		$comment = false;
 
-		if ( ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
+		if ( isset( $args[1] ) ) {
+			// comment object is available.
+			$comment = $args[1];
+		} else {
+			// comment_id is available.
+			$comment = get_comment( $args[0] );
+		}
+
+		if ( false !== $comment && ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
 			return false;
 		}
 
@@ -220,7 +229,7 @@ class Comments extends Module {
 		$post_id      = $args[0];
 		$posts_module = Modules::get_module( 'posts' );
 
-		if ( false !== $posts_module && ! $posts_module::is_post_type_allowed( $post_id ) ) {
+		if ( false !== $posts_module && ! $posts_module->is_post_type_allowed( $post_id ) ) {
 			return false;
 		}
 

--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -88,7 +88,22 @@ class Comments extends Module {
 		add_action( 'untrashed_comment', $callable, 10, 2 );
 		add_action( 'unspammed_comment', $callable, 10, 2 );
 		add_filter( 'wp_update_comment_data', array( $this, 'handle_comment_contents_modification' ), 10, 3 );
+
+		// comment actions.
 		add_filter( 'jetpack_sync_before_enqueue_wp_insert_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_deleted_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_trashed_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_untrashed_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_spammed_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_unspammed_comment', array( $this, 'only_allow_white_listed_comment_types' ) );
+
+		// comment status transitions.
+		add_filter( 'jetpack_sync_before_enqueue_comment_approved_to_unapproved', array( $this, 'only_allow_white_listed_comment_type_transitions' ) );
+		add_filter( 'jetpack_sync_before_enqueue_comment_unapproved_to_approved', array( $this, 'only_allow_white_listed_comment_type_transitions' ) );
+
+		// Post Actions.
+		add_filter( 'jetpack_sync_before_enqueue_trashed_post_comments', array( $this, 'filter_blacklisted_post_types' ) );
+		add_filter( 'jetpack_sync_before_enqueue_untrash_post_comments', array( $this, 'filter_blacklisted_post_types' ) );
 
 		/**
 		 * Even though it's messy, we implement these hooks because
@@ -181,12 +196,46 @@ class Comments extends Module {
 	/**
 	 * Prevents any comment types that are not in the whitelist from being enqueued and sent to WordPress.com.
 	 *
-	 * @param array $args Arguments passed to wp_insert_comment.
+	 * @param array $args Arguments passed to wp_insert_comment, deleted_comment, spammed_comment, etc.
 	 *
-	 * @return bool or array $args Arguments passed to wp_insert_comment
+	 * @return bool or array $args Arguments passed to wp_insert_comment, deleted_comment, spammed_comment, etc.
 	 */
 	public function only_allow_white_listed_comment_types( $args ) {
 		$comment = $args[1];
+
+		if ( ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
+			return false;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Filter all blacklisted post types.
+	 *
+	 * @param array $args Hook arguments.
+	 * @return array|false Hook arguments, or false if the post type is a blacklisted one.
+	 */
+	public function filter_blacklisted_post_types( $args ) {
+		$post_id      = $args[0];
+		$posts_module = Modules::get_module( 'posts' );
+
+		if ( false !== $posts_module && ! $posts_module::is_post_type_allowed( $post_id ) ) {
+			return false;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Prevents any comment types that are not in the whitelist from being enqueued and sent to WordPress.com.
+	 *
+	 * @param array $args Arguments passed to wp_{old_status}_to_{new_status}.
+	 *
+	 * @return bool or array $args Arguments passed to wp_{old_status}_to_{new_status}
+	 */
+	public function only_allow_white_listed_comment_type_transitions( $args ) {
+		$comment = $args[0];
 
 		if ( ! in_array( $comment->comment_type, $this->get_whitelisted_comment_types(), true ) ) {
 			return false;

--- a/packages/sync/src/modules/class-comments.php
+++ b/packages/sync/src/modules/class-comments.php
@@ -207,7 +207,7 @@ class Comments extends Module {
 		if ( isset( $args[1] ) ) {
 			// comment object is available.
 			$comment = $args[1];
-		} else {
+		} elseif ( is_numeric( $args[0] ) ) {
 			// comment_id is available.
 			$comment = get_comment( $args[0] );
 		}

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -450,4 +450,9 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 		$comment_types[] = 'product_feedback';
 		return $comment_types;
 	}
+
+	/*
+	 * Need to duplicate all above tests for individual actions to ensure they don't fire for non whitelisted post-types.
+	 */
+
 }

--- a/tests/php/sync/test_class.jetpack-sync-comments.php
+++ b/tests/php/sync/test_class.jetpack-sync-comments.php
@@ -4,6 +4,8 @@ use Automattic\Jetpack\Sync\Modules;
 
 /**
  * Testing CRUD on Comments
+ *
+ * @group jetpack-sync
  */
 class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 
@@ -452,7 +454,164 @@ class WP_Test_Jetpack_Sync_Comments extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/*
-	 * Need to duplicate all above tests for individual actions to ensure they don't fire for non whitelisted post-types.
+	 * Verify Whitelist is applied to all actions.
 	 */
+
+	/**
+	 * Helper function to generate unknown comment data.
+	 *
+	 * @param string $comment_type comment_type of generated comment.
+	 *
+	 * @return false|int Comment ID or false if failure.
+	 */
+	private function generate_unknown_comment( $comment_type = 'action_log' ) {
+		$comment_data = array(
+			'comment_post_ID'  => $this->post_id,
+			'comment_date'     => gmdate( 'Y-m-d H:i:s', time() ),
+			'comment_date_gmt' => gmdate( 'Y-m-d H:i:s', time() ),
+			'comment_author'   => 'ActionScheduler',
+			'comment_content'  => 'fun!',
+			'comment_agent'    => 'ActionScheduler',
+			'comment_type'     => $comment_type,
+		);
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		return $comment_id;
+	}
+
+	/**
+	 * Test that `trashed_comment` actions are not sent for unknown comment types.
+	 */
+	public function test_wp_trash_comment_unknown_type() {
+		$this->server_event_storage->reset();
+
+		$comment_id = $this->generate_unknown_comment();
+		$this->sender->do_sync();
+
+		wp_trash_comment( $comment_id );
+
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'trashed_comment' );
+		$this->assertFalse( $event );
+	}
+
+	/**
+	 * Test that `untrashed_comment` actions are not sent for unknown comment types.
+	 */
+	public function test_wp_untrash_comment_unknown_type() {
+		$this->server_event_storage->reset();
+
+		$comment_id = $this->generate_unknown_comment();
+		wp_trash_comment( $comment_id );
+		wp_untrash_comment( $comment_id );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'untrashed_comment' );
+		$this->assertFalse( $event );
+	}
+
+	/**
+	 * Test that `spammed_comment` actions are not sent for unknown comment types.
+	 */
+	public function test_wp_spam_comment_unknown_type() {
+		$this->server_event_storage->reset();
+
+		$comment_id = $this->generate_unknown_comment();
+		$this->sender->do_sync();
+		wp_spam_comment( $comment_id );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'spammed_comment' );
+		$this->assertFalse( $event );
+	}
+
+	/**
+	 * Test that `unspammed_comment` actions are not sent for unknown comment types.
+	 */
+	public function test_wp_unspam_comment_unknown_type() {
+		$this->server_event_storage->reset();
+
+		$comment_id = $this->generate_unknown_comment();
+		wp_spam_comment( $comment_id );
+		wp_unspam_comment( $comment_id );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'unspammed_comment' );
+		$this->assertFalse( $event );
+	}
+
+	/**
+	 * Test that `deleted_comment` actions are not sent for unknown comment types.
+	 */
+	public function test_delete_comment_unknown_type() {
+		$this->server_event_storage->reset();
+
+		$comment_id = $this->generate_unknown_comment();
+		wp_delete_comment( $comment_id, true );
+		$this->sender->do_sync();
+
+		$event = $this->server_event_storage->get_most_recent_event( 'deleted_comment' );
+		$this->assertFalse( $event );
+	}
+
+	/**
+	 * Test that `comment_approved_to_unapproved` and `comment_unapproved_to_approved` actions are not sent for unknown comment types.
+	 */
+	public function test_transition_comment_unknown_type() {
+		$this->server_event_storage->reset();
+
+		$comment_id = $this->generate_unknown_comment();
+		$comment    = get_comment( $comment_id );
+
+		$comment->comment_approved = 0;
+		wp_update_comment( (array) $comment );
+
+		$this->sender->do_sync();
+
+		$comment_approved_to_unapproved_event = $this->server_event_storage->get_most_recent_event( 'comment_approved_to_unapproved' );
+		$this->assertFalse( $comment_approved_to_unapproved_event );
+
+		$this->server_event_storage->reset();
+
+		$comment->comment_approved = 1;
+		wp_update_comment( (array) $comment );
+		$this->sender->do_sync();
+
+		$comment_unapproved_to_approved_event = $this->server_event_storage->get_most_recent_event( 'comment_unapproved_to_approved' );
+		$this->assertFalse( $comment_unapproved_to_approved_event );
+	}
+
+	/**
+	 * Test that `trashed_post_comments` and `untrashed_post_comments` are not sent for blacklisted post_types.
+	 */
+	public function test_post_comments_blacklisted_post_type() {
+		$args = array(
+			'public' => true,
+			'label'  => 'Snitch',
+		);
+		register_post_type( 'snitch', $args );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'snitch' ) );
+		$this->factory->comment->create_post_comments( $post_id );
+
+		$this->sender->do_sync();
+		$this->server_event_storage->reset();
+
+		// Trash unknown post_type comments.
+		wp_trash_post_comments( $post_id );
+		$this->sender->do_sync();
+
+		$trashed_post_comments_event = $this->server_event_storage->get_most_recent_event( 'trashed_post_comments' );
+		$this->assertFalse( $trashed_post_comments_event );
+
+		// Untrash unknown post_type comments.
+		wp_untrash_post_comments( $post_id );
+		$this->sender->do_sync();
+
+		$untrash_post_comments_event = $this->server_event_storage->get_most_recent_event( 'untrash_post_comments' );
+		$this->assertFalse( $untrash_post_comments_event );
+	}
 
 }

--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -8,6 +8,8 @@ use Automattic\Jetpack\Sync\Settings;
 
 /**
  * Testing CRUD on Posts
+ *
+ * @group jetpack-sync
  */
 class WP_Test_Jetpack_Sync_Post extends WP_Test_Jetpack_Sync_Base {
 


### PR DESCRIPTION
Update Sync Comment Module to apply whitelist to comment actions and also apply post_type_blacklist on full post actions.

#### Changes proposed in this Pull Request:
* Reduce overall sync actions by applying whitelist to all comment actions

Actions Impacted
* deleted_comment
* trashed_comment
* spammed_comment
* trashed_post_comments
* untrash_post_comments
* comment_approved_to_unapproved
* comment_unapproved_to_approved
* untrashed_comment
* unspammed_comment

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Existing Functionality, performance improvement by limiting sync actions

#### Testing instructions:
* Ensure Sync is enabled on your test site
* Create a comment with a non-whitelisted comment_type ("excalibur", "test", etc)
* Verify no `wp_insert_comment` action is queued
* Trash the comment
* Verify no `trashed_comment` action is queued
* Delete the comment
* Verify no `deleted_comment` action is queued

#### Proposed changelog entry for your changes:
* N/A - whitelist was existing functionality but not applied to all comment related actions.
