### PR TITLE
Calendly Block: Replace SubmitButton with new button block

### DIFF
--- a/extensions/blocks/calendly/attributes.js
+++ b/extensions/blocks/calendly/attributes.js
@@ -1,9 +1,4 @@
 /**
- * External Dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import colorValidator from '../../shared/colorValidator';
@@ -16,17 +11,6 @@ export default {
 		default: 'ffffff',
 		validator: colorValidator,
 	},
-	submitButtonText: {
-		type: 'string',
-		default: __( 'Schedule time with me', 'jetpack' ),
-	},
-	submitButtonTextColor: {
-		type: 'string',
-	},
-	submitButtonBackgroundColor: {
-		type: 'string',
-	},
-	submitButtonClasses: { type: 'string' },
 	hideEventTypeDetails: {
 		type: 'boolean',
 		default: false,
@@ -49,19 +33,5 @@ export default {
 	url: {
 		type: 'string',
 		validator: urlValidator,
-	},
-	backgroundButtonColor: {
-		type: 'string',
-	},
-	textButtonColor: {
-		type: 'string',
-	},
-	customBackgroundButtonColor: {
-		type: 'string',
-		validator: colorValidator,
-	},
-	customTextButtonColor: {
-		type: 'string',
-		validator: colorValidator,
 	},
 };

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -84,8 +84,8 @@ function load_assets( $attr, $content ) {
 			wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
 		}
 
-		// Render deprecated version of Calendly block if needed. New markup contains fallback link.
-		if ( false === strpos( $content, 'wp-block-jetpack-calendly__fallback' ) ) {
+		// Render deprecated version of Calendly block if needed. New markup block button class before rendering here.
+		if ( false === strpos( $content, 'wp-block-jetpack-button' ) ) {
 			$content = deprecated_render_button_v1( $attr, $block_id, $classes, $url );
 		} else {
 			$content = str_replace( 'calendly-widget-id', esc_attr( $block_id ), $content );
@@ -165,9 +165,7 @@ function enqueue_calendly_js() {
 			if ( widget ) {
 				widget.addEventListener( 'click', function( event ) {
 					event.preventDefault();
-					Calendly.initPopupWidget( {
-						url: event.target.href || event.target.parentElement.nextElementSibling.href,
-					} );
+					Calendly.initPopupWidget( { url: event.target.href } );
 				} );
 				widget.addEventListener( 'keydown', function( event ) {
 					// Enter and space keys.

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -55,25 +55,19 @@ function load_assets( $attr, $content ) {
 	 * Enqueue necessary scripts and styles.
 	 */
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-	wp_enqueue_script(
-		'jetpack-calendly-external-js',
-		'https://assets.calendly.com/assets/external/widget.js',
-		null,
-		JETPACK__VERSION,
-		true
-	);
 
