### PR TITLE
Admin Page: display update modal correctly

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -377,14 +377,13 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 
 		$post = $post_data['posts'][0];
 
-		$post_content = isset( $post['content'] ) ? $post['content'] : null;
-		if ( empty( $post_content ) ) {
+		if ( empty( $post['content'] ) ) {
 			return;
 		}
 
 		// This allows us to embed videopress videos into the release post.
 		add_filter( 'wp_kses_allowed_html', array( $this, 'allow_post_embed_iframe' ), 10, 2 );
-		$content = wp_kses_post( $post_content );
+		$content = wp_kses_post( $post['content'] );
 		remove_filter( 'wp_kses_allowed_html', array( $this, 'allow_post_embed_iframe' ), 10, 2 );
 
 		$post_title = isset( $post['title'] ) ? $post['title'] : null;

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -312,7 +312,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'messageCode'      => Jetpack::state( 'message' ),
 				'errorCode'        => Jetpack::state( 'error' ),
 				'errorDescription' => Jetpack::state( 'error_description' ),
-				'messageContent'   => Jetpack::state( 'message_content' ),
+				'messageContent'   => Jetpack::state( 'display_update_modal' ) ? $this->get_update_modal_data() : null,
 			),
 			'tracksUserData'              => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 			'currentIp'                   => function_exists( 'jetpack_protect_get_ip' ) ? jetpack_protect_get_ip() : false,
@@ -362,6 +362,117 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		return apply_filters( 'jetpack_show_setup_wizard', false )
 			&& Jetpack::is_active()
 			&& current_user_can( 'jetpack_manage_modules' );
