### PR TITLE
AMP support for [gravatar-profile] shortcode

### DIFF
--- a/modules/shortcodes/css/gravatar-amp.css
+++ b/modules/shortcodes/css/gravatar-amp.css
@@ -1,4 +1,7 @@
-.grofile-wrap {
+/**
+ * Styles for the [gravatar_profile] shortcode when it is called from an AMP context
+ */
+ .grofile-wrap {
 	border: solid 1px #eee;
 	padding: 10px;
 }

--- a/modules/shortcodes/css/gravatar.css
+++ b/modules/shortcodes/css/gravatar.css
@@ -1,0 +1,38 @@
+.grofile-wrap {
+	border: solid 1px #eee;
+	padding: 10px;
+}
+
+.grofile {
+	padding: 0 0 5px 0;
+}
+
+.grofile-left {
+	float: left;
+	display: block;
+	width: 96px;
+	margin-right: 15px;
+}
+
+.grofile .gravatar {
+	margin-bottom: 5px;
+}
+
+.grofile-clear {
+	clear: left;
+	font-size: 1px;
+	height: 1px;
+}
+
+.grofile ul li a {
+	text-indent: -99999px;
+}
+
+.grofile .grofile-left a:hover {
+	text-decoration: none !important;
+	border: none !important;
+}
+
+.grofile-name {
+	margin-top: 0;
+}

--- a/modules/shortcodes/gravatar.php
+++ b/modules/shortcodes/gravatar.php
@@ -107,8 +107,11 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 
 	ob_start();
 
-	?>
-	<script type="text/javascript">
+	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		wp_enqueue_style( 'gravatar-style', plugins_url( '/css/gravatar.css', __FILE__ ), array(), JETPACK__VERSION );
+	} else {
+		?>
+		<script type="text/javascript">
 		( function() {
 			if ( null === document.getElementById( 'gravatar-profile-embed-styles' ) ) {
 				var headID = document.getElementsByTagName( 'head' )[0];
@@ -127,7 +130,10 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 				headID.appendChild( styleNode );
 			}
 		} )();
-	</script>
+		</script>
+		<?php
+	}
+	?>
 
 	<div class="grofile vcard" id="grofile-embed-<?php echo esc_attr( $instance ); ?>">
 		<div class="grofile-inner">

--- a/modules/shortcodes/gravatar.php
+++ b/modules/shortcodes/gravatar.php
@@ -108,7 +108,7 @@ function jetpack_gravatar_profile_shortcode( $atts ) {
 	ob_start();
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
-		wp_enqueue_style( 'gravatar-style', plugins_url( '/css/gravatar.css', __FILE__ ), array(), JETPACK__VERSION );
+		wp_enqueue_style( 'gravatar-style', plugins_url( '/css/gravatar-amp.css', __FILE__ ), array(), JETPACK__VERSION );
 	} else {
 		?>
 		<script type="text/javascript">


### PR DESCRIPTION
This adds AMP support for the `[gravatar_profile]` shortcode.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*  This change enqueues the necessary CSS file for the `[gravatar_profile]` shortcode, as opposed to adding the `<style>` tag via JS.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This enhances an existing feature.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Ensure the AMP plugin is active
* In AMP > Settings, select Transitional mode
* In a post, add a shortcode block and input `[gravatar_profile who="ashicus@gmail.com"]`
* View the post with ?amp appended to the end URL
* Expected: The Gravatar profile looks the same in AMP and non-AMP pages

#### Proposed changelog entry for your changes:
* Adds AMP support for [gavatar_profile] shortcode
