### PR TITLE
Instant Search: Migrate settings from widgets into the customizer

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -47,6 +47,7 @@ module.exports = [
 	'modules/search/class-jetpack-search-customize.php',
 	'modules/search/class.jetpack-search-options.php',
 	'modules/search/class.jetpack-search.php',
+	'modules/search/customize-controls/class-label-control.php',
 	'modules/sharedaddy.php',
 	'modules/shortcodes/',
 	'modules/sitemaps/sitemaps.php',

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -107,7 +107,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		}
 		unset( $filter );
 
-		$post_type_objs   = get_post_types( array(), 'objects' );
+		$post_type_objs   = get_post_types( array( 'exclude_from_search' => false ), 'objects' );
 		$post_type_labels = array();
 		foreach ( $post_type_objs as $key => $obj ) {
 			$post_type_labels[ $key ] = array(

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -121,10 +121,19 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		if ( ( $posts_per_page > 20 ) || ( $posts_per_page <= 0 ) ) {
 			$posts_per_page = 20;
 		}
+
+		$enabled_post_types = array();
+		foreach ( Jetpack_Search_Helpers::generate_post_type_customizer_ids() as $post_type => $customizer_key ) {
+			if ( (bool) get_option( $customizer_key, true ) ) {
+				$enabled_post_types[] = $post_type;
+			}
+		}
+
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
 				'enableInfScroll' => (bool) get_option( $prefix . 'inf_scroll', false ),
+				'enableSort'      => (bool) get_option( $prefix . 'enable_sort', true ),
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
 				'opacity'         => (int) get_option( $prefix . 'opacity', 97 ),
 				'overlayTrigger'  => get_option( $prefix . 'overlay_trigger', 'immediate' ),
@@ -136,8 +145,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'locale'                => str_replace( '_', '-', Jetpack_Search_Helpers::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
 			'postsPerPage'          => $posts_per_page,
 			'siteId'                => Jetpack::get_option( 'id' ),
-
 			'postTypes'             => $post_type_labels,
+
+			// search options.
+			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
+			'enabledPostTypes'      => $enabled_post_types,
+
+			// widget info.
 			'widgets'               => array_values( $widgets ),
 			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
 		);

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -83,8 +83,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$widget_options = end( $widget_options );
 		}
 
-		$overlay_widget_ids      = array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
-			get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'] : array();
+		$overlay_widget_ids      = is_active_sidebar( 'jetpack-instant-search-sidebar' ) ?
+			wp_get_sidebars_widgets()['jetpack-instant-search-sidebar'] : array();
 		$filters                 = Jetpack_Search_Helpers::get_filters_from_widgets();
 		$widgets                 = array();
 		$widgets_outside_overlay = array();

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Constants;
+require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
 
 /**
  * Class to load Instant Search experience on the site.
@@ -62,13 +63,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			return;
 		}
 
-		$script_version = self::get_asset_version( $script_relative_path );
+		$script_version = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
 		$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
 
-		$style_version = self::get_asset_version( $style_relative_path );
+		$style_version = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
 		$style_path    = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
 		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
 	}
@@ -191,18 +192,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 */
 	public function load_and_initialize_tracks() {
 		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
-	}
-
-	/**
-	 * Get the version number to use when loading the file. Allows us to bypass cache when developing.
-	 *
-	 * @param string $file Path of the file we are looking for.
-	 * @return string $script_version Version number.
-	 */
-	public static function get_asset_version( $file ) {
-		return Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $file )
-			? filemtime( JETPACK__PLUGIN_DIR . $file )
-			: JETPACK__VERSION;
 	}
 
 	/**

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -122,13 +122,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$posts_per_page = 20;
 		}
 
-		$enabled_post_types = array();
-		foreach ( Jetpack_Search_Helpers::generate_post_type_customizer_ids() as $post_type => $customizer_key ) {
-			if ( (bool) get_option( $customizer_key, true ) ) {
-				$enabled_post_types[] = $post_type;
-			}
-		}
-
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -149,7 +142,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
-			'enabledPostTypes'      => $enabled_post_types,
 
 			// widget info.
 			'widgets'               => array_values( $widgets ),

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -10,7 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
 require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
+require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
 
 /**
  * Class to customize search on the site.
@@ -42,10 +44,9 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_section(
 			$section_id,
 			array(
-				'title'       => esc_html__( 'Jetpack Search', 'jetpack' ),
-				'description' => __( 'Use these settings to customize the search overlay.', 'jetpack' ),
-				'capability'  => 'edit_theme_options',
-				'priority'    => 200,
+				'title'      => esc_html__( 'Jetpack Search', 'jetpack' ),
+				'capability' => 'edit_theme_options',
+				'priority'   => 200,
 			)
 		);
 
@@ -62,13 +63,36 @@ class Jetpack_Search_Customize {
 			$id,
 			array(
 				'label'       => __( 'Theme', 'jetpack' ),
-				'description' => __( 'A light or dark theme for your search overlay.', 'jetpack' ),
+				'description' => __( 'Select a theme for your search overlay.', 'jetpack' ),
 				'section'     => $section_id,
 				'type'        => 'radio',
 				'choices'     => array(
 					'light' => __( 'Light', 'jetpack' ),
 					'dark'  => __( 'Dark', 'jetpack' ),
 				),
+			)
+		);
+
+		$id = $setting_prefix . 'default_sort';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default' => 'relevance',
+				'type'    => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'choices'     => array(
+					'relevance' => __( 'Relevance (recommended)', 'jetpack' ),
+					'newest'    => __( 'Newest first', 'jetpack' ),
+					'oldest'    => __( 'Oldest first', 'jetpack' ),
+				),
+				'description' => __( 'Pick the initial sort for your search results.', 'jetpack' ),
+				'label'       => __( 'Default Sort', 'jetpack' ),
+				'section'     => $section_id,
+				'type'        => 'select',
 			)
 		);
 
@@ -84,8 +108,8 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_control(
 			$id,
 			array(
-				'label'       => __( 'Overlay Trigger', 'jetpack' ),
-				'description' => __( 'Choose when the search overlay should appear.', 'jetpack' ),
+				'label'       => __( 'Search Overlay Trigger', 'jetpack' ),
+				'description' => __( 'Select when your overlay should appear.', 'jetpack' ),
 				'section'     => $section_id,
 				'type'        => 'select',
 				'choices'     => array(
@@ -110,7 +134,7 @@ class Jetpack_Search_Customize {
 				'type'        => 'range',
 				'section'     => $section_id,
 				'label'       => __( 'Background Opacity', 'jetpack' ),
-				'description' => __( 'Select an opacity for the search overlay.', 'jetpack' ),
+				'description' => __( 'Select an opacity for your search overlay.', 'jetpack' ),
 				'input_attrs' => array(
 					'min'  => 85,
 					'max'  => 100,
@@ -137,6 +161,76 @@ class Jetpack_Search_Customize {
 					'description' => __( 'Choose a color to highlight matching search terms.', 'jetpack' ),
 					'section'     => $section_id,
 				)
+			)
+		);
+
+		$id = $setting_prefix . 'post_types_title_placeholder';
+		$wp_customize->add_setting(
+			$id,
+			array( 'type' => 'option' )
+		);
+		$wp_customize->add_control(
+			new Label_Control(
+				$wp_customize,
+				$id,
+				array(
+					'description' => __( 'Choose post types to include in search results.', 'jetpack' ),
+					'label'       => __( 'Searchable Post Types', 'jetpack' ),
+					'section'     => $section_id,
+				)
+			)
+		);
+
+		foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) {
+			$id = Jetpack_Search_Helpers::generate_post_type_customizer_id( $post_type );
+			$wp_customize->add_setting(
+				$id,
+				array(
+					'default' => true,
+					'type'    => 'option',
+				)
+			);
+			$wp_customize->add_control(
+				$id,
+				array(
+					'label'   => $post_type->label,
+					'section' => $section_id,
+					'type'    => 'checkbox',
+				)
+			);
+		}
+
+		$id = $setting_prefix . 'additional_settings_placeholder';
+		$wp_customize->add_setting(
+			$id,
+			array( 'type' => 'option' )
+		);
+		$wp_customize->add_control(
+			new Label_Control(
+				$wp_customize,
+				$id,
+				array(
+					'label'   => __( 'Additional Jetpack Search Settings', 'jetpack' ),
+					'section' => $section_id,
+				)
+			)
+		);
+
+		$id = $setting_prefix . 'enable_sort';
+		$wp_customize->add_setting(
+			$id,
+			array(
+				'default'   => true,
+				'transport' => 'postMessage',
+				'type'      => 'option',
+			)
+		);
+		$wp_customize->add_control(
+			$id,
+			array(
+				'label'   => __( 'Show Sort Selector', 'jetpack' ),
+				'section' => $section_id,
+				'type'    => 'checkbox',
 			)
 		);
 

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -164,42 +164,6 @@ class Jetpack_Search_Customize {
 			)
 		);
 
-		$id = $setting_prefix . 'post_types_title_placeholder';
-		$wp_customize->add_setting(
-			$id,
-			array( 'type' => 'option' )
-		);
-		$wp_customize->add_control(
-			new Label_Control(
-				$wp_customize,
-				$id,
-				array(
-					'description' => __( 'Choose post types to include in search results.', 'jetpack' ),
-					'label'       => __( 'Searchable Post Types', 'jetpack' ),
-					'section'     => $section_id,
-				)
-			)
-		);
-
-		foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) {
-			$id = Jetpack_Search_Helpers::generate_post_type_customizer_id( $post_type );
-			$wp_customize->add_setting(
-				$id,
-				array(
-					'default' => true,
-					'type'    => 'option',
-				)
-			);
-			$wp_customize->add_control(
-				$id,
-				array(
-					'label'   => $post_type->label,
-					'section' => $section_id,
-					'type'    => 'checkbox',
-				)
-			);
-		}
-
 		$id = $setting_prefix . 'additional_settings_placeholder';
 		$wp_customize->add_setting(
 			$id,

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -700,4 +700,18 @@ class Jetpack_Search_Helpers {
 		}
 		return false !== GP_Locales::by_field( 'wp_locale', $locale );
 	}
+
+	/**
+	 * Get the version number to use when loading the file. Allows us to bypass cache when developing.
+	 *
+	 * @since 8.6.0
+	 * @param string $file Path of the file we are looking for.
+	 * @return string $script_version Version number.
+	 */
+	public static function get_asset_version( $file ) {
+		return Jetpack::is_development_version() && file_exists( JETPACK__PLUGIN_DIR . $file )
+			? filemtime( JETPACK__PLUGIN_DIR . $file )
+			: JETPACK__VERSION;
+	}
+
 }

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -714,4 +714,27 @@ class Jetpack_Search_Helpers {
 			: JETPACK__VERSION;
 	}
 
