### PR TITLE
Actions: do not bail when a package does not have a src dir

### DIFF
--- a/bin/update-package.sh
+++ b/bin/update-package.sh
@@ -61,7 +61,7 @@ for package in packages/*; do
 	cp -r $BASE/packages/$NAME/. .
 
 	# Before we commit any changes, ensure that the repo has the basics we need for any package.
-	if [ ! -f "composer.json" -o ! -d "src" ]; then
+	if [ ! -f "composer.json" ]; then
 		echo "  Those changes remove essential parts of the package. They will not be committed."
 	# Commit if there is any change that could be committed
 	elif [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Some of our packages, compat and options, do not have a src directory. That should not stop us from updating those packages.

#### Testing instructions:

* Not much should change. In future PRs that modify the packages above, the action should be triggered and the packages should be updated.

#### Proposed changelog entry for your changes:

* N/A
