### PR TITLE
Don't assume a site has Administrator-level users

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1151,7 +1151,21 @@ class Manager {
 				'number'  => 1,
 			)
 		);
-		$earliest_registration_date = $earliest_registered_users[0]->user_registered;
+		if ( ! $earliest_registered_users ) {
+			$earliest_registered_users  = get_users(
+				array(
+					'orderby' => 'user_registered',
+					'order'   => 'ASC',
+					'fields'  => array( 'user_registered' ),
+					'number'  => 1,
+				)
+			);
+		}
+
+		$earliest_registration_date = false;
+		if ( $earliest_registered_users ) {
+			$earliest_registration_date = $earliest_registered_users[0]->user_registered;
+		}
 
 		$earliest_posts = get_posts(
 			array(


### PR DESCRIPTION
Don't assume a site has Administrator-level users, fall back to users of any role when they don't exist.

Avoids PHP Notices:
> E_NOTICE: jetpack/vendor/automattic/jetpack-connection/src/class-manager.php:1126 - Undefined offset: 0
> E_NOTICE: jetpack/vendor/automattic/jetpack-connection/src/class-manager.php:1126 - Trying to get property 'user_registered' of non-object

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoids PHP Notices when a site has no administrator users, such as a Multisite with non-admin users managed by Super Admins.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bugfix only

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, although Jetpack may now have an accurate "site creation date" where it may not have before.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a multisite site, with no users
* View dashboard, without having connected Jetpack.
* Observe PHP Notices.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