+	/**
+	 * Generates a customizer settings ID for a given post type.
+	 *
+	 * @since 8.6.0
+	 * @param object $post_type Post type object returned from get_post_types.
+	 * @return string $customizer_id Customizer setting ID.
+	 */
+	public static function generate_post_type_customizer_id( $post_type ) {
+		return Jetpack_Search_Options::OPTION_PREFIX . 'enable_post_type_' . $post_type->name;
+	}
+
+	/**
+	 * Generates an array of post types associated with their customizer IDs.
+	 *
+	 * @since 8.6.0
+	 * @return array $ids Post type => post type customizer ID object.
+	 */
+	public static function generate_post_type_customizer_ids() {
+		return array_map(
+			array( 'self', 'generate_post_type_customizer_id' ),
+			get_post_types( array( 'exclude_from_search' => false ), 'objects' )
+		);
+	}
 }

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -713,28 +713,4 @@ class Jetpack_Search_Helpers {
 			? filemtime( JETPACK__PLUGIN_DIR . $file )
 			: JETPACK__VERSION;
 	}
-
-	/**
-	 * Generates a customizer settings ID for a given post type.
-	 *
-	 * @since 8.6.0
-	 * @param object $post_type Post type object returned from get_post_types.
-	 * @return string $customizer_id Customizer setting ID.
-	 */
-	public static function generate_post_type_customizer_id( $post_type ) {
-		return Jetpack_Search_Options::OPTION_PREFIX . 'enable_post_type_' . $post_type->name;
-	}
-
-	/**
-	 * Generates an array of post types associated with their customizer IDs.
-	 *
-	 * @since 8.6.0
-	 * @return array $ids Post type => post type customizer ID object.
-	 */
-	public static function generate_post_type_customizer_ids() {
-		return array_map(
-			array( 'self', 'generate_post_type_customizer_id' ),
-			get_post_types( array( 'exclude_from_search' => false ), 'objects' )
-		);
-	}
 }

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -261,7 +261,7 @@ class Jetpack_Search_Template_Tags {
 
 		$fields_to_inject = array(
 			'orderby' => $orderby,
-			'order'   => $order
+			'order'   => $order,
 		);
 
 		// If the widget has specified post types to search within and IF the post types differ
@@ -276,6 +276,27 @@ class Jetpack_Search_Template_Tags {
 		echo '<div class="jetpack-search-form">';
 		echo $form;
 		echo '</div>';
+	}
+
+	/**
+	 * Renders the search box for the Instant Search version of the Jetpack Search widget on the frontend.
+	 *
+	 * @since 8.6.0
+	 *
+	 * @param array $post_types_whitelist Array of post types to limit search results to.
+	 */
+	public static function render_instant_widget_search_form( $post_types_whitelist ) {
+		$form = get_search_form( false );
+
+		if ( ! empty( $post_types_whitelist ) ) {
+			$form = str_replace(
+				'<form',
+				'<form data-post-type-whitelist=' . rawurlencode( wp_json_encode( $post_types_whitelist ) ),
+				$form
+			);
+		}
+
+		echo '<div class="jetpack-search-form">' . $form . '</div>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/modules/search/customize-controls/class-label-control.css
+++ b/modules/search/customize-controls/class-label-control.css
@@ -1,3 +1,7 @@
+#sub-accordion-section-jetpack_search .customize-control {
+  margin-bottom: 14px;
+}
+
 #sub-accordion-section-jetpack_search .customize-label-control,
 #sub-accordion-section-jetpack_search .customize-control-checkbox {
   margin-bottom: 0;
@@ -5,4 +9,10 @@
 
 #sub-accordion-section-jetpack_search .customize-control-checkbox ~ .customize-label-control {
   margin-top: 12px;
+}
+
+#sub-accordion-section-jetpack_search .customize-control-radio {
+  margin-bottom: 6px;
+  padding-bottom: 0;
+  padding-top: 0;
 }

