### PR TITLE
PHPCS: Allow auto-fixing of translation functions with no text domain to 'jetpack'

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -29,6 +29,13 @@
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack" />
+		</properties>
+	</rule>
+
 	<!-- Check all PHP files in directory tree by default. -->
 	<arg name="extensions" value="php"/>
 	<file>.</file>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Including a "fixable" sniff if a translation function is included without a textdomain. Previously, this would error without an option to auto-fix, but let's be opinionated.

Open question -- Did we ever make a decision about what to do with packages that will require translatable strings on how we'd handle the textdomain?

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* On this branch, make a change to a php file to add a line with a translating function without a textdomain, e.g. `$something = __( 'something' );` (it is helpful to do to a file that is otherwise error-free, like 3rd-party/3rd-party.php.
* Run `vendor/bin/phpcs path-to-that-file`
* Should see two errors, both reporting that the text domain is missing. One of them is autofixable.
* Run `vendor/bin/phpcbf path-to-file.
* See the line now is `$something = __( 'something', 'jetpack' );`
* Same as above, but add a line with the wrong textdomain. (e.g. `__( 'something', 'test' );`).
* Run PHPCS. See an error for the wrong text domain.

Since we are not passing any "old" textdomains to the config, this is not auto-fixable. That's expected. It will still throw an error for the mismatch.

Note: I ran this over the codebase and no instances of no textdomain was found. Since it already has errored, this would normally be caught during `phpcs-changed`, but for files on the whitelist, this would auto-correct. It also lets developers fix it faster in the command line vs needing to find the specific line.

#### Proposed changelog entry for your changes:
* n/a
