### PR TITLE
Instagram Gallery Block: Test if the gallery is a WP_Error before using it

### DIFF
--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -64,11 +64,10 @@ function render_block( $attributes, $content ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
 	}
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
-	$images  = array_slice( $gallery->images, 0, $count );
-
 	if ( is_wp_error( $gallery ) || empty( $gallery->images ) ) {
 		return '';
 	}
+	$images = array_slice( $gallery->images, 0, $count );
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Move the `is_wp_error` check before using the `$gallery`, preventing an `array_slice` error that might compromise the rendering of the entire page.

#### Testing instructions:

Testing this is a bit complicated, as it would require to first manually change `Jetpack_Instagram_Gallery_Helper::get_instagram_gallery()` to return a `WP_Error`.

- Add an Instagram Gallery block, connect it, and save the post.
- Reload the editor, while monitoring the Network tab.
- Make sure the editor load.
- Search for the get post request (will be listed with the post ID), and make sure the response doesn't contain any PHP errors (which they won't, or otherwise the editor wouldn't load).

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A