### PR TITLE
Dashboard: remove context from plural string

### DIFF
--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -236,7 +236,6 @@ class ProStatus extends React.Component {
 								<SimpleNotice showDismiss={ false } status="is-error" isCompact>
 									{ __( 'Threat', 'Threats', {
 										count: scanStatus.threats.length,
-										context: 'A caption for a small button to fix security issues.',
 									} ) }
 								</SimpleNotice>
 							);


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This change was introduced in #15795, and while it works well on its own it introduces a small issue whenever we want to gather translations from the Dashboard to send them to translate.wordpress.org.

If it were PHP, the string would use WordPress' `_nx` function, as we're dealing with a string with a singular/plural variant, and some added context. Unfortunately, the tool we use to extract strings from React to PHP does not support `_nx` at the moment.

I would be tempted to fix our tool to support this, but since we'll be moving away from this approach to translate the React dashboard soon (we'll be relying on `@wordpress/i18n` package instead, and we'll let WordPress do the work of extracting translations), I think it's best if we just avoid relying on `_nx` for now; I don't think it's very necessary in this case.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* It should not change any existing functionality. I would recommend checking the AAG dashboard on a site with threats and using Jetpack Scan.

#### Proposed changelog entry for your changes:

* N/A
