### PR TITLE
Eventbrite Block: Move anchor inside of block wrapper

### DIFF
--- a/extensions/blocks/eventbrite/eventbrite.php
+++ b/extensions/blocks/eventbrite/eventbrite.php
@@ -66,12 +66,14 @@ function render_block( $attr, $content ) {
 
 		// $content contains a fallback link to the event that's saved in the post_content.
 		// Append a div that will hold the iframe embed created by the Eventbrite widget.js.
-		$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+		$classes     = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
+		$direct_link = '<a class="eventbrite__direct-link" href="' . esc_url( $attr['url'] ) . '">' . esc_url( $attr['url'] ) . '</a>';
 
 		$content .= sprintf(
-			'<div id="%1$s" class="%2$s"></div>',
+			'<div id="%1$s" class="%2$s">%3$s</div>',
 			esc_attr( $widget_id ),
-			esc_attr( $classes )
+			esc_attr( $classes ),
+			$direct_link
 		);
 
 		return sprintf(

--- a/extensions/blocks/eventbrite/save.js
+++ b/extensions/blocks/eventbrite/save.js
@@ -65,21 +65,11 @@ function saveButton( attributes ) {
 }
 
 export default function save( { attributes } ) {
-	const { eventId, style, url } = attributes;
+	const { eventId, style } = attributes;
 
-	if ( ! eventId ) {
+	if ( ! eventId || style !== 'modal' ) {
 		return;
 	}
 
-	if ( style === 'modal' ) {
-		return saveButton( attributes );
-	}
-
-	return (
-		url && (
-			<a className="eventbrite__direct-link" href={ url }>
-				{ url }
-			</a>
-		)
-	);
+	return saveButton( attributes );
 }


### PR DESCRIPTION
Move the direct link URL inside of the top level div wrapper for the eventbrite block. Fixes #15518.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an Eventbrite block to a new post and add an event.
* Use the modal version of the block.
* Publish the post and confirm the embed works on the front end as expected.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
