### PR TITLE
Jetpack Scan: Update Scan to Daily Scan.

### DIFF
--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -132,7 +132,7 @@ class MyPlanHeader extends React.Component {
 					tagLine: __(
 						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
 					),
-					title: __( 'Jetpack Scan {{em}}Daily{{em/}}', { components: { em: <em /> } } ),
+					title: __( 'Jetpack Scan {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
 				};
 
 			default:

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -122,11 +122,7 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: imagePath + '/products/product-jetpack-search.svg',
 					tagLine: __( 'Fast, highly relevant search results and powerful filtering.' ),
-					title: __( 'Jetpack Search', {
-						components: {
-							em: <em />,
-						},
-					} ),
+					title: __( 'Jetpack Search' ),
 				};
 
 			case 'is-scan-plan':
@@ -136,7 +132,7 @@ class MyPlanHeader extends React.Component {
 					tagLine: __(
 						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
 					),
-					title: __( 'Jetpack Scan' ),
+					title: __( 'Jetpack Scan {{em}}Daily{{em/}}', { components: { em: <em /> } } ),
 				};
 
 			default:

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7499,7 +7499,7 @@ endif;
 						'type'      => 'scan',
 						'slug'      => 'jetpack-scan',
 						'key'       => 'jetpack_scan',
-						'name'      => __( 'Scan', 'jetpack' ),
+						'name'      => __( 'Daily Scan', 'jetpack' ),
 					),
 				),
 				'default_option'    => 'scan',


### PR DESCRIPTION
Simple change from Jetpack Scan to Jetpack Scan Daily. 

We will be using jetpack scan realtime in the future. So it good to be more specific now. 
Related: PR 

After:
<img width="541" alt="Screen Shot 2020-05-20 at 4 32 27 PM" src="https://user-images.githubusercontent.com/115071/82459136-d87d3b80-9ab7-11ea-90ff-b5e2332aea95.png">
<img width="1114" alt="Screen Shot 2020-05-20 at 4 33 57 PM" src="https://user-images.githubusercontent.com/115071/82459146-dc10c280-9ab7-11ea-90c6-40620caf4b1c.png">


#### Testing instructions:
* Go to the plans page. Do you see the expected "Daily Scan" as the selection?
* Once you buy Jetpack Scan Daily. Do you notice the new Jetpack Scan `Daily` as the product that you purchased. 



#### Proposed changelog entry for your changes:
nothing roll them up to the jepack scan product.
