### PR TITLE
Adjust labels in the modal and add warning icons

### DIFF
--- a/_inc/client/components/jetpack-termination-dialog/features.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/features.jsx
@@ -12,6 +12,7 @@ import getRedirectUrl from 'lib/jp-redirect';
  */
 import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 import SingleFeature from './single-feature';
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies
@@ -88,9 +89,12 @@ class JetpackTerminationDialogFeatures extends Component {
 
 	renderConnectedPlugins( plugins ) {
 		return (
-			<ul>
+			<ul class="jetpack-termination-dialog__active-plugins-list">
 				{ plugins.map( plugin => (
-					<li key={ plugin.slug }>{ plugin.name }</li>
+					<li key={ plugin.slug }>
+						<Gridicon icon="notice-outline" size={ 18 } />
+						{ plugin.name }
+					</li>
 				) ) }
 			</ul>
 		);
@@ -149,22 +153,13 @@ class JetpackTerminationDialogFeatures extends Component {
 					<div className="jetpack-termination-dialog__generic-info">
 						<h2>
 							{ __(
-								'The Jetpack Connection is also used by another plugin.',
-								'The Jetpack Connection is also used by other plugins.',
+								'The Jetpack Connection is also used by another plugin, and it will lose connection.',
+								'The Jetpack Connection is also used by other plugins, and they will lose connection.',
 								{
 									count: connectedPlugins.length,
 								}
 							) }
 						</h2>
-						<p>
-							{ __(
-								'If you disconnect Jetpack from WordPress.com, the following plugin will also be disconnected:',
-								'If you disconnect Jetpack from WordPress.com, the following plugins will also be disconnected:',
-								{
-									count: connectedPlugins.length,
-								}
-							) }
-						</p>
 						{ this.renderConnectedPlugins( connectedPlugins ) }
 					</div>
 				) }

--- a/_inc/client/components/jetpack-termination-dialog/style.scss
+++ b/_inc/client/components/jetpack-termination-dialog/style.scss
@@ -202,3 +202,17 @@ a.jetpack-termination-dialog__link {
 	font-style: normal !important;
 	text-decoration: underline !important;
 }
+
+ul.jetpack-termination-dialog__active-plugins-list {
+
+	list-style-type: none;
+
+	li {
+		svg {
+			color: red;
+			margin-right: 10px;
+			vertical-align: sub;
+		}
+	}
+
+}


### PR DESCRIPTION
Make Active plugins relying on Connection more prominent on the Disconnect modal

After some discussion in p1HpG7-8VJ-p2 we decided to change the labels and add Warning icons to the list of active plugins relying on the connection.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout this branch
* `yarn build-client`
* Add a plugin with the following content:
```
/** Plugin Name: Jetpack Connection Test Plugin (1) */
add_action( 'plugins_loaded', function() {
	( new Automattic\Jetpack\Config() )->ensure( 'connection', array( 'slug' => 'jetpack-connection-test-1', 'name' => 'Jetpack Connection Test Plugin (1)' ) );
}, 1 );
```
* Activate it
* Go to the Jetpack Dashboard
* Click on "Manage site Connection":
![Captura de tela de 2020-05-15 19-30-45](https://user-images.githubusercontent.com/971483/82102026-88336180-96e4-11ea-8b11-b5dd00104203.png)

* Check the modal window and confirm there's a red icon by the plugin name:
![Captura de tela de 2020-05-15 19-30-30](https://user-images.githubusercontent.com/971483/82102029-89648e80-96e4-11ea-94de-557af0a2eb37.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No need, there's already a merged PR that added this new plugins list in the modal.
