### PR TITLE
Dashboard Setup page: do not add menu for non-admins

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -359,7 +359,9 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		 *
 		 * @param array $jetpack_show_setup_wizard If true, the Setup Wizard will be displayed. Otherwise it will not display.
 		 */
-		return apply_filters( 'jetpack_show_setup_wizard', false ) && Jetpack::is_active();
+		return apply_filters( 'jetpack_show_setup_wizard', false )
+			&& Jetpack::is_active()
+			&& current_user_can( 'jetpack_manage_modules' );
 	}
 }
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Non-admins are not allowed to activate / deactivate modules, they consequently do not need to see the setup wizard.

#### Testing instructions:

* Add a new user to your site, and give it the Editor role.
* Check it this branch
* Add the following filter to a functionality plugin:
`add_filter( 'jetpack_show_setup_wizard', '__return_true' );`
* Make sure your admin user sees the "Set Up" menu item in the admin menu.
* Make sure your editor user does not.

#### Proposed changelog entry for your changes:

* N/A
