### PR TITLE
Embeds: consolidate use of embed_autourls and filters

### DIFF
--- a/modules/shortcodes/hulu.php
+++ b/modules/shortcodes/hulu.php
@@ -17,13 +17,17 @@
  * @package Jetpack
  */
 
-if ( get_option( 'embed_autourls' ) ) {
+add_shortcode( 'hulu', 'jetpack_hulu_shortcode' );
 
-	// Convert hulu URLS to shortcodes for old comments, saved before comments for shortcodes were enabled.
+if (
+	! is_admin()
+	/** This filter is documented in modules/shortcodes/youtube.php */
+	&& apply_filters( 'jetpack_comments_allow_oembed', true )
+	// No need for this on WordPress.com, this is done for multiple shortcodes at a time there.
+	&& ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM )
+) {
 	add_filter( 'comment_text', 'jetpack_hulu_link', 1 );
 }
-
-add_shortcode( 'hulu', 'jetpack_hulu_shortcode' );
 
 /**
  * Return a Hulu video ID from a given set to attributes.

--- a/modules/shortcodes/spotify.php
+++ b/modules/shortcodes/spotify.php
@@ -10,11 +10,6 @@
 
 if ( ! shortcode_exists( 'spotify' ) ) {
 	add_shortcode( 'spotify', 'jetpack_spotify_shortcode' );
-
-	if ( get_option( 'embed_autourls' ) ) {
-		// If user enabled autourls, also convert syntax like spotify:track:4bz7uB4edifWKJXSDxwHcs.
-		add_filter( 'the_content', 'jetpack_spotify_embed_ids', 7 );
-	}
 }
 
 /**
@@ -84,6 +79,7 @@ function jetpack_spotify_embed_ids( $content ) {
 
 	return implode( '', $textarr );
 }
+add_filter( 'the_content', 'jetpack_spotify_embed_ids', 7 );
 
 /**
  * Call shortcode with ID provided by matching pattern.

--- a/modules/shortcodes/youtube.php
+++ b/modules/shortcodes/youtube.php
@@ -467,16 +467,21 @@ function wpcom_youtube_embed_crazy_url_init() {
 }
 add_action( 'init', 'wpcom_youtube_embed_crazy_url_init' );
 
-/**
- * Allow oEmbeds in Jetpack's Comment form.
- *
- * @module shortcodes
- *
- * @since 2.8.0
- *
- * @param int get_option('embed_autourls') Option to automatically embed all plain text URLs.
- */
-if ( ! is_admin() && apply_filters( 'jetpack_comments_allow_oembed', true ) ) {
+if (
+	! is_admin()
+	/**
+	 * Allow oEmbeds in Jetpack's Comment form.
+	 *
+	 * @module shortcodes
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param int $allow_oembed Option to automatically embed all plain text URLs.
+	 */
+	&& apply_filters( 'jetpack_comments_allow_oembed', true )
+	// No need for this on WordPress.com, this is done for multiple shortcodes at a time there.
+	&& ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM )
+) {
 	/*
 	 * We attach wp_kses_post to comment_text in default-filters.php with priority of 10 anyway,
 	 * so the iframe gets filtered out.


### PR DESCRIPTION
Follow-up to #4281

#### Changes proposed in this Pull Request:

`embed_autourls` was deprecated a long time ago, no need to use it anymore.

We can also remove its use in the `jetpack_comments_allow_oembed` filter.

#### Testing instructions:

* Start on a site where the Shortcodes module is enabled.
* We'll be testing 4 shortcodes:
    - In a new comment, add the following link: `http://www.hulu.com/watch/369061` (in my tests it did not always work, the Hulu service seems spotty, I would receive "Service unavailable" responses; maybe that's because I'm outside of the US)
    - In a new post, add the following text on its own line: `spotify:track:4bz7uB4edifWKJXSDxwHcs`
    - In a new comment, add the following link: `https://www.youtube.com/watch?v=Slp7N6NK0CE`
* Embeds should keep working.

#### Proposed changelog entry for your changes:

* Embeds: stop using deprecated WordPress option.
