### PR TITLE
Track stats from the Deactivation Modal

### DIFF
--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -17,10 +17,10 @@
 						// NodeList is static, we need to modify this in the DOM
 
 						$( '#TB_window' ).addClass( 'jetpack-disconnect-modal' );
-						centralizeDeactivationModal();
+						deactivationModalCentralize();
 
 						$( '#TB_closeWindowButton, #TB_overlay' ).on( 'click', function( e ) {
-							trackDeactivationModalClose();
+							deactivationModalTrackCloseEvent();
 						} );
 
 						document.onkeyup = function( e ) {
@@ -33,7 +33,7 @@
 							}
 							if ( keycode == 27 ) {
 								// close
-								trackDeactivationModalClose();
+								deactivationModalTrackCloseEvent();
 							}
 						};
 
@@ -44,13 +44,13 @@
 		} );
 	} );
 
-	window.centralizeDeactivationModal = function() {
+	window.deactivationModalCentralize = function() {
 		var modal = $( '#TB_window.jetpack-disconnect-modal' );
 		var top = $( window ).height() / 2 - $( modal ).height() / 2;
 		$( modal ).css( 'top', top + 'px' );
 	};
 
-	window.trackDeactivationModalClose = function() {
+	window.deactivationModalTrackCloseEvent = function() {
 		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_close_click', 'click', tracksProps );
 		document.onkeyup = '';
 	};
@@ -73,7 +73,7 @@
 
 	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function( e ) {
 		tb_remove();
-		trackDeactivationModalClose();
+		deactivationModalTrackCloseEvent();
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-deactivate' ).on( 'click', function( e ) {

--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -33,19 +33,29 @@
 
 	var body = $( 'body' )[ 0 ];
 
+	var tracksProps = {
+		location: 'plugins',
+		purpose: 'deactivate',
+	};
+
 	deactivateLinkElem.attr( 'href', 'plugins.php#TB_inline?inlineId=jetpack_deactivation_dialog' );
 	deactivateLinkElem.attr( 'title', deactivate_dialog.title );
 	deactivateLinkElem.addClass( 'thickbox' );
 	deactivateLinkElem.html( deactivate_dialog.deactivate_label );
 	deactivateLinkElem.on( 'click', function( e ) {
 		observer.observe( body, { childList: true } );
+		analytics.tracks.recordEvent( 'jetpack_wpa_click', {
+			target: 'disconnect_and_deactivate',
+		} );
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function( e ) {
 		tb_remove();
+		analytics.tracks.recordEvent( 'jetpack_termination_dialog_close_click', tracksProps );
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-deactivate' ).on( 'click', function( e ) {
+		analytics.tracks.recordEvent( 'jetpack_termination_dialog_termination_click', tracksProps );
 		deactivateJetpack();
 	} );
 } )( jQuery );

--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -44,9 +44,7 @@
 	deactivateLinkElem.html( deactivate_dialog.deactivate_label );
 	deactivateLinkElem.on( 'click', function( e ) {
 		observer.observe( body, { childList: true } );
-		analytics.tracks.recordEvent( 'jetpack_wpa_click', {
-			target: 'disconnect_and_deactivate',
-		} );
+		analytics.tracks.recordEvent( 'jetpack_termination_dialog_open', tracksProps );
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function( e ) {

--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -79,6 +79,8 @@
 	$( '#jetpack_deactivation_dialog_content__button-deactivate' ).on( 'click', function( e ) {
 		e.preventDefault();
 
+		$( this ).prop( 'disabled', true );
+
 		window.jpTracksAJAX
 			.record_ajax_event( 'termination_dialog_termination_click', 'click', tracksProps )
 			.always( function() {

--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -18,6 +18,25 @@
 
 						$( '#TB_window' ).addClass( 'jetpack-disconnect-modal' );
 						centralizeDeactivationModal();
+
+						$( '#TB_closeWindowButton, #TB_overlay' ).on( 'click', function( e ) {
+							trackDeactivationModalClose();
+						} );
+
+						document.onkeyup = function( e ) {
+							if ( e === null ) {
+								// ie
+								keycode = event.keyCode;
+							} else {
+								// mozilla
+								keycode = e.which;
+							}
+							if ( keycode == 27 ) {
+								// close
+								trackDeactivationModalClose();
+							}
+						};
+
 						observer.disconnect();
 					}
 				} );
@@ -29,6 +48,11 @@
 		var modal = $( '#TB_window.jetpack-disconnect-modal' );
 		var top = $( window ).height() / 2 - $( modal ).height() / 2;
 		$( modal ).css( 'top', top + 'px' );
+	};
+
+	window.trackDeactivationModalClose = function() {
+		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_close_click', 'click', tracksProps );
+		document.onkeyup = '';
 	};
 
 	var body = $( 'body' )[ 0 ];
@@ -49,7 +73,7 @@
 
 	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function( e ) {
 		tb_remove();
-		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_close_click', 'click', tracksProps );
+		trackDeactivationModalClose();
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-deactivate' ).on( 'click', function( e ) {

--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -44,16 +44,21 @@
 	deactivateLinkElem.html( deactivate_dialog.deactivate_label );
 	deactivateLinkElem.on( 'click', function( e ) {
 		observer.observe( body, { childList: true } );
-		analytics.tracks.recordEvent( 'jetpack_termination_dialog_open', tracksProps );
+		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_open', 'click', tracksProps );
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function( e ) {
 		tb_remove();
-		analytics.tracks.recordEvent( 'jetpack_termination_dialog_close_click', tracksProps );
+		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_close_click', 'click', tracksProps );
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-deactivate' ).on( 'click', function( e ) {
-		analytics.tracks.recordEvent( 'jetpack_termination_dialog_termination_click', tracksProps );
-		deactivateJetpack();
+		e.preventDefault();
+
+		window.jpTracksAJAX
+			.record_ajax_event( 'termination_dialog_termination_click', 'click', tracksProps )
+			.always( function() {
+				deactivateJetpack();
+			} );
 	} );
 } )( jQuery );

--- a/_inc/jetpack-deactivate-dialog.js
+++ b/_inc/jetpack-deactivate-dialog.js
@@ -1,4 +1,15 @@
+/**
+ * Adds the Deactivation modal.
+ *
+ * Depends on _inc/lib/tracks/tracks-callables.js and //stats.wp.com/w.js
+ *
+ */
 ( function( $ ) {
+	// Initialize Tracks and bump stats.
+	var tracksUser = deactivate_dialog.tracksUserData;
+
+	analytics.initialize( tracksUser.userid, tracksUser.username );
+
 	var deactivateLinkElem = $(
 		'tr[data-slug=jetpack] > td.plugin-title > div > span.deactivate > a'
 	);
@@ -51,7 +62,7 @@
 	};
 
 	window.deactivationModalTrackCloseEvent = function() {
-		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_close_click', 'click', tracksProps );
+		analytics.tracks.recordEvent( 'jetpack_termination_dialog_close_click', tracksProps );
 		document.onkeyup = '';
 	};
 
@@ -68,7 +79,7 @@
 	deactivateLinkElem.html( deactivate_dialog.deactivate_label );
 	deactivateLinkElem.on( 'click', function( e ) {
 		observer.observe( body, { childList: true } );
-		window.jpTracksAJAX.record_ajax_event( 'termination_dialog_open', 'click', tracksProps );
+		analytics.tracks.recordEvent( 'jetpack_termination_dialog_open', tracksProps );
 	} );
 
 	$( '#jetpack_deactivation_dialog_content__button-cancel' ).on( 'click', function( e ) {
@@ -80,11 +91,7 @@
 		e.preventDefault();
 
 		$( this ).prop( 'disabled', true );
-
-		window.jpTracksAJAX
-			.record_ajax_event( 'termination_dialog_termination_click', 'click', tracksProps )
-			.always( function() {
-				deactivateJetpack();
-			} );
+		analytics.tracks.recordEvent( 'jetpack_termination_dialog_termination_click', tracksProps );
+		deactivateJetpack();
 	} );
 } )( jQuery );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4083,6 +4083,14 @@ p {
 					true
 				);
 
+				wp_enqueue_script(
+					'jp-tracks-functions',
+					plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ),
+					array(),
+					JETPACK__VERSION,
+					false
+				);
+
 				wp_localize_script(
 					'jetpack-deactivate-dialog-js',
 					'deactivate_dialog',

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4072,13 +4072,30 @@ p {
 			if ( count( $active_plugins_using_connection ) > 1 ) {
 
 				add_thickbox();
+
+				wp_register_script(
+					'jp-tracks',
+					'//stats.wp.com/w.js',
+					array(),
+					gmdate( 'YW' ),
+					true
+				);
+
+				wp_register_script(
+					'jp-tracks-functions',
+					plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ),
+					array( 'jp-tracks' ),
+					JETPACK__VERSION,
+					false
+				);
+
 				wp_enqueue_script(
 					'jetpack-deactivate-dialog-js',
 					Assets::get_file_url_for_environment(
 						'_inc/build/jetpack-deactivate-dialog.min.js',
 						'_inc/jetpack-deactivate-dialog.js'
 					),
-					array( 'jquery' ),
+					array( 'jquery', 'jp-tracks-functions' ),
 					JETPACK__VERSION,
 					true
 				);
@@ -4089,6 +4106,7 @@ p {
 					array(
 						'title'            => __( 'Deactivate Jetpack', 'jetpack' ),
 						'deactivate_label' => __( 'Disconnect and Deactivate', 'jetpack' ),
+						'tracksUserData'   => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 					)
 				);
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4083,14 +4083,6 @@ p {
 					true
 				);
 
-				wp_enqueue_script(
-					'jp-tracks-functions',
-					plugins_url( '_inc/lib/tracks/tracks-callables.js', JETPACK__PLUGIN_FILE ),
-					array(),
-					JETPACK__VERSION,
-					false
-				);
-
 				wp_localize_script(
 					'jetpack-deactivate-dialog-js',
 					'deactivate_dialog',

--- a/scss/jetpack-deactivate-dialog.scss
+++ b/scss/jetpack-deactivate-dialog.scss
@@ -171,6 +171,12 @@
 					border-color: darken( $alert-red, 20% );
 					color: $white;
 					margin-bottom: 0px;
+
+					&[disabled],
+					&:disabled {
+						background: lighten( $alert-red, 20% );
+						border-color: tint( $alert-red, 30% );
+					}
 				}
 			}
 


### PR DESCRIPTION
Track stats from the Deactivation Modal actions

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds tracking to actions in the Deactivation modal (open the dialog, cancel and confirm)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This is part of the "Handle disconnections gracefully" project - p1HpG7-8VJ-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, we are now tracking:
* When the user clicks "Disconnect and Deactivate", in order to deactivate the plugin (This only shows up if there's at least one other plugin relying on the Jetpack connection
* When the user confirms the deactivation
* When the user cancels the deactivation

#### Feedback wanted

* Are these the best event names? I'm using the same events used in the termination dialog in the Jetpack Dashboard. It already has these `location` and `purpose` that were meant to be used to differentiate when we reused this modal in the deactivation context (which we didn't do. We created another dialog from scratch)
* On the termination dialog in the Jetpack Dashboard there is no specific action to track the click to open the dialog. I kept the same standard.
* The deactivation click triggers a `window.location.href` change, it will take the user away from that page. Does it mean it could cancel the tracking that is fired just before?
* I'm not sure how to test it. I can confirm the function is being triggered correctly and there are no errors in the console, but I don't see the stats showing up on Tracks

#### Testing instructions:
* Set up a site using this branch and connect Jetpack
* Visit Plugins page on the Admin dashboard
* Check and see that the "Deactivate" link for the Jetpack plugin looks the same and nothing changed
* Create a file `wp-content/plugins/jetpack-connection-test-1.php` with following content:
```
<?php
/** Plugin Name: Jetpack Connection Test Plugin (1) */
add_action( 'plugins_loaded', function() {
	( new Automattic\Jetpack\Config() )->ensure( 'connection', array( 'slug' => 'jetpack-connection-test-1', 'name' => 'Jetpack Connection Test Plugin (1)' ) );
}, 1 );
```
* Activate this new plugin
* Now check that the label to deactivate Jetpack says "Disconnect and Deactivate"
* Click "Disconnect and Deactivate" and check that it opens a modal looking like the screenshots below
* Click Cancel and the close button at the top and confirm it closes the window
* Click the red "Disconnect and Deactivate" button and confirm it deactivates Jetpack

Now visit Tracks Live View and search for `jetpack_termination_dialog_%`

Make sure you see the sequence of events you've just performed (open, close, open terminate)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Tracks deactivation modal events
