### PR TITLE
Instagram Gallery Block: Add some error handling in the SSR

### DIFF
--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -67,9 +67,23 @@ function render_block( $attributes, $content ) {
 		\jetpack_require_lib( 'class-jetpack-instagram-gallery-helper' );
 	}
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
-	if ( is_wp_error( $gallery ) || empty( $gallery->images ) ) {
+
+	if ( is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
+		if ( current_user_can( 'edit_post' ) ) {
+			return sprintf(
+				'<div class="%s"><p>%s<br />%s</p></div>',
+				Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ),
+				esc_html__( 'An error occurred in the Latest Instagram Posts block. Please try again later.', 'jetpack' ),
+				esc_html__( '(Only administrators will see this message.)', 'jetpack' )
+			);
+		}
 		return '';
 	}
+
+	if ( empty( $gallery->images ) ) {
+		return '';
+	}
+
 	$images = array_slice( $gallery->images, 0, $count );
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -69,7 +69,7 @@ function render_block( $attributes, $content ) {
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
 
 	if ( is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
-		if ( current_user_can( 'edit_post' ) ) {
+		if ( current_user_can( 'edit_post', get_the_ID() ) ) {
 			return sprintf(
 				'<div class="%s"><p>%s<br />%s</p></div>',
 				Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ),

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -70,12 +70,10 @@ function render_block( $attributes, $content ) {
 
 	if ( is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
 		if ( current_user_can( 'edit_post', get_the_ID() ) ) {
-			return sprintf(
-				'<div class="%s"><p>%s<br />%s</p></div>',
-				Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ),
-				esc_html__( 'An error occurred in the Latest Instagram Posts block. Please try again later.', 'jetpack' ),
-				esc_html__( '(Only administrators will see this message.)', 'jetpack' )
-			);
+			$message = esc_html__( 'An error occurred in the Latest Instagram Posts block. Please try again later.', 'jetpack' )
+				. '<br />'
+				. esc_html__( '(Only administrators and the post author will see this message.)', 'jetpack' );
+			return Jetpack_Gutenberg::notice( $message, 'error', Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ) );
 		}
 		return '';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* If the Instagram Gallery fails to load, display an error message only visible to whoever can edit the current post (administrators, editors, and the post author).

<img width="704" alt="Screenshot 2020-05-18 at 14 44 58" src="https://user-images.githubusercontent.com/2070010/82220235-4853c080-9916-11ea-8287-1cab3f5eaeb7.png">

#### Testing instructions:

* Insert an Instagram Gallery block, and publish the post.
* Edit `instagram-gallery.php` by force the gallery to fail loading (i.e. satisfy the new error conditions).
* View the post, and make sure you can see the error message.
* Open the post in incognito, and make sure you cannot see the error message.

#### Proposed changelog entry for your changes:

* N/A
