### PR TITLE
JITM: add Redirect use statement

### DIFF
--- a/packages/jitm/src/class-post-connection-jitm.php
+++ b/packages/jitm/src/class-post-connection-jitm.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\JITMS;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Partner;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\JITMS\JITM;
 
@@ -177,9 +178,8 @@ class Post_Connection_JITM extends JITM {
 			$this->tracking->record_user_event( 'delete_connection_owner_notice_view' );
 		}
 
-		$connection_manager = new Manager();
-		$connected_admins   = $connection_manager->get_connected_users( 'jetpack_disconnect' );
-		$user               = is_a( $connection_owner_userdata, 'WP_User' ) ? esc_html( $connection_owner_userdata->data->user_login ) : '';
+		$connected_admins = $connection_manager->get_connected_users( 'jetpack_disconnect' );
+		$user             = is_a( $connection_owner_userdata, 'WP_User' ) ? esc_html( $connection_owner_userdata->data->user_login ) : '';
 
 		echo "<div class='notice notice-warning' id='jetpack-notice-switch-connection-owner'>";
 		echo '<h2>' . esc_html__( 'Important notice about your Jetpack connection:', 'jetpack' ) . '</h2>';


### PR DESCRIPTION
Fixes #15965 

The bug was introduced in the 8.6 cycle, so I've added this PR to the 8.6 milestone.

#### Changes proposed in this Pull Request:
* Add a use statement for `Automattic\Jetpack\Redirect`
* Remove the duplicate instantiation of `Connection\Manager`. (See line 149.)

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
This changes an existing part of Jetpack.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

##### Test Site
- Must have Jetpack active.
- Must have at least two connected admins.

##### Test Steps
1. Log in as a secondary admin (not the master user).
2. Navigate to wp-admin -> Users.
3. Attempt to delete the master user.
4. You should see a notice that provides instructions for changing the master user. Confirm that no errors have been generated.
5. Change the master user.

#### Proposed changelog entry for your changes:
* tbd
