### PR TITLE
Travis: Unblock PRs by allowing falures for E2E tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ matrix:
     - name: "PHP Nightly"
     - name: "Spell check Markdown files"
     - name: "Code Coverage"
+    - name: "E2E tests"
 
 cache:
   directories:


### PR DESCRIPTION
Suddenly, ngrok setup, which is used in CI E2E tests stoped working. This PR will move E2E tests to "Allowed failures" section thus unblock the PRs

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* move E2E tests CI job to "allowed failures"

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure the E2E tests job is not blocking the PR
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
