### PR TITLE
Update ReplicaStore to utilize clean_comment_cache

### DIFF
--- a/packages/sync/src/class-replicastore.php
+++ b/packages/sync/src/class-replicastore.php
@@ -21,6 +21,12 @@ class Replicastore implements Replicastore_Interface {
 		global $wpdb;
 
 		$wpdb->query( "DELETE FROM $wpdb->posts" );
+
+		// Delete comments from cache.
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments" );
+		if ( ! empty( $comment_ids ) ) {
+			clean_comment_cache( $comment_ids );
+		}
 		$wpdb->query( "DELETE FROM $wpdb->comments" );
 
 		// Also need to delete terms from cache.
@@ -426,6 +432,8 @@ class Replicastore implements Replicastore_Interface {
 		} else {
 			$wpdb->insert( $wpdb->comments, $comment );
 		}
+		// Remove comment from cache.
+		clean_comment_cache( $comment['comment_ID'] );
 
 		wp_update_comment_count( $comment['comment_post_ID'] );
 	}


### PR DESCRIPTION
When doing a reset of the WP.com Cache site we are not clearing the comment cache. This PR doesn't impact any Jetpack Functionality but aligns it with updates being made on the WP.com side.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fully utilize clean_comment_cache as outlined in https://wp.me/p94tqY-mg

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Testing instructions:

* Regression Testing as beyond tests modified functions are not utilized.
* On master get the results for /sites/%s/data-check  
   or by wp shell call `$store = new Replicastore(); return $store->checksum_all();`
* Switch to fix/comment_cache branch and make the same call
* Verify no warnings/errors and the results are the same.

#### Proposed changelog entry for your changes:
* N/A
