### PR TITLE
Jetpack Setup Wizard: Add margin between feature toggle groups

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle-group/style.scss
+++ b/_inc/client/setup-wizard/feature-toggle-group/style.scss
@@ -2,6 +2,11 @@
 @import '../recommended-features/variables';
 
 .jp-setup-wizard-feature-toggle-group {
+	margin-bottom: 75px;
+	@include breakpoint( $less-than-vertical-break ) {
+		margin-bottom: 50px;
+	}
+
 	h2 {
 		text-align: left;
 		margin: 1rem 0 0.25rem 0;

--- a/_inc/client/setup-wizard/recommended-features/index.jsx
+++ b/_inc/client/setup-wizard/recommended-features/index.jsx
@@ -54,15 +54,17 @@ class RecommendedFeatures extends Component {
 				<p className="jp-setup-wizard-recommended-features-p2">
 					{ __( 'You can change your feature settings at any time.' ) }
 				</p>
-				{ this.props.recommendedFeatureGroups.map( featureGroup => {
-					return (
-						<FeatureToggleGroup
-							title={ featureGroup.title }
-							details={ featureGroup.details }
-							features={ featureGroup.features }
-						/>
-					);
-				} ) }
+				<div className="jp-setup-wizard-feature-groups-container">
+					{ this.props.recommendedFeatureGroups.map( featureGroup => {
+						return (
+							<FeatureToggleGroup
+								title={ featureGroup.title }
+								details={ featureGroup.details }
+								features={ featureGroup.features }
+							/>
+						);
+					} ) }
+				</div>
 				<div className="jp-setup-wizard-recommended-features-buttons-container">
 					<Button primary href="#/dashboard" onClick={ this.onDoneButtonClick }>
 						{ __( 'I’m done for now' ) }

--- a/_inc/client/setup-wizard/recommended-features/style.scss
+++ b/_inc/client/setup-wizard/recommended-features/style.scss
@@ -59,3 +59,9 @@
 		}
 	}
 }
+
+.jp-setup-wizard-feature-groups-container {
+	:last-child {
+		margin-bottom: 0;
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15974

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds margins between the groups of feature toggles in the Setup Wizard.

Before:
<img width="804" alt="image" src="https://user-images.githubusercontent.com/42627630/83208555-9c7f5180-a11b-11ea-8d1e-6a475511b6fd.png">

After:
<img width="814" alt="image" src="https://user-images.githubusercontent.com/42627630/83208509-84a7cd80-a11b-11ea-849b-9473934531ab.png">


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. Add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/features`.
3. Verify that there is appropriate space between each feature group.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None
