### PR TITLE
Instant Search: Build CSS during yarn build-search

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"build": "yarn install-if-deps-outdated && yarn clean && yarn build-client && yarn build-php && yarn build-extensions && yarn build-search",
 		"build-client": "gulp",
 		"build-extensions": "webpack --config ./webpack.config.extensions.js",
-		"build-search": "webpack --config ./webpack.config.search.js",
+		"build-search": "webpack --config ./webpack.config.search.js && gulp sass:instant-search",
 		"build-php": "composer install --ignore-platform-reqs",
 		"build-production-php": "COMPOSER_MIRROR_PATH_REPOS=1 composer install -o --no-dev --classmap-authoritative --prefer-dist",
 		"build-production-client": "NODE_ENV=production BABEL_ENV=production yarn build-client",


### PR DESCRIPTION
Instant Search uses the gulp command for CSS, but the yarn command to build only search lacks this.

In support of p3topS-Hw-p2
Fixes #14382

Change is being reviewed on wp.com via D42668-code so don't merge this until we confirm that's good to go.

#### Changes proposed in this Pull Request:
* Adds CSS build to the yarn command.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* `yarn build-search`
* Confirm instant-search.min.css is created.

#### Proposed changelog entry for your changes:
* n/a, just build.
