### PR TITLE
JITM: expand docs and tests to account for pre-connection messages

### DIFF
--- a/packages/jitm/README.md
+++ b/packages/jitm/README.md
@@ -1,6 +1,13 @@
 # Jetpack Just In Time Messages
 
-A package encapsulating Just In Time Messages
+A package encapsulating Just In Time Messages.
+
+Just In Time Messages (JITMs) are real-time contextual in-admin notices. Such notices are displayed on specific admin pages, based on multiple parameters (page visited, Jetpack connection status, plan status, features active, ...).
+
+There are 2 main ways to use JITMs:
+
+- You can create static notices within the Jetpack plugin. Those will be displayed before the site is connected to WordPress.com. See `Pre_Connection_JITM` to find out more.
+- You can create dynamic notices once the Jetpack plugin is connected to WordPress.com. Those notices will be pulled from WordPress.com depending on the parameters mentioned above. See `Post_Connection_JITM` to find out more.
 
 ### Usage
 

--- a/packages/jitm/composer.json
+++ b/packages/jitm/composer.json
@@ -9,8 +9,10 @@
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
+		"automattic/jetpack-partner": "@dev",
 		"automattic/jetpack-tracking": "@dev",
-		"automattic/jetpack-redirect": "@dev"
+		"automattic/jetpack-redirect": "@dev",
+		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/jitm/tests/php/test_JITM.php
+++ b/packages/jitm/tests/php/test_JITM.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack;
 
 use Automattic\Jetpack\JITMS\JITM;
+use Automattic\Jetpack\JITMS\Pre_Connection_JITM;
 use phpmock\functions\FunctionProvider;
 use phpmock\Mock;
 use phpmock\MockBuilder;
@@ -63,6 +64,21 @@ class Test_Jetpack_JITM extends TestCase {
 
 		$jitm = new JITM();
 		$this->assertTrue( $jitm->register() );
+
+		$this->clear_mock_filters();
+	}
+
+	/**
+	 * Pre-connection JITMs are disabled by default,
+	 * unless a filter is used.
+	 */
+	public function test_pre_connection_jitms_disabled() {
+		$this->mock_filters( array(
+			array( 'jetpack_pre_connection_prompt_helpers', false, false ),
+		), "Automattic\Jetpack\JITMS" );
+
+		$jitm = new Pre_Connection_JITM();
+		$this->assertEmpty( $jitm->get_messages( '/wp:edit-post:admin_notices/', '', false ) );
 
 		$this->clear_mock_filters();
 	}


### PR DESCRIPTION

Fixes #15802

#### Changes proposed in this Pull Request:

This is a follow-up from #15718. 

* add missing dependencies to `composer.json` so the package can properly be used by others.
* expand a bit on the initial docs so one can quickly see we now have 2 types of JITM.
* add a basic test to ensure we don't show the pre-connection messages to everyone by mistake.

#### Does this pull request change what data or activity we track or use?

* This does not make changes to privacy.

#### Testing instructions:

* Do the tests pass?

#### Proposed changelog entry for your changes:

* N/A
