### PR TITLE
Add Jetpack Scan threat notifications

### DIFF
--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -188,19 +188,12 @@ class DashScan extends Component {
 					<h2 className="jp-dash-item__count is-alert">{ numberFormat( numberOfThreats ) }</h2>,
 					<p className="jp-dash-item__description">
 						{ __(
-							'Security threat found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible or {{supportLink}}contact support{{/supportLink}}.',
-							'Security threats found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible or {{supportLink}}contact support{{/supportLink}}.',
+							'Security threat found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible.',
+							'Security threats found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible.',
 							{
 								count: numberOfThreats,
 								components: {
 									fixThreats: <a href={ dashboardUrl } />,
-									supportLink: (
-										<a
-											href={ getRedirectUrl( 'jetpack-support', {
-												site: siteRawUrl,
-											} ) }
-										/>
-									),
 								},
 							}
 						) }

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -206,10 +206,7 @@ class DashScan extends Component {
 						) }
 					</p>,
 				] ) }
-				{ renderAction(
-					dashboardUrl,
-					__( 'View threat detail', 'View threats details', { count: numberOfThreats } )
-				) }
+				{ renderAction( dashboardUrl, __( 'View security scan details' ) ) }
 			</>
 		);
 	}

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -208,7 +208,7 @@ class DashScan extends Component {
 				] ) }
 				{ renderAction(
 					dashboardUrl,
-					__( 'View threat details', 'View threats details', { count: numberOfThreats } )
+					__( 'View threat detail', 'View threats details', { count: numberOfThreats } )
 				) }
 			</>
 		);

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -195,7 +195,7 @@ class DashScan extends Component {
 					<h2 className="jp-dash-item__count is-alert">{ numberFormat( numberOfThreats ) }</h2>,
 					<p className="jp-dash-item__description">
 						{ __(
-							'Security threat found. Please {{a}}fix these{{/a}} as soon as possible.',
+							'Security threat found. Please {{a}}fix it{{/a}} as soon as possible.',
 							'Security threats found. Please {{a}}fix these{{/a}} as soon as possible.',
 							{
 								count: numberOfThreats,

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -198,6 +198,31 @@ class DashScan extends Component {
 				content: message,
 			} );
 
+		if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
+			return (
+				<>
+					{ buildCard( [
+						<h3 className="jp-dash-item__title jp-dash-item__title_fullwidth jp-dash-item__title_top">
+							{ __( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', {
+								count: scanStatus.threats.length,
+								args: { number: numberFormat( scanStatus.threats.length ) },
+							} ) }
+						</h3>,
+						<p className="jp-dash-item__description">
+							{ __( '{{a}}View details{{/a}}', {
+								components: { a: <a href={ getRedirectUrl( 'jetpack-scan-threat' ) } /> },
+							} ) }
+							<br />
+							{ __( '{{a}}Contact Support{{/a}}', {
+								components: { a: <a href={ getRedirectUrl( 'jetpack-support' ) } /> },
+							} ) }
+						</p>,
+					] ) }
+					{ buildAction( getRedirectUrl( 'jetpack-scan-threat' ), __( 'View details' ) ) }
+				</>
+			);
+		}
+
 		if ( scanStatus.credentials && scanStatus.credentials.length === 0 ) {
 			return (
 				<React.Fragment>

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -188,12 +188,12 @@ class DashScan extends Component {
 					<h2 className="jp-dash-item__count is-alert">{ numberFormat( numberOfThreats ) }</h2>,
 					<p className="jp-dash-item__description">
 						{ __(
-							'Security threat found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible.',
-							'Security threats found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible.',
+							'Security threat found. Please {{a}}fix these{{/a}} as soon as possible.',
+							'Security threats found. Please {{a}}fix these{{/a}} as soon as possible.',
 							{
 								count: numberOfThreats,
 								components: {
-									fixThreats: <a href={ dashboardUrl } />,
+									a: <a href={ dashboardUrl } target="_blank" rel="noopener noreferrer" />,
 								},
 							}
 						) }

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -54,7 +54,14 @@ const renderCard = props => (
 );
 
 const renderAction = ( url, message ) => (
-	<Card compact key="manage-scan" className="jp-dash-item__manage-in-wpcom" href={ url }>
+	<Card
+		compact
+		key="manage-scan"
+		className="jp-dash-item__manage-in-wpcom"
+		href={ url }
+		target="_blank"
+		rel="noopener noreferrer"
+	>
 		{ message }
 	</Card>
 );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -53,6 +53,20 @@ const renderCard = props => (
 	</DashItem>
 );
 
+const renderAction = ( url, message ) => (
+	<Card compact key="manage-scan" className="jp-dash-item__manage-in-wpcom" href={ url }>
+		{ message }
+	</Card>
+);
+
+const renderActiveCard = message => {
+	return renderCard( {
+		className: 'jp-dash-item__is-active',
+		status: 'is-working',
+		content: message,
+	} );
+};
+
 class DashScan extends Component {
 	static propTypes = {
 		siteRawUrl: PropTypes.string.isRequired,
@@ -95,25 +109,7 @@ class DashScan extends Component {
 				// Check for threats
 				const threats = this.props.scanThreats;
 				if ( threats !== 0 ) {
-					return renderCard( {
-						content: [
-							<h3 className="jp-dash-item__title jp-dash-item__title_fullwidth jp-dash-item__title_top">
-								{ __( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', {
-									count: threats,
-									args: { number: numberFormat( threats ) },
-								} ) }
-							</h3>,
-							<p className="jp-dash-item__description">
-								{ __( '{{a}}View details at VaultPress.com{{/a}}', {
-									components: { a: <a href={ getRedirectUrl( 'vaultpress-dashboard' ) } /> },
-								} ) }
-								<br />
-								{ __( '{{a}}Contact Support{{/a}}', {
-									components: { a: <a href={ getRedirectUrl( 'jetpack-support' ) } /> },
-								} ) }
-							</p>,
-						],
-					} );
+					return this.renderThreatsFound( threats, getRedirectUrl( 'vaultpress-dashboard' ) );
 				}
 
 				// All good
@@ -184,79 +180,80 @@ class DashScan extends Component {
 		);
 	}
 
+	renderThreatsFound( numberOfThreats, dashboardUrl ) {
+		const { siteRawUrl } = this.props;
+		return (
+			<>
+				{ renderActiveCard( [
+					<h2 className="jp-dash-item__count is-alert">{ numberFormat( numberOfThreats ) }</h2>,
+					<p className="jp-dash-item__description">
+						{ __(
+							'Security threat found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible or {{supportLink}}contact support{{/supportLink}}.',
+							'Security threats found. Please {{fixThreats}}fix these{{/fixThreats}} as soon as possible or {{supportLink}}contact support{{/supportLink}}.',
+							{
+								count: numberOfThreats,
+								components: {
+									fixThreats: <a href={ dashboardUrl } />,
+									supportLink: (
+										<a
+											href={ getRedirectUrl( 'jetpack-support', {
+												site: siteRawUrl,
+											} ) }
+										/>
+									),
+								},
+							}
+						) }
+					</p>,
+				] ) }
+				{ renderAction( dashboardUrl, __( 'View threats details' ) ) }
+			</>
+		);
+	}
+
 	getRewindContent() {
 		const { scanStatus, siteRawUrl } = this.props;
-		const buildAction = ( url, message ) => (
-			<Card compact key="manage-backups" className="jp-dash-item__manage-in-wpcom" href={ url }>
-				{ message }
-			</Card>
-		);
-		const buildCard = message =>
-			renderCard( {
-				className: 'jp-dash-item__is-active',
-				status: 'is-working',
-				content: message,
-			} );
+
+		const scanDashboardUrl = getRedirectUrl( 'calypso-scanner', {
+			site: siteRawUrl,
+		} );
 
 		if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
-			return (
-				<>
-					{ buildCard( [
-						<h3 className="jp-dash-item__title jp-dash-item__title_fullwidth jp-dash-item__title_top">
-							{ __( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', {
-								count: scanStatus.threats.length,
-								args: { number: numberFormat( scanStatus.threats.length ) },
-							} ) }
-						</h3>,
-						<p className="jp-dash-item__description">
-							{ __( '{{a}}View details{{/a}}', {
-								components: { a: <a href={ getRedirectUrl( 'jetpack-scan-threat' ) } /> },
-							} ) }
-							<br />
-							{ __( '{{a}}Contact Support{{/a}}', {
-								components: { a: <a href={ getRedirectUrl( 'jetpack-support' ) } /> },
-							} ) }
-						</p>,
-					] ) }
-					{ buildAction( getRedirectUrl( 'jetpack-scan-threat' ), __( 'View details' ) ) }
-				</>
-			);
+			return this.renderThreatsFound( scanStatus.threats.length, scanDashboardUrl );
 		}
 
 		if ( scanStatus.credentials && scanStatus.credentials.length === 0 ) {
 			return (
-				<React.Fragment>
-					{ buildCard( __( "You need to enter your server's credentials to finish the setup." ) ) }
-					{ buildAction(
+				<>
+					{ renderActiveCard(
+						__( "You need to enter your server's credentials to finish the setup." )
+					) }
+					{ renderAction(
 						getRedirectUrl( 'calypso-settings-security', { site: siteRawUrl } ),
 						__( 'Enter credentials' )
 					) }
-				</React.Fragment>
+				</>
 			);
 		}
 
 		switch ( scanStatus.state ) {
 			case 'provisioning':
-				return (
-					<React.Fragment>
-						{ buildCard( __( 'We are configuring your site protection.' ) ) }
-					</React.Fragment>
-				);
+				return <>{ renderActiveCard( __( 'We are configuring your site protection.' ) ) }</>;
 			case 'idle':
 			case 'scanning':
 				return (
-					<React.Fragment>
-						{ buildCard(
+					<>
+						{ renderActiveCard(
 							__(
 								'We are making sure your site stays free of security threats. ' +
 									'You will be notified if we find one.'
 							)
 						) }
-						{ buildAction(
+						{ renderAction(
 							getRedirectUrl( 'calypso-scanner', { site: siteRawUrl } ),
 							__( 'View security scan details' )
 						) }
-					</React.Fragment>
+					</>
 				);
 		}
 

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -206,7 +206,10 @@ class DashScan extends Component {
 						) }
 					</p>,
 				] ) }
-				{ renderAction( dashboardUrl, __( 'View threats details' ) ) }
+				{ renderAction(
+					dashboardUrl,
+					__( 'View threat details', 'View threats details', { count: numberOfThreats } )
+				) }
 			</>
 		);
 	}

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -48,6 +48,11 @@
 	+ .jp-dash-item__description {
 		max-width: 61%;
 	}
+   &.is-alert {
+	 color: $white;
+	 background: $alert-red;
+	 border-color: $alert-red;
+   }
 }
 
 .jp-dash-item__title {

--- a/_inc/client/components/dash-item/style.scss
+++ b/_inc/client/components/dash-item/style.scss
@@ -48,11 +48,11 @@
 	+ .jp-dash-item__description {
 		max-width: 61%;
 	}
-   &.is-alert {
-	 color: $white;
-	 background: $alert-red;
-	 border-color: $alert-red;
-   }
+	&.is-alert {
+		color: $white;
+		background: $alert-red;
+		border-color: $alert-red;
+	}
 }
 
 .jp-dash-item__title {

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -234,13 +234,10 @@ class ProStatus extends React.Component {
 						if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
 							return (
 								<SimpleNotice showDismiss={ false } status="is-error" isCompact>
-									{ scanStatus.threats.length === 1
-										? __( 'Threat', {
-												context: 'A caption for a small button to fix security issues.',
-										  } )
-										: __( 'Threats', {
-												context: 'A caption for a small button to fix security issues.',
-										  } ) }
+									{ __( 'Threat', 'Threats', {
+										count: scanStatus.threats.length,
+										context: 'A caption for a small button to fix security issues.',
+									} ) }
 								</SimpleNotice>
 							);
 						}

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -231,6 +231,15 @@ class ProStatus extends React.Component {
 							'scan'
 						);
 					} else if ( scanStatus && scanStatus.state !== 'unavailable' ) {
+						if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
+							return (
+								<SimpleNotice showDismiss={ false } status="is-error" isCompact>
+									{ __( 'Threats', {
+										context: 'A caption for a small button to fix security issues.',
+									} ) }
+								</SimpleNotice>
+							);
+						}
 						if ( ! scanStatus.credentials ) {
 							return '';
 						}

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -234,9 +234,13 @@ class ProStatus extends React.Component {
 						if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
 							return (
 								<SimpleNotice showDismiss={ false } status="is-error" isCompact>
-									{ __( 'Threats', {
-										context: 'A caption for a small button to fix security issues.',
-									} ) }
+									{ scanStatus.threats.length === 1
+										? __( 'Threat', {
+												context: 'A caption for a small button to fix security issues.',
+										  } )
+										: __( 'Threats', {
+												context: 'A caption for a small button to fix security issues.',
+										  } ) }
 								</SimpleNotice>
 							);
 						}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1308,7 +1308,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$body   = wp_remote_retrieve_body( $response );
 		$result = json_decode( $body );
-		set_transient( 'jetpack_scan_state', $result, 15 * MINUTE_IN_SECONDS );
+		set_transient( 'jetpack_scan_state', $result, 30 * MINUTE_IN_SECONDS );
 
 		return $result;
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1285,6 +1285,13 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return array|WP_Error Result from WPCOM API or error.
 	 */
 	public static function scan_state() {
+
+		if ( ! isset( $_GET['_cacheBuster'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$scan_state = get_site_transient( 'jetpack_scan_state' );
+			if ( ! empty( $scan_state ) ) {
+				return $scan_state;
+			}
+		}
 		$site_id = Jetpack_Options::get_option( 'id' );
 
 		if ( ! $site_id ) {
@@ -1297,9 +1304,11 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return new WP_Error( 'scan_state_fetch_failed' );
 		}
 
-		$body = wp_remote_retrieve_body( $response );
+		$body   = wp_remote_retrieve_body( $response );
+		$result = json_decode( $body );
+		set_site_transient( 'jetpack_scan_state', $result, 10 * MINUTE_IN_SECONDS );
 
-		return json_decode( $body );
+		return $result;
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1287,7 +1287,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function scan_state() {
 
 		if ( ! isset( $_GET['_cacheBuster'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$scan_state = get_site_transient( 'jetpack_scan_state' );
+			$scan_state = get_transient( 'jetpack_scan_state' );
 			if ( ! empty( $scan_state ) ) {
 				return $scan_state;
 			}
@@ -1308,7 +1308,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 		$body   = wp_remote_retrieve_body( $response );
 		$result = json_decode( $body );
-		set_site_transient( 'jetpack_scan_state', $result, 10 * MINUTE_IN_SECONDS );
+		set_transient( 'jetpack_scan_state', $result, 15 * MINUTE_IN_SECONDS );
 
 		return $result;
 	}

--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -40,6 +40,7 @@ module.exports = [
 	'modules/post-by-email.php',
 	'modules/post-by-email/',
 	'modules/publicize.php',
+	'modules/scan/',
 	'modules/search/class-jetpack-instant-search.php',
 	'modules/search/class-jetpack-search-customize.php',
 	'modules/search/class.jetpack-search-options.php',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7547,7 +7547,7 @@ endif;
 					sprintf( _n( '%s Security Threat', '%s Security Threats', $threat_count, 'jetpack' ), $threat_count )
 				),
 				'parent' => 'top-secondary',
-				'href'   => esc_url( Redirect::get_url( 'jetpack-scan-threat' ) ),
+				'href'   => esc_url( Redirect::get_url( 'calypso-scanner' ) ),
 				'meta'   => array(
 					'title'   => esc_attr__( 'Visit your scan dashboard', 'jetpack' ),
 					'onclick' => 'window.open( this.href ); return false;',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -85,15 +85,6 @@ class Jetpack {
 	);
 
 	/**
-	 * The handles of scripts that can be loaded asynchronously.
-	 *
-	 * @var array
-	 */
-	public $async_script_handles = array(
-		'woocommerce-analytics',
-	);
-
-	/**
 	 * Contains all assets that have had their URL rewritten to minified versions.
 	 *
 	 * @var array
@@ -738,11 +729,6 @@ class Jetpack {
 		if ( ! has_action( 'shutdown', array( $this, 'push_stats' ) ) ) {
 			add_action( 'shutdown', array( $this, 'push_stats' ) );
 		}
-
-		/*
-		 * Load some scripts asynchronously.
-		 */
-		add_action( 'script_loader_tag', array( $this, 'script_add_async' ), 10, 3 );
 
 		// Actions for Manager::authorize().
 		add_action( 'jetpack_authorize_starting', array( $this, 'authorize_starting' ) );
@@ -6853,21 +6839,11 @@ endif;
 	}
 
 	/**
-	 * Add an async attribute to scripts that can be loaded asynchronously.
-	 * https://www.w3schools.com/tags/att_script_async.asp
-	 *
-	 * @since 7.7.0
-	 *
-	 * @param string $tag    The <script> tag for the enqueued script.
-	 * @param string $handle The script's registered handle.
-	 * @param string $src    The script's source URL.
+	 * @deprecated
+	 * @see Automattic\Jetpack\Assets\add_aync_script
 	 */
 	public function script_add_async( $tag, $handle, $src ) {
-		if ( in_array( $handle, $this->async_script_handles, true ) ) {
-			return preg_replace( '/^<script /i', '<script async ', $tag );
-		}
-
-		return $tag;
+		_deprecated_function( __METHOD__, 'jetpack-8.6.0' );
 	}
 
 	/*

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -672,6 +672,11 @@ class Jetpack {
 
 		add_action( 'wp_loaded', array( $this, 'register_assets' ) );
 
+		// Add display for Scan threats.
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_toolbar_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_toolbar_styles' ) );
+		add_action( 'admin_bar_menu', array( $this, 'add_threats_to_toolbar' ), 999 );
+
 		/**
 		 * These actions run checks to load additional files.
 		 * They check for external files or plugins, so they need to run as late as possible.
@@ -7255,8 +7260,8 @@ endif;
 	}
 
 	/**
-	 * Checks for whether Jetpack Backup & Scan is enabled.
-	 * Will return true if the state of Backup & Scan is anything except "unavailable".
+	 * Checks for whether Jetpack Backup is enabled.
+	 * Will return true if the state of Backup is anything except "unavailable".
 	 *
 	 * @return bool|int|mixed
 	 */
@@ -7278,6 +7283,38 @@ endif;
 			set_transient( 'jetpack_rewind_enabled', $rewind_enabled, 10 * MINUTE_IN_SECONDS );
 		}
 		return $rewind_enabled;
+	}
+
+	/**
+	 * Checks for whether Jetpack Scan is enabled.
+	 * Will return true if the state of Scan is anything except "unavailable".
+	 *
+	 * @return bool|int|mixed
+	 */
+	public static function is_scan_enabled() {
+		if ( ! self::is_active() ) {
+			return false;
+		}
+
+		$scan_enabled = get_transient( 'jetpack_scan_enabled' );
+		if ( false === $scan_enabled ) {
+			jetpack_require_lib( 'class.core-rest-api-endpoints' );
+			$scan_state   = Jetpack_Core_Json_Api_Endpoints::scan_state();
+			$scan_enabled = ( ! is_wp_error( $scan_state )
+				&& ! empty( $scan_state->state )
+				&& 'unavailable' !== $scan_state->state )
+				? 1
+				: 0;
+
+			set_transient( 'jetpack_scan_enabled', $scan_enabled, 10 * MINUTE_IN_SECONDS );
+
+			$num_threats = ( $scan_enabled && ! empty( $scan_state->threats ) )
+				? count( $scan_state->threats )
+				: 0;
+
+			set_transient( 'jetpack_scan_threat_count', $num_threats, 10 * MINUTE_IN_SECONDS );
+		}
+		return $scan_enabled;
 	}
 
 	/**
@@ -7449,6 +7486,75 @@ endif;
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Adds custom styles for Jetpack Scan threat indicator.
+	 *
+	 * @since 8.6.0
+	 * @return void
+	 */
+	public function enqueue_toolbar_styles() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! self::is_scan_enabled() ) {
+			return;
+		}
+
+		wp_add_inline_style(
+			'admin-bar',
+			'#wp-admin-bar-jp-scan-notice.error { background-color: #D63638; }
+				#wp-admin-bar-jp-scan-notice.error:hover { background-color: #B32D2E; }
+				#wp-admin-bar-jp-scan-notice.error > ab-item { color: #FFF; }'
+		);
+	}
+
+	/**
+	 * Adds Jetpack Scan threat indicator to the WordPress admin bar.
+	 *
+	 * @since 8.6.0
+	 * @param WP_Admin_Bar $wp_admin_bar Reference to admin bar.
+	 * @return void
+	 */
+	public function add_threats_to_toolbar( $wp_admin_bar ) {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '3.3', '<' ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! self::is_scan_enabled() ) {
+			return;
+		}
+
+		$threat_count = intval( get_transient( 'jetpack_scan_threat_count' ) );
+		if ( $threat_count < 1 ) {
+			return;
+		}
+
+		$threat_count = number_format( $threat_count, 0 );
+		$wp_admin_bar->add_node(
+			array(
+				'id'     => 'jp-scan-notice',
+				'title'  => esc_html(
+					// translators: %s is number of threats found.
+					sprintf( _n( '%s Security Threat', '%s Security Threats', $threat_count, 'jetpack' ), $threat_count )
+				),
+				'parent' => 'top-secondary',
+				'href'   => esc_url( Redirect::get_url( 'jetpack-scan-threat' ) ),
+				'meta'   => array(
+					'title'   => esc_attr__( 'Visit your scan dashboard', 'jetpack' ),
+					'onclick' => 'window.open( this.href ); return false;',
+					'class'   => 'error',
+				),
+			)
+		);
 	}
 
 	/**

--- a/modules/masterbar/masterbar.php
+++ b/modules/masterbar/masterbar.php
@@ -4,6 +4,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Scan\Admin_Bar_Notice;
 
 require_once dirname( __FILE__ ) . '/rtl-admin-bar.php';
 
@@ -367,6 +368,11 @@ class A8C_WPCOM_Masterbar {
 		// Recovery mode exit.
 		if ( function_exists( 'wp_admin_bar_recovery_mode_menu' ) ) {
 			wp_admin_bar_recovery_mode_menu( $wp_admin_bar );
+		}
+
+		if ( class_exists( 'Automattic\Jetpack\Scan\Admin_Bar_Notice' ) ) {
+			$scan_admin_bar_notice = Admin_Bar_Notice::instance();
+			$scan_admin_bar_notice->add_threats_to_toolbar( $wp_admin_bar );
 		}
 	}
 

--- a/modules/masterbar/overrides.css
+++ b/modules/masterbar/overrides.css
@@ -80,6 +80,15 @@
 	color: #fff;
 	margin-right: 1em;
 }
+#wpadminbar #wp-admin-bar-jetpack-scan-notice {
+	margin-right: 1em;
+}
+@media screen and (max-width: 959px ) {
+	#wpadminbar #wp-admin-bar-jetpack-scan-notice {
+		width:32px;
+	}
+	#wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important;}
+}
 
 @media screen and (max-width: 480px) {
 	.jetpack-masterbar.post-new-php.block-editor-page #wp-toolbar ul li {
@@ -125,7 +134,7 @@
 	.jetpack-masterbar.post-new-php.block-editor-page #wpadminbar li#wp-admin-bar-newdash {
 		order: 3;
 	}
-
+	#wpadminbar #wp-admin-bar-jetpack-scan-notice,
 	.jetpack-masterbar #wpadminbar #wp-admin-bar-recovery-mode {
 		display: none;
 	}

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -48,6 +48,7 @@ $connected_tools = array(
 	'simple-payments/simple-payments.php',
 	'wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'wpcom-tos/wpcom-tos.php',
+	'scan/scan.php', // Shows Jetpack Scan Alerts if threats found in the adminbar.
 );
 
 // Add connected features to our existing list if the site is currently connected.

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -45,10 +45,10 @@ $tools = array(
 $connected_tools = array(
 	'calypsoify/class.jetpack-calypsoify.php',
 	'plugin-search.php',
+	'scan/scan.php', // Shows Jetpack Scan alerts in the admin bar if threats found.
 	'simple-payments/simple-payments.php',
 	'wpcom-block-editor/class-jetpack-wpcom-block-editor.php',
 	'wpcom-tos/wpcom-tos.php',
-	'scan/scan.php', // Shows Jetpack Scan Alerts if threats found in the adminbar.
 );
 
 // Add connected features to our existing list if the site is currently connected.

--- a/modules/scan/admin-bar-notice.js
+++ b/modules/scan/admin-bar-notice.js
@@ -1,0 +1,50 @@
+( function( localized ) {
+	function ready( fn ) {
+		if ( document.readyState != 'loading' ) {
+			fn();
+		} else {
+			document.addEventListener( 'DOMContentLoaded', fn );
+		}
+	}
+
+	function fetch_scan_treats_and_add_link() {
+		fetch( localized.scan_endpoint, {
+			credentials: 'same-origin',
+			headers: {
+				'X-WP-Nonce': localized.nonce,
+			},
+		} )
+			.then( function( response ) {
+				if ( response.status >= 200 && response.status < 400 ) {
+					return response.json();
+				}
+				return false;
+			} )
+			.then( function( body ) {
+				if ( body && body.data ) {
+					var apiResponse = JSON.parse( body.data );
+					var numberOfThreats =
+						apiResponse.threats && apiResponse.threats.length ? apiResponse.threats.length : 0;
+					update_threats_link( numberOfThreats );
+				} else {
+					update_threats_link( 0 );
+				}
+			} );
+	}
+
+	ready( function() {
+		fetch_scan_treats_and_add_link();
+	} );
+
+	function update_threats_link( numberOfThreats ) {
+		var element = document.getElementById( 'wp-admin-bar-jp-scan-notice' );
+		if ( ! numberOfThreats ) {
+			element.parentNode.removeChild( element );
+			return;
+		}
+
+		var textLabel = numberOfThreats == 1 ? localized.singular : localized.multiple;
+		element.innerHTML =
+			'<a href="' + localized.scan_dashboard_url + '" class="ab-item">' + textLabel + '</a>';
+	}
+} )( window.Jetpack_Scan );

--- a/modules/scan/admin-bar-notice.js
+++ b/modules/scan/admin-bar-notice.js
@@ -35,7 +35,7 @@
 	} );
 
 	function update_threats_link( numberOfThreats ) {
-		var element = document.getElementById( 'wp-admin-bar-jp-scan-notice' );
+		var element = document.getElementById( 'wp-admin-bar-jetpack-scan-notice' );
 		if ( ! numberOfThreats ) {
 			element.parentNode.removeChild( element );
 			return;

--- a/modules/scan/admin-bar-notice.js
+++ b/modules/scan/admin-bar-notice.js
@@ -8,19 +8,12 @@
 	}
 
 	function fetch_scan_treats_and_add_link() {
-		fetch( localized.scan_endpoint, {
-			credentials: 'same-origin',
-			headers: {
-				'X-WP-Nonce': localized.nonce,
-			},
-		} )
-			.then( function( response ) {
-				if ( response.status >= 200 && response.status < 400 ) {
-					return response.json();
-				}
-				return false;
-			} )
-			.then( function( body ) {
+		var xhrRequest = new XMLHttpRequest();
+		xhrRequest.open( 'GET', localized.scan_endpoint, true );
+		xhrRequest.onload = function() {
+			if ( this.status == 200 ) {
+				// Success!
+				var body = JSON.parse( this.response );
 				if ( body && body.data ) {
 					var apiResponse = JSON.parse( body.data );
 					var numberOfThreats =
@@ -29,7 +22,12 @@
 				} else {
 					update_threats_link( 0 );
 				}
-			} );
+			} else {
+				update_threats_link( 0 );
+			}
+		};
+		xhrRequest.setRequestHeader( 'X-WP-Nonce', localized.nonce );
+		xhrRequest.send();
 	}
 
 	ready( function() {

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * A class that adds the scan notice to the admin bar.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Scan;
+
+use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Redirect;
+
+/**
+ * Class Main
+ *
+ * Responsible for loading the admin bar notice if threats are found.
+ *
+ * @package Automattic\Jetpack\Scan
+ */
+class Admin_Bar_Notice {
+	const SCRIPT_NAME    = 'jetpack-scan-show-notice';
+	const SCRIPT_VERSION = '1';
+
+	/**
+	 * The singleton instance of this class.
+	 *
+	 * @var Admin_Bar_Notice
+	 */
+	protected static $instance;
+
+	/**
+	 * Get the singleton instance of the class.
+	 *
+	 * @return Admin_Bar_Notice
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Admin_Bar_Notice();
+			self::$instance->init_hooks();
+		}
+
+		return self::$instance;
+	}
+	/**
+	 * Initalize the hooks as needed.
+	 */
+	private function init_hooks() {
+		if ( is_multisite() ) {
+			return; // Jetpack Scan is currently not supported on multisite.
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return; // Only show the notice to admins.
+		}
+
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_toolbar_script' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_toolbar_script' ) );
+		add_filter( 'script_loader_tag', array( $this, 'add_async_defer_attribute' ), 10, 2 );
+		add_action( 'admin_bar_menu', array( $this, 'add_threats_to_toolbar' ), 999 );
+	}
+
+	/**
+	 * Adds the sync and defer attributes to the js so that it loads last.
+	 *
+	 * @param string $tag Html script tag about to get inserted.
+	 * @param string $handle Name of the script about to get inserted.
+	 *
+	 * @return string
+	 */
+	public function add_async_defer_attribute( $tag, $handle ) {
+		if ( self::SCRIPT_NAME !== $handle ) {
+			return $tag;
+		}
+		return str_replace( ' src', ' async defer src', $tag );
+	}
+
+	/**
+	 * Add the inline styles and scripts if they are needed.
+	 */
+	public function enqueue_toolbar_script() {
+		$this->add_inline_styles();
+
+		if ( ! is_null( $this->has_threats() ) ) {
+			return;
+		}
+		// We don't know about threats in the cache lets load the JS that fetches the info and updates the admin bar.
+		wp_enqueue_script( self::SCRIPT_NAME, Assets::get_file_url_for_environment( 'modules/scan/admin-bar-notice.js', 'modules/scan/admin-bar-notice.js' ), array(), self::SCRIPT_VERSION, true );
+
+		$script_data = array(
+			'nonce'              => wp_create_nonce( 'wp_rest' ),
+			'scan_endpoint'      => get_rest_url( null, 'jetpack/v4/scan' ),
+			'scan_dashboard_url' => Redirect::get_url( 'calypso-scanner' ),
+			/* translators: %s is the alert icon */
+			'singular'           => sprintf( esc_html__( '%s Threat Found', 'jetpack' ), $this->get_icon() ),
+			/* translators: %s is the alert icon */
+			'multiple'           => sprintf( esc_html__( '%s Threats Found', 'jetpack' ), $this->get_icon() ),
+		);
+		wp_localize_script( self::SCRIPT_NAME, 'Jetpack_Scan', $script_data );
+	}
+
+	/**
+	 * Adds the inline styles if they are needed.
+	 */
+	public function add_inline_styles() {
+		// We know there are no threats so lets not include any css.
+		if ( false === $this->has_threats() ) {
+			return;
+		}
+
+		// We might be showing the threats in the admin bar lets make sure that they look great!
+		$style = '#wp-admin-bar-jp-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; }';
+		if ( is_rtl() ) {
+			$style = '#wp-admin-bar-jp-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; }';
+		}
+		wp_add_inline_style( 'admin-bar', $style );
+	}
+
+	/**
+	 * Add the link to the admin bar.
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar WP Admin Bar class object.
+	 */
+	public function add_threats_to_toolbar( $wp_admin_bar ) {
+		$has_threats = $this->has_threats();
+		if ( false === $has_threats ) {
+			return;
+		}
+		$node = array(
+			'id'     => 'jp-scan-notice',
+			'title'  => '',
+			'parent' => 'top-secondary',
+			'meta'   => array(
+				'title' => esc_attr__( 'Visit your scan dashboard', 'jetpack' ),
+				'class' => 'error',
+			),
+		);
+
+		// No need to do anything...
+		if ( $has_threats ) {
+			/* translators: %s is the alert icon */
+			$node['title']           = sprintf( esc_html__( '%s Threats Found', 'jetpack' ), $this->get_icon() );
+			$node['href']            = esc_url( Redirect::get_url( 'calypso-scanner' ) );
+			$node['meta']['onclick'] = 'window.open( this.href ); return false;';
+		}
+
+		$wp_admin_bar->add_node( $node );
+	}
+
+	/**
+	 * Returns the shield icon.
+	 *
+	 * @return string
+	 */
+	private function get_icon() {
+		return '<svg width="18" height="22" viewBox="0 0 18 22" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 0L0 4V10C0 15.55 3.84 20.74 9 22C14.16 20.74 18 15.55 18 10V4L9 0Z" fill="#D63638"/><path d="M7.99121 6.00894H10.0085V11.9968H7.99121V6.00894Z" fill="#FFF"/><path d="M7.99121 14.014H10.0085V15.9911H7.99121V14.014Z" fill="#FFF"/></svg>';
+	}
+
+	/**
+	 *
+	 * Return Whether boolean cached threats exist or null if the state is unknown.
+	 * * @return boolean or null
+	 */
+	public function has_threats() {
+		$scan_state = get_site_transient( 'jetpack_scan_state' );
+		if ( empty( $scan_state ) ) {
+			return null;
+		}
+
+		// Return true if there is at least one threat found.
+		return (bool) isset( $scan_state->threats[0] );
+	}
+}

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -84,7 +84,7 @@ class Admin_Bar_Notice {
 			return;
 		}
 		// We don't know about threats in the cache lets load the JS that fetches the info and updates the admin bar.
-		wp_enqueue_script( self::SCRIPT_NAME, Assets::get_file_url_for_environment( 'modules/scan/admin-bar-notice.js', 'modules/scan/admin-bar-notice.js' ), array(), self::SCRIPT_VERSION, true );
+		wp_enqueue_script( self::SCRIPT_NAME, Assets::get_file_url_for_environment( '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js' ), array(), self::SCRIPT_VERSION, true );
 
 		$script_data = array(
 			'nonce'              => wp_create_nonce( 'wp_rest' ),

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -145,10 +145,16 @@ class Admin_Bar_Notice {
 
 		// No need to do anything...
 		if ( $has_threats ) {
-			/* translators: %s is the alert icon */
-			$node['title']           = sprintf( esc_html__( '%s Threats found', 'jetpack' ), $this->get_icon() );
 			$node['href']            = esc_url( Redirect::get_url( 'calypso-scanner' ) );
 			$node['meta']['onclick'] = 'window.open( this.href ); return false;';
+			$node['title']           = sprintf(
+				esc_html(
+				/* translators: %s is the alert icon */
+					_n( '%s Threat found', '%s Threats found', $this->get_threat_count(), 'jetpack' )
+				),
+				$this->get_icon()
+			);
+
 		}
 
 		$wp_admin_bar->add_node( $node );
@@ -176,5 +182,19 @@ class Admin_Bar_Notice {
 
 		// Return true if there is at least one threat found.
 		return (bool) isset( $scan_state->threats[0] );
+	}
+
+	/**
+	 * Returns the number of threats found or 0.
+	 *
+	 * @return int
+	 */
+	public function get_threat_count() {
+		if ( ! $this->has_threats() ) {
+			return 0;
+		}
+
+		$scan_state = get_transient( 'jetpack_scan_state' );
+		return is_array( $scan_state->threats ) ? count( $scan_state->threats ) : 0;
 	}
 }

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Scan;
 
-use Automattic\Jetpack\Assets;
+use function Automattic\Jetpack\enqueue_async_script as jetpack_enqueue_async_script;
 use Automattic\Jetpack\Redirect;
 
 /**
@@ -55,23 +55,7 @@ class Admin_Bar_Notice {
 
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_toolbar_script' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_toolbar_script' ) );
-		add_filter( 'script_loader_tag', array( $this, 'add_async_defer_attribute' ), 10, 2 );
 		add_action( 'admin_bar_menu', array( $this, 'add_threats_to_toolbar' ), 999 );
-	}
-
-	/**
-	 * Adds the sync and defer attributes to the js so that it loads last.
-	 *
-	 * @param string $tag Html script tag about to get inserted.
-	 * @param string $handle Name of the script about to get inserted.
-	 *
-	 * @return string
-	 */
-	public function add_async_defer_attribute( $tag, $handle ) {
-		if ( self::SCRIPT_NAME !== $handle ) {
-			return $tag;
-		}
-		return str_replace( ' src', ' async defer src', $tag );
 	}
 
 	/**
@@ -83,8 +67,9 @@ class Admin_Bar_Notice {
 		if ( ! is_null( $this->has_threats() ) ) {
 			return;
 		}
+
 		// We don't know about threats in the cache lets load the JS that fetches the info and updates the admin bar.
-		wp_enqueue_script( self::SCRIPT_NAME, Assets::get_file_url_for_environment( '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js' ), array(), self::SCRIPT_VERSION, true );
+		jetpack_enqueue_async_script( self::SCRIPT_NAME, '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js', array(), self::SCRIPT_VERSION, true );
 
 		$script_data = array(
 			'nonce'              => wp_create_nonce( 'wp_rest' ),

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -7,7 +7,7 @@
 
 namespace Automattic\Jetpack\Scan;
 
-use function Automattic\Jetpack\enqueue_async_script as jetpack_enqueue_async_script;
+use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Redirect;
 
 /**
@@ -87,7 +87,7 @@ class Admin_Bar_Notice {
 		}
 
 		// We don't know about threats in the cache lets load the JS that fetches the info and updates the admin bar.
-		jetpack_enqueue_async_script( self::SCRIPT_NAME, '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js', array(), self::SCRIPT_VERSION, true );
+		Assets::enqueue_async_script( self::SCRIPT_NAME, '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js', array(), self::SCRIPT_VERSION, true );
 
 		$script_data = array(
 			'nonce'              => wp_create_nonce( 'wp_rest' ),

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -65,7 +65,8 @@ class Admin_Bar_Notice {
 			return false;
 		}
 
-		// Check if VaultPress is active.
+		// Check if VaultPress is active, the assumtion there is that VaultPress is working.
+		// It has its own notice in the admin bar.
 		if ( class_exists( 'VaultPress' ) ) {
 			return false;
 		}
@@ -180,7 +181,7 @@ class Admin_Bar_Notice {
 		if ( empty( $scan_state ) ) {
 			return null;
 		}
-
+		// Return true if there is at least one threat found.
 		return (bool) isset( $scan_state->threats[0] );
 	}
 

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -110,10 +110,12 @@ class Admin_Bar_Notice {
 			return;
 		}
 
+		$hide_wording_on_mobile = '@media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; }';
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$style = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }';
+		$style = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
+
 		if ( is_rtl() ) {
-			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }';
+			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
 		}
 		wp_add_inline_style( 'admin-bar', $style );
 	}

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -146,7 +146,7 @@ class Admin_Bar_Notice {
 	 * * @return boolean or null
 	 */
 	public function has_threats() {
-		$scan_state = get_site_transient( 'jetpack_scan_state' );
+		$scan_state = get_transient( 'jetpack_scan_state' );
 		if ( empty( $scan_state ) ) {
 			return null;
 		}

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -91,9 +91,9 @@ class Admin_Bar_Notice {
 			'scan_endpoint'      => get_rest_url( null, 'jetpack/v4/scan' ),
 			'scan_dashboard_url' => Redirect::get_url( 'calypso-scanner' ),
 			/* translators: %s is the alert icon */
-			'singular'           => sprintf( esc_html__( '%s Threat Found', 'jetpack' ), $this->get_icon() ),
+			'singular'           => sprintf( esc_html__( '%s Threat found', 'jetpack' ), $this->get_icon() ),
 			/* translators: %s is the alert icon */
-			'multiple'           => sprintf( esc_html__( '%s Threats Found', 'jetpack' ), $this->get_icon() ),
+			'multiple'           => sprintf( esc_html__( '%s Threats found', 'jetpack' ), $this->get_icon() ),
 		);
 		wp_localize_script( self::SCRIPT_NAME, 'Jetpack_Scan', $script_data );
 	}
@@ -138,7 +138,7 @@ class Admin_Bar_Notice {
 		// No need to do anything...
 		if ( $has_threats ) {
 			/* translators: %s is the alert icon */
-			$node['title']           = sprintf( esc_html__( '%s Threats Found', 'jetpack' ), $this->get_icon() );
+			$node['title']           = sprintf( esc_html__( '%s Threats found', 'jetpack' ), $this->get_icon() );
 			$node['href']            = esc_url( Redirect::get_url( 'calypso-scanner' ) );
 			$node['meta']['onclick'] = 'window.open( this.href ); return false;';
 		}

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -108,9 +108,9 @@ class Admin_Bar_Notice {
 		}
 
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$style = '#wp-admin-bar-jp-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; }';
+		$style = '#wp-admin-bar-jp-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }';
 		if ( is_rtl() ) {
-			$style = '#wp-admin-bar-jp-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; }';
+			$style = '#wp-admin-bar-jp-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }';
 		}
 		wp_add_inline_style( 'admin-bar', $style );
 	}

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -60,8 +60,9 @@ class Admin_Bar_Notice {
 	 * @return bool
 	 */
 	private function should_try_to_display_notice() {
+		// Jetpack Scan is currently not supported on multisite.
 		if ( is_multisite() ) {
-			return false; // Jetpack Scan is currently not supported on multisite.
+			return false;
 		}
 
 		// Check if VaultPress is active.
@@ -69,8 +70,9 @@ class Admin_Bar_Notice {
 			return false;
 		}
 
+		// Only show the notice to admins.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			return false; // Only show the notice to admins.
+			return false;
 		}
 
 		return true;
@@ -110,10 +112,9 @@ class Admin_Bar_Notice {
 			return;
 		}
 
-		$hide_wording_on_mobile = '@media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; }';
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$style = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
-
+		$hide_wording_on_mobile = '@media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; }';
+		$style                  = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
 		if ( is_rtl() ) {
 			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
 		}
@@ -145,7 +146,6 @@ class Admin_Bar_Notice {
 			),
 		);
 
-		// No need to do anything...
 		if ( $has_threats ) {
 			$node['href']            = esc_url( Redirect::get_url( 'calypso-scanner' ) );
 			$node['meta']['onclick'] = 'window.open( this.href ); return false;';
@@ -156,7 +156,6 @@ class Admin_Bar_Notice {
 				),
 				$this->get_icon()
 			);
-
 		}
 
 		$wp_admin_bar->add_node( $node );
@@ -182,7 +181,6 @@ class Admin_Bar_Notice {
 			return null;
 		}
 
-		// Return true if there is at least one threat found.
 		return (bool) isset( $scan_state->threats[0] );
 	}
 

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -108,9 +108,9 @@ class Admin_Bar_Notice {
 		}
 
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$style = '#wp-admin-bar-jp-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }';
+		$style = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }';
 		if ( is_rtl() ) {
-			$style = '#wp-admin-bar-jp-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }';
+			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }';
 		}
 		wp_add_inline_style( 'admin-bar', $style );
 	}
