### PR TITLE
Instagram Gallery: On WPCOM, Bypass the WPCOM API

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -37,6 +37,20 @@ class Jetpack_Instagram_Gallery_Helper {
 			}
 		}
 
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			if ( ! class_exists( 'WPCOM_Instagram_Gallery_Helper' ) ) {
+				\jetpack_require_lib( 'instagram-gallery-helper' );
+			}
+
+			$gallery = WPCOM_Instagram_Gallery_Helper::get_gallery( $access_token, $count );
+			if ( is_wp_error( $gallery ) ) {
+				return $gallery;
+			}
+
+			set_transient( $transient_key, wp_json_encode( $gallery ), HOUR_IN_SECONDS );
+			return $gallery;
+		}
+
 		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/instagram/%s?count=%d', $site_id, $access_token, (int) $count ),
 			2,

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -20,6 +20,15 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	public function __construct() {
 		$this->namespace = 'wpcom/v2';
 		$this->rest_base = 'instagram-gallery';
+		$this->is_wpcom  = false;
+
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			$this->is_wpcom = true;
+
+			if ( ! class_exists( 'WPCOM_Instagram_Gallery_Helper' ) ) {
+				\jetpack_require_lib( 'instagram-gallery-helper' );
+			}
+		}
 
 		if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 			\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
@@ -97,7 +106,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	public function get_instagram_connect_url() {
-		if ( $this->is_wpcom() ) {
+		if ( $this->is_wpcom ) {
 			return WPCOM_Instagram_Gallery_Helper::get_connect_url();
 		}
 
@@ -130,7 +139,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	public function get_instagram_access_token() {
-		if ( $this->is_wpcom() ) {
+		if ( $this->is_wpcom ) {
 			return WPCOM_Instagram_Gallery_Helper::get_token_id();
 		}
 
@@ -166,7 +175,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 
 		Jetpack_Instagram_Gallery_Helper::delete_instagram_gallery_cache( $request['access_token'] );
 
-		if ( $this->is_wpcom() ) {
+		if ( $this->is_wpcom ) {
 			$response = WPCOM_Instagram_Gallery_Helper::delete_token( $request['access_token'] );
 			if ( is_wp_error( $response ) ) {
 				return $response;
@@ -200,25 +209,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	public function get_instagram_gallery( $request ) {
-		if ( $this->is_wpcom() ) {
-			return WPCOM_Instagram_Gallery_Helper::get_gallery( $request['access_token'], $request['count'] );
-		}
-
 		return Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $request['access_token'], $request['count'] );
-	}
-
-	/**
-	 * Determine if we are on WordPress.com,
-	 * and conditionally requires the WPCOM Instagram Gallery Helper library.
-	 *
-	 * @return boolean
-	 */
-	private function is_wpcom() {
-		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			require_lib( 'instagram-gallery-helper' );
-			return true;
-		}
-		return false;
 	}
 }
 


### PR DESCRIPTION
Requires D42946-code

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On WordPress.com, avoid unnecessarily calling the WPCOM REST API.

Reasons:
- `wpcom_json_api_request_as_user` and `wpcom_json_api_request_as_blog` currently don't work as expected on WPCOM (see https://github.com/Automattic/jetpack/issues/15468).
- There's no real need to hit the WPCOM REST API when on WPCOM.

To avoid exposing lots of internal WPCOM and Keyring logic in Jetpack, I've externalized a bit of the Instagram WPCOM endpoint into an helper class, easier to use in Jetpack.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Jetpack setup: apply D42946-code and sandbox the API.
WPCOM setup: apply D43015-code, D42946-code, sandbox the API and a test site.

Smoke test the Instagram Gallery block: connect to Instagram, embed a gallery, disconnect from Instagram, and whatever else you can think of.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