--- a/modules/search/customize-controls/class-label-control.css
+++ b/modules/search/customize-controls/class-label-control.css
@@ -1,0 +1,8 @@
+#sub-accordion-section-jetpack_search .customize-label-control,
+#sub-accordion-section-jetpack_search .customize-control-checkbox {
+  margin-bottom: 0;
+}
+
+#sub-accordion-section-jetpack_search .customize-control-checkbox ~ .customize-label-control {
+  margin-top: 12px;
+}

--- a/modules/search/customize-controls/class-label-control.php
+++ b/modules/search/customize-controls/class-label-control.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * A label-only Customizer control for use with Jetpack Search configuration
+ *
+ * @package jetpack
+ * @since 8.6.0
+ */
+
+/**
+ * Label Control class.
+ */
+class Label_Control extends WP_Customize_Control {
+	/**
+	 * Enqueue styles related to this control.
+	 */
+	public function enqueue() {
+		require_once dirname( dirname( __FILE__ ) ) . '/class.jetpack-search-helpers.php';
+		$style_relative_path = 'modules/search/customize-controls/label-control.css';
+		$style_version       = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
+		$style_path          = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
+	}
+
+	/**
+	 * Override rendering for custom class name; omit element ID.
+	 */
+	protected function render() {
+		echo '<li class="customize-control customize-label-control">';
+		$this->render_content();
+		echo '</li>';
+	}
+
+	/**
+	 * Override content rendering.
+	 */
+	protected function render_content() {
+		if ( ! empty( $this->label ) ) : ?>
+			<label class="customize-control-title">
+				<?php echo esc_html( $this->label ); ?>
+			</label>
+		<?php endif; ?>
+		<?php if ( ! empty( $this->description ) ) : ?>
+			<span class="description customize-control-description">
+				<?php echo esc_html( $this->description ); ?>
+			</span>
+		<?php endif;
+	}
+}
+?>

