### PR TITLE
Infinite Scroll: Provide the 'X-Requested-With' header

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -353,6 +353,7 @@
 		// Fire the ajax request.
 		xhr = new XMLHttpRequest();
 		xhr.open( 'POST', infiniteScroll.settings.ajaxurl, true );
+		xhr.setRequestHeader( 'X-Requested-With', 'XMLHttpRequest' );
 		xhr.setRequestHeader( 'Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8' );
 		xhr.send( self.urlEncodeJSON( query ) );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15837

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Make the IS AJAX request with `X-Requested-With` header to set `DOING_AJAX` in WordPress and ensure backwards compatibility.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Fixes an issue in the Infinite Scroll module.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* It's a regression fix, can only be tested in code by observing the value of `DOING_AJAX` when the infinite scroll page request is made.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes issues with the Infinite Scroll AJAX request not being recognized as AJAX request by WordPress.
