### PR TITLE
add filter to Redirect::get_url

### DIFF
--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -99,6 +99,6 @@ class Redirect {
 		 * @param array   $args   The arguments informed to Redirect::get_url.
 		 * @param boolean $is_url Whether $source is a URL or not.
 		 */
-		return apply_filters( 'jetpack_redirects_get_url', $url, $source, $args, $is_url );
+		return \apply_filters( 'jetpack_redirects_get_url', $url, $source, $args, $is_url );
 	}
 }

--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -92,7 +92,7 @@ class Redirect {
 		/**
 		 * Filters the return of the Redirect URL.
 		 *
-		 * @since 8.6
+		 * @since 8.6.0
 		 *
 		 * @param string  $url    The redirect URL.
 		 * @param string  $source The $source informed to Redirect::get_url.

--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -60,9 +60,11 @@ class Redirect {
 		$accepted_args = array( 'site', 'path', 'query', 'anchor' );
 
 		$source_key = 'source';
+		$is_url     = false;
 
 		if ( 0 === strpos( $source, 'https://' ) ) {
 			$source_key = 'url';
+			$is_url     = true;
 			$source_url = \wp_parse_url( $source );
 
 			// discard any query and fragments.
@@ -87,6 +89,16 @@ class Redirect {
 			$url = add_query_arg( $to_be_added, $url );
 		}
 
-		return $url;
+		/**
+		 * Filters the return of the Redirect URL.
+		 *
+		 * @since 8.6
+		 *
+		 * @param string  $url    The redirect URL.
+		 * @param string  $source The $source informed to Redirect::get_url.
+		 * @param array   $args   The arguments informed to Redirect::get_url.
+		 * @param boolean $is_url Whether $source is a URL or not.
+		 */
+		return apply_filters( 'jetpack_redirects_get_url', $url, $source, $args, $is_url );
 	}
 }

--- a/packages/redirect/tests/php/bootstrap.php
+++ b/packages/redirect/tests/php/bootstrap.php
@@ -14,6 +14,10 @@ function wp_parse_url( $url ) {
 	return parse_url( $url );
 }
 
+function apply_filters( $hook, $string ) {
+	return $string;
+}
+
 function wp_parse_args( $args, $defaults = '' ) {
 	if ( is_object( $args ) ) {
 		$parsed_args = get_object_vars( $args );


### PR DESCRIPTION
Adds a filter to `get_url` method so it can be modified on the wpcom side.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* It adds a filter to an existing feature

#### Testing instructions:
Nothing to test here, just evaluate if it looks good.

For testing, see D43528-code
