### PR TITLE
Podcast Player: fix type error

### DIFF
--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -92,7 +92,7 @@ const PodcastPlayerEdit = ( {
 	// State.
 	const [ editedUrl, setEditedUrl ] = useState( url || '' );
 	const [ isEditing, setIsEditing ] = useState( false );
-	const [ feedData, setFeedData ] = useState( exampleFeedData );
+	const [ feedData, setFeedData ] = useState( exampleFeedData || {} );
 	const cancellableFetch = useRef();
 	const [ isInteractive, setIsInteractive ] = useState( false );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

It looks like we introduced a type error in https://github.com/Automattic/jetpack/pull/15806 which this PR aims to resolve.

Prior to this change `feedData` defaulted to an empty object while now it's undefined when no `exampleFeedData` is set. This PR suggests to change the default to an empty object again.




#### Testing instructions:
* `yarn run build-extensions`
* Add the Podcast Player to a post, add a podcast (e.g. anchor.fm/dissect) and confirm it's working as expected (no type error)
* In the inserter, hover "Podcast Player" block and check if the the new block preview is still working (see screenshot below)



#### Screenshots:
<img width="689" alt="Screenshot 2020-05-15 at 13 40 23" src="https://user-images.githubusercontent.com/156676/82046704-ae8bd980-96b1-11ea-9b12-71888af145e7.png">