### PR TITLE
AMP Support for Cookies and Consent

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -51,6 +51,7 @@ module.exports = [
 	'modules/theme-tools/devicepx.php',
 	'modules/verification-tools.php',
 	'modules/widgets/contact-info.php',
+	'modules/widgets/eu-cookie-law/widget-amp.php',
 	'modules/widgets/social-icons.php',
 	'modules/woocommerce-analytics.php',
 	'modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php',

--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -99,16 +99,19 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		 */
 		function enqueue_frontend_scripts() {
 			wp_enqueue_style( 'eu-cookie-law-style', plugins_url( 'eu-cookie-law/style.css', __FILE__ ), array(), '20170403' );
-			wp_enqueue_script(
-				'eu-cookie-law-script',
-				Assets::get_file_url_for_environment(
-					'_inc/build/widgets/eu-cookie-law/eu-cookie-law.min.js',
-					'modules/widgets/eu-cookie-law/eu-cookie-law.js'
-				),
-				array(),
-				'20180522',
-				true
-			);
+
+			if ( ! Jetpack_AMP_Support::is_amp_request() ) {
+				wp_enqueue_script(
+					'eu-cookie-law-script',
+					Assets::get_file_url_for_environment(
+						'_inc/build/widgets/eu-cookie-law/eu-cookie-law.min.js',
+						'modules/widgets/eu-cookie-law/eu-cookie-law.js'
+					),
+					array(),
+					'20180522',
+					true
+				);
+			}
 		}
 
 		/**
@@ -155,6 +158,11 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 			}
 
 			$instance = wp_parse_args( $instance, $this->defaults() );
+
+			if ( Jetpack_AMP_Support::is_amp_request() ) {
+				require dirname( __FILE__ ) . '/eu-cookie-law/widget-amp.php';
+				return;
+			}
 
 			$classes         = array();
 			$classes['hide'] = 'hide-on-' . esc_attr( $instance['hide'] );

--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -98,9 +98,9 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 		 * Enqueue scripts and styles.
 		 */
 		function enqueue_frontend_scripts() {
-			wp_enqueue_style( 'eu-cookie-law-style', plugins_url( 'eu-cookie-law/style.css', __FILE__ ), array(), '20170403' );
+			wp_enqueue_style( 'eu-cookie-law-style', plugins_url( 'eu-cookie-law/style.css', __FILE__ ), array(), JETPACK__VERSION );
 
-			if ( ! Jetpack_AMP_Support::is_amp_request() ) {
+			if ( ! class_exists( 'Jetpack_AMP_Support' ) || ! Jetpack_AMP_Support::is_amp_request() ) {
 				wp_enqueue_script(
 					'eu-cookie-law-script',
 					Assets::get_file_url_for_environment(
@@ -159,7 +159,7 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 
 			$instance = wp_parse_args( $instance, $this->defaults() );
 
-			if ( Jetpack_AMP_Support::is_amp_request() ) {
+			if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 				require dirname( __FILE__ ) . '/eu-cookie-law/widget-amp.php';
 				return;
 			}

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -32,7 +32,7 @@ amp-consent.widget_eu_cookie_law_widget.widget.top {
 
 .admin-bar amp-consent.widget_eu_cookie_law_widget.widget.top {
 	top: 0;
-	margin-top: 5rem;
+	margin-top: 3em;
 }
 
 #eu-cookie-law {

--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -25,6 +25,16 @@
 	top: 3em;
 }
 
+amp-consent.widget_eu_cookie_law_widget.widget.top {
+	top: 1em;
+	margin: 0;
+}
+
+.admin-bar amp-consent.widget_eu_cookie_law_widget.widget.top {
+	top: 0;
+	margin-top: 5rem;
+}
+
 #eu-cookie-law {
 	background-color: #fff;
 	border: 1px solid #dedede;

--- a/modules/widgets/eu-cookie-law/widget-amp.php
+++ b/modules/widgets/eu-cookie-law/widget-amp.php
@@ -1,0 +1,38 @@
+<?php // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+/**
+ * AMP Widget for Cookies and Consent.
+ *
+ * @package Jetpack
+ */
+?>
+
+<amp-consent id="eu-cookie-consent" layout="nodisplay" class="widget widget_eu_cookie_law_widget<?php echo esc_attr( ! empty( $instance['position'] ) && 'top' === $instance['position'] ? ' top' : '' ); ?>">
+	<script type="application/json">
+		{
+			"consentInstanceId": "eu-cookie-consent",
+			"consentRequired": true,
+			"promptUI": "eu-cookie-consent-prompt"
+		}
+	</script>
+	<div class="popupOverlay" id="eu-cookie-consent-prompt">
+		<div class="consentPopup<?php echo esc_attr( ! empty( $instance['color-scheme'] ) && 'negative' === $instance['color-scheme'] ? ' negative' : '' ); ?>" id="eu-cookie-law">
+			<form>
+				<input type="button" on="tap:eu-cookie-consent.accept" class="accept" value="<?php echo esc_attr( $instance['button'] ); ?>" />
+			</form>
+			<?php
+			if ( 'default' === $instance['text'] || empty( $instance['customtext'] ) ) {
+				echo wp_kses_post( nl2br( $instance['default-text'] ) );
+			} else {
+				echo esc_html( $instance['customtext'] );
+			}
+
+			$policy_link_text = 'default' === $instance['policy-url'] || empty( $instance['custom-policy-url'] )
+					? $instance['default-policy-url']
+					: $instance['custom-policy-url'];
+			?>
+			<a href="<?php echo esc_url( $policy_link_text ); ?>">
+				<?php echo esc_html( $instance['policy-link-text'] ); ?>
+			</a>
+		</div>
+	</div>
+</amp-consent>


### PR DESCRIPTION
Adds an `amp-consent` component when the AMP site is being viewed based on the Cookies and Consent widget settings.

Fixes #14398 (EU Cookie Law Widget)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This enhances an existing feature.

#### Testing instructions:
* Ensure the [AMP plugin](https://wordpress.org/plugins/amp/) is active
* In AMP > Settings, select Transitional mode
* Enable the extra widgets in Jetpack > Settings > Writing > Widgets
* Add the Cookies & Consents Banner (Jetpack) widget to a sidebar on your theme
<img width="1310" alt="Screenshot 2020-05-08 at 13 34 32" src="https://user-images.githubusercontent.com/49400/81401998-d5399580-9130-11ea-8c09-9173f8c7449b.png">
* Customise the widget options as desired
* Go to the AMP frontend by adding `?amp` to the end of your site url and ensure the consent banner shows up and is customised as per the options selected on the widget.
<img width="1200" alt="Screenshot 2020-05-08 at 13 38 16" src="https://user-images.githubusercontent.com/49400/81402172-2fd2f180-9131-11ea-9393-05e861ef2b12.png">

#### Additional considerations

I was able to apply most of the settings from the widget to the AMP version of the widget, however the the AMP Consent tag does now allow us to expire after a certain number of days, unless we do server side consent and not client side.

Additionally, the is an option to accept consent on first scroll or after a certain amount of time has passed. However, with AMP we would be able to hide the notice on the above parameters, but there does not appear to be a way to hide and accept the notice. So even though it disappears, the consent would not have been accepted.

I feel for AMP, we should just force the user to click Accept for the modal to be removed. Here are the options I'm talking about:

<img width="432" alt="Screenshot 2020-05-08 at 13 39 18" src="https://user-images.githubusercontent.com/49400/81402250-52fda100-9131-11ea-838f-944f6023fc90.png">

Lastly, there are no widget areas on the "Reader" mode template. So it's not possible to add this. widget to that theme unless a user customises the theme and adds widget areas.