### PR TITLE
Re-enable the connection banner and make it non-dismissable

### DIFF
--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -66,8 +66,11 @@ class Jetpack_Connection_Banner {
 	 */
 	function maybe_initialize_hooks( $current_screen ) {
 
-		// Kill if banner has been dismissed
-		if ( Jetpack_Options::get_option( 'dismissed_connection_banner' ) ) {
+		// Kill if banner has been dismissed and the pre-connection helpers filter is not set.
+		if (
+			Jetpack_Options::get_option( 'dismissed_connection_banner' ) &&
+			! apply_filters( 'jetpack_pre_connection_prompt_helpers', false )
+		) {
 			return;
 		}
 
@@ -202,10 +205,19 @@ class Jetpack_Connection_Banner {
 				</span>
 			</div>
 			<div class="jp-wpcom-connect__inner-container">
-				<span
-					class="notice-dismiss connection-banner-dismiss"
-					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
-				</span>
+
+				<?php
+				if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) :
+					?>
+
+					<span
+						class="notice-dismiss connection-banner-dismiss"
+						title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
+					</span>
+
+					<?php
+				endif;
+				?>
 
 				<div class="jp-wpcom-connect__content-container">
 
@@ -295,9 +307,18 @@ class Jetpack_Connection_Banner {
 					echo $logo->render();
 					?>
 
-					<div class="jp-connect-full__dismiss">
-						<svg class="jp-connect-full__svg-dismiss" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>Dismiss Jetpack Connection Window</title><rect x="0" fill="none" /><g><path d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/></g></svg>
-					</div>
+					<?php
+					if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) :
+						?>
+
+						<div class="jp-connect-full__dismiss">
+							<svg class="jp-connect-full__svg-dismiss" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><title>Dismiss Jetpack Connection Window</title><rect x="0" fill="none" /><g><path d="M17.705 7.705l-1.41-1.41L12 10.59 7.705 6.295l-1.41 1.41L10.59 12l-4.295 4.295 1.41 1.41L12 13.41l4.295 4.295 1.41-1.41L13.41 12l4.295-4.295z"/></g></svg>
+						</div>
+
+						<?php
+					endif;
+					?>
+
 				<?php endif; ?>
 
 				<div class="jp-connect-full__step-header">
@@ -359,17 +380,27 @@ class Jetpack_Connection_Banner {
 				</div>
 
 				<?php if ( 'plugins' === $current_screen->base ) : ?>
-					<p class="jp-connect-full__dismiss-paragraph">
-						<a>
-							<?php
-							echo esc_html_x(
-								'Not now, thank you.',
-								'a link that closes the modal window that offers to connect Jetpack',
-								'jetpack'
-							);
-							?>
-						</a>
-					</p>
+
+					<?php
+					if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) :
+						?>
+
+						<p class="jp-connect-full__dismiss-paragraph">
+							<a>
+								<?php
+								echo esc_html_x(
+									'Not now, thank you.',
+									'a link that closes the modal window that offers to connect Jetpack',
+									'jetpack'
+								);
+								?>
+							</a>
+						</p>
+
+						<?php
+						endif;
+					?>
+
 				<?php endif; ?>
 			</div>
 		</div>

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -29,6 +29,22 @@ class Jetpack_Connection_Banner {
 	}
 
 	/**
+	 * The banner is forcibly displayed.
+	 *
+	 * @return bool
+	 */
+	public static function force_display() {
+		/**
+		 * This is an experiment for partners to test. Allow customization of the behavior of pre-connection banners.
+		 *
+		 * @since 8.6.0
+		 *
+		 * @param bool $always_show_prompt Should this prompt always appear? Default to false.
+		 */
+		return apply_filters( 'jetpack_pre_connection_prompt_helpers', false );
+	}
+
+	/**
 	 * Given a string for the the banner was added, and an int that represents the slide to
 	 * a URL for, this function returns a connection URL with a from parameter that will
 	 * support split testing.
@@ -69,14 +85,7 @@ class Jetpack_Connection_Banner {
 		// Kill if banner has been dismissed and the pre-connection helpers filter is not set.
 		if (
 			Jetpack_Options::get_option( 'dismissed_connection_banner' ) &&
-			/**
-			 * Allow customization of the behavior of pre-connection banners.
-			 *
-			 * @since 8.6.0
-			 *
-			 * @param bool $always_show_prompt Should the connection prompt always appear? Default to false.
-			 */
-			! apply_filters( 'jetpack_pre_connection_prompt_helpers', false )
+			! $this->force_display()
 		) {
 			return;
 		}
@@ -202,7 +211,7 @@ class Jetpack_Connection_Banner {
 	 * @since 7.2   Copy and visual elements reduced to show the new focus of Jetpack on Security and Performance.
 	 * @since 4.4.0
 	 */
-	function render_banner() {
+	public function render_banner() {
 		?>
 		<div id="message" class="updated jp-wpcom-connect__container">
 			<div class="jp-wpcom-connect__container-top-text">
@@ -214,7 +223,7 @@ class Jetpack_Connection_Banner {
 			<div class="jp-wpcom-connect__inner-container">
 
 				<?php
-				if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) :
+				if ( ! $this->force_display() ) :
 					?>
 
 					<span
@@ -315,7 +324,7 @@ class Jetpack_Connection_Banner {
 					?>
 
 					<?php
-					if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) :
+					if ( ! self::force_display() ) :
 						?>
 
 						<div class="jp-connect-full__dismiss">
@@ -389,7 +398,7 @@ class Jetpack_Connection_Banner {
 				<?php if ( 'plugins' === $current_screen->base ) : ?>
 
 					<?php
-					if ( ! apply_filters( 'jetpack_pre_connection_prompt_helpers', false ) ) :
+					if ( ! self::force_display() ) :
 						?>
 
 						<p class="jp-connect-full__dismiss-paragraph">

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -69,6 +69,13 @@ class Jetpack_Connection_Banner {
 		// Kill if banner has been dismissed and the pre-connection helpers filter is not set.
 		if (
 			Jetpack_Options::get_option( 'dismissed_connection_banner' ) &&
+			/**
+			 * Allow customization of the behavior of pre-connection banners.
+			 *
+			 * @since 8.6.0
+			 *
+			 * @param bool $always_show_prompt Should the connection prompt always appear? Default to false.
+			 */
 			! apply_filters( 'jetpack_pre_connection_prompt_helpers', false )
 		) {
 			return;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -990,7 +990,7 @@ class Jetpack {
 		// Disable the banner dismiss functionality if the pre-connection prompt helpers filter is set.
 		if (
 			isset( $_REQUEST['dismissBanner'] ) &&
-			! apply_filters( 'jetpack_pre_connection_prompt_helpers', false )
+			! Jetpack_Connection_Banner::force_display()
 		) {
 			Jetpack_Options::update_option( 'dismissed_connection_banner', 1 );
 			wp_send_json_success();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -987,7 +987,11 @@ class Jetpack {
 	function jetpack_connection_banner_callback() {
 		check_ajax_referer( 'jp-connection-banner-nonce', 'nonce' );
 
-		if ( isset( $_REQUEST['dismissBanner'] ) ) {
+		// Disable the banner dismiss functionality if the pre-connection prompt helpers filter is set.
+		if (
+			isset( $_REQUEST['dismissBanner'] ) &&
+			! apply_filters( 'jetpack_pre_connection_prompt_helpers', false )
+		) {
 			Jetpack_Options::update_option( 'dismissed_connection_banner', 1 );
 			wp_send_json_success();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Re-enabled the connection banner (or "connection prompt") and made it non-dismissable in order to force users who dismissed it to connect. This feature is enabled by setting the **jetpack_pre_connection_prompt_helpers** filter.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This is a change to the behavior of an existing feature.

#### Testing instructions:
* Create a new Jetpack site.
* Activate the JP plugin but don't connect.
* Navigate to the main wp-admin Dashboard, you will see the connection banner (the one with the green header) with the dismiss button:

<img width="1309" alt="Screen Shot 2020-05-06 at 01 17 30" src="https://user-images.githubusercontent.com/2166135/81138176-8c6abc80-8f37-11ea-9741-6e868ac174b9.png">

* Click the dismiss button, which will make the banner disappear forever.
* Apply the changes on this PR.
* Somewhere like in wp-config.php, add the following filter:
> add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
* Refresh your Dashboard.
* You should see the connection banner again, without the dismiss button:

<img width="1301" alt="Screen Shot 2020-05-05 at 23 23 26" src="https://user-images.githubusercontent.com/2166135/81138300-fc794280-8f37-11ea-947d-043386766f25.png">

#### Proposed changelog entry for your changes:
Re-enabled the connection banner and made it non-dismissable.