### PR TITLE
Instant Search: do not enqueue widget if Search isn't available

### DIFF
--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -176,7 +176,10 @@ class Jetpack_Search_Widget extends WP_Widget {
 	 * @since 5.8.0
 	 */
 	public function enqueue_frontend_scripts() {
-		if ( ! is_active_widget( false, false, $this->id_base, true ) || Jetpack_Search_Options::is_instant_enabled() ) {
+		if (
+			! is_active_widget( false, false, $this->id_base, true )
+			|| ! Jetpack_Search_Options::is_instant_enabled()
+		) {
 			return;
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* If a site does not support Instant Search, bail early and do not load the Search widget.

#### Testing instructions:

* Check if `search-widget.js` is enqueued on a site where Instant Search is not available.

#### Proposed changelog entry for your changes:

* Instant Search: do not enqueue widget if Search isn't available
