### PR TITLE
Correct inline documentation "Array" type

### DIFF
--- a/3rd-party/class-jetpack-bbpress-rest-api.php
+++ b/3rd-party/class-jetpack-bbpress-rest-api.php
@@ -43,7 +43,7 @@ class Jetpack_BbPress_REST_API {
 	/**
 	 * Adds the bbPress post types to the rest_api_allowed_post_types filter.
 	 *
-	 * @param Array $allowed_post_types Allowed post types.
+	 * @param array $allowed_post_types Allowed post types.
 	 *
 	 * @return array
 	 */
@@ -57,7 +57,7 @@ class Jetpack_BbPress_REST_API {
 	/**
 	 * Adds the bbpress meta keys to the rest_api_allowed_public_metadata filter.
 	 *
-	 * @param Array $allowed_meta_keys Allowed meta keys.
+	 * @param array $allowed_meta_keys Allowed meta keys.
 	 *
 	 * @return array
 	 */

--- a/_inc/lib/class.jetpack-password-checker.php
+++ b/_inc/lib/class.jetpack-password-checker.php
@@ -97,7 +97,7 @@ class Jetpack_Password_Checker {
 		 *
 		 * @since 7.2.0
 		 *
-		 * @param Array $restricted_passwords strings that are forbidden for use as passwords.
+		 * @param array $restricted_passwords strings that are forbidden for use as passwords.
 		 */
 		$this->common_passwords = apply_filters( 'jetpack_password_checker_restricted_strings', array() );
 
@@ -125,7 +125,7 @@ class Jetpack_Password_Checker {
 	 *
 	 * @param String  $password      the tested string.
 	 * @param Boolean $required_only only test against required conditions, defaults to false.
-	 * @return Array $results an array containing failed and passed test results.
+	 * @return array $results an array containing failed and passed test results.
 	 */
 	public function test( $password, $required_only = false ) {
 
@@ -146,7 +146,7 @@ class Jetpack_Password_Checker {
 		 *
 		 * @since 7.2.0
 		 *
-		 * @param Array $minimum_entropy_bits minimum entropy bits requirement.
+		 * @param array $minimum_entropy_bits minimum entropy bits requirement.
 		 */
 		$bits         = apply_filters( 'jetpack_password_checker_minimum_entropy_bits', self::MINIMUM_BITS );
 		$entropy_bits = $this->calculate_entropy_bits( $this->password );
@@ -169,9 +169,9 @@ class Jetpack_Password_Checker {
 	/**
 	 * Run the tests using the currently set up object values.
 	 *
-	 * @param Array   $tests tests to run.
+	 * @param array   $tests tests to run.
 	 * @param Boolean $required_only whether to run only required tests.
-	 * @return Array test results.
+	 * @return array test results.
 	 */
 	protected function run_tests( $tests, $required_only = false ) {
 
@@ -213,8 +213,8 @@ class Jetpack_Password_Checker {
 	/**
 	 * Returns a list of tests that need to be run on password strings.
 	 *
-	 * @param Array $sections only return specific sections with the passed keys, defaults to all.
-	 * @return Array test descriptions.
+	 * @param array $sections only return specific sections with the passed keys, defaults to all.
+	 * @return array test descriptions.
 	 */
 	protected function list_tests( $sections = false ) {
 		// Note: these should be in order of priority.
@@ -273,7 +273,7 @@ class Jetpack_Password_Checker {
 		 *
 		 * @since 7.2.0
 		 *
-		 * @param Array $minimum_entropy_bits minimum entropy bits requirement.
+		 * @param array $minimum_entropy_bits minimum entropy bits requirement.
 		 */
 		$tests = apply_filters( 'jetpack_password_checker_tests', $tests );
 
@@ -288,7 +288,7 @@ class Jetpack_Password_Checker {
 	/**
 	 * Provides the regular expression tester functionality.
 	 *
-	 * @param Array $test_data the current test data.
+	 * @param array $test_data the current test data.
 	 * @return Boolean does the test pass?
 	 */
 	protected function test_preg_match( $test_data ) {
@@ -308,7 +308,7 @@ class Jetpack_Password_Checker {
 	/**
 	 * Provides the comparison tester functionality.
 	 *
-	 * @param Array $test_data the current test data.
+	 * @param array $test_data the current test data.
 	 * @return Boolean does the test pass?
 	 */
 	protected function test_compare_to_list( $test_data ) {
@@ -333,7 +333,7 @@ class Jetpack_Password_Checker {
 	/**
 	 * Getter for the common password list.
 	 *
-	 * @return Array common passwords.
+	 * @return array common passwords.
 	 */
 	protected function get_common_passwords() {
 		return $this->common_passwords;
@@ -343,7 +343,7 @@ class Jetpack_Password_Checker {
 	 * Returns the widely known user data that can not be used in the password to avoid
 	 * predictable strings.
 	 *
-	 * @return Array user data.
+	 * @return array user data.
 	 */
 	protected function get_other_user_data() {
 
@@ -377,7 +377,7 @@ class Jetpack_Password_Checker {
 	 * Compare the password for matches with known user data.
 	 *
 	 * @param String $password the string to be tested.
-	 * @param Array  $strings_to_test known user data.
+	 * @param array  $strings_to_test known user data.
 	 * @return Boolean does the test pass?
 	 */
 	protected function test_not_same_as_other_user_data( $password, $strings_to_test ) {
@@ -409,7 +409,7 @@ class Jetpack_Password_Checker {
 	 * A shorthand for the not in array construct.
 	 *
 	 * @param Mixed $needle the needle.
-	 * @param Array $haystack the haystack.
+	 * @param array $haystack the haystack.
 	 * @return is the needle not in the haystack?
 	 */
 	protected function negative_in_array( $needle, $haystack ) {

--- a/_inc/lib/class.jetpack-photon-image.php
+++ b/_inc/lib/class.jetpack-photon-image.php
@@ -232,7 +232,7 @@ class Jetpack_Photon_Image {
 	/**
 	 * Sets proper width and height from dimensions.
 	 *
-	 * @param Array $dimensions an array of image dimensions.
+	 * @param array $dimensions an array of image dimensions.
 	 * @return void
 	 */
 	protected function set_width_height( $dimensions ) {

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -482,8 +482,8 @@ class Jetpack_Network {
 	/**
 	 * Filters the registration request body to include additional properties.
 	 *
-	 * @param Array $properties standard register request body properties.
-	 * @return Array amended properties.
+	 * @param array $properties standard register request body properties.
+	 * @return array amended properties.
 	 */
 	public function filter_register_request_body( $properties ) {
 		$blog_details = get_blog_details();

--- a/class.jetpack-post-images.php
+++ b/class.jetpack-post-images.php
@@ -232,7 +232,7 @@ class Jetpack_PostImages {
 	 * format to the other images?_from_*() methods.
 	 *
 	 * @param  int $post_id The post ID to check
-	 * @return Array containing details of the Featured Image, or empty array if none.
+	 * @return array containing details of the Featured Image, or empty array if none.
 	 */
 	static function from_thumbnail( $post_id, $width = 200, $height = 200 ) {
 		$images = array();
@@ -385,7 +385,7 @@ class Jetpack_PostImages {
 	 *
 	 * @uses DOMDocument
 	 *
-	 * @return Array containing images
+	 * @return array containing images
 	 */
 	static function from_html( $html_or_id, $width = 200, $height = 200 ) {
 		$images = array();
@@ -472,7 +472,7 @@ class Jetpack_PostImages {
 	/**
 	 * @param    int $post_id The post ID to check
 	 * @param    int $size
-	 * @return Array containing details of the image, or empty array if none.
+	 * @return array containing details of the image, or empty array if none.
 	 */
 	static function from_blavatar( $post_id, $size = 96 ) {
 
@@ -512,7 +512,7 @@ class Jetpack_PostImages {
 	 * @param int    $post_id The post ID to check.
 	 * @param int    $size The size of the avatar to get.
 	 * @param string $default The default image to use.
-	 * @return Array containing details of the image, or empty array if none.
+	 * @return array containing details of the image, or empty array if none.
 	 */
 	static function from_gravatar( $post_id, $size = 96, $default = false ) {
 		$post      = get_post( $post_id );
@@ -552,7 +552,7 @@ class Jetpack_PostImages {
 	 *
 	 * @param  int   $post_id
 	 * @param array $args Other arguments (currently width and height required for images where possible to determine)
-	 * @return Array containing details of the best image to be used
+	 * @return array containing details of the best image to be used
 	 */
 	static function get_image( $post_id, $args = array() ) {
 		$image = '';
@@ -594,7 +594,7 @@ class Jetpack_PostImages {
 	 *
 	 * @param  int   $post_id
 	 * @param  array $args Optional args, see defaults list for details
-	 * @return Array containing images that would be good for representing this post
+	 * @return array containing images that would be good for representing this post
 	 */
 	static function get_images( $post_id, $args = array() ) {
 		// Figure out which image to attach to this post.

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -849,7 +849,7 @@ class Jetpack {
 	 * @deprecated since 7.7.0
 	 * @see Automattic\Jetpack\Connection\Manager::setup_xmlrpc_handlers()
 	 *
-	 * @param Array                 $request_params Incoming request parameters.
+	 * @param array                 $request_params Incoming request parameters.
 	 * @param Boolean               $is_active      Whether the connection is currently active.
 	 * @param Boolean               $is_signed      Whether the signature check has been successful.
 	 * @param Jetpack_XMLRPC_Server $xmlrpc_server  (optional) An instance of the server to use instead of instantiating a new one.
@@ -4795,8 +4795,8 @@ endif;
 	/**
 	 * Filters the connection URL parameter array.
 	 *
-	 * @param Array $args default URL parameters used by the package.
-	 * @return Array the modified URL arguments array.
+	 * @param array $args default URL parameters used by the package.
+	 * @return array the modified URL arguments array.
 	 */
 	public static function filter_connect_request_body( $args ) {
 		if (
@@ -5378,8 +5378,8 @@ endif;
 	/**
 	 * Filters the registration request body to include tracking properties.
 	 *
-	 * @param Array $properties
-	 * @return Array amended properties.
+	 * @param array $properties
+	 * @return array amended properties.
 	 */
 	public static function filter_register_request_body( $properties ) {
 		$tracking        = new Tracking();
@@ -5397,8 +5397,8 @@ endif;
 	/**
 	 * Filters the token request body to include tracking properties.
 	 *
-	 * @param Array $properties
-	 * @return Array amended properties.
+	 * @param array $properties
+	 * @return array amended properties.
 	 */
 	public static function filter_token_request_body( $properties ) {
 		$tracking        = new Tracking();

--- a/class.photon.php
+++ b/class.photon.php
@@ -154,7 +154,7 @@ class Jetpack_Photon {
 	/**
 	 * Disables intermediate sizes to disallow resizing.
 	 *
-	 * @param Array $sizes an array containing image sizes.
+	 * @param array $sizes an array containing image sizes.
 	 * @return Boolean
 	 */
 	public static function filter_photon_noresize_intermediate_sizes( $sizes ) {

--- a/modules/sitemaps/sitemap-buffer-fallback.php
+++ b/modules/sitemaps/sitemap-buffer-fallback.php
@@ -98,7 +98,7 @@ abstract class Jetpack_Sitemap_Buffer_Fallback extends Jetpack_Sitemap_Buffer {
 	/**
 	 * Legacy implementation of array to XML conversion without using DOMDocument.
 	 *
-	 * @param Array $array
+	 * @param array $array
 	 * @return String $result
 	 */
 	public function array_to_xml_string( $array, $parent = null, $root = null ) {

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -817,7 +817,7 @@ class Jetpack_Subscriptions {
 		 * @since 5.5.0
 		 *
 		 * @param NULL|WP_Error $result Result of form submission: NULL on success, WP_Error otherwise.
-		 * @param Array $post_ids An array of post IDs that the user subscribed to, 0 means blog subscription.
+		 * @param array $post_ids An array of post IDs that the user subscribed to, 0 means blog subscription.
 		 */
 		do_action( 'jetpack_subscriptions_comment_form_submission', $result, $post_ids );
 	}

--- a/packages/compat/legacy/class-jetpack-client.php
+++ b/packages/compat/legacy/class-jetpack-client.php
@@ -50,7 +50,7 @@ class Jetpack_Client {
 	 * @param null   $body Request body.
 	 * @param string $base_api_path Endpoint base prefix.
 	 *
-	 * @return Array|WP_Error
+	 * @return array|WP_Error
 	 */
 	public static function wpcom_json_api_request_as_blog(
 		$path,
@@ -79,7 +79,7 @@ class Jetpack_Client {
 	 * @see Utils::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
-	 * @param Array   $args request arguments.
+	 * @param array   $args request arguments.
 	 * @param Boolean $set_fallback whether to allow flagging this request to use a fallback certficate override.
 	 * @return array|WP_Error WP HTTP response on success
 	 */

--- a/packages/compat/legacy/class-jetpack-sync-actions.php
+++ b/packages/compat/legacy/class-jetpack-sync-actions.php
@@ -140,7 +140,7 @@ class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 	 *
 	 * @deprecated Automattic\Jetpack\Sync\Actions::do_full_sync
 	 *
-	 * @param Array $modules the modules list.
+	 * @param array $modules the modules list.
 	 * @return Boolean whether the sync was initialized.
 	 */
 	public static function do_full_sync( $modules = null ) {
@@ -154,7 +154,7 @@ class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 	 *
 	 * @deprecated Automattic\Jetpack\Sync\Actions::jetpack_cron_schedule
 	 *
-	 * @param Array $schedules the schedules to add.
+	 * @param array $schedules the schedules to add.
 	 */
 	public static function jetpack_cron_schedule( $schedules ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
@@ -189,7 +189,7 @@ class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 	 *
 	 * @deprecated Automattic\Jetpack\Sync\Actions::do_cron_sync_by_type
 	 *
-	 * @param Array $type the type of object to sync.
+	 * @param array $type the type of object to sync.
 	 */
 	public static function do_cron_sync_by_type( $type ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
@@ -235,7 +235,7 @@ class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 	 *
 	 * @deprecated Automattic\Jetpack\Sync\Actions::add_woocommerce_sync_module
 	 *
-	 * @param Array $sync_modules an array of modules.
+	 * @param array $sync_modules an array of modules.
 	 */
 	public static function add_woocommerce_sync_module( $sync_modules ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
@@ -259,7 +259,7 @@ class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 	 *
 	 * @deprecated Automattic\Jetpack\Sync\Actions::add_wp_super_cache_sync_module
 	 *
-	 * @param Array $sync_modules the list to be amended.
+	 * @param array $sync_modules the list to be amended.
 	 */
 	public static function add_wp_super_cache_sync_module( $sync_modules ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );
@@ -351,7 +351,7 @@ class Jetpack_Sync_Actions extends Automattic\Jetpack\Sync\Actions {
 	 *
 	 * @deprecated Automattic\Jetpack\Sync\Actions::get_sync_status
 	 *
-	 * @param Array $fields sync fields to get status of.
+	 * @param array $fields sync fields to get status of.
 	 */
 	public static function get_sync_status( $fields = null ) {
 		_deprecated_function( __METHOD__, 'jetpack-7.5', 'Automattic\Jetpack\Sync\Actions' );

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -222,7 +222,7 @@ class Jetpack_XMLRPC_Server {
 		 *
 		 * @param String  $action the action name, i.e., 'remote_authorize'.
 		 * @param String  $stage  the execution stage, can be 'begin', 'success', 'error', etc.
-		 * @param Array   $parameters extra parameters from the event.
+		 * @param array   $parameters extra parameters from the event.
 		 * @param WP_User $user the acting user.
 		 */
 		do_action( 'jetpack_xmlrpc_server_event', 'remote_authorize', 'begin', array(), $user );

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -18,8 +18,8 @@ class Client {
 	/**
 	 * Makes an authorized remote request using Jetpack_Signature
 	 *
-	 * @param Array        $args the arguments for the remote request.
-	 * @param Array|String $body the request body.
+	 * @param array        $args the arguments for the remote request.
+	 * @param array|String $body the request body.
 	 * @return array|WP_Error WP HTTP response on success
 	 */
 	public static function remote_request( $args, $body = null ) {
@@ -181,7 +181,7 @@ class Client {
 	 * @see Utils::fix_url_for_bad_hosts()
 	 *
 	 * @param String  $url the request URL.
-	 * @param Array   $args request arguments.
+	 * @param array   $args request arguments.
 	 * @param Boolean $set_fallback whether to allow flagging this request to use a fallback certficate override.
 	 * @return array|WP_Error WP HTTP response on success
 	 */
@@ -357,10 +357,10 @@ class Client {
 	 *
 	 * @param String $path The API endpoint relative path.
 	 * @param String $version The API version.
-	 * @param Array  $args Request arguments.
+	 * @param array  $args Request arguments.
 	 * @param String $body Request body.
 	 * @param String $base_api_path (optional) the API base path override, defaults to 'rest'.
-	 * @return Array|WP_Error $response Data.
+	 * @return array|WP_Error $response Data.
 	 */
 	public static function wpcom_json_api_request_as_blog(
 		$path,
@@ -414,7 +414,7 @@ class Client {
 	 * make sure that body hashes are made ith the string version, which is what will be seen after a
 	 * server pulls up the data in the $_POST array.
 	 *
-	 * @param Array|Mixed $data the data that needs to be stringified.
+	 * @param array|Mixed $data the data that needs to be stringified.
 	 *
 	 * @return array|string
 	 */

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -81,7 +81,7 @@ class Manager {
 	/**
 	 * Sets up the XMLRPC request handlers.
 	 *
-	 * @param Array                  $request_params incoming request parameters.
+	 * @param array                  $request_params incoming request parameters.
 	 * @param Boolean                $is_active whether the connection is currently active.
 	 * @param Boolean                $is_signed whether the signature check has been successful.
 	 * @param \Jetpack_XMLRPC_Server $xmlrpc_server (optional) an instance of the server to use instead of instantiating a new one.
@@ -463,8 +463,8 @@ class Manager {
 		 *
 		 * @since 7.7.0
 		 *
-		 * @param Array $post_data request data.
-		 * @param Array $token_data token data.
+		 * @param array $post_data request data.
+		 * @param array $token_data token data.
 		 */
 		return apply_filters(
 			'jetpack_signature_check_token',
@@ -813,7 +813,7 @@ class Manager {
 		 *
 		 * @since 7.7.0
 		 *
-		 * @param Array $post_data request data.
+		 * @param array $post_data request data.
 		 * @param Array $token_data token data.
 		 */
 		$body = apply_filters(
@@ -1160,8 +1160,8 @@ class Manager {
 	 *
 	 * @todo Refactor to use rawurlencode() instead of urlencode().
 	 *
-	 * @param Array $args arguments that need to have the source added.
-	 * @return Array $amended arguments.
+	 * @param array $args arguments that need to have the source added.
+	 * @return array $amended arguments.
 	 */
 	public static function apply_activation_source_to_args( $args ) {
 		list( $activation_source_name, $activation_source_keyword ) = get_option( 'jetpack_activation_source' );
@@ -1548,7 +1548,7 @@ class Manager {
 		 *
 		 * @since 8.0.0
 		 *
-		 * @param Array $request_data request data.
+		 * @param array $request_data request data.
 		 */
 		$body = apply_filters(
 			'jetpack_token_request_body',
@@ -1690,7 +1690,7 @@ class Manager {
 		 *
 		 * @since 8.0.0
 		 *
-		 * @param Array $request_data request data.
+		 * @param array $request_data request data.
 		 */
 		$body = apply_filters(
 			'jetpack_connect_request_body',
@@ -2072,8 +2072,8 @@ class Manager {
 	 * since it is passed by reference to various methods.
 	 * Capture it here so we can verify the signature later.
 	 *
-	 * @param Array $methods an array of available XMLRPC methods.
-	 * @return Array the same array, since this method doesn't add or remove anything.
+	 * @param array $methods an array of available XMLRPC methods.
+	 * @return array the same array, since this method doesn't add or remove anything.
 	 */
 	public function xmlrpc_methods( $methods ) {
 		$this->raw_post_data = $GLOBALS['HTTP_RAW_POST_DATA'];
@@ -2090,8 +2090,8 @@ class Manager {
 	/**
 	 * Registering an additional method.
 	 *
-	 * @param Array $methods an array of available XMLRPC methods.
-	 * @return Array the amended array in case the method is added.
+	 * @param array $methods an array of available XMLRPC methods.
+	 * @return array the amended array in case the method is added.
 	 */
 	public function public_xmlrpc_methods( $methods ) {
 		if ( array_key_exists( 'wp.getOptions', $methods ) ) {
@@ -2103,7 +2103,7 @@ class Manager {
 	/**
 	 * Handles a getOptions XMLRPC method call.
 	 *
-	 * @param Array $args method call arguments.
+	 * @param array $args method call arguments.
 	 * @return an amended XMLRPC server options array.
 	 */
 	public function jetpack_get_options( $args ) {
@@ -2151,8 +2151,8 @@ class Manager {
 	/**
 	 * Adds Jetpack-specific options to the output of the XMLRPC options method.
 	 *
-	 * @param Array $options standard Core options.
-	 * @return Array amended options.
+	 * @param array $options standard Core options.
+	 * @return array amended options.
 	 */
 	public function xmlrpc_options( $options ) {
 		$jetpack_client_id = false;

--- a/packages/sync/src/modules/class-full-sync-immediately.php
+++ b/packages/sync/src/modules/class-full-sync-immediately.php
@@ -428,7 +428,7 @@ class Full_Sync_Immediately extends Module {
 	/**
 	 * Empty Function as we don't close buffers on Immediate Full Sync.
 	 *
-	 * @param Array $actions an array of actions, ignored for queueless sync.
+	 * @param array $actions an array of actions, ignored for queueless sync.
 	 */
 	public function update_sent_progress_action( $actions ) {
 		return;

--- a/src/class-tracking.php
+++ b/src/class-tracking.php
@@ -195,7 +195,7 @@ class Tracking {
 	 *
 	 * @param String                   $action the action name, i.e., 'remote_authorize'.
 	 * @param String                   $stage  the execution stage, can be 'begin', 'success', 'error', etc.
-	 * @param Array|WP_Error|IXR_Error $parameters (optional) extra parameters to be passed to the tracked action.
+	 * @param array|WP_Error|IXR_Error $parameters (optional) extra parameters to be passed to the tracked action.
 	 * @param WP_User                  $user (optional) the acting user.
 	 */
 	public function jetpack_xmlrpc_server_event( $action, $stage, $parameters = array(), $user = null ) {

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -43,7 +43,7 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 	 *
 	 * @author zinigor
 	 * @since 3.8.2
-	 * @param Array $data an array of data returned by the filter
+	 * @param array $data an array of data returned by the filter
 	 * @return String $query_string
 	 */
 	protected function _get_query( $data ) {


### PR DESCRIPTION
Change inline documentation types of `Array` to `array`. The current version is confusing to some IDEs.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Updated inline PHP documentation to correctly indicate the `array` type.