### PR TITLE
Latest Instagram Posts Block: Convert the sidebar notice from HOC to simple component

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -11,6 +11,7 @@ import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
+	Notice,
 	PanelBody,
 	PanelRow,
 	Placeholder,
@@ -82,11 +83,10 @@ const InstagramGalleryEdit = props => {
 	const gridStyle = { gridGap: spacing };
 	const photoStyle = { padding: spacing };
 
-	useEffect( () => {
+	const renderSidebarNotice = () => {
 		const accountImageTotal = images.length;
 
 		if ( showSidebar && ! showLoadingSpinner && accountImageTotal < count ) {
-			noticeOperations.removeAllNotices();
 			const noticeContent = accountImageTotal
 				? sprintf(
 						_n(
@@ -98,14 +98,15 @@ const InstagramGalleryEdit = props => {
 						accountImageTotal
 				  )
 				: __( 'There are currently no posts in your Instagram account.', 'jetpack' );
-
-			noticeOperations.createNotice( {
-				status: 'info',
-				content: noticeContent,
-				isDismissible: false,
-			} );
+			return (
+				<div className="wp-block-jetpack-instagram-gallery__count-notice">
+					<Notice isDismissible={ false } status="info">
+						{ noticeContent }
+					</Notice>
+				</div>
+			);
 		}
-	}, [ count, images, noticeOperations, showLoadingSpinner, showSidebar ] );
+	};
 
 	const renderImage = index => {
 		if ( images[ index ] ) {
@@ -213,7 +214,7 @@ const InstagramGalleryEdit = props => {
 						) }
 					</PanelBody>
 					<PanelBody title={ __( 'Display Settings', 'jetpack' ) }>
-						<div className="wp-block-jetpack-instagram-gallery__count-notice">{ noticeUI }</div>
+						{ renderSidebarNotice() }
 						<RangeControl
 							label={ __( 'Number of Posts', 'jetpack' ) }
 							value={ count }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Convert the sidebar notice from HOC to simple component.

While working with the block errors handling, I've noticed (pun intended) that we are using the `withNotices` HOC in two different locations (placeholder and sidebar) to display two different kinds of notices.
The sidebar notice informs if the selected Instagram account has less images than requested; the placeholder notice will keep track of all kinds of server and connection errors.

Since the sidebar is not rendered when the block is a placeholder, we thought it was ok to "overload" `withNotices` this way.
Though, it can happen (and it has happened to me while testing) that notices intended for the sidebar might end up being displayed in the placeholder too, where they would make no sense.

Instead of unnecessarily complicating the notices displaying logic, I'm "reverting" the sidebar notice from using the `withNotice` HOC to being a simple `<Notice>` component.
This way, the HOC will handle only the placeholder notices without risk of "leaks".

#### Testing instructions:

Testing for notice leaks is very complicated, so let's just test if the sidebar notice is still working as intended.

* Insert a Latest Instagram Posts block, and connect it to an account with less than 30 images.
* In the block sidebar, make sure there is an info notice about "There are currently only X posts in your Instagram account".
<img width="277" alt="Screenshot 2020-05-20 at 12 23 28" src="https://user-images.githubusercontent.com/2070010/82440747-c047f500-9a94-11ea-820a-32a73475cc2a.png">

* Move the "Number of Posts" slider down, until it's lower than the images count.
* Make sure the notice disappears.
<img width="274" alt="Screenshot 2020-05-20 at 12 23 17" src="https://user-images.githubusercontent.com/2070010/82440759-c3db7c00-9a94-11ea-801b-f0d95c7c7387.png">

* Move the slider back up, and make sure the notice reappears.
<img width="275" alt="Screenshot 2020-05-20 at 12 23 10" src="https://user-images.githubusercontent.com/2070010/82440765-c63dd600-9a94-11ea-9de6-1350e03a18a3.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
