### PR TITLE
Blocks: add utility to display messages in blocks

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1011,7 +1011,7 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Output an notice within a block.
+	 * Output a notice within a block.
 	 *
 	 * @since 8.6.0
 	 *

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -499,7 +499,7 @@ class Jetpack_Gutenberg {
 		$available_extensions = array();
 
 		foreach ( self::$extensions as $extension ) {
-			$is_available = self::is_registered_and_no_entry_in_availability( $extension ) || self::is_available( $extension );
+			$is_available                       = self::is_registered_and_no_entry_in_availability( $extension ) || self::is_available( $extension );
 			$available_extensions[ $extension ] = array(
 				'available' => $is_available,
 			);
@@ -1007,6 +1007,57 @@ class Jetpack_Gutenberg {
 			array(
 				'plan' => $plan,
 			)
+		);
+	}
+
+	/**
+	 * Output an notice within a block.
+	 *
+	 * @since 8.6.0
+	 *
+	 * @param string $message Notice we want to output.
+	 * @param string $status  Status of the notice. Can be one of success, info, warning, error. info by default.
+	 * @param string $classes List of CSS classes.
+	 *
+	 * @return string
+	 */
+	public static function notice( $message, $status = 'info', $classes = '' ) {
+		if (
+			empty( $message )
+			|| ! in_array( $status, array( 'success', 'info', 'warning', 'error' ), true )
+		) {
+			return '';
+		}
+
+		$color = '';
+		switch ( $status ) {
+			case 'success':
+				$color = '#46b450';
+				break;
+			case 'warning':
+				$color = '#ffb900';
+				break;
+			case 'error':
+				$color = '#dc3232';
+				break;
+			case 'info':
+			default:
+				$color = '#00a0d2';
+				break;
+		}
+
+		return sprintf(
+			'<div class="jetpack-block__notice %1$s %3$s" style="border-left:5px solid %4$s;padding:1em;background-color:#f8f9f9;">%2$s</div>',
+			esc_attr( $status ),
+			wp_kses(
+				$message,
+				array(
+					'br' => array(),
+					'p'  => array(),
+				)
+			),
+			esc_attr( $classes ),
+			sanitize_hex_color( $color )
 		);
 	}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Add a new utility we can rely on to display messages instead / alongside blocks on the frontend.

<img width="710" alt="screenshot 2020-05-15 at 19 33 29" src="https://user-images.githubusercontent.com/426388/82079650-7bfad480-96e3-11ea-80f2-762def41b278.png">
<img width="690" alt="screenshot 2020-05-15 at 19 33 16" src="https://user-images.githubusercontent.com/426388/82079652-7d2c0180-96e3-11ea-9be8-1307c118789b.png">
<img width="808" alt="screenshot 2020-05-15 at 19 33 02" src="https://user-images.githubusercontent.com/426388/82079653-7d2c0180-96e3-11ea-80c0-594ed4e2b71c.png">
<img width="736" alt="screenshot 2020-05-15 at 19 32 31" src="https://user-images.githubusercontent.com/426388/82079654-7dc49800-96e3-11ea-9df2-bd6ca793906a.png">

#### Testing instructions:

* Try adding something like this to the render function of a block:
`echo Jetpack_Gutenberg::notice( 'a test', 'success' );`
* Ensure that things get displayed properly on the frontend.

#### Proposed changelog entry for your changes:

* N/A
