### PR TITLE
Search: Ensure required php files are loaded

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -22,8 +22,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 * @since 8.3.0
 	 */
 	public function load_php() {
-		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
-		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
+		$this->base_load_php();
 
 		if ( class_exists( 'WP_Customize_Manager' ) ) {
 			require_once dirname( __FILE__ ) . '/class-jetpack-search-customize.php';

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -192,6 +192,13 @@ class Jetpack_Search {
 	 * @since 8.3.0
 	 */
 	public function load_php() {
+		$this->base_load_php();
+	}
+
+	/**
+	 * Loads the PHP common to all search. Should be called from extending classes.
+	 */
+	protected function base_load_php() {
 		require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
 		require_once dirname( __FILE__ ) . '/class.jetpack-search-template-tags.php';
 		require_once JETPACK__PLUGIN_DIR . 'modules/widgets/search.php';
@@ -350,9 +357,6 @@ class Jetpack_Search {
 	 * @since 5.7.0
 	 */
 	public function set_filters_from_widgets() {
-		if ( ! class_exists( 'Jetpack_Search_Helpers' ) ) {
-			return;
-		}
 		if ( Jetpack_Search_Helpers::are_filters_by_widget_disabled() ) {
 			return;
 		}

--- a/modules/search/class.jetpack-search.php
+++ b/modules/search/class.jetpack-search.php
@@ -350,6 +350,9 @@ class Jetpack_Search {
 	 * @since 5.7.0
 	 */
 	public function set_filters_from_widgets() {
+		if ( ! class_exists( 'Jetpack_Search_Helpers' ) ) {
+			return;
+		}
 		if ( Jetpack_Search_Helpers::are_filters_by_widget_disabled() ) {
 			return;
 		}


### PR DESCRIPTION
This is a very simple fix for #15570 that I feel safe for 8.5.

My initial thought is `load_php` for `Jetpack_Search` is including the Search Helpers file, but `load_php` for the instance search isn't. `set_filters_from_widgets` is being called for both classes, so calling `Jetpack_Search`'s which is using the helper class without checking if it is defined.

@gibrown What do you think about that? With code freeze tonight, this PR would/should stop a fatal but not really fix anything.


Fixes #15570

#### Changes proposed in this Pull Request:
* Checks for a class before use.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* See 15570.
*

#### Proposed changelog entry for your changes:
* Instant Search: Prevents a fatal in some circumstances.
