### PR TITLE
Autoloader: Support Composer v2.0

### DIFF
--- a/packages/autoloader/composer.json
+++ b/packages/autoloader/composer.json
@@ -4,7 +4,7 @@
 	"type": "composer-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"composer-plugin-api": "^1.1"
+		"composer-plugin-api": "^1.1 || ^2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"

--- a/packages/autoloader/src/CustomAutoloaderPlugin.php
+++ b/packages/autoloader/src/CustomAutoloaderPlugin.php
@@ -54,9 +54,38 @@ class CustomAutoloaderPlugin implements PluginInterface, EventSubscriberInterfac
 	}
 
 	/**
+	 * Do nothing.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	 *
+	 * @param Composer    $composer Composer object.
+	 * @param IOInterface $io IO object.
+	 */
+	public function deactivate( Composer $composer, IOInterface $io ) {
+		/*
+		 * Intentionally left empty. This is a PluginInterface method.
+		 * phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		 */
+	}
+
+	/**
+	 * Do nothing.
+	 * phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	 *
+	 * @param Composer    $composer Composer object.
+	 * @param IOInterface $io IO object.
+	 */
+	public function uninstall( Composer $composer, IOInterface $io ) {
+		/*
+		 * Intentionally left empty. This is a PluginInterface method.
+		 * phpcs:enable VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		 */
+	}
+
+
+	/**
 	 * Tell composer to listen for events and do something with them.
 	 *
-	 * @return array List of succribed events.
+	 * @return array List of subscribed events.
 	 */
 	public static function getSubscribedEvents() {
 		return array(


### PR DESCRIPTION
Fixes #15793

Composer v2.0 will be released soon, and the autoloader needs to be updated to add support for v2.0.

**NOTE:** One of Jetpack's [dependencies](https://github.com/Automattic/jetpack/blob/master/composer.json#L35), `dealerdirect/phpcodesniffer-composer-installer` v0.6.2, requires `composer-plugin-api` v^1.0 so it's not compatible with Composer 2.0. Adding support for Composer v2.0 is in progress [here](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/pull/111).

#### Changes proposed in this Pull Request:
* Allow version **^2.0** of the `composer-plugin-api` package.
* Implement the `CustomAutoloaderPlugin::deactivate()` and `CustomAutoloaderPlug::uninstall()` methods which have been added to `PluginInterface`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This updates an existing part of Jetpack.

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:
`CustomAutoloaderPlugin` must work with both Composer v1.x and v2.0, so we'll test with version 1.10.6 and version 2.0

##### Test with the latest stable version of Composer, v1.10.6

1) Run `composer --version` and confirm that you’re using v1.10.6. If not, use `composer self-update --stable` to update.
2) Run `composer update` and verify that no errors are generated. The Jetpack Autoloader files should be generated:

   - vendor/composer/autoload_classmap_package.php
   - vendor/composer/autoload_files_package.php
   - vendor/autoload_packages.php


##### Test with the Composer v2.0 snapshot version:
1) Run `composer self-update --snapshot` to install v2.0.
2) Run `composer update --ignore-platform-reqs` and verify that no errors are generated. The Jetpack Autoloader files listed above should be generated.

**NOTE:** The `—ignore-platform-reqs` option is required for this test because one of Jetpack’s dependencies does not support Composer 2.0 (see details above). 

3) You can also test these changes by removing the `dealerdirect/phpcodesniffer-composer-installer` requirement from Jetpack’s `composer.json` file, then running `composer update`. No errors should be generated, and the autoloader files listed above should be created.


#### Proposed changelog entry for your changes:
* Autoloader: add support for Composer 2.0
