### PR TITLE
External Media: Fix Pexels search markup

### DIFF
--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -60,7 +60,12 @@ function PexelsMedia( props ) {
 	return (
 		<div className="jetpack-external-media-wrapper__pexels">
 			<form className="jetpack-external-media-header__pexels" onSubmit={ onSearch }>
-				<TextControl type="search" value={ searchQuery } onChange={ setSearchQuery } />
+				<TextControl
+					aria-label={ __( 'Search', 'jetpack' ) }
+					type="search"
+					value={ searchQuery }
+					onChange={ setSearchQuery }
+				/>
 				<Button
 					isPrimary
 					onClick={ onSearch }

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -45,7 +45,7 @@ function PexelsMedia( props ) {
 
 	const previousSearchQueryValue = useRef();
 	const onSearch = useCallback(
-		( event ) => {
+		event => {
 			event.preventDefault();
 			setLastSearchQuery( searchQuery );
 			getNextPage( event, true );
@@ -60,7 +60,7 @@ function PexelsMedia( props ) {
 	return (
 		<div className="jetpack-external-media-wrapper__pexels">
 			<form className="jetpack-external-media-header__pexels" onSubmit={ onSearch }>
-				<TextControl value={ searchQuery } onChange={ setSearchQuery } />
+				<TextControl type="search" value={ searchQuery } onChange={ setSearchQuery } />
 				<Button
 					isPrimary
 					onClick={ onSearch }


### PR DESCRIPTION
The input for searching for images in Pexels uses `type="text"`, but it should be `type="search"`. It doesn't need a `<label>`, as the input is `search` and the button says `search`.

Fixes https://github.com/Automattic/jetpack/issues/15827

#### Changes proposed in this Pull Request:
* Uses `type="search"` for the search field so it's more semantic
* Adds `aria-label="Search"`

I was originally going to use a visually-hidden `<label>`, but using `TextControl` and needing to repeat the `.screen-reader-text` CSS seemed like a worse solution. The downside with using `aria-label` is that `aria-label` isn't exposed to browser translations. I'm 100% open to doing a visually hidden label instead if people have a recommended clean way of doing it (or not doing it cleanly because it is arguably better 😊)

#### Testing instructions:
* Open the editor and insert an image block.
* Click the Select Image button and choose Pexels
* Check that the search input is `type="search"` and has `aria-label="Search"`
