### PR TITLE
Admin Page: display local user's Gravatar when in dev mode

### DIFF
--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -111,13 +111,17 @@ export class DashConnections extends Component {
 			// return nothing if this is an account connection card
 			cardContent = (
 				<div className="jp-connection-settings__info">
-					<img
-						alt="gravatar"
-						width="64"
-						height="64"
-						className="jp-connection-settings__gravatar"
-						src={ this.props.userGravatar }
-					/>
+					{ this.props.userGravatar ? (
+						<img
+							alt="gravatar"
+							width="64"
+							height="64"
+							className="jp-connection-settings__gravatar"
+							src={ this.props.userGravatar }
+						/>
+					) : (
+						<Gridicon icon="user" size={ 64 } />
+					) }
 					<div className="jp-connection-settings__text">
 						{ __( 'The site is in Development Mode, so you can not connect to WordPress.com.' ) }
 					</div>

--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -18,6 +18,7 @@ import {
 	getUserWpComLogin,
 	getUserWpComEmail,
 	getUserWpComAvatar,
+	getUserGravatar,
 	getUsername,
 	getSiteIcon,
 } from 'state/initial-state';
@@ -115,7 +116,7 @@ export class DashConnections extends Component {
 						width="64"
 						height="64"
 						className="jp-connection-settings__gravatar"
-						src={ this.props.userWpComAvatar }
+						src={ this.props.userGravatar }
 					/>
 					<div className="jp-connection-settings__text">
 						{ __( 'The site is in Development Mode, so you can not connect to WordPress.com.' ) }
@@ -202,6 +203,7 @@ DashConnections.propTypes = {
 	userWpComLogin: PropTypes.any.isRequired,
 	userWpComEmail: PropTypes.any.isRequired,
 	userWpComAvatar: PropTypes.any.isRequired,
+	userGravatar: PropTypes.any.isRequired,
 	username: PropTypes.any.isRequired,
 };
 
@@ -214,6 +216,7 @@ export default connect( state => {
 		userWpComLogin: getUserWpComLogin( state ),
 		userWpComEmail: getUserWpComEmail( state ),
 		userWpComAvatar: getUserWpComAvatar( state ),
+		userGravatar: getUserGravatar( state ),
 		username: getUsername( state ),
 		isLinked: isCurrentUserLinked( state ),
 		siteIcon: getSiteIcon( state ),

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -151,6 +151,10 @@ export function getUserWpComAvatar( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'wpcomUser', 'avatar' ] );
 }
 
+export function getUserGravatar( state ) {
+	return get( state.jetpack.initialState.userData.currentUser, [ 'gravatar' ] );
+}
+
 export function getUsername( state ) {
 	return get( state.jetpack.initialState.userData.currentUser, [ 'username' ] );
 }

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -392,7 +392,7 @@ function jetpack_current_user_data() {
 		'username'    => $current_user->user_login,
 		'id'          => $current_user->ID,
 		'wpcomUser'   => $dotcom_data,
-		'gravatar'    => get_avatar( $current_user->ID, 40, 'mm', '', array( 'force_display' => true ) ),
+		'gravatar'    => get_avatar_url( $current_user->ID, 64, 'mm', '', array( 'force_display' => true ) ),
 		'permissions' => array(
 			'admin_page'         => current_user_can( 'jetpack_admin_page' ),
 			'connect'            => current_user_can( 'jetpack_connect' ),


### PR DESCRIPTION
Alternative solution to #15647.
Fixes #15646 

#### Changes proposed in this Pull Request:

Rely on the local user's Gravatar when in development mode, instead of trying to use the connecter WordPress.com user data, which we don't have.

To do that, I repurposed `gravatar` in the initial state we pass alongside the React bundle. We were not using it anymore.

Another approach to solve that problem could be to use a generic icon instead, as suggested in #15647.

To do:

- [x] Handle use-cases when that ID does not have a matching avatar (i.e. `get_avatar_url` returns `false`).

#### Testing instructions:

* Start with a brand new site, not connected to WordPress.com yet.
* Add the following to your site's `wp-config.php` file: `define( 'JETPACK_DEV_DEBUG', true );`
* Head to Jetpack > Dashboard
* Check the image at the bottom of the dashboard. It was previously broken, now it shows your local user's Gravatar.

#### Proposed changelog entry for your changes:

* Admin Page: avoid broken Profile image in the Jetpack Dashboard.
