### PR TITLE
Refactor block attributes

### DIFF
--- a/extensions/blocks/image-compare/edit.js
+++ b/extensions/blocks/image-compare/edit.js
@@ -90,10 +90,11 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 							placeHolderLabel={ __( 'Image before', 'jetpack' ) }
 							onChange={ img => {
 								if ( img.media_type === 'image' || img.type === 'image' ) {
+									const { src } = photonizedImgProps( img );
 									setAttributes( {
 										imageBefore: {
 											id: img.id,
-											url: img.url,
+											url: src ? src : img.url,
 											alt: img.alt,
 											width: img.width,
 											height: img.height,

--- a/extensions/blocks/image-compare/index.js
+++ b/extensions/blocks/image-compare/index.js
@@ -31,46 +31,16 @@ export const settings = {
 	],
 
 	attributes: {
-		imageBeforeId: {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'id',
-			selector: '.image-compare__image-before',
+		imageBefore: {
+			type: 'object',
+			default: {},
 		},
-		imageBeforeUrl: {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'src',
-			selector: '.image-compare__image-before',
-		},
-		imageBeforeAlt: {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'alt',
-			selector: '.image-compare__image-before',
-		},
-		imageAfterId: {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'id',
-			selector: '.image-compare__image-after',
-		},
-		imageAfterUrl: {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'src',
-			selector: '.image-compare__image-after',
-		},
-		imageAfterAlt: {
-			type: 'string',
-			source: 'attribute',
-			attribute: 'alt',
-			selector: '.image-compare__image-after',
+		imageAfter: {
+			type: 'object',
+			default: {},
 		},
 		caption: {
 			type: 'string',
-			source: 'html',
-			selector: 'figcaption',
 		},
 		orientation: {
 			type: 'string',
@@ -79,13 +49,17 @@ export const settings = {
 
 	example: {
 		attributes: {
-			imageBeforeId: '1',
-			imageBeforeUrl: imgExampleBefore,
-			imageBeforeAlt: __( 'Before', 'jetpack' ),
-			imageAfterId: '2',
-			imageAfterUrl: imgExampleAfter,
-			imageAfterAlt: __( 'After', 'jetpack' ),
-			caption: __( 'Wonder Woman', 'jetpack' ),
+			imageBefore: {
+				id: 1,
+				url: imgExampleBefore,
+				alt: __( 'Before', 'jetpack' ),
+			},
+			imageAfter: {
+				id: 2,
+				url: imgExampleAfter,
+				alt: __( 'After', 'jetpack' ),
+			},
+			caption: __( 'Example image', 'jetpack' ),
 		},
 	},
 

--- a/extensions/blocks/image-compare/save.js
+++ b/extensions/blocks/image-compare/save.js
@@ -4,30 +4,25 @@
 import { RichText } from '@wordpress/block-editor';
 
 const save = ( { attributes, className } ) => {
-	const {
-		imageBeforeId,
-		imageBeforeUrl,
-		imageBeforeAlt,
-		imageAfterId,
-		imageAfterUrl,
-		imageAfterAlt,
-		caption,
-		orientation,
-	} = attributes;
+	const { imageBefore, imageAfter, caption, orientation } = attributes;
 
 	return (
 		<figure className={ className }>
 			<div className="juxtapose" data-mode={ orientation }>
 				<img
-					id={ imageBeforeId }
-					src={ imageBeforeUrl }
-					alt={ imageBeforeAlt }
+					id={ imageBefore.id }
+					src={ imageBefore.url }
+					alt={ imageBefore.alt }
+					width={ imageBefore.width }
+					height={ imageBefore.height }
 					className="image-compare__image-before"
 				/>
 				<img
-					id={ imageAfterId }
-					src={ imageAfterUrl }
-					alt={ imageAfterAlt }
+					id={ imageAfter.id }
+					src={ imageAfter.url }
+					alt={ imageAfter.alt }
+					width={ imageAfter.width }
+					height={ imageAfter.height }
 					className="image-compare__image-after"
 				/>
 			</div>


### PR DESCRIPTION
Due to changes for AMP support in #15753 we are changing the attributes to not be pulled from source. This allows switching the images to objects and simplifies the code.

Additionally, adds width/height attributes and uses the `photonizeImageProps` utility to set a photon URL.

Fixes: #15741

#### Changes proposed in this Pull Request:

* Switch attributes to remove source
* Switch image attributes to be objects
* Add width/height attributes to images
* Use photonizeImageProps to set src 


#### Testing instructions:

* Due to refactoring attributes, any old Image Compare blocks will invalidate
* Create a new Image Compare block
* Confirm block works as expected on edit/view/re-edit

Note: after this change goes in, the AMP part will need to be updated to include width/height that will also fix the aspect ratio issue.

#### Proposed changelog entry for your changes:

* For this PR, not necessary because the feature it is modifying is all new. So rolls up to the top entry which should be something like: "New Image Compare block"
