### PR TITLE
Jetpack Setup Wizard: Adjust borders of recommended features page in mobile view

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/style.scss
+++ b/_inc/client/setup-wizard/feature-toggle/style.scss
@@ -20,6 +20,8 @@
 	@include breakpoint( $less-than-vertical-break ) {
 		grid-template-rows: 65px auto auto;
 		grid-template-columns: 90px auto;
+
+		border-width: 1px 0;
 	}
 
 	.dops-button {

--- a/_inc/client/setup-wizard/feature-toggle/style.scss
+++ b/_inc/client/setup-wizard/feature-toggle/style.scss
@@ -4,14 +4,14 @@
 
 .jp-setup-wizard-feature-toggle {
 	border: 1px solid #ccd0d4;
-	border-radius: 4px;
 
 	display: grid;
-
 	grid-template-rows: 100px;
 	grid-template-columns: 100px auto auto;
 
 	@include breakpoint( $greater-than-vertical-break ) {
+		border-radius: 4px;
+
 		&.jp-setup-wizard-fixed-right-column {
 			grid-template-columns: 100px auto 220px;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15949

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The borders of the features page were rounded in the mobile view, creating a bad aesthetic effect:
<img width="450" alt="image" src="https://user-images.githubusercontent.com/42627630/83079465-856c3100-a041-11ea-90cd-3a6d0db1ab1a.png">

Now the borders are no longer rounded in the mobile view:
<img width="486" alt="image" src="https://user-images.githubusercontent.com/42627630/83079513-9f0d7880-a041-11ea-9aa7-631949e0d3db.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/features`.
3. Resize the window to be narrow.
4. Verify that the rounded borders are no longer present.

#### Proposed changelog entry for your changes:
None
