### PR TITLE
Instagram Gallery Block: Rename to Latest Instagram Posts

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -121,7 +121,7 @@ const InstagramGalleryEdit = props => {
 
 		return (
 			<img
-				alt={ __( 'Instagram Gallery placeholder', 'jetpack' ) }
+				alt={ __( 'Latest Instagram Posts placeholder', 'jetpack' ) }
 				src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNMyc2tBwAEOgG/c94mJwAAAABJRU5ErkJggg=="
 			/>
 		);
@@ -137,7 +137,7 @@ const InstagramGalleryEdit = props => {
 							? __( "First, you'll need to connect to WordPress.com.", 'jetpack' )
 							: __( 'Connect to Instagram to start sharing your images.', 'jetpack' )
 					}
-					label={ __( 'Instagram Gallery', 'jetpack' ) }
+					label={ __( 'Latest Instagram Posts', 'jetpack' ) }
 					notices={ noticeUI }
 				>
 					{ IS_CURRENT_USER_CONNECTED_TO_WPCOM ? (
@@ -204,7 +204,7 @@ const InstagramGalleryEdit = props => {
 							</PanelRow>
 						) }
 					</PanelBody>
-					<PanelBody title={ __( 'Gallery Settings', 'jetpack' ) }>
+					<PanelBody title={ __( 'Display Settings', 'jetpack' ) }>
 						<div className="wp-block-jetpack-instagram-gallery__count-notice">{ noticeUI }</div>
 						<RangeControl
 							label={ __( 'Number of Posts', 'jetpack' ) }

--- a/extensions/blocks/instagram-gallery/index.js
+++ b/extensions/blocks/instagram-gallery/index.js
@@ -14,8 +14,11 @@ import { supportsCollections } from '../../shared/block-category';
 export const name = 'instagram-gallery';
 
 export const settings = {
-	title: __( 'Instagram Gallery', 'jetpack' ),
-	description: __( 'Embed posts from your Instagram account.', 'jetpack' ),
+	title: __( 'Latest Instagram Posts', 'jetpack' ),
+	description: __(
+		'Display an automatically updating list of the latest posts from your Instagram feed.',
+		'jetpack'
+	),
 	icon: 'instagram',
 	category: supportsCollections() ? 'embed' : 'jetpack',
 	keywords: [


### PR DESCRIPTION
Fixes issues raised in p58i-8Zc-p2

#### Changes proposed in this Pull Request:

* Rename the Instagram Gallery block to "Latest Instagram Posts", to make clear that it automatically embeds the latest posts, updating when new posts are published on Instagram.

#### Testing instructions:

* Insert a Latest Instagram Posts block and make sure the block title and description are those introduced in this PR.

#### Proposed changelog entry for your changes:

* N/A