--- a/modules/search/customize-controls/class-label-control.php
+++ b/modules/search/customize-controls/class-label-control.php
@@ -15,7 +15,7 @@ class Label_Control extends WP_Customize_Control {
 	 */
 	public function enqueue() {
 		require_once dirname( dirname( __FILE__ ) ) . '/class.jetpack-search-helpers.php';
-		$style_relative_path = 'modules/search/customize-controls/label-control.css';
+		$style_relative_path = 'modules/search/customize-controls/class-label-control.css';
 		$style_version       = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
 		$style_path          = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
 		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -128,6 +128,8 @@ class SearchApp extends Component {
 		document.body.style.overflowY = null;
 	}
 
+	getSort = () => getSortQuery( this.props.initialSort );
+
 	hasActiveQuery() {
 		return getSearchQuery() !== '' || hasFilter();
 	}
@@ -207,12 +209,14 @@ class SearchApp extends Component {
 		} );
 
 		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
-			select.value = getSortOptionFromSortKey( getSortQuery() );
+			select.value = getSortOptionFromSortKey( this.getSort() );
 		} );
 
 		// NOTE: This is necessary to ensure that the search query has been propagated to SearchBox
 		this.forceUpdate();
 	};
+
+	onChangeSort = sort => setSortQuery( sort );
 
 	loadNextPage = () => {
 		this.hasNextPage() && this.getResults( { pageHandle: this.state.response.page_handle } );
@@ -221,7 +225,7 @@ class SearchApp extends Component {
 	getResults = ( {
 		query = getSearchQuery(),
 		filter = getFilterQuery(),
-		sort = getSortQuery(),
+		sort = this.getSort(),
 		resultFormat = getResultFormatQuery(),
 		pageHandle,
 	} = {} ) => {
@@ -288,6 +292,7 @@ class SearchApp extends Component {
 					isLoading={ this.state.isLoading }
 					isVisible={ this.state.showResults }
 					locale={ this.props.options.locale }
+					onChangeSort={ this.onChangeSort }
 					onLoadNextPage={ this.loadNextPage }
 					overlayTrigger={ this.state.overlayOptions.overlayTrigger }
 					postTypes={ this.props.options.postTypes }
@@ -295,6 +300,7 @@ class SearchApp extends Component {
 					response={ this.state.response }
 					resultFormat={ getResultFormatQuery() }
 					showPoweredBy={ this.state.overlayOptions.showPoweredBy }
+					sort={ this.getSort() }
 					widgets={ this.props.options.widgets }
 					widgetsOutsideOverlay={ this.props.options.widgetsOutsideOverlay }
 				/>

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -24,8 +24,6 @@ import {
 	hasFilter,
 	setSearchQuery,
 	setSortQuery,
-	getSortKeyFromSortOption,
-	getSortOptionFromSortKey,
 	setFilterQuery,
 	restorePreviousHref,
 } from '../lib/query-string';
@@ -73,9 +71,6 @@ class SearchApp extends Component {
 		window.addEventListener( 'queryStringChange', this.onChangeQueryString );
 
 		this.updateEventListeners( this.state.overlayOptions.overlayTrigger );
-		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
-			select.addEventListener( 'change', this.handleSortChange );
-		} );
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
@@ -90,10 +85,6 @@ class SearchApp extends Component {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
 			input.removeEventListener( 'focus', this.handleInputFocus );
-		} );
-
-		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
-			select.removeEventListener( 'change', this.handleSortChange );
 		} );
 
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
@@ -171,10 +162,6 @@ class SearchApp extends Component {
 		}
 	};
 
