### PR TITLE
Unit Tests: Add WPcom check

### DIFF
--- a/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
+++ b/tests/php/json-api/test-class.json-api-jetpack-endpoints.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( defined( 'JETPACK__PLUGIN_DIR' ) && JETPACK__PLUGIN_DIR  ) {
+if ( ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) && defined( 'JETPACK__PLUGIN_DIR' ) && JETPACK__PLUGIN_DIR ) {
 	require_once JETPACK__PLUGIN_DIR . 'modules/module-extras.php';
 }
 


### PR DESCRIPTION
In #11771, we added a check for `JETPACK__PLUGIN_DIR` before adding a file. This constant is defined on WP.com but the file we are including is not.

Adding a wpcom check so we can finish up some fusion work for 11771.

#### Changes proposed in this Pull Request:
* Add a WP.com conditional.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Unit tests pass.

#### Proposed changelog entry for your changes:
* n/a
