### PR TITLE
Fix Mosaic and Columns styles for Tiled Gallery block on AMP pages.

### DIFF
--- a/extensions/blocks/tiled-gallery/deprecated/index.js
+++ b/extensions/blocks/tiled-gallery/deprecated/index.js
@@ -1,0 +1,7 @@
+/**
+ * Internal Dependencies
+ */
+import * as deprecatedV1 from './v1';
+import * as deprecatedV2 from './v2';
+
+export default [ deprecatedV1, deprecatedV2 ];

--- a/extensions/blocks/tiled-gallery/deprecated/v2/constants.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/constants.js
@@ -1,0 +1,29 @@
+export const ALLOWED_MEDIA_TYPES = [ 'image' ];
+export const DEFAULT_GALLERY_WIDTH = 580;
+export const GUTTER_WIDTH = 4;
+export const MAX_COLUMNS = 20;
+export const MAX_ROUNDED_CORNERS = 20;
+export const PHOTON_MAX_RESIZE = 2000;
+
+/**
+ * Layouts
+ */
+export const LAYOUT_CIRCLE = 'circle';
+export const LAYOUT_COLUMN = 'columns';
+export const LAYOUT_DEFAULT = 'rectangular';
+export const LAYOUT_SQUARE = 'square';
+export const LAYOUT_STYLES = [
+	{
+		isDefault: true,
+		name: LAYOUT_DEFAULT,
+	},
+	{
+		name: LAYOUT_CIRCLE,
+	},
+	{
+		name: LAYOUT_SQUARE,
+	},
+	{
+		name: LAYOUT_COLUMN,
+	},
+];

