### PR TITLE
Jetpack Setup Wizard: Fix positioning of Setup Wizard banner dismiss button

### DIFF
--- a/class-jetpack-wizard-banner.php
+++ b/class-jetpack-wizard-banner.php
@@ -227,7 +227,7 @@ class Jetpack_Wizard_Banner {
 				</div>
 
 				<span
-					class="notice-dismiss wizard-banner-dismiss"
+					class="notice-dismiss"
 					title="<?php esc_attr_e( 'Dismiss this notice', 'jetpack' ); ?>">
 				</span>
 

--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -1,8 +1,8 @@
 @import 'node_modules/@automattic/color-studio/dist/color-variables.scss';
 @import '../_inc/client/scss/mixin_breakpoint';
 
-
 .jp-wizard-banner {
+	position: relative;
 	text-align: left;
 	background: $studio-white;
 	padding: 2rem;
@@ -56,20 +56,6 @@
 
 	@include breakpoint( '<960px' ) {
 		display: none;
-	}
-}
-
-.wizard-banner-dismiss {
-	float: right;
-	height: 20px;
-	width: 20px;
-	margin-top: 80px;
-	margin-right: 30px;
-	position: fixed;
-
-	@include breakpoint( '<660px' ) {
-		margin-top: 95px;
-		margin-right: 25px;
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15916

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The dismiss button of the Setup Wizard banner would stay in one place on the screen even as the screen scrolled. This is because it had a fixed position.

This PR fixes that by removing the fixed position CSS and giving the `jp-wizard-banner` a relative position so that the dismiss button will be positioned correctly by its `notice-dismiss` class.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/index.php` on a site that has yet to begin the setup wizard and verify that you can see the Setup Wizard banner.
3. Scroll down and verify that the dismiss button of the banner is positioned as it should be.

#### Proposed changelog entry for your changes:
None
