### PR TITLE
Avoid PHP Notices/warnings on invalid form input

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -458,8 +458,10 @@ class Grunion_Contact_Form_Plugin {
 			$post = get_post( $id );
 
 			// Process the content to populate Grunion_Contact_Form::$last
-			/** This filter is already documented in core. wp-includes/post-template.php */
-			apply_filters( 'the_content', $post->post_content );
+			if ( $post ) {
+				/** This filter is already documented in core. wp-includes/post-template.php */
+				apply_filters( 'the_content', $post->post_content );
+			}
 		}
 
 		$form = isset( Grunion_Contact_Form::$forms[ $hash ] ) ? Grunion_Contact_Form::$forms[ $hash ] : null;

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3161,7 +3161,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		switch ( $field_type ) {
 			case 'email':
 				// Make sure the email address is valid
-				if ( ! is_email( $field_value ) ) {
+				if ( ! is_string( $field_value ) || ! is_email( $field_value ) ) {
 					/* translators: %s is the name of a form field */
 					$this->add_error( sprintf( __( '%s requires a valid email address', 'jetpack' ), $field_label ) );
 				}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3175,7 +3175,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				break;
 			default:
 				// Just check for presence of any text
-				if ( ! strlen( trim( $field_value ) ) ) {
+				if ( ! is_string( $field_value ) || ! strlen( trim( $field_value ) ) ) {
 					/* translators: %s is the name of a form field */
 					$this->add_error( sprintf( __( '%s is required', 'jetpack' ), $field_label ) );
 				}

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -668,8 +668,8 @@ class Grunion_Contact_Form_Plugin {
 	function prepare_for_akismet( $form ) {
 		$form['comment_type'] = 'contact_form';
 		$form['user_ip']      = $_SERVER['REMOTE_ADDR'];
-		$form['user_agent']   = $_SERVER['HTTP_USER_AGENT'];
-		$form['referrer']     = $_SERVER['HTTP_REFERER'];
+		$form['user_agent']   = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+		$form['referrer']     = isset( $_SERVER['HTTP_REFERER'] ) ? $_SERVER['HTTP_REFERER'] : '';
 		$form['blog']         = get_option( 'home' );
 
 		foreach ( $_SERVER as $key => $value ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoids PHP Notices and warnings on invalid contact form inputs.
* This is mostly achieved by returning early and checking submitted field types prior to performing string operations on them.
* Each change is it's own commit with an example of the warning/notice and any reasoning why it seems safe.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bugfix only.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a form into a post/widget/area and view the form.
* Manipulate the front-end of the form to change the field types to arrays (ie. `name="g90-youremail"` to `name="g90-youremail[]"`
* Submit the junk input, watch logs for PHP Notices and Warnings.

Please note: This needs careful code review, I believe these changes are safe, but I haven't fully tested every format of contact form.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog needed.
