### PR TITLE
Sender needs to load consistently utilizing  logic

### DIFF
--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -182,7 +182,7 @@ class Actions {
 			return self::sync_via_cron_allowed();
 		}
 
-		return false;
+		return true;
 	}
 
 	/**

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -170,6 +170,22 @@ class Actions {
 	}
 
 	/**
+	 * Decides if the sender should run on shutdown when actions are queued.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return bool
+	 */
+	public static function should_initialize_sender_enqueue() {
+		if ( Constants::is_true( 'DOING_CRON' ) ) {
+			return self::sync_via_cron_allowed();
+		}
+
+		return false;
+	}
+
+	/**
 	 * Decides if sync should run at all during this request.
 	 *
 	 * @access public

--- a/packages/sync/src/class-listener.php
+++ b/packages/sync/src/class-listener.php
@@ -349,7 +349,7 @@ class Listener {
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible.
 		if ( ! Actions::$sender ) {
-			add_filter( 'jetpack_sync_sender_should_load', '__return_true' );
+			add_filter( 'jetpack_sync_sender_should_load', Actions::should_initialize_sender() );
 			if ( did_action( 'init' ) ) {
 				Actions::add_sender_shutdown();
 			}

--- a/packages/sync/src/class-listener.php
+++ b/packages/sync/src/class-listener.php
@@ -349,7 +349,7 @@ class Listener {
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible.
 		if ( ! Actions::$sender ) {
-			add_filter( 'jetpack_sync_sender_should_load', __NAMESPACE__ . '\Actions::should_initialize_sender' );
+			add_filter( 'jetpack_sync_sender_should_load', __NAMESPACE__ . '\Actions::should_initialize_sender_enqueue' );
 			if ( did_action( 'init' ) ) {
 				Actions::add_sender_shutdown();
 			}

--- a/packages/sync/src/class-listener.php
+++ b/packages/sync/src/class-listener.php
@@ -349,7 +349,7 @@ class Listener {
 
 		// since we've added some items, let's try to load the sender so we can send them as quickly as possible.
 		if ( ! Actions::$sender ) {
-			add_filter( 'jetpack_sync_sender_should_load', Actions::should_initialize_sender() );
+			add_filter( 'jetpack_sync_sender_should_load', __NAMESPACE__ . '\Actions::should_initialize_sender' );
 			if ( did_action( 'init' ) ) {
 				Actions::add_sender_shutdown();
 			}

--- a/tests/php/sync/test_class.jetpack-sync-integration.php
+++ b/tests/php/sync/test_class.jetpack-sync-integration.php
@@ -103,7 +103,7 @@ class WP_Test_Jetpack_Sync_Integration extends WP_Test_Jetpack_Sync_Base {
 
 		$this->listener->enqueue_action( 'test_action', array( 'test_arg' ), $this->listener->get_sync_queue() );
 
-		$this->assertTrue( !! has_filter( 'jetpack_sync_sender_should_load', '__return_true' ) );
+		$this->assertTrue( has_filter( 'jetpack_sync_sender_should_load' ) );
 		$this->assertTrue( Actions::$sender !== null );
 	}
 


### PR DESCRIPTION
Jetpack Sync has various settings/filters that determine whether data should be sent on shutdown. Unfortunately this logic wasn't being applied consistently within the listener when data was queued.

This change simply re-uses the should_initialize_sender function to ensure that we don't send data when we are not supposed to.

#### Changes proposed in this Pull Request:
* consistently use `should_initialize_sender` to determine if the Sender should be initialized

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug Fix

#### Testing instructions:

* Apply https://github.com/Automattic/jetpack/pull/15726 
* Run the unit tests 
* WP_Test_Jetpack_Sync_Integration::test_do_not_load_sender_if_is_cron_and_cron_sync_disabled will fail
* Apply this PR
* Runt the unit tests
* WP_Test_Jetpack_Sync_Integration::test_do_not_load_sender_if_is_cron_and_cron_sync_disabled will pass

#### Proposed changelog entry for your changes:
* Jetpack Sync :: Bug fix to ensure sender is loaded consistently for cron
