### PR TITLE
Change the Contact Form "Empty Spam" button to empty the spam in batches so the page doesn't time out when there's a lot of spam.

### DIFF
--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -938,7 +938,7 @@ function grunion_delete_spam_feedbacks() {
 	 *
 	 * @module contact-form
 	 *
-	 * @since 8.6.0
+	 * @since 8.7.0
 	 *
 	 * @param int $delete_limit Number of spam to process at once. Default to 25.
 	 */

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -946,10 +946,9 @@ add_action( 'wp_ajax_grunion_recheck_queue', 'grunion_recheck_queue' );
  */
 function grunion_delete_spam_feedbacks() {
 	if ( ! wp_verify_nonce( $_POST['nonce'], 'jetpack_delete_spam_feedbacks' ) ) {
-		wp_send_json(
-			array(
-				'error' => __( 'You don&#8217;t have permission to do that.', 'jetpack' ),
-			)
+		wp_send_json_error(
+			__( 'You don&#8217;t have permission to do that.', 'jetpack' ),
+			403
 		);
 
 		return;
@@ -967,10 +966,9 @@ function grunion_delete_spam_feedbacks() {
 
 	foreach ( $spam_feedbacks as $feedback ) {
 		if ( ! current_user_can( 'delete_post', $feedback->ID ) ) {
-			wp_send_json(
-				array(
-					'error' => __( 'You don&#8217;t have permission to do that.', 'jetpack' ),
-				)
+			wp_send_json_error(
+				__( 'You don&#8217;t have permission to do that.', 'jetpack' ),
+				403
 			);
 
 			return;
@@ -983,8 +981,11 @@ function grunion_delete_spam_feedbacks() {
 
 	wp_send_json(
 		array(
-			'counts' => array(
-				'deleted' => $deleted_feedbacks,
+			'success' => true,
+			'data'    => array(
+				'counts' => array(
+					'deleted' => $deleted_feedbacks,
+				),
 			),
 		)
 	);

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -933,6 +933,15 @@ function grunion_delete_spam_feedbacks() {
 	$deleted_feedbacks = 0;
 
 	$delete_limit = 25;
+	/**
+	 * Filter the amount of Spam feedback one can delete at once.
+	 *
+	 * @module contact-form
+	 *
+	 * @since 8.6.0
+	 *
+	 * @param int $delete_limit Number of spam to process at once. Default to 25.
+	 */
 	$delete_limit = apply_filters( 'jetpack_delete_spam_feedbacks_limit', $delete_limit );
 	$delete_limit = intval( $delete_limit );
 	$delete_limit = max( 1, min( 100, $delete_limit ) ); // Allow a range of 1-100 for the delete limit.

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -914,6 +914,15 @@ add_action( 'wp_ajax_grunion_recheck_queue', 'grunion_recheck_queue' );
 function grunion_delete_spam_feedbacks() {
 	if ( ! wp_verify_nonce( $_POST['nonce'], 'jetpack_delete_spam_feedbacks' ) ) {
 		wp_send_json_error(
+			__( 'You aren&#8217;t authorized to do that.', 'jetpack' ),
+			403
+		);
+
+		return;
+	}
+
+	if ( ! current_user_can( 'delete_others_posts' ) ) {
+		wp_send_json_error(
 			__( 'You don&#8217;t have permission to do that.', 'jetpack' ),
 			403
 		);
@@ -938,15 +947,6 @@ function grunion_delete_spam_feedbacks() {
 	$spam_feedbacks = $query->get_posts();
 
 	foreach ( $spam_feedbacks as $feedback ) {
-		if ( ! current_user_can( 'delete_post', $feedback->ID ) ) {
-			wp_send_json_error(
-				__( 'You don&#8217;t have permission to do that.', 'jetpack' ),
-				403
-			);
-
-			return;
-		}
-
 		wp_delete_post( $feedback->ID, true );
 
 		$deleted_feedbacks++;

--- a/modules/contact-form/admin.php
+++ b/modules/contact-form/admin.php
@@ -954,15 +954,21 @@ function grunion_delete_spam_feedbacks() {
 		return;
 	}
 
-	$query = 'post_type=feedback&post_status=spam';
-
-	if ( isset( $_POST['limit'] ) ) {
-		$query .= '&posts_per_page=' . intval( $_POST['limit'] );
-	}
-
-	$spam_feedbacks = get_posts( $query );
-
 	$deleted_feedbacks = 0;
+
+	$delete_limit = 25;
+	$delete_limit = apply_filters( 'jetpack_delete_spam_feedbacks_limit', $delete_limit );
+	$delete_limit = intval( $delete_limit );
+	$delete_limit = max( 1, min( 100, $delete_limit ) ); // Allow a range of 1-100 for the delete limit.
+
+	$query_args = array(
+		'post_type'      => 'feedback',
+		'post_status'    => 'spam',
+		'posts_per_page' => $delete_limit,
+	);
+
+	$query          = new WP_Query( $query_args );
+	$spam_feedbacks = $query->get_posts();
 
 	foreach ( $spam_feedbacks as $feedback ) {
 		if ( ! current_user_can( 'delete_post', $feedback->ID ) ) {
@@ -985,6 +991,7 @@ function grunion_delete_spam_feedbacks() {
 			'data'    => array(
 				'counts' => array(
 					'deleted' => $deleted_feedbacks,
+					'limit'   => $delete_limit,
 				),
 			),
 		)

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -114,3 +114,15 @@
 		width: 50%;
 	}
 }
+
+/** For the "Empty Spam" button on /wp-admin/edit.php?post_status=spam&post_type=feedback **/
+.jetpack-empty-spam-container {
+	display: inline-block;
+}
+.jetpack-empty-spam {
+    display: inline-block;
+}
+.jetpack-empty-spam-spinner {
+    display: inline-block;
+    margin-top: 7px;
+}

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -120,9 +120,9 @@
 	display: inline-block;
 }
 .jetpack-empty-spam {
-    display: inline-block;
+	display: inline-block;
 }
 .jetpack-empty-spam-spinner {
-    display: inline-block;
-    margin-top: 7px;
+	display: inline-block;
+	margin-top: 7px;
 }

--- a/modules/contact-form/js/grunion-admin.js
+++ b/modules/contact-form/js/grunion-admin.js
@@ -72,28 +72,24 @@ jQuery( function( $ ) {
 			empty_spam_buttons.data( 'progress-label' ).replace( '%1$s', percentage_complete )
 		);
 
-		$.post(
-			ajaxurl,
-			{
-				action: 'jetpack_delete_spam_feedbacks',
-				limit: limit,
-				nonce: nonce,
-			},
-			function( result ) {
-				if ( 'error' in result ) {
-					// An error is only returned in the case of a missing nonce, so we don't need the actual error message.
-					window.location.href = empty_spam_buttons.data( 'failure-url' );
-					return;
-				}
+		$.post( ajaxurl, {
+			action: 'jetpack_delete_spam_feedbacks',
+			limit: limit,
+			nonce: nonce,
+		} )
+			.fail( function( result ) {
+				// An error is only returned in the case of a missing nonce or invalid permissions, so we don't need the actual error message.
+				window.location.href = empty_spam_buttons.data( 'failure-url' );
+				return;
+			} )
+			.done( function( result ) {
+				deleted_spam_count += result.data.counts.deleted;
 
-				deleted_spam_count += result.counts.deleted;
-
-				if ( result.counts.deleted < limit ) {
+				if ( result.data.counts.deleted < limit ) {
 					window.location.href = empty_spam_buttons.data( 'success-url' );
 				} else {
 					grunion_delete_spam( limit );
 				}
-			}
-		);
+			} );
 	}
 } );

--- a/modules/contact-form/js/grunion-admin.js
+++ b/modules/contact-form/js/grunion-admin.js
@@ -55,10 +55,10 @@ jQuery( function( $ ) {
 
 		initial_spam_count = parseInt( $( this ).data( 'spam-feedbacks-count' ), 10 );
 
-		grunion_delete_spam( 25 );
+		grunion_delete_spam();
 	} );
 
-	function grunion_delete_spam( limit ) {
+	function grunion_delete_spam() {
 		var empty_spam_buttons = $( '.jetpack-empty-spam' );
 
 		var nonce = empty_spam_buttons.data( 'nonce' );
@@ -74,7 +74,6 @@ jQuery( function( $ ) {
 
 		$.post( ajaxurl, {
 			action: 'jetpack_delete_spam_feedbacks',
-			limit: limit,
 			nonce: nonce,
 		} )
 			.fail( function( result ) {
@@ -85,10 +84,10 @@ jQuery( function( $ ) {
 			.done( function( result ) {
 				deleted_spam_count += result.data.counts.deleted;
 
-				if ( result.data.counts.deleted < limit ) {
+				if ( result.data.counts.deleted < result.data.counts.limit ) {
 					window.location.href = empty_spam_buttons.data( 'success-url' );
 				} else {
-					grunion_delete_spam( limit );
+					grunion_delete_spam();
 				}
 			} );
 	}

--- a/modules/contact-form/js/grunion-admin.js
+++ b/modules/contact-form/js/grunion-admin.js
@@ -1,5 +1,34 @@
 /* global ajaxurl */
 jQuery( function( $ ) {
+	if ( typeof jetpack_empty_spam_button_parameters !== 'undefined' ) {
+		// Create the "Empty Spam" button and add it above and below the list of spam feedbacks.
+		var jetpack_empty_spam_feedbacks_button_container = $( '<div/>' ).addClass(
+			'jetpack-empty-spam-container'
+		);
+
+		var jetpack_empty_spam_feedbacks_button = $( '<a />' )
+			.addClass( 'button-secondary' )
+			.addClass( 'jetpack-empty-spam' )
+			.attr( 'href', '#' )
+			.attr( 'data-progress-label', jetpack_empty_spam_button_parameters.progress_label )
+			.attr( 'data-success-url', jetpack_empty_spam_button_parameters.success_url )
+			.attr( 'data-failure-url', jetpack_empty_spam_button_parameters.failure_url )
+			.attr( 'data-spam-feedbacks-count', jetpack_empty_spam_button_parameters.spam_count )
+			.attr( 'data-nonce', jetpack_empty_spam_button_parameters.nonce )
+			.text( jetpack_empty_spam_button_parameters.label );
+		jetpack_empty_spam_feedbacks_button_container.append( jetpack_empty_spam_feedbacks_button );
+
+		var jetpack_empty_spam_feedbacks_spinner = $( '<span />' ).addClass(
+			'jetpack-empty-spam-spinner'
+		);
+		jetpack_empty_spam_feedbacks_button_container.append( jetpack_empty_spam_feedbacks_spinner );
+
+		// Add the button both above and below the list of spam feedbacks.
+		$( '.tablenav.top .actions, .tablenav.bottom .actions' )
+			.not( '.bulkactions' )
+			.append( jetpack_empty_spam_feedbacks_button_container );
+	}
+
 	$( document ).on( 'click', '#jetpack-check-feedback-spam:not(.button-disabled)', function( e ) {
 		e.preventDefault();
 


### PR DESCRIPTION
This is modeled after how the "Check for Spam" button in Akismet (and also the Jetpack Contact Form admin page) functions.

Fixes #15661

#### Changes proposed in this Pull Request:

* This changes the "Empty Spam" button from performing a simple POST request that deletes all spam feedbacks to a button that initiates a series of AJAX requests to delete spam in batches of 25.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

This improves an existing part of Jetpack.

#### Testing instructions:

1. Amass a thousand spam feedbacks
2. Go to /wp-admin/edit.php?post_status=spam&post_type=feedback
3. Click "Empty Spam"
4. Wait
5. The page will likely time out or lead to an error page.

Apply the patch.

1. Amass a thousand spam feedbacks
2. Go to /wp-admin/edit.php?post_status=spam&post_type=feedback
3. Click "Empty Spam"
4. Observe that the button changes to say "Emptying Spam (0%)" along with a loading indicator.
5. Observe that the button updates with the progress percentage as spam is deleted.
6. The page should reload/redirect to the "All" feedbacks page after the spam is emptied.

Also test that reloading the page while the spam is being emptied does show that the spam folder has been partially emptied.

#### Proposed changelog entry for your changes:
* Improve the "Empty Spam" process for the Contact Form so that it does not time out on large spam folders.