### PR TITLE
Recurring Payments: Use a secondary-styled buttons for payment options

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -322,6 +322,7 @@ class MembershipsButtonEdit extends Component {
 				<Button
 					className="membership-button__field-button"
 					isLarge
+					isSecondary
 					key={ product.id }
 					onClick={ () => this.setMembershipAmount( product.id ) }
 				>

--- a/extensions/blocks/recurring-payments/editor.scss
+++ b/extensions/blocks/recurring-payments/editor.scss
@@ -17,7 +17,7 @@
 			max-width: 500px;
 			p {
 				font-size: 13px;
-				margin: 0 0 20px;
+				margin: 0 0 10px;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #15607

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates the button type from standard to secondary for the Recurring Payments list of available options. This adds a border for each button to clean up the UI a bit.
* Also tidies the spacing between buttons and text to even things out.

**Before**

<img width="619" alt="Screen Shot 2020-05-18 at 2 27 45 PM" src="https://user-images.githubusercontent.com/2124984/82247061-c498d480-9913-11ea-9beb-06450f211c0f.png">

**After**

<img width="627" alt="Screen Shot 2020-05-18 at 3 52 47 PM" src="https://user-images.githubusercontent.com/2124984/82253826-b355c500-991f-11ea-95f7-29d807f0afb7.png">


#### Testing instructions:

* Spin up a test site with this branch: https://jurassic.ninja/create?jetpack-beta&branch=update/recurring-payments-styles
* Connect to WP.com and make sure you're on the Jetpack Premium plan
* Add a new post and add a Recurring Payments block to the post
* Connect to Stripe
* Add a couple instances of Recurring Payments buttons
* Note the style changes

#### Proposed changelog entry for your changes:

* Fix Recurring Payments button styles.
