### PR TITLE
UnitTest: Fix broken YouTube oEmbed unit test.

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-posts.php
+++ b/tests/php/sync/test_class.jetpack-sync-posts.php
@@ -1009,7 +1009,7 @@ That was a cool video.';
 
 		$oembeded =
 			'<p>Check out this cool video:</p>
-<p><span class="embed-youtube" style="text-align:center; display: block;"><iframe class=\'youtube-player\' #DIMENSIONS# src=\'https://www.youtube.com/embed/dQw4w9WgXcQ?version=3&#038;rel=1&#038;fs=1&#038;autohide=2&#038;showsearch=0&#038;showinfo=1&#038;iv_load_policy=1&#038;wmode=transparent\' allowfullscreen=\'true\' style=\'border:0;\'></iframe></span></p>
+<p><iframe title="Rick Astley - Never Gonna Give You Up (Video)" #DIMENSIONS# src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></p>
 <p>That was a cool video.</p>'. "\n";
 
 		$filtered = '<p>Check out this cool video:</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Seems the YouTube oEmbed syntax changed and broke the test. This PR fixes it.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Not a new feature, just a unit test fix

#### Testing instructions:

* Checkout branch
* Run `yarn docker:phpunit --filter test_embed_shortcode_is_disabled_on_the_content_filter_during_sync`
* Make sure the test passes

#### Proposed changelog entry for your changes:

* No changelog
