### PR TITLE
Photon: exclude Wikimedia images from Photon

### DIFF
--- a/functions.photon.php
+++ b/functions.photon.php
@@ -352,6 +352,7 @@ function jetpack_photon_banned_domains( $skip, $image_url ) {
 		'/\.paypalobjects\.com$/',
 		'/\.dropbox\.com$/',
 		'/\.cdninstagram\.com$/',
+		'/\.wikimedia\.org$/',
 	);
 
 	$host = wp_parse_url( $image_url, PHP_URL_HOST );


### PR DESCRIPTION
Fixes #15772

#### Changes proposed in this Pull Request:

Wikimedia uses a specific image URL format, such as this one:
https://commons.wikimedia.org/wiki/File:Dapper_Gentleman.jpg

Although the url uses .jpg, the image is wrapped and displayed within Wikipedia's UI. We consequently should not try to serve such html pages from our CDN.

#### Testing instructions:

* Start on a site where the Site Accelerator feature is active.
* In a new post, add an image block, with just about any image.
* After adding the image, add a link to `https://commons.wikimedia.org/wiki/File:Dapper_Gentleman.jpg` to the image like so:
![image](https://user-images.githubusercontent.com/426388/81793218-5ca84f80-9509-11ea-8dd3-afa68d06b0d4.png)
* Publish your post.
* Check the published post. The image should link to `https://commons.wikimedia.org/wiki/File:Dapper_Gentleman.jpg`, not `https://i0.wp.com/commons.wikimedia.org/wiki/File:Dapper_Gentleman.jpg`

#### Proposed changelog entry for your changes:

* Site Accelerator: avoid breaking links when linking to Wikimedia images.
