### PR TITLE
Button Block: Properly render inner HTML if context-appropriate

### DIFF
--- a/extensions/blocks/button/button.php
+++ b/extensions/blocks/button/button.php
@@ -43,69 +43,36 @@ function render_block( $attributes, $content ) {
 	}
 
 	$element   = get_attribute( $attributes, 'element' );
-	$text      = wp_strip_all_tags( get_attribute( $attributes, 'text' ), true );
+	$text      = get_attribute( $attributes, 'text' );
 	$unique_id = get_attribute( $attributes, 'uniqueId' );
+	$url       = get_attribute( $attributes, 'url' );
 	$classes   = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
 
-	$dom    = new \DOMDocument();
-	$button = $dom->createElement( $element, $content );
+	$button_classes = get_button_classes( $attributes );
+	$button_styles  = get_button_styles( $attributes );
 
-	if ( 'input' === $element ) {
-		$button = $dom->createElement( 'input' );
+	$button_attributes = sprintf( ' class="%s" style="%s"', esc_attr( $button_classes ), esc_attr( $button_styles ) );
 
-		$attribute        = $dom->createAttribute( 'value' );
-		$attribute->value = $text;
-		$button->appendChild( $attribute );
+	if ( empty( $unique_id ) ) {
+		$button_attributes .= ' data-id-attr="placeholder"';
 	} else {
-		$button = $dom->createElement( $element, $text );
-	}
-
-	$attribute        = $dom->createAttribute( 'class' );
-	$attribute->value = get_button_classes( $attributes );
-	$button->appendChild( $attribute );
-
-	$button_styles = get_button_styles( $attributes );
-	if ( ! empty( $button_styles ) ) {
-		$attribute        = $dom->createAttribute( 'style' );
-		$attribute->value = $button_styles;
-		$button->appendChild( $attribute );
-	}
-
-	$attribute        = $dom->createAttribute( 'data-id-attr' );
-	$attribute->value = empty( $unique_id ) ? 'placeholder' : $unique_id;
-	$button->appendChild( $attribute );
-	if ( $unique_id ) {
-		$attribute        = $dom->createAttribute( 'id' );
-		$attribute->value = $unique_id;
-		$button->appendChild( $attribute );
+		$button_attributes .= sprintf( ' data-id-attr="%1$s" id="%1$s"', esc_attr( $unique_id ) );
 	}
 
 	if ( 'a' === $element ) {
-		$attribute        = $dom->createAttribute( 'href' );
-		$attribute->value = get_attribute( $attributes, 'url' );
-		$button->appendChild( $attribute );
-
-		$attribute        = $dom->createAttribute( 'target' );
-		$attribute->value = '_blank';
-		$button->appendChild( $attribute );
-
-		$attribute        = $dom->createAttribute( 'role' );
-		$attribute->value = 'button';
-		$button->appendChild( $attribute );
-
-		$attribute        = $dom->createAttribute( 'rel' );
-		$attribute->value = 'noopener noreferrer';
-		$button->appendChild( $attribute );
-	} elseif ( 'button' === $element || 'input' === $element ) {
-		$attribute        = $dom->createAttribute( 'type' );
-		$attribute->value = 'submit';
-		$button->appendChild( $attribute );
+		$button_attributes .= sprintf( ' href="%s" target="_blank" role="button" rel="noopener noreferrer"', esc_url( $url ) );
+	} elseif ( 'button' === $element ) {
+		$button_attributes .= ' type="submit"';
+	} elseif ( 'input' === $element ) {
+		$button_attributes .= sprintf( ' type="submit" value="%s"', wp_strip_all_tags( $text, true ) );
 	}
 
-	$dom->appendChild( $button );
+	$button = 'input' === $element
+		? '<' . $element . $button_attributes . ' />'
+		: '<' . $element . $button_attributes . '>' . $text . '</' . $element . '>';
 
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	return '<div class="' . esc_attr( $classes ) . '">' . $dom->saveHTML() . '</div>';
+	return '<div class="' . esc_attr( $classes ) . '">' . $button . '</div>';
 }
 
 /**

--- a/extensions/blocks/button/button.php
+++ b/extensions/blocks/button/button.php
@@ -43,7 +43,7 @@ function render_block( $attributes, $content ) {
 	}
 
 	$element   = get_attribute( $attributes, 'element' );
-	$text      = get_attribute( $attributes, 'text' );
+	$text      = wp_strip_all_tags( get_attribute( $attributes, 'text' ), true );
 	$unique_id = get_attribute( $attributes, 'uniqueId' );
 	$classes   = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes );
 

--- a/extensions/blocks/button/edit.js
+++ b/extensions/blocks/button/edit.js
@@ -35,7 +35,13 @@ function ButtonEdit( {
 	setTextColor,
 	textColor,
 } ) {
-	const { borderRadius, placeholder, text } = attributes;
+	const { borderRadius, element, placeholder, text } = attributes;
+
+	const onChange = value => {
+		// TODO: Remove `replace` once minimum Gutenberg version is 8.0 (to fully support `disableLineBreaks`)
+		const newValue = 'input' === element ? value.replace( /<br>/gim, ' ' ) : value;
+		setAttributes( { text: newValue } );
+	};
 
 	/* eslint-disable react-hooks/rules-of-hooks */
 	const {
@@ -74,9 +80,8 @@ function ButtonEdit( {
 			<RichText
 				allowedFormats={ [] }
 				className={ buttonClasses }
-				disableLineBreaks
-				// TODO: Remove `replace` once minimum Gutenberg version is 8.0 (to fully support `disableLineBreaks`)
-				onChange={ value => setAttributes( { text: value.replace( /<br>/gim, ' ' ) } ) }
+				disableLineBreaks={ 'input' === element }
+				onChange={ onChange }
 				placeholder={ placeholder || __( 'Add text…', 'jetpack' ) }
 				style={ buttonStyles }
 				value={ text }

--- a/extensions/blocks/button/edit.js
+++ b/extensions/blocks/button/edit.js
@@ -74,6 +74,7 @@ function ButtonEdit( {
 			<RichText
 				allowedFormats={ [] }
 				className={ buttonClasses }
+				disableLineBreaks
 				onChange={ value => setAttributes( { text: value } ) }
 				placeholder={ placeholder || __( 'Add text…', 'jetpack' ) }
 				style={ buttonStyles }

--- a/extensions/blocks/button/edit.js
+++ b/extensions/blocks/button/edit.js
@@ -75,7 +75,8 @@ function ButtonEdit( {
 				allowedFormats={ [] }
 				className={ buttonClasses }
 				disableLineBreaks
-				onChange={ value => setAttributes( { text: value } ) }
+				// TODO: Remove `replace` once minimum Gutenberg version is 8.0 (to fully support `disableLineBreaks`)
+				onChange={ value => setAttributes( { text: value.replace( /<br>/gim, ' ' ) } ) }
 				placeholder={ placeholder || __( 'Add text…', 'jetpack' ) }
 				style={ buttonStyles }
 				value={ text }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15578

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* If the Button block is set to output as `a` or `button`, make sure the inner HTML is rendered.
* If the Button block is set to output as `input`, prevent inserting newlines and strip any HTML tags.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Revue block, and add a Revue username (or some random text).
* Smoke test the block CSS classes and styles: set custom colors, change the border radius. Make sure they are rendered as expected in the front end.
* Try inserting a newline in the button text.
* Make sure the newline appears in the front end, and there is no unparsed HTML content.

Now modify the [Revue inner block definition](https://github.com/Automattic/jetpack/blob/a483211b27167830f0adee2c6d31c4062c0dfdb7/extensions/blocks/revue/index.js#L19).

* Change the element into an `a`, and add an `url` attribute (with an URL as value).
* Reload and insert a new Revue block, adding some newlines in the button text.
* Make sure the newline appears in the front end, and clicking the button opens the `url` in a new tab (also it should have the following attributes: `target="_blank" role="button" rel="noopener noreferrer"`).

Modify the Revue inner block definition again.

* Change the element into an `input`, and add an `uniqueId` attribute (any value will do).
* Reload and insert a new Revue block, and try adding some newlines in the button text.
* Make sure the newlines are converted into simple spaces.
* Make sure there aren't any newlines in the front end as well, and check if the `data-id-attr` and `id` attributes are set to the `uniqueId` defined above.
* _Note: ignore the fact that the button width is now the same as the other input fields. It's a Revue CSS setting, which don't expect the button to be an `input` element._

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Button Block: Properly render inner HTML if context-appropriate