### PR TITLE
AMP support for [dailymotion-channel] shortcode

### DIFF
--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -255,15 +255,20 @@ add_shortcode( 'dailymotion', 'dailymotion_shortcode' );
 function dailymotion_channel_shortcode( $atts ) {
 	$username = $atts['user'];
 
+	$sandbox = '';
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$sandbox = 'allow-popups allow-scripts allow-same-origin allow-presentation';
+	}
+
 	switch ( $atts['type'] ) {
 		case 'grid':
-			$channel_iframe = '<iframe width="300px" height="264px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=grid' ) . '"></iframe>';
+			$channel_iframe = '<iframe sandbox="' . esc_attr( $sandbox ) . '" width="300px" height="264px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=grid' ) . '"></iframe>';
 			break;
 		case 'carousel':
-			$channel_iframe = '<iframe width="300px" height="360px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=carousel' ) . '"></iframe>';
+			$channel_iframe = '<iframe sandbox="' . esc_attr( $sandbox ) . '" width="300px" height="360px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=carousel' ) . '"></iframe>';
 			break;
 		default:
-			$channel_iframe = '<iframe width="300px" height="78px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username ) . '"></iframe>';
+			$channel_iframe = '<iframe sandbox="' . esc_attr( $sandbox ) . '" width="300px" height="78px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username ) . '"></iframe>';
 	}
 
 	return $channel_iframe;

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -255,20 +255,15 @@ add_shortcode( 'dailymotion', 'dailymotion_shortcode' );
 function dailymotion_channel_shortcode( $atts ) {
 	$username = $atts['user'];
 
-	$sandbox = '';
-	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		$sandbox = 'allow-popups allow-scripts allow-same-origin allow-presentation';
-	}
-
 	switch ( $atts['type'] ) {
 		case 'grid':
-			$channel_iframe = '<iframe sandbox="' . esc_attr( $sandbox ) . '" width="300px" height="264px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=grid' ) . '"></iframe>';
+			$channel_iframe = '<iframe sandbox="allow-popups allow-scripts allow-same-origin allow-presentation" width="300px" height="264px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=grid' ) . '"></iframe>';
 			break;
 		case 'carousel':
-			$channel_iframe = '<iframe sandbox="' . esc_attr( $sandbox ) . '" width="300px" height="360px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=carousel' ) . '"></iframe>';
+			$channel_iframe = '<iframe sandbox="allow-popups allow-scripts allow-same-origin allow-presentation" width="300px" height="360px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=carousel' ) . '"></iframe>';
 			break;
 		default:
-			$channel_iframe = '<iframe sandbox="' . esc_attr( $sandbox ) . '" width="300px" height="78px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username ) . '"></iframe>';
+			$channel_iframe = '<iframe sandbox="allow-popups allow-scripts allow-same-origin allow-presentation" width="300px" height="78px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username ) . '"></iframe>';
 	}
 
 	return $channel_iframe;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* In the `[dailymotion-channel]` shortcode, adds a `sandbox` attribute which allows opening links in a new window and fixes a console error on page load.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This enhances an existing feature.

#### Testing instructions:
* Ensure the AMP plugin is active
* In AMP Settings, select 'Transitional' mode
* In Jetpack > Settings > Writing, ensure 'Compose using shortcodes' option is toggled on
* Add a shortcode block with: `[dailymotion-channel user=PAworldnews type=grid]` or `[dailymotion-channel user=PAworldnews type=carousel]`
* View the page with `?amp` in the query string
* Click a link inside the Dailymotion embed
* Expected: Link opens up in a new window/tab, and does not throw a console error

#### Proposed changelog entry for your changes:
* Improved dailymotion-channel shortcode AMP compatibility
