### PR TITLE
Remove Recommendations from master bar #15222

### DIFF
--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -445,7 +445,7 @@ class A8C_WPCOM_Masterbar {
 				'id'     => 'streams-header',
 				'title'  => esc_html_x(
 					'Streams',
-					'Title for Reader sub-menu that contains followed sites, likes, and recommendations',
+					'Title for Reader sub-menu that contains followed sites, likes, and search',
 					'jetpack'
 				),
 				'meta'   => array(
@@ -494,18 +494,6 @@ class A8C_WPCOM_Masterbar {
 				'id'     => 'discover-search',
 				'title'  => esc_html__( 'Search', 'jetpack' ),
 				'href'   => Redirect::get_url( 'calypso-read-search' ),
-				'meta'   => array(
-					'class' => 'mb-icon-spacer',
-				),
-			)
-		);
-
-		$wp_admin_bar->add_menu(
-			array(
-				'parent' => 'newdash',
-				'id'     => 'discover-recommended-blogs',
-				'title'  => esc_html__( 'Recommendations', 'jetpack' ),
-				'href'   => Redirect::get_url( 'calypso-recommendations' ),
 				'meta'   => array(
 					'class' => 'mb-icon-spacer',
 				),

--- a/modules/masterbar/tracks-events.js
+++ b/modules/masterbar/tracks-events.js
@@ -45,7 +45,6 @@
 		'wp-admin-bar-reader-followed-sites-manage': 'reader_manage_followed_sites',
 		'wp-admin-bar-discover-discover': 'reader_discover',
 		'wp-admin-bar-discover-search': 'reader_search',
-		'wp-admin-bar-discover-recommended-blogs': 'reader_recommendations',
 		'wp-admin-bar-my-activity-my-likes': 'reader_my_likes',
 		//account
 		'wp-admin-bar-user-info': 'my_account_user_name',


### PR DESCRIPTION
Remove Recommendations from master bar

Fixes #15222

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The Master Bar still displays a link under "Reader" that points to wordpress.com/recommendations, but this page was retired. See p5PDj3-3ka-p2#comment-4520

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes a bug, removing a broken link from the master bar

#### Testing instructions:

* Activate the Master Bar module
* Click on Reader
* See that there is a link to "Recommendations" 
* checkout this branch and see that the "Recommendations" link is gone.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove retired "Recommendations" link from Masterbar
