### PR TITLE
Image Compare: Promote from beta to production 🎓

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -8,6 +8,7 @@
 		"eventbrite",
 		"gif",
 		"google-calendar",
+		"image-compare",
 		"instagram-gallery",
 		"likes",
 		"mailchimp",
@@ -31,7 +32,7 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "image-compare" ],
+	"beta": [ "amazon" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [
 		"business-hours",


### PR DESCRIPTION
Moves the Image Compare block from a beta block to a production block. 🚀

It is considered ready for a v1 launch, see master issue for list of known issues and improvements for a v2 update. https://github.com/Automattic/jetpack/issues/15742

#### Changes proposed in this Pull Request:

* Update block from beta array to production array

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* See internal announcement post: https://wp.me/p1HpG7-8NH

#### Testing instructions:

* Create a new Image Compare block
* View on front-end normal view, AMP view
* Edit the block, confirm it doesn't invalidate

#### Proposed changelog entry for your changes:

* Adds new Image Compare block
