### PR TITLE
Jetpack Setup Wizard: Fix the configure button alignment

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/style.scss
+++ b/_inc/client/setup-wizard/feature-toggle/style.scss
@@ -13,7 +13,7 @@
 
 	@include breakpoint( $greater-than-vertical-break ) {
 		&.jp-setup-wizard-fixed-right-column {
-			grid-template-columns: 100px auto 220px;
+			grid-template-columns: 100px auto 240px;
 		}
 	}
 
@@ -112,7 +112,7 @@
 .jp-setup-wizard-feature-toggle-button-container {
 	display: flex;
 	flex-direction: column;
-	align-items: center;
+	align-items: flex-end;
 	justify-content: center;
 
 	padding-right: 1rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15972

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adjust the layout of the feature toggle to avoid a layout conflict between the configure button and the text below it.

Before:
![image](https://user-images.githubusercontent.com/426388/83150236-52867380-a0fb-11ea-99ed-cb4b78c5aa74.png)

After:
<img width="981" alt="image" src="https://user-images.githubusercontent.com/42627630/83207363-a3f12b80-a118-11ea-9f12-b17afcb1b86d.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. On a brand new site, before to connect to WordPress.com, add the following:
```php
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Connect your site to WordPress.com and pick a Professional plan.
3. Head back to wp-admin.
4. Click on setup.
5. Pick Business and the Advertising option in the flow.
6. On the recommended features find the Ads card and verify that it has no visual issues.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None
