### PR TITLE
Social Menu: Make sure Menu is being displayed via Rest API

### DIFF
--- a/modules/theme-tools/social-menu.php
+++ b/modules/theme-tools/social-menu.php
@@ -49,6 +49,7 @@ function jetpack_social_menu_init() {
 	}
 }
 add_action( 'after_setup_theme', 'jetpack_social_menu_init', 99 );
+add_action( 'restapi_theme_init', 'jetpack_social_menu_init' );
 
 /**
  * Return the type of menu the theme is using.


### PR DESCRIPTION
Use `restapi_theme_init` -- props @michaeldcain 

This commit syncs r129550-wpcom from too long ago.