### PR TITLE
Image Compare: Add keywords to block

### DIFF
--- a/extensions/blocks/image-compare/index.js
+++ b/extensions/blocks/image-compare/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,6 +22,13 @@ export const settings = {
 	icon,
 
 	category: supportsCollections() ? 'layout' : 'jetpack',
+	keywords: [
+		_x( 'juxtapose', 'block search term', 'jetpack' ),
+		_x( 'photos', 'block search term', 'jetpack' ),
+		_x( 'pictures', 'block search term', 'jetpack' ),
+		_x( 'side by side', 'block search term', 'jetpack' ),
+		_x( 'slider', 'block search term', 'jetpack' ),
+	],
 
 	attributes: {
 		imageBeforeId: {


### PR DESCRIPTION

Fixes #15744 

#### Changes proposed in this Pull Request:

* Adds keywords to block to improve search
* Keywords added: juxtapose, photos, pictures, side by side, slider


#### Testing instructions:

* Confirm Image Compare block works as expected
* Confirm search terms in block inspector work
