### PR TITLE
Pre-connection JITMS: Link to connect-in-place flow

### DIFF
--- a/packages/jitm/src/class-pre-connection-jitm.php
+++ b/packages/jitm/src/class-pre-connection-jitm.php
@@ -24,7 +24,7 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:edit-post:admin_notices/',
 				'message'        => __( 'Do you know which of these posts gets the most traffic?', 'jetpack' ),
 				'description'    => __( 'Setup Jetpack to get in-depth stats about your content and visitors.', 'jetpack' ),
-				'button_link'    => esc_url( \Jetpack::init()->build_connect_url( true, false, 'pre-connection-jitm-posts' ) ),
+				'button_link'    => \Jetpack::admin_url( '#/setup' ),
 				'button_caption' => __( 'Setup Jetpack', 'jetpack' ),
 			),
 			array(
@@ -32,7 +32,7 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:upload:admin_notices/',
 				'message'        => __( 'Do you want lightning-fast images?', 'jetpack' ),
 				'description'    => __( 'Setup Jetpack, enable Site Accelerator, and start serving your images lightning fast, for free.', 'jetpack' ),
-				'button_link'    => esc_url( \Jetpack::init()->build_connect_url( true, false, 'pre-connection-jitm-upload' ) ),
+				'button_link'    => \Jetpack::admin_url( '#/setup' ),
 				'button_caption' => __( 'Setup Jetpack', 'jetpack' ),
 			),
 			array(
@@ -40,7 +40,7 @@ class Pre_Connection_JITM extends JITM {
 				'message_path'   => '/wp:widgets:admin_notices/',
 				'message'        => __( 'Looking for even more widgets?', 'jetpack' ),
 				'description'    => __( 'Setup Jetpack for great additional widgets that display business contact info and maps, blog stats, and top posts.', 'jetpack' ),
-				'button_link'    => esc_url( \Jetpack::init()->build_connect_url( true, false, 'pre-connection-jitm-widgets' ) ),
+				'button_link'    => \Jetpack::admin_url( '#/setup' ),
 				'button_caption' => __( 'Setup Jetpack', 'jetpack' ),
 			),
 		);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15971

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR updates the pre-connection JITMs to use the connect-in-place flow instead of the wordpress.com flow.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. On a brand new site, before connecting to WordPress.com, add the following:
```php
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Go to the Posts screen
3. Click on Setup Jetpack at the top of the page in the notice
4. Verify that you are taken to `/wp-admin/admin.php?page=jetpack#/setup` and that you see the connect-in-place flow.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None
