### PR TITLE
Jetpack Setup Wizard: Increase font size of feature toggle content on large screens

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/style.scss
+++ b/_inc/client/setup-wizard/feature-toggle/style.scss
@@ -96,6 +96,8 @@
 	text-align: left;
 
 	@include breakpoint( $greater-than-vertical-break ) {
+		font-size: 15px;
+
 		span {
 			font-weight: bold;
 			margin-right: 0.5rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15942

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR increases the font size of recommended feature toggles on large screens.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit /wp-admin/admin.php?page=jetpack#/setup/features.
3. Check that the font size is larger on large screens

#### Proposed changelog entry for your changes:
None
