### PR TITLE
Git Hooks: First pass at notices for changing lock or package files

### DIFF
--- a/bin/post-merge-checkout-hook.sh
+++ b/bin/post-merge-checkout-hook.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+changedFiles="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+runOnChange() {
+	echo "$changedFiles" | grep -q "$1" && echo -e "$2"
+}
+
+runOnChange yarn.lock "yarn.lock has changed. Consider running yarn build to update your working copy."
+runOnChange composer.lock "composer.lock has changed. Consider running composer install to update your working copy."
+runOnChange packages/ "Files within the packages directory have changed. Consider running composer install."
+
+exit 0

--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
 	"husky": {
 		"hooks": {
 			"pre-commit": "node bin/pre-commit-hook.js",
-			"prepare-commit-msg": "node bin/prepare-commit-msg.js"
+			"prepare-commit-msg": "node bin/prepare-commit-msg.js",
+			"post-merge": "./bin/post-merge-checkout-hook.sh",
+			"post-checkout": "./bin/post-merge-checkout-hook.sh"
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* First attempt at throwing a notice when a package file has changed to encourage building new.

I'm having some trouble testing this reliably, so might be something we need to commit to test. All of the individual parts work.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Switching to this branch will run the hook, but there aren't any changes to impacted files.

#### Proposed changelog entry for your changes:
* n/a
