### PR TITLE
Settings - Sitemaps: replace text links with control to copy them to the clipboard

### DIFF
--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -22,12 +22,26 @@ import ClipboardButtonInput from 'components/clipboard-button-input';
 import { getSiteAdminUrl, isSiteVisibleToSearchEngines } from 'state/initial-state';
 
 export class Sitemaps extends React.Component {
-	trackSitemapUrl = () => {
-		analytics.tracks.recordJetpackClick( 'sitemap-url-link' );
-	};
-
-	trackSitemapNewsUrl = () => {
-		analytics.tracks.recordJetpackClick( 'sitemap-news-url-link' );
+	renderSitemapRow = ( sitemap, sitemapTrack ) => {
+		const trackSitemapUrl = () => analytics.tracks.recordJetpackClick( sitemapTrack );
+		return (
+			<span className="jp-sitemap-row">
+				<ClipboardButtonInput
+					value={ sitemap }
+					copy={ __( 'Copy', { context: 'verb' } ) }
+					copied={ __( 'Copied!' ) }
+					prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+				/>
+				<ExternalLink
+					// eslint-disable-next-line react/jsx-no-bind
+					onClick={ trackSitemapUrl }
+					icon={ true }
+					target="_blank"
+					rel="noopener noreferrer"
+					href={ sitemap }
+				/>
+			</span>
+		);
 	};
 
 	render() {
@@ -76,36 +90,8 @@ export class Sitemaps extends React.Component {
 										'Good news: Jetpack is sending your sitemap automatically ' +
 											'to all major search engines for indexing.'
 									) }
-									<span className="jp-sitemap-row">
-										<ClipboardButtonInput
-											value={ sitemap_url }
-											copy={ __( 'Copy', { context: 'verb' } ) }
-											copied={ __( 'Copied!' ) }
-											prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
-										/>
-										<ExternalLink
-											onClick={ this.trackSitemapUrl }
-											icon={ true }
-											target="_blank"
-											rel="noopener noreferrer"
-											href={ sitemap_url }
-										/>
-									</span>
-									<span className="jp-sitemap-row">
-										<ClipboardButtonInput
-											value={ news_sitemap_url }
-											copy={ __( 'Copy', { context: 'verb' } ) }
-											copied={ __( 'Copied!' ) }
-											prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
-										/>
-										<ExternalLink
-											onClick={ this.trackSitemapNewsUrl }
-											icon={ true }
-											target="_blank"
-											rel="noopener noreferrer"
-											href={ news_sitemap_url }
-										/>
-									</span>
+									{ this.renderSitemapRow( sitemap_url, 'sitemap-url-link' ) }
+									{ this.renderSitemapRow( news_sitemap_url, 'sitemap-news-url-link' ) }
 								</p>
 							</FormFieldset>
 						)

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -18,6 +18,7 @@ import { withModuleSettingsFormHelpers } from 'components/module-settings/with-m
 import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import ClipboardButtonInput from 'components/clipboard-button-input';
 import { getSiteAdminUrl, isSiteVisibleToSearchEngines } from 'state/initial-state';
 
 export class Sitemaps extends React.Component {
@@ -75,26 +76,36 @@ export class Sitemaps extends React.Component {
 										'Good news: Jetpack is sending your sitemap automatically ' +
 											'to all major search engines for indexing.'
 									) }
-									<br />
-									<ExternalLink
-										onClick={ this.trackSitemapUrl }
-										icon={ true }
-										target="_blank"
-										rel="noopener noreferrer"
-										href={ sitemap_url }
-									>
-										{ sitemap_url }
-									</ExternalLink>
-									<br />
-									<ExternalLink
-										onClick={ this.trackSitemapNewsUrl }
-										icon={ true }
-										target="_blank"
-										rel="noopener noreferrer"
-										href={ news_sitemap_url }
-									>
-										{ news_sitemap_url }
-									</ExternalLink>
+									<span className="jp-sitemap-row">
+										<ClipboardButtonInput
+											value={ sitemap_url }
+											copy={ __( 'Copy', { context: 'verb' } ) }
+											copied={ __( 'Copied!' ) }
+											prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+										/>
+										<ExternalLink
+											onClick={ this.trackSitemapUrl }
+											icon={ true }
+											target="_blank"
+											rel="noopener noreferrer"
+											href={ sitemap_url }
+										/>
+									</span>
+									<span className="jp-sitemap-row">
+										<ClipboardButtonInput
+											value={ news_sitemap_url }
+											copy={ __( 'Copy', { context: 'verb' } ) }
+											copied={ __( 'Copied!' ) }
+											prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+										/>
+										<ExternalLink
+											onClick={ this.trackSitemapNewsUrl }
+											icon={ true }
+											target="_blank"
+											rel="noopener noreferrer"
+											href={ news_sitemap_url }
+										/>
+									</span>
 								</p>
 							</FormFieldset>
 						)

--- a/_inc/client/traffic/style.scss
+++ b/_inc/client/traffic/style.scss
@@ -21,6 +21,15 @@
 	}
 }
 
+.jp-sitemap-row {
+	display: flex;
+	align-items: center;
+	margin-top: 1rem;
+	
+	.dops-clipboard-button-input {
+		flex-grow: 1;
+	}
+}
 
 // we want to place.jp-form-input-with-prefix's margin after this element
 .jp-form-input-with-prefix-bottom-message {
@@ -29,7 +38,6 @@
 	line-height: 2em;
 	margin-top: 5px;
 }
-
 
 .jp-form-site-verification-verified {
 	background-color: $white;


### PR DESCRIPTION
This PR seeks to ease the process of copying the sitemap and news sitemap URLs to paste them in the sitemap input fields from Google Search Console for example. I recently had to setup GSC for two websites, and found not optimal to have to select the text to copy the sitemap URLs and enter them in the GSC input fields. It's much faster to have this button to quickly copy them to the clipboard.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The text links to each sitemap have been replaced with controls to copy the link to the clipboard. This offers a better UX since user doesn't need to highlight the link to copy and it's faster. Links to each sitemap are preserved next to the control to copy the links.

### Before

<img width="522" alt="Screen Shot 2020-05-14 at 22 59 18" src="https://user-images.githubusercontent.com/1041600/82004365-13571d80-9639-11ea-893d-2bf95a916743.png">

### After

<img width="1064" alt="Screen Shot 2020-05-14 at 23 09 20" src="https://user-images.githubusercontent.com/1041600/82004358-105c2d00-9639-11ea-982f-854af8fc1cdd.png">

#### Testing instructions:

* Go to Settings > Traffic
* Scroll down to the Sitemaps card. If it's disabled, enable it
* You should see the controls to copy the links to the clipboard
* They should work properly

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Copying the sitemap URLs now it's easier thanks to the new control to automatically copy them to the clipboard.
