### PR TITLE
Instagram Gallery: Add the local user ID as state to the connect URL

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -117,7 +117,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 			);
 		}
 
-		return $body->services->{ 'instagram-basic-display' }->connect_URL;
+		return add_query_arg( 'state', get_current_user_id(), $body->services->{ 'instagram-basic-display' }->connect_URL );
 	}
 
 	/**

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -126,13 +126,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	public function get_instagram_access_token() {
-		$site_id = Jetpack_Instagram_Gallery_Helper::get_site_id();
-		if ( is_wp_error( $site_id ) ) {
-			return $site_id;
-		}
-
-		$path     = sprintf( '/sites/%d/external-services/connections', $site_id );
-		$response = Client::wpcom_json_api_request_as_user( $path );
+		$response = Client::wpcom_json_api_request_as_user( '/me/connections' );
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -40,11 +40,12 @@ const InstagramGalleryEdit = props => {
 
 	const [ images, setImages ] = useState( [] );
 	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
-	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram(
+	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram( {
+		accessToken,
+		noticeOperations,
 		setAttributes,
 		setImages,
-		noticeOperations
-	);
+	} );
 	const { isRequestingWpcomConnectUrl, wpcomConnectUrl } = useConnectWpcom();
 
 	const unselectedCount = count > images.length ? images.length : count;


### PR DESCRIPTION
If the current user is logged out of WPCOM then the nonce checks fail
when they try to connect to Instagram. By adding the local user ID to
the connect URL the changes in D42574-code will run the nonce checks
against the connected Jetpack user account ID.

#### Testing instructions:

Using this branch and having applied D42574-code. Sandbox the API, and test connecting the Instagram gallery block to Instagram while your connected Jetpack user is logged out of WPCOM.

Everything should work as expected!