### PR TITLE
Instagram Gallery Block: Move to Production

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -8,6 +8,7 @@
 		"eventbrite",
 		"gif",
 		"google-calendar",
+		"instagram-gallery",
 		"likes",
 		"mailchimp",
 		"map",
@@ -30,7 +31,7 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "image-compare", "instagram-gallery" ],
+	"beta": [ "amazon", "image-compare" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [
 		"business-hours",
@@ -41,6 +42,7 @@
 		"eventbrite",
 		"gif",
 		"google-calendar",
+		"instagram-gallery",
 		"mailchimp",
 		"map",
 		"markdown",


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move the Instagram Gallery block to production.

⚠️ Do not sync to WPCOM before the Jetpack 8.6 release!

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Smoke test all the things, I guess?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Instagram Gallery Block: embed posts from your Instagram account.
