### PR TITLE
API: Add Earth Day Live API endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -103,6 +103,7 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'posts_per_page'               => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'              => '(bool) Whether the RSS feed will use post excerpts',
+		'earth_day_live'			   => '(bool) Whether to show the Earth Day Live modal for a site.',
 	),
 
 	'response_format' => array(
@@ -326,6 +327,11 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				$api_cache = $is_jetpack ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
+				$earth_day_live_option = get_option( 'earth-day-live' );
+				$earth_day_live = ( $earth_day_live_option )
+					? true
+					: false;
+
 				$response[ $key ] = array(
 
 					// also exists as "options"
@@ -395,6 +401,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'posts_per_page'          => (int) get_option( 'posts_per_page' ),
 					'posts_per_rss'           => (int) get_option( 'posts_per_rss' ),
 					'rss_use_excerpt'         => (bool) get_option( 'rss_use_excerpt' ),
+					'earth_day_live'		  => $earth_day_live,
 				);
 
 				if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -788,6 +795,13 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'rss_use_excerpt':
 					update_option( 'rss_use_excerpt', (int)(bool) $value );
+					break;
+
+				case 'earth_day_live':
+					$save = (bool) $value;
+					if ( update_option( 'earth-day-live', $save ) ) {
+						$updated[ $key ] = $save;
+					}
 					break;
 
 				default:

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -100,6 +100,7 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
+		'earth_day_live'					   => '(bool) Whether to show the Earth Day Live modal for a site',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -100,6 +100,7 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
+		'earth_day_live'					   => '(bool) Whether to show the Earth Day Live modal for a site',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -100,6 +100,7 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
+		'earth_day_live'					   => '(bool) Whether to show the Earth Day Live modal for a site',
 	),
 
 	'response_format' => array(


### PR DESCRIPTION
This is unused in Jetpack but keeps our files in sync with WP.com

Differential Revision: D42135-code

This commit syncs r206116-wpcom