### PR TITLE
Instagram Gallery Block: Test the token by using it

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -51,6 +51,7 @@ const InstagramGalleryEdit = props => {
 	} );
 	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram( {
 		accessToken,
+		isLoadingGallery,
 		noticeOperations,
 		setAttributes,
 		setImages,

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -7,7 +7,6 @@ import { isEmpty, isEqual, times } from 'lodash';
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
@@ -19,9 +18,8 @@ import {
 	Spinner,
 	withNotices,
 } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -31,6 +29,7 @@ import { IS_CURRENT_USER_CONNECTED_TO_WPCOM, MAX_IMAGE_COUNT } from './constants
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import useConnectInstagram from './use-connect-instagram';
 import useConnectWpcom from './use-connect-wpcom';
+import useInstagramGallery from './use-instagram-gallery';
 import ImageTransition from './image-transition';
 import './editor.scss';
 
@@ -38,8 +37,18 @@ const InstagramGalleryEdit = props => {
 	const { attributes, className, isSelected, noticeOperations, noticeUI, setAttributes } = props;
 	const { accessToken, align, columns, count, instagramUser, spacing } = attributes;
 
-	const [ images, setImages ] = useState( [] );
-	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
+	useEffect( () => {
+		const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
+		if ( ! isEqual( validatedAttributes, attributes ) ) {
+			setAttributes( validatedAttributes );
+		}
+	}, [ attributes, setAttributes ] );
+
+	const { images, isLoadingGallery, setImages } = useInstagramGallery( {
+		accessToken,
+		noticeOperations,
+		setAttributes,
+	} );
 	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram( {
 		accessToken,
 		noticeOperations,
@@ -49,41 +58,6 @@ const InstagramGalleryEdit = props => {
 	const { isRequestingWpcomConnectUrl, wpcomConnectUrl } = useConnectWpcom();
 
 	const unselectedCount = count > images.length ? images.length : count;
-
-	useEffect( () => {
-		const validatedAttributes = getValidatedAttributes( defaultAttributes, attributes );
-		if ( ! isEqual( validatedAttributes, attributes ) ) {
-			setAttributes( validatedAttributes );
-		}
-	}, [ attributes, setAttributes ] );
-
-	useEffect( () => {
-		if ( ! accessToken ) {
-			return;
-		}
-
-		noticeOperations.removeAllNotices();
-		setIsLoadingGallery( true );
-
-		apiFetch( {
-			path: addQueryArgs( '/wpcom/v2/instagram-gallery/gallery', {
-				access_token: accessToken,
-				count: MAX_IMAGE_COUNT,
-			} ),
-		} ).then( ( { external_name: externalName, images: imageList } ) => {
-			setIsLoadingGallery( false );
-
-			if ( isEmpty( imageList ) ) {
-				noticeOperations.createErrorNotice(
-					__( 'No images were found in your Instagram account.', 'jetpack' )
-				);
-				return;
-			}
-
-			setAttributes( { instagramUser: externalName } );
-			setImages( imageList );
-		} );
-	}, [ accessToken, noticeOperations, setAttributes ] );
 
 	const showPlaceholder = ! isLoadingGallery && ( ! accessToken || isEmpty( images ) );
 	const showSidebar = ! showPlaceholder;

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -64,11 +64,10 @@ function render_block( $attributes, $content ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
 	}
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
-	$images  = array_slice( $gallery->images, 0, $count );
-
 	if ( is_wp_error( $gallery ) || empty( $gallery->images ) ) {
 		return '';
 	}
+	$images = array_slice( $gallery->images, 0, $count );
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -14,6 +14,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 export default function useConnectInstagram( {
 	accessToken,
+	isLoadingGallery,
 	noticeOperations,
 	setAttributes,
 	setImages,
@@ -36,15 +37,24 @@ export default function useConnectInstagram( {
 
 	// Automatically retrieve a working Instagram access token, if it exists.
 	useEffect( () => {
-		// If the block already has a token, and that token is marked as connected, don't retrieve it again.
-		if ( isTokenConnected ) {
-			return;
-		}
+		// Only try to skip retrieving a token if the block already has a token.
+		if ( accessToken ) {
+			// On a fresh page with clean state, the block will start by attempting to load the gallery.
+			// If it works, the token is valid and will be marked as connected, or as disconnected otherwise.
+			if ( isLoadingGallery || ( ! isTokenConnected && ! isTokenDisconnected ) ) {
+				return;
+			}
 
-		// If the block already has a token, and that token is marked as disconnected, remove it from the block.
-		if ( isTokenDisconnected ) {
-			setAttributes( { accessToken: undefined } );
-			return;
+			// If the block already has a token, and that token is marked as connected, don't retrieve it again.
+			if ( isTokenConnected ) {
+				return;
+			}
+
+			// If the block already has a token, and that token is marked as disconnected, remove it from the block.
+			if ( isTokenDisconnected ) {
+				setAttributes( { accessToken: undefined } );
+				return;
+			}
 		}
 
 		// Otherwise, try to retrieve it from the API.
@@ -70,6 +80,7 @@ export default function useConnectInstagram( {
 		accessToken,
 		connectInstagramGalleryToken,
 		disconnectInstagramGalleryToken,
+		isLoadingGallery,
 		isTokenConnected,
 		isTokenDisconnected,
 		setAttributes,

--- a/extensions/blocks/instagram-gallery/use-instagram-gallery.js
+++ b/extensions/blocks/instagram-gallery/use-instagram-gallery.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { MAX_IMAGE_COUNT } from './constants';
+
+export default function useInstagramGallery( { accessToken, noticeOperations, setAttributes } ) {
+	const [ images, setImages ] = useState( [] );
+	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
+
+	useEffect( () => {
+		if ( ! accessToken ) {
+			return;
+		}
+
+		noticeOperations.removeAllNotices();
+		setIsLoadingGallery( true );
+
+		apiFetch( {
+			path: addQueryArgs( '/wpcom/v2/instagram-gallery/gallery', {
+				access_token: accessToken,
+				count: MAX_IMAGE_COUNT,
+			} ),
+		} ).then( ( { external_name: externalName, images: imageList } ) => {
+			setIsLoadingGallery( false );
+
+			if ( isEmpty( imageList ) ) {
+				noticeOperations.createErrorNotice(
+					__( 'No images were found in your Instagram account.', 'jetpack' )
+				);
+				return;
+			}
+
+			setAttributes( { instagramUser: externalName } );
+			setImages( imageList );
+		} );
+	}, [ accessToken, noticeOperations, setAttributes ] );
+
+	return { images, isLoadingGallery, setImages };
+}


### PR DESCRIPTION
Fixes issue reported on p58i-8Zc-p2.

> One oddity I found was that when I connected my account I got a warning about only 5 images being available (when my account definitely has more than that – and shows more on the front end.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move the Instagram Gallery retrieval into a custom hook.
* Handle more API errors.
* In the SSR, check if the gallery is a `WP_Error` _before_ using it.
* When the state is clean, test tokens by directly using them to retrieve a gallery.

##### Previously

When we edited a post containing a (previously inserted and connected, so with the `accessToken` attribute set) Instagram Gallery block, to confirm that the token was still valid, the block called `GET access-token`.
Then, depending by its answer, would have proceeded to `GET gallery`.

This was both a waste of an API call, and also could have led to unexpected issues with automatic connections to incorrect tokens, breaking the block or ending up into infinite loops.

##### Now

When we _start editing_ a post (the Redux state is clean, and we don't know if tokens are valid or not) with an IG block with the `accessToken` set, we first try using it to `GET gallery`.

If the gallery returns, the token is valid; we can mark it as connected in state, and skip unnecessarily calling `GET access-token`.
If the gallery returns as error, the token is not valid; we mark it as disconnected and avoid trying to automatically connect the token with `GET access-token`.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Manual sync for testing on WPCOM: D43366-code

* Smoke test all the things!
* Try adding multiple IG blocks in the same post.
* Try adding more in another post.
* Try disconnecting them from one post, and see if reloading the other post the blocks are disconnected.
* Make sure the flow works as expected, and especially that there are no infinite loops to be seen.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A (unreleased block)
