### PR TITLE
Revue Block: Avoid JS Error in the Front End

### DIFF
--- a/extensions/blocks/revue/view.js
+++ b/extensions/blocks/revue/view.js
@@ -14,6 +14,10 @@ if ( typeof window !== 'undefined' && window.jQuery ) {
 
 		revueBlocks.forEach( block => {
 			const form = block.querySelector( '.wp-block-jetpack-revue__form' );
+			if ( ! form ) {
+				return;
+			}
+
 			const message = block.querySelector( '.wp-block-jetpack-revue__message' );
 
 			form.addEventListener( 'submit', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15629

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoid adding event listeners to non existing elements.

The Revue block has a front end script that adds a `submit` event listener to the form, in order to eventually replace it with a success message.
The initial selector targets `.wp-block-jetpack-revue`, which is the Revue block class.
Until recently, we used to manually build the block output, and so the class could only ever appear in the outer wrapper of the block.
By introducing the Button inner block, we started also outputting the original block's `$content` (containing the Button markup). This `$content` also contains a wrapper with the block class.
So, we end up with two different `.wp-block-jetpack-revue` elements, one containing the form and the success message, and the other just the button.

This PR simply checks if the form exists before adding the event listener to it.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a Revue block, and fill the username (random string will do).
* Save and view the post on the front end.
* Make sure there are no JS errors in console like this:
```
Uncaught TypeError: Cannot read property 'addEventListener' of null
    at view.js:formatted:91
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Revue Block: Fix JavaScript error in the front end
