### PR TITLE
Button Block: Add parent-child syncing mechanism

### DIFF
--- a/extensions/blocks/button/attributes.js
+++ b/extensions/blocks/button/attributes.js
@@ -15,6 +15,9 @@ export default {
 	uniqueId: {
 		type: 'string',
 	},
+	passthroughAttributes: {
+		type: 'object',
+	},
 	text: {
 		type: 'string',
 	},

--- a/extensions/blocks/button/edit.js
+++ b/extensions/blocks/button/edit.js
@@ -22,12 +22,14 @@ import applyFallbackStyles from './apply-fallback-styles';
 import ButtonBorderPanel from './button-border-panel';
 import ButtonColorsPanel from './button-colors-panel';
 import { IS_GRADIENT_AVAILABLE } from './constants';
+import usePassthroughAttributes from './use-passthrough-attributes';
 import './editor.scss';
 
 function ButtonEdit( {
 	attributes,
 	backgroundColor,
 	className,
+	clientId,
 	fallbackBackgroundColor,
 	fallbackTextColor,
 	setAttributes,
@@ -36,6 +38,8 @@ function ButtonEdit( {
 	textColor,
 } ) {
 	const { borderRadius, element, placeholder, text } = attributes;
+
+	usePassthroughAttributes( { attributes, clientId, setAttributes } );
 
 	const onChange = value => {
 		// TODO: Remove `replace` once minimum Gutenberg version is 8.0 (to fully support `disableLineBreaks`)

--- a/extensions/blocks/button/use-passthrough-attributes.js
+++ b/extensions/blocks/button/use-passthrough-attributes.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { isEmpty, mapValues, pickBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+export default function usePassthroughAttributes( { attributes, clientId, setAttributes } ) {
+	// `passthroughAttributes` is a map of child/parent attribute names,
+	// to indicate which parent attribute values will be injected into which child attributes.
+	// E.g. { childAttribute: 'parentAttribute' }
+	const { passthroughAttributes } = attributes;
+
+	const { attributesToSync } = useSelect( select => {
+		const { getBlockAttributes, getBlockHierarchyRootClientId } = select( 'core/block-editor' );
+		const parentAttributes = getBlockAttributes( getBlockHierarchyRootClientId( clientId ) );
+
+		// Here we actually map the parent attribute value to the child attribute.
+		// E.g. { childAttribute: 'foobar' }
+		const mappedAttributes = mapValues( passthroughAttributes, key => parentAttributes[ key ] );
+
+		// Discard all equals attributes
+		const validAttributes = pickBy(
+			mappedAttributes,
+			( value, key ) => value !== attributes[ key ]
+		);
+
+		return { attributesToSync: validAttributes };
+	} );
+
+	useEffect( () => {
+		if ( ! isEmpty( attributesToSync ) ) {
+			setAttributes( attributesToSync );
+		}
+	}, [ attributesToSync, setAttributes ] );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add a `passthroughAttributes` attribute to the Button block, to map parent attribute values to child (Button) attributes.

In some cases, we might want the Button block to use a parent attribute.
For example, the parent block might have a link that we want to use for the button as well.

Inner blocks templates don't update after mount, so we need another way to keep them in sync.

The `passthroughAttributes` is an object that indicates which parent attributes we want to sync to which child attributes.
E.g. `{ childAttribute: 'parentAttribute' }`

The `usePassthroughAttributes` hook retrieves the parent attributes values and sets them to the Button attributes, effectively keeping them in sync.

See also: https://github.com/Automattic/jetpack/pull/15370#issuecomment-614071023

##### Notes

- This is a one-way sync (hence the "passthrough" term), so it's should only be used for Button attributes that aren't supposed to be modified manually.
For example, the `url` attribute is fine, but the `text` (used in the testing instructions below) not really.
- I've created some docs for this block in #15934. It already includes this change.

##### Example scenario

The Calendly block as a `url` attribute that stores a Calendly link, which is then used to either embed a Calendly widget, or as the href of a Button link.

We can create the Button like this:
```jsx
<InnerBlocks template={ [ [
  'jetpack/button', {
    element: 'a',
    text: 'Submit',
    passthroughAttributes: {
      url: 'url', // buttonBlockUrl: 'calendlyBlockUrl'
    },
  },
] ] } />
```

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

Since this block is not used anywhere yet, an easy test would be to manually update the Revue edit.js to fake a sync between the parent's `revueUsername` and the Button's `text`.

```jsx
<InnerBlocks
	template={ [
		[
			innerButtonBlock.name,
			{
				...innerButtonBlock.attributes,
				passthroughAttributes: {
					text: 'revueUsername',
				},
			},
		],
	] }
	templateLock="all"
/>
```

* Insert a Revue block, and add a name (a random string will do).
* Make sure the button text is that name.
* Open the Revue block sidebar, and change the name.
* Make sure the button text updates accordingly.

#### Proposed changelog entry for your changes:

* Button block: Add mechanism to sync attributes with the parent block.