### PR TITLE
Widgets: Remove redirect

### DIFF
--- a/modules/widgets/gravatar-profile.php
+++ b/modules/widgets/gravatar-profile.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Redirect;
-
 /**
  * Register the widget for use in Appearance -> Widgets
  */
@@ -270,7 +268,7 @@ class Jetpack_Gravatar_Profile_Widget extends WP_Widget {
 			$profile_url = admin_url( 'profile.php' );
 
 			if ( isset( $_REQUEST['calypso'] ) ) {
-				$profile_url = Redirect::get_url( 'calypso-me' );
+				$profile_url = 'https://wordpress.com/me';
 			}
 		}
 		?>

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -307,7 +307,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 */
 	public function get_docs_link( $hash = '' ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$base_url = esc_url( Redirect::get_url( 'wpcom-support-widgets-twitter-timeline-widget' ) );
+			$base_url = 'https://support.wordpress.com/widgets/twitter-timeline-widget/';
 		} else {
 			$base_url = esc_url( Redirect::get_url( 'jetpack-support-extra-sidebar-widgets-twitter-timeline-widget' ) );
 		}

--- a/modules/widgets/twitter-timeline.php
+++ b/modules/widgets/twitter-timeline.php
@@ -307,7 +307,7 @@ class Jetpack_Twitter_Timeline_Widget extends WP_Widget {
 	 */
 	public function get_docs_link( $hash = '' ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-			$base_url = 'https://support.wordpress.com/widgets/twitter-timeline-widget/';
+			$base_url = 'https://wordpress.com/support/widgets/twitter-timeline-widget/';
 		} else {
 			$base_url = esc_url( Redirect::get_url( 'jetpack-support-extra-sidebar-widgets-twitter-timeline-widget' ) );
 		}


### PR DESCRIPTION
This code is only fires on WP.com.

Bypassed pre-commit hooks since I haven't added the redirect line to WP.com yet, so want to keep this PR clean wrt bringing it back in line with WP.com.

#### Changes proposed in this Pull Request:
* Remove code that doesn't fire in Jetpack.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* None needed.
