### PR TITLE
Instagram Gallery Block: Improve the "not many posts" Notice

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -102,24 +102,26 @@ const InstagramGalleryEdit = props => {
 		noticeOperations.removeAllNotices();
 		const accountImageTotal = images.length;
 
-		if ( showSidebar && accountImageTotal < count ) {
-			noticeOperations.createNotice( {
-				status: 'info',
-				content: __(
-					sprintf(
+		if ( showSidebar && ! showLoadingSpinner && accountImageTotal < count ) {
+			const noticeContent = accountImageTotal
+				? sprintf(
 						_n(
-							'There is currently only %s post in your Instagram account',
-							'There are currently only %s posts in your Instagram account',
+							'There is currently only %s post in your Instagram account.',
+							'There are currently only %s posts in your Instagram account.',
 							accountImageTotal,
 							'jetpack'
 						),
 						accountImageTotal
-					)
-				),
+				  )
+				: __( 'There are currently no posts in your Instagram account.', 'jetpack' );
+
+			noticeOperations.createNotice( {
+				status: 'info',
+				content: noticeContent,
 				isDismissible: false,
 			} );
 		}
-	}, [ count, images, noticeOperations, showSidebar ] );
+	}, [ count, images, noticeOperations, showLoadingSpinner, showSidebar ] );
 
 	const renderImage = index => {
 		if ( images[ index ] ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Stop showing the `There are currently only %s posts in your Instagram account` notice in the sidebar while the block is embedding (the image count is zero at that point, but that's about to change shortly).
* Add a variation for when the Instagram account contains zero posts. "There are currently only 0 posts" sounded very awkward.
* Add periods to all variations.
* Remove an accidental double translation:
```diff
- __( sprintf( _n( ... ) ) )
+ sprintf( _n( ... ) )
```

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert an Instagram Gallery block, and display its sidebar.
* Connect it to Instagram, and observe the sidebar.
* Make sure the "there are only 0 posts" notice doesn't show up.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (unreleased block)
