### PR TITLE
OpenTable Block: CSS Class to counter button padding

### DIFF
--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -61,7 +61,7 @@ export const defaultAttributes = {
 		default: false,
 		type: 'boolean',
 	},
-	counterPadding: {
+	negativeMargin: {
 		default: false,
 		type: 'boolean',
 	},

--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -61,4 +61,8 @@ export const defaultAttributes = {
 		default: false,
 		type: 'boolean',
 	},
+	counterPadding: {
+		default: false,
+		type: 'boolean',
+	},
 };

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -176,11 +176,13 @@ function OpenTableEdit( {
 					onChange={ () => setAttributes( { iframe: ! iframe } ) }
 					className="is-opentable"
 				/>
-				<ToggleControl
-					label={ __( 'Remove button padding', 'jetpack' ) }
-					checked={ counterPadding }
-					onChange={ () => setAttributes( { counterPadding: ! counterPadding } ) }
-				/>
+				{ 'button' === style && (
+					<ToggleControl
+						label={ __( 'Remove button padding', 'jetpack' ) }
+						checked={ counterPadding }
+						onChange={ () => setAttributes( { counterPadding: ! counterPadding } ) }
+					/>
+				) }
 			</InspectorAdvancedControls>
 			<BlockStylesSelector
 				clientId={ clientId }

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -64,7 +64,7 @@ function OpenTableEdit( {
 		domain,
 		lang,
 		newtab,
-		counterPadding,
+		negativeMargin,
 		__isBlockPreview,
 	} = attributes;
 	const isPlaceholder = isEmpty( rid );
@@ -178,9 +178,9 @@ function OpenTableEdit( {
 				/>
 				{ 'button' === style && (
 					<ToggleControl
-						label={ __( 'Remove button padding', 'jetpack' ) }
-						checked={ counterPadding }
-						onChange={ () => setAttributes( { counterPadding: ! counterPadding } ) }
+						label={ __( 'Remove button margin', 'jetpack' ) }
+						checked={ negativeMargin }
+						onChange={ () => setAttributes( { negativeMargin: ! negativeMargin } ) }
 					/>
 				) }
 			</InspectorAdvancedControls>
@@ -241,7 +241,7 @@ function OpenTableEdit( {
 		'is-placeholder': isPlaceholder,
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
 		[ `align${ align }` ]: align,
-		'has-no-padding': counterPadding,
+		'has-no-margin': negativeMargin,
 	} );
 
 	return (

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -56,7 +56,17 @@ function OpenTableEdit( {
 		setAttributes( validatedAttributes );
 	}
 
-	const { align, rid, style, iframe, domain, lang, newtab, __isBlockPreview } = attributes;
+	const {
+		align,
+		rid,
+		style,
+		iframe,
+		domain,
+		lang,
+		newtab,
+		counterPadding,
+		__isBlockPreview,
+	} = attributes;
 	const isPlaceholder = isEmpty( rid );
 
 	useEffect( () => {
@@ -166,6 +176,11 @@ function OpenTableEdit( {
 					onChange={ () => setAttributes( { iframe: ! iframe } ) }
 					className="is-opentable"
 				/>
+				<ToggleControl
+					label={ __( 'Remove button padding', 'jetpack' ) }
+					checked={ counterPadding }
+					onChange={ () => setAttributes( { counterPadding: ! counterPadding } ) }
+				/>
 			</InspectorAdvancedControls>
 			<BlockStylesSelector
 				clientId={ clientId }
@@ -224,6 +239,7 @@ function OpenTableEdit( {
 		'is-placeholder': isPlaceholder,
 		'is-multi': 'multi' === getTypeAndTheme( style )[ 0 ],
 		[ `align${ align }` ]: align,
+		'has-no-padding': counterPadding,
 	} );
 
 	return (

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -100,7 +100,7 @@
 	}
 
 	&-theme-button {
-		&.has-no-padding {
+		&.has-no-margin {
 			iframe {
 				margin: -14px;
 			}

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -99,6 +99,14 @@
 		}
 	}
 
+	&-theme-button {
+		&.has-no-padding {
+			iframe {
+				margin: -14px;
+			}
+		}
+	}
+
 	.editor-styles-wrapper & .components-form-token-field__suggestions-list {
 		font-family: $default-font;
 		text-align: left;

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -55,6 +55,7 @@ export const settings = {
 			domain: 'com',
 			lang: 'en-US',
 			newtab: false,
+			counterPadding: false,
 		},
 	},
 	transforms: {

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -55,7 +55,7 @@ export const settings = {
 			domain: 'com',
 			lang: 'en-US',
 			newtab: false,
-			counterPadding: false,
+			negativeMargin: false,
 		},
 	},
 	transforms: {

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -97,6 +97,9 @@ function load_assets( $attributes ) {
 	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
 		$classes[] = 'is-multi';
 	}
+	if ( array_key_exists( 'counterPadding', $attributes ) && $attributes['counterPadding'] ) {
+		$classes[] = 'has-no-padding';
+	}
 	$classes = Jetpack_Gutenberg::block_classes(
 		FEATURE_NAME,
 		$attributes,

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -97,8 +97,8 @@ function load_assets( $attributes ) {
 	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
 		$classes[] = 'is-multi';
 	}
-	if ( array_key_exists( 'counterPadding', $attributes ) && $attributes['counterPadding'] ) {
-		$classes[] = 'has-no-padding';
+	if ( array_key_exists( 'negativeMargin', $attributes ) && $attributes['negativeMargin'] ) {
+		$classes[] = 'has-no-margin';
 	}
 	$classes = Jetpack_Gutenberg::block_classes(
 		FEATURE_NAME,

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -40,6 +40,12 @@
 		&.aligncenter iframe {
 			width: 210px !important;
 		}
+
+		&.has-no-padding {
+			> div[id^="ot-widget-container"] {
+				margin: -14px;
+			}
+		}
 	}
 
 	.ot-dtp-picker {

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -41,7 +41,7 @@
 			width: 210px !important;
 		}
 
-		&.has-no-padding {
+		&.has-no-margin {
 			> div[id^="ot-widget-container"] {
 				margin: -14px;
 			}


### PR DESCRIPTION
Fixes #15267

#### Changes proposed in this Pull Request:
* The OpenTable button is within an iframe and has default padding. A new optional CSS class has been added to apply a negative margin to the container matching the default padding.

_Note: When this is merged, [documentation](https://wordpress.com/support/wordpress-editor/blocks/opentable-block/#advanced) will need to be updated. Docs need info about the "load in iframe" setting as well._

#### Testing instructions:
1. Edit a post using the block editor
2. Add a paragraph block of text for visual alignment check
3. Add an OpenTable block using the button style
4. You should see that there is padding within the OpenTable block indenting it
5. Select the OpenTable block and expand it's Advanced settings panel
6. Toggle on the new "Remove button padding" setting
6. Block should appear visually aligned now
7. Save post and check alignment on frontend

![OpenTableCSS](https://user-images.githubusercontent.com/60436221/81065054-2a518d80-8f1e-11ea-984d-27fdaf28741e.gif)


**Before:**

<img width="623" alt="OpenTableBlock-before" src="https://user-images.githubusercontent.com/60436221/80796066-9b710800-8be1-11ea-8be5-1cd236870745.png">

**After:**

<img width="614" alt="OpenTableBlock-after" src="https://user-images.githubusercontent.com/60436221/80796074-9f9d2580-8be1-11ea-9679-3a65d8106e27.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Bug Fix (#15267): Add optional CSS class to counter OpenTable block button's padding.