### PR TITLE
Backup & Scan: Load Rewind state on Settings page render

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -16,6 +16,7 @@ import getRedirectUrl from 'lib/jp-redirect';
  */
 import { getPlanClass, FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import QueryRewindStatus from 'components/data/query-rewind-status';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { getVaultPressData, getVaultPressScanThreatCount } from 'state/at-a-glance';
@@ -254,6 +255,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					action="scan"
 					hideButton
 				>
+					<QueryRewindStatus />
 					<SettingsGroup
 						disableInDevMode
 						module={ { module: 'backups' } }


### PR DESCRIPTION
**Fixes #15903 and 1169345694087188-as-1177746785538170.**

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In #15903, we see that the status of Jetpack Backup and Scan is not updated when we navigate to WP Admin / Settings / Security without first going through the Dashboard. This PR adds a reference to `QueryRewindStatus` in the `BackupsScan` render, ensuring that we retrieve this state information and show it correctly on the page.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions (see original issue for more details and screenshots):

* On a site that has Jetpack Backup and is properly set up, go directly to the Settings page by pasting the URL into your browser: `<site URL>/wp-admin/admin.php?page=jetpack#/settings`
* Verify that when the page loads, the status under "Backups and security scanning" automatically updates to reflect the true state of the site.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Correctly retrieve connection status on page load for Jetpack Backup and Scan in Settings -> Security.
