### PR TITLE
Remove Earth Day Live plugin and API endpoint

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -103,7 +103,6 @@ new WPCOM_JSON_API_Site_Settings_Endpoint( array(
 		'posts_per_page'               => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'              => '(bool) Whether the RSS feed will use post excerpts',
-		'earth_day_live'			   => '(bool) Whether to show the Earth Day Live modal for a site.',
 	),
 
 	'response_format' => array(
@@ -327,11 +326,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				$api_cache = $is_jetpack ? (bool) get_option( 'jetpack_api_cache_enabled' ) : true;
 
-				$earth_day_live_option = get_option( 'earth-day-live' );
-				$earth_day_live = ( $earth_day_live_option )
-					? true
-					: false;
-
 				$response[ $key ] = array(
 
 					// also exists as "options"
@@ -401,7 +395,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'posts_per_page'          => (int) get_option( 'posts_per_page' ),
 					'posts_per_rss'           => (int) get_option( 'posts_per_rss' ),
 					'rss_use_excerpt'         => (bool) get_option( 'rss_use_excerpt' ),
-					'earth_day_live'		  => $earth_day_live,
 				);
 
 				if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
@@ -795,13 +788,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 				case 'rss_use_excerpt':
 					update_option( 'rss_use_excerpt', (int)(bool) $value );
-					break;
-
-				case 'earth_day_live':
-					$save = (bool) $value;
-					if ( update_option( 'earth-day-live', $save ) ) {
-						$updated[ $key ] = $save;
-					}
 					break;
 
 				default:

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -100,7 +100,6 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
-		'earth_day_live'					   => '(bool) Whether to show the Earth Day Live modal for a site',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -100,7 +100,6 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
-		'earth_day_live'					   => '(bool) Whether to show the Earth Day Live modal for a site',
 	),
 
 	'response_format' => array(

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -100,7 +100,6 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'posts_per_page'                       => '(int) Number of posts to show on blog pages',
 		'posts_per_rss'                        => '(int) Number of posts to show in the RSS feed',
 		'rss_use_excerpt'                      => '(bool) Whether the RSS feed will use post excerpts',
-		'earth_day_live'					   => '(bool) Whether to show the Earth Day Live modal for a site',
 	),
 
 	'response_format' => array(


### PR DESCRIPTION
Easy come, easy go.

Summary:
This removes the necessary settings to display banner for Earth Day Live up to and including April 22nd.

Reverses: D42135

Test Plan: Manual testing.

Reviewers: cojennin

Reviewed By: cojennin

Tags: #touches_jetpack_files

Differential Revision: D42822-code