### PR TITLE
VideoPress Block: Disable media placeholder for GB >= 8.1

### DIFF
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -5,6 +5,7 @@ import { Button } from '@wordpress/components';
 import { createBlobURL } from '@wordpress/blob';
 import { createBlock } from '@wordpress/blocks';
 import { mediaUpload } from '@wordpress/editor';
+import { useBlockEditContext } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +25,8 @@ import './editor.scss';
 
 const videoPressNoPlanMediaPlaceholder = createHigherOrderComponent(
 	OriginalPlaceholder => props => {
-		if ( ! props.className || props.className.indexOf( 'wp-block-video' ) === -1 ) {
+		const { name } = useBlockEditContext();
+		if ( name !== 'core/video' ) {
 			return <OriginalPlaceholder { ...props } />;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes part of #15796, and all of https://github.com/Automattic/wp-calypso/issues/42358 :smile: 

#### Changes proposed in this Pull Request:

Previously, the block's `className` was used to determine whether we were dealing with a `core/video` block. This stopped working with the advent of Gutenberg 8.1, where the `className` was no longer passed to the `editor.MediaPlaceholder` filter.

Thanks to a [tip](https://github.com/WordPress/gutenberg/pull/22028#issuecomment-632564313) by @youknowriad, we can use `useBlockEditContext` instead to determine the block's name :tada: 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Bugfix.

#### Does this pull request change what data or activity we track or use?
No.

#### Screenshots

(Ignore the width of the upgrade nudge, this is being fixed [elsewhere](https://github.com/Automattic/jetpack/pull/15883).)

##### Before

![image](https://user-images.githubusercontent.com/96308/82706376-ba5f3900-9c79-11ea-9d42-5fd59f65cd5a.png)

##### After

![image](https://user-images.githubusercontent.com/96308/82706643-67d24c80-9c7a-11ea-80ba-3f0601c27358.png)

##### With GB < 8.1 (unchanged)

![image](https://user-images.githubusercontent.com/96308/82706253-8126c900-9c79-11ea-87bd-5760699dada8.png)


#### Testing instructions:

(Not adding to `to-test.md` since these are kinda WP.com specific)

- Install and activate Gutenberg 8.1
- Check out this branch, and apply the following diff:
```diff
diff --git a/extensions/blocks/videopress/editor.js b/extensions/blocks/videopress/editor.js
index 989e927f3..f8302a870 100644
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -65,7 +65,7 @@ const addVideoPressSupport = ( settings, name ) => {
 	const { available, unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
 	// Check if VideoPress is unavailable and filter the mediaplaceholder to limit options
-	if ( isSimpleSite() && [ 'missing_plan', 'unknown' ].includes( unavailableReason ) ) {
+	if ( [ 'missing_plan', 'unknown' ].includes( unavailableReason ) ) {
 		addFilter( 'editor.MediaPlaceholder', 'jetpack/videopress', videoPressNoPlanMediaPlaceholder );
 		addFilter(
 			'editor.BlockListBlock',
@@ -158,22 +158,21 @@ const addVideoPressSupport = ( settings, name ) => {
 				reusable: false,
 			},
 
-			edit:
-				isSimpleSite() && [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-					? wrapPaidBlock( {
-							requiredPlan: 'value_bundle',
-							customTitle: {
-								knownPlan: __( 'Upgrade to %(planName)s to upload videos.', 'jetpack' ),
-								unknownPlan: __( 'Upgrade to a paid plan to upload videos.', 'jetpack' ),
-							},
-							customSubTitle: __(
-								'Upload unlimited videos to your website and \
+			edit: [ 'missing_plan', 'unknown' ].includes( unavailableReason )
+				? wrapPaidBlock( {
+						requiredPlan: 'value_bundle',
+						customTitle: {
+							knownPlan: __( 'Upgrade to %(planName)s to upload videos.', 'jetpack' ),
+							unknownPlan: __( 'Upgrade to a paid plan to upload videos.', 'jetpack' ),
+						},
+						customSubTitle: __(
+							'Upload unlimited videos to your website and \
 						display them using a fast, unbranded, \
 						customizable player.',
-								'jetpack'
-							),
-					  } )( withVideoPressEdit( edit ) )
-					: withVideoPressEdit( edit ),
+							'jetpack'
+						),
+				  } )( withVideoPressEdit( edit ) )
+				: withVideoPressEdit( edit ),
 
 			save: withVideoPressSave( save ),
 
```
- Run `yarn build-extensions`.
- Make sure you're on a free plan.
- Insert the 'Video' block.
- Make sure it looks like in the screenshot (media placeholder buttons).
- Disable Gutenberg 8.1, and verify that the block's media placeholder also looks as in the corresponding screenshot above.

#### Question

Do we need to disable the 'Insert from URL' button? AFAICS this wasn't disabled even prior to GB 8.1.

#### Proposed changelog entry for your changes:
VideoPress Block: Disable media placeholder for GB >= 8.1