### PR TITLE
Editor: Update switch to classic editor link

### DIFF
--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -51,14 +51,6 @@ class Jetpack_Admin {
 
 		// Add module bulk actions handler
 		add_action( 'jetpack_unrecognized_action', array( $this, 'handle_unrecognized_action' ) );
-
-		add_action( 'admin_init', array( $this, 'activate_classic_editor' ), 9 );
-	}
-
-	public function activate_classic_editor() {
-		if ( 'classic' === $_GET['set-editor']  && current_user_can( 'activate_plugin' ) ) {
-			activate_plugin( 'classic-editor/classic-editor.php' );
-		}
 	}
 
 	static function sort_requires_connection_last( $module1, $module2 ) {

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -51,6 +51,14 @@ class Jetpack_Admin {
 
 		// Add module bulk actions handler
 		add_action( 'jetpack_unrecognized_action', array( $this, 'handle_unrecognized_action' ) );
+
+		add_action( 'admin_init', array( $this, 'activate_classic_editor' ), 9 );
+	}
+
+	public function activate_classic_editor() {
+		if ( 'classic' === $_GET['set-editor']  && current_user_can( 'activate_plugin' ) ) {
+			activate_plugin( 'classic-editor/classic-editor.php' );
+		}
 	}
 
 	static function sort_requires_connection_last( $module1, $module2 ) {

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -416,16 +416,22 @@ class Jetpack_Calypsoify {
 	}
 
 	/**
-	 * Returns the URL for switching the user's editor to the Calypso (WordPress.com Classic) editor.
+	 * Returns the URL for switching the user's editor to the Classic editor.
 	 *
 	 * @return string
 	 */
 	public function get_switch_to_classic_editor_url() {
-		return add_query_arg(
-			'set-editor',
-			'classic',
-			$this->is_calypsoify_enabled ? $this->get_calypso_url( get_the_ID() ) : false
+		$post_id    = get_the_ID();
+		$post_type  = get_current_screen()->post_type;
+		$path       = is_null( $post_id ) ? 'post-new.php' : 'post.php';
+		$query_args = array(
+			'post'       => $post_id,
+			'action'     => ( $post_id ) ? 'edit' : null,
+			'post_type'  => ( 'post' !== $post_type ) ? $post_type : null,
+			'set-editor' => 'classic',
 		);
+
+		return add_query_arg( $query_args, admin_url( $path ) );
 	}
 
 	public function check_param() {

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -421,17 +421,26 @@ class Jetpack_Calypsoify {
 	 * @return string
 	 */
 	public function get_switch_to_classic_editor_url() {
-		$post_id    = get_the_ID();
-		$post_type  = get_current_screen()->post_type;
-		$path       = is_null( $post_id ) ? 'post-new.php' : 'post.php';
-		$query_args = array(
-			'post'       => $post_id,
-			'action'     => ( $post_id ) ? 'edit' : null,
-			'post_type'  => ( 'post' !== $post_type ) ? $post_type : null,
-			'set-editor' => 'classic',
-		);
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_GET['editor/after-deprecation'] ) ) {
+			$post_id    = get_the_ID();
+			$post_type  = get_current_screen()->post_type;
+			$path       = is_null( $post_id ) ? 'post-new.php' : 'post.php';
+			$query_args = array(
+				'post'       => $post_id,
+				'action'     => ( $post_id ) ? 'edit' : null,
+				'post_type'  => ( 'post' !== $post_type ) ? $post_type : null,
+				'set-editor' => 'classic',
+			);
 
-		return add_query_arg( $query_args, admin_url( $path ) );
+			return add_query_arg( $query_args, admin_url( $path ) );
+		}
+
+		return add_query_arg(
+			'set-editor',
+			'classic',
+			$this->is_calypsoify_enabled ? $this->get_calypso_url( get_the_ID() ) : false
+		);
 	}
 
 	public function check_param() {

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -284,7 +284,7 @@ class Jetpack_WPCOM_Block_Editor {
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
-					'isVisible' => $this->is_iframed_block_editor(),
+					'isVisible' => jetpack_is_atomic_site() && $this->is_iframed_block_editor(),
 					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
 					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
 				),

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -595,6 +595,8 @@ class Jetpack_WPCOM_Block_Editor {
 		if ( ! empty( $_GET['set-editor'] ) && 'classic' === $_GET['set-editor'] && current_user_can( 'activate_plugin' ) ) {
 			if ( is_plugin_inactive( 'classic-editor/classic-editor.php' ) ) {
 				activate_plugin( 'classic-editor/classic-editor.php' );
+				update_network_option( null, 'classic-editor-replace', 'classic' );
+				update_user_option( get_current_user_id(), 'classic-editor-settings', 'classic' );
 				wp_safe_redirect( remove_query_arg( 'set-editor', $_SERVER['REQUEST_URI'] ) );
 			}
 		}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -279,12 +279,22 @@ class Jetpack_WPCOM_Block_Editor {
 			true
 		);
 
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$editor_deprecated = isset( $_GET['editor/after-deprecation'] );
+		$switch_visible    = ( ! $editor_deprecated || jetpack_is_atomic_site() ) && $this->is_iframed_block_editor();
+
+		// The following is only to allow testing link without an atomic site.
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( 'show' === $_GET['editor/after-deprecation'] ) {
+			$switch_visible = true;
+		}
+
 		wp_localize_script(
 			'wpcom-block-editor-default-editor-script',
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
-					'isVisible' => jetpack_is_atomic_site() && $this->is_iframed_block_editor(),
+					'isVisible' => $switch_visible,
 					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
 					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
 				),

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -597,7 +597,16 @@ class Jetpack_WPCOM_Block_Editor {
 				activate_plugin( 'classic-editor/classic-editor.php' );
 				update_network_option( null, 'classic-editor-replace', 'classic' );
 				update_user_option( get_current_user_id(), 'classic-editor-settings', 'classic' );
-				wp_safe_redirect( remove_query_arg( 'set-editor', $_SERVER['REQUEST_URI'] ) );
+
+				$classic_url = add_query_arg(
+					array(
+						'classic-editor'         => '',
+						'classic-editor__forget' => '',
+					),
+					remove_query_arg( 'set-editor', $_SERVER['REQUEST_URI'] )
+				);
+
+				wp_safe_redirect( $classic_url );
 			}
 		}
 	}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -283,7 +283,7 @@ class Jetpack_WPCOM_Block_Editor {
 		// phpcs:ignore WordPress.Security.NonceVerification
 		$editor_deprecated               = isset( $_GET['editor/after-deprecation'] );
 		$classic_editor_plugin_available = is_plugin_inactive( 'classic-editor/classic-editor.php' );
-		$switch_visible                  = ( ! $editor_deprecated || jetpack_is_atomic_site() ) && $this->is_iframed_block_editor() && $classic_editor_plugin_available;
+		$switch_visible                  = ( ! $editor_deprecated || jetpack_is_atomic_site() ) && $this->is_iframed_block_editor() && $classic_editor_plugin_available && current_user_can( 'activate_plugin' );
 
 		// The following is only to allow testing link without an atomic site.
 		// phpcs:ignore WordPress.Security.NonceVerification

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -287,7 +287,7 @@ class Jetpack_WPCOM_Block_Editor {
 
 		// The following is only to allow testing link without an atomic site.
 		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( 'show' === $_GET['editor/after-deprecation'] ) {
+		if ( $editor_deprecated && 'show' === $_GET['editor/after-deprecation'] ) {
 			$switch_visible = true;
 		}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -294,11 +294,12 @@ class Jetpack_WPCOM_Block_Editor {
 			&& current_user_can( 'activate_plugin' );
 
 		/**
-		 * Due to difficulties in being able test with an iFramed editor the
-		 * following has been added so that the link display can be forced on.
+		 * Due to difficulties in being able test with an iFramed editor, the
+		 * following has been added so that requirement can be worked around.
 		 */
 		if ( isset( $_GET['editor/after-deprecation'] ) && 'show' === $_GET['editor/after-deprecation'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$switch_visible = true;
+			$switch_visible = is_plugin_inactive( 'classic-editor/classic-editor.php' )
+				&& current_user_can( 'activate_plugin' );
 		}
 
 		wp_localize_script(

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -280,14 +280,24 @@ class Jetpack_WPCOM_Block_Editor {
 			true
 		);
 
-		// phpcs:ignore WordPress.Security.NonceVerification
-		$editor_deprecated               = isset( $_GET['editor/after-deprecation'] );
-		$classic_editor_plugin_available = is_plugin_inactive( 'classic-editor/classic-editor.php' );
-		$switch_visible                  = ( ! $editor_deprecated || jetpack_is_atomic_site() ) && $this->is_iframed_block_editor() && $classic_editor_plugin_available && current_user_can( 'activate_plugin' );
+		/**
+		 * Offer an option to switch to the classic editor when the following
+		 * criteria are met:
+		 * - The editor/after-deprecation query string param is present (Temporary requirement).
+		 * - In the iFramed block editor.
+		 * - The classic editor plugin is installed but not active.
+		 * - User has permission to activate plugins e.g. admins.
+		 */
+		$switch_visible = $this->is_iframed_block_editor()
+			&& isset( $_GET['editor/after-deprecation'] ) // phpcs:ignore WordPress.Security.NonceVerification
+			&& is_plugin_inactive( 'classic-editor/classic-editor.php' )
+			&& current_user_can( 'activate_plugin' );
 
-		// The following is only to allow testing link without an atomic site.
-		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( $editor_deprecated && 'show' === $_GET['editor/after-deprecation'] ) {
+		/**
+		 * Due to difficulties in being able test with an iFramed editor the
+		 * following has been added so that the link display can be forced on.
+		 */
+		if ( isset( $_GET['editor/after-deprecation'] ) && 'show' === $_GET['editor/after-deprecation'] ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$switch_visible = true;
 		}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -290,6 +290,7 @@ class Jetpack_WPCOM_Block_Editor {
 		 */
 		$switch_visible = $this->is_iframed_block_editor()
 			&& isset( $_GET['editor/after-deprecation'] ) // phpcs:ignore WordPress.Security.NonceVerification
+			&& file_exists( WP_PLUGIN_DIR . 'classic-editor/classic-editor.php' )
 			&& is_plugin_inactive( 'classic-editor/classic-editor.php' )
 			&& current_user_can( 'activate_plugin' );
 
@@ -298,7 +299,8 @@ class Jetpack_WPCOM_Block_Editor {
 		 * following has been added so that requirement can be worked around.
 		 */
 		if ( isset( $_GET['editor/after-deprecation'] ) && 'show' === $_GET['editor/after-deprecation'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$switch_visible = is_plugin_inactive( 'classic-editor/classic-editor.php' )
+			$switch_visible = file_exists( WP_PLUGIN_DIR . '/classic-editor/classic-editor.php' )
+				&& is_plugin_inactive( 'classic-editor/classic-editor.php' )
 				&& current_user_can( 'activate_plugin' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When the WP.com classic editor is deprecated the Switch to Classic Editor link needs to go to the WP admin classic editor. 
* This will also activate the classic editor plugin and reset its options as needed to ensure user ends up on the classic editor. This will happen on Atomic sites, but also on Jetpack sites if the classic editor is installed but not activated.

**Important note**
In production the "The Switch To Classic Editor" link will only be shown when:

* Loading an Atomic or Jetpack site in WPcom Calypso and using the iFramed block editor 
* The `editor/after-deprecation` query string param is present (Temporary feature flag).
* The classic editor plugin is installed but not active.
* User has permission to activate plugins e.g. admins.

However, because it is impossible to get the editor to run in the iframe in a local jetpack environment due to CORs issues, etc. this PR overrides the need to run in the iFrame, and the link shows under the following criteria:

* The `editor/after-deprecation=show` query string param is not only present but set to `show` (Temporary feature flag).
* The classic editor plugin is installed but not active.
* User has permission to activate plugins e.g. admins.

#### Merge & Deploy Requirements

**_These changes are intended to be merged after the WP.com classic editor has been deprecated. They are now also behind a feature flag "editor/after-deprecation"_**

pb5gDS-wm-p2

#### Testing instructions:

Test without classic editor plugin not installed or with it already active.

* Activate or uninstall classic editor plugin.
* Go to block editor and add query param of `editor/after-deprecation=show` to the URL
* Open more tools menu from the top right of the editor.
* Confirm that the Switch To Classic editor does not show.

Test with installed but inactive classic editor plugin.

* Ensure the Classic Editor plugin is installed but not activated
* Visit site and edit a post
* Add query param of `editor/after-deprecation=show` to the URL
* Open the more tools menu at the top right of the page
* The Switch to Classic Editor link should be present. Follow it and confirm it goes to a valid WP admin URL
* Confirm that the Editor that loads is the Classic Editor
* Confirm the Classic Editor plugin is now active.

Test Edge Cases

_It is possible that the classic editor plugin will have previously been activated and its options set to use the block editor before the plugin was deactivated.  If the plugin's options are not reset to classic the user will end up on the block editor_

1. Within WP Admin, activate Classic Editor plugin.
2. Visit Settings > Writing.
3. Set the default editor to the block editor and allow users to choose their editor. Save settings.
4. Visit Your Profile and set your default editor to block.
5. Deactivate Classic Editor plugin.
6. Edit a post (should be loading the block editor).
7. Append `&set-editor=classic` to the url and go. (same as Switch to Classic Editor link click)
8. You should be redirected to the WP admin classic editor
9. Confirm that the Classic Editor plugin has been activated.
10. Confirm that Settings > Writing > Default Editor option has been set back to classic.
11. Confirm that Your Profile > Default Editor option has been set back to classic.

#### Proposed changelog entry for your changes:
*  Update "Switch to Classic Editor" link to go to WP Admin classic editor

Resolves https://github.com/Automattic/wp-calypso/issues/41108
