### PR TITLE
External Media: add scaffolding

### DIFF
--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -5,6 +5,7 @@ import './shared/public-path';
 import './shared/block-category';
 import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
+import './shared/external-media';
 import analytics from '../_inc/client/lib/analytics';
 
 // @TODO Please make a shared analytics solution and remove this!

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -1,0 +1,7 @@
+/*
+ * External Media editor-canvas styles.
+ */
+
+.jetpack-external-media-browse-button {
+	margin-right: 8px !important;
+}

--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -1,0 +1,40 @@
+/**
+* WordPress dependencies
+*/
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import MediaButton from './media-button';
+import './editor.scss';
+
+function insertExternalMediaBlocks( settings, name ) {
+	if ( name !== 'core/image' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		keywords: [ ...settings.keywords ], // we'll populate with the sources keywords
+	};
+}
+
+// Register the new 'browse media' button
+addFilter(
+	'editor.MediaUpload',
+	'external-media/replace-media-upload',
+	OriginalComponent => props => (
+		<OriginalComponent
+			{ ...props }
+			render={ button => <MediaButton { ...button } mediaProps={ props } /> }
+		/>
+	)
+);
+
+// Register the individual external media blocks
+addFilter(
+	'blocks.registerBlockType',
+	'external-media/individual-blocks',
+	insertExternalMediaBlocks
+);

--- a/extensions/shared/external-media/media-button/index.js
+++ b/extensions/shared/external-media/media-button/index.js
@@ -1,0 +1,16 @@
+
+/**
+ * Internal dependencies
+ */
+import MediaButtonMenu from './media-menu';
+
+function MediaButton( props ) {
+	const { mediaProps } = props;
+	return (
+		<div>
+			<MediaButtonMenu mediaProps={ mediaProps } />
+		</div>
+	);
+}
+
+export default MediaButton;

--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -1,0 +1,31 @@
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+function MediaButtonMenu( props ) {
+	const { mediaProps, open, isFeatured } = props;
+	const originalComponent = mediaProps.render;
+
+	if ( isFeatured && mediaProps.value === undefined ) {
+		return originalComponent( { open } );
+	}
+
+	return (
+		<Button
+			className="jetpack-external-media-browse-button"
+			isTertiary={ ! isFeatured }
+			isPrimary={ isFeatured }
+		>
+			{ __( 'Select Image', 'jetpack' ) }
+		</Button>
+	);
+}
+
+export default MediaButtonMenu;


### PR DESCRIPTION
It implements the scaffolding for the external media feature. Changes here were based and mostly copied from https://github.com/Automattic/jetpack/pull/15721/files.

#### Testing instructions:

* Apply these changes
* Create a `core/image` block
* Confirm that there is a useless (for now we hope 😅 )`Select Image` button there.
![image](https://user-images.githubusercontent.com/77539/81820982-b27bf800-9507-11ea-8bbf-36c1467a6aa8.png)
* You can confirm that the component is already there inspecting it from the dev tool:

<img width="796" alt="Screen Shot 2020-05-13 at 10 52 07 AM" src="https://user-images.githubusercontent.com/77539/81821067-d2abb700-9507-11ea-9789-4e2429ce54fb.png">
