### PR TITLE
Jetpack Setup Wizard: Do not show pre-connection JITMs to non admins

### DIFF
--- a/packages/jitm/src/class-pre-connection-jitm.php
+++ b/packages/jitm/src/class-pre-connection-jitm.php
@@ -100,6 +100,10 @@ class Pre_Connection_JITM extends JITM {
 			return array();
 		}
 
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return array();
+		}
+
 		$messages = $this->filter_messages( $message_path );
 
 		if ( empty( $messages ) ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15968

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Pre-connection JITMs were showing to all users. This PR makes it so that they only show to admins.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. On a pre-connection Jetpack on an admin account visit `/wp-admin/upload.php` and verify that you see a pre-connection JITM.
3. On a pre-connection Jetpack on an author account visit `/wp-admin/upload.php` and verify that you do not see a pre-connection JITM.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
