### PR TITLE
SAL Post Base: Capture exception when seralizing

### DIFF
--- a/sal/class.json-api-post-base.php
+++ b/sal/class.json-api-post-base.php
@@ -141,7 +141,7 @@ abstract class SAL_Post {
 				$metadata[] = array(
 					'id'    => $meta['meta_id'],
 					'key'   => $meta['meta_key'],
-					'value' => maybe_unserialize( $meta['meta_value'] ),
+					'value' => $this->safe_maybe_unserialize( $meta['meta_value'] ),
 				);
 			}
 		}
@@ -678,5 +678,21 @@ abstract class SAL_Post {
 		}
 
 		return (object) $response;
+	}
+
+	/**
+	 * Temporary wrapper around maybe_unserialize() to catch exceptions thrown by unserialize().
+	 *
+	 * Can be removed after https://core.trac.wordpress.org/ticket/45895 lands in Core.
+	 *
+	 * @param  string $original Serialized string.
+	 * @return string Unserialized string or original string if an exception was raised.
+	 **/
+	protected function safe_maybe_unserialize( $original ) {
+		try {
+			return maybe_unserialize( $original );
+		} catch ( Exception $e ) {
+			return $original;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #p2EDhh-zj-p2

Syncs r186840-wpcom with changes staged in D42763-code

When encountering a SimpleXMLElement object in post meta, an exception can be thrown. The core maybe_unserialize() function does not yet handle this scenario.

This patch adds a temporary fix to SAL_Post so that exceptions are handled.