### PR TITLE
Tasks: add task to lint a single js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
 		"docker:update-core-unit-tests": "yarn docker:compose exec wordpress svn up /tmp/wordpress-develop/tests/phpunit/data/ /tmp/wordpress-develop/tests/phpunit/includes",
 		"lint": "eslint --ext .js,.jsx . _inc extensions modules",
+		"lint-file": "eslint --ext .js,.jsx",
 		"php:compatibility": "composer php:compatibility",
 		"php:lint": "composer php:lint",
 		"php:autofix": "composer php:autofix",


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Sometimes you need to check for linting errors in a single file in the codebase. We currently do not have that option, unless you have your editor set up and can view linting errors there. This simple task should give us that option.

#### Testing instructions:

* Try `yarn lint-file _inc/client/admin.js`
* Add code that will triggered a linting error to that file.
* Run the above again.
* You should get something like this:

![image](https://user-images.githubusercontent.com/426388/81418990-d2996900-914d-11ea-8b80-769a3955ed54.png)


#### Proposed changelog entry for your changes:

* N/A
