### PR TITLE
JITM: Allow JITM on stats pages

### DIFF
--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -83,7 +83,6 @@ class JITM {
 		if ( ! in_array(
 			$screen->id,
 			array(
-				'jetpack_page_stats',
 				'jetpack_page_akismet-key-config',
 				'admin_page_jetpack_modules',
 			),


### PR DESCRIPTION
I'm not sure why this is explicitly disabled. It seems to work just fine in my testing.

Testing:
- connect your jp site to a wp.com sandbox
- modify jitm-engine to remove the message_path() call for one of the existing messages (maybe also remove a few other checks so that it shows everywhere for you)
- Go to the old stats page in the wp-admin dashboard and verify that the message is shown.

