### PR TITLE
Add support for detecting deprecated functions in the Analyzer

### DIFF
--- a/packages/analyzer/src/Declarations.php
+++ b/packages/analyzer/src/Declarations.php
@@ -128,7 +128,7 @@ class Declarations extends PersistentList {
 
 					case 'function':
 						$params      = json_decode( $params_json );
-						$declaration = new Declarations\Function_( $file, $line, $name );
+						$declaration = new Declarations\Function_( $file, $line, $name, $deprecated );
 						if ( is_array( $params ) ) {
 							foreach ( $params as $param ) {
 								$declaration->add_param( $param->name, $param->default, $param->type, $param->byRef, $param->variadic );

--- a/packages/analyzer/src/Declarations.php
+++ b/packages/analyzer/src/Declarations.php
@@ -99,7 +99,7 @@ class Declarations extends PersistentList {
 		if ( ( $handle = fopen( $file_path, 'r' ) ) !== false ) {
 			while ( ( $data = fgetcsv( $handle, 1000, ',' ) ) !== false ) {
 				$num = count( $data );
-				@list( $type, $file, $line, $class_name, $name, $static, $params_json ) = $data;
+				@list( $type, $file, $line, $class_name, $name, $static, $params_json, $deprecated ) = $data;
 				switch ( $type ) {
 					case 'class':
 						$this->add( new Declarations\Class_( $file, $line, $class_name ) );
@@ -115,7 +115,7 @@ class Declarations extends PersistentList {
 
 					case 'method':
 						$params      = json_decode( $params_json );
-						$declaration = new Declarations\Class_Method( $file, $line, $class_name, $name, $static );
+						$declaration = new Declarations\Class_Method( $file, $line, $class_name, $name, $static, $deprecated );
 						if ( is_array( $params ) ) {
 							foreach ( $params as $param ) {
 								$declaration->add_param( $param->name, $param->default, $param->type, $param->byRef, $param->variadic );

--- a/packages/analyzer/src/Declarations/Class_Method.php
+++ b/packages/analyzer/src/Declarations/Class_Method.php
@@ -10,12 +10,14 @@ class Class_Method extends Declaration {
 	public $method_name;
 	public $params;
 	public $static;
+	public $deprecated;
 
-	function __construct( $path, $line, $class_name, $method_name, $static ) {
+	function __construct( $path, $line, $class_name, $method_name, $static, $deprecated = false ) {
 		$this->class_name  = $class_name;
 		$this->method_name = $method_name;
 		$this->params      = array();
 		$this->static      = $static;
+		$this->deprecated  = $deprecated;
 		parent::__construct( $path, $line );
 	}
 
@@ -33,6 +35,7 @@ class Class_Method extends Declaration {
 			$this->method_name,
 			$this->static,
 			json_encode( $this->params ),
+			$this->deprecated,
 		);
 	}
 

--- a/packages/analyzer/src/Declarations/Function_.php
+++ b/packages/analyzer/src/Declarations/Function_.php
@@ -8,10 +8,12 @@ namespace Automattic\Jetpack\Analyzer\Declarations;
 class Function_ extends Declaration {
 	public $func_name;
 	public $params;
+	public $deprecated;
 
-	function __construct( $path, $line, $func_name ) {
-		$this->func_name = $func_name;
-		$this->params    = array();
+	function __construct( $path, $line, $func_name, $deprecated = false ) {
+		$this->func_name  = $func_name;
+		$this->params     = array();
+		$this->deprecated = $deprecated;
 		parent::__construct( $path, $line );
 	}
 
@@ -29,6 +31,7 @@ class Function_ extends Declaration {
 			$this->func_name,
 			'',
 			json_encode( $this->params ),
+			$this->deprecated,
 		);
 	}
 

--- a/packages/analyzer/src/Declarations/Visitor.php
+++ b/packages/analyzer/src/Declarations/Visitor.php
@@ -45,7 +45,10 @@ class Visitor extends NodeVisitorAbstract {
 			if ( ! $this->current_class ) {
 				return;
 			}
-			$method = new Class_Method( $this->current_relative_path, $node->getLine(), $this->current_class, $node->name->name, $node->isStatic() );
+
+			// Check for a doc block or a function call to indicate the method is deprecated.
+			$deprecated = Utils::has_doc_comment( $node, '@deprecated' ) || Utils::has_function_call( $node, 'deprecated_function' );
+			$method     = new Class_Method( $this->current_relative_path, $node->getLine(), $this->current_class, $node->name->name, $node->isStatic(), $deprecated );
 			foreach ( $node->getParams() as $param ) {
 				$param_default = Utils::get_param_default_as_string( $param->default, $this->current_class );
 				$method->add_param( $param->var->name, $param_default, $param->type, $param->byRef, $param->variadic );

--- a/packages/analyzer/src/Declarations/Visitor.php
+++ b/packages/analyzer/src/Declarations/Visitor.php
@@ -47,7 +47,7 @@ class Visitor extends NodeVisitorAbstract {
 			}
 
 			// Check for a doc block or a function call to indicate the method is deprecated.
-			$deprecated = Utils::has_doc_comment( $node, '@deprecated' ) || Utils::has_function_call( $node, 'deprecated_function' );
+			$deprecated = Utils::has_doc_comment( $node, '@deprecated' ) || Utils::has_function_call( $node, '_deprecated_function' );
 			$method     = new Class_Method( $this->current_relative_path, $node->getLine(), $this->current_class, $node->name->name, $node->isStatic(), $deprecated );
 			foreach ( $node->getParams() as $param ) {
 				$param_default = Utils::get_param_default_as_string( $param->default, $this->current_class );
@@ -58,7 +58,9 @@ class Visitor extends NodeVisitorAbstract {
 		}
 
 		if ( $node instanceof Node\Stmt\Function_ ) {
-			$function = new Function_( $this->current_relative_path, $node->getLine(), $node->name->name );
+			// Check for a doc block or a function call to indicate the function is deprecated.
+			$deprecated = Utils::has_doc_comment( $node, '@deprecated' ) || Utils::has_function_call( $node, '_deprecated_function' );
+			$function   = new Function_( $this->current_relative_path, $node->getLine(), $node->name->name, $deprecated );
 			foreach ( $node->getParams() as $param ) {
 				$param_default = Utils::get_param_default_as_string( $param->default, $this->current_class );
 				$function->add_param( $param->var->name, $param_default, $param->type, $param->byRef, $param->variadic );

--- a/packages/analyzer/src/Differences.php
+++ b/packages/analyzer/src/Differences.php
@@ -79,6 +79,9 @@ class Differences extends PersistentList {
 					case 'method':
 						$this->add( new Differences\Class_Method_Deprecated( $prev_declaration, $new_declaration ) );
 						break;
+					case 'function':
+						$this->add( new Differences\Function_Deprecated( $prev_declaration, $new_declaration ) );
+						break;
 					default:
 						echo 'Unknown deprecated type ' . $new_declaration->type() . "\n";
 				}

--- a/packages/analyzer/src/Differences/Class_Method_Deprecated.php
+++ b/packages/analyzer/src/Differences/Class_Method_Deprecated.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Class Method Moved checker.
+ *
+ * @package automattic/jetpack-analyzer
+ */
+
+namespace Automattic\Jetpack\Analyzer\Differences;
+
+use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
+use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
+use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
+
+/**
+ * Class Class_Method_Deprecated
+ */
+class Class_Method_Deprecated extends PersistentListItem implements Invocation_Warner {
+	/**
+	 * Old declaration.
+	 *
+	 * @var object
+	 */
+	public $old_declaration;
+	/**
+	 * New declaration.
+	 *
+	 * @var object
+	 */
+	public $new_declaration;
+
+	/**
+	 * Class_Method_Deprecated constructor.
+	 *
+	 * @param object $old_declaration Old declaration.
+	 * @param object $new_declaration New declaration.
+	 */
+	public function __construct( $old_declaration, $new_declaration ) {
+		$this->old_declaration = $old_declaration;
+		$this->new_declaration = $new_declaration;
+	}
+
+	/**
+	 * Return array of declaration items.
+	 *
+	 * @return array
+	 */
+	public function to_csv_array() {
+		return array(
+			$this->type(),
+			$this->old_declaration->path,
+			$this->old_declaration->line,
+			$this->old_declaration->display_name(),
+		);
+	}
+
+	/**
+	 * Returns type of issue.
+	 *
+	 * @return string 'method_deprecated'
+	 */
+	public function type() {
+		return 'method_deprecated';
+	}
+
+	/**
+	 * Display name of issue.
+	 *
+	 * @return string
+	 */
+	public function display_name() {
+		return $this->old_declaration->display_name();
+	}
+
+	/**
+	 * Find warnings.
+	 *
+	 * @param object $invocation Invocation.
+	 * @param object $warnings Warnings.
+	 */
+	public function find_invocation_warnings( $invocation, $warnings ) {
+		if ( $invocation->depends_on( $this->old_declaration ) ) {
+			$warnings->add(
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class method ' . $this->old_declaration->display_name() . ' is deprecated ' . $this->old_declaration->path . ' line ' . $this->old_declaration->line, $this->old_declaration )
+			);
+		}
+	}
+}

--- a/packages/analyzer/src/Differences/Function_Deprecated.php
+++ b/packages/analyzer/src/Differences/Function_Deprecated.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Method Deprecated checker.
+ * Function Deprecated Checker.
  *
  * @package automattic/jetpack-analyzer
  */
@@ -8,19 +8,20 @@
 namespace Automattic\Jetpack\Analyzer\Differences;
 
 use Automattic\Jetpack\Analyzer\PersistentList\Item as PersistentListItem;
-use Automattic\Jetpack\Analyzer\Invocations\Static_Call;
+use Automattic\Jetpack\Analyzer\Invocations\Function_Call;
 use Automattic\Jetpack\Analyzer\Warnings\Warning; // TODO - subclasses?
 
 /**
- * Class Class_Method_Deprecated
+ * Class Function_Deprecated
  */
-class Class_Method_Deprecated extends PersistentListItem implements Invocation_Warner {
+class Function_Deprecated extends PersistentListItem implements Invocation_Warner {
 	/**
 	 * Old declaration.
 	 *
 	 * @var object
 	 */
 	public $old_declaration;
+
 	/**
 	 * New declaration.
 	 *
@@ -29,7 +30,7 @@ class Class_Method_Deprecated extends PersistentListItem implements Invocation_W
 	public $new_declaration;
 
 	/**
-	 * Class_Method_Deprecated constructor.
+	 * Function_Moved constructor.
 	 *
 	 * @param object $old_declaration Old declaration.
 	 * @param object $new_declaration New declaration.
@@ -54,18 +55,18 @@ class Class_Method_Deprecated extends PersistentListItem implements Invocation_W
 	}
 
 	/**
-	 * Returns type of issue.
+	 * Returns type of issue discovered.
 	 *
-	 * @return string 'method_deprecated'
+	 * @return string 'function_deprecated'
 	 */
 	public function type() {
-		return 'method_deprecated';
+		return 'function_deprecated';
 	}
 
 	/**
-	 * Display name of issue.
+	 * Returns the display name of the issue.
 	 *
-	 * @return string
+	 * @return mixed
 	 */
 	public function display_name() {
 		return $this->old_declaration->display_name();
@@ -80,7 +81,7 @@ class Class_Method_Deprecated extends PersistentListItem implements Invocation_W
 	public function find_invocation_warnings( $invocation, $warnings ) {
 		if ( $invocation->depends_on( $this->old_declaration ) ) {
 			$warnings->add(
-				new Warning( $this->type(), $invocation->path, $invocation->line, 'Class method ' . $this->old_declaration->display_name() . ' is deprecated ' . $this->old_declaration->path . ' line ' . $this->old_declaration->line, $this->old_declaration )
+				new Warning( $this->type(), $invocation->path, $invocation->line, 'Function ' . $this->old_declaration->display_name() . ' is deprecated ' . $this->old_declaration->path . ' line ' . $this->old_declaration->line, $this->old_declaration )
 			);
 		}
 	}

--- a/packages/analyzer/src/Utils.php
+++ b/packages/analyzer/src/Utils.php
@@ -86,4 +86,45 @@ class Utils {
 		// or methods they use without runtime analysis.
 		return get_class( $object );
 	}
+
+	/**
+	 * Check if a node has a docblock containing a specific comment string.
+	 *
+	 * @param PhpParser/Node $node    Current node we are parsing.
+	 * @param string         $comment Comment to match.
+	 * @return boolean
+	 */
+	public static function has_doc_comment( $node, $comment ) {
+		if ( $node->getDocComment() && false !== strpos( $node->getDocComment(), $comment ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if a node contains a call to a function name.
+	 * Any part of the function name will be matched.
+	 *
+	 * @param PhpParser/Node $node Current node we are parsing.
+	 * @param string         $name Function name to match.
+	 * @return boolean
+	 */
+	public static function has_function_call( $node, $name ) {
+		if ( empty( $node->getStmts() ) ) {
+			return false;
+		}
+
+		foreach ( $node->getStmts() as $stmt ) {
+			if ( ! $stmt instanceof Node\Stmt\Expression || ! $stmt->expr instanceof Node\Expr\FuncCall ) {
+				continue;
+			}
+			if ( false !== strpos( $stmt->expr->name->toCodeString(), $name ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 }


### PR DESCRIPTION
We currently use the Jetpack Analyzer to scan for changes within WooCommerce versions. One of the things we are looking to improve is the possibility to find any usage of deprecated functions.

### Changes proposed in this Pull Request:

This PR provides some changes to the Analyzer classes which allow for detecting deprecated functions and finding invocations of these deprecated functions. In WooCommerce a function is marked as deprecated by adding `@deprecated` to the DocBlock and also a call to `wc_deprecated_function` is used (similar to the WordPress function `_deprecated_function`).

Outline of the changes:
- Visitor class: scan for functions and methods which have the deprecated docblock or a call to a function called `_deprecated_function`
- Utils class: add a helper function for finding a text string within a docblock, add a helper function for finding a function call with a specific name
- Declarations class: for methods and functions specifically we add a deprecation parameter, for the main declarations class we add the possibility of loading this parameter from CSV
- Differences class: add a parameter to the find function to scan for deprecated functions (by default this remains disabled)
- Add two new difference types "Function_Deprecated" and "Method_Deprecated". When the invocation warnings are created these will show up in the list of warnings

### Is this a new feature or does it add/remove features to an existing part of Jetpack?
The changes add the possibility to scan for deprecated functions using the Jetpack Analyzer,  see post for additional details: p75Izm-2wQ-p2

### Testing instructions:
In order to test the changes we need to have two older versions of WooCommerce to compare, as well as a small plugin which calls some of the deprecated code.

1\. Download WooCommerce 3.5.8 from https://wordpress.org/plugins/woocommerce/advanced/ and unpack in `/tmp/woocommerce-3.5.8`
2\. Download WooCommerce 3.6.0 from https://wordpress.org/plugins/woocommerce/advanced/ and unpack in `/tmp/woocommerce-3.6.0`
3\. Create a test plugin in `/tmp/testplugin`. Add a `plugin.php` file in this folder with the contents:

```
<?php
woocommerce_show_messages();
get_woocommerce_term_meta( 1, 'foobar' );

WC_Abstract_Legacy_Product::sync_rating_count();
WC_Form_Handler::order_again();
```

4\. In the folder `jetpack/packages/analyzer/scripts` add a test script (`wc-deprecated-functions.php`) with the following contents:

```
<?php
require dirname( __DIR__ ) . '/vendor/autoload.php';

$wc_prev_deprecated = new Automattic\Jetpack\Analyzer\Declarations();
$wc_prev_deprecated->scan( '/tmp/woocommerce-3.5.8' );

$wc_new_deprecated = new Automattic\Jetpack\Analyzer\Declarations();
$wc_new_deprecated->scan( '/tmp/woocommerce-3.6.0' );

$differences = new Automattic\Jetpack\Analyzer\Differences();
$differences->find( $wc_new_deprecated, $wc_prev_deprecated, '/tmp/woocommerce-3.6.0', true );

$invocations = new Automattic\Jetpack\Analyzer\Invocations();
$invocations->scan( '/tmp/testplugin' );

$warnings = new Automattic\Jetpack\Analyzer\Warnings();
$warnings->generate( $invocations, $differences );
$warnings->output();
```

5\. Run the script with `php wc-deprecated-functions.php` (within the scripts folder)
6\. Expected output:

```
Total Declarations: 5926
Total Differences: 590
Moved: 1
Moved with stubbed file: 222
Missing: 277
Deprecated: 312
function_deprecated,main.php,3,"Function woocommerce_show_messages() is deprecated woocommerce/includes/wc-deprecated-functions.php line 141",woocommerce_show_messages()
function_deprecated,main.php,5,"Function get_woocommerce_term_meta($term_id,$key,$single=\true) is deprecated woocommerce/includes/wc-term-functions.php line 340","get_woocommerce_term_meta($term_id,$key,$single=\true)"
method_deprecated,main.php,10,"Class method \WC_Abstract_Legacy_Product::sync_rating_count($post_id) is deprecated woocommerce/includes/legacy/abstract-wc-legacy-product.php line 666","\WC_Abstract_Legacy_Product::sync_rating_count($post_id)"
method_deprecated,main.php,11,"Class method \WC_Form_Handler::order_again() is deprecated woocommerce/includes/class-wc-form-handler.php line 649","\WC_Form_Handler::order_again()"
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add - Scan for deprecated functions with the JetPack Analyzer.
