### PR TITLE
Jetpack Setup Wizard: Add Tracks events

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/index.jsx
+++ b/_inc/client/setup-wizard/feature-toggle/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import analytics from 'lib/analytics';
 
 import {
 	mapStateToFeatureToggleProps,
@@ -23,6 +24,7 @@ import './style.scss';
 
 let FeatureToggle = props => {
 	const {
+		feature,
 		title,
 		details,
 		info,
@@ -52,13 +54,40 @@ let FeatureToggle = props => {
 	const onToggleChange = useCallback( () => {
 		if ( 'function' === typeof props.onToggleChange ) {
 			props.onToggleChange( checked );
+			analytics.tracks.recordEvent( 'jetpack_wizard_feature_toggled', {
+				feature,
+				newValue: ! checked,
+			} );
 		}
 	}, [ checked, props.onToggleChange ] );
+
+	const onUpgradeButtonClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_feature_upgrade', {
+			feature,
+		} );
+	}, [ feature ] );
+
+	const onConfigureButtonClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_feature_configure', {
+			feature,
+		} );
+	}, [ feature ] );
+
+	const onViewOptionsClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_feature_view_options', {
+			feature,
+		} );
+	}, [ feature ] );
 
 	let buttonContent;
 	if ( ! checked && upgradeLink ) {
 		buttonContent = (
-			<Button href={ upgradeLink } primary target={ isButtonLinkExternal ? '_blank' : '' }>
+			<Button
+				href={ upgradeLink }
+				primary
+				target={ isButtonLinkExternal ? '_blank' : '' }
+				onClick={ onUpgradeButtonClick }
+			>
 				{ __( 'Upgrade now' ) }
 				{ isButtonLinkExternal && (
 					<span>
@@ -69,7 +98,11 @@ let FeatureToggle = props => {
 		);
 	} else if ( configureLink ) {
 		buttonContent = (
-			<Button href={ configureLink } target={ isButtonLinkExternal ? '_blank' : '' }>
+			<Button
+				href={ configureLink }
+				target={ isButtonLinkExternal ? '_blank' : '' }
+				onClick={ onConfigureButtonClick }
+			>
 				{ __( 'Configure' ) }
 				{ isButtonLinkExternal && (
 					<span>
@@ -99,6 +132,7 @@ let FeatureToggle = props => {
 				href={ optionsLink }
 				className="jp-setup-wizard-view-options-link"
 				{ ...externalLinkProps }
+				onClick={ onViewOptionsClick }
 			>
 				{ __( 'View options' ) }
 				{ isOptionsLinkExternal && <Gridicon icon="external" size="18" /> }
@@ -147,6 +181,7 @@ let FeatureToggle = props => {
 };
 
 FeatureToggle.propTypes = {
+	feature: PropTypes.string.isRequired,
 	title: PropTypes.string.isRequired,
 	details: PropTypes.string.isRequired,
 	info: PropTypes.string,

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -40,6 +40,7 @@ const features = {
 			}
 
 			return {
+				feature: 'ads',
 				title: __( 'Ads' ),
 				details: __( 'Generate income with high-quality ads.' ),
 				checked: getSetting( state, 'wordads' ),
@@ -85,6 +86,7 @@ const features = {
 			}
 
 			return {
+				feature: 'anti-spam',
 				title: __( 'Anti-spam' ),
 				details: __( 'No more approving or vetting.' ),
 				checked: true === isAkismetKeyValid( state ),
@@ -135,6 +137,7 @@ const features = {
 			}
 
 			return {
+				feature: 'backups',
 				title: __( 'Daily or Real-time backups' ),
 				details: __( 'Get time travel for your site with Jetpack Backup.' ),
 				checked: backupsActive,
@@ -150,6 +153,7 @@ const features = {
 	'beautiful-math': {
 		mapStateToProps: state => {
 			return {
+				feature: 'beautiful-math',
 				title: __( 'Beautiful math' ),
 				details: __( 'Display math and formulas beautifully.' ),
 				checked: getSetting( state, 'latex' ),
@@ -168,6 +172,7 @@ const features = {
 	'brute-force-protect': {
 		mapStateToProps: state => {
 			return {
+				feature: 'brute-force-protect',
 				title: __( 'Brute force protection' ),
 				details: __( 'Stop malicious login attempts.' ),
 				checked: getSetting( state, 'protect' ),
@@ -186,6 +191,7 @@ const features = {
 	carousel: {
 		mapStateToProps: state => {
 			return {
+				feature: 'carousel',
 				title: __( 'Carousel' ),
 				details: __(
 					'Create full-screen carousel slideshows for the images in your posts and pages.'
@@ -206,6 +212,7 @@ const features = {
 	'comment-likes': {
 		mapStateToProps: state => {
 			return {
+				feature: 'comment-likes',
 				title: __( 'Comment Likes' ),
 				details: __( 'Increase engagement with liking on comments.' ),
 				checked: getSetting( state, 'comment-likes' ),
@@ -225,6 +232,7 @@ const features = {
 	comments: {
 		mapStateToProps: state => {
 			return {
+				feature: 'comments',
 				title: __( 'Comments' ),
 				details: __( 'An enhanced comments section with better verfiication.' ),
 				checked: getSetting( state, 'comments' ),
@@ -243,6 +251,7 @@ const features = {
 	'contact-form': {
 		mapStateToProps: state => {
 			return {
+				feature: 'contact-form',
 				title: __( 'Contact Form' ),
 				details: __( 'Gutenberg ready forms!' ),
 				checked: getSetting( state, 'contact-form' ),
@@ -261,6 +270,7 @@ const features = {
 	'copy-post': {
 		mapStateToProps: state => {
 			return {
+				feature: 'copy-post',
 				title: __( 'Copy Post' ),
 				details: __( 'Simply duplicate content.' ),
 				checked: getSetting( state, 'copy-post' ),
@@ -279,6 +289,7 @@ const features = {
 	'custom-css': {
 		mapStateToProps: state => {
 			return {
+				feature: 'custom-css',
 				title: __( 'Custom CSS' ),
 				details: __( 'Enable an enhanced CSS customization panel.' ),
 				checked: getSetting( state, 'custom-css' ),
@@ -297,6 +308,7 @@ const features = {
 	'enhanced-distribution': {
 		mapStateToProps: state => {
 			return {
+				feature: 'enhanced-distribution',
 				title: __( 'Enhanced Distribution' ),
 				details: __( 'Increase reach and traffic.' ),
 				checked: getSetting( state, 'enhanced-distribution' ),
@@ -315,6 +327,7 @@ const features = {
 	'extra-sidebar-widgets': {
 		mapStateToProps: state => {
 			return {
+				feature: 'extra-sidebar-widgets',
 				title: __( 'Extra Sidebar Widgets' ),
 				details: __( 'Add more widgets.' ),
 				checked: getSetting( state, 'widgets' ),
@@ -350,6 +363,7 @@ const features = {
 			}
 
 			return {
+				feature: 'google-analytics',
 				title: __( 'Google Analytics' ),
 				details: __( 'Add your Google Analytics account.' ),
 				checked: getSetting( state, 'google-analytics' ),
@@ -371,6 +385,7 @@ const features = {
 	'gravatar-hovercards': {
 		mapStateToProps: state => {
 			return {
+				feature: 'gravatar-hovercards',
 				title: __( 'Gravatar Hovercards' ),
 				details: __( 'Give comments life.' ),
 				checked: getSetting( state, 'gravatar-hovercards' ),
@@ -389,6 +404,7 @@ const features = {
 	'infinite-scroll': {
 		mapStateToProps: state => {
 			return {
+				feature: 'infinite-scroll',
 				title: __( 'Infinite Scroll' ),
 				details: __(
 					'Create a smooth, uninterrupted reading experience by loading more content as visitors scroll to the bottom of your archive pages.'
@@ -412,6 +428,7 @@ const features = {
 	'json-api': {
 		mapStateToProps: state => {
 			return {
+				feature: 'json-api',
 				title: __( 'JSON API' ),
 				details: __( 'JSON API access for developers.' ),
 				checked: getSetting( state, 'json-api' ),
@@ -430,6 +447,7 @@ const features = {
 	'lazy-images': {
 		mapStateToProps: state => {
 			return {
+				feature: 'lazy-images',
 				title: __( 'Lazy Loading Images' ),
 				details: __( 'Further improve site speed and only load images visitors need.' ),
 				checked: getSetting( state, 'lazy-images' ),
@@ -448,6 +466,7 @@ const features = {
 	likes: {
 		mapStateToProps: state => {
 			return {
+				feature: 'likes',
 				title: __( 'Likes' ),
 				details: __( 'Add a like button to your posts.' ),
 				checked: getSetting( state, 'likes' ),
@@ -466,6 +485,7 @@ const features = {
 	markdown: {
 		mapStateToProps: state => {
 			return {
+				feature: 'markdown',
 				title: __( 'Markdown' ),
 				details: __( 'Write faster rich-text.' ),
 				checked: getSetting( state, 'markdown' ),
@@ -484,6 +504,7 @@ const features = {
 	masterbar: {
 		mapStateToProps: state => {
 			return {
+				feature: 'masterbar',
 				title: __( 'WordPress.com Toolbar' ),
 				details: __( 'The WordPress.com toolbar replaces the default WordPress admin toolbar.' ),
 				checked: getSetting( state, 'masterbar' ),
@@ -502,6 +523,7 @@ const features = {
 	monitor: {
 		mapStateToProps: state => {
 			return {
+				feature: 'monitor',
 				title: __( 'Downtime Monitoring' ),
 				details: __( 'Get an alert immediately if your site goes down.' ),
 				checked: getSetting( state, 'monitor' ),
@@ -520,6 +542,7 @@ const features = {
 	notifications: {
 		mapStateToProps: state => {
 			return {
+				feature: 'notifications',
 				title: __( 'Notifications' ),
 				details: __( 'Stay up-to-date with your site.' ),
 				checked: getSetting( state, 'notes' ),
@@ -538,6 +561,7 @@ const features = {
 	portfolio: {
 		mapStateToProps: state => {
 			return {
+				feature: 'portfolio',
 				title: __( 'Portfolio: Custom content types' ),
 				details: __( 'Use portfolios on your site to showcase your best work.' ),
 				checked: getSetting( state, 'jetpack_portfolio' ),
@@ -566,6 +590,7 @@ const features = {
 	'post-by-email': {
 		mapStateToProps: state => {
 			return {
+				feature: 'post-by-email',
 				title: __( 'Post by email' ),
 				details: __(
 					'Post by email is a quick way to publish new posts without visiting your site.'
@@ -588,6 +613,7 @@ const features = {
 			const siteRawUrl = getSiteRawUrl( state );
 
 			return {
+				feature: 'publicize',
 				title: __( 'Publicize' ),
 				details: __( 'Automaticaly share content on your favorite social media accounts.' ),
 				checked: getSetting( state, 'publicize' ),
@@ -607,6 +633,7 @@ const features = {
 	'related-posts': {
 		mapStateToProps: state => {
 			return {
+				feature: 'related-posts',
 				title: __( 'Related posts' ),
 				details: __(
 					'Keep your visitors engaged with related content at the bottom of each post.'
@@ -653,6 +680,7 @@ const features = {
 			}
 
 			return {
+				feature: 'scan',
 				title: __( 'Security scanning' ),
 				details: __( 'Stop threats to keep your website safe.' ),
 				checked: isScanEnabled,
@@ -680,6 +708,7 @@ const features = {
 			}
 
 			return {
+				feature: 'search',
 				title: __( 'Search' ),
 				details: __(
 					'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
@@ -702,6 +731,7 @@ const features = {
 	sso: {
 		mapStateToProps: state => {
 			return {
+				feature: 'sso',
 				title: __( 'Secure Sign On' ),
 				details: __( 'Add an extra layer of security.' ),
 				checked: getSetting( state, 'sso' ),
@@ -735,6 +765,7 @@ const features = {
 			}
 
 			return {
+				feature: 'seo',
 				title: __( 'SEO' ),
 				details: __( 'Take control of the way search engines represent your site.' ),
 				checked: getSetting( state, 'seo-tools' ),
@@ -755,6 +786,7 @@ const features = {
 	sitemaps: {
 		mapStateToProps: state => {
 			return {
+				feature: 'sitemaps',
 				title: __( 'Sitemaps' ),
 				details: __( 'Automatically generate sitemaps for all your content.' ),
 				checked: getSetting( state, 'sitemaps' ),
@@ -773,6 +805,7 @@ const features = {
 	sharing: {
 		mapStateToProps: state => {
 			return {
+				feature: 'sharing',
 				title: __( 'Sharing' ),
 				details: __( 'Increase sharing of your posts and pages. ' ),
 				checked: getSetting( state, 'sharedaddy' ),
@@ -791,6 +824,7 @@ const features = {
 	shortcodes: {
 		mapStateToProps: state => {
 			return {
+				feature: 'shortcodes',
 				title: __( 'Shortcode Embeds' ),
 				details: __( 'Embed YouTube videos, and other content easily.' ),
 				checked: getSetting( state, 'shortcodes' ),
@@ -809,6 +843,7 @@ const features = {
 	shortlinks: {
 		mapStateToProps: state => {
 			return {
+				feature: 'shortlinks',
 				title: __( 'WP.me Shortlinks' ),
 				details: __( 'Build quick links for sharing.' ),
 				checked: getSetting( state, 'shortlinks' ),
@@ -846,6 +881,7 @@ const features = {
 			}
 
 			return {
+				feature: 'simple-payments-block',
 				title: __( 'Simple Payments Block' ),
 				details: __( 'A simple way to accept payments.' ),
 				checked: inCurrentPlan,
@@ -862,6 +898,7 @@ const features = {
 	'site-accelerator': {
 		mapStateToProps: state => {
 			return {
+				feature: 'site-accelerator',
 				title: __( 'Site Accelerator' ),
 				details: __( 'Enable for faster images and a faster site.' ),
 				checked: getSetting( state, 'photon' ) && getSetting( state, 'photon-cdn' ),
@@ -882,6 +919,7 @@ const features = {
 	'site-stats': {
 		mapStateToProps: state => {
 			return {
+				feature: 'site-stats',
 				title: __( 'Site Stats' ),
 				details: __( 'Track your site visitors and learn about your most popular content.' ),
 				checked: getSetting( state, 'stats' ),
@@ -900,6 +938,7 @@ const features = {
 	'site-verification': {
 		mapStateToProps: state => {
 			return {
+				feature: 'site-verification',
 				title: __( 'Site verification' ),
 				details: __( 'Verify your site with Google, Bing, Yandex, and Pinterest.' ),
 				checked: getSetting( state, 'verification-tools' ),
@@ -918,6 +957,7 @@ const features = {
 	subscriptions: {
 		mapStateToProps: state => {
 			return {
+				feature: 'subscriptions',
 				title: __( 'Subscriptions' ),
 				details: __( 'Send post notifications to your visitors.' ),
 				checked: getSetting( state, 'subscriptions' ),
@@ -936,6 +976,7 @@ const features = {
 	testimonials: {
 		mapStateToProps: state => {
 			return {
+				feature: 'testimonials',
 				title: __( 'Testimonial: Custom content type' ),
 				details: __( 'Add testimonials to your website to attract new customers.' ),
 				checked: getSetting( state, 'jetpack_testimonial' ),
@@ -965,6 +1006,7 @@ const features = {
 	'tiled-galleries': {
 		mapStateToProps: state => {
 			return {
+				feature: 'tiled-galleries',
 				title: __( 'Tiled Galleries' ),
 				details: 'Add beautifully laid out galleries as a Gutenberg block',
 				checked: getSetting( state, 'tiled-gallery' ),
@@ -1001,6 +1043,7 @@ const features = {
 			}
 
 			return {
+				feature: 'videopress',
 				title: __( 'VideoPress' ),
 				details: __( 'Host fast, high-quality, ad-free video.' ),
 				checked: getSetting( state, 'videopress' ),
@@ -1022,6 +1065,7 @@ const features = {
 	'widget-visibility': {
 		mapStateToProps: state => {
 			return {
+				feature: 'widget-visibility',
 				title: __( 'Widget Visibility' ),
 				details: __( 'Control your widgets at the post or page level.' ),
 				checked: getSetting( state, 'widget-visibility' ),

--- a/_inc/client/setup-wizard/income-question/index.jsx
+++ b/_inc/client/setup-wizard/income-question/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
@@ -12,11 +12,16 @@ import { translate as __ } from 'i18n-calypso';
 import { ChecklistAnswer } from '../checklist-answer';
 import Button from 'components/button';
 import { imagePath } from 'constants/urls';
+import analytics from 'lib/analytics';
 import { saveSetupWizardQuestionnnaire } from 'state/setup-wizard';
 
 import './style.scss';
 
 let IncomeQuestion = props => {
+	useEffect( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_page_view', { step: 'income-page' } );
+	}, [] );
+
 	return (
 		<div className="jp-setup-wizard-main">
 			<img

--- a/_inc/client/setup-wizard/intro-page/index.jsx
+++ b/_inc/client/setup-wizard/intro-page/index.jsx
@@ -24,12 +24,26 @@ let IntroPage = props => {
 	const onPersonalButtonClick = useCallback( () => {
 		props.updateSiteUseQuestion( { use: 'personal' } );
 		props.saveQuestionnaire();
-	} );
+		analytics.tracks.recordEvent( 'jetpack_wizard_question_answered', {
+			question: 'use',
+			answer: 'personal',
+		} );
+	}, [] );
 
 	const onBusinessButtonClick = useCallback( () => {
 		props.updateSiteUseQuestion( { use: 'business' } );
 		props.saveQuestionnaire();
-	} );
+		analytics.tracks.recordEvent( 'jetpack_wizard_question_answered', {
+			question: 'use',
+			answer: 'business',
+		} );
+	}, [] );
+
+	const onSkipLinkClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_setup_wizard_question_skipped', {
+			question: 'use',
+		} );
+	}, [] );
 
 	return (
 		<div className="jp-setup-wizard-main">
@@ -72,7 +86,11 @@ let IntroPage = props => {
 						{ __( 'Business Use' ) }
 					</Button>
 				</div>
-				<a className="jp-setup-wizard-skip-link" href="#/setup/features">
+				<a
+					className="jp-setup-wizard-skip-link"
+					href="#/setup/features"
+					onClick={ onSkipLinkClick }
+				>
 					{ __( 'Skip to recommended features' ) }
 				</a>
 			</div>

--- a/_inc/client/setup-wizard/intro-page/index.jsx
+++ b/_inc/client/setup-wizard/intro-page/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 
@@ -11,11 +11,16 @@ import { translate as __ } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { imagePath } from 'constants/urls';
+import analytics from 'lib/analytics';
 import { saveSetupWizardQuestionnnaire, updateSetupWizardQuestionnaire } from 'state/setup-wizard';
 
 import './style.scss';
 
 let IntroPage = props => {
+	useEffect( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_page_view', { step: 'intro-page' } );
+	}, [] );
+
 	const onPersonalButtonClick = useCallback( () => {
 		props.updateSiteUseQuestion( { use: 'personal' } );
 		props.saveQuestionnaire();

--- a/_inc/client/setup-wizard/recommended-features/index.jsx
+++ b/_inc/client/setup-wizard/recommended-features/index.jsx
@@ -12,6 +12,7 @@ import { FeatureToggleGroup } from '../feature-toggle-group';
 import { recommendedFeatureGroups } from '../feature-toggle-group/content';
 import Button from 'components/button';
 import { imagePath } from 'constants/urls';
+import analytics from 'lib/analytics';
 import { fetchSettings, isFetchingSettingsList } from 'state/settings';
 
 import './style.scss';
@@ -21,6 +22,7 @@ class RecommendedFeatures extends Component {
 		if ( ! this.props.isFetchingSettingsList ) {
 			this.props.fetchSettings();
 		}
+		analytics.tracks.recordEvent( 'jetpack_wizard_page_view', { step: 'features-page' } );
 	}
 
 	render() {

--- a/_inc/client/setup-wizard/recommended-features/index.jsx
+++ b/_inc/client/setup-wizard/recommended-features/index.jsx
@@ -18,12 +18,20 @@ import { fetchSettings, isFetchingSettingsList } from 'state/settings';
 import './style.scss';
 
 class RecommendedFeatures extends Component {
-	componentDidMount() {
+	componentDidMount = () => {
 		if ( ! this.props.isFetchingSettingsList ) {
 			this.props.fetchSettings();
 		}
 		analytics.tracks.recordEvent( 'jetpack_wizard_page_view', { step: 'features-page' } );
-	}
+	};
+
+	onDoneButtonClick = () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_features_done' );
+	};
+
+	onExploreMoreButtonClick = () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_features_explore_more' );
+	};
 
 	render() {
 		return (
@@ -51,10 +59,12 @@ class RecommendedFeatures extends Component {
 					);
 				} ) }
 				<div className="jp-setup-wizard-recommended-features-buttons-container">
-					<Button primary href="#/dashboard">
+					<Button primary href="#/dashboard" onClick={ this.onDoneButtonClick }>
 						{ __( 'I’m done for now' ) }
 					</Button>
-					<Button href="#/settings">{ __( 'Explore more features' ) }</Button>
+					<Button href="#/settings" onClick={ this.onExploreMoreButtonClick }>
+						{ __( 'Explore more features' ) }
+					</Button>
 				</div>
 			</div>
 		);

--- a/_inc/client/setup-wizard/updates-question/index.jsx
+++ b/_inc/client/setup-wizard/updates-question/index.jsx
@@ -23,12 +23,26 @@ let UpdatesQuestion = props => {
 	const onYesButtonClick = useCallback( () => {
 		props.updateUpdatesQuestion( { 'site-updates': true } );
 		props.saveQuestionnaire();
-	} );
+		analytics.tracks.recordEvent( 'jetpack_wizard_question_answered', {
+			question: 'updates',
+			answer: 'yes',
+		} );
+	}, [] );
 
 	const onNoButtonClick = useCallback( () => {
 		props.updateUpdatesQuestion( { 'site-updates': false } );
 		props.saveQuestionnaire();
-	} );
+		analytics.tracks.recordEvent( 'jetpack_wizard_question_answered', {
+			question: 'updates',
+			answer: 'no',
+		} );
+	}, [] );
+
+	const onSkipLinkClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_setup_wizard_question_skipped', {
+			question: 'updates',
+		} );
+	}, [] );
 
 	return (
 		<div className="jp-setup-wizard-main jp-setup-wizard-updates-main">
@@ -58,7 +72,7 @@ let UpdatesQuestion = props => {
 					{ __( 'No' ) }
 				</Button>
 			</div>
-			<a className="jp-setup-wizard-skip-link" href="#/setup/features">
+			<a className="jp-setup-wizard-skip-link" href="#/setup/features" onClick={ onSkipLinkClick }>
 				{ __( 'Skip' ) }
 			</a>
 		</div>

--- a/_inc/client/setup-wizard/updates-question/index.jsx
+++ b/_inc/client/setup-wizard/updates-question/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
 
@@ -10,11 +10,16 @@ import { translate as __ } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { imagePath } from 'constants/urls';
+import analytics from 'lib/analytics';
 import { saveSetupWizardQuestionnnaire, updateSetupWizardQuestionnaire } from 'state/setup-wizard';
 
 import './style.scss';
 
 let UpdatesQuestion = props => {
+	useEffect( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_page_view', { step: 'updates-page' } );
+	}, [] );
+
 	const onYesButtonClick = useCallback( () => {
 		props.updateUpdatesQuestion( { 'site-updates': true } );
 		props.saveQuestionnaire();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds Tracks events to the Setup Wizard.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Project: p1HpG7-8BF-p2
Design: pbtFPC-ol-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to the end of wp-config.php: add_filter( 'jetpack_show_setup_wizard', '__return_true' );
2. Visit `/wp-admin/admin.php?page=jetpack#/setup`.
3. Advance through the flow, verifying that each possible action sends an appropriate Tracks event. The easiest way to check this is to search for `t.gif` in the Network tools.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed, should be one entry for entire Setup Wizard.
