### PR TITLE
Change post stripe connection messaging: 

### DIFF
--- a/extensions/shared/stripe-connection-notification.js
+++ b/extensions/shared/stripe-connection-notification.js
@@ -17,7 +17,7 @@ if ( undefined !== typeof window && window.location ) {
 		dispatch( 'core/notices' ).createNotice(
 			'success',
 			__(
-				'Congrats! Your site is now connected to Stripe. You can start making money by adding your first subscription!',
+				'Congrats! Your site is now connected to Stripe. You can now start making money!',
 				'jetpack'
 			)
 		);


### PR DESCRIPTION
See <https://github.com/Automattic/wp-calypso/issues/41586> for additional context/information.

<!--- Provide a general summary of your changes in the Title above -->
Changes 1 string.

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
No

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* None

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Sign up for a new site, purchase a plan (on WordPress.com)
* Create a page/post with a premium content block.
* Follow the prompts to add a Stripe connection.
* After the connection is created you should see a notice: "Congrats! Your site is now connected to Stripe. You can now start making money!"

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed
