### PR TITLE
Plans: Fix Backup and Scan should only be puchased on single sites

### DIFF
--- a/_inc/client/plans/single-product/index.js
+++ b/_inc/client/plans/single-product/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 
 /**
  * Internal dependencies
@@ -44,14 +44,15 @@ function handleUpgradeLinkClick( selectedUpgrade, route ) {
 			type: 'upgrade',
 			product: selectedUpgrade.type,
 			// NOTE: This depends on React-Router's withRouter HOC
-			page: name,
+			page: route,
 		} );
 	};
 }
 
 function renderPossiblePurchase( product, props ) {
-	const { planDuration, selectedUpgrade, routes } = props;
-	const name = routes[ 0 ] && routes[ 0 ].name;
+	const { planDuration, selectedUpgrade, match } = props;
+
+	const name = match && match.path;
 
 	function handleSelectedTypeChange( key, type ) {
 		return () => {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7439,8 +7439,9 @@ endif;
 	 * Returns the list of products that we have available for purchase.
 	 */
 	public static function get_products_for_purchase() {
-		return array(
-			array(
+		$products = array();
+		if ( ! is_multisite() ) {
+			$products[] = array(
 				'key'               => 'backup',
 				'title'             => __( 'Jetpack Backup', 'jetpack' ),
 				'short_description' => __( 'Always-on backups ensure you never lose your site.', 'jetpack' ),
@@ -7467,8 +7468,9 @@ endif;
 				'show_promotion'    => true,
 				'discount_percent'  => 70,
 				'included_in_plans' => array( 'personal-plan', 'premium-plan', 'business-plan', 'daily-backup-plan', 'realtime-backup-plan' ),
-			),
-			array(
+			);
+
+			$products[] = array(
 				'key'               => 'scan',
 				'title'             => __( 'Jetpack Scan', 'jetpack' ),
 				'short_description' => __( 'Automatic scanning and one-click fixes keep your site one step ahead of security threats.', 'jetpack' ),
@@ -7486,27 +7488,30 @@ endif;
 				),
 				'default_option'    => 'scan',
 				'included_in_plans' => array( 'premium-plan', 'business-plan', 'scan-plan' ),
-			),
-			array(
-				'key'               => 'search',
-				'title'             => __( 'Jetpack Search', 'jetpack' ),
-				'short_description' => __( 'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.', 'jetpack' ),
-				'learn_more'        => __( 'Learn More', 'jetpack' ),
-				'description'       => __( 'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.', 'jetpack' ),
-				'label_popup'  		=> __( 'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.' ),
-				'options'           => array(
-					array(
-						'type'      => 'search',
-						'slug'      => 'jetpack-search',
-						'key'       => 'jetpack_search',
-						'name'      => __( 'Search', 'jetpack' ),
-					),
+			);
+		}
+
+		$products[] = array(
+			'key'               => 'search',
+			'title'             => __( 'Jetpack Search', 'jetpack' ),
+			'short_description' => __( 'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.', 'jetpack' ),
+			'learn_more'        => __( 'Learn More', 'jetpack' ),
+			'description'       => __( 'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.', 'jetpack' ),
+			'label_popup'  		=> __( 'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.' ),
+			'options'           => array(
+				array(
+					'type'      => 'search',
+					'slug'      => 'jetpack-search',
+					'key'       => 'jetpack_search',
+					'name'      => __( 'Search', 'jetpack' ),
 				),
-				'tears'             => array(),
-				'default_option'    => 'search',
-				'show_promotion'    => false,
-				'included_in_plans' => array( 'search-plan' ),
-			)
+			),
+			'tears'             => array(),
+			'default_option'    => 'search',
+			'show_promotion'    => false,
+			'included_in_plans' => array( 'search-plan' ),
 		);
+
+		return $products;
 	}
 }


### PR DESCRIPTION
Currently we show Jetpack Scan and Backup as something that can be purchased on multisites. 

This PR fixes this regression. 

It also fixes a bug that was preventing me from seeing the plans page as expected. 

#### Changes proposed in this Pull Request:
* Remove the list of products that we show to customers on multiste. 

#### Testing instructions:
On a multisite, go to the plans page. Notice that you don't see the Scan and Backup plans page. 
On a single site notice that on the plans page you see scan and backup as products for purchase. 

#### Proposed changelog entry for your changes:
* none it should be rolled into the Scan Purchase flow update. 
