### PR TITLE
Implement Jetpack Wizard banner

### DIFF
--- a/_inc/jetpack-jitm.js
+++ b/_inc/jetpack-jitm.js
@@ -201,6 +201,11 @@ jQuery( document ).ready( function( $ ) {
 	};
 
 	var reFetch = function() {
+		// Do not render JITMs if the Wizard Banner is displayed.
+		if ( $( '#jp-wizard-banner' ).length ) {
+			return;
+		}
+
 		$( '.jetpack-jitm-message' ).each( function() {
 			var $el = $( this );
 

--- a/_inc/jetpack-wizard-banner.js
+++ b/_inc/jetpack-wizard-banner.js
@@ -1,0 +1,23 @@
+/* global jQuery, jp_banner */
+
+( function( $ ) {
+	var wizardBanner = $( '#jp-wizard-banner' ),
+		wizardBannerDismiss = $( '.wizard-banner-dismiss' );
+
+	// Dismiss the wizard banner via AJAX
+	wizardBannerDismiss.on( 'click', function() {
+		$( wizardBanner ).hide();
+
+		var data = {
+			action: 'jetpack_wizard_banner',
+			nonce: jp_banner.wizardBannerNonce,
+			dismissBanner: true,
+		};
+
+		$.post( jp_banner.ajax_url, data, function( response ) {
+			if ( true !== response.success ) {
+				$( wizardBanner ).show();
+			}
+		} );
+	} );
+} )( jQuery );

--- a/_inc/jetpack-wizard-banner.js
+++ b/_inc/jetpack-wizard-banner.js
@@ -2,11 +2,13 @@
 
 ( function( $ ) {
 	var wizardBanner = $( '#jp-wizard-banner' ),
+		wizardBannerContainer = $( '#jp-wizard-banner-container' ),
 		wizardBannerDismiss = $( '.wizard-banner-dismiss' );
 
 	// Dismiss the wizard banner via AJAX
 	wizardBannerDismiss.on( 'click', function() {
 		$( wizardBanner ).hide();
+		$( wizardBannerContainer ).hide();
 
 		var data = {
 			action: 'jetpack_wizard_banner',

--- a/_inc/jetpack-wizard-banner.js
+++ b/_inc/jetpack-wizard-banner.js
@@ -2,7 +2,6 @@
 
 ( function( $ ) {
 	var wizardBanner = $( '#jp-wizard-banner' ),
-		wizardBannerContainer = $( '#jp-wizard-banner-container' ),
 		wizardBannerDismiss = $( '.wizard-banner-dismiss' );
 
 	// Dismiss the wizard banner via AJAX

--- a/_inc/jetpack-wizard-banner.js
+++ b/_inc/jetpack-wizard-banner.js
@@ -7,7 +7,6 @@
 	// Dismiss the wizard banner via AJAX
 	wizardBannerDismiss.on( 'click', function() {
 		$( wizardBanner ).hide();
-		$( wizardBannerContainer ).hide();
 
 		var data = {
 			action: 'jetpack_wizard_banner',

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -36,7 +36,7 @@ class Jetpack_Wizard {
 	 * @return bool
 	 */
 	public static function can_be_displayed() {
-		return apply_filters( 'jetpack_connection_prompt_helpers', false ) &&
+		return apply_filters( 'jetpack_show_setup_wizard', false ) &&
 			Jetpack::is_active() &&
 			! self::is_finished();
 	}

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -2,7 +2,7 @@
 /**
  * Displays the first page of the Wizard in a banner form
  *
- * @package none
+ * @package Jetpack
  */
 
 /**

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -41,5 +41,5 @@ class Jetpack_Wizard {
 			! self::is_finished();
 	}
 
-	// TODO: move save and get from the endpoint (update_setup_questionnaire() and get_setup_questionnaire()) to this class.
+	// TODO: move save and get logic from the endpoint (update_setup_questionnaire() and get_setup_questionnaire()) to this class.
 }

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -17,7 +17,7 @@ class Jetpack_Wizard {
 	 */
 	public static function is_started() {
 		// TODO: check saved Jetpack_Option (to be implemented).
-		return true;
+		return false;
 	}
 
 	/**
@@ -30,5 +30,16 @@ class Jetpack_Wizard {
 		return false;
 	}
 
-	// TODO: move option save from the endpoint into here.
+	/**
+	 * Can the Wizard be displayed?
+	 *
+	 * @return bool
+	 */
+	public static function can_be_displayed() {
+		return apply_filters( 'jetpack_connection_prompt_helpers', false ) &&
+			Jetpack::is_active() &&
+			! self::is_finished();
+	}
+
+	// TODO: move save and get from the endpoint (update_setup_questionnaire() and get_setup_questionnaire()) to this class.
 }

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -37,8 +37,10 @@ class Jetpack_Wizard {
 	 */
 	public static function can_be_displayed() {
 		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
-		return apply_filters( 'jetpack_show_setup_wizard', false ) &&
-			Jetpack::is_active() &&
-			! self::is_finished();
+		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
+		return apply_filters( 'jetpack_show_setup_wizard', false )
+				&& Jetpack::is_active()
+				&& ! self::is_finished()
+				&& current_user_can( 'jetpack_manage_modules' );
 	}
 }

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -40,6 +40,4 @@ class Jetpack_Wizard {
 			Jetpack::is_active() &&
 			! self::is_finished();
 	}
-
-	// TODO: move save and get logic from the endpoint (update_setup_questionnaire() and get_setup_questionnaire()) to this class.
 }

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Displays the first page of the Wizard in a banner form
+ *
+ * @package none
+ */
+
+/**
+ * Jetpack_Wizard class
+ */
+class Jetpack_Wizard {
+
+	/**
+	 * Has the user started the Wizard?
+	 *
+	 * @return bool
+	 */
+	public static function is_started() {
+		// TODO: check saved Jetpack_Option (to be implemented).
+		return true;
+	}
+
+	/**
+	 * Has the user finished the Wizard?
+	 *
+	 * @return bool
+	 */
+	public static function is_finished() {
+		// TODO: check saved Jetpack_Option (to be implemented).
+		return false;
+	}
+
+	// TODO: move option save from the endpoint into here.
+}

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -36,6 +36,7 @@ class Jetpack_Wizard {
 	 * @return bool
 	 */
 	public static function can_be_displayed() {
+		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 		return apply_filters( 'jetpack_show_setup_wizard', false ) &&
 			Jetpack::is_active() &&
 			! self::is_finished();

--- a/_inc/lib/class-jetpack-wizard.php
+++ b/_inc/lib/class-jetpack-wizard.php
@@ -37,7 +37,6 @@ class Jetpack_Wizard {
 	 */
 	public static function can_be_displayed() {
 		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
-		/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 		return apply_filters( 'jetpack_show_setup_wizard', false )
 				&& Jetpack::is_active()
 				&& ! self::is_finished()

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -57,4 +57,6 @@ module.exports = [
 	'modules/wpcom-tos/wpcom-tos.php',
 	'packages',
 	'tests/e2e/plugins/e2e-plan-data-interceptor.php',
+	'_inc/lib/class-jetpack-wizard.php',
+	'class-jetpack-wizard-banner.php',
 ];

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Displays the first page of the Wizard in a banner form
+ *
+ * @package none
+ */
+
+use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+
+/**
+ * Jetpack_Wizard_Banner
+ **/
+class Jetpack_Wizard_Banner {
+	/**
+	 * Jetpack_Wizard_Banner
+	 *
+	 * @var Jetpack_Wizard_Banner
+	 **/
+	private static $instance = null;
+
+	/**
+	 * Factory method
+	 */
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new Jetpack_Wizard_Banner();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Jetpack_Wizard_Banner constructor.
+	 */
+	private function __construct() {
+		add_action( 'current_screen', array( $this, 'maybe_initialize_hooks' ) );
+	}
+
+	/**
+	 * Initialize hooks to display the banner
+	 */
+	public function maybe_initialize_hooks() {
+		// Kill if banner has been dismissed.
+		if ( Jetpack_Options::get_option( 'dismissed_wizard_banner' ) ) {
+			return;
+		}
+
+		add_action( 'admin_print_styles', array( $this, 'admin_banner_styles' ) );
+		add_action( 'admin_notices', array( $this, 'render_banner' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_banner_scripts' ) );
+	}
+
+	/**
+	 * Enqueue JavaScript files.
+	 */
+	public static function enqueue_banner_scripts() {
+		wp_enqueue_script(
+			'jetpack-wizard-banner-js',
+			Assets::get_file_url_for_environment(
+				'_inc/build/jetpack-wizard-banner.min.js',
+				'_inc/jetpack-wizard-banner.js'
+			),
+			array( 'jquery' ),
+			JETPACK__VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'jetpack-wizard-banner-js',
+			'jp_banner',
+			array(
+				'ajax_url'          => admin_url( 'admin-ajax.php' ),
+				'wizardBannerNonce' => wp_create_nonce( 'jp-wizard-banner-nonce' ),
+			)
+		);
+	}
+
+	/**
+	 * Include the needed styles
+	 */
+	public function admin_banner_styles() {
+		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+		wp_enqueue_style(
+			'jetpack',
+			plugins_url( "css/jetpack-wizard-banner{$min}.css", JETPACK__PLUGIN_FILE ),
+			array(),
+			JETPACK__VERSION
+		);
+	}
+
+	/**
+	 * AJAX callback
+	 */
+	public static function ajax_callback() {
+		check_ajax_referer( 'jp-wizard-banner-nonce', 'nonce' );
+
+		if ( isset( $_REQUEST['dismissBanner'] ) ) {
+			Jetpack_Options::update_option( 'dismissed_wizard_banner', 1 );
+			wp_send_json_success();
+		}
+
+		wp_die();
+	}
+
+	/**
+	 * Renders the Wizard Banner
+	 */
+	public function render_banner() {
+		$jetpack_logo = new Jetpack_Logo();
+		?>
+
+		<div id="jp-wizard-banner" class="">
+			<div class="jp-setup-wizard-intro">
+				<span
+					class="notice-dismiss wizard-banner-dismiss"
+					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
+				</span>
+				<div class="jp-emblem">
+				<?php
+					echo $jetpack_logo->get_jp_emblem_larger(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				?>
+				</div>
+				<img
+					width="200px"
+					height="200px"
+					src="
+					<?php
+					esc_attr_e( plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ), 'jetpack' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+					?>
+					"
+					alt="<?php esc_attr_e( 'A jetpack site powering up', 'jetpack' ); ?>"
+				/>
+				<h1 class="jp-setup-wizard-header">
+					<?php esc_html_e( 'Set up Jetpack for better site security, performance, and more', 'jetpack' ); ?>
+				</h1>
+				<p class="jp-setup-wizard-paragraph">
+					<?php esc_html_e( 'Jetpack is a cloud-powered tool built by Automattic.', 'jetpack' ); ?>
+				</p>
+				<p class="jp-setup-wizard-paragraph">
+					<?php esc_html_e( 'Answer a few questions and we’ll help you secure, speed up, customize, and grow your WordPress website.', 'jetpack' ); ?>
+				</p>
+				<div class="jp-setup-wizard-intro-question">
+					<h2>
+						<?php
+						/* translators: %s is the site name */
+						esc_html_e( sprintf( 'What will %s be used for?', get_bloginfo( 'name' ) ), 'jetpack' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+						?>
+					</h2>
+					<div class="jp-setup-wizard-answer-buttons">
+						<a class="button button-primary jp-setup-wizard-button" href="setup/income?use=personal">
+						<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
+						</a>
+						<a class="button button-primary jp-setup-wizard-button" href="setup/income?use=business">
+							<?php esc_html_e( 'Business Use', 'jetpack' ); ?>
+						</a>
+					</div>
+					<a class="jp-setup-wizard-skip-link" href="setup/features">
+						<?php esc_html_e( 'Skip to recommended features', 'jetpack' ); ?>
+					</a>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+}

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -144,63 +144,74 @@ class Jetpack_Wizard_Banner {
 
 		?>
 		<div id="jp-wizard-banner" class="jp-wizard-banner">
-			<span
-				class="notice-dismiss wizard-banner-dismiss"
-				title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-			</span>
-			<div class="jp-emblem">
-			<?php
-				echo $jetpack_logo->get_jp_emblem_larger(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			?>
-			</div>
-			<img
-				class="powering-up-img"
-				width="200px"
-				height="200px"
-				src="<?php echo esc_url( $powering_up_logo ); ?>"
-				alt="<?php esc_attr_e( 'A jetpack site powering up', 'jetpack' ); ?>"
-			/>
-			<h2 class="jp-wizard-banner-wizard-header">
-				<?php esc_html_e( 'Set up Jetpack for better site security, performance, and more', 'jetpack' ); ?>
-			</h2>
-			<p class="jp-wizard-banner-wizard-paragraph">
-				<?php esc_html_e( 'Jetpack is a cloud-powered tool built by Automattic.', 'jetpack' ); ?>
-			</p>
-			<p class="jp-wizard-banner-wizard-paragraph">
-				<?php esc_html_e( 'Answer a few questions and we’ll help you secure, speed up, customize, and grow your WordPress website.', 'jetpack' ); ?>
-			</p>
-			<div class="jp-wizard-banner-wizard-intro-question">
-				<h2>
-					<?php
-					/* translators: %s is the site name */
-					printf(
-						/* translators: %s is the site name */
-						esc_html__( 'What will %s be used for?', 'jetpack' ),
-						esc_html( get_bloginfo( 'name' ) )
-					);
-					?>
-				</h2>
-				<div class="jp-wizard-banner-wizard-answer-buttons">
-					<a
-						class="button button-primary jp-wizard-banner-wizard-button"
-						href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=personal' ) ); ?>"
-					>
-					<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
-					</a>
-					<a
-						class="button button-primary jp-wizard-banner-wizard-button"
-						href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=business' ) ); ?>"
-					>
-						<?php esc_html_e( 'Business Use', 'jetpack' ); ?>
-					</a>
+			<div class="jp-wizard-banner-grid">
+				<div class="jp-wizard-banner-grid-a">
+					<div class="jp-emblem">
+						<?php
+							echo $jetpack_logo->get_jp_emblem_larger(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
+					</div>
+					<h2 class="jp-wizard-banner-wizard-header">
+						<?php esc_html_e( 'Set up Jetpack for better site security, performance, and more', 'jetpack' ); ?>
+					</h2>
+					<p class="jp-wizard-banner-wizard-paragraph">
+						<?php esc_html_e( 'Jetpack is a cloud-powered tool built by Automattic.', 'jetpack' ); ?>
+					</p>
+					<p class="jp-wizard-banner-wizard-paragraph">
+						<?php esc_html_e( 'Answer a few questions and we’ll help you secure, speed up, customize, and grow your WordPress website.', 'jetpack' ); ?>
+					</p>
+					<div class="jp-wizard-banner-wizard-intro-question">
+						<h2>
+							<?php
+							/* translators: %s is the site name */
+							printf(
+								/* translators: %s is the site name */
+								esc_html__( 'What will %s be used for?', 'jetpack' ),
+								esc_html( get_bloginfo( 'name' ) )
+							);
+							?>
+						</h2>
+						<div class="jp-wizard-banner-wizard-answer-buttons">
+							<a
+								class="button button-primary jp-wizard-banner-wizard-button"
+								href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=personal' ) ); ?>"
+							>
+							<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
+							</a>
+							<a
+								class="button button-primary jp-wizard-banner-wizard-button"
+								href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=business' ) ); ?>"
+							>
+								<?php esc_html_e( 'Business Use', 'jetpack' ); ?>
+							</a>
+						</div>
+						<a
+							class="jp-wizard-banner-wizard-skip-link"
+							href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/features' ) ); ?>"
+						>
+							<?php esc_html_e( 'Skip to recommended features', 'jetpack' ); ?>
+						</a>
+					</div>
 				</div>
-				<a
-					class="jp-wizard-banner-wizard-skip-link"
-					href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/features' ) ); ?>"
-				>
-					<?php esc_html_e( 'Skip to recommended features', 'jetpack' ); ?>
-				</a>
+
+
+				<div class="jp-wizard-banner-grid-b">
+					<img
+						class="powering-up-img"
+						width="200px"
+						height="200px"
+						src="<?php echo esc_url( $powering_up_logo ); ?>"
+						alt="<?php esc_attr_e( 'A jetpack site powering up', 'jetpack' ); ?>"
+					/>
+				</div>
+
+				<span
+					class="notice-dismiss wizard-banner-dismiss"
+					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
+				</span>
+
 			</div>
+
 		</div>
 		<?php
 	}

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -85,11 +85,12 @@ class Jetpack_Wizard_Banner {
 	 * Include the needed styles
 	 */
 	public function admin_banner_styles() {
-		$min = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-
 		wp_enqueue_style(
-			'jetpack',
-			plugins_url( "css/jetpack-wizard-banner{$min}.css", JETPACK__PLUGIN_FILE ),
+			'jetpack-wizard-banner',
+			Assets::get_file_url_for_environment(
+				'css/jetpack-wizard-banner.min.css',
+				'css/jetpack-wizard-banner.css'
+			),
 			array(),
 			JETPACK__VERSION
 		);

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -42,7 +42,7 @@ class Jetpack_Wizard_Banner {
 	 */
 	public function maybe_initialize_hooks() {
 		// We already display the wizard at the Jetpack area.
-		if ( strpos( get_current_screen()->id, 'jetpack' ) !== false ) {
+		if ( false !== strpos( get_current_screen()->id, 'jetpack' ) ) {
 			return;
 		}
 

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -2,7 +2,7 @@
 /**
  * Displays the first page of the Wizard in a banner form
  *
- * @package none
+ * @package Jetpack
  */
 
 use Automattic\Jetpack\Assets;

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -101,7 +101,10 @@ class Jetpack_Wizard_Banner {
 	public static function ajax_callback() {
 		check_ajax_referer( 'jp-wizard-banner-nonce', 'nonce' );
 
-		if ( isset( $_REQUEST['dismissBanner'] ) ) {
+		if (
+			current_user_can( 'jetpack_manage_modules' )
+			&& isset( $_REQUEST['dismissBanner'] )
+		) {
 			Jetpack_Options::update_option( 'dismissed_wizard_banner', 1 );
 			wp_send_json_success();
 		}

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -153,14 +153,23 @@ class Jetpack_Wizard_Banner {
 					?>
 				</h2>
 				<div class="jp-wizard-banner-wizard-answer-buttons">
-					<a class="button button-primary jp-wizard-banner-wizard-button" href="setup/income?use=personal">
+					<a
+						class="button button-primary jp-wizard-banner-wizard-button"
+						href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=personal' ) ); ?>"
+					>
 					<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
 					</a>
-					<a class="button button-primary jp-wizard-banner-wizard-button" href="setup/income?use=business">
+					<a
+						class="button button-primary jp-wizard-banner-wizard-button"
+						href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=business' ) ); ?>"
+					>
 						<?php esc_html_e( 'Business Use', 'jetpack' ); ?>
 					</a>
 				</div>
-				<a class="jp-wizard-banner-wizard-skip-link" href="setup/features">
+				<a
+					class="jp-wizard-banner-wizard-skip-link"
+					href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/features' ) ); ?>"
+				>
 					<?php esc_html_e( 'Skip to recommended features', 'jetpack' ); ?>
 				</a>
 			</div>

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -109,59 +109,73 @@ class Jetpack_Wizard_Banner {
 	 */
 	public function render_banner() {
 		$jetpack_logo = new Jetpack_Logo();
-		?>
 
-		<div id="jp-wizard-banner" class="">
-			<div class="jp-setup-wizard-intro">
-				<span
-					class="notice-dismiss wizard-banner-dismiss"
-					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-				</span>
-				<div class="jp-emblem">
+		// When navigating into the Jetpack area of wp-admin, the element #wpcontent does not have padding, except on the other areas.
+		// Adding extra margin using a container div for when we're in Jetpack.
+		$add_margin = ( get_current_screen()->parent_file === 'jetpack' ) ? true : false;
+
+		if ( $add_margin ) {
+			?>
+			<div id="jp-wizard-banner-container" class="jp-wizard-banner-container">
+			<?php
+		}
+		?>
+		<div id="jp-wizard-banner" class="jp-wizard-banner">
+			<span
+				class="notice-dismiss wizard-banner-dismiss"
+				title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
+			</span>
+			<div class="jp-emblem">
+			<?php
+				echo $jetpack_logo->get_jp_emblem_larger(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			?>
+			</div>
+			<img
+				width="200px"
+				height="200px"
+				src="
 				<?php
-					echo $jetpack_logo->get_jp_emblem_larger(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				esc_attr_e( plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ), 'jetpack' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 				?>
-				</div>
-				<img
-					width="200px"
-					height="200px"
-					src="
+				"
+				alt="<?php esc_attr_e( 'A jetpack site powering up', 'jetpack' ); ?>"
+			/>
+			<h1 class="jp-wizard-banner-wizard-header">
+				<?php esc_html_e( 'Set up Jetpack for better site security, performance, and more', 'jetpack' ); ?>
+			</h1>
+			<p class="jp-wizard-banner-wizard-paragraph">
+				<?php esc_html_e( 'Jetpack is a cloud-powered tool built by Automattic.', 'jetpack' ); ?>
+			</p>
+			<p class="jp-wizard-banner-wizard-paragraph">
+				<?php esc_html_e( 'Answer a few questions and we’ll help you secure, speed up, customize, and grow your WordPress website.', 'jetpack' ); ?>
+			</p>
+			<div class="jp-wizard-banner-wizard-intro-question">
+				<h2>
 					<?php
-					esc_attr_e( plugins_url( 'images/jetpack-powering-up.svg', JETPACK__PLUGIN_FILE ), 'jetpack' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
+					/* translators: %s is the site name */
+					esc_html_e( sprintf( 'What will %s be used for?', get_bloginfo( 'name' ) ), 'jetpack' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
 					?>
-					"
-					alt="<?php esc_attr_e( 'A jetpack site powering up', 'jetpack' ); ?>"
-				/>
-				<h1 class="jp-setup-wizard-header">
-					<?php esc_html_e( 'Set up Jetpack for better site security, performance, and more', 'jetpack' ); ?>
-				</h1>
-				<p class="jp-setup-wizard-paragraph">
-					<?php esc_html_e( 'Jetpack is a cloud-powered tool built by Automattic.', 'jetpack' ); ?>
-				</p>
-				<p class="jp-setup-wizard-paragraph">
-					<?php esc_html_e( 'Answer a few questions and we’ll help you secure, speed up, customize, and grow your WordPress website.', 'jetpack' ); ?>
-				</p>
-				<div class="jp-setup-wizard-intro-question">
-					<h2>
-						<?php
-						/* translators: %s is the site name */
-						esc_html_e( sprintf( 'What will %s be used for?', get_bloginfo( 'name' ) ), 'jetpack' ); // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText
-						?>
-					</h2>
-					<div class="jp-setup-wizard-answer-buttons">
-						<a class="button button-primary jp-setup-wizard-button" href="setup/income?use=personal">
-						<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
-						</a>
-						<a class="button button-primary jp-setup-wizard-button" href="setup/income?use=business">
-							<?php esc_html_e( 'Business Use', 'jetpack' ); ?>
-						</a>
-					</div>
-					<a class="jp-setup-wizard-skip-link" href="setup/features">
-						<?php esc_html_e( 'Skip to recommended features', 'jetpack' ); ?>
+				</h2>
+				<div class="jp-wizard-banner-wizard-answer-buttons">
+					<a class="button button-primary jp-wizard-banner-wizard-button" href="setup/income?use=personal">
+					<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
+					</a>
+					<a class="button button-primary jp-wizard-banner-wizard-button" href="setup/income?use=business">
+						<?php esc_html_e( 'Business Use', 'jetpack' ); ?>
 					</a>
 				</div>
+				<a class="jp-wizard-banner-wizard-skip-link" href="setup/features">
+					<?php esc_html_e( 'Skip to recommended features', 'jetpack' ); ?>
+				</a>
 			</div>
 		</div>
+		<?php
+		if ( $add_margin ) {
+			?>
+			</div>
+			<?php
+		}
+		?>
 		<?php
 	}
 }

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -45,7 +45,9 @@ class Jetpack_Wizard_Banner {
 		if ( false !== strpos( get_current_screen()->id, 'jetpack' ) ) {
 			return;
 		}
-
+		if ( ! current_user_can( 'jetpack_manage_modules' ) ) {
+			return;
+		}
 		// Kill if banner has been dismissed.
 		if ( Jetpack_Options::get_option( 'dismissed_wizard_banner' ) ) {
 			return;

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -163,7 +163,6 @@ class Jetpack_Wizard_Banner {
 					<div class="jp-wizard-banner-wizard-intro-question">
 						<h2>
 							<?php
-							/* translators: %s is the site name */
 							printf(
 								/* translators: %s is the site name */
 								esc_html__( 'What will %s be used for?', 'jetpack' ),

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -41,6 +41,11 @@ class Jetpack_Wizard_Banner {
 	 * Initialize hooks to display the banner
 	 */
 	public function maybe_initialize_hooks() {
+		// We already display the wizard at the Jetpack area.
+		if ( strpos( get_current_screen()->id, 'jetpack' ) !== false ) {
+			return;
+		}
+
 		// Kill if banner has been dismissed.
 		if ( Jetpack_Options::get_option( 'dismissed_wizard_banner' ) ) {
 			return;
@@ -110,15 +115,6 @@ class Jetpack_Wizard_Banner {
 	public function render_banner() {
 		$jetpack_logo = new Jetpack_Logo();
 
-		// When navigating into the Jetpack area of wp-admin, the element #wpcontent does not have padding, except on the other areas.
-		// Adding extra margin using a container div for when we're in Jetpack.
-		$add_margin = ( get_current_screen()->parent_file === 'jetpack' ) ? true : false;
-
-		if ( $add_margin ) {
-			?>
-			<div id="jp-wizard-banner-container" class="jp-wizard-banner-container">
-			<?php
-		}
 		?>
 		<div id="jp-wizard-banner" class="jp-wizard-banner">
 			<span
@@ -169,13 +165,6 @@ class Jetpack_Wizard_Banner {
 				</a>
 			</div>
 		</div>
-		<?php
-		if ( $add_margin ) {
-			?>
-			</div>
-			<?php
-		}
-		?>
 		<?php
 	}
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3734,10 +3734,7 @@ p {
 			);
 		}
 
-		// Show the Wizard Banner if someone is connected but did not start the wizard yet.
-		if ( Jetpack_Wizard::can_be_displayed() ) {
-			Jetpack_Wizard_Banner::init();
-		}
+		Jetpack_Wizard_Banner::init();
 
 		if ( current_user_can( 'manage_options' ) && 'AUTO' == JETPACK_CLIENT__HTTPS && ! self::permit_ssl() ) {
 			add_action( 'jetpack_notices', array( $this, 'alert_auto_ssl_fail' ) );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3735,10 +3735,7 @@ p {
 		}
 
 		// Show the Wizard Banner if someone is connected but did not start the wizard yet.
-		// Forcing Jetpack_Wizard::is_started() to true as a feature flag.
-		// TODO: implement Jetpack_Wizard::is_started().
-		// TODO: add host detection here.
-		if ( self::is_active() && ! Jetpack_Wizard::is_started() ) {
+		if ( Jetpack_Wizard::can_be_displayed() ) {
 			Jetpack_Wizard_Banner::init();
 		}
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -670,6 +670,8 @@ class Jetpack {
 
 		add_action( 'wp_ajax_jetpack_connection_banner', array( $this, 'jetpack_connection_banner_callback' ) );
 
+		add_action( 'wp_ajax_jetpack_wizard_banner', array( 'Jetpack_Wizard_Banner', 'ajax_callback' ) );
+
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 
 		/**
@@ -3730,6 +3732,14 @@ p {
 				$args,
 				true
 			);
+		}
+
+		// Show the Wizard Banner if someone is connected but did not start the wizard yet.
+		// Forcing Jetpack_Wizard::is_started() to true as a feature flag.
+		// TODO: implement Jetpack_Wizard::is_started().
+		// TODO: add host detection here.
+		if ( self::is_active() && ! Jetpack_Wizard::is_started() ) {
+			Jetpack_Wizard_Banner::init();
 		}
 
 		if ( current_user_can( 'manage_options' ) && 'AUTO' == JETPACK_CLIENT__HTTPS && ! self::permit_ssl() ) {

--- a/load-jetpack.php
+++ b/load-jetpack.php
@@ -60,6 +60,9 @@ require_once JETPACK__PLUGIN_DIR . 'class.jetpack-idc.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-connection-banner.php';
 require_once JETPACK__PLUGIN_DIR . 'class.jetpack-plan.php';
 
+jetpack_require_lib( 'class-jetpack-wizard' );
+require_once JETPACK__PLUGIN_DIR . 'class-jetpack-wizard-banner.php';
+
 if ( is_admin() ) {
 	require_once JETPACK__PLUGIN_DIR . 'class.jetpack-admin.php';
 	jetpack_require_lib( 'debugger' );

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -71,6 +71,7 @@ class Jetpack_Options {
 					'mapbox_api_key',              // (string) Mapbox API Key, for use with Map block.
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
+					'dismissed_wizard_banner',     // (int) True if the Wizard banner has been dismissed.
 				);
 
 			case 'private':

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -1,0 +1,110 @@
+@import '../_inc/client/scss/mixin_breakpoint';
+@import '../_inc/client/scss/calypso-colors';
+
+
+.jp-setup-wizard-intro {
+	text-align: left;
+	background: $white;
+	padding: 2rem;
+	box-shadow: 0px 2px 6px rgba( 0, 0, 0, 0.03 ), 0px 1px 2px rgba( 0, 0, 0, 0.03 );
+	border: 1px solid #dcdcde;
+	margin: 40px 20px 0 2px;
+	@include breakpoint( '<660px' ) {
+		margin: 45px 20px 0 2px;
+		padding-bottom: 50px;
+	}
+}
+
+.jp-setup-wizard-header {
+	margin-bottom: 1rem !important;
+	margin-top: 1rem !important;
+	font-weight: 500;
+	font-size: 1.5em;
+	@include breakpoint( '<660px' ) {
+		text-align: left;
+		font-weight: 400;
+	}
+}
+
+img {
+	border: none;
+	float: right;
+	margin-right: 1rem;
+	margin-top: 2rem;
+
+	@include breakpoint( '<660px' ) {
+		display: none;
+	}
+}
+
+.wizard-banner-dismiss {
+	position: relative;
+	float: right;
+	margin-top: -25px;
+	margin-right: -25px;
+}
+
+.jp-setup-wizard-paragraph {
+	font-size: 1rem;
+
+	@include breakpoint( '>660px' ) {
+		margin: 0;
+	}
+
+	@include breakpoint( '<660px' ) {
+		text-align: left;
+	}
+}
+
+.jp-setup-wizard-intro-question {
+	box-sizing: border-box;
+
+	@include breakpoint( '>480px' ) {
+		border: 1px solid #dddddd;
+		border-radius: 4px;
+	}
+
+	max-width: 720px;
+	padding: 1.5rem 0;
+	text-align: center;
+	height: 11rem;
+	margin-top: 2rem;
+
+	h2 {
+		margin-top: 0px;
+
+		@include breakpoint( '<480px' ) {
+			text-align: left;
+		}
+	}
+}
+
+.jp-setup-wizard-answer-buttons {
+	display: flex;
+
+	flex-direction: row;
+	justify-content: center;
+
+	@include breakpoint( '<480px' ) {
+		flex-direction: column;
+		align-items: center;
+	}
+}
+
+.jp-setup-wizard-button {
+	margin: 1rem;
+	width: 160px;
+	margin-right: 10px !important;
+
+	@include breakpoint( '<480px' ) {
+		width: 100%;
+		margin: 0.5rem 0;
+	}
+}
+
+.jp-setup-wizard-skip-link {
+	text-decoration: underline !important;
+	color: #000000;
+	margin-top: 1rem;
+	display: block;
+}

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -99,8 +99,6 @@
 	margin-top: 2rem;
 
 	h2 {
-		margin-top: 0px;
-
 		@include breakpoint( '<480px' ) {
 			text-align: left;
 		}
@@ -133,7 +131,7 @@
 
 .jp-wizard-banner-wizard-skip-link {
 	text-decoration: underline !important;
-	color: #000000;
+	color: $studio-black;
 	margin-top: 1rem;
 	display: block;
 }

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -15,10 +15,6 @@
 	}
 }
 
-.jp-wizard-banner-container {
-	margin: 20px 0 20px 20px;
-}
-
 .jp-wizard-banner-wizard-header {
 	margin-bottom: 1rem !important;
 	margin-top: 1rem !important;

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -26,7 +26,7 @@
 	}
 }
 
-img {
+.powering-up-img {
 	border: none;
 	float: right;
 	margin-right: 1rem;

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -2,7 +2,7 @@
 @import '../_inc/client/scss/calypso-colors';
 
 
-.jp-setup-wizard-intro {
+.jp-wizard-banner {
 	text-align: left;
 	background: $white;
 	padding: 2rem;
@@ -15,7 +15,11 @@
 	}
 }
 
-.jp-setup-wizard-header {
+.jp-wizard-banner-container {
+	margin: 20px 0 20px 20px;
+}
+
+.jp-wizard-banner-wizard-header {
 	margin-bottom: 1rem !important;
 	margin-top: 1rem !important;
 	font-weight: 500;
@@ -44,7 +48,7 @@ img {
 	margin-right: -25px;
 }
 
-.jp-setup-wizard-paragraph {
+.jp-wizard-banner-wizard-paragraph {
 	font-size: 1rem;
 
 	@include breakpoint( '>660px' ) {
@@ -56,7 +60,7 @@ img {
 	}
 }
 
-.jp-setup-wizard-intro-question {
+.jp-wizard-banner-wizard-intro-question {
 	box-sizing: border-box;
 
 	@include breakpoint( '>480px' ) {
@@ -79,7 +83,7 @@ img {
 	}
 }
 
-.jp-setup-wizard-answer-buttons {
+.jp-wizard-banner-wizard-answer-buttons {
 	display: flex;
 
 	flex-direction: row;
@@ -91,7 +95,7 @@ img {
 	}
 }
 
-.jp-setup-wizard-button {
+.jp-wizard-banner-wizard-button {
 	margin: 1rem;
 	width: 160px;
 	margin-right: 10px !important;
@@ -102,7 +106,7 @@ img {
 	}
 }
 
-.jp-setup-wizard-skip-link {
+.jp-wizard-banner-wizard-skip-link {
 	text-decoration: underline !important;
 	color: #000000;
 	margin-top: 1rem;

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -26,11 +26,33 @@
 	}
 }
 
+.jp-wizard-banner-grid {
+	display: flex;
+}
+
+.jp-wizard-banner-grid-a {
+	width: 95%;
+
+	@include breakpoint( '<960px' ) {
+		width: 100%;
+	}
+}
+
+.jp-wizard-banner-grid-b {
+	width: 20%;
+	display: block;
+	min-width: 200px;
+
+	@include breakpoint( '<960px' ) {
+		display: none;
+	}
+}
+
 .powering-up-img {
 	border: none;
-	float: right;
 	margin-right: 1rem;
-	margin-top: 1rem;
+	margin-top: 3rem;
+	margin-left: 1rem;
 
 	@include breakpoint( '<960px' ) {
 		display: none;
@@ -38,10 +60,17 @@
 }
 
 .wizard-banner-dismiss {
-	position: relative;
 	float: right;
-	margin-top: -25px;
-	margin-right: -25px;
+	height: 20px;
+	width: 20px;
+	margin-top: 80px;
+	margin-right: 30px;
+	position: fixed;
+
+	@include breakpoint( '<660px' ) {
+		margin-top: 95px;
+		margin-right: 25px;
+	}
 }
 
 .jp-wizard-banner-wizard-paragraph {

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -1,13 +1,13 @@
+@import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import '../_inc/client/scss/mixin_breakpoint';
-@import '../_inc/client/scss/calypso-colors';
 
 
 .jp-wizard-banner {
 	text-align: left;
-	background: $white;
+	background: $studio-white;
 	padding: 2rem;
 	box-shadow: 0px 2px 6px rgba( 0, 0, 0, 0.03 ), 0px 1px 2px rgba( 0, 0, 0, 0.03 );
-	border: 1px solid #dcdcde;
+	border: 1px solid $studio-gray-5;
 	margin: 40px 20px 0 2px;
 	@include breakpoint( '<660px' ) {
 		margin: 45px 20px 0 2px;

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -11,7 +11,6 @@
 	margin: 40px 20px 0 2px;
 	@include breakpoint( '<660px' ) {
 		margin: 45px 20px 0 2px;
-		padding-bottom: 0px;
 	}
 }
 

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -32,7 +32,7 @@ img {
 	margin-right: 1rem;
 	margin-top: 2rem;
 
-	@include breakpoint( '<660px' ) {
+	@include breakpoint( '<960px' ) {
 		display: none;
 	}
 }

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -11,7 +11,7 @@
 	margin: 40px 20px 0 2px;
 	@include breakpoint( '<660px' ) {
 		margin: 45px 20px 0 2px;
-		padding-bottom: 50px;
+		padding-bottom: 0px;
 	}
 }
 
@@ -20,6 +20,7 @@
 	margin-top: 1rem !important;
 	font-weight: 500;
 	font-size: 1.5em;
+	line-height: 150%;
 	@include breakpoint( '<660px' ) {
 		text-align: left;
 		font-weight: 400;
@@ -30,7 +31,7 @@ img {
 	border: none;
 	float: right;
 	margin-right: 1rem;
-	margin-top: 2rem;
+	margin-top: 1rem;
 
 	@include breakpoint( '<960px' ) {
 		display: none;
@@ -65,9 +66,8 @@ img {
 	}
 
 	max-width: 720px;
-	padding: 1.5rem 0;
+	padding: 1.5rem 0 1.5rem;
 	text-align: center;
-	height: 11rem;
 	margin-top: 2rem;
 
 	h2 {
@@ -88,6 +88,7 @@ img {
 	@include breakpoint( '<480px' ) {
 		flex-direction: column;
 		align-items: center;
+		width: 100%;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR implements the Jetpack Wizard banner, which is basically the page 1 of the Wizard in a banner form to be displayed in all pages to encourage users to complete the Jetpack setup after a connection.

<img width="1352" alt="Screen Shot 2020-05-05 at 18 40 38" src="https://user-images.githubusercontent.com/2166135/81119785-dfc21800-8f01-11ea-84d9-bef84577c8f5.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a new feature.

#### Testing instructions:
* Check out the branch, build,
* Connect Jetpack, but don't set it up yet.
* Add the following filter into wp_config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
```
* Refresh your wp-admin, you should see the banner.

#### Proposed changelog entry for your changes:
* Implemented Jetpack Wizard banner.
