### PR TITLE
Jetpack Setup Wizard: Add Tracks events to the Setup Wizard banner

### DIFF
--- a/_inc/jetpack-wizard-banner.js
+++ b/_inc/jetpack-wizard-banner.js
@@ -1,23 +1,50 @@
 /* global jQuery, jp_banner */
 
 ( function( $ ) {
-	var wizardBanner = $( '#jp-wizard-banner' ),
-		wizardBannerDismiss = $( '.wizard-banner-dismiss' );
+	var wizardBanner = $( '#jp-wizard-banner' );
+	var wizardBannerDismiss = $( '.wizard-banner-dismiss' );
+	var personalButton = $( '#jp-wizard-banner-personal-button' );
+	var businessButton = $( '#jp-wizard-banner-business-button' );
+	var skipLink = $( '.jp-wizard-banner-wizard-skip-link' );
 
 	// Dismiss the wizard banner via AJAX
 	wizardBannerDismiss.on( 'click', function() {
 		$( wizardBanner ).hide();
 
 		var data = {
+			dismissBanner: true,
 			action: 'jetpack_wizard_banner',
 			nonce: jp_banner.wizardBannerNonce,
-			dismissBanner: true,
 		};
 
 		$.post( jp_banner.ajax_url, data, function( response ) {
 			if ( true !== response.success ) {
 				$( wizardBanner ).show();
 			}
+		} );
+	} );
+
+	personalButton.on( 'click', function() {
+		$.post( jp_banner.ajax_url, {
+			personal: true,
+			action: 'jetpack_wizard_banner',
+			nonce: jp_banner.wizardBannerNonce,
+		} );
+	} );
+
+	businessButton.on( 'click', function() {
+		$.post( jp_banner.ajax_url, {
+			business: true,
+			action: 'jetpack_wizard_banner',
+			nonce: jp_banner.wizardBannerNonce,
+		} );
+	} );
+
+	skipLink.on( 'click', function() {
+		$.post( jp_banner.ajax_url, {
+			skip: true,
+			action: 'jetpack_wizard_banner',
+			nonce: jp_banner.wizardBannerNonce,
 		} );
 	} );
 } )( jQuery );

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -7,6 +7,7 @@
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
+use Automattic\Jetpack\Tracking;
 
 /**
  * Jetpack_Wizard_Banner
@@ -121,11 +122,26 @@ class Jetpack_Wizard_Banner {
 	public static function ajax_callback() {
 		check_ajax_referer( 'jp-wizard-banner-nonce', 'nonce' );
 
+		$tracking = new Tracking();
+
+		if ( isset( $_REQUEST['personal'] ) ) {
+			$tracking->record_user_event( 'jetpack_setup_wizard_banner_click', array( 'button' => 'personal' ) );
+		}
+
+		if ( isset( $_REQUEST['business'] ) ) {
+			$tracking->record_user_event( 'jetpack_setup_wizard_banner_click', array( 'button' => 'business' ) );
+		}
+
+		if ( isset( $_REQUEST['skip'] ) ) {
+			$tracking->record_user_event( 'jetpack_setup_wizard_banner_click', array( 'button' => 'skip' ) );
+		}
+
 		if (
 			current_user_can( 'jetpack_manage_modules' )
 			&& isset( $_REQUEST['dismissBanner'] )
 		) {
 			Jetpack_Options::update_option( 'dismissed_wizard_banner', 1 );
+			$tracking->record_user_event( 'jetpack_setup_wizard_banner_dismiss' );
 			wp_send_json_success();
 		}
 
@@ -172,12 +188,14 @@ class Jetpack_Wizard_Banner {
 						</h2>
 						<div class="jp-wizard-banner-wizard-answer-buttons">
 							<a
+								id="jp-wizard-banner-personal-button"
 								class="button button-primary jp-wizard-banner-wizard-button"
 								href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=personal' ) ); ?>"
 							>
 							<?php esc_html_e( 'Personal Use', 'jetpack' ); ?>
 							</a>
 							<a
+								id="jp-wizard-banner-business-button"
 								class="button button-primary jp-wizard-banner-wizard-button"
 								href="<?php echo esc_url( Jetpack::admin_url( 'page=jetpack#/setup/income?use=business' ) ); ?>"
 							>

--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -125,15 +125,15 @@ class Jetpack_Wizard_Banner {
 		$tracking = new Tracking();
 
 		if ( isset( $_REQUEST['personal'] ) ) {
-			$tracking->record_user_event( 'jetpack_setup_wizard_banner_click', array( 'button' => 'personal' ) );
+			$tracking->record_user_event( 'setup_wizard_banner_click', array( 'button' => 'personal' ) );
 		}
 
 		if ( isset( $_REQUEST['business'] ) ) {
-			$tracking->record_user_event( 'jetpack_setup_wizard_banner_click', array( 'button' => 'business' ) );
+			$tracking->record_user_event( 'setup_wizard_banner_click', array( 'button' => 'business' ) );
 		}
 
 		if ( isset( $_REQUEST['skip'] ) ) {
-			$tracking->record_user_event( 'jetpack_setup_wizard_banner_click', array( 'button' => 'skip' ) );
+			$tracking->record_user_event( 'setup_wizard_banner_click', array( 'button' => 'skip' ) );
 		}
 
 		if (
@@ -141,7 +141,7 @@ class Jetpack_Wizard_Banner {
 			&& isset( $_REQUEST['dismissBanner'] )
 		) {
 			Jetpack_Options::update_option( 'dismissed_wizard_banner', 1 );
-			$tracking->record_user_event( 'jetpack_setup_wizard_banner_dismiss' );
+			$tracking->record_user_event( 'setup_wizard_banner_dismiss' );
 			wp_send_json_success();
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR adds dedicated Tracks events to the Jetpack Setup Wizard banner so that we can analyze how it is used.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Add the following to the end of wp-config.php: add_filter( 'jetpack_show_setup_wizard', '__return_true' );
2. Visit the Dashboard and choose any option from the Jetpack Setup banner.
3. Visit the tracks live tool in mc and verify that the event shows.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
