### PR TITLE
Protect against invalid form input

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -620,7 +620,7 @@ class Jetpack_Subscriptions {
 		if ( isset( $_REQUEST['redirect_fragment'] ) ) {
 			$redirect_fragment = preg_replace( '/[^a-z0-9_-]/i', '', $_REQUEST['redirect_fragment'] );
 		}
-		if ( !$redirect_fragment ) {
+		if ( !$redirect_fragment || ! is_string( $_REQUEST['redirect_fragment'] ) ) {
 			$redirect_fragment = 'subscribe-blog';
 		}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -620,7 +620,7 @@ class Jetpack_Subscriptions {
 		if ( isset( $_REQUEST['redirect_fragment'] ) ) {
 			$redirect_fragment = preg_replace( '/[^a-z0-9_-]/i', '', $_REQUEST['redirect_fragment'] );
 		}
-		if ( !$redirect_fragment || ! is_string( $_REQUEST['redirect_fragment'] ) ) {
+		if ( !$redirect_fragment || ! is_string( $redirect_fragment ) ) {
 			$redirect_fragment = 'subscribe-blog';
 		}
 

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -613,7 +613,7 @@ class Jetpack_Subscriptions {
 			check_admin_referer( 'blogsub_subscribe_' . get_current_blog_id() );
 		}
 
-		if ( empty( $_REQUEST['email'] ) )
+		if ( empty( $_REQUEST['email'] ) || ! is_string( $_REQUEST['email'] ) )
 			return false;
 
 		$redirect_fragment = false;


### PR DESCRIPTION
Vulnerability scanners often attempt to inject invalid data into any form fields on a website, and when such a scanner does this to a site with the Jetpack Subscription widget on it, it's common to pass an array to the subscription fields.

Ultimately, this causes a PHP Warning to be generated similar to the following:
> E_WARNING: wp-includes/formatting.php:3413 - strlen() expects parameter 1 to be string, array given

That's caused by passing an array to the `is_email()` function, which only accepts strings.

and a PHP Notice similar to:
> E_NOTICE: wp-content/plugins/jetpack/modules/subscriptions.php:688 - Array to string conversion

which is caused by attempting to use `$redirect_fragment` in the redirect later in the function.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* An extra input check to validate that the arguments are valid strings.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bugfix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable Jetpack Subscriptions on a site, add the widget.
* Use the browser inspector to alter the `email` field name to be `name="email[]"`.
* Submit an email address, monitor the PHP logs, note the warning.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
