### PR TITLE
External Media: Media Item Markup

### DIFF
--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -65,7 +65,7 @@ function MediaBrowser( props ) {
 
 	return (
 		<div className={ wrapper }>
-			<div className={ classes }>
+			<ul className={ classes }>
 				{ media.map( item => (
 					<MediaItem
 						item={ item }
@@ -89,7 +89,7 @@ function MediaBrowser( props ) {
 						{ __( 'Load More', 'jetpack' ) }
 					</Button>
 				) }
-			</div>
+			</ul>
 
 			{ hasMediaItems && (
 				<div className="jetpack-external-media-browser__media__toolbar">

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -16,6 +16,15 @@ function MediaItem( props ) {
 		}
 	}, [ props.onClick ] );
 
+	// Catch space and enter keypresses
+	const onKeyDown = e => {
+		if ( e.which === 13 || e.which === 32 ) {
+			// Prevent spacebar from scrolling the page down
+			e.preventDefault();
+			onClick( event );
+		}
+	};
+
 	const { item, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;
 	const { medium = null, fmt_hd = null } = thumbnails;
@@ -27,9 +36,16 @@ function MediaItem( props ) {
 		'is-transient': isSelected && isCopying,
 	} );
 
-	/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (
-		<button className={ classes } onClick={ onClick }>
+		<li
+			className={ classes }
+			onClick={ onClick }
+			onKeyDown={ onKeyDown }
+			role="checkbox"
+			tabindex="0"
+			aria-checked={ isSelected ? 'true' : 'false' }
+		>
 			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />
 
 			{ type === 'folder' && (
@@ -40,7 +56,7 @@ function MediaItem( props ) {
 			) }
 
 			{ isSelected && isCopying && <Spinner /> }
-		</button>
+		</li>
 	);
 }
 

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -16,11 +16,11 @@ function MediaItem( props ) {
 		}
 	}, [ props.onClick ] );
 
-	// Catch space and enter keypresses
-	const onKeyDown = e => {
-		if ( e.which === 13 || e.which === 32 ) {
-			// Prevent spacebar from scrolling the page down
-			e.preventDefault();
+	// Catch space and enter keypresses.
+	const onKeyDown = event => {
+		if ( event.which === 13 || event.which === 32 ) {
+			// Prevent spacebar from scrolling the page down.
+			event.preventDefault();
 			onClick( event );
 		}
 	};


### PR DESCRIPTION
The media item in the external media modal did not contain valid markup for the images, and diverged from what the core media library used. In order to be more similar to the core media library, I changed the markup of the media items to this structure:

```
<ul>
  <li role="checkbox" aria-checked... >
  ...
```

Fixes https://github.com/Automattic/jetpack/issues/15829

#### Changes proposed in this Pull Request:
* Uses `<ul>` for the media items wrapper
* Each `MediaItem` is an `<li>` with `role="checkbox" tabindex="0"` and an `aria-checked` attribute (either `true` or `false`)
* Adds `onKeydown` listener to each `MediaItem` to catch `enter` and `space` presses

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the editor and insert an image block.
* Click the Select Image button and choose Pexels
* Use the keyboard to change the selected image with space or enter
* Inspect the HTML to make sure the `aria-checked` value is updated appropriately
* Do the same for a gallery block (multiple images should be able to be selected)
