### PR TITLE
Use docker image automattic/jetpack-wordpress-dev instead of local build for the docker environment

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -112,7 +112,7 @@ yarn docker:up
 
 Start three containers (WordPress, MySQL and MailDev) defined in `docker-composer.yml`. Wrapper for `docker-composer up`.
 
-This command will rebuild the WordPress container if you made any changes to `docker-composer.yml`. It won’t build the images again on its own if you changed any of the other files like `Dockerfile`, `run.sh` (the entry-point file) or the provisioned files for configuring Apache and PHP. See "rebuilding images".
+This command will rebuild the WordPress container if you made any changes to `docker-composer.yml`.
 
 For running the containers in the background, use:
 
@@ -133,14 +133,6 @@ yarn docker:down
 ```
 
 Will stop all of the containers created by this docker-compose configuration and remove them, too. It won’t remove the images. Just the containers that have just been stopped.
-
-### Rebuild images
-
-```sh
-yarn docker:build-image
-```
-
-You need to rebuild the WordPress image with this command if you modified `Dockerfile`, `docker-composer.yml` or the provisioned files we use for configuring Apache and PHP.
 
 ### Running unit tests
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,8 +61,7 @@ services:
     depends_on:
       - db
       - maildev
-    build: .
-    image: jetpack_wordpress:localbuild
+    image: automattic/jetpack-wordpress-dev:latest
     volumes:
       - ..:/var/www/html/wp-content/plugins/jetpack
       ## Kludge for not having docker contain recursive stuff

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"docker:stop": "yarn docker:compose stop",
 		"docker:down": "yarn docker:compose down",
 		"docker:build": "docker run -it --rm  -v ${PWD}:/usr/src/app -w /usr/src/app node yarn build",
-		"docker:build-image": "yarn docker:compose build",
+		"docker:build-image": "docker build -t automattic/jetpack-wordpress-dev docker",
 		"docker:wp": "yarn docker:compose exec wordpress wp --allow-root --path=/var/www/html/",
 		"docker:install": "yarn docker:compose exec wordpress bash -c \"/var/scripts/install.sh\"",
 		"docker:uninstall": "yarn docker:compose exec wordpress bash -c \"/var/scripts/uninstall.sh\"",


### PR DESCRIPTION
Introduce usage of the published image [automattic/jetpack-wordpress-dev](https://hub.docker.com/r/automattic/jetpack-wordpress-dev) which is built from the Dockerfile contained in this repo: See [docker/Dockerfile](https://github.com/Automattic/jetpack/blob/master/docker/Dockerfile)

## Why

The current approach to getting the environment running implies bulding of a docker image which consumes much battery and bandwidth. On top of that one needs to install node packages and such, thus adding to the consumption of battery and bandwidth. **Less than ideal for meetup situations**.

Usage of a pre-built image should decrease significantly the time from cloning Jetpack to having the docker environment running locally, **by a factor 7** approximately. (That is if the whole setup currently takes 3 mins, now it will take 25 seconds). This mostly depends on bandwidth available. It also reduces CPU consumption **significantly** as we don't need to buld the image.


**Notes:** I'd like to discuss the naming of the image and the implications of switching to using this image for people already using the environment. (Should be null). 

## PR stuff

#### Changes proposed in this Pull Request:

* Updates the docker-compose.yml file to not declare the need for building the image locally and to depend on `automattic/jetpack-wordpress-dev`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Incoming link to P2 post.

#### Testing instructions:

For current users of the Jetpack Docker Environment

1. Checkout this branch
2. Run `yarn docker:up`.
3. Confirm the WordPress container is running by visiting the site as you usually do with the docker environment. 
4. Confirm that your WordPress works exactly the same as before. The database will be the same, the content inside the `wordpress` (and thus anything in `wp-content` will be the same


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
