### PR TITLE
Leverage AMP plugin to output the AMP Google Analytics tag

### DIFF
--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -69,10 +69,11 @@ class Jetpack_Google_Analytics_Legacy {
 			return;
 		}
 
-		if ( class_exists( 'Jetpack_AMP_Support' )
-			&& Jetpack_AMP_Support::is_amp_request()
-		) {
-			add_filter( 'amp_analytics_entries', 'Jetpack_Google_Analytics::amp_analytics_entries' );
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			// For Reader mode — legacy.
+			add_filter( 'amp_post_template_analytics', 'Jetpack_Google_Analytics::amp_analytics_entries', 1000 );
+			// For Standard and Transitional modes.
+			add_filter( 'amp_analytics_entries', 'Jetpack_Google_Analytics::amp_analytics_entries', 1000 );
 			return;
 		}
 

--- a/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -69,6 +69,13 @@ class Jetpack_Google_Analytics_Legacy {
 			return;
 		}
 
+		if ( class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
+			add_filter( 'amp_analytics_entries', 'Jetpack_Google_Analytics::amp_analytics_entries' );
+			return;
+		}
+
 		$custom_vars = array(
 			"_gaq.push(['_setAccount', '{$tracking_id}']);",
 		);

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -49,10 +49,11 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
-		if ( class_exists( 'Jetpack_AMP_Support' )
-			&& Jetpack_AMP_Support::is_amp_request()
-		) {
-			add_filter( 'amp_analytics_entries', 'Jetpack_Google_Analytics::amp_analytics_entries' );
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			// For Reader mode — legacy.
+			add_filter( 'amp_post_template_analytics', 'Jetpack_Google_Analytics::amp_analytics_entries', 1000 );
+			// For Standard and Transitional modes.
+			add_filter( 'amp_analytics_entries', 'Jetpack_Google_Analytics::amp_analytics_entries', 1000 );
 			return;
 		}
 

--- a/modules/google-analytics/classes/wp-google-analytics-universal.php
+++ b/modules/google-analytics/classes/wp-google-analytics-universal.php
@@ -49,6 +49,13 @@ class Jetpack_Google_Analytics_Universal {
 			return;
 		}
 
+		if ( class_exists( 'Jetpack_AMP_Support' )
+			&& Jetpack_AMP_Support::is_amp_request()
+		) {
+			add_filter( 'amp_analytics_entries', 'Jetpack_Google_Analytics::amp_analytics_entries' );
+			return;
+		}
+
 		/**
 		 * Allow for additional elements to be added to the universal Google Analytics queue (ga) array
 		 *

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -83,6 +83,14 @@ class Jetpack_Google_Analytics {
 			$analytics_entries = array();
 		}
 
+		$amp_tracking_codes = static::get_amp_tracking_codes( $analytics_entries );
+		$jetpack_account    = Jetpack_Google_Analytics_Options::get_tracking_code();
+
+		// Bypass tracking codes already set on AMP plugin.
+		if ( in_array( $jetpack_account, $amp_tracking_codes, true ) ) {
+			return $analytics_entries;
+		}
+
 		$config_data = wp_json_encode(
 			array(
 				'vars'     => array(
@@ -107,13 +115,26 @@ class Jetpack_Google_Analytics {
 
 		$data = apply_filters( 'jetpack_amp_analytics_entries', $data, $entry_id );
 
-		if ( empty( $data ) ) {
-			return $analytics_entries;
+	/**
+	 * Get AMP tracking codes.
+	 *
+	 * @param array $analytics_entries The codes available for AMP.
+	 *
+	 * @return array
+	 */
+	protected static function get_amp_tracking_codes( $analytics_entries ) {
+		$entries  = array_column( $analytics_entries, 'config' );
+		$accounts = array();
+
+		foreach ( $entries as $entry ) {
+			$entry = json_decode( $entry );
+
+			if ( ! empty( $entry->vars->account ) ) {
+				$accounts[] = $entry->vars->account;
+			}
 		}
 
-		$analytics_entries[ $entry_id ] = $data;
-
-		return $analytics_entries;
+		return $accounts;
 	}
 }
 

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -70,6 +70,51 @@ class Jetpack_Google_Analytics {
 
 		return self::$instance;
 	}
+
+	/**
+	 * Add amp-analytics tags.
+	 *
+	 * @param array $analytics_entries An associative array of the analytics entries.
+	 *
+	 * @return array
+	 */
+	public static function amp_analytics_entries( $analytics_entries ) {
+		if ( ! is_array( $analytics_entries ) ) {
+			$analytics_entries = array();
+		}
+
+		$config_data = wp_json_encode(
+			array(
+				'vars'     => array(
+					'account' => Jetpack_Google_Analytics_Options::get_tracking_code(),
+				),
+				'triggers' => array(
+					'trackPageview' => array(
+						'on'      => 'visible',
+						'request' => 'pageview',
+					),
+				),
+			)
+		);
+
+		// Generate a hash string to uniquely identify this entry.
+		$entry_id = substr( md5( 'googleanalytics' . $config_data ), 0, 12 );
+
+		$data = array(
+			'type'   => 'googleanalytics',
+			'config' => $config_data,
+		);
+
+		$data = apply_filters( 'jetpack_amp_analytics_entries', $data, $entry_id );
+
+		if ( empty( $data ) ) {
+			return $analytics_entries;
+		}
+
+		$analytics_entries[ $entry_id ] = $data;
+
+		return $analytics_entries;
+	}
 }
 
 global $jetpack_google_analytics;

