### PR TITLE
Privacy Updates: add new section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,10 @@ Fixes #
 #### Is this a new feature or does it add/remove features to an existing part of Jetpack?
 * If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.
 
+#### Does this pull request change what data or activity we track or use?
+<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
+<!--- Check existing Jetpack support documents for a preview of the information we need. -->
+
 #### Testing instructions:
 <!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
 <!-- Please include detailed testing steps, explaining how to test your change. -->


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Recommend the use of the new label when a privacy update is necessary.

Alongside this change, I've added 2 labels:
- [Status] Needs Privacy Updates
- [Status] Has Privacy Updates

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Internal reference: p1HpG7-97O-p2

#### Testing instructions:

* Check the PR template for typos.

#### Proposed changelog entry for your changes:

* N/A
