### PR TITLE
Image Compare: Add help panel

### DIFF
--- a/extensions/blocks/image-compare/edit.js
+++ b/extensions/blocks/image-compare/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { InnerBlocks, InspectorControls, RichText } from '@wordpress/block-editor';
-import { PanelBody, Placeholder, RadioControl, Tip } from '@wordpress/components';
+import { PanelBody, Placeholder, RadioControl } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { useLayoutEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -63,16 +63,6 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 		<figure className={ className } id={ clientId }>
 			{ resizeListener }
 			<InspectorControls key="controls">
-				<PanelBody title={ __( 'Help', 'jetpack' ) }>
-					<Tip>
-						<p>
-							{ __(
-								'Block works best using two images with the same width and height.',
-								'jetpack'
-							) }
-						</p>
-					</Tip>
-				</PanelBody>
 				<PanelBody title={ __( 'Orientation', 'jetpack' ) }>
 					<RadioControl
 						selected={ orientation || 'horizontal' }

--- a/extensions/blocks/image-compare/edit.js
+++ b/extensions/blocks/image-compare/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { InnerBlocks, InspectorControls, RichText } from '@wordpress/block-editor';
-import { PanelBody, Placeholder, RadioControl } from '@wordpress/components';
+import { PanelBody, Placeholder, RadioControl, Tip } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { useLayoutEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -63,6 +63,16 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 		<figure className={ className } id={ clientId }>
 			{ resizeListener }
 			<InspectorControls key="controls">
+				<PanelBody title={ __( 'Help', 'jetpack' ) }>
+					<Tip>
+						<p>
+							{ __(
+								'Block works best using two images with the same width and height.',
+								'jetpack'
+							) }
+						</p>
+					</Tip>
+				</PanelBody>
 				<PanelBody title={ __( 'Orientation', 'jetpack' ) }>
 					<RadioControl
 						selected={ orientation || 'horizontal' }

--- a/extensions/blocks/image-compare/index.js
+++ b/extensions/blocks/image-compare/index.js
@@ -17,7 +17,7 @@ export const name = 'image-compare';
 
 export const settings = {
 	title: __( 'Image Compare', 'jetpack' ),
-	description: __( 'Compare two images with a slider.', 'jetpack' ),
+	description: __( 'Compare two images with a slider. Works best with images of the same size.', 'jetpack' ),
 
 	icon,
 


### PR DESCRIPTION
Adds a help panel in the inspector to guide the user to use two images of the same size.

<img width="230" alt="img-compare-help" src="https://user-images.githubusercontent.com/45363/82503838-dd89bd00-9aae-11ea-977e-8cbf1659d1cd.png">


@jasmussen let me know what you think


#### Changes proposed in this Pull Request:

* Adds help panel

#### Testing instructions:

* No functional change, confirm help panel shows on right

#### Proposed changelog entry for your changes:

* New block, changelog already addressed
