### PR TITLE
Image Compare: Force a default orientation of horizontal in save

### DIFF
--- a/extensions/blocks/image-compare/save.js
+++ b/extensions/blocks/image-compare/save.js
@@ -8,7 +8,7 @@ const save = ( { attributes, className } ) => {
 
 	return (
 		<figure className={ className }>
-			<div className="juxtapose" data-mode={ orientation }>
+			<div className="juxtapose" data-mode={ orientation || 'horizontal' }>
 				<img
 					id={ imageBefore.id }
 					src={ imageBefore.url }


### PR DESCRIPTION

I've noticed a couple of block invalidations depending on how orientation is set, this fill force the orientation to horizontal if empty, which is the default behavior.

## Changes proposed in this Pull Request:

* Adds a default horizontal of orientation is not set.

#### Testing instructions:

* Add the Image Compare block, only test against new posts with new block - existing posts might have the same problem. The block hasn't been published so this should effective any real customers, only previous testing.

* Publish block without changing orientation, re-edit block and confirm in JavaScript console that there are no validation errors

* Try a combination of changing orientations (side-by-side and above/below) publishing and re-editing and confirm there continues no validation errors.

#### Proposed changelog entry for your changes:

* ( This is covered in new block changelog )
