### PR TITLE
Add related posts js to footer instead of header

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1662,7 +1662,8 @@ EOT;
 					'modules/related-posts/related-posts.js'
 				),
 				$dependencies,
-				self::VERSION
+				self::VERSION,
+				true
 			);
 			$related_posts_js_options = array(
 				/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The related post should be in footer like other js files.

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->



#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* change the $footer parameter to `true` in related post's `wp_enqueue_script`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable related post
* Go to any post page and view source
* Scroll to bottom, the related post js should be there

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Move related posts js to footer