--- a/modules/google-analytics/wp-google-analytics.php
+++ b/modules/google-analytics/wp-google-analytics.php
@@ -108,12 +108,13 @@ class Jetpack_Google_Analytics {
 		// Generate a hash string to uniquely identify this entry.
 		$entry_id = substr( md5( 'googleanalytics' . $config_data ), 0, 12 );
 
-		$data = array(
+		$analytics_entries[ $entry_id ] = array(
 			'type'   => 'googleanalytics',
 			'config' => $config_data,
 		);
 
-		$data = apply_filters( 'jetpack_amp_analytics_entries', $data, $entry_id );
+		return $analytics_entries;
+	}
 
 	/**
 	 * Get AMP tracking codes.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -107,6 +107,9 @@
 		<testsuite name="geo-location">
 			<directory prefix="test_" suffix=".php">tests/php/modules/geo-location</directory>
 		</testsuite>
+		<testsuite name="google-analytics">
+			<directory prefix="test" suffix=".php">tests/php/modules/google-analytics</directory>
+		</testsuite>
 		<testsuite name="deprecation">
 			<file>tests/php/test_deprecation.php</file>
 		</testsuite>

--- a/tests/php/modules/google-analytics/test-class.google-analytics.php
+++ b/tests/php/modules/google-analytics/test-class.google-analytics.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for the Google Analytics module.
+ *
+ * @package Jetpack
+ */
+
+require_jetpack_file( 'modules/google-analytics/wp-google-analytics.php' );
+
+/**
+ * Class WP_Test_Jetpack_Google_Analytics.
+ */
+class WP_Test_Jetpack_Google_Analytics extends WP_UnitTestCase {
+
+	/**
+	 * Testing Google Analytics account.
+	 *
+	 * @var string
+	 */
+	const GA_ID = 'UA-000000000-1';
+
+	/**
+	 * Runs the routine before each test is executed.
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Hijack the option for Jetpack_Google_Analytics_Options::get_tracking_code().
+		add_filter(
+			'pre_option_jetpack_wga',
+			function( $option ) {
+				$option['code'] = self::GA_ID;
+				return $option;
+			}
+		);
+	}
+
+	/**
+	 * Prepare sample data.
+	 *
+	 * @return array
+	 */
+	protected function get_sample() {
+		$entries = array();
+
+		$config_data = wp_json_encode(
+			array(
+				'vars'     => array(
+					'account' => self::GA_ID,
+				),
+				'triggers' => array(
+					'trackPageview' => array(
+						'on'      => 'visible',
+						'request' => 'pageview',
+					),
+				),
+			)
+		);
+
+		// Generate a hash string to uniquely identify this entry.
+		$entry_id = substr( md5( 'googleanalytics' . $config_data ), 0, 12 );
+
+		$entries[ $entry_id ] = array(
+			'type'   => 'googleanalytics',
+			'config' => $config_data,
+		);
+
+		return $entries;
+	}
+
+	/**
+	 * Confirm that the JSON information for the GA account is added to the AMP analytics entries.
+	 */
+	public function test_amp_analytics_entries() {
+		$this->assertEquals(
+			Jetpack_Google_Analytics::amp_analytics_entries( array() ),
+			$this->get_sample()
+		);
+	}
+
+	/**
+	 * Confirm that the GA account is not added twice to the AMP analytics entries.
+	 */
+	public function test_amp_analytics_single_entry() {
+		$this->assertEquals(
+			Jetpack_Google_Analytics::amp_analytics_entries( $this->get_sample() ),
+			$this->get_sample()
+		);
+	}
+}


### PR DESCRIPTION
The current implementation of Google Analytics is not compatible with AMP requests.

#### Changes proposed in this Pull Request:
* For AMP requests, the PR leverages `amp_analytics_entries` filter from AMP plugin to append the Jetpack Google Analytics Tracking ID. This affects both Jetpack flows for GA Legacy and Universal.
* This functionality is dependant of the [AMP](https://wordpress.org/plugins/amp/) plugin

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds Google Analytics on AMP requests;

#### Testing instructions:
1. Ensure the [AMP](https://wordpress.org/plugins/amp/) plugin is enabled;
1. Under Jetpack Settings > Traffic > Google Analytics, click `Configure your Google Analytics settings`. This should take you to your wordpress.com dashboard;
1. On `Marketing and Integrations` page, scroll down to Google Analytics section and set the Google Analytics Tracking ID and enable the tracking toggle:
<img width="497" alt="Screenshot 2020-05-05 at 18 44 23" src="https://user-images.githubusercontent.com/2189187/81097946-8c02ff00-8f00-11ea-9ef6-fd07f9991030.png">.
1. Open a published page in AMP mode;
1. Open the DevTools. You should see the defined `<amp-analytics>` tag. Multiple if you also set any on AMP plugin: 
<img width="678" alt="Screenshot 2020-05-05 at 18 48 14" src="https://user-images.githubusercontent.com/2189187/81098251-06cc1a00-8f01-11ea-9800-17814c515982.png">

#### Proposed changelog entry for your changes:
* Fix the Google Analytics tag compatibility on AMP requests;
