### PR TITLE
Jetpack Setup Wizard: Add handling for query param in income page

### DIFF
--- a/_inc/client/setup-wizard/income-question/index.jsx
+++ b/_inc/client/setup-wizard/income-question/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'i18n-calypso';
 
@@ -13,14 +14,32 @@ import { ChecklistAnswer } from '../checklist-answer';
 import Button from 'components/button';
 import { imagePath } from 'constants/urls';
 import analytics from 'lib/analytics';
-import { getSetupWizardAnswer, saveSetupWizardQuestionnnaire } from 'state/setup-wizard';
+import {
+	getSetupWizardAnswer,
+	saveSetupWizardQuestionnnaire,
+	updateSetupWizardQuestionnaire,
+} from 'state/setup-wizard';
 
 import './style.scss';
 
 let IncomeQuestion = props => {
+	const location = useLocation();
+
 	useEffect( () => {
 		analytics.tracks.recordEvent( 'jetpack_wizard_page_view', { step: 'income-page' } );
-	}, [] );
+
+		const queryParams = new URLSearchParams( location.search );
+		const useAnswer = queryParams.get( 'use' );
+
+		if ( [ 'personal', 'business' ].includes( useAnswer ) ) {
+			props.updateSiteUseQuestion( { use: useAnswer } );
+			props.saveQuestionnaire();
+			analytics.tracks.recordEvent( 'jetpack_wizard_question_answered', {
+				question: 'use',
+				answer: useAnswer,
+			} );
+		}
+	}, [ location ] );
 
 	const onContinueClick = useCallback( () => {
 		props.saveQuestionnaire();
@@ -118,6 +137,7 @@ IncomeQuestion = connect(
 	} ),
 	dispatch => ( {
 		saveQuestionnaire: () => dispatch( saveSetupWizardQuestionnnaire() ),
+		updateSiteUseQuestion: answer => dispatch( updateSetupWizardQuestionnaire( answer ) ),
 	} )
 )( IncomeQuestion );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds support for a `use` parameter on the income page to enable a URL to provide an answer to the first question of the setup wizard. 

This will enable the Setup Wizard banner to be a part of the questionnaire flow, as the user's choice of personal or business can be "passed" in to React by using the URL query parameters.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add the following to the end of wp-config.php: add_filter( 'jetpack_show_setup_wizard', '__return_true' );
2. Visit `/wp-admin/index.php`.
3. The top banner should be the first question of the setup wizard. Select Personal or Business and verify that you are taken to the income page, and that the `use` question has been answered. The easiest way to check this is to search for a POST to `/jetpack/v4/setup/questionnaire` in the network dev tools.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed, should only be one entry for whole Setup Wizard.
