### PR TITLE
Instagram Gallery Block: Make sure the gallery is an object

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -47,8 +47,12 @@ class Jetpack_Instagram_Gallery_Helper {
 				return $gallery;
 			}
 
-			set_transient( $transient_key, wp_json_encode( $gallery ), HOUR_IN_SECONDS );
-			return $gallery;
+			$encoded_gallery = wp_json_encode( $gallery );
+
+			set_transient( $transient_key, $encoded_gallery, HOUR_IN_SECONDS );
+
+			// Make sure the gallery is an object.
+			return json_decode( $encoded_gallery );
 		}
 
 		$response = Client::wpcom_json_api_request_as_blog(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes issue reported on p58i-8Zc-p2.

> Front-end – The block was not displayed at all with the above settings. Tried changing the number of posts equal to or less than the available limit and the block showed up without any problems.
> Problem is WordPress.com specific I guess.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make sure the gallery is an object before attempting to display it.

On Jetpack we retrieve the gallery through the API, which ensures that the output is a JSON object.
On WPCOM, we skip the API, and use the gallery straight away. But the gallery is an array, and so parsing it fails.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test this change on both Jetpack and WPCOM.
* Make sure the Instagram Gallery block is rendered successfully on the front end of the site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (block still unreleased)
