### PR TITLE
IDC fix: avoid fatals when calling build_connect_url without params

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1398,7 +1398,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @return string|WP_Error A raw URL if the connection URL could be built; error message otherwise.
 	 */
-	public static function build_connect_url( $request ) {
+	public static function build_connect_url( $request = array() ) {
 		$from     = isset( $request['from'] ) ? $request['from'] : false;
 		$redirect = isset( $request['redirect'] ) ? $request['redirect'] : false;
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* In #15470, we made some changes to build_connect_url and added one $request parameter. However, not all calls to build_connect_url currently provide that parameter. Let's consequently provide a default.

#### Testing instructions:

* Start from a Jetpack site connected to WordPress.com.
* Update the site URL (like [so](https://wordpress.org/support/article/editing-wp-config-php/#wp_siteurl) for example).
* After a little while, you should see a prompt at the top of the Jetpack dashboard to either fix the connection issue by reconnecting, or putting the site in safe mode.
* Click to reconnect the site, and monitor your logs to ensure that no fatals happen.

#### Proposed changelog entry for your changes:

* N/A
