### PR TITLE
Revert "getSitePurchases: Fix blank Dashboard on API errors "

### DIFF
--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -216,7 +216,7 @@ export function getAvailablePlans( state ) {
 }
 
 export function getSitePurchases( state ) {
-	return get( state.jetpack.siteData, [ 'data', 'sitePurchases', 'purchase' ], [] );
+	return get( state.jetpack.siteData, [ 'data', 'sitePurchases' ], [] );
 }
 
 /**


### PR DESCRIPTION
Reverts Automattic/jetpack#15807.

The prior pull request broke state as the `sitePurchases` key is an array of purchase objects, so `purchase` cannot be queried there.

To verify, on a site with a product purchased:
1. View My Plan page.
2. View Plans page.

In both, the UI acts as if there are no products bought as it cannot query the purchases for the site.