### PR TITLE
External Media: Focus modal elements for a11y improvement

### DIFF
--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -27,6 +27,7 @@ const EmptyResults = memo( () => (
 function MediaBrowser( props ) {
 	const { media, isLoading, pageHandle, className, multiple, setPath, nextPage, onCopy } = props;
 	const [ selected, setSelected ] = useState( [] );
+	const [ focusedItemIndex, setFocusedItemIndex ] = useState( -1 );
 
 	const onSelectImage = useCallback(
 		newlySelected => {
@@ -63,14 +64,22 @@ function MediaBrowser( props ) {
 		[ className ]: true,
 	} );
 
+	const onLoadMoreClick = () => {
+		if ( media.length ) {
+			setFocusedItemIndex( media.length );
+		}
+		nextPage();
+	};
+
 	return (
 		<div className={ wrapper }>
 			<ul className={ classes }>
-				{ media.map( item => (
+				{ media.map( ( item, index ) => (
 					<MediaItem
 						item={ item }
 						key={ item.ID }
 						onClick={ onSelectImage }
+						isFocused={ index === focusedItemIndex }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
 					/>
 				) ) }
@@ -84,7 +93,7 @@ function MediaBrowser( props ) {
 						isSecondary
 						className="jetpack-external-media-browser__loadmore"
 						disabled={ isLoading }
-						onClick={ nextPage }
+						onClick={ onLoadMoreClick }
 					>
 						{ __( 'Load More', 'jetpack' ) }
 					</Button>

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -79,7 +79,7 @@ function MediaBrowser( props ) {
 						item={ item }
 						key={ item.ID }
 						onClick={ onSelectImage }
-						isFocused={ index === focusedItemIndex }
+						focusOnMount={ index === focusedItemIndex }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
 					/>
 				) ) }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -63,12 +63,10 @@ function MediaBrowser( props ) {
 		[ className ]: true,
 	} );
 
-	const focusedItemIndex = useRef( -1 );
+	const prevMediaCount = useRef();
 
 	const onLoadMoreClick = () => {
-		if ( media.length ) {
-			focusedItemIndex.current = media.length;
-		}
+		prevMediaCount.current = media.length;
 		nextPage();
 	};
 
@@ -80,7 +78,7 @@ function MediaBrowser( props ) {
 						item={ item }
 						key={ item.ID }
 						onClick={ onSelectImage }
-						focusOnMount={ index === focusedItemIndex.current }
+						focusOnMount={ index === prevMediaCount.current }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
 					/>
 				) ) }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -63,7 +63,7 @@ function MediaBrowser( props ) {
 		[ className ]: true,
 	} );
 
-	const prevMediaCount = useRef();
+	const prevMediaCount = useRef( 0 );
 
 	const onLoadMoreClick = () => {
 		prevMediaCount.current = media.length;
@@ -78,7 +78,7 @@ function MediaBrowser( props ) {
 						item={ item }
 						key={ item.ID }
 						onClick={ onSelectImage }
-						focusOnMount={ index === prevMediaCount.current }
+						focusOnMount={ !! prevMediaCount.current && index === prevMediaCount.current }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
 					/>
 				) ) }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { memo, useCallback, useState } from '@wordpress/element';
+import { memo, useCallback, useState, useRef } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -27,7 +27,6 @@ const EmptyResults = memo( () => (
 function MediaBrowser( props ) {
 	const { media, isLoading, pageHandle, className, multiple, setPath, nextPage, onCopy } = props;
 	const [ selected, setSelected ] = useState( [] );
-	const [ focusedItemIndex, setFocusedItemIndex ] = useState( -1 );
 
 	const onSelectImage = useCallback(
 		newlySelected => {
@@ -64,9 +63,11 @@ function MediaBrowser( props ) {
 		[ className ]: true,
 	} );
 
+	const focusedItemIndex = useRef( -1 );
+
 	const onLoadMoreClick = () => {
 		if ( media.length ) {
-			setFocusedItemIndex( media.length );
+			focusedItemIndex.current = media.length;
 		}
 		nextPage();
 	};
@@ -79,7 +80,7 @@ function MediaBrowser( props ) {
 						item={ item }
 						key={ item.ID }
 						onClick={ onSelectImage }
-						focusOnMount={ index === focusedItemIndex }
+						focusOnMount={ index === focusedItemIndex.current }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
 					/>
 				) ) }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
@@ -26,7 +26,7 @@ function MediaItem( props ) {
 		}
 	};
 
-	const { item, isSelected, isCopying = false } = props;
+	const { item, isFocused, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;
 	const { medium = null, fmt_hd = null } = thumbnails;
 	const alt = title || caption || name;
@@ -37,9 +37,15 @@ function MediaItem( props ) {
 		'is-transient': isSelected && isCopying,
 	} );
 
+	const itemEl = useRef( null );
+	useEffect( () => {
+		isFocused && itemEl.current.focus();
+	}, [ isFocused ] );
+
 	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (
 		<li
+			ref={ itemEl }
 			className={ classes }
 			onClick={ onClick }
 			onKeyDown={ onKeyDown }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -26,7 +26,7 @@ function MediaItem( props ) {
 		}
 	};
 
-	const { item, isFocused, isSelected, isCopying = false } = props;
+	const { item, focusOnMount, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;
 	const { medium = null, fmt_hd = null } = thumbnails;
 	const alt = title || caption || name;
@@ -38,9 +38,14 @@ function MediaItem( props ) {
 	} );
 
 	const itemEl = useRef( null );
+
 	useEffect( () => {
-		isFocused && itemEl.current.focus();
-	}, [ isFocused ] );
+		if ( focusOnMount ) {
+			itemEl.current.focus();
+		}
+		// Passing empty dependency array to focus on mount only.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -47,7 +47,8 @@ function GooglePhotosMedia( props ) {
 
 	const listUrl = getApiUrl( 'list', SOURCE_GOOGLE_PHOTOS, params );
 
-	const getNextPage = useCallback( ( event, reset = false ) => {
+	const getNextPage = useCallback(
+		( event, reset = false ) => {
 			getMedia( listUrl, reset );
 		},
 		[ getMedia, listUrl ]
@@ -77,17 +78,26 @@ function GooglePhotosMedia( props ) {
 		}
 	}, [ lastQuery, listUrl, getNextPage, path ] );
 
+	const viewSelectFormEl = useRef( null );
+	useEffect( () => {
+		const viewSelectEl = viewSelectFormEl.current.elements[ 0 ];
+
+		viewSelectEl.focus();
+	} );
+
 	return (
 		<div className="jetpack-external-media-wrapper__google">
 			<div className="jetpack-external-media-header__view">
-				<SelectControl
-					className="jetpack-external-media-header__select"
-					label={ __( 'View', 'jetpack' ) }
-					value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
-					disabled={ isLoading }
-					options={ PATH_OPTIONS }
-					onChange={ setPath }
-				/>
+				<form ref={ viewSelectFormEl }>
+					<SelectControl
+						className="jetpack-external-media-header__select"
+						label={ __( 'View', 'jetpack' ) }
+						value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
+						disabled={ isLoading }
+						options={ PATH_OPTIONS }
+						onChange={ setPath }
+					/>
+				</form>
 
 				{ path.ID === PATH_RECENT && (
 					<GoogleFilterView

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -78,17 +78,9 @@ function GooglePhotosMedia( props ) {
 		}
 	}, [ lastQuery, listUrl, getNextPage, path ] );
 
-	const filtersFormEl = useRef( null );
-
-	useEffect( () => {
-		const firstInputEl = filtersFormEl.current.elements[ 0 ];
-
-		firstInputEl.focus();
-	} );
-
 	return (
 		<div className="jetpack-external-media-wrapper__google">
-			<form ref={ filtersFormEl } className="jetpack-external-media-header__view">
+			<div className="jetpack-external-media-header__view">
 				<SelectControl
 					className="jetpack-external-media-header__select"
 					label={ __( 'View', 'jetpack' ) }
@@ -106,7 +98,7 @@ function GooglePhotosMedia( props ) {
 						canChangeMedia={ ! imageOnly }
 					/>
 				) }
-			</form>
+			</div>
 
 			<div className="jetpack-external-media-header__filter">
 				{ path.ID === PATH_RECENT && (

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -78,26 +78,25 @@ function GooglePhotosMedia( props ) {
 		}
 	}, [ lastQuery, listUrl, getNextPage, path ] );
 
-	const viewSelectFormEl = useRef( null );
-	useEffect( () => {
-		const viewSelectEl = viewSelectFormEl.current.elements[ 0 ];
+	const filtersFormEl = useRef( null );
 
-		viewSelectEl.focus();
+	useEffect( () => {
+		const firstInputEl = filtersFormEl.current.elements[ 0 ];
+
+		firstInputEl.focus();
 	} );
 
 	return (
 		<div className="jetpack-external-media-wrapper__google">
-			<div className="jetpack-external-media-header__view">
-				<form ref={ viewSelectFormEl }>
-					<SelectControl
-						className="jetpack-external-media-header__select"
-						label={ __( 'View', 'jetpack' ) }
-						value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
-						disabled={ isLoading }
-						options={ PATH_OPTIONS }
-						onChange={ setPath }
-					/>
-				</form>
+			<form ref={ filtersFormEl } className="jetpack-external-media-header__view">
+				<SelectControl
+					className="jetpack-external-media-header__select"
+					label={ __( 'View', 'jetpack' ) }
+					value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
+					disabled={ isLoading }
+					options={ PATH_OPTIONS }
+					onChange={ setPath }
+				/>
 
 				{ path.ID === PATH_RECENT && (
 					<GoogleFilterView
@@ -107,7 +106,7 @@ function GooglePhotosMedia( props ) {
 						canChangeMedia={ ! imageOnly }
 					/>
 				) }
-			</div>
+			</form>
 
 			<div className="jetpack-external-media-header__filter">
 				{ path.ID === PATH_RECENT && (

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -57,9 +57,21 @@ function PexelsMedia( props ) {
 	// Load initial results for the random example query.
 	useEffect( getNextPage, [] );
 
+	const searchFormEl = useRef( null );
+	useEffect( () => {
+		const searchInputEl = searchFormEl.current.elements[ 0 ];
+
+		searchInputEl.focus();
+		searchInputEl.select();
+	}, [] );
+
 	return (
 		<div className="jetpack-external-media-wrapper__pexels">
-			<form className="jetpack-external-media-header__pexels" onSubmit={ onSearch }>
+			<form
+				ref={ searchFormEl }
+				className="jetpack-external-media-header__pexels"
+				onSubmit={ onSearch }
+			>
 				<TextControl
 					aria-label={ __( 'Search', 'jetpack' ) }
 					type="search"

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -58,12 +58,23 @@ function PexelsMedia( props ) {
 	useEffect( getNextPage, [] );
 
 	const searchFormEl = useRef( null );
-	useEffect( () => {
-		const searchInputEl = searchFormEl.current.elements[ 0 ];
 
-		searchInputEl.focus();
-		searchInputEl.select();
-	}, [] );
+	const focusSearchInput = () => {
+		if ( ! searchFormEl.current ) {
+			return;
+		}
+
+		const formElements = Array.from( searchFormEl.current.elements );
+		// TextControl does not support ref forwarding, so we need to find the input:
+		const searchInputEl = formElements.find( element => element.type === 'search' );
+
+		if ( searchInputEl ) {
+			searchInputEl.focus();
+			searchInputEl.select();
+		}
+	};
+
+	useEffect( focusSearchInput, [] );
 
 	return (
 		<div className="jetpack-external-media-wrapper__pexels">


### PR DESCRIPTION
Fixes #15830

#### Changes proposed in this Pull Request:
- Make the first input element focus on modal open:
   - For Pexels, search input is focused and the text is selected,
   - For Google Photos, the `View` select is focused.
- Move focus to the first appended image on the "Load More" button click.

#### Testing instructions:
1. Add `Image` block,
2. Click `Select Image` button and select Pexels,
3. When the modal opens, the search input should be focused and its text selected.
4. Click on "Load More" button,
5. The first newly appended image should be focused on.

#### Proposed changelog entry for your changes:
- External Media: Focus modal elements for a11y improvement
