### PR TITLE
Add Hooks to Jetpack Login SSO Form for Extension

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -466,7 +466,17 @@ class Jetpack_SSO {
 
 		?>
 		<div id="jetpack-sso-wrap">
-			<?php if ( $display_name && $gravatar ) : ?>
+			<?php
+				/**
+				 * Allow extension above Jetpack's SSO form.
+				 *
+				 * @module sso
+				 *
+				 * @since 8.6.0
+				 */
+				do_action( 'jetpack_sso_login_form_above_wpcom' );
+				
+				if ( $display_name && $gravatar ) : ?>
 				<div id="jetpack-sso-wrap__user">
 					<img width="72" height="72" src="<?php echo esc_html( $gravatar ); ?>" />
 
@@ -503,6 +513,17 @@ class Jetpack_SSO {
 					</p>
 				<?php endif; ?>
 			</div>
+
+			<?php
+				/**
+				 * Allow extension below Jetpack's SSO form.
+				 *
+				 * @module sso
+				 *
+				 * @since 8.6.0
+				 */
+				do_action( 'jetpack_sso_login_form_below_wpcom' );
+			?>
 
 			<?php if ( ! Jetpack_SSO_Helpers::should_hide_login_form() ) : ?>
 				<div class="jetpack-sso-or">

--- a/modules/sso.php
+++ b/modules/sso.php
@@ -523,24 +523,23 @@ class Jetpack_SSO {
 				 * @since 8.6.0
 				 */
 				do_action( 'jetpack_sso_login_form_below_wpcom' );
-			?>
+				
+				if ( ! Jetpack_SSO_Helpers::should_hide_login_form() ) : ?>
+					<div class="jetpack-sso-or">
+						<span><?php esc_html_e( 'Or', 'jetpack' ); ?></span>
+					</div>
 
-			<?php if ( ! Jetpack_SSO_Helpers::should_hide_login_form() ) : ?>
-				<div class="jetpack-sso-or">
-					<span><?php esc_html_e( 'Or', 'jetpack' ); ?></span>
-				</div>
+					<a href="<?php echo esc_url( add_query_arg( 'jetpack-sso-show-default-form', '1' ) ); ?>" class="jetpack-sso-toggle wpcom">
+						<?php
+							esc_html_e( 'Log in with username and password', 'jetpack' )
+						?>
+					</a>
 
-				<a href="<?php echo esc_url( add_query_arg( 'jetpack-sso-show-default-form', '1' ) ); ?>" class="jetpack-sso-toggle wpcom">
-					<?php
-						esc_html_e( 'Log in with username and password', 'jetpack' )
-					?>
-				</a>
-
-				<a href="<?php echo esc_url( add_query_arg( 'jetpack-sso-show-default-form', '0' ) ); ?>" class="jetpack-sso-toggle default">
-					<?php
-						esc_html_e( 'Log in with WordPress.com', 'jetpack' )
-					?>
-				</a>
+					<a href="<?php echo esc_url( add_query_arg( 'jetpack-sso-show-default-form', '0' ) ); ?>" class="jetpack-sso-toggle default">
+						<?php
+							esc_html_e( 'Log in with WordPress.com', 'jetpack' )
+						?>
+					</a>
 			<?php endif; ?>
 		</div>
 		<?php


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Revisits #12915.

Adds action hooks before and after Jetpack's Single-Sign On Login Form that overrides WordPress Core. 

#### Changes proposed in this Pull Request:
*Adds before/after action hooks on the Jetpack SSO Form.

Because Jetpack obfuscates the default login form -- where other Single-Sign On solutions may be extending with their own button -- and labels the default form as "Login with Username & Password," it can be confusing to users where their other SSO button went and requires an extra click. 

There is a reasonable scenario where some users may want to Login with WordPress.com and other users may want to login using a different service. If Jetpack is going to supersede the Core experience, there should at minimum be an opportunity for other products to add their buttons adjacent to Jetpack's.

![Jetpack login form with additional login button](https://user-images.githubusercontent.com/9565066/80620227-9140e500-89fa-11ea-801d-298451ea02d5.png)

#### Testing instructions:
1. Add an action to `jetpack_sso_login_form_above_wpcom` or `jetpack_sso_login_form_below_wpcom` with a callback containing markup.

#### Proposed changelog entry for your changes:
* Allow extension of Jetpack SSO Form that override's WordPress' login form.
