### PR TITLE
Instagram Gallery Block: Improve Caching

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\Connection\Client;
  * Class Jetpack_Instagram_Gallery_Helper
  */
 class Jetpack_Instagram_Gallery_Helper {
+	const TRANSIENT_KEY_PREFIX = 'jetpack_instagram_gallery_block_';
+
 	/**
 	 * Get the Instagram Gallery.
 	 *
@@ -24,11 +26,15 @@ class Jetpack_Instagram_Gallery_Helper {
 			return $site_id;
 		}
 
-		$transient_key = 'jetpack_instagram_gallery_block_' . $access_token . '_' . $count;
+		$transient_key = self::TRANSIENT_KEY_PREFIX . $access_token;
 
 		$cached_gallery = get_transient( $transient_key );
 		if ( $cached_gallery ) {
-			return json_decode( $cached_gallery );
+			$decoded_cached_gallery = json_decode( $cached_gallery );
+			$cached_count           = count( $decoded_cached_gallery->images );
+			if ( $cached_count >= $count ) {
+				return $decoded_cached_gallery;
+			}
 		}
 
 		$response = Client::wpcom_json_api_request_as_blog(
@@ -63,5 +69,14 @@ class Jetpack_Instagram_Gallery_Helper {
 			);
 		}
 		return (int) $site_id;
+	}
+
+	/**
+	 * Delete the Instagram Gallery cache associated to an access token.
+	 *
+	 * @param string $access_token The Instagram access token.
+	 */
+	public static function delete_instagram_gallery_cache( $access_token ) {
+		delete_transient( self::TRANSIENT_KEY_PREFIX . $access_token );
 	}
 }

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -156,6 +156,8 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 			return $site_id;
 		}
 
+		Jetpack_Instagram_Gallery_Helper::delete_instagram_gallery_cache( $request['access_token'] );
+
 		$path     = sprintf( '/sites/%d/instagram/%s', $site_id, $request['access_token'] );
 		$response = Client::wpcom_json_api_request_as_blog(
 			$path,

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -64,6 +64,7 @@ function render_block( $attributes, $content ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
 	}
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
+	$images  = array_slice( $gallery->images, 0, $count );
 
 	if ( is_wp_error( $gallery ) || empty( $gallery->images ) ) {
 		return '';
@@ -75,7 +76,7 @@ function render_block( $attributes, $content ) {
 	?>
 
 	<div class="<?php echo esc_attr( $grid_classes ); ?>" style="<?php echo esc_attr( $grid_style ); ?>">
-		<?php foreach ( $gallery->images as $image ) : ?>
+		<?php foreach ( $images as $image ) : ?>
 			<a
 				class="wp-block-jetpack-instagram-gallery__grid-post"
 				href="<?php echo esc_url( $image->link ); ?>"

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -24,7 +24,7 @@ export default function useConnectInstagram( {
 			return;
 		}
 		setIsConnecting( true );
-		apiFetch( { path: `/wpcom/v2/instagram/access-token` } )
+		apiFetch( { path: `/wpcom/v2/instagram-gallery/access-token` } )
 			.then( token => {
 				setIsConnecting( false );
 				if ( token ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #15551

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Improve the Instagram Gallery block cache.
  * Use cache if a request asks for _less_ images than what is cached.
  * Delete the cache when a block is disconnected.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

This doesn't have any visible effects, so it's useful to scatter a bunch of logs in the code!
Some suggestions: try replacing this [block](https://github.com/Automattic/jetpack/blob/update/instagram-gallery-cache/_inc/lib/class-jetpack-instagram-gallery-helper.php#L31-L38) with the following, and start tailing the PHP error log.
```php
		$cached_gallery = get_transient( $transient_key );
		l( $cached_gallery ? 'Cache found' : 'Cache not found' );
		if ( $cached_gallery ) {
			$decoded_cached_gallery = json_decode( $cached_gallery );
			$cached_count           = count( $decoded_cached_gallery->images );
			l( 'Request count: ' . $count );
			l( 'Cached count: ' . $cached_count );
			if ( $cached_count >= $count ) {
				l( 'Returning cache' );
				return $decoded_cached_gallery;
			}
		}
```

Before checking out this PR, insert an IG block and disconnect it to start without tokens. Delete the block, save the post, and reload.

* Insert an Instagram Gallery block, and connect it to Instagram.
* Make sure the log says `Cache not found`.
* Insert a second IG block.
* Make sure the log says `Cache found`, and eventually `Returning cache`.
  * Since in the editor we always request the maximum amount of images (30), there's nothing interesting going on here.
* Remove the second block, save, and open the block on the front end.
* Make sure the log says `Cache found`, `Request count: 9`, `Cached count: 30`, `Returning cache`.
* Back in the editor: disconnect the block from Instagram.
* Connect it again.
* Make sure the log says `Cache not found`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (unreleased block)
