### PR TITLE
Jetpack Sync :: Alternate non-blocking flow

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -301,6 +301,7 @@ class Jetpack_JSON_API_Sync_Checkout_Endpoint extends Jetpack_JSON_API_Sync_Endp
 
 class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoint {
 	protected function result() {
+
 		$request_body = $this->input();
 		$queue_name = $this->validate_queue( $request_body['queue'] );
 

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -317,10 +317,12 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 
 		$items = $queue->peek_by_id( $request_body['item_ids'] );
 
-		/** This action is documented in packages/sync/src/modules/Full_Sync.php */
-		$full_sync_module = Modules::get_module( 'full-sync' );
+		// Update Full Sync Status if queue is "full_sync".
+		if ( 'full_sync' === $queue_name ) {
+			$full_sync_module = Modules::get_module( 'full-sync' );
 
-		$full_sync_module->update_sent_progress_action( $items );
+			$full_sync_module->update_sent_progress_action( $items );
+		}
 
 		$buffer = new Queue_Buffer( $request_body['buffer_id'], $request_body['item_ids'] );
 		$response = $queue->close( $buffer, $request_body['item_ids'] );

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -336,7 +336,7 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 		$response = $queue->close( $buffer, $request_body['item_ids'] );
 
 		// Perform another checkout?
-		if ( $request_body['continue'] ) {
+		if ( isset( $request_body['continue'] ) && $request_body['continue'] ) {
 			if ( in_array( $queue_name, array( 'full_sync', 'immediate' ), true ) ) {
 				// Send Full Sync Actions.
 				Sender::get_instance()->do_full_sync();

--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -336,7 +336,6 @@ class Jetpack_JSON_API_Sync_Close_Endpoint extends Jetpack_JSON_API_Sync_Endpoin
 
 		// Perform another checkout?
 		if ( $request_body['continue'] ) {
-
 			if ( in_array( $queue_name, array( 'full_sync', 'immediate' ), true ) ) {
 				// Send Full Sync Actions.
 				Sender::get_instance()->do_full_sync();

--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -710,8 +710,9 @@ new Jetpack_JSON_API_Sync_Close_Endpoint( array(
 	),
 	'request_format' => array(
 		'item_ids'  => '(array) Item IDs to delete from the queue.',
-		'queue'      => '(string) sync or full_sync',
-		'buffer_id'  => '(string) buffer ID that was opened during the checkout step.',
+		'queue'     => '(string) sync or full_sync',
+		'buffer_id' => '(string) buffer ID that was opened during the checkout step.',
+		'continue'  => '(bool=false) Perform another checkout from queue.',
 	),
 	'response_format' => array(
 		'success' => '(bool) Closed the buffer successfully?'

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -312,7 +312,7 @@ class Actions {
 			array(
 				'url'     => $url,
 				'user_id' => JETPACK_MASTER_USER,
-				'timeout' => $query_args['timeout'],
+				'timeout' => 0.01,
 			)
 		);
 

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -261,9 +261,10 @@ class Actions {
 	 * @param float  $checkout_duration      Time spent retrieving queue items from the DB.
 	 * @param float  $preprocess_duration    Time spent converting queue items into data to send.
 	 * @param int    $queue_size             The size of the sync queue at the time of processing.
+	 * @param string $buffer_id              The ID of the Queue buffer checked out for processing.
 	 * @return Jetpack_Error|mixed|WP_Error  The result of the sending request.
 	 */
-	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration, $queue_size = null ) {
+	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration, $queue_size = null, $buffer_id = null ) {
 		$query_args = array(
 			'sync'       => '1',             // Add an extra parameter to the URL so we can tell it's a sync action.
 			'codec'      => $codec_name,
@@ -274,6 +275,7 @@ class Actions {
 			'cd'         => sprintf( '%.4f', $checkout_duration ),
 			'pd'         => sprintf( '%.4f', $preprocess_duration ),
 			'queue_size' => $queue_size,
+			'buffer_id'  => $buffer_id,
 		);
 
 		// Has the site opted in to IDC mitigation?
@@ -312,7 +314,7 @@ class Actions {
 			array(
 				'url'     => $url,
 				'user_id' => JETPACK_MASTER_USER,
-				'timeout' => 0.01,
+				'timeout' => $query_args['timeout'],
 			)
 		);
 
@@ -508,7 +510,7 @@ class Actions {
 	 */
 	public static function initialize_sender() {
 		self::$sender = Sender::get_instance();
-		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 7 );
+		add_filter( 'jetpack_sync_send_data', array( __CLASS__, 'send_data' ), 10, 8 );
 	}
 
 	/**

--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -159,6 +159,7 @@ class Defaults {
 		'site_vertical',
 		'jetpack_excluded_extensions',
 		'jetpack_publicize_options',
+		'jetpack_sync_non_blocking', // is non-blocking Jetpack Sync flow enabled.
 	);
 
 	/**

--- a/packages/sync/src/class-main.php
+++ b/packages/sync/src/class-main.php
@@ -45,6 +45,25 @@ class Main {
 		Sync_Actions::initialize_woocommerce();
 		Sync_Actions::initialize_wp_super_cache();
 
+		// Enable non-blocking Jetpack Sync flow.
+		$non_block_enabled = get_option( 'jetpack_sync_non_blocking', false );
+
+		/**
+		 * Filters the option to enable non-blocking sync.
+		 *
+		 * Default value is false, filter to true to enable non-blocking mode which will have
+		 * WP.com return early and use the sync/close endpoint to check-in processed items.
+		 *
+		 * @since 8.6.0
+		 *
+		 * @param false $enabled Should non-blocking flow be enabled.
+		 */
+		$filtered = (array) apply_filters( 'jetpack_sync_non_blocking', false );
+
+		if ( is_bool( $filtered ) && $non_block_enabled !== $filtered ) {
+			update_option( 'jetpack_sync_non_blocking', $filtered, false );
+		}
+
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Automattic\\Jetpack\\Sync\\Actions', 'cleanup_on_upgrade' ), 10, 2 );
 	}

--- a/packages/sync/src/class-main.php
+++ b/packages/sync/src/class-main.php
@@ -45,25 +45,6 @@ class Main {
 		Sync_Actions::initialize_woocommerce();
 		Sync_Actions::initialize_wp_super_cache();
 
-		// Enable non-blocking Jetpack Sync flow.
-		$non_block_enabled = get_option( 'jetpack_sync_non_blocking', false );
-
-		/**
-		 * Filters the option to enable non-blocking sync.
-		 *
-		 * Default value is false, filter to true to enable non-blocking mode which will have
-		 * WP.com return early and use the sync/close endpoint to check-in processed items.
-		 *
-		 * @since 8.6.0
-		 *
-		 * @param false $enabled Should non-blocking flow be enabled.
-		 */
-		$filtered = (array) apply_filters( 'jetpack_sync_non_blocking', false );
-
-		if ( is_bool( $filtered ) && $non_block_enabled !== $filtered ) {
-			update_option( 'jetpack_sync_non_blocking', $filtered, false );
-		}
-
 		// We need to define this here so that it's hooked before `updating_jetpack_version` is called.
 		add_action( 'updating_jetpack_version', array( 'Automattic\\Jetpack\\Sync\\Actions', 'cleanup_on_upgrade' ), 10, 2 );
 	}
@@ -79,6 +60,26 @@ class Main {
 		 * with a high priority or sites that use alternate cron.
 		 */
 		Sync_Actions::init();
+
+		// Enable non-blocking Jetpack Sync flow.
+		$non_block_enabled = (bool) get_option( 'jetpack_sync_non_blocking', false );
+
+		/**
+		 * Filters the option to enable non-blocking sync.
+		 *
+		 * Default value is false, filter to true to enable non-blocking mode which will have
+		 * WP.com return early and use the sync/close endpoint to check-in processed items.
+		 *
+		 * @since 8.6.0
+		 *
+		 * @param bool $enabled Should non-blocking flow be enabled.
+		 */
+		$filtered = (bool) apply_filters( 'jetpack_sync_non_blocking', $non_block_enabled );
+
+		if ( $non_block_enabled !== $filtered ) {
+			update_option( 'jetpack_sync_non_blocking', $filtered, false );
+		}
+
 		// Initialize health-related hooks after plugins have loaded.
 		Health::init();
 	}

--- a/packages/sync/src/class-queue.php
+++ b/packages/sync/src/class-queue.php
@@ -389,8 +389,6 @@ class Queue {
 		$this->delete_checkout_id();
 
 		// By default clear all items in the buffer.
-		// TODO this should run even when the buffer is no longer valid.
-		// They were processed by WP.com so even if the lock is gone it should ensure items are removed from queue.
 		if ( is_null( $ids_to_remove ) ) {
 			$ids_to_remove = $buffer->get_item_ids();
 		}

--- a/packages/sync/src/class-queue.php
+++ b/packages/sync/src/class-queue.php
@@ -389,6 +389,8 @@ class Queue {
 		$this->delete_checkout_id();
 
 		// By default clear all items in the buffer.
+		// TODO this should run even when the buffer is no longer valid.
+		// They were processed by WP.com so even if the lock is gone it should ensure items are removed from queue.
 		if ( is_null( $ids_to_remove ) ) {
 			$ids_to_remove = $buffer->get_item_ids();
 		}

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -526,6 +526,7 @@ class Sender {
 				}
 			}
 		}
+
 		return true;
 	}
 

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -431,6 +431,7 @@ class Sender {
 		if ( $queue->size() === 0 ) {
 			return new \WP_Error( 'empty_queue_' . $queue->id );
 		}
+
 		/**
 		 * Now that we're sure we are about to sync, try to ignore user abort
 		 * so we can avoid getting into a bad state.
@@ -477,7 +478,7 @@ class Sender {
 			 * @param int    $queue_size The size of the sync queue at the time of processing.
 			 */
 			Settings::set_is_sending( true );
-			$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id, $checkout_duration, $preprocess_duration, $queue->size() );
+			$processed_item_ids = apply_filters( 'jetpack_sync_send_data', $items_to_send, $this->codec->name(), microtime( true ), $queue->id, $checkout_duration, $preprocess_duration, $queue->size(), $buffer->id );
 			Settings::set_is_sending( false );
 		} else {
 			$processed_item_ids = $skipped_items_ids;

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -204,6 +204,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_excluded_extensions'              => 'pineapple',
 			'jetpack-memberships-connected-account-id' => '340',
 			'jetpack_publicize_options'                => array(),
+			'jetpack_sync_non_blocking'                => false,
 		);
 
 		$theme_mod_key             = 'theme_mods_' . get_option( 'stylesheet' );


### PR DESCRIPTION
Jetpack Sync currently functions by making a remote call to WP.com to process actions and awaits the response. Within profiling tools (New Relic, etc) the shutdown action continually gets flagged as an issue as these requests can take 10+ seconds. In addition the request can time out which then causes the actions to be re-sent.

With the non-blocking flow WP.com returns early so that the remote server is not waiting for a response. Instead when WP.com finishes processing the actions it makes a call to the sync/close endpoint to check-in the processed data. In addition the check-in will trigger sending the next payload to WP.com which will help move the queue for site's with limited traffic and other scenarios.

This feature is opt-in and requires the below code to enable.

```add_filter( 'jetpack_sync_non_blocking', '__return_true' );``` 

#### Changes proposed in this Pull Request:
* non-blocking Jetpack Sync flow to reduce footprint on remote servers.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Enhancement to stability of Jetpack Sync 

#### Testing instructions:

Requires a WP.com Sandbox to enable functionality

1) Apply D43022 to your WP.com Sandbox
2) Update your Jetpack site so that the Jetpack connection is sandboxed to your WP.com Sandbox
define( 'JETPACK__SANDBOX_DOMAIN', '*****.wordpress.com' );
3) Install latest version of Jetpack with this PR applied 
4) Enable the non-blocking flow by adding the following snippet to your site.
`add_filter( 'jetpack_sync_non_blocking', '__return_true' );`

#### Proposed changelog entry for your changes:
* Optimizing Jetpack Sync by minimizing footprint on servers by having actions processed by WP.com async(non-blocking) which allows the process to complete and be used by other requests.
To enable this feature users will need to add `add_filter( 'jetpack_sync_non_blocking', '__return_true' );` to their site's functions.php or appropriate code file.
