### PR TITLE
Re-enabled the connection banner and made it non-dismissable

### DIFF
--- a/_inc/jetpack-connection-banner.js
+++ b/_inc/jetpack-connection-banner.js
@@ -4,32 +4,12 @@
 	var nav = $( '.jp-wpcom-connect__vertical-nav-container' ),
 		contentContainer = $( '.jp-wpcom-connect__content-container' ),
 		nextFeatureButtons = $( '.jp-banner__button-container .next-feature' ),
-		fullScreenContainer = $( '.jp-connect-full__container' ),
-		fullScreenDismiss = $( '.jp-connect-full__dismiss, .jp-connect-full__dismiss-paragraph' ),
 		wpWelcomeNotice = $( '#welcome-panel' ),
-		connectionBanner = $( '#message' ),
-		connectionBannerDismiss = $( '.connection-banner-dismiss' );
+		connectionBanner = $( '#message' );
 
 	// Move the banner below the WP Welcome notice on the dashboard
 	$( window ).on( 'load', function() {
 		wpWelcomeNotice.insertBefore( connectionBanner );
-	} );
-
-	// Dismiss the connection banner via AJAX
-	connectionBannerDismiss.on( 'click', function() {
-		$( connectionBanner ).hide();
-
-		var data = {
-			action: 'jetpack_connection_banner',
-			nonce: jp_banner.connectionBannerNonce,
-			dismissBanner: true,
-		};
-
-		$.post( jp_banner.ajax_url, data, function( response ) {
-			if ( true !== response.success ) {
-				$( connectionBanner ).show();
-			}
-		} );
 	} );
 
 	nav.on(
@@ -69,17 +49,4 @@
 			.eq( index )
 			.addClass( 'jp__slide-is-active' );
 	}
-
-	/**
-	 * Full-screen connection prompt
-	 */
-	fullScreenDismiss.on( 'click', function() {
-		$( fullScreenContainer ).hide();
-	} );
-
-	$( document ).keyup( function( e ) {
-		if ( 27 === e.keyCode ) {
-			$( fullScreenDismiss ).click();
-		}
-	} );
 } )( jQuery );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -66,11 +66,6 @@ class Jetpack_Connection_Banner {
 	 */
 	function maybe_initialize_hooks( $current_screen ) {
 
-		// Kill if banner has been dismissed
-		if ( Jetpack_Options::get_option( 'dismissed_connection_banner' ) ) {
-			return;
-		}
-
 		// Don't show the connect notice anywhere but the plugins.php after activating
 		if ( 'plugins' !== $current_screen->base && 'dashboard' !== $current_screen->base ) {
 			return;
@@ -202,10 +197,6 @@ class Jetpack_Connection_Banner {
 				</span>
 			</div>
 			<div class="jp-wpcom-connect__inner-container">
-				<span
-					class="notice-dismiss connection-banner-dismiss"
-					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-				</span>
 
 				<div class="jp-wpcom-connect__content-container">
 
@@ -295,9 +286,6 @@ class Jetpack_Connection_Banner {
 					echo $logo->render();
 					?>
 
-					<div class="jp-connect-full__dismiss">
-						<svg class="jp-connect-full__svg-dismiss" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>Dismiss Jetpack Connection Window</title><rect x="0" fill="none" /><g><path d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/></g></svg>
-					</div>
 				<?php endif; ?>
 
 				<div class="jp-connect-full__step-header">
@@ -358,19 +346,6 @@ class Jetpack_Connection_Banner {
 					</div>
 				</div>
 
-				<?php if ( 'plugins' === $current_screen->base ) : ?>
-					<p class="jp-connect-full__dismiss-paragraph">
-						<a>
-							<?php
-							echo esc_html_x(
-								'Not now, thank you.',
-								'a link that closes the modal window that offers to connect Jetpack',
-								'jetpack'
-							);
-							?>
-						</a>
-					</p>
-				<?php endif; ?>
 			</div>
 		</div>
 		<?php

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -984,17 +984,6 @@ class Jetpack {
 		return $params;
 	}
 
-	function jetpack_connection_banner_callback() {
-		check_ajax_referer( 'jp-connection-banner-nonce', 'nonce' );
-
-		if ( isset( $_REQUEST['dismissBanner'] ) ) {
-			Jetpack_Options::update_option( 'dismissed_connection_banner', 1 );
-			wp_send_json_success();
-		}
-
-		wp_die();
-	}
-
 	/**
 	 * Removes all XML-RPC methods that are not `jetpack.*`.
 	 * Only used in our alternate XML-RPC endpoint, where we want to
@@ -3432,7 +3421,6 @@ p {
 		self::load_modules();
 
 		Jetpack_Options::delete_option( 'do_activate' );
-		Jetpack_Options::delete_option( 'dismissed_connection_banner' );
 	}
 
 	/**

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -63,7 +63,6 @@ class Jetpack_Options {
 					'sync_health_status',          // (bool|array) An array of data relating to Jetpack's sync health.
 					'safe_mode_confirmed',         // (bool) True if someone confirms that this site was correctly put into safe mode automatically after an identity crisis is discovered.
 					'migrate_for_idc',             // (bool) True if someone confirms that this site should migrate stats and subscribers from its previous URL
-					'dismissed_connection_banner', // (bool) True if the connection banner has been dismissed
 					'ab_connect_banner_green_bar', // (int) Version displayed of the A/B test for the green bar at the top of the connect banner.
 					'onboarding',                  // (string) Auth token to be used in the onboarding connection flow
 					'tos_agreed',                  // (bool)   Whether or not the TOS for connection has been agreed upon.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Re-enabled the connection banner (or "connection prompt") and made it non-dismissable in order to force users who dismissed it to connect.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a change to the behavior of an existing feature.

#### Testing instructions:
* Create a new Jetpack site.
* Activate the JP plugin but don't connect.
* Navigate to the main wp-admin Dashboard, you will see the connection banner (the one with the green header) with the dismiss button:

<img width="1309" alt="Screen Shot 2020-05-06 at 01 17 30" src="https://user-images.githubusercontent.com/2166135/81138176-8c6abc80-8f37-11ea-9741-6e868ac174b9.png">

* Click the dismiss button, which will make the banner disappear forever.
* Apply the changes on this PR.
* Refresh your Dashboard.
* You should see the connection banner again, without the dismiss button:

<img width="1301" alt="Screen Shot 2020-05-05 at 23 23 26" src="https://user-images.githubusercontent.com/2166135/81138300-fc794280-8f37-11ea-947d-043386766f25.png">

#### Proposed changelog entry for your changes:
Re-enabled the connection banner and made it non-dismissable.