@@ -126,7 +126,7 @@ class Admin_Bar_Notice {
 			return;
 		}
 		$node = array(
-			'id'     => 'jp-scan-notice',
+			'id'     => 'jetpack-scan-notice',
 			'title'  => '',
 			'parent' => 'top-secondary',
 			'meta'   => array(

--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -114,7 +114,7 @@ class Admin_Bar_Notice {
 		}
 
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$hide_wording_on_mobile = '@media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; }';
+		$hide_wording_on_mobile = '#wp-admin-bar-jetpack-scan-notice .is-hidden { display:none; } @media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; }';
 		$style                  = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
 		if ( is_rtl() ) {
 			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
@@ -142,14 +142,15 @@ class Admin_Bar_Notice {
 			'title'  => '',
 			'parent' => 'top-secondary',
 			'meta'   => array(
-				'title' => esc_attr__( 'Visit your scan dashboard', 'jetpack' ),
-				'class' => 'error',
+				'title' => esc_attr__( 'View security scan details', 'jetpack' ),
+				'class' => 'error is-hidden',
 			),
 		);
 
 		if ( $has_threats ) {
 			$node['href']            = esc_url( Redirect::get_url( 'calypso-scanner' ) );
 			$node['meta']['onclick'] = 'window.open( this.href ); return false;';
+			$node['meta']['class']   = 'error';
 			$node['title']           = sprintf(
 				esc_html(
 				/* translators: %s is the alert icon */

--- a/modules/scan/scan.php
+++ b/modules/scan/scan.php
@@ -3,7 +3,7 @@
  * Jetpack Scan features that show up on the jetpack admin side.
  * - Adds a admin bar notice when the site has threats.
  *
- * @package automattic/jetpack
+ * @package Jetpack
  */
 
 namespace Automattic\Jetpack\Scan;

--- a/modules/scan/scan.php
+++ b/modules/scan/scan.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The entry point to the admin bar notice class.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Scan;
+
+require_once 'class-admin-bar-notice.php';
+
+Admin_Bar_Notice::instance();

--- a/modules/scan/scan.php
+++ b/modules/scan/scan.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * The entry point to the admin bar notice class.
+ * Jetpack Scan features that show up on the jetpack admin side.
+ * - Adds a admin bar notice when the site has threats.
  *
  * @package automattic/jetpack
  */

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -6,7 +6,7 @@
  * @author Automattic
  */
 
-use function Automattic\Jetpack\enqueue_async_script as jetpack_enqueue_async_script;
+use Automattic\Jetpack\Assets;
 
 /**
  * Bail if accessed directly
@@ -77,7 +77,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			gmdate( 'YW' )
 		);
 
-		jetpack_enqueue_async_script( 'woocommerce-analytics', esc_url( $filename ), esc_url( $filename ), array(), null, false );
+		Assets::enqueue_async_script( 'woocommerce-analytics', esc_url( $filename ), esc_url( $filename ), array(), null, false );
 	}
 
 	/**

--- a/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
+++ b/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php
@@ -6,6 +6,8 @@
  * @author Automattic
  */
 
+use function Automattic\Jetpack\enqueue_async_script as jetpack_enqueue_async_script;
+
 /**
  * Bail if accessed directly
  */
@@ -75,8 +77,7 @@ class Jetpack_WooCommerce_Analytics_Universal {
 			gmdate( 'YW' )
 		);
 
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_enqueue_script( 'woocommerce-analytics', esc_url( $filename ), array(), null, false );
+		jetpack_enqueue_async_script( 'woocommerce-analytics', esc_url( $filename ), esc_url( $filename ), array(), null, false );
 	}
 
 	/**

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -1,6 +1,7 @@
 # Jetpack Asset Management
 
 A package containing functionality to manipulate paths
+And enqueing async scripts. 
 
 ### Usage TODO
 

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -1,7 +1,6 @@
 # Jetpack Asset Management
 
-A package containing functionality to manipulate paths
-And enqueing async scripts. 
+A package containing functionality to manipulate paths and enqueing async scripts.
 
 ### Usage TODO
 

--- a/packages/assets/src/class-assets.php
+++ b/packages/assets/src/class-assets.php
@@ -136,5 +136,3 @@ class Assets {
 	}
 
 }
-
-

--- a/packages/assets/src/class-assets.php
+++ b/packages/assets/src/class-assets.php
@@ -14,11 +14,76 @@ use Automattic\Jetpack\Constants as Jetpack_Constants;
  */
 class Assets {
 	/**
+	 * Holds all the scripts handles that should be loaded in an async fashion.
+	 *
+	 * @var array
+	 */
+	private $async_script_handles = array();
+	/**
+	 * The singleton instance of this class.
+	 *
+	 * @var Assets
+	 */
+	protected static $instance;
+
+	/**
 	 * Constructor.
 	 *
 	 * Static-only class, so nothing here.
 	 */
 	private function __construct() {}
+
+	/**
+	 * Get the singleton instance of the class.
+	 *
+	 * @return Assets
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Assets();
+			self::$instance->init_hooks();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Initalize the hooks as needed.
+	 */
+	private function init_hooks() {
+		/*
+		 * Load some scripts asynchronously.
+		 */
+		add_filter( 'script_loader_tag', array( $this, 'script_add_async' ), 10, 2 );
+	}
+
+	/**
+	 * A public method for adding the async script.
+	 *
+	 * @param string $script_handle Script handle.
+	 */
+	public function add_async_script( $script_handle ) {
+		$this->async_script_handles[] = $script_handle;
+	}
+
+	/**
+	 * Add an async attribute to scripts that can be loaded asynchronously.
+	 * https://www.w3schools.com/tags/att_script_async.asp
+	 *
+	 * @param string $tag    The <script> tag for the enqueued script.
+	 * @param string $handle The script's registered handle.
+	 */
+	public function script_add_async( $tag, $handle ) {
+		if ( empty( $this->async_script_handles ) ) {
+			return $tag;
+		}
+
+		if ( in_array( $handle, $this->async_script_handles, true ) ) {
+			return preg_replace( '/^<script /i', '<script async defer ', $tag );
+		}
+
+		return $tag;
+	}
 
 	/**
 	 * Given a minified path, and a non-minified path, will return
@@ -53,4 +118,21 @@ class Assets {
 		 */
 		return apply_filters( 'jetpack_get_file_for_environment', $url, $min_path, $non_min_path );
 	}
+
+}
+
+/**
+ * A helper function that lets you enqueue scripts in an async fashion.
+ *
+ * @param string $handle        Name of the script. Should be unique.
+ * @param string $min_path      Minimized script path.
+ * @param string $non_min_path  Full Script path.
+ * @param array  $deps           Array of script dependencies.
+ * @param bool   $ver             The script version.
+ * @param bool   $in_footer       Should the script be included in the footer.
+ */
+function enqueue_async_script( $handle, $min_path, $non_min_path, $deps = array(), $ver = false, $in_footer = true ) {
+	$assets_instance = Assets::instance();
+	$assets_instance->add_async_script( $handle );
+	wp_enqueue_script( $handle, Assets::get_file_url_for_environment( $min_path, $non_min_path ), $deps, $ver, $in_footer );
 }

--- a/packages/assets/src/class-assets.php
+++ b/packages/assets/src/class-assets.php
@@ -119,20 +119,22 @@ class Assets {
 		return apply_filters( 'jetpack_get_file_for_environment', $url, $min_path, $non_min_path );
 	}
 
+	/**
+	 * A helper function that lets you enqueue scripts in an async fashion.
+	 *
+	 * @param string $handle        Name of the script. Should be unique.
+	 * @param string $min_path      Minimized script path.
+	 * @param string $non_min_path  Full Script path.
+	 * @param array  $deps           Array of script dependencies.
+	 * @param bool   $ver             The script version.
+	 * @param bool   $in_footer       Should the script be included in the footer.
+	 */
+	public static function enqueue_async_script( $handle, $min_path, $non_min_path, $deps = array(), $ver = false, $in_footer = true ) {
+		$assets_instance = self::instance();
+		$assets_instance->add_async_script( $handle );
+		wp_enqueue_script( $handle, self::get_file_url_for_environment( $min_path, $non_min_path ), $deps, $ver, $in_footer );
+	}
+
 }
 
-/**
- * A helper function that lets you enqueue scripts in an async fashion.
- *
- * @param string $handle        Name of the script. Should be unique.
- * @param string $min_path      Minimized script path.
- * @param string $non_min_path  Full Script path.
- * @param array  $deps           Array of script dependencies.
- * @param bool   $ver             The script version.
- * @param bool   $in_footer       Should the script be included in the footer.
- */
-function enqueue_async_script( $handle, $min_path, $non_min_path, $deps = array(), $ver = false, $in_footer = true ) {
-	$assets_instance = Assets::instance();
-	$assets_instance->add_async_script( $handle );
-	wp_enqueue_script( $handle, Assets::get_file_url_for_environment( $min_path, $non_min_path ), $deps, $ver, $in_footer );
-}
+

--- a/packages/assets/tests/php/test_Assets.php
+++ b/packages/assets/tests/php/test_Assets.php
@@ -82,7 +82,7 @@ class AssetsTest extends TestCase {
 	 * Test that enqueue_async_script calls adds the script_loader_tag filter
 	 */
 	public function test_enqueue_async_script_adds_script_loader_tag_filter() {
-		enqueue_async_script( 'handle', 'minpath.js', 'path.js', array(), '123', true );
+		Assets::enqueue_async_script( 'handle', 'minpath.js', 'path.js', array(), '123', true );
 		$asset_instance = Assets::instance();
 		self::assertTrue( has_filter( 'script_loader_tag', array( $asset_instance, 'script_add_async' ) ) );
 	}
@@ -91,7 +91,7 @@ class AssetsTest extends TestCase {
 	 * Test that enqueue_async_script calls wp_enqueue_script
 	 */
 	public function test_enqueue_async_script_calls_wp_enqueue_script() {
-		enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
+		Assets::enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
 		$this->assertEquals(
 			$GLOBALS['_was_called_wp_enqueue_script'],
 			array( array( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true ) )

--- a/packages/assets/tests/php/test_Assets.php
+++ b/packages/assets/tests/php/test_Assets.php
@@ -11,11 +11,17 @@ function plugins_url( $path, $plugin_path ) {
 	return $plugin_path . $path;
 }
 
+function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $in_footer = false ) {
+	$GLOBALS['_was_called_wp_enqueue_script'][] = array( $handle, $src, $deps, $ver, $in_footer );
+}
+
 class AssetsTest extends TestCase {
+
 	public function setUp() {
 		Monkey\setUp();
 		$plugin_file = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/jetpack.php';
 		Jetpack_Constants::set_constant( 'JETPACK__PLUGIN_FILE', $plugin_file );
+
 	}
 
 	/**
@@ -23,6 +29,7 @@ class AssetsTest extends TestCase {
 	 */
 	public function tearDown() {
 		Monkey\tearDown();
+		$GLOBALS['_was_called_wp_enqueue_script'] = array();
 	}
 
 	/**
@@ -54,20 +61,40 @@ class AssetsTest extends TestCase {
 
 	function get_file_url_for_environment_data_provider() {
 		return array(
-			'script-debug-true' => array(
+			'script-debug-true'  => array(
 				'_inc/build/shortcodes/js/instagram.js',
 				'modules/shortcodes/js/instagram.js',
 				true,
 				'non_min_path',
-				'min_path'
+				'min_path',
 			),
 			'script-debug-false' => array(
 				'_inc/build/shortcodes/js/instagram.js',
 				'modules/shortcodes/js/instagram.js',
 				false,
 				'min_path',
-				'non_min_path'
+				'non_min_path',
 			),
+		);
+	}
+
+	/**
+	 * Test that enqueue_async_script calls adds the script_loader_tag filter
+	 */
+	public function test_enqueue_async_script_adds_script_loader_tag_filter() {
+		enqueue_async_script( 'handle', 'minpath.js', 'path.js', array(), '123', true );
+		$asset_instance = Assets::instance();
+		self::assertTrue( has_filter( 'script_loader_tag', array( $asset_instance, 'script_add_async' ) ) );
+	}
+
+	/**
+	 * Test that enqueue_async_script calls wp_enqueue_script
+	 */
+	public function test_enqueue_async_script_calls_wp_enqueue_script() {
+		enqueue_async_script( 'handle', '/minpath.js', '/path.js', array(), '123', true );
+		$this->assertEquals(
+			$GLOBALS['_was_called_wp_enqueue_script'],
+			array( array( 'handle', Assets::get_file_url_for_environment( '/minpath.js', '/path.js' ), array(), '123', true ) )
 		);
 	}
 }

--- a/tools/builder/react.js
+++ b/tools/builder/react.js
@@ -90,6 +90,7 @@ function onBuild( done, err, stats ) {
 		'videopress',
 		'comment-likes',
 		'lazy-images',
+		'scan',
 	];
 
 	// Source any JS for whitelisted modules, which will minimize us shipping much


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 1151678672052943-as-1173872646945049.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This implements threat notifications from Jetpack Scan in two places, the admin bar, and the Jetpack dashboard.

#### Is this a new feature, or does it add/remove elements to an existing part of Jetpack?
* Part of Scan release.

The new admin bar with the notice. 
<img width="603" alt="Screen Shot 2020-05-18 at 3 24 01 PM" src="https://user-images.githubusercontent.com/115071/82218143-be0e5b00-991b-11ea-8def-212d53eee352.png">

<img width="584" alt="Screen Shot 2020-05-18 at 3 25 09 PM" src="https://user-images.githubusercontent.com/115071/82218182-ca92b380-991b-11ea-8bf4-801f4f7de1dd.png">



#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a site with Jetpack Scan.
* Create a threat.
* Look at admin and Jetpack dashboard.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A, part of Scan changelog.