### PR TITLE
Latest Instagram Posts Block: Crop images to square

### DIFF
--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -65,7 +65,7 @@
 	}
 }
 
-@supports ( display: grid ) {
+@supports ( object-fit: cover ) {
 	.wp-block-jetpack-instagram-gallery__placeholder.is-loaded {
 		height: 100%;
 		img {

--- a/extensions/blocks/instagram-gallery/editor.scss
+++ b/extensions/blocks/instagram-gallery/editor.scss
@@ -16,3 +16,61 @@
 	font-style: italic;
 	margin-bottom: 0;
 }
+
+.wp-block-jetpack-instagram-gallery__placeholder {
+	animation-name: fadeIn, pulse;
+	animation-duration: 300ms, 1.6s;
+	animation-delay: 0ms, 300ms; /* add this */
+	animation-timing-function: ease-out, ease-out;
+	animation-iteration-count: 1, infinite;
+	background-color: #a7a79f;
+	display: block;
+	opacity: 1;
+
+	&.is-loaded {
+		animation: none;
+		height: auto;
+	}
+
+	img {
+		opacity: 0;
+		transition: opacity 0.5s ease-in-out;
+
+		&.is-loaded {
+			opacity: 1;
+		}
+	}
+}
+
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+@keyframes pulse {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}
+
+@supports ( display: grid ) {
+	.wp-block-jetpack-instagram-gallery__placeholder.is-loaded {
+		height: 100%;
+		img {
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+}

--- a/extensions/blocks/instagram-gallery/image-transition.js
+++ b/extensions/blocks/instagram-gallery/image-transition.js
@@ -1,11 +1,12 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useEffect, useState, useRef } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 
 export default function ImageTransition( { src, alt } ) {
 	const [ loaded, setLoaded ] = useState( false );
@@ -32,40 +33,15 @@ export default function ImageTransition( { src, alt } ) {
 		}
 	}, [ src ] );
 
-	const imageStyle = {
-		opacity: '0',
-		transition: `opacity .5s ease-in-out`,
-	};
-
-	const imageLoadedStyle = {
-		opacity: '1',
-	};
-
-	const containerStyle = {
-		opacity: '1',
-		backgroundColor: '#A7A79F',
-		height: containerHeight,
-		display: 'block',
-	};
-
-	const containerLoadedStyle = {
-		height: 'auto',
-		animation: 'none',
-	};
+	const containerClasses = classnames( 'wp-block-jetpack-instagram-gallery__placeholder', {
+		'is-loaded': loaded,
+	} );
+	const containerStyles = loaded ? {} : { height: containerHeight };
+	const imageClasses = classnames( { 'is-loaded': loaded } );
 
 	return (
-		<>
-			<span
-				style={ loaded ? { ...containerStyle, ...containerLoadedStyle } : containerStyle }
-				className="wp-block-jetpack-instagram-gallery__placeholder"
-			>
-				<img
-					ref={ img }
-					alt={ alt }
-					src={ src }
-					style={ loaded ? { ...imageStyle, ...imageLoadedStyle } : imageStyle }
-				/>
-			</span>
-		</>
+		<span style={ containerStyles } className={ containerClasses }>
+			<img alt={ alt } className={ imageClasses } ref={ img } src={ src } />
+		</span>
 	);
 }

--- a/extensions/blocks/instagram-gallery/view.scss
+++ b/extensions/blocks/instagram-gallery/view.scss
@@ -57,6 +57,11 @@
 
 		.wp-block-jetpack-instagram-gallery__grid-post {
 			width: auto;
+
+			img {
+				height: 100%;
+				object-fit: cover;
+			}
 		}
 	}
 
@@ -64,36 +69,5 @@
 		.wp-block-jetpack-instagram-gallery__grid-columns-#{$i} {
 			grid-template-columns: repeat( $i, 1fr );
 		}
-	}
-}
-
-.wp-block-jetpack-instagram-gallery__placeholder {
-	animation-name: fadeIn, pulse;
-	animation-duration: 300ms, 1.6s;
-	animation-delay: 0ms, 300ms; /* add this */
-	animation-timing-function: ease-out, ease-out;
-	animation-iteration-count: 1, infinite;
-}
-
-@keyframes fadeIn {
-	0% {
-		opacity: 0;
-	}
-	50% {
-		opacity: 0.5;
-	}
-	100% {
-		opacity: 1;
-	}
-}
-@keyframes pulse {
-	0% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.5;
-	}
-	100% {
-		opacity: 1;
 	}
 }

--- a/extensions/blocks/instagram-gallery/view.scss
+++ b/extensions/blocks/instagram-gallery/view.scss
@@ -71,3 +71,10 @@
 		}
 	}
 }
+
+@supports ( object-fit: cover ) {
+	.wp-block-jetpack-instagram-gallery__grid-post img {
+		height: 100%;
+		object-fit: cover;
+	}
+}


### PR DESCRIPTION
Fixes #15767

#### Changes proposed in this Pull Request:

* On modern browsers, crop the Latest Instagram Posts images to be square.

| Before | After |
| - | - |
| <img width="628" alt="Screenshot 2020-05-21 at 17 33 10" src="https://user-images.githubusercontent.com/2070010/82582046-5b21fb80-9b89-11ea-872c-266945c282da.png"> | <img width="628" alt="Screenshot 2020-05-21 at 17 32 03" src="https://user-images.githubusercontent.com/2070010/82582092-6bd27180-9b89-11ea-84b2-486f8c39666b.png"> |

I've chosen the simple way of using the new-ish `object-fit` rule, which is [supported in all modern browsers except IE11](https://caniuse.com/#search=object-fit).
Older browsers will display the images in their original ratio.

I've also moved one last piece of `view.scss` affecting only the editor into `editor.scss`, and moved most of the `ImageTransition` classes and styles to CSS, which should reduce the whole specificity.

#### Testing instructions:

* Insert a Latest Instagram Posts block and connect it to an account containing non-square images.
* Make sure they are all displayed as square, in both the editor and the front end.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
