### PR TITLE
JITM: fix use statements

### DIFF
--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -8,8 +8,6 @@
 namespace Automattic\Jetpack\JITMS;
 
 use Automattic\Jetpack\Assets;
-use Automattic\Jetpack\Connection\Manager;
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\JITMS\Post_Connection_JITM;

--- a/packages/jitm/src/class-post-connection-jitm.php
+++ b/packages/jitm/src/class-post-connection-jitm.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\JITMS;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\JITMS\JITM;


### PR DESCRIPTION
Fixes #15884

#### Changes proposed in this Pull Request:
* Remove the `Automattic\Jetpack\Connection` use statements from `class-jitm.php`. The `Manager` and `Client` classes aren't used in this file.

* Add the `Automattic\Jetpack\Connection\Manager` use statement to the `class-post-connection-jitm.php` file. The `Manager` class is used in the `delete_user_update_connection_owner_notice()` method.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This fixes an existing part of Jetpack.

#### Testing instructions:
##### Test site
* Must have Jetpack activated and connected.
* Must have JITMs to display (that is, the JITMs have not been dismissed).
* Must have at least two admin users.
* Debug logging should be enabled.

##### Test steps
1. Navigate to the Jetpack dashboard and confirm that a JITM displays.
2. Navigate to wp-admin -> Users. Attempt to delete a user. If the user is not the connection's master user, you should see the normal user deletion page. If the user is the connection's master user, you should see a notice that provides instructions on changing the master user. In either case, you should not see any errors.
3. Check the debug log and confirm that no errors were generated

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a - this bug was generated in this release cycle.