### PR TITLE
Debugger: Remove return for hiding in site health.

### DIFF
--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -35,7 +35,24 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 
 		$core_tests['direct'][ $test['name'] ] = array(
 			'label' => __( 'Jetpack: ', 'jetpack' ) . $test['name'],
-			'test'  => function() use ( $test, $cxn_tests ) { // phpcs:ignore PHPCompatibility.FunctionDeclarations.NewClosure.Found
+			/**
+			 * Callable for Core's Site Health system to execute.
+			 *
+			 * @param array $test A Jetpack Testing Suite test array.
+			 * @param Jetpack_Cxn_Tests $cxn_tests An instance of the Jetpack Test Suite.
+			 *
+			 * @return array {
+			 *      A results array to match the format expected by WordPress Core.
+			 *
+			 *      @type string $label Name for the test.
+			 *      @type string $status 'critical', 'recommended', or 'good'.
+			 *      @type array $badge Array for Site Health status. Keys label and color.
+			 *      @type string $description Description of the test result.
+			 *      @type string $action HTML to a link to resolve issue.
+			 *      @type string $test Unique test identifier.
+			 *  }
+			 */
+			'test'  => function() use ( $test, $cxn_tests ) {
 				$results = $cxn_tests->run_test( $test['name'] );
 				if ( is_wp_error( $results ) ) {
 					return;

--- a/_inc/lib/debugger/debug-functions.php
+++ b/_inc/lib/debugger/debug-functions.php
@@ -41,10 +41,6 @@ function jetpack_debugger_site_status_tests( $core_tests ) {
 					return;
 				}
 
-				if ( isset( $results['show_in_site_health'] ) && false === $results['show_in_site_health'] ) {
-					return;
-				}
-
 				$label = $results['label'] ?
 					$results['label'] :
 					ucwords(


### PR DESCRIPTION
In #14901, an early return was added for test results that are marked to hide from Site Health.

This is problematic because site health keeps the test item present, but now with an empty result, which causes Core to JS fatal as described in https://github.com/Automattic/jetpack/issues/15709#issuecomment-625496903.

This is a bit of a pickle since for Core, we're just passing the knowledge of a test and the callable used to run the test itself. In our test, Jetpack was changing the value of `show_in_site_health` based on the test results, so the test is still existing in the test array.

I was able to "fix" this by, in the scope of our filter adding the tests, to run each test and if the result returned was a known value to indicate it should be skipped, unset it from the array, but that requires all of the tests to *run* whenever WordPress is seeking the list of tests.

In effect, each test would then be running a minimum of twice -- once when the list is being pulled and then again when the test is actually intended to run. 

I'm not extremely happy with the options I've thought about to resolve this while maintaining functionality:
* Go back to a singleton approach where the tests run once and those same results are used multiple times. That would allow us to run our tests once early, then have those results available when inserting our specific tests into the Core list.
* The previous mentioned method of running the tests when adding them and then selectively unset them if we've decided to skip them.

I'm leaning towards removing the feature to remove a test and opt instead to better describe the tests. All of these tests contribute to Site Health in some way and I'm personally unsure of the benefit of selectively removing them, vs improving the text surrounding them. If nothing else, improve the names of the tests.

This is a long-winded way of saying that in this PR, I am removing the early return to fix the JS fatal so this can go into a point release, but an actual resolution will require more work than I'm comfortable shipping in a potential point release.

Fixes #15709

#### Changes proposed in this Pull Request:
* Remove the early return for results marked to hide from site health.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* A Jetpack site that is connected and sync is functional.
* Confirm that a Full Sync is not in progress.
* Check Core's site health before and after the patch.
* Before, see the JS error in the console and see that Site Health never indicates the site's status (at the top of the page).
* After, it completes without error and "finishes".

#### Proposed changelog entry for your changes:
* Debugger: Correct issue that prevented the WordPress Site Health area from completing all checks.
