### PR TITLE
Instagram Gallery Block: Add a "Stack on mobile" setting

### DIFF
--- a/extensions/blocks/instagram-gallery/attributes.js
+++ b/extensions/blocks/instagram-gallery/attributes.js
@@ -23,4 +23,8 @@ export default {
 		min: 0,
 		max: 50,
 	},
+	isStackedOnMobile: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -16,6 +16,7 @@ import {
 	Placeholder,
 	RangeControl,
 	Spinner,
+	ToggleControl,
 	withNotices,
 } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
@@ -35,7 +36,15 @@ import './editor.scss';
 
 const InstagramGalleryEdit = props => {
 	const { attributes, className, isSelected, noticeOperations, noticeUI, setAttributes } = props;
-	const { accessToken, align, columns, count, instagramUser, spacing } = attributes;
+	const {
+		accessToken,
+		align,
+		columns,
+		count,
+		instagramUser,
+		isStackedOnMobile,
+		spacing,
+	} = attributes;
 
 	const { images, isLoadingGallery, setImages } = useInstagramGallery( {
 		accessToken,
@@ -67,7 +76,8 @@ const InstagramGalleryEdit = props => {
 	const blockClasses = classnames( className, { [ `align${ align }` ]: align } );
 	const gridClasses = classnames(
 		'wp-block-jetpack-instagram-gallery__grid',
-		`wp-block-jetpack-instagram-gallery__grid-columns-${ columns }`
+		`wp-block-jetpack-instagram-gallery__grid-columns-${ columns }`,
+		{ 'is-stacked-on-mobile': isStackedOnMobile }
 	);
 	const gridStyle = { gridGap: spacing };
 	const photoStyle = { padding: spacing };
@@ -216,6 +226,15 @@ const InstagramGalleryEdit = props => {
 							onChange={ value => setAttributes( { spacing: value } ) }
 							min={ 0 }
 							max={ 50 }
+						/>
+						<ToggleControl
+							label={ __( 'Stack on mobile' ) }
+							checked={ isStackedOnMobile }
+							onChange={ () =>
+								setAttributes( {
+									isStackedOnMobile: ! isStackedOnMobile,
+								} )
+							}
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -228,7 +228,7 @@ const InstagramGalleryEdit = props => {
 							max={ 50 }
 						/>
 						<ToggleControl
-							label={ __( 'Stack on mobile' ) }
+							label={ __( 'Stack on mobile', 'jetpack' ) }
 							checked={ isStackedOnMobile }
 							onChange={ () =>
 								setAttributes( {

--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -1,3 +1,5 @@
+@import '../../shared/styles/gutenberg-base-styles.scss';
+
 .wp-block-jetpack-instagram-gallery__count-notice {
 	.components-notice {
 		margin: 0 0 15px 0;
@@ -34,6 +36,12 @@
 		width: calc( 100% / #{$i} );
 	}
 }
+@media ( max-width: $break-small ) {
+	.wp-block-jetpack-instagram-gallery__grid.is-stacked-on-mobile
+		.wp-block-jetpack-instagram-gallery__grid-post {
+		width: 100%;
+	}
+}
 
 @supports ( display: grid ) {
 	.wp-block-jetpack-instagram-gallery__grid {
@@ -41,8 +49,24 @@
 		grid-gap: 10px;
 		grid-auto-columns: 1fr;
 
+		@media ( max-width: $break-small ) {
+			&.is-stacked-on-mobile {
+				display: block;
+			}
+			&:not( .is-stacked-on-mobile ) {
+				.wp-block-jetpack-instagram-gallery__grid-post {
+					padding: 0 !important; // Overrides the block style
+				}
+			}
+		}
+
+		@media ( min-width: $break-small ) {
+			.wp-block-jetpack-instagram-gallery__grid-post {
+				padding: 0 !important; // Overrides the block style
+			}
+		}
+
 		.wp-block-jetpack-instagram-gallery__grid-post {
-			padding: 0 !important; // Overrides the block style
 			width: auto;
 		}
 	}

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -44,10 +44,11 @@ function render_block( $attributes, $content ) {
 		return '';
 	}
 
-	$access_token = $attributes['accessToken'];
-	$columns      = get_instagram_gallery_attribute( 'columns', $attributes );
-	$count        = get_instagram_gallery_attribute( 'count', $attributes );
-	$spacing      = get_instagram_gallery_attribute( 'spacing', $attributes );
+	$access_token         = $attributes['accessToken'];
+	$columns              = get_instagram_gallery_attribute( 'columns', $attributes );
+	$count                = get_instagram_gallery_attribute( 'count', $attributes );
+	$is_stacked_on_mobile = get_instagram_gallery_attribute( 'isStackedOnMobile', $attributes );
+	$spacing              = get_instagram_gallery_attribute( 'spacing', $attributes );
 
 	$grid_classes = Jetpack_Gutenberg::block_classes(
 		FEATURE_NAME,
@@ -57,8 +58,12 @@ function render_block( $attributes, $content ) {
 			'wp-block-jetpack-instagram-gallery__grid-columns-' . $columns,
 		)
 	);
-	$grid_style   = 'grid-gap: ' . $spacing . 'px;';
-	$photo_style  = 'padding: ' . $spacing . 'px;';
+	if ( $is_stacked_on_mobile ) {
+		$grid_classes .= ' is-stacked-on-mobile';
+	}
+
+	$grid_style  = 'grid-gap: ' . $spacing . 'px;';
+	$photo_style = 'padding: ' . $spacing . 'px;';
 
 	if ( ! class_exists( 'Jetpack_Instagram_Gallery_Helper' ) ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
@@ -109,9 +114,10 @@ function get_instagram_gallery_attribute( $attribute, $attributes ) {
 	}
 
 	$default_attributes = array(
-		'columns' => 3,
-		'count'   => 9,
-		'spacing' => 10,
+		'columns'           => 3,
+		'count'             => 9,
+		'isStackedOnMobile' => true,
+		'spacing'           => 10,
 	);
 
 	if ( array_key_exists( $attribute, $default_attributes ) ) {

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -56,11 +56,9 @@ function render_block( $attributes, $content ) {
 		array(
 			'wp-block-jetpack-instagram-gallery__grid',
 			'wp-block-jetpack-instagram-gallery__grid-columns-' . $columns,
+			( $is_stacked_on_mobile ? 'is-stacked-on-mobile' : null ),
 		)
 	);
-	if ( $is_stacked_on_mobile ) {
-		$grid_classes .= ' is-stacked-on-mobile';
-	}
 
 	$grid_style  = 'grid-gap: ' . $spacing . 'px;';
 	$photo_style = 'padding: ' . $spacing . 'px;';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes issue reported on p58i-8Zc-p2.

> Mobile Layout – No responsive settings

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a "Stack on mobile" setting, similar to the one used for the Core Media & Text block.

| Large screens | Small screens |
| - | - |
| <img width="1065" alt="Screenshot 2020-05-13 at 11 10 17" src="https://user-images.githubusercontent.com/2070010/81800242-7007ea80-950a-11ea-85f0-b9021ada25ec.png"> | <img width="382" alt="Screenshot 2020-05-13 at 11 10 31" src="https://user-images.githubusercontent.com/2070010/81800251-71d1ae00-950a-11ea-8a63-aa4ed1f4a81b.png"> |

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert an Instagram Gallery block and connect it to an account with more than 1 image.
* Make sure there is a "Stack on mobile" setting in the block sidebar, and it's on by default.
* Resize the browser to a mobile width, and make sure the gallery is displayed in 1 column.
* Toggle off the "Stack on mobile" setting, and make sure the gallery is displayed in 3 columns on mobile as well.
* Repeat the test checking the rendered block in the front end.
* Now open the block's `editor.scss` and edit the `@supports ( display: grid )` line, and replace it with something like `@supports ( display: foobar )`. This is helpful to test what happens on browsers that don't support CSS grids.
* Repeat the tests above in both the editor and front end.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (block still unreleased)
