### PR TITLE
Crowdsignal shortcode: Convert survey.fm links to shortcodes.

### DIFF
--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -453,7 +453,7 @@ if (
 							do_action( 'crowdsignal_shortcode_before', intval( $poll ) );
 
 							return sprintf(
-								'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="%2$s" style="display:inline-block;%3$s%4$s"></div><div id="PD_superContainer"></div><noscript>%5$s</noscript>',
+								'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="%2$s" style="%3$s%4$s"></div><div id="PD_superContainer"></div><noscript>%5$s</noscript>',
 								absint( $poll ),
 								esc_attr( wp_json_encode( $data ) ),
 								$float,
@@ -477,7 +477,7 @@ if (
 							do_action( 'crowdsignal_shortcode_before', intval( $poll ) );
 
 							return sprintf(
-								'<a id="pd_a_%1$s"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$s" style="display:inline-block;%2$s%3$s"></div><div id="PD_superContainer"></div><noscript>%4$s</noscript>',
+								'<a id="pd_a_%1$s"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$s" style="%2$s%3$s"></div><div id="PD_superContainer"></div><noscript>%4$s</noscript>',
 								absint( $poll ),
 								$float,
 								$margins,
@@ -732,7 +732,7 @@ if (
 	if ( ! function_exists( 'crowdsignal_link' ) ) {
 		/**
 		 * Replace link with shortcode.
-		 * Example: http://polldaddy.com/poll/1562975/?view=results&msg=voted
+		 * Examples: https://poll.fm/10499328 | https://7iger.survey.fm/test-embed
 		 *
 		 * @param string $content Post content.
 		 */
@@ -744,11 +744,21 @@ if (
 				return $content;
 			}
 
-			return jetpack_preg_replace_outside_tags(
+			// Replace poll links
+			$content = jetpack_preg_replace_outside_tags(
 				'!(?:\n|\A)https?://(polldaddy\.com/poll|poll\.fm)/([0-9]+?)(/.*)?(?:\n|\Z)!i',
 				'[crowdsignal poll=$2]',
 				$content
 			);
+
+			// Replace survey.fm links
+			$content = preg_replace(
+				'!(?:\n|\A)https?://(.*).survey.fm/(.*)(/.*)?(?:\n|\Z)!i',
+				'[crowdsignal type="iframe" survey="true" height="auto" domain="$1" id="$2"]',
+				$content
+			);
+
+			return $content;
 		}
 
 		// higher priority because we need it before auto-link and autop get to it.

--- a/tests/php/modules/shortcodes/test-class.crowdsignal.php
+++ b/tests/php/modules/shortcodes/test-class.crowdsignal.php
@@ -60,7 +60,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style=""></div><div id="PD_superContainer"></div><noscript><a href="https://polldaddy.com/p/%1$d" target="_blank">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content
@@ -81,7 +81,7 @@ class WP_Test_Jetpack_Shortcodes_CrowdSignal extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			sprintf(
-				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style="display:inline-block;"></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
+				'<a name="pd_a_%1$d"></a><div class="CSS_Poll PDS_Poll" id="PDI_container%1$d" data-settings="{&quot;url&quot;:&quot;https:\/\/secure.polldaddy.com\/p\/%1$d.js&quot;}" style=""></div><div id="PD_superContainer"></div><noscript><a href="https://poll.fm/%1$d" target="_blank">Take Our Poll</a></noscript>',
 				$id
 			),
 			$shortcode_content


### PR DESCRIPTION
This commit syncs r206937-wpcom.

#### Changes proposed in this Pull Request:
* Fixes `unfurling` of survey.fm links on themes such as P2 that load posts asyncronously so that they get transformed into a proper crowdsignal shortcode and rendered on the front-end.
* Removed inline `display-block` style to get the embed rendering properly within its container.

#### Testing instructions:
* Switch your site to the P2 theme.
* Add a new post in the block editor.
* Type `/crowdsignal` to add a new Crowdsignal embed block.
* Paste a survey.fm link into the block, here's one you can use: `https://7iger.survey.fm/test-embed`. 
* The survey should embed into the block editor.
* Publish the post, and view it on the front-end of the site. The embed should also render here.
* Try switching to a different theme. The embeds should still render appropriately.
* Ensure poll embeds still work with the block as well. Here's a test link: `https://poll.fm/10499328`

#### Proposed changelog entry for your changes:
* No changelog needed?
