### PR TITLE
adds support for direct URL to getRedirectUrl lib

### DIFF
--- a/_inc/client/lib/jp-redirect/index.js
+++ b/_inc/client/lib/jp-redirect/index.js
@@ -1,9 +1,15 @@
 /**
  * Builds an URL using the jetpack.com/redirect service
  *
+ * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
+ *
+ * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
+ *
+ * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
+ *
  * @since 8.5.0
  *
- * @param {string}  source The URL handler registered in the server
+ * @param {string}  source The URL handler registered in the server or the full destination URL (starting with https://).
  * @param {object}  args {
  *
  * 		Additional arguments to build the url
@@ -14,12 +20,20 @@
  * 		@type {string} anchor Anchor to be added to the URL
  * }
  *
- * @return {string} The redirect URL
+ * @returns {string} The redirect URL
  */
 export default function getRedirectUrl( source, args = {} ) {
-	const queryVars = {
-		source: source,
-	};
+	const queryVars = {};
+
+	if ( source.search( 'https://' ) === 0 ) {
+		const parsedUrl = new URL( source );
+
+		// discard any query and fragments.
+		source = `https://${ parsedUrl.host }${ parsedUrl.pathname }`;
+		queryVars.url = encodeURIComponent( source );
+	} else {
+		queryVars.source = encodeURIComponent( source );
+	}
 
 	const acceptedArgs = [ 'site', 'path', 'query', 'anchor' ];
 


### PR DESCRIPTION
After D42161-code, our redirect service also accetps a `url` parameter that will redirect the visitor to this URL without the need of registering this url in our backend beforehand. This will only work for a few Automattic domains.

This PR adds the possibility of creating such links using the `Redirects` package.

This is the JS relative of https://github.com/Automattic/jetpack/pull/15525

#### Testing instructions:

Note: This lib is being moved to its own npm package. There are tests there, so these changes should be fine: https://github.com/Automattic/wp-calypso/pull/41497

* Create some test links:

```
import getRedirectUrl from 'lib/jp-redirect';
const url = getRedirectUrl( 'https://wordpress.com/support' );
```

Check if this links creates an URL pointing to jetpack.com/redirect?url=https%3A%2F%2Fwordpress.com%2Fsupport
Click on it and see if it works.


```
import getRedirectUrl from 'lib/jp-redirect';
const url = getRedirectUrl( 'jetpack-support' );
```

Check if this links creates an URL pointing to jetpack.com/redirect?source=jetpack-support
Click on it and see if it works. (should go to jetpack.com/support)

```
import getRedirectUrl from 'lib/jp-redirect';
const url = getRedirectUrl( 'https://waltdisneyworld.com );
```

Check if this links creates an URL pointing to jetpack.com/redirect?url=https%3A%2F%2Fwaltdisneyworld.com
Click on it and see if it works. (it should go to jetpack.com homepage, since this domain is not whitelsted)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add support to inform the direct URL in getRedirectUrl lib
