### PR TITLE
External Media: Arrow keys interactions and aria on Select Image Dropdown

### DIFF
--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, MenuItem, MenuGroup, Dropdown } from '@wordpress/components';
+import { Button, MenuItem, MenuGroup, Dropdown, NavigableMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -46,27 +46,31 @@ function MediaButtonMenu( props ) {
 
 			<Dropdown
 				position="bottom right"
-				renderToggle={ ( { onToggle } ) => (
+				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
 						isTertiary={ ! isFeatured }
 						isPrimary={ isFeatured }
 						className="jetpack-external-media-browse-button"
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
 						onClick={ onToggle }
 					>
 						{ __( 'Select Image', 'jetpack' ) }
 					</Button>
 				) }
 				renderContent={ ( { onToggle } ) => (
-					<MenuGroup>
-						<MenuItem icon="admin-media" onClick={ () => openLibrary( onToggle ) }>
-							{ __( 'Media Library', 'jetpack' ) }
-						</MenuItem>
+					<NavigableMenu aria-label={ __( 'Select Image', 'jetpack' ) }>
+						<MenuGroup>
+							<MenuItem icon="admin-media" onClick={ () => openLibrary( onToggle ) }>
+								{ __( 'Media Library', 'jetpack' ) }
+							</MenuItem>
 
-						<MediaSources
-							open={ () => dropdownOpen( onToggle ) }
-							setSource={ source => changeSource( source, onToggle ) }
-						/>
-					</MenuGroup>
+							<MediaSources
+								open={ () => dropdownOpen( onToggle ) }
+								setSource={ source => changeSource( source, onToggle ) }
+							/>
+						</MenuGroup>
+					</NavigableMenu>
 				) }
 			/>
 		</>


### PR DESCRIPTION
~~The popover dropdown should be a `DropdownMenu` component instead of a `Dropdown` so it's consistent with other similar dropdowns in Gutenberg.~~ 

The included `@wordpress/components` package version doesn't have the functionality we need. I've recreated it using the minimum states and functionality we need: aria states and arrow key navigation on the menu.
 
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Wraps the dropdown in `<NavigableContainer>` to trap focus and allow arrow keys to navigate the menu
* Adds an `aria-label` to the dropdown 
* Adds `aria-expanded` and `aria-haspopup=true` to the toggle button

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add an image block to a post
* Click the Select Image button
* Use the arrow keys and tab to move around the menu
* Focus should be trapped (tabbing after the last one resets to the first item)
* Pressing `escape` should close the menu and return focus to the Select Image button
