### PR TITLE
getSitePurchases: Fix blank Dashboard on API errors 

### DIFF
--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -216,7 +216,7 @@ export function getAvailablePlans( state ) {
 }
 
 export function getSitePurchases( state ) {
-	return get( state.jetpack.siteData, [ 'data', 'sitePurchases' ], [] );
+	return get( state.jetpack.siteData, [ 'data', 'sitePurchases', 'purchase' ], [] );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

The `getSitePurchases` selector is not checking explicitly for the state object `purchase` that many other selectors rely on. When it's not there, it causes a fatal JS error and the dashboard is blank. 

Ideally, we'd be handling errors when `JETPACK_SITE_PURCHASES_FETCH_FAIL` is fired. Instead, everything is set up to just fall back to a blank default via this reducer. But I understand that this is just following a bad pattern set by othes a while ago. We'll get back around to this, but in the meantime this PR should resolve bricking the Dashboard in any case. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Updates getSitePurchases to check for more contextual default. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bugfix

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Before applying this patch, you can get your dashboard to the broken state by: 
- Connect Jetpack 
- Point to your sandbox
- Apply this patch D43509-code (this represents real broken states of some Jetpack sites)
- Visit the Jetpack dashboard in wp-admin. 

With this PR applied, the dashboard will still appear broken, but it should at least load up.  

Also make sure that everything you rely on for this state is functioning properly. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Bugfix: Fix blank dashboard in rare cases the connection is broken. 
