### PR TITLE
Only update Full Sync Progress if we are checking in the full_sync queue

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -317,10 +317,12 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 
 		$items = $queue->peek_by_id( $request_body['item_ids'] );
 
-		/** This action is documented in packages/sync/src/modules/Full_Sync.php */
-		$full_sync_module = Modules::get_module( 'full-sync' );
+		// Update Full Sync Status if queue is "full_sync".
+		if ( 'full_sync' === $queue_name ) {
+			$full_sync_module = Modules::get_module( 'full-sync' );
 
-		$full_sync_module->update_sent_progress_action( $items );
+			$full_sync_module->update_sent_progress_action( $items );
+		}
 
 		$buffer = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
 		$response = $queue->close( $buffer, $request_body['item_ids'] );


### PR DESCRIPTION
sync/close endpoint can be used for full_sync, Immediate or sync queues. The update_sent_progress_action function should only be called if we are checking in actions from the full_sync queue.

#### Changes proposed in this Pull Request:
* Only call update_sent_progress_action if full_sync queue is being checked-in

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Existing, Optimizing Code

#### Testing instructions:

* From a WP.com sandbox run a full sync `wp jetpack-sync pull --blog_id=XXXX --start`
* Confirm the Sync fully executes.

#### Proposed changelog entry for your changes:
* N/A - no functional change.
