### PR TITLE
Instagram Gallery Block: Move the gallery fetching in an external hook

### DIFF
--- a/extensions/blocks/instagram-gallery/use-instagram-gallery.js
+++ b/extensions/blocks/instagram-gallery/use-instagram-gallery.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { MAX_IMAGE_COUNT } from './constants';
+
+export default function useInstagramGallery( { accessToken, noticeOperations, setAttributes } ) {
+	const [ images, setImages ] = useState( [] );
+	const [ isLoadingGallery, setIsLoadingGallery ] = useState( false );
+
+	useEffect( () => {
+		if ( ! accessToken ) {
+			return;
+		}
+
+		noticeOperations.removeAllNotices();
+		setIsLoadingGallery( true );
+
+		apiFetch( {
+			path: addQueryArgs( '/wpcom/v2/instagram-gallery/gallery', {
+				access_token: accessToken,
+				count: MAX_IMAGE_COUNT,
+			} ),
+		} ).then( ( { external_name: externalName, images: imageList } ) => {
+			setIsLoadingGallery( false );
+
+			if ( isEmpty( imageList ) ) {
+				noticeOperations.createErrorNotice(
+					__( 'No images were found in your Instagram account.', 'jetpack' )
+				);
+				return;
+			}
+
+			setAttributes( { instagramUser: externalName } );
+			setImages( imageList );
+		} );
+	}, [ accessToken, noticeOperations, setAttributes ] );
+
+	return { images, isLoadingGallery, setImages };
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Move the gallery fetching logic into an external hook to simplify the development of the new connection flows.

Note: this is literally moving code from one file to the other. Nothing else changed!

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Smoke test the Instagram Gallery block.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
