### PR TITLE
Adds link to Backup & Scan into sidebar

### DIFF
--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -82,7 +82,7 @@ class Admin_Sidebar_Link {
 		}
 
 		// Check if VaultPress is active, the assumption there is that VaultPress is working.
-		// It has its own notice in the admin bar.
+		// It has its link the adminbar.
 		if ( class_exists( 'VaultPress' ) ) {
 			return false;
 		}

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -61,8 +61,10 @@ class Admin_Sidebar_Link {
 		$has_scan   = $this->has_scan();
 		$has_backup = $this->has_backup();
 
+		$url = Redirect::get_url( 'calypso-backups' );
 		if ( $has_scan && ! $has_backup ) {
 			$menu_label = __( 'Scan', 'jetpack' );
+			$url        = Redirect::get_url( 'calypso-scanner' );
 		} elseif ( ! $has_scan && $has_backup ) {
 			$menu_label = __( 'Backup', 'jetpack' );
 		} else {
@@ -73,7 +75,7 @@ class Admin_Sidebar_Link {
 		$new_link = array(
 			esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>',
 			'manage_options', // Check permissions here.
-			esc_url( Redirect::get_url( 'calypso-backups' ) ),
+			esc_url( $url ),
 		);
 
 		// Splice the nav menu item into the Jetpack nav.

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -87,7 +87,7 @@ class Admin_Sidebar_Link {
 
 		// Splice the nav menu item into the Jetpack nav.
 		global $submenu;
-		array_splice( $submenu['jetpack'], 1, 0, array( $new_link ) );
+		array_splice( $submenu['jetpack'], 2, 0, array( $new_link ) );
 	}
 
 	/**

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -69,7 +69,7 @@ class Admin_Sidebar_Link {
 
 		// Splice the nav menu item into the Jetpack nav.
 		global $submenu;
-		array_splice( $submenu['jetpack'], 2, 0, array( $new_link ) );
+		array_splice( $submenu['jetpack'], $this->get_link_offset(), 0, array( $new_link ) );
 	}
 
 	/**
@@ -98,6 +98,24 @@ class Admin_Sidebar_Link {
 			esc_url( $url ),
 		);
 
+	}
+
+	/**
+	 * We create a menu offset by counting all the pages that have a jetpack_admin_page set as the link.
+	 *
+	 * This makes it so that the highlight of the pages works as expected. When you click on the Setting or Dashboard.
+	 *
+	 * @return int Menu offset.
+	 */
+	private function get_link_offset() {
+		global $submenu;
+		$offset = 0;
+		foreach ( $submenu['jetpack'] as $link ) {
+			if ( 'jetpack_admin_page' !== $link[1] ) {
+				return $offset;
+			}
+			$offset++;
+		}
 	}
 
 	/**
@@ -170,3 +188,5 @@ class Admin_Sidebar_Link {
 		$this->schedule_refresh_checked = true;
 	}
 }
+
+

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -65,6 +65,19 @@ class Admin_Sidebar_Link {
 			return;
 		}
 
+		$new_link = $this->get_new_link();
+
+		// Splice the nav menu item into the Jetpack nav.
+		global $submenu;
+		array_splice( $submenu['jetpack'], 2, 0, array( $new_link ) );
+	}
+
+	/**
+	 * Retuns the new link.
+	 *
+	 *  @return array Link array to be added to the sidebar.
+	 */
+	private function get_new_link() {
 		$has_scan   = $this->has_scan();
 		$has_backup = $this->has_backup();
 
@@ -79,15 +92,12 @@ class Admin_Sidebar_Link {
 			$menu_label = __( 'Backup & Scan', 'jetpack' );
 		}
 
-		$new_link = array(
+		return array(
 			esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>',
 			'manage_options', // Check permissions here.
 			esc_url( $url ),
 		);
 
-		// Splice the nav menu item into the Jetpack nav.
-		global $submenu;
-		array_splice( $submenu['jetpack'], 2, 0, array( $new_link ) );
 	}
 
 	/**

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -22,11 +22,30 @@ class Admin_Sidebar_Link {
 	const SCHEDULE_ACTION_HOOK = 'jetpack_scan_refresh_states_event';
 
 	/**
-	 * Constructor.
+	 * The singleton instance of this class.
 	 *
+	 * @var Admin_Sidebar_Link
+	 */
+	protected static $instance;
+
+	/**
+	 * Get the singleton instance of the class.
+	 *
+	 * @return Admin_Sidebar_Link
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new Admin_Sidebar_Link();
+			self::$instance->init_hooks();
+		}
+
+		return self::$instance;
+	}
+
+	/**
 	 * Adds action hooks.
 	 */
-	public function __construct() {
+	public function init_hooks() {
 		add_action( 'jetpack_admin_menu', array( $this, 'maybe_add_admin_link' ), 99 );
 		add_action( self::SCHEDULE_ACTION_HOOK, array( $this, 'refresh_state_cache' ) );
 	}
@@ -75,7 +94,7 @@ class Admin_Sidebar_Link {
 	 *
 	 * @return boolean
 	 */
-	protected function should_show_link() {
+	private function should_show_link() {
 		// Jetpack Scan/Backup is currently not supported on multisite.
 		if ( is_multisite() ) {
 			return false;
@@ -95,7 +114,7 @@ class Admin_Sidebar_Link {
 	 *
 	 * @return boolean
 	 */
-	protected function has_scan() {
+	private function has_scan() {
 		$this->maybe_refresh_transient_cache();
 		$scan_state = get_transient( 'jetpack_scan_state' );
 		return ! $scan_state || 'unavailable' !== $scan_state->state;
@@ -106,7 +125,7 @@ class Admin_Sidebar_Link {
 	 *
 	 * @return boolean
 	 */
-	protected function has_backup() {
+	private function has_backup() {
 		$this->maybe_refresh_transient_cache();
 		$rewind_state = get_transient( 'jetpack_rewind_state' );
 		return ! $rewind_state || 'unavailable' !== $rewind_state->state;
@@ -115,7 +134,8 @@ class Admin_Sidebar_Link {
 	/**
 	 * Triggers a cron job to refresh the Scan and Rewind state cache.
 	 */
-	protected function maybe_refresh_transient_cache() {
+	private function maybe_refresh_transient_cache() {
+
 		if ( false !== get_transient( 'jetpack_scan_state' ) && false !== get_transient( 'jetpack_rewind_state' ) ) {
 			return;
 		}

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -149,7 +149,7 @@ class Admin_Sidebar_Link {
 		}
 
 		// Do we have a jetpack_scan and jetpack_rewind state set?
-		if ( false !== get_transient( 'jetpack_scan_state' ) && false !== get_transient( 'jetpack_rewind_state' ) ) {
+		if ( get_transient( 'jetpack_scan_state' ) && get_transient( 'jetpack_rewind_state' ) ) {
 			return;
 		}
 

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * A class that adds a scan and backup link to the admin sidebar.
+ *
+ * @package automattic/jetpack
+ */
+
+namespace Automattic\Jetpack\Scan;
+
+use Automattic\Jetpack\Redirect;
+use Jetpack_Core_Json_Api_Endpoints;
+
+/**
+ * Class Main
+ *
+ * Responsible for showing the link if available.
+ *
+ * @package Automattic\Jetpack\Scan
+ */
+class Admin_Sidebar_Link {
+
+	const SCHEDULE_ACTION_HOOK = 'jetpack_scan_refresh_states_event';
+
+	/**
+	 * Constructor.
+	 *
+	 * Adds action hooks.
+	 */
+	public function __construct() {
+		add_action( 'jetpack_admin_menu', array( $this, 'maybe_add_admin_link' ), 99 );
+		add_action( self::SCHEDULE_ACTION_HOOK, array( $this, 'refresh_state_cache' ) );
+	}
+
+	/**
+	 * Adds a link to the Scan and Backup page.
+	 */
+	public function maybe_add_admin_link() {
+		if ( ! $this->should_show_link() ) {
+			return;
+		}
+
+		$has_scan   = $this->has_scan();
+		$has_backup = $this->has_backup();
+
+		if ( $has_scan && ! $has_backup ) {
+			$menu_label = __( 'Scan', 'jetpack' );
+		} elseif ( ! $has_scan && $has_backup ) {
+			$menu_label = __( 'Backup', 'jetpack' );
+		} else {
+			// Will be both, as the code won't get this far if neither is true.
+			$menu_label = __( 'Backup & Scan', 'jetpack' );
+		}
+
+		$new_link = array(
+			esc_html( $menu_label ) . ' <span class="dashicons dashicons-external"></span>',
+			'manage_options', // Check permissions here.
+			esc_url( Redirect::get_url( 'calypso-backups' ) ),
+		);
+
+		// Splice the nav menu item into the Jetpack nav.
+		global $submenu;
+		array_splice( $submenu['jetpack'], 1, 0, array( $new_link ) );
+	}
+
+	/**
+	 * Refreshes the state cache via API call. Called via cron.
+	 */
+	public function refresh_state_cache() {
+		Jetpack_Core_Json_Api_Endpoints::get_scan_state();
+		Jetpack_Core_Json_Api_Endpoints::get_rewind_data();
+	}
+
+	/**
+	 * Returns true if the link should appear.
+	 *
+	 * @return boolean
+	 */
+	protected function should_show_link() {
+		// Jetpack Scan/Backup is currently not supported on multisite.
+		if ( is_multisite() ) {
+			return false;
+		}
+
+		// Check if VaultPress is active, the assumption there is that VaultPress is working.
+		// It has its own notice in the admin bar.
+		if ( class_exists( 'VaultPress' ) ) {
+			return false;
+		}
+
+		return $this->has_backup() || $this->has_scan();
+	}
+
+	/**
+	 * Detects if Scan is enabled.
+	 *
+	 * @return boolean
+	 */
+	protected function has_scan() {
+		$this->maybe_refresh_transient_cache();
+		$scan_state = get_transient( 'jetpack_scan_state' );
+		return ! $scan_state || 'unavailable' !== $scan_state->state;
+	}
+
+	/**
+	 * Detects if Backup is enabled.
+	 *
+	 * @return boolean
+	 */
+	protected function has_backup() {
+		$this->maybe_refresh_transient_cache();
+		$rewind_state = get_transient( 'jetpack_rewind_state' );
+		return ! $rewind_state || 'unavailable' !== $rewind_state->state;
+	}
+
+	/**
+	 * Triggers a cron job to refresh the Scan and Rewind state cache.
+	 */
+	protected function maybe_refresh_transient_cache() {
+		if ( false !== get_transient( 'jetpack_scan_state' ) && false !== get_transient( 'jetpack_rewind_state' ) ) {
+			return;
+		}
+
+		if ( false === wp_next_scheduled( self::SCHEDULE_ACTION_HOOK ) ) {
+			wp_schedule_single_event( time(), self::SCHEDULE_ACTION_HOOK );
+		}
+	}
+}

--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -29,6 +29,13 @@ class Admin_Sidebar_Link {
 	protected static $instance;
 
 	/**
+	 * Used to check if we need to schedule the refresh or we need to do it.
+	 *
+	 * @var boolean | null
+	 */
+	private $schedule_refresh_checked;
+
+	/**
 	 * Get the singleton instance of the class.
 	 *
 	 * @return Admin_Sidebar_Link
@@ -137,7 +144,11 @@ class Admin_Sidebar_Link {
 	 * Triggers a cron job to refresh the Scan and Rewind state cache.
 	 */
 	private function maybe_refresh_transient_cache() {
+		if ( $this->schedule_refresh_checked ) {
+			return;
+		}
 
+		// Do we have a jetpack_scan and jetpack_rewind state set?
 		if ( false !== get_transient( 'jetpack_scan_state' ) && false !== get_transient( 'jetpack_rewind_state' ) ) {
 			return;
 		}
@@ -145,5 +156,7 @@ class Admin_Sidebar_Link {
 		if ( false === wp_next_scheduled( self::SCHEDULE_ACTION_HOOK ) ) {
 			wp_schedule_single_event( time(), self::SCHEDULE_ACTION_HOOK );
 		}
+
+		$this->schedule_refresh_checked = true;
 	}
 }

--- a/modules/scan/scan.php
+++ b/modules/scan/scan.php
@@ -9,5 +9,7 @@
 namespace Automattic\Jetpack\Scan;
 
 require_once 'class-admin-bar-notice.php';
+require_once 'class-admin-sidebar-link.php';
 
 Admin_Bar_Notice::instance();
+new Admin_Sidebar_Link();

--- a/modules/scan/scan.php
+++ b/modules/scan/scan.php
@@ -12,4 +12,4 @@ require_once 'class-admin-bar-notice.php';
 require_once 'class-admin-sidebar-link.php';
 
 Admin_Bar_Notice::instance();
-new Admin_Sidebar_Link();
+Admin_Sidebar_Link::instance();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 1169345694087188-as-1164157450632310.

#### Changes proposed in this Pull Request
<!--- Explain what functional changes your PR includes -->
* Adds a new class that inserts an external link to the sidebar under the Jetpack category.
* Class checks cache for Scan and Backup state, refreshing via cron if either cache is empty.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Part of Backup & Scan features.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* It tracks users going to their backups dashboard.

#### Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that the context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Visit admin on a site with a valid product (see below) as an admin.
* View link to Backup and Scan.
* Click the link.

##### Valid Products
* Backup
* Scan
* Personal with Rewind enabled (just backups)
* Premium or Pro with Rewind enabled (backup & scan)

#### Screenshot
<img width="158" alt="Screen Shot 2020-05-22 at 4 05 16 PM" src="https://user-images.githubusercontent.com/1760168/82706038-cda4e100-9c46-11ea-81af-f4378d057303.png">

#### Proposed changelog entry for your changes
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Backup & Scan: Adds a link to access your backups easily from the admin.
