### PR TITLE
Jetpack Setup Wizard: Update Subheader Tag on Income Question Page

### DIFF
--- a/_inc/client/setup-wizard/income-question/index.jsx
+++ b/_inc/client/setup-wizard/income-question/index.jsx
@@ -28,7 +28,7 @@ const IncomeQuestion = props => {
 					args: { siteUrl: props.siteTitle },
 				} ) }
 			</h1>
-			<p className="jp-setup-wizard-subtitle">{ __( 'Check all that apply' ) }</p>
+			<h2 className="jp-setup-wizard-subtitle">{ __( 'Check all that apply' ) }</h2>
 			<div className="jp-setup-wizard-income-answer-container">
 				<ChecklistAnswer
 					title={ __( 'Advertising or affiliate marketing' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This updates the subheader on the Setup Wizard income page to use a `h2` tag instead of a `p` tag based on [this feedback](https://github.com/Automattic/jetpack/pull/15637#issuecomment-630486812) from @jeffgolenski.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to the end of wp-config.php: add_filter( 'jetpack_show_setup_wizard', '__return_true' );
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/income`.
3. Inspect the HTML and verify that the "Check all that apply" subheader is in a `h2` tag instead of a `p` tag.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed, should be one entry for the whole wizard.
