### PR TITLE
Subscriptions Widget: ensure titles are displayed nicely in 2020

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -300,12 +300,18 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 
 		if ( self::is_wpcom() && ! self::wpcom_has_status_message() ) {
 			global $current_blog;
-			$url = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '';
+
+			$url     = defined( 'SUBSCRIBE_BLOG_URL' ) ? SUBSCRIBE_BLOG_URL : '';
+			$form_id = 'subscribe-blog' . self::$instance_count > 1
+				? '-' . self::$instance_count
+				: '';
 			?>
-            <form action="<?php echo $url; ?>" method="post" accept-charset="utf-8"
-                  id="subscribe-blog<?php if ( Jetpack_Subscriptions_Widget::$instance_count > 1 ) {
-				      echo '-' . Jetpack_Subscriptions_Widget::$instance_count;
-			      } ?>">
+			<form
+				action="<?php echo esc_url( $url ); ?>"
+				method="post"
+				accept-charset="utf-8"
+				id="<?php echo esc_attr( $form_id ); ?>"
+			>
 				<?php if ( is_user_logged_in() ) : ?>
 					<?php
 					if ( ! $show_only_email_and_button ) {
@@ -325,12 +331,20 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 						/* translators: %s: number of folks following the blog */
 						echo wpautop( sprintf( _n( 'Join %s other follower', 'Join %s other followers', $subscribers_total ), number_format_i18n( $subscribers_total ) ) );
 					}
+					$email_field_id = 'subscribe-field' . self::$instance_count > 1
+						? '-' . self::$instance_count
+						: '';
 					?>
-                    <p><input type="text" name="email" style="width: 95%; padding: 1px 10px"
-                              placeholder="<?php esc_attr_e( 'Enter your email address' ); ?>" value=""
-                              id="subscribe-field<?php if ( Jetpack_Subscriptions_Widget::$instance_count > 1 ) {
-						          echo '-' . Jetpack_Subscriptions_Widget::$instance_count;
-					          } ?>"/></p>
+					<p>
+						<input
+							type="text"
+							name="email"
+							style="width: 95%; padding: 1px 10px"
+							placeholder="<?php esc_attr_e( 'Enter your email address', 'jetpack' ); ?>"
+							value=""
+							id="<?php echo esc_attr( $email_field_id ); ?>"
+						/>
+					</p>
 				<?php endif; ?>
 
                 <p>

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -176,6 +176,15 @@
 	}
 }
 
+/*
+ * This overwrites inline styles added to the wpcom widget,
+ * hence the use of !important
+ */
+.widget_blog_subscription form p:not(#subscribe-email) input[type="text"] {
+	padding: 1.5rem 1.8rem !important;
+	width: 100% !important;
+}
+
 /* Related Posts */
 
 .entry-content #jp-relatedposts {

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -163,6 +163,19 @@
 	}
 }
 
+/* Subscriptions Widget */
+
+.jetpack_subscription_widget .widget-title label {
+	font-size: 2.8rem;
+	font-weight: 700;
+	margin: 0;
+}
+@media ( min-width: 700px ) {
+	.jetpack_subscription_widget .widget-title label {
+			font-size: 4rem;
+	}
+}
+
 /* Related Posts */
 
 .entry-content #jp-relatedposts {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

On WordPress.com (and only on wpcom), Subscription widget titles are wrapped in label tags.
This is problematic with the Twenty Twenty theme, since that theme has custom label styles that overwrite the default widget title style. Let's fix that.

**Before**

![image](https://user-images.githubusercontent.com/426388/80618318-7b0b4700-8a43-11ea-955e-e79ddadbcd8c.png)

**After**

![image](https://user-images.githubusercontent.com/426388/80618401-9ece8d00-8a43-11ea-8edb-09381c0a435a.png)

This was originally reported by @kathrynwp here:
https://core.trac.wordpress.org/ticket/49137

#### Testing instructions:

* Nothing should change if you use the widget with the Twenty Twenty theme on a Jetpack site; the look of the widget title should match the other titles before and after this patch was applied.
* On WordPress.com (see D42586-code), you should see the changes in the screenshot above.

#### Proposed changelog entry for your changes:

* N/A
