### PR TITLE
Jetpack Setup Wizard: Fix upgrade states of backup and scan feature toggles

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -13,7 +13,14 @@ import { getVaultPressData, isAkismetKeyValid } from 'state/at-a-glance';
 import { getSiteRawUrl } from 'state/initial-state';
 import { getRewindStatus } from 'state/rewind';
 import { getSetting, updateSettings } from 'state/settings';
-import { getSitePlan, hasActiveSearchPurchase } from 'state/site';
+import {
+	getActiveBackupPurchase,
+	getActiveScanPurchase,
+	getSitePlan,
+	hasActiveBackupPurchase,
+	hasActiveScanPurchase,
+	hasActiveSearchPurchase,
+} from 'state/site';
 
 function getInfoString( productName ) {
 	return __( 'Included with %(productName)s', { args: { productName } } );
@@ -102,46 +109,41 @@ const features = {
 
 	backups: {
 		mapStateToProps: state => {
-			const vaultPressData = getVaultPressData( state );
-			const isVaultPressEnabled = get( vaultPressData, [ 'data', 'features', 'backups' ], false );
-
-			const rewindStatus = getRewindStatus( state );
-			const rewindState = get( rewindStatus, 'state', false );
-
 			const sitePlan = getSitePlan( state );
 			const planClass = getPlanClass( sitePlan.product_slug );
-
-			const backupsActive = true === isVaultPressEnabled || 'active' === rewindState;
-
-			const inCurrentPlan = [
-				'is-personal-plan',
-				'is-premium-plan',
-				'is-business-plan',
-				'is-daily-backup-plan',
-				'is-realtime-backup-plan',
-			].includes( planClass );
+			const isBackupsPurchased =
+				hasActiveBackupPurchase( state ) ||
+				[
+					'is-personal-plan',
+					'is-premium-plan',
+					'is-business-plan',
+					'is-daily-backup-plan',
+					'is-realtime-backup-plan',
+				].includes( planClass );
 
 			let optionsLink;
-			if ( inCurrentPlan ) {
+			if ( isBackupsPurchased ) {
 				optionsLink = '#/settings?term=backup';
 			}
 
 			let upgradeLink;
-			if ( ! inCurrentPlan ) {
+			if ( ! isBackupsPurchased ) {
 				upgradeLink = '#/plans';
 			}
 
 			let info;
-			if ( inCurrentPlan ) {
-				info = getInfoString( sitePlan.product_name );
+			if ( isBackupsPurchased ) {
+				const backupsPurchase = getActiveBackupPurchase( state );
+				const productName = backupsPurchase ? backupsPurchase.product_name : sitePlan.product_name;
+				info = getInfoString( productName );
 			}
 
 			return {
 				feature: 'backups',
 				title: __( 'Daily or Real-time backups' ),
 				details: __( 'Get time travel for your site with Jetpack Backup.' ),
-				checked: backupsActive,
-				isDisabled: inCurrentPlan,
+				checked: isBackupsPurchased,
+				isDisabled: isBackupsPurchased,
 				optionsLink,
 				upgradeLink,
 				info,
@@ -653,38 +655,35 @@ const features = {
 
 	scan: {
 		mapStateToProps: state => {
-			const vaultPressData = getVaultPressData( state );
-			const isScanEnabled =
-				true === get( vaultPressData, [ 'data', 'features', 'security' ], false );
-
 			const sitePlan = getSitePlan( state );
 			const planClass = getPlanClass( sitePlan.product_slug );
-
-			const inCurrentPlan = [ 'is-premium-plan', 'is-business-plan', 'is-scan-plan' ].includes(
-				planClass
-			);
+			const isScanPurchased =
+				hasActiveScanPurchase( state ) ||
+				[ 'is-premium-plan', 'is-business-plan', 'is-scan-plan' ].includes( planClass );
 
 			let optionsLink;
-			if ( inCurrentPlan ) {
+			if ( isScanPurchased ) {
 				optionsLink = '#/settings?term=scan';
 			}
 
 			let upgradeLink;
-			if ( ! inCurrentPlan ) {
+			if ( ! isScanPurchased ) {
 				upgradeLink = '#/plans';
 			}
 
 			let info;
-			if ( inCurrentPlan ) {
-				info = getInfoString( sitePlan.product_name );
+			if ( isScanPurchased ) {
+				const scanPurchase = getActiveScanPurchase( state );
+				const productName = scanPurchase ? scanPurchase.product_name : sitePlan.product_name;
+				info = getInfoString( productName );
 			}
 
 			return {
 				feature: 'scan',
 				title: __( 'Security scanning' ),
 				details: __( 'Stop threats to keep your website safe.' ),
-				checked: isScanEnabled,
-				isDisabled: inCurrentPlan,
+				checked: isScanPurchased,
+				isDisabled: isScanPurchased,
 				isPaid: true,
 				optionsLink,
 				upgradeLink,

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -7,7 +7,12 @@ import { assign, find, get, merge } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isJetpackProduct, isJetpackSearch } from 'lib/plans/constants';
+import {
+	isJetpackProduct,
+	isJetpackBackup,
+	isJetpackScan,
+	isJetpackSearch,
+} from 'lib/plans/constants';
 import {
 	JETPACK_SITE_DATA_FETCH,
 	JETPACK_SITE_DATA_FETCH_RECEIVE,
@@ -232,6 +237,26 @@ export function getActiveProductPurchases( state ) {
 	return getActiveSitePurchases( state ).filter( purchase =>
 		isJetpackProduct( purchase.product_slug )
 	);
+}
+
+export function getActiveBackupPurchase( state ) {
+	return find( getActiveProductPurchases( state ), product =>
+		isJetpackBackup( product.product_slug )
+	);
+}
+
+export function hasActiveBackupPurchase( state ) {
+	return !! getActiveBackupPurchase( state );
+}
+
+export function getActiveScanPurchase( state ) {
+	return find( getActiveProductPurchases( state ), product =>
+		isJetpackScan( product.product_slug )
+	);
+}
+
+export function hasActiveScanPurchase( state ) {
+	return !! getActiveScanPurchase( state );
 }
 
 export function getActiveSearchPurchase( state ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15943

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Backup and Scan feature toggles were prompting upgrades in the case where the site had single product purchases of Backup and Scan. This was happening because they only considered the site's plan, which is still Jetpack Free when single products have been purchased.

They now look at current active purchases of Backup and Scan in addition to the site plan to determine when to prompt an upgrade.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. On a free site, visit `/wp-admin/admin.php?page=jetpack#/setup/features` and verify that both Backup and Scan prompt an upgrade.
3. Purchase Back and Scan single products and then visit `/wp-admin/admin.php?page=jetpack#/setup/features`. Verify that there is no upgrade prompt and that both toggles display the correct plan in their content.
4. On a different site purchase a Jetpack Plan that includes Backup and Scan. Visit `/wp-admin/admin.php?page=jetpack#/setup/features` and verify that there is no upgrade prompt and that both toggles display the correct plan in their content.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
