### PR TITLE
Image Compare: set width and height attributes for block's images

### DIFF
--- a/extensions/blocks/image-compare/edit.js
+++ b/extensions/blocks/image-compare/edit.js
@@ -91,13 +91,15 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 							onChange={ img => {
 								if ( img.media_type === 'image' || img.type === 'image' ) {
 									const { src } = photonizedImgProps( img );
-									const { width, height } = img.media_details;
+									const { alt, id, media_details } = img;
+									const width = media_details?.width ?? img.width;
+									const height = media_details?.height ?? img.height;
 
 									setAttributes( {
 										imageBefore: {
-											id: img.id,
+											id,
 											url: src ? src : img.url,
-											alt: img.alt,
+											alt,
 											width,
 											height,
 										},
@@ -117,13 +119,15 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 							onChange={ img => {
 								if ( img.media_type === 'image' || img.type === 'image' ) {
 									const { src } = photonizedImgProps( img );
-									const { width, height } = img.media_details;
+									const { alt, id, media_details } = img;
+									const width = media_details?.width ?? img.width;
+									const height = media_details?.height ?? img.height;
 
 									setAttributes( {
 										imageAfter: {
-											id: img.id,
+											id,
 											url: src ? src : img.url,
-											alt: img.alt,
+											alt,
 											width,
 											height,
 										},

--- a/extensions/blocks/image-compare/edit.js
+++ b/extensions/blocks/image-compare/edit.js
@@ -91,13 +91,15 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 							onChange={ img => {
 								if ( img.media_type === 'image' || img.type === 'image' ) {
 									const { src } = photonizedImgProps( img );
+									const { width, height } = img.media_details;
+
 									setAttributes( {
 										imageBefore: {
 											id: img.id,
 											url: src ? src : img.url,
 											alt: img.alt,
-											width: img.width,
-											height: img.height,
+											width,
+											height,
 										},
 									} );
 								}
@@ -115,13 +117,15 @@ const Edit = ( { attributes, className, clientId, isSelected, setAttributes } ) 
 							onChange={ img => {
 								if ( img.media_type === 'image' || img.type === 'image' ) {
 									const { src } = photonizedImgProps( img );
+									const { width, height } = img.media_details;
+
 									setAttributes( {
 										imageAfter: {
 											id: img.id,
 											url: src ? src : img.url,
 											alt: img.alt,
-											width: img.width,
-											height: img.height,
+											width,
+											height,
 										},
 									} );
 								}

--- a/extensions/blocks/image-compare/image-compare.php
+++ b/extensions/blocks/image-compare/image-compare.php
@@ -58,9 +58,9 @@ function render_amp( $attr ) {
 	$img_after  = $attr['imageAfter'];
 
 	return sprintf(
-		'<amp-image-slider layout="responsive" width="%1$d" height="%2$d"> <amp-img id="%3$d" src="%4$s" alt="%5$s" layout="fill"></amp-img> <amp-img id="%6$d" src="%7$s" alt="%8$s" layout="fill"></amp-img></amp-image-slider>',
-		absint( $img_before['width'] ),
-		absint( $img_before['height'] ),
+		'<amp-image-slider layout="responsive"%1$s%2$s> <amp-img id="%3$d" src="%4$s" alt="%5$s" layout="fill"></amp-img> <amp-img id="%6$d" src="%7$s" alt="%8$s" layout="fill"></amp-img></amp-image-slider>',
+		! empty( $img_before['width'] ) ? ' width="' . absint( $img_before['width'] ) . '"' : '',
+		! empty( $img_before['height'] ) ? ' height="' . absint( $img_before['height'] ) . '"' : '',
 		absint( $img_before['id'] ),
 		esc_url( $img_before['url'] ),
 		esc_attr( $img_before['alt'] ),


### PR DESCRIPTION
Fixes #16001

#### Changes proposed in this Pull Request:

* Pick image's width and height attributes from the sizes made available by the upload. In some cases it may come from `img` (when you select an existing image in the media libray) but in others it may come from `img.media_details` (when uploading a new image).
* Do not set any width or height attributes to the AMP slider when sizes are not available.

#### Does this pull request change what data or activity we track or use?

* No.

#### Testing instructions:

* Install the AMP plugin on your site.
* Go to Posts > Add New and add a new Image Compare block.
* Upload one image, and set one from an existing image in your media library to test both scenarios.
* View that post in an AMP view, and in a regular view; the block should be displayed nicely.
* Back in the editor, switch to the code editor in the editor sidebar. Check the block's attributes for width and height attributes for each image.

#### Proposed changelog entry for your changes:

* N/A
