### PR TITLE
Jetpack Setup Wizard: Make the setup wizard banner show when the first step has been started

### DIFF
--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -73,7 +73,7 @@ class Jetpack_Wizard_Banner {
 			return false;
 		}
 
-		if ( 'not-started' !== Jetpack_Options::get_option( 'setup_wizard_status', 'not-started' ) ) {
+		if ( ! in_array( Jetpack_Options::get_option( 'setup_wizard_status', 'not-started' ), array( 'not-started', 'intro-page' ), true ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15944

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Setup Wizard banner currently hides whenever the current status is not `not-started`. When the user visits `/setup` for the first time and is redirected to `/setup/intro` the status is considered `intro-page` and so the banner would hide even though the user had not answered the question.

This PR changes this so that the Setup Wizard banner continues to display while the user is on the first question, and hides only after it has been answered.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit the `/wp-admin/index.php` and verify that the setup wizard prompt banner shows.
3. Visit `/wp-admin/admin.php?page=jetpack#/setup` and verify that you are routed to `#/setup/intro`.
4. Return to `/wp-admin/index.php`. Verify that the setup wizard prompt banner still shows.
5. Answer the question in the banner. Verify that you are taken to `#/setup/income`. 
6. Return to `/wp-admin/index.php`. Verify that the setup wizard prompt banner no longer shows.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None
