### PR TITLE
REST API: Adds an integrations proxy endpoint

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -56,6 +56,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-xmlrpc-consumer-endpoint.php';
 
 		// Load API endpoints
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-integrations-proxy-endpoint.php';
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php';
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php';
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php';
@@ -75,6 +76,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$module_toggle_endpoint = new Jetpack_Core_API_Module_Toggle_Endpoint( new Jetpack_IXR_Client() );
 		$site_endpoint = new Jetpack_Core_API_Site_Endpoint();
 		$widget_endpoint = new Jetpack_Core_API_Widget_Endpoint();
+		$integrations_endpoint  = new Jetpack_Core_API_Integrations_Proxy();
 
 		register_rest_route( 'jetpack/v4', 'plans', array(
 			'methods'             => WP_REST_Server::READABLE,
@@ -506,6 +508,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => __CLASS__ . '::send_mobile_magic_link',
 				'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
+			)
+		);
+
+		register_rest_route(
+			'jetpack/v4',
+			'integrations/(?P<path>.+)',
+			array(
+				'methods'             => WP_REST_Server::ALLMETHODS,
+				'callback'            => array( $integrations_endpoint, 'wpcom_request_as_user' ),
+				'permission_callback' => array( $integrations_endpoint, 'user_can_proxy_request' ),
 			)
 		);
 	}

--- a/_inc/lib/core-api/class.jetpack-core-api-integrations-proxy-endpoint.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-integrations-proxy-endpoint.php
@@ -1,0 +1,61 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * REST API Endpoint for proxying requests to wpcom.
+ *
+ * @since 8.4.0
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Proxy `/integrations/%s` calls to wpcom.
+ *
+ * @since 8.4.0
+ */
+class Jetpack_Core_API_Integrations_Proxy {
+	/**
+	 * Proxy request to wpcom as the current logged in user.
+	 *
+	 * @param WP_REST_Request $request API request.
+	 */
+	public function wpcom_request_as_user( WP_REST_Request $request ) {
+		$site_id = Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return new WP_Error( 'site_id_missing' );
+		}
+
+		$integrations_path = $request->get_param( 'path' );
+		if ( ! $integrations_path ) {
+			return new WP_Error( 'rest_invalid_path' );
+		}
+
+		$response = Client::wpcom_json_api_request_as_user(
+			sprintf( '/sites/%d/integrations/%s', $site_id, $integrations_path ),
+			'2',
+			array(),
+			null,
+			'wpcom'
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$response_data = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( is_string( $response_data ) ) {
+			$response_data = array( 'connect_url' => $response_data );
+		}
+
+		return rest_ensure_response( $response_data );
+	}
+
+	/**
+	 * Permissions check for proxied requests.
+	 *
+	 * Each /integrations endpoint on wpcom should do it's own, more granular, checks.
+	 */
+	public function user_can_proxy_request() {
+		return is_user_logged_in();
+	}
+}

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -21,6 +21,7 @@ module.exports = [
 	'_inc/lib/class-jetpack-podcast-helper.php',
 	'_inc/lib/class.jetpack-password-checker.php',
 	'_inc/lib/components.php',
+	'_inc/lib/core-api/class.jetpack-core-api-integrations-proxy-endpoint.php',
 	'_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php',


### PR DESCRIPTION
Example that may be useful for blocks that need to proxy REST API requests to wpcom.

Should implement a whitelist for endpoint names are allowed to be proxied before being used in production.