### PR TITLE
Unit Tests: share more code with the isolated base testcase

### DIFF
--- a/tests/php/core-api/wpcom-fields/test-class.subscribers-endpoint.php
+++ b/tests/php/core-api/wpcom-fields/test-class.subscribers-endpoint.php
@@ -16,8 +16,8 @@ class Test_WPCOM_REST_API_V2_Subscribers_Endpoint extends WP_Test_Jetpack_REST_T
 		self::$subscriber_user_id = $factory->user->create( array( 'role' => 'subscriber' ) );
 	}
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 		self::set_subscribers_count( 100 );
 	}
 


### PR DESCRIPTION
There is not reason the core base testcase should not call the parent tearDown method, like all other testcases do.
Core's cache flush is simplified, and the redundant calls compared to the base isolation testcase are removed.

This makes the environment slightly incompatible with the alloptions tests, and reveals a test that should be failing, but reduces the testcase maintenance burden. Fixes are provided for the tests

Test Plan: TC

Tags: #touches_jetpack_files

Differential Revision: D38799-code

This commit syncs r202837-wpcom
