### PR TITLE
Contact Form Block: Support flex field widths from master

### DIFF
--- a/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-checkbox.js
@@ -10,9 +10,10 @@ import { withInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import JetpackFieldLabel from './jetpack-field-label';
+import JetpackFieldWidth from './jetpack-field-width';
 
 function JetpackFieldCheckbox( props ) {
-	const { instanceId, required, label, setAttributes, isSelected, defaultValue } = props;
+	const { instanceId, required, label, setAttributes, width, defaultValue } = props;
 
 	return (
 		<BaseControl
@@ -30,7 +31,6 @@ function JetpackFieldCheckbox( props ) {
 						required={ required }
 						label={ label }
 						setAttributes={ setAttributes }
-						isSelected={ isSelected }
 					/>
 					<InspectorControls>
 						<PanelBody title={ __( 'Field Settings', 'jetpack' ) }>
@@ -39,6 +39,8 @@ function JetpackFieldCheckbox( props ) {
 								checked={ defaultValue }
 								onChange={ value => setAttributes( { defaultValue: value } ) }
 							/>
+
+							<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 						</PanelBody>
 					</InspectorControls>
 				</>

--- a/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
-import { addFilter } from '@wordpress/hooks';
-import { createHigherOrderComponent } from '@wordpress/compose';
 import {
 	InspectorAdvancedControls,
 	InspectorControls,
@@ -23,8 +20,9 @@ import {
  * Internal Dependencies
  */
 import renderMaterialIcon from '../../../shared/render-material-icon';
+import JetpackFieldWidth from './jetpack-field-width';
 
-const JetpackFieldControls = ( { setAttributes, id, required } ) => {
+const JetpackFieldControls = ( { setAttributes, width, id, required } ) => {
 	return (
 		<>
 			<BlockControls>
@@ -54,6 +52,8 @@ const JetpackFieldControls = ( { setAttributes, id, required } ) => {
 							'jetpack'
 						) }
 					/>
+
+					<JetpackFieldWidth setAttributes={ setAttributes } width={ width } />
 				</PanelBody>
 			</InspectorControls>
 

--- a/extensions/blocks/contact-form/components/jetpack-field-controls.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-controls.js
@@ -30,7 +30,10 @@ const JetpackFieldControls = ( { setAttributes, width, id, required } ) => {
 					<ToolbarButton
 						title={ __( 'Required', 'jetpack' ) }
 						icon={ renderMaterialIcon(
-							<Path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zm4.24 16L12 15.45 7.77 18l1.12-4.81-3.73-3.23 4.92-.42L12 5l1.92 4.53 4.92.42-3.73 3.23L16.23 18z" />
+							<Path
+								d="M8.23118 8L16 16M8 16L15.7688 8 M6.5054 11.893L17.6567 11.9415M12.0585 17.6563L12 6.5"
+								stroke="currentColor"
+							/>
 						) }
 						onClick={ () => {
 							setAttributes( { required: ! required } );

--- a/extensions/blocks/contact-form/components/jetpack-field-multiple.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-multiple.js
@@ -14,7 +14,17 @@ import JetpackOption from './jetpack-option';
 import JetpackFieldControls from './jetpack-field-controls';
 
 function JetpackFieldMultiple( props ) {
-	const { id, type, instanceId, required, label, setAttributes, isSelected, options } = props;
+	const {
+		id,
+		type,
+		instanceId,
+		required,
+		label,
+		setAttributes,
+		isSelected,
+		width,
+		options,
+	} = props;
 
 	const [ inFocus, setInFocus ] = useState( null );
 
@@ -95,7 +105,12 @@ function JetpackFieldMultiple( props ) {
 				) }
 			</BaseControl>
 
-			<JetpackFieldControls id={ id } required={ required } setAttributes={ setAttributes } />
+			<JetpackFieldControls
+				id={ id }
+				required={ required }
+				setAttributes={ setAttributes }
+				width={ width }
+			/>
 		</Fragment>
 	);
 }

--- a/extensions/blocks/contact-form/components/jetpack-field-textarea.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-textarea.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { TextareaControl, Disabled } from '@wordpress/components';
 
 /**
@@ -12,17 +11,12 @@ import JetpackFieldLabel from './jetpack-field-label';
 import JetpackFieldControls from './jetpack-field-controls';
 
 export default function JetpackFieldTextarea( props ) {
-	const { id, required, label, setAttributes, isSelected, placeholder } = props;
+	const { id, required, label, setAttributes, placeholder, width } = props;
 
 	return (
-		<Fragment>
+		<>
 			<div className="jetpack-field">
-				<JetpackFieldLabel
-					required={ required }
-					label={ label }
-					setAttributes={ setAttributes }
-					isSelected={ isSelected }
-				/>
+				<JetpackFieldLabel required={ required } label={ label } setAttributes={ setAttributes } />
 				<Disabled>
 					<TextareaControl
 						placeholder={ placeholder }
@@ -33,7 +27,12 @@ export default function JetpackFieldTextarea( props ) {
 				</Disabled>
 			</div>
 
-			<JetpackFieldControls id={ id } required={ required } setAttributes={ setAttributes } />
-		</Fragment>
+			<JetpackFieldControls
+				id={ id }
+				required={ required }
+				setAttributes={ setAttributes }
+				width={ width }
+			/>
+		</>
 	);
 }

--- a/extensions/blocks/contact-form/components/jetpack-field-width.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-width.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { BaseControl, Button, ButtonGroup } from '@wordpress/components';
 
-const JetpackFieldWidth = ( { setAttributes, width } ) => {
+export default function JetpackFieldWidth( { setAttributes, width } ) {
 	return (
 		<BaseControl
 			label={ __( 'Field Width', 'jetpack' ) }
@@ -30,6 +30,4 @@ const JetpackFieldWidth = ( { setAttributes, width } ) => {
 			</ButtonGroup>
 		</BaseControl>
 	);
-};
-
-export default JetpackFieldWidth;
+}

--- a/extensions/blocks/contact-form/components/jetpack-field-width.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-width.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { BaseControl, Button, ButtonGroup } from '@wordpress/components';
+
+const JetpackFieldWidth = ( { setAttributes, width } ) => {
+	return (
+		<BaseControl
+			label={ __( 'Field Width', 'jetpack' ) }
+			help={ __(
+				'Adjust the width of the field to include multiple fields on a single line.',
+				'jetpack'
+			) }
+			className="jetpack-field-label__width"
+		>
+			<ButtonGroup aria-label={ __( 'Field Width' ) }>
+				{ [ 25, 50, 75, 100 ].map( widthValue => {
+					return (
+						<Button
+							key={ widthValue }
+							isSmall
+							isPrimary={ widthValue === width }
+							onClick={ () => setAttributes( { width: widthValue } ) }
+						>
+							{ widthValue }%
+						</Button>
+					);
+				} ) }
+			</ButtonGroup>
+		</BaseControl>
+	);
+};
+
+export default JetpackFieldWidth;

--- a/extensions/blocks/contact-form/components/jetpack-field-width.js
+++ b/extensions/blocks/contact-form/components/jetpack-field-width.js
@@ -14,7 +14,7 @@ export default function JetpackFieldWidth( { setAttributes, width } ) {
 			) }
 			className="jetpack-field-label__width"
 		>
-			<ButtonGroup aria-label={ __( 'Field Width' ) }>
+			<ButtonGroup aria-label={ __( 'Field Width', 'jetpack' ) }>
 				{ [ 25, 50, 75, 100 ].map( widthValue => {
 					return (
 						<Button

--- a/extensions/blocks/contact-form/components/jetpack-field.js
+++ b/extensions/blocks/contact-form/components/jetpack-field.js
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { TextControl, Disabled } from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -13,17 +13,12 @@ import JetpackFieldLabel from './jetpack-field-label';
 import JetpackFieldControls from './jetpack-field-controls';
 
 export default function JetpackField( props ) {
-	const { id, isSelected, type, required, label, setAttributes, placeholder } = props;
+	const { id, type, required, label, setAttributes, placeholder, width } = props;
 
 	return (
-		<Fragment>
-			<div className={ classNames( 'jetpack-field', { 'is-selected': isSelected } ) }>
-				<JetpackFieldLabel
-					required={ required }
-					label={ label }
-					setAttributes={ setAttributes }
-					isSelected={ isSelected }
-				/>
+		<>
+			<div className="jetpack-field">
+				<JetpackFieldLabel required={ required } label={ label } setAttributes={ setAttributes } />
 				<Disabled>
 					<TextControl
 						type={ type }
@@ -35,7 +30,28 @@ export default function JetpackField( props ) {
 				</Disabled>
 			</div>
 
-			<JetpackFieldControls id={ id } required={ required } setAttributes={ setAttributes } />
-		</Fragment>
+			<JetpackFieldControls
+				id={ id }
+				required={ required }
+				width={ width }
+				setAttributes={ setAttributes }
+			/>
+		</>
 	);
 }
+
+const withCustomClassName = createHigherOrderComponent( BlockListBlock => {
+	return props => {
+		if ( props.name.indexOf( 'jetpack/field' ) > -1 ) {
+			const customClassName = props.attributes.width
+				? 'jetpack-field__width-' + props.attributes.width
+				: '';
+
+			return <BlockListBlock { ...props } className={ customClassName } />;
+		}
+
+		return <BlockListBlock { ...props } />;
+	};
+}, 'withCustomClassName' );
+
+addFilter( 'editor.BlockListBlock', 'jetpack/contact-form', withCustomClassName );

--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -15,6 +15,40 @@
 			margin-right: 0;
 		}
 	}
+
+	.block-editor-block-list__layout {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		flex-direction: row;
+
+		.wp-block {
+			flex: 0 0 100%;
+			margin: 0;
+			border-right: 15px solid transparent;
+			border-bottom: 15px solid transparent;
+
+			&.jetpack-field__width-25 {
+				flex: 0 0 25%;
+
+				.jetpack-option__input.jetpack-option__input.jetpack-option__input {
+					width: 70px;
+				}
+			}
+
+			&.jetpack-field__width-50 {
+				flex: 0 0 50%;
+			}
+
+			&.jetpack-field__width-75 {
+				flex: 0 0 75%;
+			}
+
+			&[data-type="jetpack/field-checkbox"] {
+				align-self: center;
+			}
+		}
+	}
 }
 
 .jetpack-contact-form .components-placeholder {
@@ -124,6 +158,16 @@ input.components-text-control__input {
 
 	textarea.components-textarea-control__input {
 		min-height: 150px;
+	}
+}
+
+.jetpack-field-label__width {
+	.components-button-group {
+		display: block;
+	}
+
+	.components-base-control__field {
+		margin-bottom: 12px;
 	}
 }
 

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -77,6 +77,10 @@ const FieldDefaults = {
 			type: 'string',
 			default: '',
 		},
+		width: {
+			type: 'number',
+			default: 100,
+		},
 	},
 	transforms: {
 		to: [
@@ -161,6 +165,7 @@ const editField = type => props => {
 			defaultValue={ props.attributes.defaultValue }
 			placeholder={ props.attributes.placeholder }
 			id={ props.attributes.id }
+			width={ props.attributes.width }
 		/>
 	);
 };
@@ -174,6 +179,7 @@ const editMultiField = type => props => (
 		type={ type }
 		isSelected={ props.isSelected }
 		id={ props.attributes.id }
+		width={ props.attributes.width }
 	/>
 );
 
@@ -284,6 +290,7 @@ export const childBlocks = [
 					defaultValue={ props.attributes.defaultValue }
 					placeholder={ props.attributes.placeholder }
 					id={ props.attributes.id }
+					width={ props.attributes.width }
 				/>
 			),
 		},
@@ -306,6 +313,7 @@ export const childBlocks = [
 					isSelected={ props.isSelected }
 					defaultValue={ props.attributes.defaultValue }
 					id={ props.attributes.id }
+					width={ props.attributes.width }
 				/>
 			),
 			attributes: {

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -104,6 +104,39 @@
 	margin-top: 7px;
 }
 
+.wp-block-jetpack-contact-form {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-start;
+	flex-direction: row;
+}
+
+.wp-block-jetpack-contact-form .grunion-field-wrap, .wp-block-jetpack-button {
+	flex: 0 0 100%;
+}
+
+.wp-block-jetpack-contact-form .grunion-field-wrap {
+	/* Use transparent border to maintain consistent
+	 * space between elements with flexbox */
+	border-right: 15px solid transparent;
+}
+
+.wp-block-jetpack-contact-form .grunion-field-width-25-wrap {
+	flex: 0 0 25%;
+}
+
+.wp-block-jetpack-contact-form .grunion-field-width-50-wrap {
+	flex: 0 0 50%;
+}
+
+.wp-block-jetpack-contact-form .grunion-field-width-75-wrap {
+	flex: 0 0 75%;
+}
+
+.grunion-field-checkbox-wrap {
+	align-self: center;
+}
+
 @media only screen and (min-width: 600px) {
 	.contact-form input[type='text'],
 	.contact-form input[type='email'],

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -3062,6 +3062,7 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 				'values'      => null,
 				'placeholder' => null,
 				'class'       => null,
+				'width'       => null,
 			), $attributes, 'contact-field'
 		);
 
@@ -3221,7 +3222,12 @@ class Grunion_Contact_Form_Field extends Crunion_Contact_Form_Shortcode {
 		$field_label       = $this->get_attribute( 'label' );
 		$field_required    = $this->get_attribute( 'required' );
 		$field_placeholder = $this->get_attribute( 'placeholder' );
+		$field_width       = $this->get_attribute( 'width' );
 		$class             = 'date' === $field_type ? 'jp-contact-form-date' : $this->get_attribute( 'class' );
+
+		if ( ! empty( $field_width ) ) {
+			$class .= ' grunion-field-width-' . $field_width;
+		}
 
 		/**
 		 * Filters the "class" attribute of the contact form input


### PR DESCRIPTION
Replaces #15674

Update the contact form block to allow field widths to be set. This allows more complex layouts to be achieved:

<img width="1147" alt="Screen Shot 2020-05-04 at 3 37 36 PM" src="https://user-images.githubusercontent.com/1464705/81020242-39044b80-8e1d-11ea-9e4b-f0c450aaafff.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a Contact Form block
* Add a number of different types of fields
* Change the width setting of these fields and confirm they adjust as expected.
* Publish/update the post and confirm these settings and the layout are retained correctly.
* Confirm the same flex layout is rendered on the front end of the site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added greater support for flexible layouts using the Contact Form block.
