### PR TITLE
Mailerlite subscriber popup shortcode

### DIFF
--- a/modules/shortcodes/js/mailerlite-subscriber-popup.js
+++ b/modules/shortcodes/js/mailerlite-subscriber-popup.js
@@ -1,0 +1,10 @@
+/* global window,ml,jetpackMailerliteSettings */
+
+( function() {
+	window.ml_account = ml(
+		'accounts',
+		jetpackMailerliteSettings.account,
+		jetpackMailerliteSettings.uuid,
+		'load'
+	);
+} )();

--- a/modules/shortcodes/mailerlite.php
+++ b/modules/shortcodes/mailerlite.php
@@ -9,9 +9,7 @@ use Automattic\Jetpack\Assets;
  */
 
 /**
- * Register [mailerlite_subscriber_popup] shortcode and add a filter to 'pre_kses' queue to reverse Mailerlite embed to shortcode.
- *
- * @since 4.5.0
+ * Register [mailerlite_subscriber_popup] shortcode.
  */
 function jetpack_mailerlite_subscriber_popup() {
 	add_shortcode(

--- a/modules/shortcodes/mailerlite.php
+++ b/modules/shortcodes/mailerlite.php
@@ -1,0 +1,69 @@
+<?php //phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+use Automattic\Jetpack\Assets;
+/**
+ * Mailerlite Subscriber Popup Form shortcode
+ *
+ * Example:
+ * [mailerlite_subscriber_popup account="234532432" uuid="rat43ttatrs"]
+ */
+
+/**
+ * Register [mailerlite_subscriber_popup] shortcode and add a filter to 'pre_kses' queue to reverse Mailerlite embed to shortcode.
+ *
+ * @since 4.5.0
+ */
+function jetpack_mailerlite_subscriber_popup() {
+	add_shortcode(
+		'mailerlite_subscriber_popup',
+		array(
+			'Mailerlite_Subscriber_Popup',
+			'shortcode',
+		)
+	);
+}
+
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_action( 'init', 'jetpack_mailerlite_subscriber_popup' );
+} else {
+	jetpack_mailerlite_subscriber_popup();
+}
+
+/**
+ * Class Mailerlite_Subscriber_Popup
+ *
+ * @since 4.5.0
+ */
+class Mailerlite_Subscriber_Popup {
+	/**
+	 * Parses the shortcode back out to embedded information.
+	 *
+	 * @param array $attrs shortcode attributes.
+	 *
+	 * @return string
+	 */
+	public static function shortcode( $attrs ) {
+		if ( wp_script_is( 'mailerlite-subscriber-popup', 'enqueued' ) ) {
+			return '';
+		}
+
+		$attrs = shortcode_atts(
+			array(
+				'account' => '',
+				'uuid'    => '',
+			),
+			$attrs,
+			'mailerlite_subscriber_popup'
+		);
+		wp_register_script( 'mailerlite-universal', 'https://static.mailerlite.com/js/universal.js', array(), '20200521', true );
+		wp_enqueue_script(
+			'mailerlite-subscriber-popup',
+			Assets::get_file_url_for_environment( '_inc/build/shortcodes/js/mailerlite-subscriber-popup.min.js', 'modules/shortcodes/js/mailerlite-subscriber-popup.js' ),
+			array( 'mailerlite-universal' ),
+			'20200521',
+			true
+		);
+		wp_localize_script( 'mailerlite-subscriber-popup', 'jetpackMailerliteSettings', $attrs );
+		return '';
+	}
+}


### PR DESCRIPTION
This PR introduces a Mailerlite (https://www.mailerlite.com/) subscriber popup shortcode.
It is a (cheaper and simpler) mailchimp competitor that I personally use on my blog https://deliber.at . My other blog - https://piszek.com is hosted on WPCOM simple (on purpose). I have no way of introducing mailerlite signup on that blog.

Mailerlite subscriber popups are customized in Mailerlite interface.
All is needed to make it work is loading mailerlite JS.

<img width="1200" alt="Zrzut ekranu 2020-05-21 o 10 50 05" src="https://user-images.githubusercontent.com/3775068/82542205-e2537d00-9b51-11ea-8372-3972c46c64bf.png">

**Testing instructions**

1. Check out the PR
2. If you don't want to set up Mailerlite account, you can use my email list (continue)
3. Use the shortcode `[mailerlite_subscriber_popup account="1726876" uuid="o6h6c1w0c9"]`
4. Publish the page
5. Scroll a bit, observe popup as in the screenshot.

**Using your account**

1. Register on mailerlite.com
2. Create a form in https://app.mailerlite.com/forms/
3. Scroll down, look at 'Universal tracking script'
4. Copy values from JS: `var ml_account = ml('accounts', '1726876', 'o6h6c1w0c9', 'load');` - second argument is 'account' shortcode param, third is 'uuid'