### PR TITLE
Jetpack Sync - Queue Cleanup

### DIFF
--- a/packages/sync/src/class-queue.php
+++ b/packages/sync/src/class-queue.php
@@ -383,6 +383,11 @@ class Queue {
 		$is_valid = $this->validate_checkout( $buffer );
 
 		if ( is_wp_error( $is_valid ) ) {
+			// Always delete ids_to_remove even when buffer is no longer checked-out.
+			// They were processed by WP.com so safe to remove from queue.
+			if ( ! is_null( $ids_to_remove ) ) {
+				$this->delete( $ids_to_remove );
+			}
 			return $is_valid;
 		}
 


### PR DESCRIPTION
It is possible for a buffer to be removed before sync actions are finished processing by WP.com. WHen this happens we end up leaving the items in the queue and they get resent to WP.com for processing causing duplicate actions.

This update ensures that we always delete items from the queue even if the buffer is no longer checked out. 

#### Changes proposed in this Pull Request:
* Always delete processed sync actions even if buffer is not valid.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Existing functionality, optimization

#### Testing instructions:

* Enqueue large amounts of Sync Actions on your test site
* Perform a `wp jetpack-sync pull --blog-id=XX --queue=sync`
* When `buffer not checked out warnings are displayed the actions will still be removed from the queue.

#### Proposed changelog entry for your changes:
* N/A - internal optimization to send less duplicate actions. Won't be visible to end users.
