### PR TITLE
Connection Package: Soft Disconnects

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3373,10 +3373,10 @@ p {
 			$tracking = new Tracking();
 			$tracking->record_user_event( 'disconnect_site', array() );
 
-			$connection->disconnect_site_wpcom();
+			$connection->disconnect_site_wpcom( true );
 		}
 
-		$connection->delete_all_connection_tokens();
+		$connection->delete_all_connection_tokens( true );
 		Jetpack_IDC::clear_all_idc_options();
 
 		if ( $update_activated_state ) {

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1397,6 +1397,25 @@ class Manager {
 	}
 
 	/**
+	 * Disconnect the plugin and remove the tokens.
+	 * This function will automatically perform "soft" or "hard" disconnect depending on whether other plugins are using the connection.
+	 * This is a proxy method to simplify the Connection package API.
+	 *
+	 * @see Manager::disable_plugin()
+	 * @see Manager::disconnect_site_wpcom()
+	 * @see Manager::delete_all_connection_tokens()
+	 *
+	 * @return bool
+	 */
+	public function remove_connection() {
+		$this->disable_plugin();
+		$this->disconnect_site_wpcom();
+		$this->delete_all_connection_tokens();
+
+		return true;
+	}
+
+	/**
 	 * Responds to a WordPress.com call to register the current site.
 	 * Should be changed to protected.
 	 *

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1338,7 +1338,7 @@ class Manager {
 		 * Fires upon the disconnect attempt.
 		 * Return `false` to prevent the disconnect.
 		 *
-		 * @since 8.6.0
+		 * @since 8.7.0
 		 */
 		if ( ! apply_filters( 'jetpack_connection_delete_all_tokens', true, $this ) ) {
 			return false;
@@ -1384,7 +1384,7 @@ class Manager {
 		 * Fires upon the disconnect attempt.
 		 * Return `false` to prevent the disconnect.
 		 *
-		 * @since 8.6.0
+		 * @since 8.7.0
 		 */
 		if ( ! apply_filters( 'jetpack_connection_disconnect_site_wpcom', true, $this ) ) {
 			return false;
@@ -2318,7 +2318,7 @@ class Manager {
 
 	/**
 	 * Get all connected plugins information, excluding those disconnected by user.
-	 * WARNING: the method cannot be called until Jetpack Config has been run (`plugins_loaded`, priority 2).
+	 * WARNING: the method cannot be called until Plugin_Storage::configure is called, which happens on plugins_loaded
 	 * Even if you don't use Jetpack Config, it may be introduced later by other plugins,
 	 * so please make sure not to run the method too early in the code.
 	 *

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2340,12 +2340,12 @@ class Manager {
 	 *
 	 * @return bool
 	 */
-	public function disconnect_user_initiated() {
+	public function disable_plugin() {
 		if ( ! $this->plugin ) {
 			return false;
 		}
 
-		return $this->plugin->disconnect_user_initiated();
+		return $this->plugin->disable();
 	}
 
 	/**
@@ -2355,12 +2355,12 @@ class Manager {
 	 *
 	 * @return bool
 	 */
-	public function connect_user_initiated() {
+	public function enable_plugin() {
 		if ( ! $this->plugin ) {
 			return false;
 		}
 
-		return $this->plugin->reconnect_user_initiated();
+		return $this->plugin->enable();
 	}
 
 	/**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2325,13 +2325,13 @@ class Manager {
 	 * @return array|WP_Error
 	 */
 	public function get_connected_plugins() {
-		$maybe_plugins = Plugin_Storage::get_all();
+		$maybe_plugins = Plugin_Storage::get_all( true );
 
 		if ( $maybe_plugins instanceof WP_Error ) {
 			return $maybe_plugins;
 		}
 
-		return array_diff_key( $maybe_plugins, array_flip( Plugin_Storage::get_all_disconnected_user_initiated() ) );
+		return $maybe_plugins;
 	}
 
 	/**

--- a/packages/connection/src/class-plugin-storage.php
+++ b/packages/connection/src/class-plugin-storage.php
@@ -90,16 +90,18 @@ class Plugin_Storage {
 	 * Even if you don't use Jetpack Config, it may be introduced later by other plugins,
 	 * so please make sure not to run the method too early in the code.
 	 *
+	 * @param bool $connected_only Exclude plugins that were explicitly disconnected.
+	 *
 	 * @return array|WP_Error
 	 */
-	public static function get_all() {
+	public static function get_all( $connected_only = false ) {
 		$maybe_error = self::ensure_configured();
 
 		if ( $maybe_error instanceof WP_Error ) {
 			return $maybe_error;
 		}
 
-		return self::$plugins;
+		return $connected_only ? array_diff_key( self::$plugins, array_flip( self::get_all_disconnected_user_initiated() ) ) : self::$plugins;
 	}
 
 	/**

--- a/packages/connection/src/class-plugin-storage.php
+++ b/packages/connection/src/class-plugin-storage.php
@@ -22,7 +22,7 @@ class Plugin_Storage {
 
 	const ACTIVE_PLUGINS_OPTION_NAME = 'jetpack_connection_active_plugins';
 
-	const DISCONNECTED_PLUGINS_OPTION_NAME = 'plugins_disconnected_user_initiated';
+	const PLUGINS_DISABLED_OPTION_NAME = 'connection_plugins_disabled';
 
 	/**
 	 * Whether this class was configured for the first time or not.
@@ -101,7 +101,7 @@ class Plugin_Storage {
 			return $maybe_error;
 		}
 
-		return $connected_only ? array_diff_key( self::$plugins, array_flip( self::get_all_disconnected_user_initiated() ) ) : self::$plugins;
+		return $connected_only ? array_diff_key( self::$plugins, array_flip( self::get_all_disabled_plugins() ) ) : self::$plugins;
 	}
 
 	/**
@@ -180,12 +180,12 @@ class Plugin_Storage {
 	 *
 	 * @return bool
 	 */
-	public static function disconnect_user_initiated( $slug ) {
-		$disconnects = self::get_all_disconnected_user_initiated();
+	public static function disable_plugin( $slug ) {
+		$disconnects = self::get_all_disabled_plugins();
 
 		if ( ! in_array( $slug, $disconnects, true ) ) {
 			$disconnects[] = $slug;
-			Jetpack_Options::update_option( self::DISCONNECTED_PLUGINS_OPTION_NAME, $disconnects );
+			Jetpack_Options::update_option( self::PLUGINS_DISABLED_OPTION_NAME, $disconnects );
 		}
 
 		return true;
@@ -198,13 +198,13 @@ class Plugin_Storage {
 	 *
 	 * @return bool
 	 */
-	public static function reconnect_user_initiated( $slug ) {
-		$disconnects = self::get_all_disconnected_user_initiated();
+	public static function enable_plugin( $slug ) {
+		$disconnects = self::get_all_disabled_plugins();
 
 		$slug_index = array_search( $slug, $disconnects, true );
 		if ( false !== $slug_index ) {
 			unset( $disconnects[ $slug_index ] );
-			Jetpack_Options::update_option( self::DISCONNECTED_PLUGINS_OPTION_NAME, $disconnects );
+			Jetpack_Options::update_option( self::PLUGINS_DISABLED_OPTION_NAME, $disconnects );
 		}
 
 		return true;
@@ -215,8 +215,8 @@ class Plugin_Storage {
 	 *
 	 * @return array
 	 */
-	public static function get_all_disconnected_user_initiated() {
-		return Jetpack_Options::get_option( self::DISCONNECTED_PLUGINS_OPTION_NAME, array() );
+	public static function get_all_disabled_plugins() {
+		return Jetpack_Options::get_option( self::PLUGINS_DISABLED_OPTION_NAME, array() );
 	}
 
 }

--- a/packages/connection/src/class-plugin-storage.php
+++ b/packages/connection/src/class-plugin-storage.php
@@ -22,7 +22,7 @@ class Plugin_Storage {
 
 	const ACTIVE_PLUGINS_OPTION_NAME = 'jetpack_connection_active_plugins';
 
-	const PLUGINS_DISABLED_OPTION_NAME = 'connection_plugins_disabled';
+	const PLUGINS_DISABLED_OPTION_NAME = 'connection_disabled_plugins';
 
 	/**
 	 * Whether this class was configured for the first time or not.

--- a/packages/connection/src/class-plugin-storage.php
+++ b/packages/connection/src/class-plugin-storage.php
@@ -7,22 +7,16 @@
 
 namespace Automattic\Jetpack\Connection;
 
-use Automattic\Jetpack\Config;
-use Jetpack_Options;
 use WP_Error;
 
 /**
- * The class serves a single purpose - to store the data that plugins use the connection, along with some auxiliary information.
- * Well, we don't really store all that. The information is provided on runtime,
- * so all we need to do is to save the data into the class property and retrieve it from there on demand.
- *
- * @todo Adapt for multisite installations.
+ * The class serves a single purpose - to store the data which plugins use the connection, along with some auxiliary information.
  */
 class Plugin_Storage {
 
 	const ACTIVE_PLUGINS_OPTION_NAME = 'jetpack_connection_active_plugins';
 
-	const PLUGINS_DISABLED_OPTION_NAME = 'connection_disabled_plugins';
+	const PLUGINS_DISABLED_OPTION_NAME = 'jetpack_connection_disabled_plugins';
 
 	/**
 	 * Whether this class was configured for the first time or not.
@@ -185,7 +179,7 @@ class Plugin_Storage {
 
 		if ( ! in_array( $slug, $disconnects, true ) ) {
 			$disconnects[] = $slug;
-			Jetpack_Options::update_option( self::PLUGINS_DISABLED_OPTION_NAME, $disconnects );
+			update_option( self::PLUGINS_DISABLED_OPTION_NAME, $disconnects );
 		}
 
 		return true;
@@ -204,7 +198,7 @@ class Plugin_Storage {
 		$slug_index = array_search( $slug, $disconnects, true );
 		if ( false !== $slug_index ) {
 			unset( $disconnects[ $slug_index ] );
-			Jetpack_Options::update_option( self::PLUGINS_DISABLED_OPTION_NAME, $disconnects );
+			update_option( self::PLUGINS_DISABLED_OPTION_NAME, $disconnects );
 		}
 
 		return true;
@@ -216,7 +210,7 @@ class Plugin_Storage {
 	 * @return array
 	 */
 	public static function get_all_disabled_plugins() {
-		return Jetpack_Options::get_option( self::PLUGINS_DISABLED_OPTION_NAME, array() );
+		return get_option( self::PLUGINS_DISABLED_OPTION_NAME, array() );
 	}
 
 }

--- a/packages/connection/src/class-plugin.php
+++ b/packages/connection/src/class-plugin.php
@@ -79,4 +79,31 @@ class Plugin {
 		return ! $plugins || ( array_key_exists( $this->slug, $plugins ) && 1 === count( $plugins ) );
 	}
 
+	/**
+	 * Add the plugin to the set of disconnected ones.
+	 *
+	 * @return bool
+	 */
+	public function disconnect_user_initiated() {
+		return Plugin_Storage::disconnect_user_initiated( $this->slug );
+	}
+
+	/**
+	 * Remove the plugin from the set of disconnected ones.
+	 *
+	 * @return bool
+	 */
+	public function reconnect_user_initiated() {
+		return Plugin_Storage::reconnect_user_initiated( $this->slug );
+	}
+
+	/**
+	 * Whether this plugin is allowed to use the connection.
+	 *
+	 * @return bool
+	 */
+	public function is_enabled() {
+		return ! in_array( $this->slug, Plugin_Storage::get_all_disconnected_user_initiated(), true );
+	}
+
 }

--- a/packages/connection/src/class-plugin.php
+++ b/packages/connection/src/class-plugin.php
@@ -84,8 +84,8 @@ class Plugin {
 	 *
 	 * @return bool
 	 */
-	public function disconnect_user_initiated() {
-		return Plugin_Storage::disconnect_user_initiated( $this->slug );
+	public function disable() {
+		return Plugin_Storage::disable_plugin( $this->slug );
 	}
 
 	/**
@@ -93,8 +93,8 @@ class Plugin {
 	 *
 	 * @return bool
 	 */
-	public function reconnect_user_initiated() {
-		return Plugin_Storage::reconnect_user_initiated( $this->slug );
+	public function enable() {
+		return Plugin_Storage::enable_plugin( $this->slug );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Plugin {
 	 * @return bool
 	 */
 	public function is_enabled() {
-		return ! in_array( $this->slug, Plugin_Storage::get_all_disconnected_user_initiated(), true );
+		return ! in_array( $this->slug, Plugin_Storage::get_all_disabled_plugins(), true );
 	}
 
 }

--- a/packages/connection/src/class-plugin.php
+++ b/packages/connection/src/class-plugin.php
@@ -74,7 +74,7 @@ class Plugin {
 	 * @return bool
 	 */
 	public function is_only() {
-		$plugins = Plugin_Storage::get_all();
+		$plugins = Plugin_Storage::get_all( true );
 
 		return ! $plugins || ( array_key_exists( $this->slug, $plugins ) && 1 === count( $plugins ) );
 	}

--- a/packages/connection/tests/php/test-class-plugin.php
+++ b/packages/connection/tests/php/test-class-plugin.php
@@ -92,30 +92,4 @@ class Test_Plugin extends TestCase {
 		$this->assertArrayNotHasKey( self::PLUGIN_SLUG, Plugin_Storage::get_all() );
 	}
 
-	/**
-	 * Unit test for the `Plugin:is_only()` method.
-	 * Make sure that the method returns true if either is true:
-	 * 1. It's the last active plugin connection.
-	 * 2. There are no active connections, assuming the plugin has just been removed.
-	 *
-	 * @depends test_remove
-	 * @covers Automattic\Jetpack\Connection\Plugin::is_only
-	 */
-	public function test_is_only_active() {
-		$plugin1 = ( new Plugin( self::PLUGIN_SLUG ) )
-			->add( self::PLUGIN_NAME, $this->plugin_args );
-
-		$plugin2 = ( new Plugin( 'plugin-slug-2' ) )
-			->add( 'Plugin Name 2' );
-
-		$this->assertFalse( $plugin1->is_only() );
-		$this->assertFalse( $plugin2->is_only() );
-
-		$plugin2->remove();
-		$this->assertTrue( $plugin1->is_only() );
-
-		$plugin1->remove();
-		$this->assertTrue( $plugin1->is_only() );
-	}
-
 }

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -282,7 +282,10 @@ class ManagerTest extends TestCase {
 
 		( new Plugin( 'plugin-slug-2' ) )->add( 'Plugin Name 2' );
 
-		$manager = new Manager( 'plugin-slug-1' );
+		$stub = $this->createMock( Plugin::class );
+		$stub->method( 'is_only' )
+			->willReturn( false );
+		$manager = ( new Manager() )->set_plugin_instance( $stub );
 
 		$this->assertFalse( $manager->delete_all_connection_tokens() );
 	}
@@ -299,13 +302,14 @@ class ManagerTest extends TestCase {
 		$this->apply_filters->enable();
 		$this->do_action->enable();
 
-		$plugin1 = ( new Plugin( 'plugin-slug-1' ) )
-			->add( 'Plugin Name 1' );
+		( new Plugin( 'plugin-slug-1' ) )->add( 'Plugin Name 1' );
 
 		( new Plugin( 'plugin-slug-2' ) )->add( 'Plugin Name 2' );
 
-		$manager = ( new Manager() )
-			->set_plugin_instance( $plugin1 );
+		$stub = $this->createMock( Plugin::class );
+		$stub->method( 'is_only' )
+			->willReturn( false );
+		$manager = ( new Manager() )->set_plugin_instance( $stub );
 
 		$this->assertFalse( $manager->disconnect_site_wpcom() );
 	}

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -72,7 +72,7 @@ class Jetpack_Options {
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 					'dismissed_wizard_banner',     // (int) True if the Wizard banner has been dismissed.
-					'connection_plugins_disabled', // (array)  Set of plugin slugs that aren't allowed to use `jetpack-connection` upon user request.
+					'connection_disabled_plugins', // (array)  Set of plugin slugs that aren't allowed to use `jetpack-connection` upon user request.
 				);
 
 			case 'private':

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -72,7 +72,6 @@ class Jetpack_Options {
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 					'dismissed_wizard_banner',     // (int) True if the Wizard banner has been dismissed.
-					'connection_disabled_plugins', // (array)  Set of plugin slugs that aren't allowed to use `jetpack-connection` upon user request.
 				);
 
 			case 'private':

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -72,7 +72,7 @@ class Jetpack_Options {
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 					'dismissed_wizard_banner',     // (int) True if the Wizard banner has been dismissed.
-					'plugins_disconnected_user_initiated', // (array)  Set of plugin slugs that aren't allowed to use `jetpack-connection` upon user request.
+					'connection_plugins_disabled', // (array)  Set of plugin slugs that aren't allowed to use `jetpack-connection` upon user request.
 				);
 
 			case 'private':

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -72,6 +72,7 @@ class Jetpack_Options {
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 					'dismissed_wizard_banner',     // (int) True if the Wizard banner has been dismissed.
+					'plugins_disconnected_user_initiated', // (array)  Set of plugin slugs that aren't allowed to use `jetpack-connection` upon user request.
 				);
 
 			case 'private':


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* access tokens no longer get removed if there are other plugins using them (unless explicitly requested);
* public API to mark the plugin as "disconnected by user", and remove that mark;
* Jetpack disconnection always initiate the "hard disconnect", removing the tokens.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* `p1HpG7-8VJ-p2`

#### Testing instructions:
##### Lights!
1. Install the `client-example` plugin from the branch `add/soft-disconnect`: https://github.com/Automattic/client-example/tree/add/soft-disconnect
2. Call `composer install` over the `client-example` directory to update the dependencies.

##### Camera!
3. Create a file `wp-content/plugins/jetpack-connection-test-1.php` with following content:
```
<?php
/** Plugin Name: Jetpack Connection Test Plugin (1) */
add_action( 'plugins_loaded', function() {
	( new Automattic\Jetpack\Config() )->ensure( 'connection', array( 'slug' => 'jetpack-connection-test-1', 'name' => 'Jetpack Connection Test Plugin (1)' ) );
}, 1 );
```
4. Go to the "Plugins" section and enable both "Jetpack Connection Test" and "Jetpack Client Example" plugins.

##### Action!
5. Go to the "WP Admin -> Client Example".
6. "Plugins requesting the connection" **should display** the list of connected plugins (Jetpack, Jetpack Client Example, Jetpack Connection Test Plugin).
7. Click "Soft Disconnect", the message "Softly Disconnected" **should appear**. Make sure **Jetpack is still connected**.
8. Click "Reconnect this site". The page **should reload** (skipping the auth flow), message "This site is registered" **should appear**.
9. Click "Hard Disconnect". The message "Unregistered" **should appear**.
10. Go to "Jetpack Dashboard", make sure **Jetpack is disconnected** too. Re-connect Jetpack.
11. Go back to "WP Admin -> Client Example", you **should see** the "Softly Disconnected" message now. Click "Reconnect".

##### Extended Edition.
12. Go to "Client Example -> Simple UI with Iframe", click "Disconnect Site".
13. **Make sure** the "Client Example" page displays "Softly Disconnected" message. Scroll down to the section "Explicitly disconnected plugins", you **should see** `client-example` listed there.
14. Go back to the "Simple UI with Iframe" and click "Set Up Connection". The page **should reload**, two _Disconnect_ buttons should appear.

##### Director's Cut.
15. Go to "WP Admin -> Simple UI with Calypso", click "Disconnect Site". The button "Set Up Connection" **should appear**.
16. Click "Set Up Connection", the page **should reload** (skipping the auth flow), the "Disconnect" buttons **should appear**.

#### Proposed changelog entry for your changes:
* Connection Package: Soft disconnects API
