### PR TITLE
Shortcodes - Spotify: Fix embed when text not preceded by HTML tag.

### DIFF
--- a/modules/shortcodes/spotify.php
+++ b/modules/shortcodes/spotify.php
@@ -75,7 +75,8 @@ function jetpack_spotify_embed_ids( $content ) {
 			continue;
 		}
 
-		if ( substr( ltrim( $element ), 0, 8 ) !== 'spotify:' ) {
+		// If this element does not contain a Spotify embed, continue.
+		if ( strpos( $element, 'spotify:' ) === false ) {
 			continue;
 		}
 

--- a/modules/shortcodes/spotify.php
+++ b/modules/shortcodes/spotify.php
@@ -76,7 +76,7 @@ function jetpack_spotify_embed_ids( $content ) {
 		}
 
 		// If this element does not contain a Spotify embed, continue.
-		if ( strpos( $element, 'spotify:' ) === false ) {
+		if ( false === strpos( $element, 'spotify:' ) ) {
 			continue;
 		}
 

--- a/tests/php/modules/shortcodes/test-class.spotify.php
+++ b/tests/php/modules/shortcodes/test-class.spotify.php
@@ -79,4 +79,18 @@ class WP_Test_Jetpack_Shortcodes_Spotify extends WP_UnitTestCase {
 		$this->assertContains( "spotify:track:$track_id", $content );
 	}
 
+	/**
+	 * Verify that content like "spotify:track:55fQ9iIkC2qajnlvI1iMWO" on its own line, not preceded by an HTML tag, will be converted to a player.
+	 *
+	 * @since 8.6.0
+	 */
+	public function test_shortcodes_spotify_player_content_no_html() {
+		$track_id = '55fQ9iIkC2qajnlvI1iMWO';
+		$content  = "This is another plain text before a spotify track
+		spotify:track:$track_id";
+
+		$content = apply_filters( 'the_content', $content );
+		$this->assertContains( 'https://embed.spotify.com/?uri=' . rawurlencode( "spotify:track:$track_id" ), $content );
+	}
+
 }


### PR DESCRIPTION
Fixes #15800 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Check if `spotify:` exists anywhere in the `$element` string instead of just the first 8 characters of the string.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a new post in the classic editor or using a classic block.
* If using the classic editor, open the `Text` view.
* Add some arbitrary text (not wrapped in an HTML tag).
* Add spotify:track:4bz7uB4edifWKJXSDxwHcs on its own line below the other text.
* View post and verify that the embed is rendered properly.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Embeds: ensure that all valid Spotify embeds are being rendered.
