### PR TITLE
Build: Remove unused resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,8 +226,6 @@
 		"yarn": "^1.3.2"
 	},
 	"resolutions": {
-		"**/webpack/acorn": "^6.4.1",
-		"**/acorn-globals/acorn": "^6.4.1",
 		"**/sharkdown/minimist": "^0.2.1",
 		"**/mkdirp/minimist": "^0.2.1",
 		"**/optimist/minimist": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,12 +3070,12 @@ acorn@5.X, acorn@^5.0.3, acorn@^5.5.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
-acorn@^6.0.1, acorn@^6.2.1, acorn@^6.4.1, acorn@^7.1.1:
+acorn@^6.0.1, acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^7.1.0:
+acorn@^7.1.0, acorn@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==


### PR DESCRIPTION
Closes #15413

Investigating `acorn`, which Renovate tagged for an update. We added it as part of #15305 to force use an updated version of `acorn`. Checking the `yarn audit` and dep treee, this resolution is no longer needed, confirming what @brbrr thought.

#### Changes proposed in this Pull Request:
* Removes resolutions.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Verify Travis. Run `yarn audit` before and after patch.

#### Proposed changelog entry for your changes:
* n/a
