### PR TITLE
Jetpack Setup Wizard: Make #/dashboard the default page

### DIFF
--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -247,18 +247,13 @@ class Main extends React.Component {
 				}
 				break;
 			default:
-				if ( this.props.showSetupWizard ) {
-					this.props.history.replace( '/setup' );
-					navComponent = null;
-					pageComponent = <SetupWizard />;
-				} else {
-					this.props.history.replace( '/dashboard' );
-					pageComponent = this.getAtAGlance();
-				}
+				this.props.history.replace( '/dashboard' );
+				pageComponent = this.getAtAGlance();
+				break;
 		}
 
 		const pageOrder = this.props.showSetupWizard
-			? { setup: 1, dashboard: 2, settings: 3 }
+			? { dashboard: 1, setup: 2, settings: 3 }
 			: { setup: -1, dashboard: 1, settings: 2 };
 
 		window.wpNavMenuClassChange( pageOrder );

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -38,8 +38,8 @@ class Jetpack_Admin {
 
 		add_action( 'admin_menu', array( $this->jetpack_react, 'add_actions' ), 998 );
 		add_action( 'admin_menu', array( $this->jetpack_react, 'add_actions' ), 998 );
-		add_action( 'jetpack_admin_menu', array( $this->jetpack_react, 'jetpack_add_set_up_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $this->jetpack_react, 'jetpack_add_dashboard_sub_nav_item' ) );
+		add_action( 'jetpack_admin_menu', array( $this->jetpack_react, 'jetpack_add_set_up_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $this->jetpack_react, 'jetpack_add_settings_sub_nav_item' ) );
 		add_action( 'jetpack_admin_menu', array( $this, 'admin_menu_debugger' ) );
 		add_action( 'jetpack_admin_menu', array( $this->fallback_page, 'add_actions' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15970

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The Setup Wizard was originally made the default page when clicking into the plugin. This PR changes it so that the dashboard is the default page when clicking into the plugin. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Starting at the dashboard with a connected Jetpack, click the "Jetpack" nav item on the left sidebar. Verify that you are taken to `/wp-admin/admin.php?page=jetpack#/dashboard`
3. Go to `/wp-admin/admin.php?page=jetpack`. Verify that you are taken to `/wp-admin/admin.php?page=jetpack#/dashboard`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