+	}
+
+	/**
+	 * Returns the release post content and image data as an associative array.
+	 * This data is used to create the update modal.
+	 */
+	public function get_update_modal_data() {
+		$post_data = $this->get_release_post_data();
+
+		if ( ! isset( $post_data['posts'][0] ) ) {
+			return;
+		}
+
+		$post = $post_data['posts'][0];
+
+		$post_content = isset( $post['content'] ) ? $post['content'] : null;
+		if ( empty( $post_content ) ) {
+			return;
+		}
+
+		// This allows us to embed videopress videos into the release post.
+		add_filter( 'wp_kses_allowed_html', array( $this, 'allow_post_embed_iframe' ), 10, 2 );
+		$content = wp_kses_post( $post_content );
+		remove_filter( 'wp_kses_allowed_html', array( $this, 'allow_post_embed_iframe' ), 10, 2 );
+
+		$post_title = isset( $post['title'] ) ? $post['title'] : null;
+		$title      = wp_kses( $post_title, array() );
+
+		$post_thumbnail = isset( $post['post_thumbnail'] ) ? $post['post_thumbnail'] : null;
+		if ( ! empty( $post_thumbnail ) ) {
+			jetpack_require_lib( 'class.jetpack-photon-image' );
+			$photon_image = new Jetpack_Photon_Image(
+				array(
+					'file'   => jetpack_photon_url( $post_thumbnail['URL'] ),
+					'width'  => $post_thumbnail['width'],
+					'height' => $post_thumbnail['height'],
+				),
+				$post_thumbnail['mime_type']
+			);
+			$photon_image->resize(
+				array(
+					'width'  => 600,
+					'height' => null,
+					'crop'   => false,
+				)
+			);
+			$post_thumbnail_url = $photon_image->get_raw_filename();
+		} else {
+			$post_thumbnail_url = null;
+		}
+
+		$post_array = array(
+			'release_post_content'        => $content,
+			'release_post_featured_image' => $post_thumbnail_url,
+			'release_post_title'          => $title,
+		);
+
+		return $post_array;
+	}
+
+	/**
+	 * Temporarily allow post content to contain iframes, e.g. for videopress.
+	 *
+	 * @param string $tags    The tags.
+	 * @param string $context The context.
+	 */
+	public function allow_post_embed_iframe( $tags, $context ) {
+		if ( 'post' === $context ) {
+			$tags['iframe'] = array(
+				'src'             => true,
+				'height'          => true,
+				'width'           => true,
+				'frameborder'     => true,
+				'allowfullscreen' => true,
+			);
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * Obtains the release post from the Jetpack release post blog. A release post will be displayed in the
+	 * update modal when a post has a tag equal to the Jetpack version number.
+	 *
+	 * The response parameters for the post array can be found here:
+	 * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/#apidoc-response
+	 *
+	 * @return array|null Returns an associative array containing the release post data at index ['posts'][0].
+	 *                    Returns null if the release post data is not available.
+	 */
+	private function get_release_post_data() {
+		if ( Constants::is_defined( 'TESTING_IN_JETPACK' ) && Constants::get_constant( 'TESTING_IN_JETPACK' ) ) {
+			return null;
+		}
+
+		$release_post_src = add_query_arg(
+			array(
+				'order_by' => 'date',
+				'tag'      => JETPACK__VERSION,
+				'number'   => '1',
+			),
+			'https://public-api.wordpress.com/rest/v1/sites/' . JETPACK__RELEASE_POST_BLOG_SLUG . '/posts'
+		);
+
+		$response = wp_remote_get( $release_post_src );
+
+		if ( ! is_array( $response ) ) {
+			return null;
+		}
+
+		return json_decode( wp_remote_retrieve_body( $response ), true );
 	}
 }
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3311,119 +3311,15 @@ p {
 	 */
 	public static function do_version_bump( $version, $old_version ) {
 		if ( $old_version ) { // For existing Jetpack installations.
-			self::send_update_modal_data();
+			add_action( 'current_screen', 'Jetpack::set_update_modal_display' );
 		}
 	}
 
 	/**
-	 * Prepares the release post content and image data and saves it in the
-	 * state array. This data is used to create the update modal.
+	 * Sets the display_update_modal state.
 	 */
-	public static function send_update_modal_data() {
-		$post_data = self::get_release_post_data();
-
-		if ( ! isset( $post_data['posts'][0] ) ) {
-			return;
-		}
-
-		$post = $post_data['posts'][0];
-
-		$post_content = isset( $post['content'] ) ? $post['content'] : null;
-		if ( empty( $post_content ) ) {
-			return;
-		}
-
-		// This allows us to embed videopress videos into the release post.
-		add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_post_embed_iframe' ), 10, 2 );
-		$content = wp_kses_post( $post_content );
-		remove_filter( 'wp_kses_allowed_html', array( __CLASS__, 'allow_post_embed_iframe' ), 10, 2 );
-
-		$post_title = isset( $post['title'] ) ? $post['title'] : null;
-		$title      = wp_kses( $post_title, array() );
-
-		$post_thumbnail = isset( $post['post_thumbnail'] ) ? $post['post_thumbnail'] : null;
-		if ( ! empty( $post_thumbnail ) ) {
-			jetpack_require_lib( 'class.jetpack-photon-image' );
-			$photon_image = new Jetpack_Photon_Image(
-				array(
-					'file'   => jetpack_photon_url( $post_thumbnail['URL'] ),
-					'width'  => $post_thumbnail['width'],
-					'height' => $post_thumbnail['height'],
-				),
-				$post_thumbnail['mime_type']
-			);
-			$photon_image->resize(
-				array(
-					'width'  => 600,
-					'height' => null,
-					'crop'   => false,
-				)
-			);
-			$post_thumbnail_url = $photon_image->get_raw_filename();
-		} else {
-			$post_thumbnail_url = null;
-		}
-
-		$post_array = array(
-			'release_post_content'        => $content,
-			'release_post_featured_image' => $post_thumbnail_url,
-			'release_post_title'          => $title,
-		);
-
-		self::state( 'message_content', $post_array );
-	}
-
-	/**
-	 * Temporarily allow post content to contain iframes, e.g. for videopress.
-	 *
-	 * @param string $tags    The tags.
-	 * @param string $context The context.
-	 */
-	public static function allow_post_embed_iframe( $tags, $context ) {
-		if ( 'post' === $context ) {
-			$tags['iframe'] = array(
-				'src'             => true,
-				'height'          => true,
-				'width'           => true,
-				'frameborder'     => true,
-				'allowfullscreen' => true,
-			);
-		}
-
-		return $tags;
-	}
-
-	/**
-	 * Obtains the release post from the Jetpack release post blog. A release post will be displayed in the
-	 * update modal when a post has a tag equal to the Jetpack version number.
-	 *
-	 * The response parameters for the post array can be found here:
-	 * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/#apidoc-response
-	 *
-	 * @return array|null Returns an associative array containing the release post data at index ['posts'][0].
-	 *                    Returns null if the release post data is not available.
-	 */
-	private static function get_release_post_data() {
-		if ( Constants::is_defined( 'TESTING_IN_JETPACK' ) && Constants::get_constant( 'TESTING_IN_JETPACK' ) ) {
-			return null;
-		}
-
-		$release_post_src = add_query_arg(
-			array(
-				'order_by' => 'date',
-				'tag'      => JETPACK__VERSION,
-				'number'   => '1',
-			),
-			'https://public-api.wordpress.com/rest/v1/sites/' . JETPACK__RELEASE_POST_BLOG_SLUG . '/posts'
-		);
-
-		$response = wp_remote_get( $release_post_src );
-
-		if ( ! is_array( $response ) ) {
-			return null;
-		}
-
-		return json_decode( wp_remote_retrieve_body( $response ), true );
+	public static function set_update_modal_display() {
+		self::state( 'display_update_modal', true );
 	}
 
 	/**
@@ -5871,9 +5767,7 @@ endif;
 
 		if ( $restate ) {
 			foreach ( $state as $k => $v ) {
-				if ( 'message_content' !== $k ) {
-					setcookie( "jetpackState[$k]", $v, 0, $path, $domain );
-				}
+				setcookie( "jetpackState[$k]", $v, 0, $path, $domain );
 			}
 			return;
 		}
@@ -5892,14 +5786,35 @@ endif;
 				$value = $value[0];
 			}
 			$state[ $key ] = $value;
-			if ( 'message_content' !== $key && ! headers_sent() ) {
-				setcookie( "jetpackState[$key]", $value, 0, $path, $domain );
+			if ( ! headers_sent() ) {
+				if ( self::should_set_cookie( $key ) ) {
+					setcookie( "jetpackState[$key]", $value, 0, $path, $domain );
+				}
 			}
 		}
 	}
 
 	public static function restate() {
 		self::state( null, null, true );
+	}
+
+	/**
+	 * Determines whether the jetpackState[$key] value should be added to the
+	 * cookie.
+	 *
+	 * @param string $key The state key.
+	 *
+	 * @return boolean Whether the value should be added to the cookie.
+	 */
+	public static function should_set_cookie( $key ) {
+		global $current_screen;
+		$page = isset( $current_screen->base ) ? $current_screen->base : null;
+
+		if ( 'toplevel_page_jetpack' === $page && 'display_update_modal' === $key ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	public static function check_privacy( $file ) {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3311,6 +3311,11 @@ p {
 	 */
 	public static function do_version_bump( $version, $old_version ) {
 		if ( $old_version ) { // For existing Jetpack installations.
+
+			// If a front end page is visited after the update, the 'wp' action will fire.
+			add_action( 'wp', 'Jetpack::set_update_modal_display' );
+
+			// If an admin page is visited after the update, the 'current_screen' action will fire.
 			add_action( 'current_screen', 'Jetpack::set_update_modal_display' );
 		}
 	}

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -1282,4 +1282,42 @@ EXPECTED;
 		$_GET['calypso_env'] = 'production';
 		$this->assertEquals( 'https://wordpress.com/', Jetpack::get_calypso_host() );
 	}
+
+	/**
+	 * Tests the Jetpack::should_set_cookie() method.
+	 *
+	 * @param string  $key The state key test value.
+	 * @param string  $set_screen The $current_screen->base test value.
+	 * @param boolean $expected_output The expected output of Jetpack::should_set_cookie().
+	 *
+	 * @covers Jetpack::should_set_cookie
+	 * @dataProvider should_set_cookie_provider
+	 */
+	public function test_should_set_cookie( $key, $set_screen, $expected_output ) {
+		global $current_screen;
+		$old_current_screen   = $current_screen;
+		$current_screen       = new stdClass();
+		$current_screen->base = $set_screen;
+
+		$this->assertEquals( $expected_output, Jetpack::should_set_cookie( $key ) );
+		$current_screen = $old_current_screen;
+	}
+
+	/**
+	 * The data provider for test_should_set_cookie(). Provides an array of
+	 * test data. Each data set is an array with the structure:
+	 *     [0] => The state key test value.
+	 *     [1] => The $current_screen->base test value.
+	 *     [2] => The expected output of Jetpack::should_set_cookie().
+	 */
+	public function should_set_cookie_provider() {
+		return array(
+			array( 'display_update_modal', 'toplevel_page_jetpack', false ),
+			array( 'display_update_modal', 'test_page', true ),
+			array( 'display_update_modal', null, true ),
+			array( 'message', 'toplevel_page_jetpack', true ),
+			array( 'message', 'test_page', true ),
+			array( 'message', null, true ),
+		);
+	}
 } // end class


### PR DESCRIPTION
Fixes #15600

The issue above describes a problem with how the update modal displays. Currently, it only displays when the user visits the Jetpack dashboard immediately after updating Jetpack. This PR fixes that. The update modal should display on the Jetpack dashboard after updating Jetpack, regardless of whether the user visits the Jetpack dashboard immediately or visits other pages first. Also, the update modal should display only once.

#### Changes proposed in this Pull Request:
* Add a new Jetpack state index, `display_update_modal`. This index will be used to determine whether the update modal should be displayed.

* In `Jetpack_React_Page::get_initial_state()`, use `Jetpack::state('display_update_modal')` to
determine whether to collect the release post content and send it to the Jetpack dashboard.

* Move the update modal methods from the `Jetpack` class to the `Jetpack_React_Page` class.
They're only used in the `Jetpack_React_Page` class, so they should be located there. These methods must be moved and should no longer be static:
  * `Jetpack::send_update_modal_data()` -> change method name to `Jetpack_React_Page::get_update_modal_data()` for clarity. Also, at the end of this method, return an associative array containing the modal data instead of setting the state.
  * `Jetpack::allow_post_embed_iframe()` (same method name)
  * `Jetpack::get_release_post_data()` (same method name)
  &nbsp;
* Remove the if statements in `Jetpack::state()` that check for the `message_content` key before setting the cookie. The `message_content` state index is no longer used.

* Set the `jetpackState['display_update_modal']` value in the cookie only if the current screen is not the Jetpack dashboard. This will prevent the modal from being displayed twice if the Jetpack dashboard is visited immediately after updating Jetpack.

* Add a unit test for the new `Jetpack:should_set_cookie()` method.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of jetpack.

#### Testing instructions:

To manually test this PR, we'll need to simulate a Jetpack update by changing the `JETPACK__VERSION` constant in the `jetpack.php` file. The update modal is displayed when a release post with a tag that matches the updated version is available. We have an example release post tagged with version 8.4. So, we'll simulate an update from 8.3 to 8.4.

##### Test site
* Must have Jetpack active and connected.

##### Test steps
###### Visit the Jetpack dashboard immediately after an update.
1. Set the `JETPACK__VERSION` constant to 8.3.
2. Navigate to an admin page.
3. Set the `JETPACK__VERSION` constant to 8.4.
4. Navigate to the Jetpack dashboard page. You should see the update modal.
5. Reload the Jetpack dashboard page again. You should not see the update modal.

###### Visit other admin pages before visiting the Jetpack dashboard after an update
1. Set the `JETPACK__VERSION` constant to 8.3.
2. Navigate to an admin page.
3. Set the `JETPACK__VERSION` constant to 8.4.
4. Navigate to any admin page except the Jetpack dashboard. (Navigate to as many admin pages as you'd like.)
5. Navigate to the Jetpack dashboard. You should see the update modal.
6. Reload the Jetpack dashboard. You should not see the update modal.

###### Visit front-end pages before visiting the Jetpack dashboard after an update
1. Set the `JETPACK__VERSION` constant to 8.3.
2. Navigate to any page.
3. Set the `JETPACK__VERSION` constant to 8.4.
4. Navigate to a front-end page. (Navigate to as many front-end and admin pages as you'd like.)
5. Navigate to the Jetpack dashboard. You should see the update modal.
6. Reload the Jetpack dashboard. You should not see the update modal.

#### Proposed changelog entry for your changes:
* tbd
