### PR TITLE
Recurring Payments: Sentence case call-to-action upgrade button

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -417,7 +417,7 @@ class MembershipsButtonEdit extends Component {
 							) }
 						>
 							<Button isSecondary isLarge href={ this.state.upgradeURL } target="_blank">
-								{ __( 'Upgrade Your Plan', 'jetpack' ) }
+								{ __( 'Upgrade your plan', 'jetpack' ) }
 							</Button>
 							{ this.renderDisclaimer() }
 						</Placeholder>


### PR DESCRIPTION
#13175 ## Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* We're making an effort to sentence-case all calls to action across WP.com. This does so for the Recurring Payments upgrade nudge.

Before

<img width="866" alt="Screen Shot 2020-05-22 at 11 16 05 AM" src="https://user-images.githubusercontent.com/2124984/82682696-a84fad00-9c1d-11ea-81f7-7577f94e4599.png">

After

<img width="852" alt="Screen Shot 2020-05-22 at 11 13 27 AM" src="https://user-images.githubusercontent.com/2124984/82682701-aab20700-9c1d-11ea-9ee7-0de925c00434.png">


#### Testing instructions:
* Switch to this PR on a site with the Jetpack Free plan
* Add a Recurring Payments block to a page or post
* Note the upsell; the call to action should be sentence case

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Update Recurring Payments CTA to sentence case
