### PR TITLE
Jetpack Setup Wizard: Substitute "block editor" for "Gutenberg"

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -253,7 +253,7 @@ const features = {
 			return {
 				feature: 'contact-form',
 				title: __( 'Contact Form' ),
-				details: __( 'Gutenberg ready forms!' ),
+				details: __( 'Add contact forms using the block editor.' ),
 				checked: getSetting( state, 'contact-form' ),
 				optionsLink: '#/settings?term=contact%20form',
 			};
@@ -1008,7 +1008,7 @@ const features = {
 			return {
 				feature: 'tiled-galleries',
 				title: __( 'Tiled Galleries' ),
-				details: 'Add beautifully laid out galleries as a Gutenberg block',
+				details: 'Add beautifully laid out galleries using the block editor.',
 				checked: getSetting( state, 'tiled-gallery' ),
 				optionsLink: 'https://jetpack.com/support/jetpack-blocks/tiled-gallery-block/',
 				isOptionsLinkExternal: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15947

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR changes the copy of the recommended features page to use "block editor" in favor of "Gutenberg".

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Visually check that the copy has been changed appropriately.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None
