### PR TITLE
SEO description: enable in Editor's Document sidebar for .com sites

### DIFF
--- a/extensions/blocks/seo/index.js
+++ b/extensions/blocks/seo/index.js
@@ -4,22 +4,37 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { PanelBody } from '@wordpress/components';
-import { PluginPrePublishPanel } from '@wordpress/edit-post';
+import { PluginDocumentSettingPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import { isSimpleSite, isAtomicSite } from '../../shared/site-type-utils';
+import JetpackLogo from '../../shared/jetpack-logo';
 import JetpackPluginSidebar from '../../shared/jetpack-plugin-sidebar';
 import SeoPanel from './panel';
+
+const isWpcom = isSimpleSite() || isAtomicSite();
+const title = __( 'SEO Description', 'jetpack' );
 
 export const name = 'seo';
 
 export const settings = {
 	render: () => (
 		<Fragment>
+			{ // On WordPress.com the panel is in "Document" tab of the default editor sidebar
+			isWpcom && (
+				<PluginDocumentSettingPanel
+					icon={ <JetpackLogo /> }
+					name="jetpack-seo-description"
+					title={ title }
+				>
+					<SeoPanel />
+				</PluginDocumentSettingPanel>
+			) }
 			<JetpackPluginSidebar>
-				<PanelBody title={ __( 'SEO Description', 'jetpack' ) }>
+				<PanelBody title={ title }>
 					<SeoPanel />
 				</PanelBody>
 			</JetpackPluginSidebar>
@@ -28,7 +43,7 @@ export const settings = {
 				id="seo-title"
 				title={
 					<span id="seo-defaults" key="seo-title-span">
-						{ __( 'SEO Description', 'jetpack' ) }
+						{ title }
 					</span>
 				}
 			>


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/36885

#### Changes proposed in this Pull Request:
* Duplicate SEO description section in Document sidebar in addition to Jetpack sidebar.
* Applies just for .com Simple and Atomic sites.

<img width="392" alt="Screenshot 2020-04-30 at 11 52 57" src="https://user-images.githubusercontent.com/87168/80691936-90cb4b80-8ad9-11ea-9a97-537b893abadd.png">
<img width="372" alt="Screenshot 2020-04-30 at 11 52 51" src="https://user-images.githubusercontent.com/87168/80691949-945ed280-8ad9-11ea-8510-8fefe13b1067.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
- Modification

#### Testing instructions:
- Apply D42612-code
- Sandbox your site
- Look up the editor sidebar
- Try modifying the description, save your post.
- Confirm from source-code on the frontend that description got saved
- Also test that for regular Jetpack site this doesn't affect anything

#### Proposed changelog entry for your changes:
- N/A
