### PR TITLE
Instagram Gallery Block: Rename Instagram endpoint to Instagram_Gallery

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -13,13 +13,13 @@ use Automattic\Jetpack\Connection\Client;
  *
  * @since 8.5
  */
-class WPCOM_REST_API_V2_Endpoint_Instagram extends WP_REST_Controller {
+class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		$this->namespace = 'wpcom/v2';
-		$this->rest_base = 'instagram';
+		$this->rest_base = 'instagram-gallery';
 
 		if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 			\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
@@ -153,4 +153,4 @@ class WPCOM_REST_API_V2_Endpoint_Instagram extends WP_REST_Controller {
 	}
 }
 
-wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Instagram' );
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Instagram_Gallery' );

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -22,7 +22,7 @@ module.exports = [
 	'_inc/lib/class.jetpack-password-checker.php',
 	'_inc/lib/components.php',
 	'_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php',
-	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram.php',
+	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php',
 	'_inc/lib/core-api/wpcom-endpoints/memberships.php',

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -65,7 +65,7 @@ const InstagramGalleryEdit = props => {
 		setIsLoadingGallery( true );
 
 		apiFetch( {
-			path: addQueryArgs( '/wpcom/v2/instagram/gallery', {
+			path: addQueryArgs( '/wpcom/v2/instagram-gallery/gallery', {
 				access_token: accessToken,
 				count: MAX_IMAGE_COUNT,
 			} ),

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -14,7 +14,7 @@ export default function useConnectInstagram( setAttributes, setImages, noticeOpe
 		noticeOperations.removeAllNotices();
 		setIsConnecting( true );
 
-		apiFetch( { path: `/wpcom/v2/instagram/connect-url` } )
+		apiFetch( { path: `/wpcom/v2/instagram-gallery/connect-url` } )
 			.then( connectUrl => {
 				const popupMonitor = new PopupMonitor();
 
@@ -48,7 +48,7 @@ export default function useConnectInstagram( setAttributes, setImages, noticeOpe
 	const disconnectFromService = accessToken => {
 		setIsConnecting( true );
 		apiFetch( {
-			path: addQueryArgs( `/wpcom/v2/instagram/delete-access-token`, {
+			path: addQueryArgs( `/wpcom/v2/instagram-gallery/delete-access-token`, {
 				access_token: accessToken,
 			} ),
 			method: 'DELETE',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the `WPCOM_REST_API_V2_Endpoint_Instagram` endpoint to `WPCOM_REST_API_V2_Endpoint_Instagram_Gallery` as the former already exists on WPCOM.

Note: this needs to be synced in D42516-code

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Smoke test the Instagram Gallery block.
* Does the "connect to Instagram" flow work?
* Does it load the gallery?
* Does the "disconnect" flow work?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (unreleased block)