### PR TITLE
Button Block: Fix border radius attr type

### DIFF
--- a/extensions/blocks/button/attributes.js
+++ b/extensions/blocks/button/attributes.js
@@ -45,6 +45,6 @@ export default {
 		type: 'string',
 	},
 	borderRadius: {
-		type: 'string',
+		type: 'number',
 	},
 };


### PR DESCRIPTION
The new Jetpack button block introduced in https://github.com/Automattic/jetpack/pull/15370 has an issue where the border radius setting does not render correctly when reloading the editor.

Changing the attribute data type from string to number resolves this issue.

Fixes https://github.com/Automattic/jetpack/pull/15370#issuecomment-620852578

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Revue block and use the username "apeatling".
* Change the border radius property on the button.
* Save the post and refresh the editor.
* Confirm the border radius property is rendered correctly in the editor after a refresh.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed an issue with the Revue block where the border radius setting would not be saved correctly.
