### PR TITLE
Recurring Payments: Make sure default values are formatted like currency

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -231,7 +231,6 @@ class MembershipsButtonEdit extends Component {
 			this.state.editedProductCurrency
 		);
 		const minimumPriceNote = sprintf( __( 'Minimum allowed price is %s.' ), minPrice );
-		const formattedMinPrice = parseFloat( this.state.editedProductPrice );
 		return (
 			<div>
 				<div className="membership-button__price-container">
@@ -254,7 +253,7 @@ class MembershipsButtonEdit extends Component {
 							min="0"
 							step="1"
 							type="number"
-							value={ formattedMinPrice || '' }
+							value={ this.state.editedProductPrice || '' }
 						/>
 						<p>{ minimumPriceNote }</p>
 					</div>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -248,7 +248,7 @@ class MembershipsButtonEdit extends Component {
 								'membership-button__field-error': ! this.state.editedProductPriceValid,
 							} ) }
 							onChange={ this.handlePriceChange }
-							placeholder={ minPrice }
+							placeholder={ parseFloat( minPrice ).toFixed( 2 ) }
 							required
 							min="0"
 							step="1"

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -56,7 +56,7 @@ class MembershipsButtonEdit extends Component {
 			products: [],
 			siteSlug: '',
 			editedProductCurrency: 'USD',
-			editedProductPrice: minimumTransactionAmountForCurrency( 'USD' ),
+			editedProductPrice: parseFloat( minimumTransactionAmountForCurrency( 'USD' ) ).toFixed( 2 ),
 			editedProductPriceValid: true,
 			editedProductTitle: '',
 			editedProductTitleValid: true,
@@ -248,7 +248,7 @@ class MembershipsButtonEdit extends Component {
 								'membership-button__field-error': ! this.state.editedProductPriceValid,
 							} ) }
 							onChange={ this.handlePriceChange }
-							placeholder={ parseFloat( minPrice ).toFixed( 2 ) }
+							placeholder={ minPrice }
 							required
 							min="0"
 							step="1"

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -231,7 +231,7 @@ class MembershipsButtonEdit extends Component {
 			this.state.editedProductCurrency
 		);
 		const minimumPriceNote = sprintf( __( 'Minimum allowed price is %s.' ), minPrice );
-		const formattedMinPrice = parseFloat( this.state.editedProductPrice ).toFixed( 2 );
+		const formattedMinPrice = parseFloat( this.state.editedProductPrice );
 		return (
 			<div>
 				<div className="membership-button__price-container">

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -56,7 +56,9 @@ class MembershipsButtonEdit extends Component {
 			products: [],
 			siteSlug: '',
 			editedProductCurrency: 'USD',
-			editedProductPrice: parseFloat( minimumTransactionAmountForCurrency( 'USD' ) ).toFixed( 2 ),
+			editedProductPrice: formatCurrency( minimumTransactionAmountForCurrency( 'USD' ), 'USD', {
+				symbol: '',
+			} ),
 			editedProductPriceValid: true,
 			editedProductTitle: '',
 			editedProductTitleValid: true,

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -231,6 +231,7 @@ class MembershipsButtonEdit extends Component {
 			this.state.editedProductCurrency
 		);
 		const minimumPriceNote = sprintf( __( 'Minimum allowed price is %s.' ), minPrice );
+		const formattedMinPrice = parseFloat( this.state.editedProductPrice ).toFixed( 2 );
 		return (
 			<div>
 				<div className="membership-button__price-container">
@@ -253,7 +254,7 @@ class MembershipsButtonEdit extends Component {
 							min="0"
 							step="1"
 							type="number"
-							value={ formatCurrency( this.state.editedProductPrice ) || '' }
+							value={ formattedMinPrice || '' }
 						/>
 						<p>{ minimumPriceNote }</p>
 					</div>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -253,7 +253,7 @@ class MembershipsButtonEdit extends Component {
 							min="0"
 							step="1"
 							type="number"
-							value={ this.state.editedProductPrice || '' }
+							value={ formatCurrency( this.state.editedProductPrice ) || '' }
 						/>
 						<p>{ minimumPriceNote }</p>
 					</div>


### PR DESCRIPTION
Fixes #15603

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Format currency for the text input value rather than displaying it as a raw decimal point

Before

<img width="455" alt="Screen Shot 2020-05-19 at 11 25 25 AM" src="https://user-images.githubusercontent.com/2124984/82345682-89ee7500-99c3-11ea-98ab-929a0e83debf.png">

After

<img width="468" alt="Screen Shot 2020-05-19 at 11 25 37 AM" src="https://user-images.githubusercontent.com/2124984/82345697-8eb32900-99c3-11ea-84f1-2326a2ff2835.png">

#### Testing instructions:

* Switch to this branch on a new Jetpack test site with a Premium or greater subscription.
* Add a Recurring Payments block to a post or page
* Check that the default currency is correctly displayed with two decimal points rather than one

#### Proposed changelog entry for your changes:

* Show Recurring Payments suggested price to two decimal points