--- a/extensions/blocks/tiled-gallery/deprecated/v2/gallery-image/save.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/gallery-image/save.js
@@ -1,0 +1,46 @@
+/**
+ * External Dependencies
+ */
+import classnames from 'classnames';
+import { isBlobURL } from '@wordpress/blob';
+
+export default function GalleryImageSave( props ) {
+	const { alt, imageFilter, height, id, link, linkTo, origUrl, url, width } = props;
+
+	if ( isBlobURL( origUrl ) ) {
+		return null;
+	}
+
+	let href;
+
+	switch ( linkTo ) {
+		case 'media':
+			href = url;
+			break;
+		case 'attachment':
+			href = link;
+			break;
+	}
+
+	const img = (
+		<img
+			alt={ alt }
+			data-height={ height }
+			data-id={ id }
+			data-link={ link }
+			data-url={ origUrl }
+			data-width={ width }
+			src={ url }
+		/>
+	);
+
+	return (
+		<figure
+			className={ classnames( 'tiled-gallery__item', {
+				[ `filter__${ imageFilter }` ]: !! imageFilter,
+			} ) }
+		>
+			{ href ? <a href={ href }>{ img }</a> : img }
+		</figure>
+	);
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/index.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/index.js
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import { LAYOUT_DEFAULT } from './constants';
+
+export { default as save } from './save';
+
+export const attributes = {
+	// Set default align
+	align: {
+		default: 'center',
+		type: 'string',
+	},
+	// Set default className (used with block styles)
+	className: {
+		default: `is-style-${ LAYOUT_DEFAULT }`,
+		type: 'string',
+	},
+	columns: {
+		type: 'number',
+	},
+	ids: {
+		default: [],
+		type: 'array',
+	},
+	imageFilter: {
+		type: 'string',
+	},
+	images: {
+		type: 'array',
+		default: [],
+		source: 'query',
+		selector: '.tiled-gallery__item',
+		query: {
+			alt: {
+				attribute: 'alt',
+				default: '',
+				selector: 'img',
+				source: 'attribute',
+			},
+			height: {
+				attribute: 'data-height',
+				selector: 'img',
+				source: 'attribute',
+				type: 'number',
+			},
+			id: {
+				attribute: 'data-id',
+				selector: 'img',
+				source: 'attribute',
+			},
+			link: {
+				attribute: 'data-link',
+				selector: 'img',
+				source: 'attribute',
+			},
+			url: {
+				attribute: 'data-url',
+				selector: 'img',
+				source: 'attribute',
+			},
+			width: {
+				attribute: 'data-width',
+				selector: 'img',
+				source: 'attribute',
+				type: 'number',
+			},
+		},
+	},
+	linkTo: {
+		default: 'none',
+		type: 'string',
+	},
+	roundedCorners: {
+		type: 'integer',
+		default: 0,
+	},
+};
+
+export const supports = {
+	align: [ 'center', 'wide', 'full' ],
+	customClassName: false,
+	html: false,
+};

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/column.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/column.js
@@ -1,0 +1,3 @@
+export default function Column( { children } ) {
+	return <div className="tiled-gallery__col">{ children }</div>;
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/gallery.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/gallery.js
@@ -1,0 +1,7 @@
+export default function Gallery( { children, galleryRef } ) {
+	return (
+		<div className="tiled-gallery__gallery" ref={ galleryRef }>
+			{ children }
+		</div>
+	);
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/index.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/index.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import GalleryImageSave from '../gallery-image/save';
+import Mosaic from './mosaic';
+import Square from './square';
+import { isSquareishLayout, photonizedImgProps } from '../utils';
+import { LAYOUT_CIRCLE, MAX_ROUNDED_CORNERS } from '../constants';
+
+export default class Layout extends Component {
+	// This is tricky:
+	// - We need to "photonize" to resize the images at appropriate dimensions
+	// - The resize will depend on the image size and the layout in some cases
+	// - Handlers need to be created by index so that the image changes can be applied correctly.
+	//   This is because the images are stored in an array in the block attributes.
+	renderImage( img, i ) {
+		const { columns, imageFilter, images, linkTo, layoutStyle, selectedImage } = this.props;
+
+		/* translators: %1$d is the order number of the image, %2$d is the total number of images. */
+		const ariaLabel = sprintf(
+			__( 'image %1$d of %2$d in gallery', 'jetpack' ),
+			i + 1,
+			images.length
+		);
+
+		const { src, srcSet } = photonizedImgProps( img, { layoutStyle } );
+
+		return (
+			<GalleryImageSave
+				alt={ img.alt }
+				aria-label={ ariaLabel }
+				columns={ columns }
+				height={ img.height }
+				id={ img.id }
+				imageFilter={ imageFilter }
+				isFirstItem={ i === 0 }
+				isLastItem={ i + 1 === images.length }
+				isSelected={ selectedImage === i }
+				key={ i }
+				link={ img.link }
+				linkTo={ linkTo }
+				origUrl={ img.url }
+				showMovers={ images.length > 1 }
+				srcSet={ srcSet }
+				url={ src }
+				width={ img.width }
+			/>
+		);
+	}
+
+	render() {
+		const { align, children, className, columns, images, layoutStyle, roundedCorners } = this.props;
+		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
+		const renderedImages = this.props.images.map( this.renderImage, this );
+		const roundedCornersValue =
+			layoutStyle !== LAYOUT_CIRCLE ? Math.min( roundedCorners, MAX_ROUNDED_CORNERS ) : 0;
+
+		return (
+			<div
+				className={ classnames( className, {
+					[ `has-rounded-corners-${ roundedCornersValue }` ]: roundedCornersValue > 0,
+				} ) }
+			>
+				<LayoutRenderer
+					align={ align }
+					columns={ columns }
+					images={ images }
+					layoutStyle={ layoutStyle }
+					renderedImages={ renderedImages }
+				/>
+				{ children }
+			</div>
+		);
+	}
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/mosaic/index.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/mosaic/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { Component, createRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Column from '../column';
+import Gallery from '../gallery';
+import Row from '../row';
+import { imagesToRatios, ratiosToColumns, ratiosToMosaicRows } from './ratios';
+
+export default class Mosaic extends Component {
+	gallery = createRef();
+	pendingRaf = null;
+
+	render() {
+		const { align, columns, images, layoutStyle, renderedImages } = this.props;
+
+		const ratios = imagesToRatios( images );
+		const rows =
+			'columns' === layoutStyle
+				? ratiosToColumns( ratios, columns )
+				: ratiosToMosaicRows( ratios, { isWide: [ 'full', 'wide' ].includes( align ) } );
+
+		let cursor = 0;
+		return (
+			<Gallery galleryRef={ this.gallery }>
+				{ rows.map( ( row, rowIndex ) => (
+					<Row key={ rowIndex }>
+						{ row.map( ( colSize, colIndex ) => {
+							const columnImages = renderedImages.slice( cursor, cursor + colSize );
+							cursor += colSize;
+							return <Column key={ colIndex }>{ columnImages }</Column>;
+						} ) }
+					</Row>
+				) ) }
+			</Gallery>
+		);
+	}
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/mosaic/ratios.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/mosaic/ratios.js
@@ -1,0 +1,280 @@
+/**
+ * External dependencies
+ */
+import {
+	drop,
+	every,
+	isEqual,
+	map,
+	overEvery,
+	some,
+	sum,
+	take,
+	takeRight,
+	takeWhile,
+	zipWith,
+} from 'lodash';
+
+export function imagesToRatios( images ) {
+	return map( images, ratioFromImage );
+}
+
+export function ratioFromImage( { height, width } ) {
+	return height && width ? width / height : 1;
+}
+
+/**
+ * Build three columns, each of which should contain approximately 1/3 of the total ratio
+ *
+ * @param  {Array.<number>}         ratios      Ratios of images put into shape
+ * @param  {number}                 columnCount Number of columns
+ *
+ * @return {Array.<Array.<number>>}             Shape of rows and columns
+ */
+export function ratiosToColumns( ratios, columnCount ) {
+	// If we don't have more than 1 per column, just return a simple 1 ratio per column shape
+	if ( ratios.length <= columnCount ) {
+		return [ Array( ratios.length ).fill( 1 ) ];
+	}
+
+	const total = sum( ratios );
+	const targetColRatio = total / columnCount;
+
+	const row = [];
+	let toProcess = ratios;
+	let accumulatedRatio = 0;
+
+	// We skip the last column in the loop and add rest later
+	for ( let i = 0; i < columnCount - 1; i++ ) {
+		const colSize = takeWhile( toProcess, ratio => {
+			const shouldTake = accumulatedRatio <= ( i + 1 ) * targetColRatio;
+			if ( shouldTake ) {
+				accumulatedRatio += ratio;
+			}
+			return shouldTake;
+		} ).length;
+		row.push( colSize );
+		toProcess = drop( toProcess, colSize );
+	}
+
+	// Don't calculate last column, just add what's left
+	row.push( toProcess.length );
+
+	// A shape is an array of rows. Wrap our row in an array.
+	return [ row ];
+}
+
+/**
+ * These are partially applied functions.
+ * They rely on helper function (defined below) to create a function that expects to be passed ratios
+ * during processing.
+ *
+ * …FitsNextImages() functions should be passed ratios to be processed
+ * …IsNotRecent() functions should be passed the processed shapes
+ */
+
+const reverseSymmetricRowIsNotRecent = isNotRecentShape( [ 2, 1, 2 ], 5 );
+const reverseSymmetricFitsNextImages = checkNextRatios( [
+	isLandscape,
+	isLandscape,
+	isPortrait,
+	isLandscape,
+	isLandscape,
+] );
+const longSymmetricRowFitsNextImages = checkNextRatios( [
+	isLandscape,
+	isLandscape,
+	isLandscape,
+	isPortrait,
+	isLandscape,
+	isLandscape,
+	isLandscape,
+] );
+const longSymmetricRowIsNotRecent = isNotRecentShape( [ 3, 1, 3 ], 5 );
+const symmetricRowFitsNextImages = checkNextRatios( [
+	isPortrait,
+	isLandscape,
+	isLandscape,
+	isPortrait,
+] );
+const symmetricRowIsNotRecent = isNotRecentShape( [ 1, 2, 1 ], 5 );
+const oneThreeFitsNextImages = checkNextRatios( [
+	isPortrait,
+	isLandscape,
+	isLandscape,
+	isLandscape,
+] );
+const oneThreeIsNotRecent = isNotRecentShape( [ 1, 3 ], 3 );
+const threeOneIsFitsNextImages = checkNextRatios( [
+	isLandscape,
+	isLandscape,
+	isLandscape,
+	isPortrait,
+] );
+const threeOneIsNotRecent = isNotRecentShape( [ 3, 1 ], 3 );
+const oneTwoFitsNextImages = checkNextRatios( [
+	lt( 1.6 ),
+	overEvery( gte( 0.9 ), lt( 2 ) ),
+	overEvery( gte( 0.9 ), lt( 2 ) ),
+] );
+const oneTwoIsNotRecent = isNotRecentShape( [ 1, 2 ], 3 );
+const fiveIsNotRecent = isNotRecentShape( [ 1, 1, 1, 1, 1 ], 1 );
+const fourIsNotRecent = isNotRecentShape( [ 1, 1, 1, 1 ], 1 );
+const threeIsNotRecent = isNotRecentShape( [ 1, 1, 1 ], 3 );
+const twoOneFitsNextImages = checkNextRatios( [
+	overEvery( gte( 0.9 ), lt( 2 ) ),
+	overEvery( gte( 0.9 ), lt( 2 ) ),
+	lt( 1.6 ),
+] );
+const twoOneIsNotRecent = isNotRecentShape( [ 2, 1 ], 3 );
+const panoramicFitsNextImages = checkNextRatios( [ isPanoramic ] );
+
+export function ratiosToMosaicRows( ratios, { isWide } = {} ) {
+	// This function will recursively process the input until it is consumed
+	const go = ( processed, toProcess ) => {
+		if ( ! toProcess.length ) {
+			return processed;
+		}
+
+		let next;
+
+		if (
+			/* Reverse_Symmetric_Row */
+			toProcess.length > 15 &&
+			reverseSymmetricFitsNextImages( toProcess ) &&
+			reverseSymmetricRowIsNotRecent( processed )
+		) {
+			next = [ 2, 1, 2 ];
+		} else if (
+			/* Long_Symmetric_Row */
+			toProcess.length > 15 &&
+			longSymmetricRowFitsNextImages( toProcess ) &&
+			longSymmetricRowIsNotRecent( processed )
+		) {
+			next = [ 3, 1, 3 ];
+		} else if (
+			/* Symmetric_Row */
+			toProcess.length !== 5 &&
+			symmetricRowFitsNextImages( toProcess ) &&
+			symmetricRowIsNotRecent( processed )
+		) {
+			next = [ 1, 2, 1 ];
+		} else if (
+			/* One_Three */
+			oneThreeFitsNextImages( toProcess ) &&
+			oneThreeIsNotRecent( processed )
+		) {
+			next = [ 1, 3 ];
+		} else if (
+			/* Three_One */
+			threeOneIsFitsNextImages( toProcess ) &&
+			threeOneIsNotRecent( processed )
+		) {
+			next = [ 3, 1 ];
+		} else if (
+			/* One_Two */
+			oneTwoFitsNextImages( toProcess ) &&
+			oneTwoIsNotRecent( processed )
+		) {
+			next = [ 1, 2 ];
+		} else if (
+			/* Five */
+			isWide &&
+			( toProcess.length === 5 || ( toProcess.length !== 10 && toProcess.length > 6 ) ) &&
+			fiveIsNotRecent( processed ) &&
+			sum( take( toProcess, 5 ) ) < 5
+		) {
+			next = [ 1, 1, 1, 1, 1 ];
+		} else if (
+			/* Four */
+			isFourValidCandidate( processed, toProcess )
+		) {
+			next = [ 1, 1, 1, 1 ];
+		} else if (
+			/* Three */
+			isThreeValidCandidate( processed, toProcess, isWide )
+		) {
+			next = [ 1, 1, 1 ];
+		} else if (
+			/* Two_One */
+			twoOneFitsNextImages( toProcess ) &&
+			twoOneIsNotRecent( processed )
+		) {
+			next = [ 2, 1 ];
+		} else if ( /* Panoramic */ panoramicFitsNextImages( toProcess ) ) {
+			next = [ 1 ];
+		} else if ( /* One_One */ toProcess.length > 3 ) {
+			next = [ 1, 1 ];
+		} else {
+			// Everything left
+			next = Array( toProcess.length ).fill( 1 );
+		}
+
+		// Add row
+		const nextProcessed = processed.concat( [ next ] );
+
+		// Trim consumed images from next processing step
+		const consumedImages = sum( next );
+		const nextToProcess = toProcess.slice( consumedImages );
+
+		return go( nextProcessed, nextToProcess );
+	};
+	return go( [], ratios );
+}
+
+function isThreeValidCandidate( processed, toProcess, isWide ) {
+	const ratio = sum( take( toProcess, 3 ) );
+	return (
+		toProcess.length >= 3 &&
+		toProcess.length !== 4 &&
+		toProcess.length !== 6 &&
+		threeIsNotRecent( processed ) &&
+		( ratio < 2.5 ||
+			( ratio < 5 &&
+				/* nextAreSymettric */
+				toProcess.length >= 3 &&
+					/* @FIXME floating point equality?? */ toProcess[ 0 ] === toProcess[ 2 ] ) ||
+			isWide )
+	);
+}
+
+function isFourValidCandidate( processed, toProcess ) {
+	const ratio = sum( take( toProcess, 4 ) );
+	return (
+		( fourIsNotRecent( processed ) && ratio < 3.5 && toProcess.length > 5 ) ||
+		( ratio < 7 && toProcess.length === 4 )
+	);
+}
+
+function isNotRecentShape( shape, numRecents ) {
+	return recents =>
+		! some( takeRight( recents, numRecents ), recentShape => isEqual( recentShape, shape ) );
+}
+
+function checkNextRatios( shape ) {
+	return ratios =>
+		ratios.length >= shape.length &&
+		every( zipWith( shape, ratios.slice( 0, shape.length ), ( f, r ) => f( r ) ) );
+}
+
+function isLandscape( ratio ) {
+	return ratio >= 1 && ratio < 2;
+}
+
+function isPortrait( ratio ) {
+	return ratio < 1;
+}
+
+function isPanoramic( ratio ) {
+	return ratio >= 2;
+}
+
+// >=
+function gte( n ) {
+	return m => m >= n;
+}
+
+// <
+function lt( n ) {
+	return m => m < n;
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/row.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/row.js
@@ -1,0 +1,8 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+export default function Row( { children, className } ) {
+	return <div className={ classnames( 'tiled-gallery__row', className ) }>{ children }</div>;
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/layout/square.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/layout/square.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { chunk, drop, take } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Row from './row';
+import Column from './column';
+import Gallery from './gallery';
+import { MAX_COLUMNS } from '../constants';
+
+export default function Square( { columns, renderedImages } ) {
+	const columnCount = Math.min( MAX_COLUMNS, columns );
+
+	const remainder = renderedImages.length % columnCount;
+
+	return (
+		<Gallery>
+			{ [
+				...( remainder ? [ take( renderedImages, remainder ) ] : [] ),
+				...chunk( drop( renderedImages, remainder ), columnCount ),
+			].map( ( imagesInRow, rowIndex ) => (
+				<Row key={ rowIndex } className={ `columns-${ imagesInRow.length }` }>
+					{ imagesInRow.map( ( image, colIndex ) => (
+						<Column key={ colIndex }>{ image }</Column>
+					) ) }
+				</Row>
+			) ) }
+		</Gallery>
+	);
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/save.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/save.js
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import Layout from './layout';
+import { getActiveStyleName } from '../../../../shared/block-styles';
+import { LAYOUT_STYLES } from './constants';
+
+function defaultColumnsNumber( attributes ) {
+	return Math.min( 3, attributes.images.length );
+}
+
+export default function TiledGallerySave( { attributes } ) {
+	const { imageFilter, images } = attributes;
+
+	if ( ! images.length ) {
+		return null;
+	}
+
+	const {
+		align,
+		className,
+		columns = defaultColumnsNumber( attributes ),
+		linkTo,
+		roundedCorners,
+	} = attributes;
+
+	return (
+		<Layout
+			align={ align }
+			className={ className }
+			columns={ columns }
+			imageFilter={ imageFilter }
+			images={ images }
+			isSave
+			layoutStyle={ getActiveStyleName( LAYOUT_STYLES, className ) }
+			linkTo={ linkTo }
+			roundedCorners={ roundedCorners }
+		/>
+	);
+}

--- a/extensions/blocks/tiled-gallery/deprecated/v2/utils/index.js
+++ b/extensions/blocks/tiled-gallery/deprecated/v2/utils/index.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import photon from 'photon';
+import { format as formatUrl, parse as parseUrl } from 'url';
+import { isBlobURL } from '@wordpress/blob';
+import { range } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PHOTON_MAX_RESIZE } from '../constants';
+
+export function isSquareishLayout( layout ) {
+	return [ 'circle', 'square' ].includes( layout );
+}
+
+/**
+ * Build src and srcSet properties which can be used on an <img />
+ *
+ * @param {Object} img        Image
+ * @param {number} img.height Image height
+ * @param {string} img.url    Image URL
+ * @param {number} img.width  Image width
+ *
+ * @param {Object} galleryAtts Gallery attributes relevant for image optimization.
+ * @param {string} galleryAtts.layoutStyle Gallery layout. 'rectangular', 'circle', etc.
+ * @param {number} galleryAtts.columns     Gallery columns. Not applicable for all layouts.
+ *
+ * @return {Object} Returns an object. If possible, the object will include `src` and `srcSet`
+ *                  properties {string} for use on an image.
+ */
+export function photonizedImgProps( img, galleryAtts = {} ) {
+	if ( ! img.height || ! img.url || ! img.width ) {
+		return {};
+	}
+
+	// Do not Photonize images that are still uploading or from localhost
+	if (
+		isBlobURL( img.url ) ||
+		/^https?:\/\/localhost/.test( img.url ) ||
+		/^https?:\/\/.*\.local\//.test( img.url )
+	) {
+		return { src: img.url };
+	}
+
+	// Drop query args, photon URLs can't handle them
+	// This should be the "raw" url, we'll add dimensions later
+	const url = img.url.split( '?', 1 )[ 0 ];
+	const { height, width } = img;
+	const { layoutStyle } = galleryAtts;
+
+	const photonImplementation =
+		isWpcomFilesUrl( url ) || true === isVIP() ? photonWpcomImage : photon;
+
+	/**
+	 * Build the `src`
+	 * We don't know what the viewport size will be like. Use full size src.
+	 */
+
+	let src;
+	if ( isSquareishLayout( layoutStyle ) && width && height ) {
+		// Layouts with 1:1 width/height ratio should be made square
+		const size = Math.min( PHOTON_MAX_RESIZE, width, height );
+		src = photonImplementation( url, {
+			resize: `${ size },${ size }`,
+		} );
+	} else {
+		src = photonImplementation( url );
+	}
+
+	/**
+	 * Build a sensible `srcSet` that will let the browser get an optimized image based on
+	 * viewport width.
+	 */
+
+	const step = 300;
+	const srcsetMinWith = 600;
+
+	let srcSet;
+	if ( isSquareishLayout( layoutStyle ) ) {
+		const minWidth = Math.min( srcsetMinWith, width, height );
+		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width, height );
+
+		srcSet = range( minWidth, maxWidth, step )
+			.map( srcsetWidth => {
+				const srcsetSrc = photonImplementation( url, {
+					resize: `${ srcsetWidth },${ srcsetWidth }`,
+					strip: 'info',
+				} );
+				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
+			} )
+			.filter( Boolean )
+			.join( ',' );
+	} else {
+		const minWidth = Math.min( srcsetMinWith, width );
+		const maxWidth = Math.min( PHOTON_MAX_RESIZE, width );
+
+		srcSet = range( minWidth, maxWidth, step )
+			.map( srcsetWidth => {
+				const srcsetSrc = photonImplementation( url, {
+					strip: 'info',
+					width: srcsetWidth,
+				} );
+				return srcsetSrc ? `${ srcsetSrc } ${ srcsetWidth }w` : null;
+			} )
+			.filter( Boolean )
+			.join( ',' );
+	}
+
+	return Object.assign( { src }, srcSet && { srcSet } );
+}
+function isVIP() {
+	/*global jetpack_plan*/
+	if ( typeof jetpack_plan !== 'undefined' && jetpack_plan.data === 'vip' ) {
+		return true;
+	}
+}
+function isWpcomFilesUrl( url ) {
+	const { host } = parseUrl( url );
+	return /\.files\.wordpress\.com$/.test( host );
+}
+
+/**
+ * Apply photon arguments to *.files.wordpress.com images
+ *
+ * This function largely duplicates the functionlity of the photon.js lib.
+ * This is necessary because we want to serve images from *.files.wordpress.com so that private
+ * WordPress.com sites can use this block which depends on a Photon-like image service.
+ *
+ * If we pass all images through Photon servers, some images are unreachable. *.files.wordpress.com
+ * is already photon-like so we can pass it the same parameters for image resizing.
+ *
+ * @param  {string} url  Image url
+ * @param  {Object} opts Options to pass to photon
+ *
+ * @return {string}      Url string with options applied
+ */
+function photonWpcomImage( url, opts = {} ) {
+	// Adhere to the same options API as the photon.js lib
+	const photonLibMappings = {
+		width: 'w',
+		height: 'h',
+		letterboxing: 'lb',
+		removeLetterboxing: 'ulb',
+	};
+
+	// Discard some param parts
+	const { auth, hash, port, query, search, ...urlParts } = parseUrl( url );
+
+	// Build query
+	// This reduction intentionally mutates the query as it is built internally.
+	urlParts.query = Object.keys( opts ).reduce(
+		( q, key ) =>
+			Object.assign( q, {
+				[ photonLibMappings.hasOwnProperty( key ) ? photonLibMappings[ key ] : key ]: opts[ key ],
+			} ),
+		{}
+	);
+
+	return formatUrl( urlParts );
+}

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -105,6 +105,7 @@ class TiledGalleryEdit extends Component {
 			},
 			onError: noticeOperations.createErrorNotice,
 		} );
+		this.setState( { changed: true } );
 	};
 
 	onRemoveImage = index => () => {
@@ -134,6 +135,7 @@ class TiledGalleryEdit extends Component {
 			columns: columns ? Math.min( images.length, columns ) : columns,
 			images: images.map( image => pickRelevantMediaFiles( image ) ),
 		} );
+		this.setState( { changed: true } );
 	};
 
 	onMove = ( oldIndex, newIndex ) => {

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -65,7 +65,7 @@ export const pickRelevantMediaFiles = image => {
 class TiledGalleryEdit extends Component {
 	state = {
 		selectedImage: null,
-		changed: false,
+		changed: 'undefined' === typeof this.props.attributes.columnWidths ? true : false,
 	};
 
 	static getDerivedStateFromProps( props, state ) {

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -65,6 +65,7 @@ export const pickRelevantMediaFiles = image => {
 class TiledGalleryEdit extends Component {
 	state = {
 		selectedImage: null,
+		changed: false,
 	};
 
 	static getDerivedStateFromProps( props, state ) {
@@ -111,6 +112,7 @@ class TiledGalleryEdit extends Component {
 		const { columns } = this.props.attributes;
 		this.setState( {
 			selectedImage: null,
+			changed: true,
 		} );
 		this.setAttributes( {
 			images,
@@ -138,7 +140,10 @@ class TiledGalleryEdit extends Component {
 		const images = [ ...this.props.attributes.images ];
 		images.splice( newIndex, 1, this.props.attributes.images[ oldIndex ] );
 		images.splice( oldIndex, 1, this.props.attributes.images[ newIndex ] );
-		this.setState( { selectedImage: newIndex } );
+		this.setState( {
+			selectedImage: newIndex,
+			changed: true,
+		} );
 		this.setAttributes( { images } );
 	};
 
@@ -161,7 +166,9 @@ class TiledGalleryEdit extends Component {
 	};
 
 	onResize = columnWidths => {
-		this.setAttributes( { columnWidths } );
+		if ( this.state.changed ) {
+			this.setAttributes( { columnWidths } );
+		}
 	};
 
 	setColumnsNumber = value => this.setAttributes( { columns: value } );

--- a/extensions/blocks/tiled-gallery/edit.js
+++ b/extensions/blocks/tiled-gallery/edit.js
@@ -160,6 +160,10 @@ class TiledGalleryEdit extends Component {
 		};
 	};
 
+	onResize = columnWidths => {
+		this.setAttributes( { columnWidths } );
+	};
+
 	setColumnsNumber = value => this.setAttributes( { columns: value } );
 
 	setRoundedCorners = value => this.setAttributes( { roundedCorners: value } );
@@ -303,6 +307,7 @@ class TiledGalleryEdit extends Component {
 					onMoveForward={ this.onMoveForward }
 					onRemoveImage={ this.onRemoveImage }
 					onSelectImage={ this.onSelectImage }
+					onResize={ this.onResize }
 					roundedCorners={ roundedCorners }
 					selectedImage={ isSelected ? selectedImage : null }
 					setImageAttributes={ this.setImageAttributes }

--- a/extensions/blocks/tiled-gallery/gallery-image/save.js
+++ b/extensions/blocks/tiled-gallery/gallery-image/save.js
@@ -31,6 +31,7 @@ export default function GalleryImageSave( props ) {
 			data-url={ origUrl }
 			data-width={ width }
 			src={ url }
+			layout={ 'responsive' }
 		/>
 	);
 

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -77,6 +77,10 @@ const blockAttributes = {
 	columns: {
 		type: 'number',
 	},
+	columnWidths: {
+		default: [],
+		type: 'array',
+	},
 	ids: {
 		default: [],
 		type: 'array',

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -25,7 +25,7 @@ import { isSimpleSite } from '../../shared/site-type-utils';
  */
 import './editor.scss';
 
-import * as deprecatedV1 from './deprecated/v1';
+import { default as deprecated } from './deprecated';
 
 /**
  * Example Images
@@ -286,7 +286,7 @@ export const settings = {
 	},
 	edit,
 	save,
-	deprecated: [ deprecatedV1 ],
+	deprecated,
 	example: {
 		attributes: exampleAttributes,
 	},

--- a/extensions/blocks/tiled-gallery/layout/column.js
+++ b/extensions/blocks/tiled-gallery/layout/column.js
@@ -1,3 +1,8 @@
-export default function Column( { children } ) {
-	return <div className="tiled-gallery__col">{ children }</div>;
+export default function Column( { children, width } ) {
+	const style = width ? { flexBasis: `${ width }%` } : undefined;
+	return (
+		<div className="tiled-gallery__col" style={ style }>
+			{ children }
+		</div>
+	);
 }

--- a/extensions/blocks/tiled-gallery/layout/index.js
+++ b/extensions/blocks/tiled-gallery/layout/index.js
@@ -76,7 +76,18 @@ export default class Layout extends Component {
 	}
 
 	render() {
-		const { align, children, className, columns, images, layoutStyle, roundedCorners } = this.props;
+		const {
+			align,
+			children,
+			className,
+			columns,
+			images,
+			layoutStyle,
+			roundedCorners,
+			onResize,
+			isSave,
+			columnWidths,
+		} = this.props;
 		const LayoutRenderer = isSquareishLayout( layoutStyle ) ? Square : Mosaic;
 		const renderedImages = this.props.images.map( this.renderImage, this );
 		const roundedCornersValue =
@@ -91,9 +102,11 @@ export default class Layout extends Component {
 				<LayoutRenderer
 					align={ align }
 					columns={ columns }
+					columnWidths={ isSave ? columnWidths : undefined }
 					images={ images }
 					layoutStyle={ layoutStyle }
 					renderedImages={ renderedImages }
+					onResize={ isSave ? undefined : onResize }
 				/>
 				{ children }
 			</div>

--- a/extensions/blocks/tiled-gallery/layout/mosaic/index.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/index.js
@@ -42,7 +42,13 @@ export default class Mosaic extends Component {
 		this.pendingRaf = requestAnimationFrame( () => {
 			for ( const { contentRect, target } of entries ) {
 				const { width } = contentRect;
-				getGalleryRows( target ).forEach( row => handleRowResize( row, width ) );
+				const colWidths = [];
+				getGalleryRows( target ).forEach( row => {
+					colWidths.push( handleRowResize( row, width ) );
+				} );
+				if ( 'undefined' !== typeof this.props.onResize ) {
+					this.props.onResize( colWidths );
+				}
 			}
 		} );
 	};
@@ -78,7 +84,7 @@ export default class Mosaic extends Component {
 	}
 
 	render() {
-		const { align, columns, images, layoutStyle, renderedImages } = this.props;
+		const { align, columns, images, layoutStyle, renderedImages, columnWidths } = this.props;
 
 		const ratios = imagesToRatios( images );
 		const rows =
@@ -94,7 +100,14 @@ export default class Mosaic extends Component {
 						{ row.map( ( colSize, colIndex ) => {
 							const columnImages = renderedImages.slice( cursor, cursor + colSize );
 							cursor += colSize;
-							return <Column key={ colIndex }>{ columnImages }</Column>;
+							return (
+								<Column
+									key={ colIndex }
+									width={ columnWidths ? columnWidths[ rowIndex ][ colIndex ] : undefined }
+								>
+									{ columnImages }
+								</Column>
+							);
 						} ) }
 					</Row>
 				) ) }

--- a/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/extensions/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -17,7 +17,7 @@ function adjustFit( parts, target ) {
 }
 
 export function handleRowResize( row, width ) {
-	applyRowRatio( row, getRowRatio( row ), width );
+	return applyRowRatio( row, getRowRatio( row ), width );
 }
 
 function getRowRatio( row ) {
@@ -69,7 +69,7 @@ function applyRowRatio( row, [ ratio, weightedRatio ], width ) {
 	const rawHeight =
 		( 1 / ratio ) * ( width - GUTTER_WIDTH * ( row.childElementCount - 1 ) - weightedRatio );
 
-	applyColRatio( row, {
+	return applyColRatio( row, {
 		rawHeight,
 		rowWidth: width - GUTTER_WIDTH * ( row.childElementCount - 1 ),
 	} );
@@ -93,6 +93,12 @@ function applyColRatio( row, { rawHeight, rowWidth } ) {
 			rawWidth,
 		} );
 	} );
+
+	const colWidthPercentages = adjustedWidths.map(
+		adjustedWidth => ( adjustedWidth / rowWidth ) * 100
+	);
+
+	return colWidthPercentages;
 }
 
 function applyImgRatio( col, { colHeight, width, rawWidth } ) {

--- a/extensions/blocks/tiled-gallery/save.js
+++ b/extensions/blocks/tiled-gallery/save.js
@@ -19,6 +19,7 @@ export default function TiledGallerySave( { attributes } ) {
 		columns = defaultColumnsNumber( attributes ),
 		linkTo,
 		roundedCorners,
+		columnWidths,
 	} = attributes;
 
 	return (
@@ -32,6 +33,7 @@ export default function TiledGallerySave( { attributes } ) {
 			layoutStyle={ getActiveStyleName( LAYOUT_STYLES, className ) }
 			linkTo={ linkTo }
 			roundedCorners={ roundedCorners }
+			columnWidths={ columnWidths }
 		/>
 	);
 }

--- a/extensions/blocks/tiled-gallery/view.scss
+++ b/extensions/blocks/tiled-gallery/view.scss
@@ -78,6 +78,7 @@ $tiled-gallery-max-rounded-corners: 20; // See constants.js for JS counterpart
 	overflow: hidden;
 	padding: 0;
 	position: relative;
+	flex-grow: 1;
 
 	&.filter__black-and-white {
 		filter: grayscale( 100% );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fix the output of the Mosaic and Columns styles of Tiled Galleries on AMP pages when they are generated using Gutenberg.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This modifies the output of the Tiled Gallery block

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure AMP plugin is activated
2. On AMP General settings page, set 'Transitional' or 'Reader' as the Template Mode
3. Ensure that Gutenberg is the default editor.
4. Create a new Post
5. Add a new `Tiled Gallery` block
![](https://user-images.githubusercontent.com/51013565/81761508-bb30e780-948f-11ea-8bb7-1eba6ac4cbf2.png)
6. Select the images for the gallery (by uploading from your pc or selecting them from the `Media Library`)
![](https://user-images.githubusercontent.com/51013565/81762057-3e067200-9491-11ea-8117-315967ae1ca8.png)

7. Click on the AMP logo close to the `Preview` button (See the red arrow on the image above)
8. On the preview page you should see the output for the gallery:
![](https://user-images.githubusercontent.com/51013565/81762202-ad7c6180-9491-11ea-9a54-d503d5895baf.png)
9. Compare the output for the AMP pages with the normal pages, go back to the edit page and click on the `Preview` button:
![](https://user-images.githubusercontent.com/51013565/81762298-ea485880-9491-11ea-8185-f050ff7541f6.png)
10. Go back to the edit page and change the style of the gallery to `Tiled columns`. Click on the gallery and then click on the `Change block type or style`, on the style selector, select `Tiled columns`:
![](https://user-images.githubusercontent.com/51013565/81762503-6478dd00-9492-11ea-953e-9d846d875580.png)
11. The gallery should change to the `Tiled Columns`. Proceed to check the AMP preview.
![](https://user-images.githubusercontent.com/51013565/81762642-cb969180-9492-11ea-86eb-71a5691ca0de.png)
12. Compare the AMP output with the normal pages:
![](https://user-images.githubusercontent.com/51013565/81762689-e6690600-9492-11ea-8460-fb855871ccce.png)

#### Before
AMP output for `Tiled mosaic`
![Before fix](https://user-images.githubusercontent.com/51013565/81764821-0c44d980-9498-11ea-994e-f37247eb2a91.png)
AMP Output for `Tiled Columns`
![Before fix](https://user-images.githubusercontent.com/51013565/81764915-3dbda500-9498-11ea-9860-60b8460d5bcb.png)

#### Note
Check the AMP output for several amount of images.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve AMP compatibility of the Tiled Gallery block
