### PR TITLE
Related Posts: Don't enque scripts in embed view

### DIFF
--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1617,6 +1617,7 @@ EOT;
 		$enabled = is_single()
 			&& ! is_attachment()
 			&& ! is_admin()
+			&& ! is_embed()			
 			&& ( ! $this->_allow_feature_toggle() || $this->get_option( 'enabled' ) );
 
 		/**

--- a/modules/related-posts/jetpack-related-posts.php
+++ b/modules/related-posts/jetpack-related-posts.php
@@ -1617,7 +1617,7 @@ EOT;
 		$enabled = is_single()
 			&& ! is_attachment()
 			&& ! is_admin()
-			&& ! is_embed()			
+			&& ! is_embed()
 			&& ( ! $this->_allow_feature_toggle() || $this->get_option( 'enabled' ) );
 
 		/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

<!-- Fixes # -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Prevent embedded posts from wastedly trying to get the related posts API 

 When embeded the post with oEmbed, the request will failed because sandbox of iframe. And, the response will not used.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Activate Jetpack and Related posts module
* embed some post to another post
* Open "another" post in Google Chrome
  * Before: Error like net::ERR_FAILED is shown in console
  ![Screenshot_20200522_165004](https://user-images.githubusercontent.com/5253290/82644903-05168c00-9c4d-11ea-9785-d0fbdba98301.png)
     * or, You can see flying request to API like `/post/embed/?relatedposts=1`
  * After: There are no one and There is no change in the appearance of the embedding
    * parent page still shows related posts

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Related posts: prevent embedded posts from wastedly trying to get the related posts API
