### PR TITLE
Search: Add boundaries to number of posts per request option

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -117,11 +117,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 		$prefix         = Jetpack_Search_Options::OPTION_PREFIX;
 		$posts_per_page = (int) get_option( 'posts_per_page' );
-		if ( $posts_per_page > 20 ) {
-			$posts_per_page = 20;
-		}
-		if ( $posts_per_page <= 0 ) {
-			// -1 is inf posts in Core WP ;)
+		if ( ( $posts_per_page > 20 ) || ( $posts_per_page <= 0 ) ) {
 			$posts_per_page = 20;
 		}
 		$options = array(

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -115,7 +115,15 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			);
 		}
 
-		$prefix  = Jetpack_Search_Options::OPTION_PREFIX;
+		$prefix         = Jetpack_Search_Options::OPTION_PREFIX;
+		$posts_per_page = (int) get_option( 'posts_per_page' );
+		if ( $posts_per_page > 20 ) {
+			$posts_per_page = 20;
+		}
+		if ( $posts_per_page <= 0 ) {
+			// -1 is inf posts in Core WP ;)
+			$posts_per_page = 20;
+		}
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -129,7 +137,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			// core config.
 			'homeUrl'               => home_url(),
 			'locale'                => str_replace( '_', '-', Jetpack_Search_Helpers::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
-			'postsPerPage'          => get_option( 'posts_per_page' ),
+			'postsPerPage'          => $posts_per_page,
 			'siteId'                => Jetpack::get_option( 'id' ),
 
 			'postTypes'             => $post_type_labels,


### PR DESCRIPTION
The wp.com api limits number of results to 20 max, so we should filter the WP Core posts_per_page setting and make sure it never exceeds 20.

#### Testing instructions:
* On a site with a JP Search plan, go to /wp-admin/options-reading.php
* Modify the "wp-admin/options-reading.php" setting and verify that different values work.
* You could also add a filter to your site to filter the `posts_per_page` option so that it returns something absurd and verify that it still works. Though it is possible WP won't.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix Instant Search bug when paging set to more than 20.
