### PR TITLE
Image Compare: Fix placeholders for non-plugin environments

### DIFF
--- a/extensions/blocks/image-compare/editor.scss
+++ b/extensions/blocks/image-compare/editor.scss
@@ -1,9 +1,21 @@
+// Remove the left and right margin of the figure element in the editor.
+// The frontend is the domain of the theme.
+.wp-block-jetpack-image-compare {
+	margin-left: 0;
+	margin-right: 0;
+}
+
 .image-compare__placeholder > .components-placeholder {
 	flex-direction: row;
 	align-items: center;
 
 	> .components-placeholder__label {
 		display: none;
+	}
+
+	// Remove backgrounds from the nested placeholders.
+	.components-placeholder {
+		background: none;
 	}
 }
 


### PR DESCRIPTION
Fixes #15737.

This PR massages the margins, and the nested placeholders, to make it look good in WordPress environments both that have, and don't have the Gutenberg plugin installed.

Before:

<img width="789" alt="before" src="https://user-images.githubusercontent.com/1204802/81664745-11763a00-9440-11ea-9506-6e7f4b746e37.png">

After:

<img width="728" alt="after" src="https://user-images.githubusercontent.com/1204802/81664763-16d38480-9440-11ea-95d7-1fb08d96eb8b.png">

After, with the plugin:

<img width="758" alt="after plugin" src="https://user-images.githubusercontent.com/1204802/81664777-19ce7500-9440-11ea-8bc6-6bf14ea1a836.png">

#### Testing instructions:

- Test this PR on a WordPress 5.4 install without the Gutenberg plugin enabled, and verify that the placeholder/setup state of the Image Compare block looks good.