### PR TITLE
Sync: Add additional support for theme_support_whitelist

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -803,6 +803,8 @@ class Defaults {
 		'jetpack-responsive-videos',
 		'infinite-scroll',
 		'site-logo',
+		'editor-color-palette',
+		'editor-gradient-presets',
 	);
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds a couple of Gutenberg-related theme-supports item to the whitelist.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds, see pb3aDo-nW-p2 for the discussion.

#### Does this pull request change what data or activity we track or use?
* It slightly expands the options we validate, but it should already be covered by past disclosure.

#### Testing instructions:
Requires a WordPress.com sandbox.

* Apply D44168-code.
* Set your sandbox as such in the jetpack constants.
* Install this branch.
* Connect (or if a previously connected site, full sync the themes via the debugger).
* Via the developer.wordpress.com/console/ debugger, check the wp/v2/themes?status[]=active endpoint for your site. Confirm it has a value for the `editor-color-palette` theme-supports item.
* Bonus points if you install the REST API console on your Jetpack site to run the same endpoint locally and confirm it is the same.

Without this branch, it would sync and output as `false` via the WP.com API but still have the full value locally.

#### Proposed changelog entry for your changes:
* Adds additional support for Gutenberg via the centralized WordPress.com API.
