### PR TITLE
Scanner: Update the link to take the user to calypso-scanner

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -228,7 +228,7 @@ class DashScan extends Component {
 							)
 						) }
 						{ buildAction(
-							getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ),
+							getRedirectUrl( 'calypso-scanner', { site: siteRawUrl } ),
 							__( 'View security scan details' )
 						) }
 					</React.Fragment>


### PR DESCRIPTION
This PR will make it possible to redirect users to jetpack cloud scanner section. 
By separating the activity log from the scanner section. 

Related D42869-code

#### Testing instructions:

* Go to At a Glance. Section. 
* When Jetpack Scan is set up as expected the link to view scanner should still take you to the activity log for now. But in the future we will be sending the user to the scanner section. 

#### Proposed changelog entry for your changes:
* Nothing to add to the change log this is part of the work that adds jetpack cloud. 
