### PR TITLE
Podcast Player: Only display frontend errors to users capable of editing

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -62,8 +62,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  */
 function render_error( $message ) {
 	// Suppress errors for users unable to address them.
-	$post = get_post();
-	if ( empty( $post ) || ! current_user_can( 'edit_post', $post->ID ) ) {
+	if ( ! current_user_can( 'edit_posts' ) ) {
 		return '';
 	}
 	return '<p>' . esc_html( $message ) . '</p>';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Suppress all block errors to public visitors, as other blocks do too (eventbrite, google cal, instagram gallery to name a few I found)
* what we do extra here compared to other blocks is that we show the error message to users with capability to edit the post. This can be helpful with their debugging.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
enhancement of the podcast player, based on the feedback p7DVsv-8oS-p2#comment-28483

#### Testing instructions:
* Insert Podcast Player that will error on the frontend:
  - for example by just inserting it, not filling anything and hitting preview
  - inserting faulty URL (probably only doable through editing post source, because our UI prevents such situations)
* publish the post and check it on the frontend as:
  - admin: you should see error
  - logged-out visitor (anonymous mode): no error

#### Proposed changelog entry for your changes:
* Remove visitor-facing fatal errors from the Podcast Player block
