### PR TITLE
Social Logos: update library to prepare for Fusion

### DIFF
--- a/_inc/social-logos.php
+++ b/_inc/social-logos.php
@@ -1,14 +1,40 @@
 <?php
 /**
+ * Social Logos
+ * Icon Font of the social logos we use on WordPress.com and in Jetpack
+ *
+ * Reference: https://github.com/Automattic/social-logos
+ *
+ * @package Jetpack
+ */
+
+/*
+ * Those references to the social logos location can be updated
+ * in other environments such as WordPress.com.
+ */
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	define( 'JETPACK_SOCIAL_LOGOS_URL', '/wp-content/mu-plugins/social-logos/' );
+	define( 'JETPACK_SOCIAL_LOGOS_DIR', ABSPATH . JETPACK_SOCIAL_LOGOS_URL );
+} else {
+	define( 'JETPACK_SOCIAL_LOGOS_URL', plugin_dir_url( __FILE__ ) . 'social-logos/' );
+	define( 'JETPACK_SOCIAL_LOGOS_DIR', plugin_dir_path( __FILE__ ) . 'social-logos/' );
+}
+
+/**
  * Globally registers the 'social-logos' style and font.
  *
  * This ensures any theme or plugin using it is on the latest version of Social Logos, and helps to avoid conflicts.
  */
-add_action( 'init', 'jetpack_register_social_logos', 1 );
 function jetpack_register_social_logos() {
 	if ( ! wp_style_is( 'social-logos', 'registered' ) ) {
-		$post_fix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-		wp_register_style( 'social-logos', plugins_url( 'social-logos/social-logos' . $post_fix . '.css', __FILE__ ), false, '1' );
+		/** This filter is documented in modules/sharedaddy/sharing.php */
+		$post_fix = apply_filters( 'jetpack_should_use_minified_assets', true ) ? '.min' : '';
+		wp_register_style(
+			'social-logos',
+			JETPACK_SOCIAL_LOGOS_URL . 'social-logos' . $post_fix . '.css',
+			false,
+			JETPACK__VERSION
+		);
 	}
 }
-
+add_action( 'init', 'jetpack_register_social_logos', 1 );

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -28,6 +28,7 @@ module.exports = [
 	'_inc/lib/core-api/wpcom-endpoints/memberships.php',
 	'_inc/lib/debugger/',
 	'_inc/lib/plans.php',
+	'_inc/social-logos.php',
 	'jetpack.php',
 	'json-endpoints/jetpack/class-jetpack-json-api-delete-backup-helper-script-endpoint.php',
 	'json-endpoints/jetpack/class-jetpack-json-api-install-backup-helper-script-endpoint.php',


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This PR introduces a few changes to Social Logos:
- Switch to using Jetpack version for versioning.
- Switch to using existing filter for minified versions.
- Introduce new constants that we'll rely on for AMP to differentiate Jetpack and wpcom platforms. See https://github.com/Automattic/jetpack/pull/15497#discussion_r421652259

In parallel, I created D43318-code so we can bring those files in sync and use those constants on WordPress.com as well.

#### Testing instructions:

- Go to Settings > Sharing
- Icons should be displayed on that page.
- The sharing icons should be displayed on the frontend as well.

#### Proposed changelog entry for your changes:

* N/A
