### PR TITLE
Image Compare: Polish focus rectangle.

### DIFF
--- a/extensions/blocks/image-compare/editor.scss
+++ b/extensions/blocks/image-compare/editor.scss
@@ -5,6 +5,13 @@
 	margin-right: 0;
 }
 
+// The positioning in the editor crops the selection focus. This accounts for that.
+.jx-slider.jx-slider {
+	top: 1px;
+	left: 1px;
+	width: calc(100% - 2px);
+}
+
 .image-compare__placeholder > .components-placeholder {
 	flex-direction: row;
 	align-items: center;

--- a/extensions/blocks/image-compare/view.scss
+++ b/extensions/blocks/image-compare/view.scss
@@ -157,7 +157,6 @@ div.jx-image {
 	display: inline-block;
 	top: 0;
 	overflow: hidden;
-	-webkit-backface-visibility: hidden;
 }
 
 .vertical div.jx-image {


### PR DESCRIPTION
Some of the CSS for the Image Compare block caused display issues in the editor. Specifically, the backface visibility caused rounding errors with the width of the focus rectangle.

This PR addresses that, and also positions the block in the editor to not crop the focus.

Before:

<img width="866" alt="Screenshot 2020-05-19 at 10 21 41" src="https://user-images.githubusercontent.com/1204802/82304086-24e35100-99bc-11ea-9010-bbcd860b8631.png">

_Note how the focus is 2px on the right and 1px below_

After:

<img width="880" alt="Screenshot 2020-05-19 at 10 31 13" src="https://user-images.githubusercontent.com/1204802/82304114-2dd42280-99bc-11ea-8727-54cf3ba83a2d.png">

Testing instructions:

- Insert an Image Compare block with two images.
- Unselect it, then select it again so it has a blue focus rectangle.
- Observe that the border has the same width all the way around.
- Also observe that it otherwise works as intended.

Proposed changelog entry: 

- Fixed inconsistent focus border when the block was selected in the editor.

