### PR TITLE
Block Nudge: Add `wp-block` class to fix width regression

### DIFF
--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -24,7 +24,7 @@ export const BlockNudge = ( { autosaveAndRedirect, buttonLabel, href, icon, subt
 				</Button>,
 			]
 		}
-		className="jetpack-block-nudge"
+		className="jetpack-block-nudge wp-block"
 	>
 		<span className="jetpack-block-nudge__info">
 			{ icon }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add the `.wp-block` class to the block nudge, in order to apply the relevant styling that was lost per https://github.com/WordPress/gutenberg/pull/22028.

Fixes part of #15796.

This is still suboptimal in a number of ways:

- Note that the block toolbar is still above the block (instead of above the nudge, as it used to be prior to Gutenberg 8.1). Not sure if we'll be able to easily fix that though.
- We might try to remove the vertical padding but need to take care not to break the nudge for other paid blocks, or Gutenberg < 8.1.
- This PR's current state unfortunately introduces a regression if the Gutenberg version is < 8.1. (e.g. no Gutenberg plugin installed) -- see screenshot further below. I've tried to tweak this for at least one hour but for the life of me couldn't find the CSS selector that's responsible for this. We might add the `wp-block` class name conditionally, but to that end, we'll need a way to determine the Gutenberg version that works across JP and WP.com.

#### Screenshots (with GB 8.1)

##### Before

![image](https://user-images.githubusercontent.com/96308/82563449-64a26800-9b77-11ea-92da-476d3b350183.png)

##### After

![image](https://user-images.githubusercontent.com/96308/82563324-29a03480-9b77-11ea-9136-e36b6ef868ee.png)

#### Screenshots (without GB)

![image](https://user-images.githubusercontent.com/96308/82604593-d3ea7d00-9bb4-11ea-81cb-5937ed373fc2.png)

#### Testing instructions

(Not adding to `to-test.md` since these are kinda WP.com specific)

- Install and activate Gutenberg 8.1
- Check out this branch, and apply the following diff:
```diff
diff --git a/extensions/blocks/videopress/editor.js b/extensions/blocks/videopress/editor.js
index 989e927f3..f8302a870 100644
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -65,7 +65,7 @@ const addVideoPressSupport = ( settings, name ) => {
 	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
 	// Check if VideoPress is unavailable and filter the mediaplaceholder to limit options
-	if ( isSimpleSite() && [ 'missing_plan', 'unknown' ].includes( unavailableReason ) ) {
+	if ( [ 'missing_plan', 'unknown' ].includes( unavailableReason ) ) {
 		addFilter( 'editor.MediaPlaceholder', 'jetpack/videopress', videoPressNoPlanMediaPlaceholder );
 		addFilter(
 			'editor.BlockListBlock',
@@ -158,22 +158,21 @@ const addVideoPressSupport = ( settings, name ) => {
 				reusable: false,
 			},
 
-			edit:
-				isSimpleSite() && [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-					? wrapPaidBlock( {
-							requiredPlan: 'value_bundle',
-							customTitle: {
-								knownPlan: __( 'Upgrade to %(planName)s to upload videos.', 'jetpack' ),
-								unknownPlan: __( 'Upgrade to a paid plan to upload videos.', 'jetpack' ),
-							},
-							customSubTitle: __(
-								'Upload unlimited videos to your website and \
+			edit: [ 'missing_plan', 'unknown' ].includes( unavailableReason )
+				? wrapPaidBlock( {
+						requiredPlan: 'value_bundle',
+						customTitle: {
+							knownPlan: __( 'Upgrade to %(planName)s to upload videos.', 'jetpack' ),
+							unknownPlan: __( 'Upgrade to a paid plan to upload videos.', 'jetpack' ),
+						},
+						customSubTitle: __(
+							'Upload unlimited videos to your website and \
 						display them using a fast, unbranded, \
 						customizable player.',
-								'jetpack'
-							),
-					  } )( withVideoPressEdit( edit ) )
-					: withVideoPressEdit( edit ),
+							'jetpack'
+						),
+				  } )( withVideoPressEdit( edit ) )
+				: withVideoPressEdit( edit ),
 
 			save: withVideoPressSave( save ),
 
```
- Run `yarn build-extensions`.
- Make sure you're on a free plan.
- Insert the 'Video' block.
- Make sure it looks like in the screenshot (especially the upgrade nudge).
- Try inserting other paid blocks, e.g. Simple Payments, and verify that their upgrade nudges also still look good.
- Disable Gutenberg 8.1, and verify that everything still looks fine.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bugfix.

#### Proposed changelog entry for your changes:
Block Nudge: Add `wp-block` class to fix width regression
