### PR TITLE
Breadcrumbs: Support position itemprop

### DIFF
--- a/bin/phpcs-whitelist.js
+++ b/bin/phpcs-whitelist.js
@@ -48,6 +48,7 @@ module.exports = [
 	'modules/shortcodes/',
 	'modules/sitemaps/sitemaps.php',
 	'modules/theme-tools/compat/twentytwenty.php',
+	'modules/theme-tools/site-breadcrumbs.php',
 	'modules/theme-tools/social-menu/',
 	'modules/theme-tools/devicepx.php',
 	'modules/verification-tools.php',

--- a/modules/theme-tools/site-breadcrumbs.php
+++ b/modules/theme-tools/site-breadcrumbs.php
@@ -35,11 +35,11 @@ function jetpack_breadcrumbs() {
 		$ancestors = array_reverse( get_post_ancestors( $post_id ) );
 		if ( $ancestors ) {
 			foreach ( $ancestors as $ancestor ) {
-				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_html( $position ) . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( $position ) . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
 				$position++;
 			}
 		}
-		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_html( $position ) . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
+		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( $position ) . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
 	} elseif ( $is_taxonomy_hierarchical ) {
 		$current = get_term( get_queried_object_id(), $taxonomy );
 
@@ -51,10 +51,10 @@ function jetpack_breadcrumbs() {
 			$breadcrumb = jetpack_get_term_parents( $current->parent, $taxonomy );
 		}
 
-		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . esc_html( $position ) . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
+		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . esc_attr( $position ) . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
 	}
 
-	$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><meta itemprop="position" content="0"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
+	$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_attr( $position ) . '"><meta itemprop="position" content="0"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
 
 	echo '<nav class="entry-breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">' . $home . $breadcrumb . '</nav>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }

--- a/modules/theme-tools/site-breadcrumbs.php
+++ b/modules/theme-tools/site-breadcrumbs.php
@@ -7,8 +7,15 @@
  * Version: 1.0
  * Author URI: https://wordpress.com
  * License: GPL2 or later
+ *
+ * @package Jetpack.
  */
 
+/**
+ * Echos a set of breadcrumbs.
+ *
+ * Themes can call this function where the breadcrumbs should be outputted.
+ */
 function jetpack_breadcrumbs() {
 	$taxonomy                 = is_category() ? 'category' : get_query_var( 'taxonomy' );
 	$is_taxonomy_hierarchical = is_taxonomy_hierarchical( $taxonomy );
@@ -28,11 +35,11 @@ function jetpack_breadcrumbs() {
 		$ancestors = array_reverse( get_post_ancestors( $post_id ) );
 		if ( $ancestors ) {
 			foreach ( $ancestors as $ancestor ) {
-				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_html( $position ) . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
 				$position++;
 			}
 		}
-		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
+		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . esc_html( $position ) . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
 	} elseif ( $is_taxonomy_hierarchical ) {
 		$current = get_term( get_queried_object_id(), $taxonomy );
 
@@ -44,12 +51,12 @@ function jetpack_breadcrumbs() {
 			$breadcrumb = jetpack_get_term_parents( $current->parent, $taxonomy );
 		}
 
-		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . $position . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
+		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . esc_html( $position ) . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
 	}
 
 	$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><meta itemprop="position" content="0"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
 
-	echo '<nav class="entry-breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">' . $home . $breadcrumb . '</nav>';
+	echo '<nav class="entry-breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">' . $home . $breadcrumb . '</nav>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 /**
@@ -70,7 +77,7 @@ function jetpack_get_term_parents( $term, $taxonomy, $visited = array() ) {
 
 	$chain = '';
 
-	if ( $parent->parent && ( $parent->parent != $parent->term_id ) && ! in_array( $parent->parent, $visited ) ) {
+	if ( $parent->parent && ( $parent->parent !== $parent->term_id ) && ! in_array( $parent->parent, $visited, true ) ) {
 		$visited[] = $parent->parent;
 		$chain    .= jetpack_get_term_parents( $parent->parent, $taxonomy, $visited );
 	}

--- a/modules/theme-tools/site-breadcrumbs.php
+++ b/modules/theme-tools/site-breadcrumbs.php
@@ -21,16 +21,18 @@ function jetpack_breadcrumbs() {
 	}
 
 	$breadcrumb = '';
+	$position   = 1;
 
 	if ( $is_post_type_hierarchical ) {
 		$post_id   = get_queried_object_id();
 		$ancestors = array_reverse( get_post_ancestors( $post_id ) );
 		if ( $ancestors ) {
 			foreach ( $ancestors as $ancestor ) {
-				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+				$breadcrumb .= '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><a href="' . esc_url( get_permalink( $ancestor ) ) . '" itemprop="item"><span itemprop="name">' . esc_html( get_the_title( $ancestor ) ) . '</span></a></span>';
+				$position++;
 			}
 		}
-		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
+		$breadcrumb .= '<span class="current-page" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><span itemprop="name">' . esc_html( get_the_title( $post_id ) ) . '</span></span>';
 	} elseif ( $is_taxonomy_hierarchical ) {
 		$current = get_term( get_queried_object_id(), $taxonomy );
 
@@ -42,10 +44,10 @@ function jetpack_breadcrumbs() {
 			$breadcrumb = jetpack_get_term_parents( $current->parent, $taxonomy );
 		}
 
-		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
+		$breadcrumb .= '<span class="current-category" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta property="position" content="' . $position . '"><span itemprop="name">' . esc_html( $current->name ) . '</span></span>';
 	}
 
-	$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
+	$home = '<span itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem"><meta itemprop="position" content="' . $position . '"><meta itemprop="position" content="0"><a href="' . esc_url( home_url( '/' ) ) . '" class="home-link" itemprop="item" rel="home"><span itemprop="name">' . esc_html__( 'Home', 'jetpack' ) . '</span></a></span>';
 
 	echo '<nav class="entry-breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">' . $home . $breadcrumb . '</nav>';
 }


### PR DESCRIPTION
Fixes #10062 

#### Changes proposed in this Pull Request:
* Adds the position itemprop to resolve schema error.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Testing instructions:
* Jetpack + Edin theme (https://wordpress.com/theme/edin) (or another that supports JP breadcrumbs.
* Via Customizer, Theme Options and activate Breadcrumbs option.
* With various pages (a page by itself, a page that itself is a child to another page), run the URLs through the Google testing tool ( https://search.google.com/structured-data/testing-tool/ )
* Ensure the Breadcrumbs are compliant.

Before:
![2020-05-20 at 5 14 PM](https://user-images.githubusercontent.com/88897/82502726-6a3b7780-9abd-11ea-9fb5-1fe39b3dc8dd.png)

After:
![2020-05-20 at 5 15 PM](https://user-images.githubusercontent.com/88897/82502771-83442880-9abd-11ea-8100-0d907a6116ba.png)



#### Proposed changelog entry for your changes:
* Theme Tools: Add correct schema.org value for Jetpack Breadcrumbs.
