### PR TITLE
Connection: increase timeout on the token request

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1590,9 +1590,9 @@ class Manager {
 			),
 		);
 
-		add_filter( 'http_request_timeout', array( $this, 'increase_timeout' ) );
+		add_filter( 'http_request_timeout', array( $this, 'increase_timeout' ), PHP_INT_MAX - 1 );
 		$response = Client::_wp_remote_request( Utils::fix_url_for_bad_hosts( $this->api_url( 'token' ) ), $args );
-		remove_filter( 'http_request_timeout', array( $this, 'increase_timeout' ) );
+		remove_filter( 'http_request_timeout', array( $this, 'increase_timeout' ), PHP_INT_MAX - 1 );
 
 		if ( is_wp_error( $response ) ) {
 			return new \WP_Error( 'token_http_request_failed', $response->get_error_message() );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1588,10 +1588,11 @@ class Manager {
 			'headers' => array(
 				'Accept' => 'application/json',
 			),
-			'timeout' => 10,
 		);
 
+		add_filter( 'http_request_timeout', array( $this, 'increase_timeout' ) );
 		$response = Client::_wp_remote_request( Utils::fix_url_for_bad_hosts( $this->api_url( 'token' ) ), $args );
+		remove_filter( 'http_request_timeout', array( $this, 'increase_timeout' ) );
 
 		if ( is_wp_error( $response ) ) {
 			return new \WP_Error( 'token_http_request_failed', $response->get_error_message() );
@@ -1657,6 +1658,15 @@ class Manager {
 		do_action( 'jetpack_user_authorized' );
 
 		return (string) $json->access_token;
+	}
+
+	/**
+	 * Increases the request timeout value to 30 seconds.
+	 *
+	 * @return int Returns 30.
+	 */
+	public function increase_timeout() {
+		return 30;
 	}
 
 	/**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1588,6 +1588,7 @@ class Manager {
 			'headers' => array(
 				'Accept' => 'application/json',
 			),
+			'timeout' => 10,
 		);
 
 		$response = Client::_wp_remote_request( Utils::fix_url_for_bad_hosts( $this->api_url( 'token' ) ), $args );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* We're seeing occasional timeouts on the token request during user authorization. Let's try increasing the timeout from the default 5s to 30s.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Testing instructions:
The test site must have Jetpack activated and disconnected.

1. Verify that the you can successfully connect to WPCOM.

#### Proposed changelog entry for your changes:
* n/a
