### PR TITLE
Instagram Gallery Block: Stop automatically connecting blocks without access token

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -53,6 +53,7 @@ const InstagramGalleryEdit = props => {
 	} );
 	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram( {
 		accessToken,
+		isLoadingGallery,
 		noticeOperations,
 		setAttributes,
 		setImages,

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -87,7 +87,7 @@ const InstagramGalleryEdit = props => {
 		noticeOperations.removeAllNotices();
 		const accountImageTotal = images.length;
 
-		if ( showSidebar && ! showLoadingSpinner && accountImageTotal < count ) {
+		if ( ! showLoadingSpinner && accountImageTotal < count ) {
 			const noticeContent = accountImageTotal
 				? sprintf(
 						_n(
@@ -106,7 +106,7 @@ const InstagramGalleryEdit = props => {
 				isDismissible: false,
 			} );
 		}
-	}, [ count, images, noticeOperations, showLoadingSpinner, showSidebar ] );
+	}, [ count, images, noticeOperations, showLoadingSpinner ] );
 
 	const renderImage = index => {
 		if ( images[ index ] ) {

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -53,7 +53,6 @@ const InstagramGalleryEdit = props => {
 	} );
 	const { isConnecting, connectToService, disconnectFromService } = useConnectInstagram( {
 		accessToken,
-		isLoadingGallery,
 		noticeOperations,
 		setAttributes,
 		setImages,

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -84,10 +84,10 @@ const InstagramGalleryEdit = props => {
 	const photoStyle = { padding: spacing };
 
 	useEffect( () => {
-		noticeOperations.removeAllNotices();
 		const accountImageTotal = images.length;
 
-		if ( ! showLoadingSpinner && accountImageTotal < count ) {
+		if ( showSidebar && ! showLoadingSpinner && accountImageTotal < count ) {
+			noticeOperations.removeAllNotices();
 			const noticeContent = accountImageTotal
 				? sprintf(
 						_n(
@@ -106,7 +106,7 @@ const InstagramGalleryEdit = props => {
 				isDismissible: false,
 			} );
 		}
-	}, [ count, images, noticeOperations, showLoadingSpinner ] );
+	}, [ count, images, noticeOperations, showLoadingSpinner, showSidebar ] );
 
 	const renderImage = index => {
 		if ( images[ index ] ) {

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -14,6 +14,7 @@ import { addQueryArgs } from '@wordpress/url';
 
 export default function useConnectInstagram( {
 	accessToken,
+	isLoadingGallery,
 	noticeOperations,
 	setAttributes,
 	setImages,
@@ -36,15 +37,23 @@ export default function useConnectInstagram( {
 
 	// Automatically retrieve a working Instagram access token, if it exists.
 	useEffect( () => {
-		// If the block already has a token, and that token is marked as connected, don't retrieve it again.
-		if ( isTokenConnected ) {
-			return;
-		}
+		// Only try to skip retrieving a token if the block already has a token.
+		if ( accessToken ) {
+			// On a fresh page with clean state, the block will start by attempting to load the gallery.
+			// If it works, the token is valid and will be marked as connected, or as disconnected otherwise.
+			if ( isLoadingGallery || ( ! isTokenConnected && ! isTokenDisconnected ) ) {
+				return;
+			}
+			// If the block already has a token, and that token is marked as connected, don't retrieve it again.
+			if ( isTokenConnected ) {
+				return;
+			}
 
-		// If the block already has a token, and that token is marked as disconnected, remove it from the block.
-		if ( isTokenDisconnected ) {
-			setAttributes( { accessToken: undefined } );
-			return;
+			// If the block already has a token, and that token is marked as disconnected, remove it from the block.
+			if ( isTokenDisconnected ) {
+				setAttributes( { accessToken: undefined } );
+				return;
+			}
 		}
 
 		// Otherwise, try to retrieve it from the API.
@@ -70,6 +79,7 @@ export default function useConnectInstagram( {
 		accessToken,
 		connectInstagramGalleryToken,
 		disconnectInstagramGalleryToken,
+		isLoadingGallery,
 		isTokenConnected,
 		isTokenDisconnected,
 		setAttributes,

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -63,6 +63,7 @@ export default function useConnectInstagram( {
 
 		// Try retrieving a valid token first;
 		// if the user has got one, skip the Instagram authorization popup.
+		// If/when the block has a valid token, the block will automatically embed the gallery.
 		if ( ! accessToken || isTokenDisconnected ) {
 			const token = await getAccessToken();
 			if ( token ) {

--- a/extensions/blocks/instagram-gallery/use-instagram-gallery.js
+++ b/extensions/blocks/instagram-gallery/use-instagram-gallery.js
@@ -55,7 +55,6 @@ export default function useInstagramGallery( { accessToken, noticeOperations, se
 					noticeOperations.createErrorNotice(
 						__( 'An error occurred. Please try again later.', 'jetpack' )
 					);
-					setIsLoadingGallery( false );
 					setImages( [] );
 					disconnectInstagramGalleryToken( accessToken );
 					return;
@@ -65,9 +64,6 @@ export default function useInstagramGallery( { accessToken, noticeOperations, se
 					noticeOperations.createErrorNotice(
 						__( 'No images were found in your Instagram account.', 'jetpack' )
 					);
-					setIsLoadingGallery( false );
-					setImages( [] );
-					return;
 				}
 
 				connectInstagramGalleryToken( accessToken );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Only attempt to automatically connect to Instagram if the Instagram Gallery block has an access token.

##### Previously

On mount, IG blocks automatically attempted to connect to Instagram.
If they had a token stored, they validated it and, if valid, used it.
If they didn't have a token, they fetched it and, if existing, used it

This had the intended side effect of automatically connecting new blocks inserted by users with valid tokens.
But it also had the unintended side effect of... automatically connecting blocks inserted by _other_ users and left "empty" (not connected, without access token) in a post.

##### Now...

On mount, IG blocks only automatically attempt to connect to Instagram if they have a token stored.
They will validate it and, if valid, use the token.

"Empty" blocks don't automatically connect anymore.
Instead, they will show the normal "Connect to Instagram" button.
But before sending the user over to Instagram to authorize the connection, we first check if they have a valid token.
If they do, the block will then, finally, automatically use the token, and the user won't be sent to Instagram anymore.
If they don't, they'll proceed to Instagram to create a new token as usual.

#### Testing instructions:

* Insert an Instagram Gallery block, and connect it to Instagram.
* If you have a valid Instagram token, make sure the block embeds the gallery straight away.
* Otherwise, make sure you are redirected to Instagram to authorize the connection.
* Insert another block, and make sure it shows the "Connect" button regardless.
* Connect the second block too (again: no Instagram authorization should be needed).
* Now disconnect one of these two blocks.
* Make sure both blocks are disconnected.
* Connect one of them: make sure you're sent to Instagram to authorize the connection.
* Make sure the other block is not connected automatically.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
