### PR TITLE
Fix the availability check logic

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -438,6 +438,28 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
+	 * Return true if the extension has been registered and there's nothing in the availablilty array.
+	 *
+	 * @param string $extension The name of the extension.
+	 *
+	 * @return bool whether the extension has been registered and there's nothing in the availablilty array.
+	 */
+	public static function is_registered_and_no_entry_in_availability( $extension ) {
+		return self::is_registered( 'jetpack/' . $extension ) && ! isset( self::$availability[ $extension ] );
+	}
+
+	/**
+	 * Return true if the extension has a true entry in the availablilty array.
+	 *
+	 * @param string $extension The name of the extension.
+	 *
+	 * @return bool whether the extension has a true entry in the availablilty array.
+	 */
+	public static function is_available( $extension ) {
+		return isset( self::$availability[ $extension ] ) && true === self::$availability[ $extension ];
+	}
+
+	/**
 	 * Get availability of each block / plugin.
 	 *
 	 * @return array A list of block and plugins and their availablity status
@@ -458,8 +480,7 @@ class Jetpack_Gutenberg {
 		$available_extensions = array();
 
 		foreach ( self::$extensions as $extension ) {
-			$is_available = self::is_registered( 'jetpack/' . $extension ) &&
-			( isset( self::$availability[ $extension ] ) && true === self::$availability[ $extension ] );
+			$is_available = self::is_registered_and_no_entry_in_availability( $extension ) || self::is_available( $extension );
 
 			$available_extensions[ $extension ] = array(
 				'available' => $is_available,

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -458,7 +458,7 @@ class Jetpack_Gutenberg {
 		$available_extensions = array();
 
 		foreach ( self::$extensions as $extension ) {
-			$is_available = self::is_registered( 'jetpack/' . $extension ) ||
+			$is_available = self::is_registered( 'jetpack/' . $extension ) &&
 			( isset( self::$availability[ $extension ] ) && true === self::$availability[ $extension ] );
 
 			$available_extensions[ $extension ] = array(


### PR DESCRIPTION
 In #14953 I removed the availability check before registering a block. I can't remember why I did this, but now looking at the way we deal with this logic I wonder if we should make this proposed change.

At the moment we make the assumption that if a block is registered it is available, which makes it hard to disable blocks once they have been registered. Here I am proposing that we check that blocks are both registered and available before we show them.

The alternative is to simply add the `is_available` check back to these blocks.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this patch to your WPCOM sandbox and sandbox a site
* Open the post editor on a free site
* Add an OpenTable and Calendly block
* Check that you still see the upgrade notice in the block editor

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