-	$style                          = get_attribute( $attr, 'style' );
-	$hide_event_type_details        = get_attribute( $attr, 'hideEventTypeDetails' );
-	$background_color               = get_attribute( $attr, 'backgroundColor' );
-	$text_color                     = get_attribute( $attr, 'textColor' );
-	$primary_color                  = get_attribute( $attr, 'primaryColor' );
-	$submit_button_text             = get_attribute( $attr, 'submitButtonText' );
-	$submit_button_classes          = get_attribute( $attr, 'submitButtonClasses' );
-	$submit_button_text_color       = get_attribute( $attr, 'customTextButtonColor' );
-	$submit_button_background_color = get_attribute( $attr, 'customBackgroundButtonColor' );
-	$classes                        = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, array( 'calendly-style-' . $style ) );
-	$block_id                       = wp_unique_id( 'calendly-block-' );
+	$style                   = get_attribute( $attr, 'style' );
+	$hide_event_type_details = get_attribute( $attr, 'hideEventTypeDetails' );
+	$background_color        = get_attribute( $attr, 'backgroundColor' );
+	$text_color              = get_attribute( $attr, 'textColor' );
+	$primary_color           = get_attribute( $attr, 'primaryColor' );
+	$classes                 = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, array( 'calendly-style-' . $style ) );
+	$block_id                = wp_unique_id( 'calendly-block-' );
+	$is_amp_request          = class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
+
+	if ( ! wp_script_is( 'jetpack-calendly-external-js' ) && ! $is_amp_request ) {
+		enqueue_calendly_js();
+	}
 
 	$url = add_query_arg(
 		array(
@@ -86,35 +80,27 @@ function load_assets( $attr, $content ) {
 	);
 
 	if ( 'link' === $style ) {
-		wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
-
-		/*
-		 * If we have some additional styles from the editor
-		 * (a custom text color, custom bg color, or both )
-		 * Let's add that CSS inline.
-		 */
-		if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
-			$inline_styles = sprintf(
-				'#%1$s .wp-block-button__link{%2$s%3$s}',
-				esc_attr( $block_id ),
-				! empty( $submit_button_text_color )
-					? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
-					: '',
-				! empty( $submit_button_background_color )
-					? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
-					: ''
-			);
-			wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+		if ( ! wp_style_is( 'jetpack-calendly-external-css' ) ) {
+			wp_enqueue_style( 'jetpack-calendly-external-css', 'https://assets.calendly.com/assets/external/widget.css', null, JETPACK__VERSION );
 		}
 
-		$content = sprintf(
-			'<div class="wp-block-button %1$s" id="%2$s"><a class="%3$s" role="button" onclick="Calendly.initPopupWidget({url:\'%4$s\'});return false;">%5$s</a></div>',
-			esc_attr( $classes ),
-			esc_attr( $block_id ),
-			! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
-			esc_js( $url ),
-			wp_kses_post( $submit_button_text )
-		);
+		// Render deprecated version of Calendly block if needed. New markup contains fallback link.
+		if ( false === strpos( $content, 'wp-block-jetpack-calendly__fallback' ) ) {
+			$content = deprecated_render_button_v1( $attr, $block_id, $classes, $url );
+		} else {
+			$content = preg_replace(
+				'/data-id-attr="placeholder"/',
+				'id="' . esc_attr( $block_id ) . '"',
+				$content
+			);
+		}
+
+		if ( ! $is_amp_request ) {
+			wp_add_inline_script(
+				'jetpack-calendly-external-js',
+				sprintf( "calendly_attach_link_events( '%s' )", esc_js( $block_id ) )
+			);
+		}
 	} else { // Inline style.
 		$content = sprintf(
 			'<div class="%1$s" id="%2$s"></div>',
@@ -159,4 +145,88 @@ function get_attribute( $attributes, $attribute_name ) {
 	if ( isset( $default_attributes[ $attribute_name ] ) ) {
 		return $default_attributes[ $attribute_name ];
 	}
+}
+
+/**
+ * Enqueues the Calendly JS library and inline function to attach event
+ * handlers to the button.
+ *
+ * @return void
+ */
+function enqueue_calendly_js() {
+	wp_enqueue_script(
+		'jetpack-calendly-external-js',
+		'https://assets.calendly.com/assets/external/widget.js',
+		null,
+		JETPACK_VERSION,
+		false
+	);
+
+	wp_add_inline_script(
+		'jetpack-calendly-external-js',
+		"function calendly_attach_link_events( elementId ) {
+			var widget = document.getElementById( elementId );
+			if ( widget ) {
+				widget.addEventListener( 'click', function( event ) {
+					event.preventDefault();
+					Calendly.initPopupWidget( {
+						url: event.target.href || event.target.parentElement.nextElementSibling.href,
+					} );
+				} );
+				widget.addEventListener( 'keydown', function( event ) {
+					// Enter and space keys.
+					if ( event.keyCode === 13 || event.keyCode === 32 ) {
+						event.preventDefault();
+						event.target && event.target.click();
+					}
+				} );
+			}
+		}"
+	);
+}
+
+/**
+ * Renders a deprecated legacy version of the button HTML.
+ *
+ * @param array  $attributes Array containing the Calendly block attributes.
+ * @param string $block_id  The value for the ID attribute of the link.
+ * @param string $classes   The CSS classes for the wrapper div.
+ * @param string $url       Calendly URL for the link HREF.
+ *
+ * @return string
+ */
+function deprecated_render_button_v1( $attributes, $block_id, $classes, $url ) {
+	// This is the legacy version, so create the full link content.
+	$submit_button_text             = get_attribute( $attributes, 'submitButtonText' );
+	$submit_button_classes          = get_attribute( $attributes, 'submitButtonClasses' );
+	$submit_button_text_color       = get_attribute( $attributes, 'customTextButtonColor' );
+	$submit_button_background_color = get_attribute( $attributes, 'customBackgroundButtonColor' );
+
+	/*
+	 * If we have some additional styles from the editor
+	 * (a custom text color, custom bg color, or both )
+	 * Let's add that CSS inline.
+	 */
+	if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
+		$inline_styles = sprintf(
+			'#%1$s .wp-block-button__link{%2$s%3$s}',
+			esc_attr( $block_id ),
+			! empty( $submit_button_text_color )
+				? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
+				: '',
+			! empty( $submit_button_background_color )
+				? 'background-color:#' . sanitize_hex_color_no_hash( $submit_button_background_color ) . ';'
+				: ''
+		);
+		wp_add_inline_style( 'jetpack-calendly-external-css', $inline_styles );
+	}
+
+	return sprintf(
+		'<div class="%1$s" id="%2$s"><a class="%3$s" href="%4$s" role="button">%5$s</a></div>',
+		esc_attr( $classes ),
+		esc_attr( $block_id ),
+		! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',
+		esc_js( $url ),
+		wp_kses_post( $submit_button_text )
+	);
 }

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -98,19 +98,29 @@ function load_assets( $attr, $content ) {
 			);
 		}
 	} else { // Inline style.
-		$content = sprintf(
-			'<div class="%1$s" id="%2$s"></div>',
-			esc_attr( $classes ),
-			esc_attr( $block_id )
-		);
-		$script  = <<<JS_END
+		if ( $is_amp_request ) {
+			$content = sprintf(
+				'<div class="%1$s" id="%2$s"><a href="%3$s" role="button" target="_blank">%4$s</a></div>',
+				esc_attr( Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr ) ),
+				esc_attr( $block_id ),
+				esc_js( $url ),
+				wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )
+			);
+		} else {
+			$content = sprintf(
+				'<div class="%1$s" id="%2$s"></div>',
+				esc_attr( $classes ),
+				esc_attr( $block_id )
+			);
+			$script  = <<<JS_END
 Calendly.initInlineWidget({
 	url: '%s',
 	parentElement: document.getElementById('%s'),
 	inlineStyles: false,
 });
 JS_END;
-		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
+			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
+		}
 	}
 
 	return $content;

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -88,11 +88,7 @@ function load_assets( $attr, $content ) {
 		if ( false === strpos( $content, 'wp-block-jetpack-calendly__fallback' ) ) {
 			$content = deprecated_render_button_v1( $attr, $block_id, $classes, $url );
 		} else {
-			$content = preg_replace(
-				'/data-id-attr="placeholder"/',
-				'id="' . esc_attr( $block_id ) . '"',
-				$content
-			);
+			$content = str_replace( 'calendly-widget-id', esc_attr( $block_id ), $content );
 		}
 
 		if ( ! $is_amp_request ) {

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -171,7 +171,7 @@ function enqueue_calendly_js() {
 	wp_add_inline_script(
 		'jetpack-calendly-external-js',
 		"function calendly_attach_link_events( elementId ) {
-			var widget = document.querySelector( '#' + elementId + ' > a' );
+			var widget = document.getElementById( elementId );
 			if ( widget ) {
 				widget.addEventListener( 'click', function( event ) {
 					event.preventDefault();
@@ -226,7 +226,7 @@ function deprecated_render_button_v1( $attributes, $block_id, $classes, $url ) {
 	}
 
 	return sprintf(
-		'<div class="%1$s" id="%2$s"><a class="%3$s" href="%4$s" role="button">%5$s</a></div>',
+		'<div class="%1$s"><a id="%2$s" class="%3$s" href="%4$s" role="button">%5$s</a></div>',
 		esc_attr( $classes ),
 		esc_attr( $block_id ),
 		! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -171,7 +171,7 @@ function enqueue_calendly_js() {
 	wp_add_inline_script(
 		'jetpack-calendly-external-js',
 		"function calendly_attach_link_events( elementId ) {
-			var widget = document.getElementById( elementId );
+			var widget = document.querySelector( '#' + elementId + ' > a' );
 			if ( widget ) {
 				widget.addEventListener( 'click', function( event ) {
 					event.preventDefault();

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -164,7 +164,7 @@ function enqueue_calendly_js() {
 		'jetpack-calendly-external-js',
 		'https://assets.calendly.com/assets/external/widget.js',
 		null,
-		JETPACK_VERSION,
+		JETPACK__VERSION,
 		false
 	);
 

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -213,7 +213,7 @@ function deprecated_render_button_v1( $attributes, $block_id, $classes, $url ) {
 	 */
 	if ( ! empty( $submit_button_text_color ) || ! empty( $submit_button_background_color ) ) {
 		$inline_styles = sprintf(
-			'#%1$s .wp-block-button__link{%2$s%3$s}',
+			'#%1$s{%2$s%3$s}',
 			esc_attr( $block_id ),
 			! empty( $submit_button_text_color )
 				? 'color:#' . sanitize_hex_color_no_hash( $submit_button_text_color ) . ';'
@@ -226,7 +226,7 @@ function deprecated_render_button_v1( $attributes, $block_id, $classes, $url ) {
 	}
 
 	return sprintf(
-		'<div class="%1$s"><a id="%2$s" class="%3$s" href="%4$s" role="button">%5$s</a></div>',
+		'<div class="wp-block-button %1$s"><a id="%2$s" class="%3$s" href="%4$s" role="button">%5$s</a></div>',
 		esc_attr( $classes ),
 		esc_attr( $block_id ),
 		! empty( $submit_button_classes ) ? esc_attr( $submit_button_classes ) : 'wp-block-button__link',

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -69,7 +69,8 @@ function load_assets( $attr, $content ) {
 		enqueue_calendly_js();
 	}
 
-	$url = add_query_arg(
+	$base_url = $url;
+	$url      = add_query_arg(
 		array(
 			'hide_event_type_details' => (int) $hide_event_type_details,
 			'background_color'        => sanitize_hex_color_no_hash( $background_color ),
@@ -89,6 +90,7 @@ function load_assets( $attr, $content ) {
 			$content = deprecated_render_button_v1( $attr, $block_id, $classes, $url );
 		} else {
 			$content = str_replace( 'calendly-widget-id', esc_attr( $block_id ), $content );
+			$content = str_replace( $base_url, $url, $content );
 		}
 
 		if ( ! $is_amp_request ) {

--- a/extensions/blocks/calendly/deprecated/v1/index.js
+++ b/extensions/blocks/calendly/deprecated/v1/index.js
@@ -91,7 +91,7 @@ export default {
 	},
 	migrate: attributes => {
 		const newAttributes = omit( attributes, deprecatedAttributes );
-		const buttonAttributes = migrateAttributes( pick( attributes, deprecatedAttributes ) );
+		const buttonAttributes = migrateAttributes( attributes );
 		const newInnerBlocks = [
 			createBlock( 'jetpack/button', {
 				element: 'button',

--- a/extensions/blocks/calendly/deprecated/v1/index.js
+++ b/extensions/blocks/calendly/deprecated/v1/index.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { isEmpty, omit, pick, some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import colorValidator from '../../../../shared/colorValidator';
+
+const urlValidator = url => ! url || url.startsWith( 'https://calendly.com/' );
+const deprecatedAttributes = [
+	'submitButtonText',
+	'submitButtonTextColor',
+	'submitButtonBackgroundColor',
+	'submitButtonClasses',
+	'backgroundButtonColor',
+	'textButtonColor',
+	'customBackgroundButtonColor',
+	'customTextButtonColor',
+];
+const migrateAttributes = oldAttributes => ( {
+	text: oldAttributes.submitButtonText || __( 'Schedule time with me', 'jetpack' ),
+	textColor: oldAttributes.submitButtonTextColor || oldAttributes.textButtonColor,
+	customTextColor: oldAttributes.customTextButtonColor,
+	backgroundColor: oldAttributes.submitButtonBackgroundColor || oldAttributes.backgroundButtonColor,
+	customBackgroundColor: oldAttributes.customBackgroundButtonColor,
+} );
+
+export default {
+	attributes: {
+		backgroundColor: {
+			type: 'string',
+			default: 'ffffff',
+			validator: colorValidator,
+		},
+		submitButtonText: {
+			type: 'string',
+			default: __( 'Schedule time with me', 'jetpack' ),
+		},
+		submitButtonTextColor: {
+			type: 'string',
+		},
+		submitButtonBackgroundColor: {
+			type: 'string',
+		},
+		submitButtonClasses: { type: 'string' },
+		hideEventTypeDetails: {
+			type: 'boolean',
+			default: false,
+		},
+		primaryColor: {
+			type: 'string',
+			default: '00A2FF',
+			validator: colorValidator,
+		},
+		textColor: {
+			type: 'string',
+			default: '4D5055',
+			validator: colorValidator,
+		},
+		style: {
+			type: 'string',
+			default: 'inline',
+			validValues: [ 'inline', 'link' ],
+		},
+		url: {
+			type: 'string',
+			validator: urlValidator,
+		},
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
+		customBackgroundButtonColor: {
+			type: 'string',
+			validator: colorValidator,
+		},
+		customTextButtonColor: {
+			type: 'string',
+			validator: colorValidator,
+		},
+	},
+	migrate: attributes => {
+		const newAttributes = omit( attributes, deprecatedAttributes );
+		const buttonAttributes = migrateAttributes( pick( attributes, deprecatedAttributes ) );
+		const newInnerBlocks = [
+			createBlock( 'jetpack/button', {
+				element: 'button',
+				...buttonAttributes,
+			} ),
+		];
+
+		return [ newAttributes, newInnerBlocks ];
+	},
+	isEligible: ( attributes, innerBlocks ) =>
+		isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ),
+	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
+};

--- a/extensions/blocks/calendly/deprecated/v1/index.js
+++ b/extensions/blocks/calendly/deprecated/v1/index.js
@@ -31,6 +31,7 @@ const migrateAttributes = oldAttributes => ( {
 	customTextColor: oldAttributes.customTextButtonColor,
 	backgroundColor: oldAttributes.submitButtonBackgroundColor || oldAttributes.backgroundButtonColor,
 	customBackgroundColor: oldAttributes.customBackgroundButtonColor,
+	url: oldAttributes.url,
 } );
 
 export default {
@@ -94,7 +95,8 @@ export default {
 		const buttonAttributes = migrateAttributes( attributes );
 		const newInnerBlocks = [
 			createBlock( 'jetpack/button', {
-				element: 'button',
+				element: 'a',
+				uniqueId: 'calendly-widget-id',
 				...buttonAttributes,
 			} ),
 		];

--- a/extensions/blocks/calendly/deprecated/v1/index.js
+++ b/extensions/blocks/calendly/deprecated/v1/index.js
@@ -102,6 +102,7 @@ export default {
 		return [ newAttributes, newInnerBlocks ];
 	},
 	isEligible: ( attributes, innerBlocks ) =>
-		isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ),
+		'link' === attributes.style &&
+		( isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ) ),
 	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
 };

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -8,7 +8,7 @@ import queryString from 'query-string';
 /**
  * WordPress dependencies
  */
-import { BlockIcon, InspectorControls } from '@wordpress/block-editor';
+import { BlockIcon, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
@@ -31,10 +31,9 @@ import './view.scss';
 import icon from './icon';
 import attributeDetails from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
-import SubmitButton from '../../shared/submit-button';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
-import { CALENDLY_EXAMPLE_URL } from './';
+import { CALENDLY_EXAMPLE_URL, innerButtonBlock } from './';
 import testEmbedUrl from '../../shared/test-embed-url';
 
 function CalendlyEdit( props ) {
@@ -65,6 +64,7 @@ function CalendlyEdit( props ) {
 	} = validatedAttributes;
 	const [ embedCode, setEmbedCode ] = useState( '' );
 	const [ isResolvingUrl, setIsResolvingUrl ] = useState( false );
+	const [ embedButtonAttributes, setEmbedButtonAttributes ] = useState( {} );
 
 	const setErrorNotice = () => {
 		noticeOperations.removeAllNotices();
@@ -95,6 +95,10 @@ function CalendlyEdit( props ) {
 		if ( ! newAttributes ) {
 			setErrorNotice();
 			return;
+		}
+
+		if ( newAttributes.buttonAttributes && 'link' === newAttributes.style ) {
+			setEmbedButtonAttributes( newAttributes.buttonAttributes );
 		}
 
 		testEmbedUrl( newAttributes.url, setIsResolvingUrl )
@@ -179,17 +183,14 @@ function CalendlyEdit( props ) {
 		</>
 	);
 
-	const submitButtonProps = {
-		attributes: pick( validatedAttributes, [
-			'submitButtonText',
-			'backgroundButtonColor',
-			'textButtonColor',
-			'customBackgroundButtonColor',
-			'customBackgroundButtonColor',
-		] ),
-		setAttributes,
-	};
-	const submitButtonPreview = <SubmitButton { ...submitButtonProps } />;
+	const buttonPreview = (
+		<InnerBlocks
+			template={ [
+				[ innerButtonBlock.name, { ...innerButtonBlock.attributes, ...embedButtonAttributes } ],
+			] }
+			templateLock="all"
+		/>
+	);
 
 	const linkPreview = (
 		<>
@@ -208,7 +209,7 @@ function CalendlyEdit( props ) {
 			return linkPreview;
 		}
 
-		return submitButtonPreview;
+		return buttonPreview;
 	};
 
 	const styleOptions = [
@@ -230,7 +231,10 @@ function CalendlyEdit( props ) {
 			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Calendar Settings', 'jetpack' ) } initialOpen={ false }>
-					<form onSubmit={ parseEmbedCode } className={ `${ defaultClassName }-embed-form-sidebar` }>
+					<form
+						onSubmit={ parseEmbedCode }
+						className={ `${ defaultClassName }-embed-form-sidebar` }
+					>
 						<input
 							type="text"
 							id="embedCode"

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -34,7 +34,7 @@ import attributeDetails from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
-import { CALENDLY_EXAMPLE_URL } from './';
+import { CALENDLY_EXAMPLE_URL, innerButtonBlock } from './';
 import testEmbedUrl from '../../shared/test-embed-url';
 
 function CalendlyEdit( props ) {
@@ -194,20 +194,13 @@ function CalendlyEdit( props ) {
 		</>
 	);
 
-	const innerButtonBlock = {
-		name: 'jetpack/button',
-		attributes: {
-			element: 'a',
-			text: __( 'Schedule time with me', 'jetpack' ),
-			uniqueId: 'calendly-widget-id',
-			url,
-		},
-	};
-
 	const buttonPreview = (
 		<InnerBlocks
 			template={ [
-				[ innerButtonBlock.name, { ...innerButtonBlock.attributes, ...embedButtonAttributes } ],
+				[
+					innerButtonBlock.name,
+					{ ...innerButtonBlock.attributes, url, ...embedButtonAttributes },
+				],
 			] }
 			templateLock="all"
 		/>

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -41,6 +41,7 @@ export const innerButtonBlock = {
 	attributes: {
 		element: 'button',
 		text: __( 'Schedule time with me', 'jetpack' ),
+		uniqueId: 'calendly-widget-id',
 	},
 };
 

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -22,6 +22,7 @@ import {
 import { useEffect, useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { getBlockDefaultClassName } from '@wordpress/blocks';
+import { select, dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -98,6 +99,16 @@ function CalendlyEdit( props ) {
 		}
 
 		if ( newAttributes.buttonAttributes && 'link' === newAttributes.style ) {
+			const innerButtons = select( 'core/editor' ).getBlocksByClientId( clientId );
+
+			if ( innerButtons.length ) {
+				innerButtons[ 0 ].innerBlocks.forEach( block => {
+					dispatch( 'core/editor' ).updateBlockAttributes(
+						block.clientId,
+						newAttributes.buttonAttributes
+					);
+				} );
+			}
 			setEmbedButtonAttributes( newAttributes.buttonAttributes );
 		}
 

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -36,15 +36,6 @@ import BlockStylesSelector from '../../shared/components/block-styles-selector';
 import { CALENDLY_EXAMPLE_URL } from './';
 import testEmbedUrl from '../../shared/test-embed-url';
 
-export const innerButtonBlock = {
-	name: 'jetpack/button',
-	attributes: {
-		element: 'button',
-		text: __( 'Schedule time with me', 'jetpack' ),
-		uniqueId: 'calendly-widget-id',
-	},
-};
-
 function CalendlyEdit( props ) {
 	const {
 		attributes,
@@ -191,6 +182,16 @@ function CalendlyEdit( props ) {
 			></iframe>
 		</>
 	);
+
+	const innerButtonBlock = {
+		name: 'jetpack/button',
+		attributes: {
+			element: 'a',
+			text: __( 'Schedule time with me', 'jetpack' ),
+			uniqueId: 'calendly-widget-id',
+			url,
+		},
+	};
 
 	const buttonPreview = (
 		<InnerBlocks

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -33,8 +33,16 @@ import attributeDetails from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { getAttributesFromEmbedCode } from './utils';
 import BlockStylesSelector from '../../shared/components/block-styles-selector';
-import { CALENDLY_EXAMPLE_URL, innerButtonBlock } from './';
+import { CALENDLY_EXAMPLE_URL } from './';
 import testEmbedUrl from '../../shared/test-embed-url';
+
+export const innerButtonBlock = {
+	name: 'jetpack/button',
+	attributes: {
+		element: 'button',
+		text: __( 'Schedule time with me', 'jetpack' ),
+	},
+};
 
 function CalendlyEdit( props ) {
 	const {

--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -199,7 +199,11 @@ function CalendlyEdit( props ) {
 			template={ [
 				[
 					innerButtonBlock.name,
-					{ ...innerButtonBlock.attributes, url, ...embedButtonAttributes },
+					{
+						...innerButtonBlock.attributes,
+						...embedButtonAttributes,
+						passthroughAttributes: { url: 'url' },
+					},
 				],
 			] }
 			templateLock="all"

--- a/extensions/blocks/calendly/editor.scss
+++ b/extensions/blocks/calendly/editor.scss
@@ -28,4 +28,8 @@
 	&-color-notice {
 		margin: 0;
 	}
+
+	div[data-align=center] > & {
+		text-align: center;
+	}
 }

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -21,15 +21,6 @@ import './editor.scss';
 import { supportsCollections } from '../../shared/block-category';
 
 export const CALENDLY_EXAMPLE_URL = 'https://calendly.com/wordpresscom/jetpack-block-example';
-
-export const innerButtonBlock = {
-	name: 'jetpack/button',
-	attributes: {
-		element: 'button',
-		text: __( 'Schedule time with me', 'jetpack' ),
-	},
-};
-
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
 export const settings = {
@@ -58,7 +49,6 @@ export const settings = {
 			style: 'inline',
 			url: CALENDLY_EXAMPLE_URL,
 		},
-		innerBlocks: [ innerButtonBlock ],
 	},
 	transforms: {
 		from: [

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -8,8 +8,10 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import attributes from './attributes';
+import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import icon from './icon';
+import save from './save';
 import { getAttributesFromEmbedCode, REGEX } from './utils';
 
 /**
@@ -19,6 +21,14 @@ import './editor.scss';
 import { supportsCollections } from '../../shared/block-category';
 
 export const CALENDLY_EXAMPLE_URL = 'https://calendly.com/wordpresscom/jetpack-block-example';
+
+export const innerButtonBlock = {
+	name: 'jetpack/button',
+	attributes: {
+		element: 'button',
+		text: __( 'Schedule time with me', 'jetpack' ),
+	},
+};
 
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
@@ -40,15 +50,15 @@ export const settings = {
 		html: false,
 	},
 	edit,
-	save: ( { attributes: { url } } ) => <a href={ url }>{ url }</a>,
+	save,
 	attributes,
 	example: {
 		attributes: {
-			submitButtonText: __( 'Schedule time with me', 'jetpack' ),
 			hideEventTypeDetails: false,
 			style: 'inline',
 			url: CALENDLY_EXAMPLE_URL,
 		},
+		innerBlocks: [ innerButtonBlock ],
 	},
 	transforms: {
 		from: [
@@ -62,4 +72,5 @@ export const settings = {
 			},
 		],
 	},
+	deprecated: [ deprecatedV1 ],
 };

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -21,6 +21,17 @@ import './editor.scss';
 import { supportsCollections } from '../../shared/block-category';
 
 export const CALENDLY_EXAMPLE_URL = 'https://calendly.com/wordpresscom/jetpack-block-example';
+
+export const innerButtonBlock = {
+	name: 'jetpack/button',
+	attributes: {
+		element: 'a',
+		text: __( 'Schedule time with me', 'jetpack' ),
+		uniqueId: 'calendly-widget-id',
+		url: CALENDLY_EXAMPLE_URL,
+	},
+};
+
 export const name = 'calendly';
 export const title = __( 'Calendly', 'jetpack' );
 export const settings = {
@@ -49,6 +60,7 @@ export const settings = {
 			style: 'inline',
 			url: CALENDLY_EXAMPLE_URL,
 		},
+		innerBlocks: [ innerButtonBlock ],
 	},
 	transforms: {
 		from: [

--- a/extensions/blocks/calendly/save.js
+++ b/extensions/blocks/calendly/save.js
@@ -1,0 +1,16 @@
+/* eslint-disable wpcalypso/import-docblock, jsdoc/require-jsdoc */
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function save( { attributes: { url } } ) {
+	return (
+		<div>
+			<InnerBlocks.Content />
+			<a className="wp-block-jetpack-calendly__fallback" href={ url }>
+				{ url }
+			</a>
+		</div>
+	);
+}

--- a/extensions/blocks/calendly/save.js
+++ b/extensions/blocks/calendly/save.js
@@ -8,9 +8,6 @@ export default function save( { attributes: { url } } ) {
 	return (
 		<div>
 			<InnerBlocks.Content />
-			<a className="wp-block-jetpack-calendly__fallback" href={ url }>
-				{ url }
-			</a>
 		</div>
 	);
 }

--- a/extensions/blocks/calendly/test/utils.js
+++ b/extensions/blocks/calendly/test/utils.js
@@ -90,8 +90,11 @@ describe( 'getAttributesFromEmbedCode', () => {
 			{
 				"style": "link",
 				"buttonAttributes": {
+					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
 					"text": "Schedule time with me",
+					"backgroundColor": undefined,
 					"customBackgroundColor": "#00a2ff",
+					"textColor": undefined,
 					"customTextColor": "#ffffff",
 				},
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
@@ -105,7 +108,10 @@ describe( 'getAttributesFromEmbedCode', () => {
 		).toEqual(
 			{
 				"style": "link",
-				"buttonAttributes": { "text": "Schedule time with me" },
+				"buttonAttributes": {
+					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
+					"text": "Schedule time with me"
+				},
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
@@ -135,8 +141,11 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"primaryColor": "1d73a4",
 				"style": "link",
 				"buttonAttributes": {
+					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
 					"text": "Schedule some time with me",
+					"backgroundColor": undefined,
 					"customBackgroundColor": "#000609",
+					"textColor": undefined,
 					"customTextColor": "#b50000",
 				},
 				"textColor": "2563ca",
@@ -153,7 +162,10 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"backgroundColor": "e32424",
 				"primaryColor": "0e425f",
 				"style": "link",
-				"buttonAttributes": { "text": "Schedule some time with me" },
+				"buttonAttributes": {
+					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
+					"text": "Schedule some time with me"
+				},
 				"textColor": "2a74ef",
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}

--- a/extensions/blocks/calendly/test/utils.js
+++ b/extensions/blocks/calendly/test/utils.js
@@ -51,7 +51,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 			}
 		);
 	} );
-	
+
 	test( 'URL without http', () => {
 		expect(
 			getAttributesFromEmbedCode( 'calendly.com/wordpresscom/jetpack-block-example' )
@@ -89,9 +89,11 @@ describe( 'getAttributesFromEmbedCode', () => {
 		).toEqual(
 			{
 				"style": "link",
-				"submitButtonText": "Schedule time with me",
-				"customBackgroundButtonColor": "#00a2ff",
-				"customTextButtonColor": "#ffffff",
+				"buttonAttributes": {
+					"text": "Schedule time with me",
+					"customBackgroundColor": "#00a2ff",
+					"customTextColor": "#ffffff",
+				},
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
@@ -103,7 +105,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 		).toEqual(
 			{
 				"style": "link",
-				"submitButtonText": "Schedule time with me",
+				"buttonAttributes": { "text": "Schedule time with me" },
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
@@ -130,11 +132,13 @@ describe( 'getAttributesFromEmbedCode', () => {
 		).toEqual(
 			{
 				"backgroundColor": "c51414",
-				"customBackgroundButtonColor": "#000609",
-				"customTextButtonColor": "#b50000",
 				"primaryColor": "1d73a4",
 				"style": "link",
-				"submitButtonText": "Schedule some time with me",
+				"buttonAttributes": {
+					"text": "Schedule some time with me",
+					"customBackgroundColor": "#000609",
+					"customTextColor": "#b50000",
+				},
 				"textColor": "2563ca",
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
@@ -149,7 +153,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"backgroundColor": "e32424",
 				"primaryColor": "0e425f",
 				"style": "link",
-				"submitButtonText": "Schedule some time with me",
+				"buttonAttributes": { "text": "Schedule some time with me" },
 				"textColor": "2a74ef",
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}

--- a/extensions/blocks/calendly/test/utils.js
+++ b/extensions/blocks/calendly/test/utils.js
@@ -90,7 +90,6 @@ describe( 'getAttributesFromEmbedCode', () => {
 			{
 				"style": "link",
 				"buttonAttributes": {
-					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
 					"text": "Schedule time with me",
 					"backgroundColor": undefined,
 					"customBackgroundColor": "#00a2ff",
@@ -108,10 +107,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 		).toEqual(
 			{
 				"style": "link",
-				"buttonAttributes": {
-					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
-					"text": "Schedule time with me"
-				},
+				"buttonAttributes": { "text": "Schedule time with me" },
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}
 		);
@@ -141,7 +137,6 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"primaryColor": "1d73a4",
 				"style": "link",
 				"buttonAttributes": {
-					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
 					"text": "Schedule some time with me",
 					"backgroundColor": undefined,
 					"customBackgroundColor": "#000609",
@@ -162,10 +157,7 @@ describe( 'getAttributesFromEmbedCode', () => {
 				"backgroundColor": "e32424",
 				"primaryColor": "0e425f",
 				"style": "link",
-				"buttonAttributes": {
-					"url": "https://calendly.com/wordpresscom/jetpack-block-example",
-					"text": "Schedule some time with me"
-				},
+				"buttonAttributes": { "text": "Schedule some time with me" },
 				"textColor": "2a74ef",
 				"url": "https://calendly.com/wordpresscom/jetpack-block-example"
 			}

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -98,7 +98,8 @@ export const getAttributesFromEmbedCode = embedCode => {
 	}
 
 	if ( 'link' === newStyle ) {
-		newAttributes.buttonAttributes = {};
+		const urlObject = new URL( newUrl );
+		newAttributes.buttonAttributes = { url: urlObject.origin + urlObject.pathname };
 
 		const text = getTextFromEmbedCode( embedCode );
 		if ( text ) {
@@ -107,11 +108,13 @@ export const getAttributesFromEmbedCode = embedCode => {
 
 		const textColor = getTextColorFromEmbedCode( embedCode );
 		if ( textColor ) {
+			newAttributes.buttonAttributes.textColor = undefined;
 			newAttributes.buttonAttributes.customTextColor = textColor;
 		}
 
 		const backgroundColor = getBackgroundColorFromEmbedCode( embedCode );
 		if ( backgroundColor ) {
+			newAttributes.buttonAttributes.backgroundColor = undefined;
 			newAttributes.buttonAttributes.customBackgroundColor = backgroundColor;
 		}
 	}

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -10,29 +10,29 @@ export const getURLFromEmbedCode = embedCode => {
 	}
 };
 
-export const getSubmitButtonTextFromEmbedCode = embedCode => {
-	let submitButtonText = embedCode.match( /false;"\>([^<]+)\<\// );
-	if ( submitButtonText ) {
-		return submitButtonText[ 1 ];
+export const getTextFromEmbedCode = embedCode => {
+	let text = embedCode.match( /false;"\>([^<]+)\<\// );
+	if ( text ) {
+		return text[ 1 ];
 	}
 
-	submitButtonText = embedCode.match( /text: '([^']*?)'/ );
-	if ( submitButtonText ) {
-		return submitButtonText[ 1 ];
-	}
-};
-
-const getSubmitButtonTextColorFromEmbedCode = embedCode => {
-	const submitButtonTextColor = embedCode.match( /textColor: '([^']*?)'/ );
-	if ( submitButtonTextColor ) {
-		return submitButtonTextColor[ 1 ];
+	text = embedCode.match( /text: '([^']*?)'/ );
+	if ( text ) {
+		return text[ 1 ];
 	}
 };
 
-const getSubmitButtonBackgroundColorFromEmbedCode = embedCode => {
-	const submitButtonBackgroundColor = embedCode.match( /color: '([^']*?)'/ );
-	if ( submitButtonBackgroundColor ) {
-		return submitButtonBackgroundColor[ 1 ];
+const getTextColorFromEmbedCode = embedCode => {
+	const textColor = embedCode.match( /textColor: '([^']*?)'/ );
+	if ( textColor ) {
+		return textColor[ 1 ];
+	}
+};
+
+const getBackgroundColorFromEmbedCode = embedCode => {
+	const backgroundColor = embedCode.match( /color: '([^']*?)'/ );
+	if ( backgroundColor ) {
+		return backgroundColor[ 1 ];
 	}
 };
 
@@ -97,19 +97,23 @@ export const getAttributesFromEmbedCode = embedCode => {
 		newAttributes.style = newStyle;
 	}
 
-	const submitButtonText = getSubmitButtonTextFromEmbedCode( embedCode );
-	if ( submitButtonText ) {
-		newAttributes.submitButtonText = submitButtonText;
-	}
+	if ( 'link' === newStyle ) {
+		newAttributes.buttonAttributes = {};
 
-	const submitButtonTextColor = getSubmitButtonTextColorFromEmbedCode( embedCode );
-	if ( submitButtonTextColor ) {
-		newAttributes.customTextButtonColor = submitButtonTextColor;
-	}
+		const text = getTextFromEmbedCode( embedCode );
+		if ( text ) {
+			newAttributes.buttonAttributes.text = text;
+		}
 
-	const submitButtonBackgroundColor = getSubmitButtonBackgroundColorFromEmbedCode( embedCode );
-	if ( submitButtonBackgroundColor ) {
-		newAttributes.customBackgroundButtonColor = submitButtonBackgroundColor;
+		const textColor = getTextColorFromEmbedCode( embedCode );
+		if ( textColor ) {
+			newAttributes.buttonAttributes.customTextColor = textColor;
+		}
+
+		const backgroundColor = getBackgroundColorFromEmbedCode( embedCode );
+		if ( backgroundColor ) {
+			newAttributes.buttonAttributes.customBackgroundColor = backgroundColor;
+		}
 	}
 
 	return newAttributes;

--- a/extensions/blocks/calendly/utils.js
+++ b/extensions/blocks/calendly/utils.js
@@ -98,8 +98,7 @@ export const getAttributesFromEmbedCode = embedCode => {
 	}
 
 	if ( 'link' === newStyle ) {
-		const urlObject = new URL( newUrl );
-		newAttributes.buttonAttributes = { url: urlObject.origin + urlObject.pathname };
+		newAttributes.buttonAttributes = {};
 
 		const text = getTextFromEmbedCode( embedCode );
 		if ( text ) {

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -6,3 +6,7 @@
 	height: 630px;
 	position: relative;
 }
+
+.wp-block-jetpack-calendly .calendly-spinner {
+	top: 50px;
+}

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -4,4 +4,9 @@
 
 .wp-block-jetpack-calendly.calendly-style-inline {
 	height: 630px;
+	position: relative;
+}
+
+.wp-block-jetpack-calendly__fallback {
+	display: none;
 }

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -6,7 +6,3 @@
 	height: 630px;
 	position: relative;
 }
-
-.wp-block-jetpack-calendly__fallback {
-	display: none;
-}

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -14,3 +14,7 @@
 .wp-block-jetpack-calendly.aligncenter {
 	text-align: center;
 }
+
+.wp-block-jetpack-calendly .wp-block-jetpack-button {
+	color: #ffffff;
+}

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -11,6 +11,6 @@
 	top: 50px;
 }
 
-.wp-block-jetpack-calendly.aligncenter .wp-block-jetpack-button {
+.wp-block-jetpack-calendly.aligncenter {
 	text-align: center;
 }

--- a/extensions/blocks/calendly/view.scss
+++ b/extensions/blocks/calendly/view.scss
@@ -10,3 +10,7 @@
 .wp-block-jetpack-calendly .calendly-spinner {
 	top: 50px;
 }
+
+.wp-block-jetpack-calendly.aligncenter .wp-block-jetpack-button {
+	text-align: center;
+}


### PR DESCRIPTION
Fixes #15711, Fixes #14564 

#### Changes proposed in this Pull Request:
* Replace the SubmitButton in the Calendly block with new shared Button block.
* Fixes minor bug where Calendly spinner for inline style widget isn't hidden when there are multiple Calendly blocks on the page.
* Switch to shared Button block also fixes issue where custom text color wasn't shown in editor.

#### Prerequisites:
- Calendly account to create blocks and embed codes
- Post with Calendly blocks created prior to applying this PR's changes.
  1.   Create a post.
  2.   Add two Calendly blocks using the `link` style.
  3.   Configure one of those blocks setting its various options e.g. background color.
  4.   Add one inline Calendly block. 
  5.   Save post.
- Have the AMP plugin installed and active

#### Testing instructions:

1. On the frontend, visit post containing previous versions of Calendly block.
2. Confirm the blocks display and function as they did when you set them up. 
    _Should still be using simple `<a>` markup._
3. Edit the post.
4. Confirm the Calendly blocks still appear correctly and their settings are correct.
5. Update the link style blocks using the new settings controls provided by button block.
6. Add new Calendly block using simple URL e.g. `https://calendly.com/<username>`
7. Add new Calendly block using customized embed code for a link style widget.
8. Check that the customized attributes from the embed code have been set on the button.
9. Save the post.
10. Re-visit the post on the frontend and confirm display and function of blocks.
11. Switch back to the editor and update the embed url under the Inspector Controls > Calender Settings with a link style URL containing custom colors.
12. Confirm button colors update, save and switch to the frontend view to check there as well.
13. Click the AMP link at the top of the page and confirm links work on the AMP request view.
  ( inline style block will show as a simple link )
14. Run tests in `extensions/blocks/calendly/test/utils.js`

<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
#### Before:
<img width="1084" alt="Calendly-Before-SubmitButtonReplacement" src="https://user-images.githubusercontent.com/60436221/82451079-dbe0e900-9af0-11ea-90c7-fe15ff918514.png">

#### After:
<img width="1066" alt="Calendly-After-SubmitButtonReplacement" src="https://user-images.githubusercontent.com/60436221/82451104-e26f6080-9af0-11ea-9ee5-5ba85525ca92.png">


#### Proposed changelog entry for your changes:
* Update Calendly block to use new shared Button block.