### PR TITLE
Make TED shortcode AMP compatible

### DIFF
--- a/modules/shortcodes/ted.php
+++ b/modules/shortcodes/ted.php
@@ -106,8 +106,11 @@ function ted_filter_oembed_fetch_url( $provider, $url, $args ) {
  * @return string|false
  */
 function ted_filter_oembed_amp_iframe( $cache, $url ) {
-	if ( is_string( $cache )
-		&& strpos( $url, 'ted.com' ) ) {
+	if ( class_exists( 'Jetpack_AMP_Support' )
+		&& Jetpack_AMP_Support::is_amp_request()
+		&& is_string( $cache )
+		&& strpos( $url, 'ted.com' )
+	) {
 		$cache = preg_replace(
 			'/src=[\'"].*?[\'"]/',
 			'$0 sandbox="allow-popups allow-scripts allow-same-origin"',

--- a/modules/shortcodes/ted.php
+++ b/modules/shortcodes/ted.php
@@ -106,9 +106,7 @@ function ted_filter_oembed_fetch_url( $provider, $url, $args ) {
  * @return string|false
  */
 function ted_filter_oembed_amp_iframe( $cache, $url ) {
-	if ( class_exists( 'Jetpack_AMP_Support' )
-		&& Jetpack_AMP_Support::is_amp_request()
-		&& is_string( $cache )
+	if ( is_string( $cache )
 		&& strpos( $url, 'ted.com' )
 	) {
 		$cache = preg_replace(

--- a/modules/shortcodes/ted.php
+++ b/modules/shortcodes/ted.php
@@ -96,3 +96,25 @@ add_shortcode( 'ted', 'shortcode_ted' );
 function ted_filter_oembed_fetch_url( $provider, $url, $args ) {
 	return add_query_arg( 'lang', $args['lang'], $provider );
 }
+
+/**
+ * Filter the oembed html to set the sandbox attribute in the iframe
+ *
+ * @param string|false $cache The cached HTML result, stored in post meta.
+ * @param string       $url   The attempted embed URL.
+ *
+ * @return string|false
+ */
+function ted_filter_oembed_amp_iframe( $cache, $url ) {
+	if ( is_string( $cache )
+		&& strpos( $url, 'ted.com' ) ) {
+		$cache = preg_replace(
+			'/src=[\'"].*?[\'"]/',
+			'$0 sandbox="allow-popups allow-scripts allow-same-origin"',
+			$cache
+		);
+	}
+
+	return $cache;
+}
+add_filter( 'embed_oembed_html', 'ted_filter_oembed_amp_iframe', 10, 2 );

--- a/tests/php/modules/shortcodes/test-class.ted.php
+++ b/tests/php/modules/shortcodes/test-class.ted.php
@@ -218,4 +218,46 @@ BODY;
 
 		unset( $GLOBALS[ 'post' ] );
 	}
+
+	/**
+	 * Gets data for test_shortcodes_ted_oembed_amp_iframe().
+	 *
+	 * @return array
+	 */
+	public function get_data_shortcodes_ted() {
+		return array(
+			'non_amp' => array(
+				'[ted id="1" lang="en"]',
+				false,
+				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
+			),
+			'amp'     => array(
+				'[ted id="1" lang="en"]',
+				true,
+				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" sandbox="allow-popups allow-scripts allow-same-origin" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
+			),
+		);
+	}
+
+	/**
+	 * Checks filtered oembed for AMP and non AMP pages.
+	 *
+	 * @dataProvider get_data_shortcodes_ted
+	 * @author pereirinha
+	 * @covers ::shortcode_ted
+	 * @since 8.5
+	 *
+	 * @param string $shortcode The shortcode.
+	 * @param bool   $is_amp    Is amp request.
+	 * @param string $expected  The expected outcome.
+	 */
+	public function test_shortcodes_ted_oembed_amp_iframe( $shortcode, $is_amp, $expected ) {
+		if ( $is_amp ) {
+			add_filter( 'jetpack_is_amp_request', '__return_true' );
+		}
+
+		$actual = do_shortcode( $shortcode );
+
+		$this->assertEquals( $actual, $expected );
+	}
 }

--- a/tests/php/modules/shortcodes/test-class.ted.php
+++ b/tests/php/modules/shortcodes/test-class.ted.php
@@ -227,12 +227,12 @@ BODY;
 	public function get_data_shortcodes_ted() {
 		return array(
 			'non_amp' => array(
-				'[ted id="1" lang="en"]',
+				'[ted id="1" lang="en" width="640" height="360"]',
 				false,
 				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
 			),
 			'amp'     => array(
-				'[ted id="1" lang="en"]',
+				'[ted id="1" lang="en" width="640" height="360"]',
 				true,
 				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" sandbox="allow-popups allow-scripts allow-same-origin" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
 			),

--- a/tests/php/modules/shortcodes/test-class.ted.php
+++ b/tests/php/modules/shortcodes/test-class.ted.php
@@ -220,20 +220,14 @@ BODY;
 	}
 
 	/**
-	 * Gets data for test_shortcodes_ted_oembed_amp_iframe().
+	 * Gets data for test_shortcodes_ted_oembed_iframe().
 	 *
 	 * @return array
 	 */
 	public function get_data_shortcodes_ted() {
 		return array(
-			'non_amp' => array(
+			'shortcode' => array(
 				'[ted id="1" lang="en" width="640" height="360"]',
-				false,
-				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
-			),
-			'amp'     => array(
-				'[ted id="1" lang="en" width="640" height="360"]',
-				true,
 				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" sandbox="allow-popups allow-scripts allow-same-origin" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
 			),
 		);
@@ -248,14 +242,9 @@ BODY;
 	 * @since 8.5
 	 *
 	 * @param string $shortcode The shortcode.
-	 * @param bool   $is_amp    Is amp request.
 	 * @param string $expected  The expected outcome.
 	 */
-	public function test_shortcodes_ted_oembed_amp_iframe( $shortcode, $is_amp, $expected ) {
-		if ( $is_amp ) {
-			add_filter( 'jetpack_is_amp_request', '__return_true' );
-		}
-
+	public function test_shortcodes_ted_oembed_iframe( $shortcode, $expected ) {
 		$actual = do_shortcode( $shortcode );
 
 		$this->assertEquals( $actual, $expected );

--- a/tests/php/modules/shortcodes/test-class.ted.php
+++ b/tests/php/modules/shortcodes/test-class.ted.php
@@ -143,6 +143,7 @@ BODY;
 		$shortcode_content = do_shortcode( $content );
 
 		$this->assertContains( 'ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world', $shortcode_content );
+		$this->assertContains( 'sandbox="allow-popups allow-scripts allow-same-origin"', $shortcode_content );
 
 		unset( $GLOBALS[ 'post' ] );
 	}
@@ -217,36 +218,5 @@ BODY;
 		$this->assertContains( 'ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world', $shortcode_content );
 
 		unset( $GLOBALS[ 'post' ] );
-	}
-
-	/**
-	 * Gets data for test_shortcodes_ted_oembed_iframe().
-	 *
-	 * @return array
-	 */
-	public function get_data_shortcodes_ted() {
-		return array(
-			'shortcode' => array(
-				'[ted id="1" lang="en" width="640" height="360"]',
-				'<iframe title="Louie Schwartzberg: Hidden miracles of the natural world" src="https://embed.ted.com/talks/louie_schwartzberg_hidden_miracles_of_the_natural_world" sandbox="allow-popups allow-scripts allow-same-origin" width="640" height="360" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>',
-			),
-		);
-	}
-
-	/**
-	 * Checks filtered oembed for AMP and non AMP pages.
-	 *
-	 * @dataProvider get_data_shortcodes_ted
-	 * @author pereirinha
-	 * @covers ::shortcode_ted
-	 * @since 8.5
-	 *
-	 * @param string $shortcode The shortcode.
-	 * @param string $expected  The expected outcome.
-	 */
-	public function test_shortcodes_ted_oembed_iframe( $shortcode, $expected ) {
-		$actual = do_shortcode( $shortcode );
-
-		$this->assertEquals( $actual, $expected );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* In the TED shortcode, allow clicking external links — the TED logo — on AMP requests.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds functionality to the current shortcode.

#### Testing instructions:
1. Ensure the AMP plugin is enabled;
1. In AMP Settings, select 'Transitional' mode;
1. In Jetpack > Settings, ensure 'Compose using shortcodes' is toggled on:
![](https://user-images.githubusercontent.com/4063887/78590154-fee85f80-7806-11ea-8291-b15b586a7ae3.png)
1. Add a Shortcode block with:
`[ted id="210"]`
1. Preview the AMP front-end by clicking the AMP icon:
![](https://user-images.githubusercontent.com/4063887/78590589-aebdcd00-7807-11ea-843e-625fd0a5c00c.png)
1. Click an external link, like the TED logo;
1. Expected: it opens a new tab or window:
![Screen Recording 2020-04-29 at 11 22 AM](https://user-images.githubusercontent.com/2189187/80585812-d91c3800-8a0b-11ea-89b2-4414f12acfb8.gif)

Before, clicking an external link did nothing.

Worthy of mention, this approach also makes the default oembed compatible with AMP.

#### Proposed changelog entry for your changes:
* Improve TED shortcode AMP compatibility.
