### PR TITLE
Widgets: update Internet Defense League for full HTTPS support

### DIFF
--- a/modules/widgets/internet-defense-league.php
+++ b/modules/widgets/internet-defense-league.php
@@ -60,11 +60,11 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			if ( ! isset( $this->badges[ $instance['badge'] ] ) ) {
 				$instance['badge'] = $this->defaults['badge'];
 			}
-			$badge_url        = esc_url( 'https://internetdefenseleague.org/images/badges/final/' . $instance['badge'] . '.png' );
+			$badge_url        = esc_url( 'https://www.internetdefenseleague.org/images/badges/final/' . $instance['badge'] . '.png' );
 			$photon_badge_url = jetpack_photon_url( $badge_url );
 			$alt_text         = esc_html__( 'Member of The Internet Defense League', 'jetpack' );
 			echo $args['before_widget'];
-			echo '<p><a href="https://internetdefenseleague.org/"><img src="' . $photon_badge_url . '" alt="' . $alt_text . '" style="max-width: 100%; height: auto;" /></a></p>';
+			echo '<p><a href="https://www.internetdefenseleague.org/"><img src="' . $photon_badge_url . '" alt="' . $alt_text . '" style="max-width: 100%; height: auto;" /></a></p>';
 			echo $args['after_widget'];
 		}
 
@@ -99,9 +99,8 @@ class Jetpack_Internet_Defense_League_Widget extends WP_Widget {
 			_idl.variant = "<?php echo esc_js( $this->variant ); ?>";
 			(function() {
 				var idl = document.createElement('script');
-				idl.type = 'text/javascript';
 				idl.async = true;
-				idl.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'members.internetdefenseleague.org/include/?url=' + (_idl.url || '') + '&campaign=' + (_idl.campaign || '') + '&variant=' + (_idl.variant || 'banner');
+				idl.src = 'https://members.internetdefenseleague.org/include/?url=' + (_idl.url || '') + '&campaign=' + (_idl.campaign || '') + '&variant=' + (_idl.variant || 'banner');
 				document.getElementsByTagName('body')[0].appendChild(idl);
 			})();
 		</script>


### PR DESCRIPTION
Related to D42942-code for WP.com backend change.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Force HTTPS when looading the IDL script
* Use www in IDL URLs to avoid 301 redirects

See docs at https://github.com/fightforthefuture/idl-members/blob/master/docs/embed.md for the updated JavaScript embed code.

#### Testing instructions:

* Widgets: enable Internet Defense League
* On front-end of site, confirm no HTTPS mixed content errors

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Widgets: update Internet Defense League for full HTTPS support
