### PR TITLE
Tracks: Send event when plugin is deactivated. 

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3456,6 +3456,8 @@ p {
 	 */
 	public static function plugin_deactivation() {
 		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		$tracking = new Tracking();
+		$tracking->record_user_event( 'deactivate_plugin', array() );
 		if ( is_plugin_active_for_network( 'jetpack/jetpack.php' ) ) {
 			Jetpack_Network::init()->deactivate();
 		} else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Currently there's no easy way to distinguish in Tracks between a regular "disconnect" and a disconnect that has happened via plugin deactivation. 

This PR adds a specific tracks even to fire on `plugin_deactivation_hook`. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Moar tracks

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Connect Jetpack 
- While Jetpack is still connected, go to plugins page
- Deactivate Jetpack from plugins page
- Wait in the "live" view of tracks. Search for events matching `jetpack_deactivate_plugin`. 
- Make sure deactivation works when Jetpack is not connected

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
