### PR TITLE
Privacy Updates: add warning when the section is deleted

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -42,6 +42,13 @@ if ( ! pr.body.includes( 'Proposed changelog entry' ) ) {
 	);
 }
 
+// Privacy section filled in
+if ( ! pr.body.includes( 'data or activity we track or use' ) ) {
+	warn(
+		'The Privacy section is missing for this PR. Please specify whether this PR includes any changes to data or privacy.'
+	);
+}
+
 // Check if newly added .php files were added to phpcs linter whitelist
 if ( newFiles.length > 0 ) {
 	const newPHPFiles = newFiles.filter(


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* When the new privacy section added in #15897 is deleted, Danger will issue a warning to let you know you should answer the question.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Internal reference: p1HpG7-97O-p2

#### Testing instructions:

* Since this PR does not include the new section, you should see a warning in the Danger output below.

#### Proposed changelog entry for your changes:

* N/A
