### PR TITLE
Recurring Payments: Replace submit button

### DIFF
--- a/extensions/blocks/recurring-payments/deprecated/v1/index.js
+++ b/extensions/blocks/recurring-payments/deprecated/v1/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, pick, some } from 'lodash';
+import { isEmpty, omit, pick, some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -65,6 +65,7 @@ export default {
 
 		return [ newAttributes, newInnerBlocks ];
 	},
-	isEligible: attributes => some( pick( attributes, deprecatedAttributes ), Boolean ),
+	isEligible: ( attributes, innerBlocks ) =>
+		isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ),
 	save: () => null,
 };

--- a/extensions/blocks/recurring-payments/deprecated/v1/index.js
+++ b/extensions/blocks/recurring-payments/deprecated/v1/index.js
@@ -58,6 +58,7 @@ export default {
 		const newInnerBlocks = [
 			createBlock( 'jetpack/button', {
 				element: 'a',
+				uniqueId: 'recurring-payments-id',
 				...buttonAttributes,
 			} ),
 		];

--- a/extensions/blocks/recurring-payments/deprecated/v1/index.js
+++ b/extensions/blocks/recurring-payments/deprecated/v1/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { omit, pick, some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const deprecatedAttributes = [
+	'submitButtonText',
+	'submitButtonClasses',
+	'backgroundButtonColor',
+	'textButtonColor',
+	'customBackgroundButtonColor',
+	'customTextButtonColor',
+];
+
+const migrateAttributes = oldAttributes => ( {
+	text: oldAttributes.submitButtonText,
+	textColor: oldAttributes.textButtonColor,
+	customTextColor: oldAttributes.customTextButtonColor,
+	backgroundColor: oldAttributes.backgroundButtonColor,
+	customBackgroundColor: oldAttributes.customBackgroundButtonColor,
+} );
+
+export default {
+	attributes: {
+		planId: {
+			type: 'integer',
+		},
+		submitButtonText: {
+			type: 'string',
+		},
+		submitButtonClasses: {
+			type: 'string',
+		},
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
+		customBackgroundButtonColor: {
+			type: 'string',
+		},
+		customTextButtonColor: {
+			type: 'string',
+		},
+		align: {
+			type: 'string',
+		},
+	},
+	migrate: attributes => {
+		const newAttributes = omit( attributes, deprecatedAttributes );
+		const buttonAttributes = migrateAttributes( attributes );
+		const newInnerBlocks = [
+			createBlock( 'jetpack/button', {
+				element: 'a',
+				...buttonAttributes,
+			} ),
+		];
+
+		return [ newAttributes, newInnerBlocks ];
+	},
+	isEligible: attributes => some( pick( attributes, deprecatedAttributes ), Boolean ),
+	save: () => null,
+};

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import SubmitButton from '../../shared/submit-button';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
-import { pick } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
 import { addQueryArgs, getQueryArg, isURL } from '@wordpress/url';
 import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import {
 	Button,
 	ExternalLink,
@@ -20,7 +18,7 @@ import {
 	withNotices,
 	SelectControl,
 } from '@wordpress/components';
-import { InspectorControls, BlockIcon } from '@wordpress/block-editor';
+import { InspectorControls, InnerBlocks, BlockIcon } from '@wordpress/block-editor';
 import { Fragment, Component } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 
@@ -346,18 +344,23 @@ class MembershipsButtonEdit extends Component {
 	};
 
 	setMembershipAmount = id => {
+		const { innerButtons, updateBlockAttributes, setAttributes } = this.props;
 		const currentPlanId = this.props.attributes.planId;
-		const currentText = this.props.attributes.submitButtonText;
 		const defaultTextForNewPlan =
 			this.getFormattedPriceByProductId( id ) + __( ' Contribution', 'jetpack' );
 		const defaultTextForCurrentPlan = currentPlanId
 			? this.getFormattedPriceByProductId( currentPlanId ) + __( ' Contribution', 'jetpack' )
 			: undefined;
-		const text = currentText === defaultTextForCurrentPlan ? defaultTextForNewPlan : currentText;
-		this.props.setAttributes( {
-			planId: id,
-			submitButtonText: text,
-		} );
+		if ( innerButtons.length ) {
+			innerButtons[ 0 ].innerBlocks.forEach( block => {
+				const currentText = block.attributes.text;
+				const text =
+					currentText === defaultTextForCurrentPlan ? defaultTextForNewPlan : currentText;
+				updateBlockAttributes( block.clientId, { text } );
+			} );
+		}
+
+		return setAttributes( { planId: id } );
 	};
 
 	renderMembershipAmounts = () => (
@@ -537,18 +540,7 @@ class MembershipsButtonEdit extends Component {
 				{ ( ( ( this.hasUpgradeNudge || ! this.state.shouldUpgrade ) &&
 					connected !== API_STATE_LOADING ) ||
 					this.props.attributes.planId ) && (
-					<SubmitButton
-						{ ...{
-							attributes: pick( this.props.attributes, [
-								'submitButtonText',
-								'backgroundButtonColor',
-								'textButtonColor',
-								'customBackgroundButtonColor',
-								'customTextButtonColor',
-							] ),
-							setAttributes: this.props.setAttributes,
-						} }
-					/>
+					<InnerBlocks template={ [ [ 'jetpack/button', { element: 'a' } ] ] } templateLock="all" />
 				) }
 				{ this.hasUpgradeNudge && connected === API_STATE_NOTCONNECTED && (
 					<div className="wp-block-jetpack-recurring-payments disclaimer-only">
@@ -561,6 +553,13 @@ class MembershipsButtonEdit extends Component {
 }
 
 export default compose( [
-	withSelect( select => ( { postId: select( 'core/editor' ).getCurrentPostId() } ) ),
+	withSelect( ( select, { clientId } ) => ( {
+		postId: select( 'core/editor' ).getCurrentPostId(),
+		innerButtons: select( 'core/editor' ).getBlocksByClientId( clientId ),
+	} ) ),
+	withDispatch( dispatch => {
+		const { updateBlockAttributes } = dispatch( 'core/editor' );
+		return { updateBlockAttributes };
+	} ),
 	withNotices,
 ] )( MembershipsButtonEdit );

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -540,7 +540,18 @@ class MembershipsButtonEdit extends Component {
 				{ ( ( ( this.hasUpgradeNudge || ! this.state.shouldUpgrade ) &&
 					connected !== API_STATE_LOADING ) ||
 					this.props.attributes.planId ) && (
-					<InnerBlocks template={ [ [ 'jetpack/button', { element: 'a' } ] ] } templateLock="all" />
+					<InnerBlocks
+						template={ [
+							[
+								'jetpack/button',
+								{
+									element: 'a',
+									uniqueId: 'recurring-payments-id',
+								},
+							],
+						] }
+						templateLock="all"
+					/>
 				) }
 				{ this.hasUpgradeNudge && connected === API_STATE_NOTCONNECTED && (
 					<div className="wp-block-jetpack-recurring-payments disclaimer-only">

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -50,7 +50,11 @@ export const settings = {
 		},
 	},
 	edit,
-	save: () => <InnerBlocks.Content />,
+	save: ( { className } ) => (
+		<div className={ className }>
+			<InnerBlocks.Content />
+		</div>
+	),
 	supports: {
 		html: false,
 		align: true,

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -6,9 +6,15 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
 import { trimEnd } from 'lodash';
 
 /**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+/**
  * Internal dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import './editor.scss';
 
@@ -39,34 +45,17 @@ export const settings = {
 		planId: {
 			type: 'integer',
 		},
-		submitButtonText: {
-			type: 'string',
-		},
-		submitButtonClasses: {
-			type: 'string',
-		},
-		backgroundButtonColor: {
-			type: 'string',
-		},
-		textButtonColor: {
-			type: 'string',
-		},
-		customBackgroundButtonColor: {
-			type: 'string',
-		},
-		customTextButtonColor: {
-			type: 'string',
-		},
 		align: {
 			type: 'string',
 		},
 	},
 	edit,
-	save: () => null,
+	save: () => <InnerBlocks.Content />,
 	supports: {
 		html: false,
 		align: true,
 	},
+	deprecated: [ deprecatedV1 ],
 };
 
 /**

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -38,3 +38,7 @@
 BODY.modal-open {
 	overflow: hidden;
 }
+
+.wp-block-jetpack-recurring-payments.aligncenter .wp-block-jetpack-button {
+	text-align: center;
+}

--- a/extensions/blocks/recurring-payments/view.scss
+++ b/extensions/blocks/recurring-payments/view.scss
@@ -42,3 +42,7 @@ BODY.modal-open {
 .wp-block-jetpack-recurring-payments.aligncenter .wp-block-jetpack-button {
 	text-align: center;
 }
+
+.wp-block-jetpack-recurring-payments .wp-block-jetpack-button {
+	color: #ffffff;
+}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -224,10 +224,10 @@ class Jetpack_Memberships {
 
 		if ( ! empty( $content ) ) {
 			$block_id = esc_attr( wp_unique_id( 'recurring-payments-block-' ) );
-			$content  = preg_replace( '/data-id-attr="placeholder"/', 'id="' . $block_id . '"', $content );
+			$content  = str_replace( 'recurring-payments-id', $block_id, $content );
 
 			$subscribe_url = $this->get_subscription_url( $plan_id );
-			$content       = preg_replace( '/href="#"/', 'href="' . $subscribe_url . '"', $content );
+			$content       = str_replace( 'href="#"', 'href="' . $subscribe_url . '"', $content );
 
 			// Allow for WPCOM VIP custom attributes or remove target="_blank" to match original behaviour.
 			$html_attributes = isset( $attrs['submitButtonAttributes'] )

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -200,11 +200,12 @@ class Jetpack_Memberships {
 	/**
 	 * Callback that parses the membership purchase shortcode.
 	 *
-	 * @param array $attrs - attributes in the shortcode. `id` here is the CPT id of the plan.
+	 * @param array  $attrs - attributes in the shortcode. `id` here is the CPT id of the plan.
+	 * @param string $content - Recurring Payment block content.
 	 *
 	 * @return string|void
 	 */
-	public function render_button( $attrs ) {
+	public function render_button( $attrs, $content ) {
 		Jetpack_Gutenberg::load_assets_as_required( self::$button_block_name, array( 'thickbox', 'wp-polyfill' ) );
 
 		if ( empty( $attrs['planId'] ) ) {
@@ -219,15 +220,58 @@ class Jetpack_Memberships {
 			return;
 		}
 
-		$data = array(
-			'blog_id'      => self::get_blog_id(),
-			'plan_id'      => $plan_id,
-			'button_label' => __( 'Your contribution', 'jetpack' ),
-		);
+		add_thickbox();
 
-		if ( isset( $attrs['submitButtonText'] ) ) {
-			$data['button_label'] = $attrs['submitButtonText'];
+		if ( ! empty( $content ) ) {
+			$block_id = esc_attr( wp_unique_id( 'recurring-payments-block-' ) );
+			$content  = preg_replace( '/data-id-attr="placeholder"/', 'id="' . $block_id . '"', $content );
+
+			$subscribe_url = $this->get_subscription_url( $plan_id );
+			$content       = preg_replace( '/href="#"/', 'href="' . $subscribe_url . '"', $content );
+
+			// TODO: Handle custom button attributes from WPCOM VIP.
+
+			return $content;
 		}
+
+		return $this->deprecated_render_button_v1( $attrs, $plan_id );
+	}
+
+	/**
+	 * Builds subscription URL for this membership using the current blog and
+	 * supplied plan IDs.
+	 *
+	 * @param integer $plan_id - Unique ID for the plan being subscribed to.
+	 * @return string
+	 */
+	public function get_subscription_url( $plan_id ) {
+		global $wp;
+
+		return add_query_arg(
+			array(
+				'blog'     => esc_attr( self::get_blog_id() ),
+				'plan'     => esc_attr( $plan_id ),
+				'lang'     => esc_attr( get_locale() ),
+				'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
+				'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
+			),
+			'https://subscribe.wordpress.com/memberships/'
+		);
+	}
+
+	/**
+	 * Renders a deprecated legacy version of the button HTML.
+	 *
+	 * @param array   $attrs - Array containing the Recurring Payment block attributes.
+	 * @param integer $plan_id - Unique plan ID the membership is for.
+	 *
+	 * @return string
+	 */
+	public function deprecated_render_button_v1( $attrs, $plan_id ) {
+		$button_label = isset( $attrs['submitButtonText'] )
+			? $attrs['submitButtonText']
+			: __( 'Your contribution', 'jetpack' );
+
 		$button_styles = array();
 		if ( ! empty( $attrs['customBackgroundButtonColor'] ) ) {
 			array_push(
@@ -248,19 +292,7 @@ class Jetpack_Memberships {
 			);
 		}
 		$button_styles = implode( ';', $button_styles );
-		add_thickbox();
-		global $wp;
 
-		$button_url = add_query_arg(
-			array(
-				'blog'     => esc_attr( $data['blog_id'] ),
-				'plan'     => esc_attr( $data['plan_id'] ),
-				'lang'     => esc_attr( get_locale() ),
-				'pid'      => esc_attr( get_the_ID() ), // Needed for analytics purposes.
-				'redirect' => esc_attr( rawurlencode( home_url( $wp->request ) ) ), // Needed for redirect back in case of redirect-based flow.
-			),
-			'https://subscribe.wordpress.com/memberships/'
-		);
 		return sprintf(
 			'<div class="%1$s"><a role="button" %6$s href="%2$s" class="%3$s" style="%4$s">%5$s</a></div>',
 			esc_attr(
@@ -270,10 +302,10 @@ class Jetpack_Memberships {
 					array( 'wp-block-button' )
 				)
 			),
-			esc_url( $button_url ),
+			esc_url( $this->get_subscription_url( $plan_id ) ),
 			isset( $attrs['submitButtonClasses'] ) ? esc_attr( $attrs['submitButtonClasses'] ) : 'wp-block-button__link',
 			esc_attr( $button_styles ),
-			wp_kses( $data['button_label'], self::$tags_allowed_in_the_button ),
+			wp_kses( $button_label, self::$tags_allowed_in_the_button ),
 			isset( $attrs['submitButtonAttributes'] ) ? sanitize_text_field( $attrs['submitButtonAttributes'] ) : '' // Needed for arbitrary target=_blank on WPCOM VIP.
 		);
 	}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -229,7 +229,14 @@ class Jetpack_Memberships {
 			$subscribe_url = $this->get_subscription_url( $plan_id );
 			$content       = preg_replace( '/href="#"/', 'href="' . $subscribe_url . '"', $content );
 
-			// TODO: Handle custom button attributes from WPCOM VIP.
+			// Needed for arbitrary target=_blank on WPCOM VIP.
+			if ( isset( $attrs['submitButtonAttributes'] ) ) {
+				$content = preg_replace(
+					'/target="_blank"/',
+					sanitize_text_field( $attrs['submitButtonAttributes'] ),
+					$content
+				);
+			}
 
 			return $content;
 		}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -229,14 +229,12 @@ class Jetpack_Memberships {
 			$subscribe_url = $this->get_subscription_url( $plan_id );
 			$content       = preg_replace( '/href="#"/', 'href="' . $subscribe_url . '"', $content );
 
-			// Needed for arbitrary target=_blank on WPCOM VIP.
-			if ( isset( $attrs['submitButtonAttributes'] ) ) {
-				$content = preg_replace(
-					'/target="_blank"/',
-					sanitize_text_field( $attrs['submitButtonAttributes'] ),
-					$content
-				);
-			}
+			// Allow for WPCOM VIP custom attributes or remove target="_blank" to match original behaviour.
+			$html_attributes = isset( $attrs['submitButtonAttributes'] )
+				? sanitize_text_field( $attrs['submitButtonAttributes'] )
+				: '';
+
+			$content = preg_replace( '/target="_blank"/', $html_attributes, $content );
 
 			return $content;
 		}

--- a/modules/memberships/class-jetpack-memberships.php
+++ b/modules/memberships/class-jetpack-memberships.php
@@ -205,7 +205,7 @@ class Jetpack_Memberships {
 	 *
 	 * @return string|void
 	 */
-	public function render_button( $attrs, $content ) {
+	public function render_button( $attrs, $content = null ) {
 		Jetpack_Gutenberg::load_assets_as_required( self::$button_block_name, array( 'thickbox', 'wp-polyfill' ) );
 
 		if ( empty( $attrs['planId'] ) ) {
@@ -223,20 +223,10 @@ class Jetpack_Memberships {
 		add_thickbox();
 
 		if ( ! empty( $content ) ) {
-			$block_id = esc_attr( wp_unique_id( 'recurring-payments-block-' ) );
-			$content  = str_replace( 'recurring-payments-id', $block_id, $content );
-
+			$block_id      = esc_attr( wp_unique_id( 'recurring-payments-block-' ) );
+			$content       = str_replace( 'recurring-payments-id', $block_id, $content );
 			$subscribe_url = $this->get_subscription_url( $plan_id );
-			$content       = str_replace( 'href="#"', 'href="' . $subscribe_url . '"', $content );
-
-			// Allow for WPCOM VIP custom attributes or remove target="_blank" to match original behaviour.
-			$html_attributes = isset( $attrs['submitButtonAttributes'] )
-				? sanitize_text_field( $attrs['submitButtonAttributes'] )
-				: '';
-
-			$content = preg_replace( '/target="_blank"/', $html_attributes, $content );
-
-			return $content;
+			return str_replace( 'href="#"', 'href="' . $subscribe_url . '"', $content );
 		}
 
 		return $this->deprecated_render_button_v1( $attrs, $plan_id );


### PR DESCRIPTION
Fixes #15713

#### Changes proposed in this Pull Request:
* Replace the SubmitButton in the Recurring Payments block with new shared Button block.

#### Does this pull request change what data or activity we track or use?
No.

#### Prerequisites
* Sandboxed `public-api.wordpress.com` and `subscribe.wordpress.com`. See instructions for sandboxing for Recurring Payments in the Field Guide.
* Site connected to Stripe and a plan created.
* A post with a Recurring Payment block added prior to checking out this PR branch.

#### Testing instructions:

1. On the frontend, visit post containing previous version of Recurring Payments block.
2. Confirm the blocks display and function as they did when you set them up. 
    _Button should still be contained within div with `.wp-block-button` class._
3. Edit the post.
4. Confirm the Recurring Payment block still appears correctly and its settings are correct.
5. Update the Recurring Payment button using the new settings controls provided by button block.
6. Add new Recurring Payment block select a plan. Ensure the button text is updated with text including the price of the plan selected.
7. Save the post.
8. Re-visit the post on the frontend and confirm display and function of Recurring Payment block.

<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
#### Before:

<img width="1031" alt="Screen Shot 2020-05-25 at 2 53 25 pm" src="https://user-images.githubusercontent.com/60436221/82779453-97aa6b80-9e97-11ea-8917-bbe1580edcfa.png">

#### After:

<img width="1032" alt="Screen Shot 2020-05-25 at 2 50 03 pm" src="https://user-images.githubusercontent.com/60436221/82779463-9c6f1f80-9e97-11ea-9b60-ddaea58440fc.png">


#### Proposed changelog entry for your changes:
* Update Recurring Payments block to use new shared Button block
