### PR TITLE
Block Extensions: Fix Stripe nudge Tracks event.

### DIFF
--- a/extensions/shared/components/stripe-nudge/index.jsx
+++ b/extensions/shared/components/stripe-nudge/index.jsx
@@ -12,7 +12,7 @@ import BlockNudge from '../block-nudge';
 
 import './style.scss';
 
-export default ( { stripeConnectUrl } ) => (
+export default ( { blockName, stripeConnectUrl } ) => (
 	<BlockNudge
 		buttonLabel={ __( 'Connect', 'jetpack' ) }
 		icon={
@@ -25,7 +25,7 @@ export default ( { stripeConnectUrl } ) => (
 			/>
 		}
 		href={ stripeConnectUrl }
-		onClick={ blockName =>
+		onClick={ () =>
 			void analytics.tracks.recordEvent( 'jetpack_editor_block_stripe_connect_click', {
 				block: blockName,
 			} )


### PR DESCRIPTION
This PR fixes the Tracks event handling for the Strip nudge in the Recurring Payments block.

#### Testing instructions:
* See D44119-code.

#### Does this pull request change what data or activity we track or use?
* It fixes a button click tracking we already thought we were doing.

#### Proposed changelog entry for your changes:
* no entry needed