-	handleSortChange = event => {
-		setSortQuery( getSortKeyFromSortOption( event.target.value ) );
-	};
-
 	handleFilterInputClick = event => {
 		event.preventDefault();
 
@@ -224,10 +211,6 @@ class SearchApp extends Component {
 
 		document.querySelectorAll( this.props.themeOptions.searchInputSelector ).forEach( input => {
 			input.value = getSearchQuery();
-		} );
-
-		document.querySelectorAll( this.props.themeOptions.searchSortSelector ).forEach( select => {
-			select.value = getSortOptionFromSortKey( this.getSort() );
 		} );
 
 		// NOTE: This is necessary to ensure that the search query has been propagated to SearchBox

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -281,6 +281,7 @@ class SearchApp extends Component {
 				<SearchResults
 					closeOverlay={ this.hideResults }
 					enableLoadOnScroll={ this.state.overlayOptions.enableInfScroll }
+					enableSort={ this.state.overlayOptions.enableSort }
 					hasError={ this.state.hasError }
 					hasNextPage={ this.hasNextPage() }
 					highlightColor={ this.state.overlayOptions.highlightColor }

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -148,10 +148,28 @@ class SearchApp extends Component {
 		if ( event.inputType.includes( 'delete' ) || event.inputType.includes( 'format' ) ) {
 			return;
 		}
+		this.handleDatasetAttributes( event.target.form );
 		setSearchQuery( event.target.value );
 	}, 200 );
 
-	handleInputFocus = () => this.showResults();
+	handleInputFocus = event => {
+		this.handleDatasetAttributes( event.target.form );
+		this.showResults();
+	};
+
+	handleDatasetAttributes = form => {
+		try {
+			if ( 'postTypeWhitelist' in form.dataset ) {
+				setFilterQuery(
+					'post_types',
+					JSON.parse( decodeURIComponent( form.dataset.postTypeWhitelist ) )
+				);
+			}
+		} catch ( error ) {
+			// Unexpected value found at data-post-type-whitelist.
+			return;
+		}
+	};
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -231,6 +231,7 @@ class SearchApp extends Component {
 		return search( {
 			// Skip aggregations when requesting for paged results
 			aggregations: !! pageHandle ? {} : this.props.aggregations,
+			enabledPostTypes: this.props.options.enabledPostTypes,
 			filter,
 			pageHandle,
 			query,

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -231,7 +231,6 @@ class SearchApp extends Component {
 		return search( {
 			// Skip aggregations when requesting for paged results
 			aggregations: !! pageHandle ? {} : this.props.aggregations,
-			enabledPostTypes: this.props.options.enabledPostTypes,
 			filter,
 			pageHandle,
 			query,

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -85,7 +85,9 @@ const SearchBox = props => {
 						</span>
 					</div>
 				) }
-				<SearchSort onChange={ props.onChangeSort } value={ getSortQuery() } />
+				{ props.enableSort && (
+					<SearchSort onChange={ props.onChangeSort } value={ getSortQuery() } />
+				) }
 			</div>
 		</Fragment>
 	);

--- a/modules/search/instant-search/components/search-box.jsx
+++ b/modules/search/instant-search/components/search-box.jsx
@@ -14,7 +14,6 @@ import uniqueId from 'lodash/uniqueId';
  */
 import Gridicon from './gridicon';
 import SearchSort from './search-sort';
-import { getSortQuery } from '../lib/query-string';
 
 let initiallyFocusedElement = null;
 const stealFocusWithInput = inputElement => () => {
@@ -85,9 +84,7 @@ const SearchBox = props => {
 						</span>
 					</div>
 				) }
-				{ props.enableSort && (
-					<SearchSort onChange={ props.onChangeSort } value={ getSortQuery() } />
-				) }
+				{ props.enableSort && <SearchSort onChange={ props.onChangeSort } value={ props.sort } /> }
 			</div>
 		</Fragment>
 	);

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -17,7 +17,6 @@ import {
 	getSearchQuery,
 	hasPreselectedFilters,
 	setSearchQuery,
-	setSortQuery,
 } from '../lib/query-string';
 import PreselectedSearchFilters from './preselected-search-filters';
 
@@ -30,7 +29,7 @@ class SearchForm extends Component {
 
 	onChangeQuery = event => setSearchQuery( event.target.value );
 	onChangeSort = sort => {
-		setSortQuery( sort );
+		this.props.onChangeSort( sort );
 		this.hideFilters();
 	};
 
@@ -67,6 +66,7 @@ class SearchForm extends Component {
 						query={ getSearchQuery() }
 						shouldRestoreFocus={ this.props.overlayTrigger !== 'immediate' }
 						showFilters={ this.state.showFilters }
+						sort={ this.props.sort }
 						toggleFilters={ this.toggleFilters }
 					/>
 				</div>

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -60,6 +60,7 @@ class SearchForm extends Component {
 				<div className="jetpack-instant-search__search-form">
 					<SearchBox
 						enableFilters={ this.hasSelectableFilters() || this.hasPreselectedFilters() }
+						enableSort={ this.props.enableSort }
 						isVisible={ this.props.isVisible }
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -69,6 +69,7 @@ class SearchResults extends Component {
 				/>
 				<SearchForm
 					className="jetpack-instant-search__search-results-search-form"
+					enableSort={ this.props.enableSort }
 					isLoading={ this.props.isLoading }
 					isVisible={ this.props.isVisible }
 					locale={ this.props.locale }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -74,8 +74,10 @@ class SearchResults extends Component {
 					isVisible={ this.props.isVisible }
 					locale={ this.props.locale }
 					postTypes={ this.props.postTypes }
+					onChangeSort={ this.props.onChangeSort }
 					overlayTrigger={ this.props.overlayTrigger }
 					response={ this.props.response }
+					sort={ this.props.sort }
 					widgets={ this.props.widgets }
 					widgetsOutsideOverlay={ this.props.widgetsOutsideOverlay }
 				/>

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -27,7 +27,7 @@ const injectSearchApp = () => {
 			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			// NOTE: initialShowResults is only used in the customizer. See lib/customize.js.
 			initialShowResults={ window[ SERVER_OBJECT_NAME ].showResults }
-			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].sort, getSearchQuery() ) }
+			initialSort={ determineDefaultSort( window[ SERVER_OBJECT_NAME ].defaultSort ) }
 			isSearchPage={ getSearchQuery() !== '' }
 			options={ window[ SERVER_OBJECT_NAME ] }
 			themeOptions={ getThemeOptions( window[ SERVER_OBJECT_NAME ] ) }

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -3,6 +3,9 @@
 /**
  * External dependencies
  */
+if ( process.env.NODE_ENV !== 'production' ) {
+	require( 'preact/debug' );
+}
 import { h, render } from 'preact';
 
 /**

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -11,7 +11,7 @@ import Cache from 'cache';
  * Internal dependencies
  */
 import { getFilterKeys } from './filters';
-import { MINUTE_IN_MILLISECONDS } from './constants';
+import { MINUTE_IN_MILLISECONDS, SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
 
 const isLengthyArray = array => Array.isArray( array ) && array.length > 0;
 // Cache contents evicted after fixed time-to-live
@@ -128,6 +128,16 @@ function buildFilterObject( filterQuery, adminQueryFilter ) {
 	return filter;
 }
 
+// Values of this map correspond to a sort value expected by the API
+const SORT_QUERY_MAP = new Map( [
+	[ 'oldest', 'date_asc' ],
+	[ 'newest', 'date_desc' ],
+	[ 'relevance', 'score_default' ],
+] );
+function mapSortToApiValue( sort ) {
+	return SORT_QUERY_MAP.get( sort, 'score_default' );
+}
+
 export function search( {
 	aggregations,
 	filter,
@@ -178,7 +188,7 @@ export function search( {
 			highlight_fields: highlightFields,
 			filter: buildFilterObject( filter, adminQueryFilter ),
 			query: encodeURIComponent( query ),
-			sort,
+			sort: mapSortToApiValue( sort ),
 			page_handle: pageHandle,
 			size: postsPerPage,
 		} )

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -103,7 +103,7 @@ const filterKeyToEsFilter = new Map( [
 	],
 ] );
 
-function buildFilterObject( filterQuery, adminQueryFilter, enabledPostTypes ) {
+function buildFilterObject( filterQuery, adminQueryFilter ) {
 	const filter = { bool: { must: [] } };
 
 	if ( filterQuery ) {
@@ -125,22 +125,11 @@ function buildFilterObject( filterQuery, adminQueryFilter, enabledPostTypes ) {
 		filter.bool.must.push( adminQueryFilter );
 	}
 
-	if ( isLengthyArray( enabledPostTypes ) ) {
-		filter.bool.must.push( {
-			bool: {
-				should: enabledPostTypes.map( postType =>
-					filterKeyToEsFilter.get( 'post_types' )( postType )
-				),
-			},
-		} );
-	}
-
 	return filter;
 }
 
 export function search( {
 	aggregations,
-	enabledPostTypes,
 	filter,
 	pageHandle,
 	query,
@@ -187,7 +176,7 @@ export function search( {
 			aggregations,
 			fields,
 			highlight_fields: highlightFields,
-			filter: buildFilterObject( filter, adminQueryFilter, enabledPostTypes ),
+			filter: buildFilterObject( filter, adminQueryFilter ),
 			query: encodeURIComponent( query ),
 			sort,
 			page_handle: pageHandle,

--- a/modules/search/instant-search/lib/constants.js
+++ b/modules/search/instant-search/lib/constants.js
@@ -1,6 +1,6 @@
 export const SERVER_OBJECT_NAME = 'JetpackInstantSearchOptions';
-export const SORT_DIRECTION_ASC = 'ASC';
-export const SORT_DIRECTION_DESC = 'DESC';
+export const SORT_DIRECTION_ASC = 'asc';
+export const SORT_DIRECTION_DESC = 'desc';
 export const RESULT_FORMAT_MINIMAL = 'minimal';
 export const RESULT_FORMAT_PRODUCT = 'product';
 export const MINUTE_IN_MILLISECONDS = 60 * 1000;

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -3,17 +3,9 @@
  */
 import { SERVER_OBJECT_NAME } from './constants';
 
-const CUSTOMIZE_SETTINGS = [
-	'jetpack_search_color_theme',
-	'jetpack_search_highlight_color',
-	'jetpack_search_inf_scroll',
-	'jetpack_search_opacity',
-	'jetpack_search_overlay_trigger',
-	'jetpack_search_show_powered_by',
-];
-
 const SETTINGS_TO_STATE_MAP = new Map( [
 	[ 'jetpack_search_color_theme', 'colorTheme' ],
+	[ 'jetpack_search_enable_sort', 'enableSort' ],
 	[ 'jetpack_search_highlight_color', 'highlightColor' ],
 	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
 	[ 'jetpack_search_opacity', 'opacity' ],
@@ -36,10 +28,10 @@ export function bindCustomizerChanges( callback ) {
 		return;
 	}
 
-	CUSTOMIZE_SETTINGS.forEach( setting => {
-		window.wp.customize( setting, value => {
+	SETTINGS_TO_STATE_MAP.forEach( ( jsName, phpName ) => {
+		window.wp.customize( phpName, value => {
 			value.bind( function( newValue ) {
-				const newOvelayOptions = { [ SETTINGS_TO_STATE_MAP.get( setting ) ]: newValue };
+				const newOvelayOptions = { [ jsName ]: newValue };
 
 				// If Instant Search hasn't been injected, update initial server object state
 				window[ SERVER_OBJECT_NAME ].showResults = true;

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -12,7 +12,6 @@ export function getThemeOptions( searchOptions ) {
 			'.search-form input.search-field:not(.jetpack-instant-search__box-input)',
 			'.searchform input.search-field:not(.jetpack-instant-search__box-input)',
 		].join( ', ' ),
-		searchSortSelector: [ '.jetpack-search-sort' ],
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -123,7 +123,7 @@ export function getSortQuery( initialSort ) {
 	const query = getQuery();
 
 	const { order, orderby } = query;
-	if ( ORDERED_SORT_TYPES.includes( orderby ) ) {
+	if ( ORDERED_SORT_TYPES.includes( orderby ) && order ) {
 		return SORT_QUERY_MAP[ orderby ][ order ];
 	} else if ( Object.keys( SORT_QUERY_MAP ).includes( orderby ) ) {
 		return SORT_QUERY_MAP[ orderby ];

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -122,8 +122,7 @@ const SORT_QUERY_MAP = {
 export function getSortQuery( initialSort ) {
 	const query = getQuery();
 
-	const order = query.order;
-	const orderby = query.orderby;
+	const { order, orderby } = query;
 	if ( ORDERED_SORT_TYPES.includes( orderby ) ) {
 		return SORT_QUERY_MAP[ orderby ][ order ];
 	} else if ( Object.keys( SORT_QUERY_MAP ).includes( orderby ) ) {

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -3,26 +3,16 @@
  */
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { SORT_DIRECTION_ASC, SORT_DIRECTION_DESC } from './constants';
-
+export const VALID_SORT_KEYS = [ 'newest', 'oldest', 'relevance' ];
 const sortOptions = {
-	score_default: {
+	relevance: {
 		label: __( 'Relevance', 'jetpack' ),
-		field: 'relevance',
-		direction: SORT_DIRECTION_DESC,
 	},
-	date_desc: {
+	newest: {
 		label: __( 'Newest', 'jetpack' ),
-		field: 'date',
-		direction: SORT_DIRECTION_DESC,
 	},
-	date_asc: {
+	oldest: {
 		label: __( 'Oldest', 'jetpack' ),
-		field: 'date',
-		direction: SORT_DIRECTION_ASC,
 	},
 };
 

--- a/modules/search/instant-search/lib/sort.js
+++ b/modules/search/instant-search/lib/sort.js
@@ -14,15 +14,15 @@ const sortOptions = {
 		field: 'relevance',
 		direction: SORT_DIRECTION_DESC,
 	},
-	date_asc: {
-		label: __( 'Oldest', 'jetpack' ),
-		field: 'date',
-		direction: SORT_DIRECTION_ASC,
-	},
 	date_desc: {
 		label: __( 'Newest', 'jetpack' ),
 		field: 'date',
 		direction: SORT_DIRECTION_DESC,
+	},
+	date_asc: {
+		label: __( 'Oldest', 'jetpack' ),
+		field: 'date',
+		direction: SORT_DIRECTION_ASC,
 	},
 };
 

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -463,7 +463,9 @@ class Jetpack_Search_Widget extends WP_Widget {
 
 		// TODO: create new search box?
 		if ( ! empty( $instance['search_box_enabled'] ) ) {
-			Jetpack_Search_Template_Tags::render_widget_search_form( array(), '', '' );
+			Jetpack_Search_Template_Tags::render_instant_widget_search_form(
+				empty( $instance['post_types'] ) ? array() : $instance['post_types']
+			);
 		}
 
 		if ( $display_filters ) {
@@ -652,7 +654,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 		$instance['title']              = sanitize_text_field( $new_instance['title'] );
 		$instance['search_box_enabled'] = empty( $new_instance['search_box_enabled'] ) ? '0' : '1';
 		$instance['user_sort_enabled']  = empty( $new_instance['user_sort_enabled'] ) ? '0' : '1';
-		$instance['sort']               = $new_instance['sort'];
+		$instance['sort']               = empty( $new_instance['user_sort_enabled'] ) ? null : $new_instance['sort'];
 		$instance['post_types']         = empty( $new_instance['post_types'] ) || empty( $instance['search_box_enabled'] )
 			? array()
 			: array_map( 'sanitize_key', $new_instance['post_types'] );

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -621,6 +621,22 @@ class Jetpack_Search_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Checks whether or not the widget exists in the Jetpack Search overlay sidebar.
+	 *
+	 * @since 8.6.0
+	 *
+	 * @return boolean Whether the widget is within the overlay sidebar.
+	 */
+	public function is_within_overlay() {
+		return in_array(
+			$this->id,
+			array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
+				get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'] : array(),
+			true
+		);
+	}
+
+	/**
 	 * Updates a particular instance of the widget. Validates and sanitizes the options.
 	 *
 	 * @since 5.0.0
@@ -719,59 +735,19 @@ class Jetpack_Search_Widget extends WP_Widget {
 				/>
 			</p>
 
-			<p>
-				<label>
-					<input
-						type="checkbox"
-						class="jetpack-search-filters-widget__search-box-enabled"
-						name="<?php echo esc_attr( $this->get_field_name( 'search_box_enabled' ) ); ?>"
-						<?php checked( $instance['search_box_enabled'] ); ?>
-					/>
-					<?php esc_html_e( 'Show search box', 'jetpack' ); ?>
-				</label>
-			</p>
-			<p>
-				<label>
-					<input
-						type="checkbox"
-						class="jetpack-search-filters-widget__sort-controls-enabled"
-						name="<?php echo esc_attr( $this->get_field_name( 'user_sort_enabled' ) ); ?>"
-						<?php checked( $instance['user_sort_enabled'] ); ?>
-						<?php disabled( ! $instance['search_box_enabled'] ); ?>
-					/>
-					<?php esc_html_e( 'Show sort selection dropdown', 'jetpack' ); ?>
-				</label>
-			</p>
-
-			<p class="jetpack-search-filters-widget__post-types-select">
-				<label><?php esc_html_e( 'Post types to search (minimum of 1):', 'jetpack' ); ?></label>
-				<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
+			<?php if ( ! $this->is_within_overlay() ) { ?>
+				<p>
 					<label>
 						<input
 							type="checkbox"
-							value="<?php echo esc_attr( $post_type->name ); ?>"
-							name="<?php echo esc_attr( $this->get_field_name( 'post_types' ) ); ?>[]"
-							<?php checked( empty( $instance['post_types'] ) || in_array( $post_type->name, $instance['post_types'] ) ); ?>
-						/>&nbsp;
-						<?php echo esc_html( $post_type->label ); ?>
+							class="jetpack-search-filters-widget__search-box-enabled"
+							name="<?php echo esc_attr( $this->get_field_name( 'search_box_enabled' ) ); ?>"
+							<?php checked( $instance['search_box_enabled'] ); ?>
+						/>
+						<?php esc_html_e( 'Show search box', 'jetpack' ); ?>
 					</label>
-				<?php endforeach; ?>
-			</p>
-
-			<p>
-				<label>
-					<?php esc_html_e( 'Default sort order:', 'jetpack' ); ?>
-					<select
-						name="<?php echo esc_attr( $this->get_field_name( 'sort' ) ); ?>"
-						class="widefat jetpack-search-filters-widget__sort-order">
-						<?php foreach ( $this->get_sort_types() as $sort_type => $label ) { ?>
-							<option value="<?php echo esc_attr( $sort_type ); ?>" <?php selected( $instance['sort'], $sort_type ); ?>>
-								<?php echo esc_html( $label ); ?>
-							</option>
-						<?php } ?>
-					</select>
-				</label>
-			</p>
+				</p>
+			<?php } ?>
 
 			<?php if ( ! $hide_filters ) : ?>
 				<script class="jetpack-search-filters-widget__filter-template" type="text/template">

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -747,6 +747,21 @@ class Jetpack_Search_Widget extends WP_Widget {
 						<?php esc_html_e( 'Show search box', 'jetpack' ); ?>
 					</label>
 				</p>
+
+				<p class="jetpack-search-filters-widget__post-types-select">
+					<label><?php esc_html_e( 'Post types to search (minimum of 1):', 'jetpack' ); ?></label>
+					<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
+						<label>
+							<input
+								type="checkbox"
+								value="<?php echo esc_attr( $post_type->name ); ?>"
+								name="<?php echo esc_attr( $this->get_field_name( 'post_types' ) ); ?>[]"
+								<?php checked( empty( $instance['post_types'] ) || in_array( $post_type->name, $instance['post_types'], true ) ); ?>
+							/>&nbsp;
+							<?php echo esc_html( $post_type->label ); ?>
+						</label>
+					<?php endforeach; ?>
+				</p>
 			<?php } ?>
 
 			<?php if ( ! $hide_filters ) : ?>

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -630,10 +630,10 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @return boolean Whether the widget is within the overlay sidebar.
 	 */
 	public function is_within_overlay() {
-		return in_array(
+		// NOTE: This will always return false for widgets that hasn't been published by the Customizer.
+		return is_active_sidebar( 'jetpack-instant-search-sidebar' ) && in_array(
 			$this->id,
-			array_key_exists( 'jetpack-instant-search-sidebar', get_option( 'sidebars_widgets', array() ) ) ?
-				get_option( 'sidebars_widgets', array() )['jetpack-instant-search-sidebar'] : array(),
+			wp_get_sidebars_widgets()['jetpack-instant-search-sidebar'],
 			true
 		);
 	}

--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -38,11 +38,7 @@ module.exports = [
 			filename: 'jp-search.bundle.js',
 		},
 		performance: isDevelopment
-			? {
-					maxAssetSize: 500000,
-					maxEntrypointSize: 500000,
-					hints: 'error',
-			  }
+			? false
 			: {
 					maxAssetSize: 122880,
 					maxEntrypointSize: 122880,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Updated Jetpack Search customizer section with two new options: Default sort and the ability to hide the sort selector.
<img width="548" alt="Customize__Instant_Search_Test_–_Just_another_WordPress_site" src="https://user-images.githubusercontent.com/4044428/81610631-129f5c80-9397-11ea-8555-8ca6b62a9b54.png">

* Removed unused Jetpack Search sort widget option when Instant Search is enabled.
> <img width="297" alt="Screen Shot 2020-05-27 at 1 38 14 PM" src="https://user-images.githubusercontent.com/4044428/83064910-d10de300-a01f-11ea-8e26-d84ac331ddc6.png">

* Adds support for post types whitelist in the Jetpack Search widget configuration in the Customizer.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Yes. This change adds the following for Jetpack Instant Search:
- Ability to set a default sort for search results.
- Ability to hide the sort selector.
- Support for whitelisting post types in Instant Search.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to a site with Jetpack Instant Search enabled.
* Add a Jetpack Search widget to your site's footer or sidebar via the customizer. Ensure that the widget title and filters remain configurable.
* Add a Jetpack Search widget to the Jetpack Search sidebar via the customizer. Ensure that only the widget filters remain configurable.

* Try limiting the widget's post type whitelist to only allow for a certain post type. Ensure that summoning the overlay using this widget's search input applies the necessary post type filter.

* Navigate to the Jetpack Search section of the customizer. Ensure that the default sort defaults to `Relevance` and that the `Show Sort Selector` defaults to being checked.
* Try changing the default sort; this should reload the iframe preview. Ensure that the default sort has changed by verifying that your newly selected default sort has been pre-selected by the sort selector.
<img width="686" alt="Screen Shot 2020-05-11 at 3 13 39 PM" src="https://user-images.githubusercontent.com/4044428/81612412-036dde00-939a-11ea-9398-9915a1721762.png">

* Try unchecking the `Show Sort Selector` checkbox. This should hide the sort selector without refreshing the page.

<img width="686" alt="Screen Shot 2020-05-11 at 3 14 36 PM" src="https://user-images.githubusercontent.com/4044428/81612478-239d9d00-939a-11ea-86eb-a27c069dd344.png">

#### Proposed changelog entry for your changes:
* Adds support for setting a default sort order for Jetpack Instant Search results.
* Adds support for hiding the sort selector for Jetpack Instant Search.
