### PR TITLE
Jetpack Setup Wizard: limit the width of the banner

### DIFF
--- a/scss/jetpack-wizard-banner.scss
+++ b/scss/jetpack-wizard-banner.scss
@@ -28,6 +28,7 @@
 
 .jp-wizard-banner-grid {
 	display: flex;
+	max-width: 1000px;
 }
 
 .jp-wizard-banner-grid-a {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* As per @jeffgolenski's recommendation, limit the width of the wizard banner.

![image](https://user-images.githubusercontent.com/426388/83151579-06d4c980-a0fd-11ea-96ba-eee269a21591.png)

-- p8oabR-vj-p2#comment-4314

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* On a connected site, add
```php
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
* Check the banner at the top of the main dashboard, its contents should never go too large.

#### Proposed changelog entry for your changes:

* N/A
