### PR TITLE
Podcast Player: Add example

### DIFF
--- a/extensions/blocks/podcast-player/attributes.js
+++ b/extensions/blocks/podcast-player/attributes.js
@@ -62,4 +62,7 @@ export default {
 		type: 'string',
 		validator: colorValidator,
 	},
+	exampleFeedData: {
+		type: 'object',
+	},
 };

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -79,14 +79,20 @@ const PodcastPlayerEdit = ( {
 } ) => {
 	// Validated attributes.
 	const validatedAttributes = getValidatedAttributes( attributesValidation, attributes );
-	const { url, itemsToShow, showCoverArt, showEpisodeDescription } = validatedAttributes;
+	const {
+		url,
+		itemsToShow,
+		showCoverArt,
+		showEpisodeDescription,
+		exampleFeedData,
+	} = validatedAttributes;
 
 	const playerId = `jetpack-podcast-player-block-${ instanceId }`;
 
 	// State.
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
 	const [ isEditing, setIsEditing ] = useState( false );
-	const [ feedData, setFeedData ] = useState( {} );
+	const [ feedData, setFeedData ] = useState( exampleFeedData );
 	const cancellableFetch = useRef();
 	const [ isInteractive, setIsInteractive ] = useState( false );
 
@@ -135,8 +141,7 @@ const PodcastPlayerEdit = ( {
 
 	// Load RSS feed.
 	useEffect( () => {
-		// Clean state.
-		setFeedData( {} );
+		// Clean notices.
 		removeAllNotices();
 
 		// Don't do anything if no url is set.
@@ -144,6 +149,8 @@ const PodcastPlayerEdit = ( {
 			return;
 		}
 
+		// Clean current podcast feed and fetch a new one.
+		setFeedData( {} );
 		fetchFeed( url );
 	}, [ fetchFeed, removeAllNotices, url ] );
 
@@ -205,7 +212,7 @@ const PodcastPlayerEdit = ( {
 		[ editedUrl, url, fetchFeed, createErrorNotice, removeAllNotices, setAttributes ]
 	);
 
-	if ( isEditing || ! url ) {
+	if ( isEditing || ( ! url && ! exampleFeedData ) ) {
 		return (
 			<Placeholder
 				icon={ <BlockIcon icon={ queueMusic } /> }

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -79,7 +79,31 @@ export const settings = {
 	attributes,
 	example: {
 		attributes: {
-			// @TODO: Add default values for block attributes, for generating the block preview.
+			customPrimaryColor: '#2fb21f',
+			hexPrimaryColor: '#2fb21f',
+			exampleFeedData: {
+				title: __( 'Jetpack Example Podcast', 'jetpack' ),
+				link: 'https://jetpack.com',
+				cover:
+					'https://jetpackme.files.wordpress.com/2020/05/jetpack-example-podcast-cover.png?w=160',
+				tracks: [
+					{
+						id: '3',
+						title: __( '3. Our third episode', 'jetpack' ),
+						duration: '14:58',
+					},
+					{
+						id: '2',
+						title: __( '2. Interview with a special guest', 'jetpack' ),
+						duration: '19:17',
+					},
+					{
+						id: '1',
+						title: __( '1. Welcome to Example Podcast', 'jetpack' ),
+						duration: '11:25',
+					},
+				],
+			},
 		},
 	},
 };

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -79,8 +79,8 @@ export const settings = {
 	attributes,
 	example: {
 		attributes: {
-			customPrimaryColor: '#2fb21f',
-			hexPrimaryColor: '#2fb21f',
+			customPrimaryColor: '#00be28',
+			hexPrimaryColor: '#00be28',
 			exampleFeedData: {
 				title: __( 'Jetpack Example Podcast', 'jetpack' ),
 				link: 'https://jetpack.com',


### PR DESCRIPTION
This adds the ability to show static example data, without fetching a remote podcast feed.

Any better ideas for the example episode titles?

Fixes #15707

#### Changes proposed in this Pull Request:
- Adds a new attribute `exampleFeedData`
- Updates `example` of the block to use the new attribute

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Update to existing block

#### Testing instructions:
* `yarn run build-extensions`
* In the inserter, hover "Podcast Player" block and see the new block preview:

<img width="689" alt="Screenshot 2020-05-15 at 13 40 23" src="https://user-images.githubusercontent.com/156676/82046704-ae8bd980-96b1-11ea-9b12-71888af145e7.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add an example usage of Podcast Player
