### PR TITLE
Jetpack Setup Wizard: Fix setup page being blank after connection

### DIFF
--- a/_inc/client/setup-wizard/index.jsx
+++ b/_inc/client/setup-wizard/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Redirect, Route, Switch, useRouteMatch } from 'react-router-dom';
+import { Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 /**
@@ -23,7 +23,6 @@ import { RecommendedFeatures } from './recommended-features';
 
 const SetupWizardComponent = props => {
 	const { siteTitle, status } = props;
-	const { path } = useRouteMatch();
 
 	let redirectPath;
 	switch ( status ) {
@@ -53,17 +52,17 @@ const SetupWizardComponent = props => {
 			<QueryAkismetKeyCheck />
 			<QuerySetupWizardQuestionnaire />
 			<Switch>
-				<Redirect exact from={ path } to={ path + redirectPath } />
-				<Route path={ `${ path }/intro` }>
+				<Redirect exact from={ '/setup' } to={ '/setup' + redirectPath } />
+				<Route path={ `/setup/intro` }>
 					<IntroPage siteTitle={ siteTitle } />
 				</Route>
-				<Route path={ `${ path }/income` }>
+				<Route path={ `/setup/income` }>
 					<IncomeQuestion siteTitle={ siteTitle } />
 				</Route>
-				<Route path={ `${ path }/updates` }>
+				<Route path={ `/setup/updates` }>
 					<UpdatesQuestion siteTitle={ siteTitle } />
 				</Route>
-				<Route path={ `${ path }/features` }>
+				<Route path={ `/setup/features` }>
 					<RecommendedFeatures />
 				</Route>
 			</Switch>

--- a/_inc/client/setup-wizard/index.jsx
+++ b/_inc/client/setup-wizard/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { Redirect, Route, Switch, useLocation, useRouteMatch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15936

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
When a user visits `/wp-admin/admin.php?page=jetpack` and the state of the plugin is such that it redirects to `/wp-admin/admin.php?page=jetpack#/setup` there was an infinite loop causing React to crash and the page to be blank.

This was happening because the `useRouteMatch()` hook in `SetupWizardComponent` was returning `/*` for this case, even after the URL had been changed to `#/setup`.

To fix this I have just hardcoded `/setup`, as there is no real need to dynamically get the URL here since these routes are not expected to change dynamically.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Go through the connect flow.
3. Choose the free plan, which should take you to `/wp-admin/admin.php?page=jetpack`.
4. Verify that you are redirected to `/wp-admin/admin.php?page=jetpack/setup/intro`, and the setup wizard loads.

#### Proposed changelog entry for your changes:
None needed
