### PR TITLE
Twitter Cards: Use additional images.

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -87,8 +87,8 @@ class Jetpack_Twitter_Cards {
 			$post_image = Jetpack_PostImages::get_image(
 				$post->ID,
 				array(
-					'width'  => 240,
-					'height' => 240,
+					'width'  => 144,
+					'height' => 144,
 				)
 			);
 			if ( ! empty( $post_image ) && is_array( $post_image ) ) {
@@ -99,7 +99,7 @@ class Jetpack_Twitter_Cards {
 						$card_type                = 'summary_large_image';
 						$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $post_image['src'] ) );
 					} else {
-						$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 240, $post_image['src'] ) );
+						$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 144, $post_image['src'] ) );
 					}
 
 					// Add the alt tag if we have one.

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -91,21 +91,25 @@ class Jetpack_Twitter_Cards {
 					'height' => 240,
 				)
 			);
-			if ( ! empty( $post_image ) ) {
-				if ( (int) $post_image['src_width'] >= 280 && (int) $post_image['src_height'] >= 150 ) {
-					$card_type                = 'summary_large_image';
-					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $post_image['src'] ) );
-				} else {
-					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 240, $post_image['src'] ) );
-				}
-
-				// Add the alt tag if we have one.
-				if ( ! empty( $post_image['alt_text'] ) ) {
-					// Shorten it if it is too long.
-					if ( strlen( $post_image['alt_text'] ) > $alt_length ) {
-						$og_tags['twitter:image:alt'] = esc_attr( mb_substr( $post_image['alt_text'], 0, $alt_length ) . '…' );
+			if ( ! empty( $post_image ) && is_array( $post_image ) ) {
+				// 4096 is the maximum size for an image per https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary .
+				if ( (int) $post_image['src_width'] <= 4096 && (int) $post_image['src_height'] <= 4096 ) {
+					// 300x157 is the minimum size for a summary_large_image per https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image .
+					if ( (int) $post_image['src_width'] >= 300 && (int) $post_image['src_height'] >= 157 ) {
+						$card_type                = 'summary_large_image';
+						$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $post_image['src'] ) );
 					} else {
-						$og_tags['twitter:image:alt'] = esc_attr( $post_image['alt_text'] );
+						$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 240, $post_image['src'] ) );
+					}
+
+					// Add the alt tag if we have one.
+					if ( ! empty( $post_image['alt_text'] ) ) {
+						// Shorten it if it is too long.
+						if ( strlen( $post_image['alt_text'] ) > $alt_length ) {
+							$og_tags['twitter:image:alt'] = esc_attr( mb_substr( $post_image['alt_text'], 0, $alt_length ) . '…' );
+						} else {
+							$og_tags['twitter:image:alt'] = esc_attr( $post_image['alt_text'] );
+						}
 					}
 				}
 			}

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -84,22 +84,28 @@ class Jetpack_Twitter_Cards {
 
 		// Try to give priority to featured images
 		if ( class_exists( 'Jetpack_PostImages' ) ) {
-			$featured = Jetpack_PostImages::from_thumbnail( $post->ID, 240, 240 );
-			if ( ! empty( $featured ) && count( $featured ) > 0 ) {
-				if ( (int) $featured[0]['src_width'] >= 280 && (int) $featured[0]['src_height'] >= 150 ) {
+			$post_image = Jetpack_PostImages::get_image(
+				$post->ID,
+				array(
+					'width'  => 240,
+					'height' => 240,
+				)
+			);
+			if ( ! empty( $post_image ) ) {
+				if ( (int) $post_image['src_width'] >= 280 && (int) $post_image['src_height'] >= 150 ) {
 					$card_type                = 'summary_large_image';
-					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $featured[0]['src'] ) );
+					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $post_image['src'] ) );
 				} else {
-					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 240, $featured[0]['src'] ) );
+					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 240, $post_image['src'] ) );
 				}
 
 				// Add the alt tag if we have one.
-				if ( ! empty( $featured[0]['alt_text'] ) ) {
+				if ( ! empty( $post_image['alt_text'] ) ) {
 					// Shorten it if it is too long.
-					if ( strlen( $featured[0]['alt_text'] ) > $alt_length ) {
-						$og_tags['twitter:image:alt'] = esc_attr( mb_substr( $featured[0]['alt_text'], 0, $alt_length ) . '…' );
+					if ( strlen( $post_image['alt_text'] ) > $alt_length ) {
+						$og_tags['twitter:image:alt'] = esc_attr( mb_substr( $post_image['alt_text'], 0, $alt_length ) . '…' );
 					} else {
-						$og_tags['twitter:image:alt'] = esc_attr( $featured[0]['alt_text'] );
+						$og_tags['twitter:image:alt'] = esc_attr( $post_image['alt_text'] );
 					}
 				}
 			}


### PR DESCRIPTION
Before this PR we only looked at a feature image in determining if a Twitter card should be `summary` or `summary_large_image`.

Since, of as #15527, we will start deferring to Twitter cards over attached media for Twitter when 8.5 ships, it was reported there is a gap when a site is not using featured images. On the WP.com side, we would look for additional images to send to Twitter. This PR would close that gap by looking for other sources within the post (no fallback to gravatars or site icons).

Fixes p8oabR-uL-p2 item 4160.

#### Changes proposed in this Pull Request:
* Use additional media beyond featured image.
* Update and enforce Twitter size requirements per their documentation.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Jetpack connected + Publicize or Sharing enabled.
* Write a post with a reasonably large image (over 300x157 at the very least) in the content.
* Do not set a featured image for the post.
* Publish post.
* In the source, confirm the twitter:card meta tag is `summary_large_image`.
* You can also tweet the post or use the Twitter validator https://cards-dev.twitter.com/validator

#### Proposed changelog entry for your changes:
* Twitter Cards: Use additional post-specific media for Twitter card tags.
