### PR TITLE
VideoPress Block: Tentative fix for unselectable block (GB 8.1)

### DIFF
--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -37,6 +37,12 @@ import { getVideoPressUrl } from './url';
 
 const VIDEO_POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 
+// For Gutenberg versions that support it, use the figure block wrapper (from '@wordpress/block-editor')
+// to wrap the VideoPress component the same way the underlying `core/video` block is wrapped.
+// (Otherwise there's an issue with Gutenberg >= 8.1 where the VideoPress block becomes unselectable,
+// see https://github.com/Automattic/jetpack/issues/15922.)
+const BlockFigureWrapper = Block ? Block.figure : 'figure';
+
 const VideoPressEdit = CoreVideoEdit =>
 	class extends Component {
 		constructor() {
@@ -273,7 +279,9 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					<Block.figure>
+					<BlockFigureWrapper
+						className={ classnames( className, 'wp-block-embed', 'is-type-video' ) }
+					>
 						{ /*
 							Disable the video player so the user clicking on it won't play the
 							video when the controls are enabled.
@@ -292,7 +300,7 @@ const VideoPressEdit = CoreVideoEdit =>
 								inlineToolbar
 							/>
 						) }
-					</Block.figure>
+					</BlockFigureWrapper>
 				</Fragment>
 			);
 		}

--- a/extensions/blocks/videopress/edit.js
+++ b/extensions/blocks/videopress/edit.js
@@ -22,6 +22,7 @@ import {
 	MediaUpload,
 	MediaUploadCheck,
 	RichText,
+	__experimentalBlock as Block,
 } from '@wordpress/block-editor';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -272,7 +273,7 @@ const VideoPressEdit = CoreVideoEdit =>
 			return (
 				<Fragment>
 					{ blockSettings }
-					<figure className={ classnames( className, 'wp-block-embed', 'is-type-video' ) }>
+					<Block.figure>
 						{ /*
 							Disable the video player so the user clicking on it won't play the
 							video when the controls are enabled.
@@ -291,7 +292,7 @@ const VideoPressEdit = CoreVideoEdit =>
 								inlineToolbar
 							/>
 						) }
-					</figure>
+					</Block.figure>
 				</Fragment>
 			);
 		}


### PR DESCRIPTION
Tentative fix for #15922.

Use the same light block wrapper that the underlying `core/video` block also uses ([see](https://github.com/WordPress/gutenberg/pull/22028/files#diff-f0c30ccbfe8a9fdb491ed1d29882e9dcR226)).

#### Question

The light wrapper pulls information (such as the block name) from block context and uses it for attributes (such as `data-type`). This means we end up with some of those set to values that correspond to the wrapped `core/video` block (rather than the wrapping `jetpack/videopress` block). It seems non-trivial to modify block context.

![image](https://user-images.githubusercontent.com/96308/83068276-6765f700-a068-11ea-90e9-2b7a877b7283.png)

The question is -- is that a problem? :grimacing: cc/ @youknowriad for advice

#### Note

If this turns out to be a viable fix, it'd be great to include it in the JP 8.6 release.

#### Changes proposed in this Pull Request:
Use light block wrapper for VideoPress block in order to prevent it from becoming unselectable.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

On a Jetpack site (e.g. your local Docker env):
- Install and activate Gutenberg >= 8.1.
- Make sure VideoPress is enabled (at the bottom of `/wp-admin/admin.php?page=jetpack#/performance`)
- Make sure you are on a paid plan that supports VideoPress.
- Insert a Video block into a new post, and upload a video through the media placeholder.
- Verify that you can still select the block (i.e. verify that #15922 is fixed).

Test the above also with the Gutenberg plugin disabled (make sure there's no error like [this](https://github.com/Automattic/jetpack/pull/15958#pullrequestreview-419954622)), and with earlier versions of Gutenberg (e.g. 8.0).

To test on WP.com

- Apply the corresponding WP.com diff (D44057-code) to your sandbox, and sandbox a test site and the REST API
- Insert a Video block into a new post. If you see a nudge telling you to upgrade your plan, do so.
- Finally, return to your post and upload a video to your block.
- Verify that you can still select the block (i.e. verify that #15922 is fixed).

#### Proposed changelog entry for your changes:
Use light block wrapper for VideoPress block in order to prevent it from becoming unselectable.