### PR TITLE
Image Compare block: add AMP support using amp-image-slider

### DIFF
--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -39,7 +39,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		return render_amp( $attr );
+		return render_amp( $attr, $content );
 	}
 
 	return $content;
@@ -49,12 +49,21 @@ function load_assets( $attr, $content ) {
 /**
  * Render image compare block for AMP
  *
- * @param array $attr Array containing the image-compare block attributes.
+ * @param array  $attr    Array containing the image-compare block attributes.
+ * @param string $content String containing the image-compare block content.
  *
  * @return string
  */
-function render_amp( $attr ) {
-	// @TODO: what to show for AMP view?
-	// :shrug-emoji:
-	return '';
+function render_amp( $attr, $content ) {
+	// Attributes that are parsed in JavaScript are not passed in, so to get
+	// the URLs we need to parse the content in PHP, which is rather lame.
+	preg_match_all( '/src="([^"]+)"/', $content, $imgs );
+	if ( empty( $imgs ) || ( count( $imgs ) < 2 ) || empty( $imgs[1] ) || ( count( $imgs[1] ) < 2 ) ) {
+		return '';
+	}
+	return sprintf(
+		'<amp-image-slider layout="responsive" width="300" height="200"><amp-img src="%s" layout="fill"></amp-img><amp-img src="%s" layout="fill"></amp-img></amp-image-slider>',
+		$imgs[1][0],
+		$imgs[1][1]
+	);
 }

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -54,20 +54,18 @@ function load_assets( $attr, $content ) {
  * @return string
  */
 function render_amp( $attr ) {
-	$img_before_id  = $attr['imageBeforeId'];
-	$img_before_url = $attr['imageBeforeUrl'];
-	$img_before_alt = $attr['imageBeforeAlt'];
-	$img_after_id   = $attr['imageAfterId'];
-	$img_after_url  = $attr['imageAfterUrl'];
-	$img_after_alt  = $attr['imageAfterAlt'];
+	$img_before = $attr['imageBefore'];
+	$img_after  = $attr['imageAfter'];
 
 	return sprintf(
-		'<amp-image-slider layout="responsive" width="300" height="200"> <amp-img id="%1$d" src="%2$s" alt="%3$s" layout="fill"></amp-img> <amp-img id="%4$d" src="%5$s" alt="%6$s" layout="fill"></amp-img></amp-image-slider>',
-		absint( $img_before_id ),
-		esc_url( $img_before_url ),
-		esc_attr( $img_before_alt ),
-		absint( $img_after_id ),
-		esc_url( $img_after_url ),
-		esc_attr( $img_after_alt )
+		'<amp-image-slider layout="responsive" width="%1$d" height="%2$d"> <amp-img id="%3$d" src="%4$s" alt="%5$s" layout="fill"></amp-img> <amp-img id="%6$d" src="%7$s" alt="%8$s" layout="fill"></amp-img></amp-image-slider>',
+		absint( $img_before['width'] ),
+		absint( $img_before['height'] ),
+		absint( $img_before['id'] ),
+		esc_url( $img_before['url'] ),
+		esc_attr( $img_before['alt'] ),
+		absint( $img_after['id'] ),
+		esc_url( $img_after['url'] ),
+		esc_attr( $img_after['alt'] )
 	);
 }

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -63,7 +63,7 @@ function render_amp( $attr, $content ) {
 	}
 	return sprintf(
 		'<amp-image-slider layout="responsive" width="300" height="200"><amp-img src="%s" layout="fill"></amp-img><amp-img src="%s" layout="fill"></amp-img></amp-image-slider>',
-		$imgs[1][0],
-		$imgs[1][1]
+		esc_attr( $imgs[1][0] ),
+		esc_attr( $imgs[1][1] )
 	);
 }

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -39,7 +39,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function load_assets( $attr, $content ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		return render_amp( $attr, $content );
+		return render_amp( $attr );
 	}
 
 	return $content;
@@ -49,21 +49,25 @@ function load_assets( $attr, $content ) {
 /**
  * Render image compare block for AMP
  *
- * @param array  $attr    Array containing the image-compare block attributes.
- * @param string $content String containing the image-compare block content.
+ * @param array $attr Array containing the image-compare block attributes.
  *
  * @return string
  */
-function render_amp( $attr, $content ) {
-	// Attributes that are parsed in JavaScript are not passed in, so to get
-	// the URLs we need to parse the content in PHP, which is rather lame.
-	preg_match_all( '/src="([^"]+)"/', $content, $imgs );
-	if ( empty( $imgs ) || ( count( $imgs ) < 2 ) || empty( $imgs[1] ) || ( count( $imgs[1] ) < 2 ) ) {
-		return '';
-	}
+function render_amp( $attr ) {
+	$img_before_id  = $attr['imageBeforeId'];
+	$img_before_url = $attr['imageBeforeUrl'];
+	$img_before_alt = $attr['imageBeforeAlt'];
+	$img_after_id   = $attr['imageAfterId'];
+	$img_after_url  = $attr['imageAfterUrl'];
+	$img_after_alt  = $attr['imageAfterAlt'];
+
 	return sprintf(
-		'<amp-image-slider layout="responsive" width="300" height="200"><amp-img src="%s" layout="fill"></amp-img><amp-img src="%s" layout="fill"></amp-img></amp-image-slider>',
-		esc_attr( $imgs[1][0] ),
-		esc_attr( $imgs[1][1] )
+		'<amp-image-slider layout="responsive" width="300" height="200"> <amp-img id="%d" src="%s" alt="%s" layout="fill"></amp-img> <amp-img id="%d" src="%s" alt="%s" layout="fill"></amp-img></amp-image-slider>',
+		esc_attr( $img_before_id ),
+		esc_attr( $img_before_url ),
+		esc_attr( $img_before_alt ),
+		esc_attr( $img_after_id ),
+		esc_attr( $img_after_url ),
+		esc_attr( $img_after_alt )
 	);
 }

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -62,12 +62,12 @@ function render_amp( $attr ) {
 	$img_after_alt  = $attr['imageAfterAlt'];
 
 	return sprintf(
-		'<amp-image-slider layout="responsive" width="300" height="200"> <amp-img id="%d" src="%s" alt="%s" layout="fill"></amp-img> <amp-img id="%d" src="%s" alt="%s" layout="fill"></amp-img></amp-image-slider>',
-		esc_attr( $img_before_id ),
-		esc_attr( $img_before_url ),
+		'<amp-image-slider layout="responsive" width="300" height="200"> <amp-img id="%1$d" src="%2$s" alt="%3$s" layout="fill"></amp-img> <amp-img id="%4$d" src="%5$s" alt="%6$s" layout="fill"></amp-img></amp-image-slider>',
+		absint( $img_before_id ),
+		esc_url( $img_before_url ),
 		esc_attr( $img_before_alt ),
-		esc_attr( $img_after_id ),
-		esc_attr( $img_after_url ),
+		absint( $img_after_id ),
+		esc_url( $img_after_url ),
 		esc_attr( $img_after_alt )
 	);
 }

--- a/extensions/blocks/image-compare/index.js
+++ b/extensions/blocks/image-compare/index.js
@@ -44,6 +44,7 @@ export const settings = {
 		},
 		orientation: {
 			type: 'string',
+			default: 'horizontal',
 		},
 	},
 


### PR DESCRIPTION
Fixes #15653 

#### Changes proposed in this Pull Request:

* Add AMP support for Image Compare using [amp-image-slider component](https://amp.dev/documentation/examples/components/amp-image-slider/).

#### Testing instructions:

* This only applies to render in AMP, no changes to non-AMP enviornments
* Install AMP plugin: https://wordpress.org/plugins/amp/
* Activate and Enable Standard AMP so all pages are rendered as AMP pages (this makes testing easier)
* Create a new post (or view existing) with an Image Compare block
* You should see a side-by-side image comparison, it should be the AMP component that looks a bit different than the non-AMP version but should work.


**Note:** the side-by-side and above-below settings will not alter the viewing (it will always be side-by-side) when viewed in AMP context. The AMP component needs to add the additional orientation support, it is on their roadmap. 

I left this as-is instead of disabling the option, because the AMP plugin can also be configured to serve regular and AMP content from the same source (determined by URL). So checking for plugin and disabling would remove the feature for non-AMP content.


