### PR TITLE
Move Jetpack logo to icon file

### DIFF
--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import JetpackLogo from '../shared/jetpack-logo';
+import { JetpackLogo } from './icons';
 import { isAtomicSite, isSimpleSite } from '../shared/site-type-utils';
 
 /**

--- a/extensions/shared/icons.js
+++ b/extensions/shared/icons.js
@@ -4,7 +4,7 @@
 import { Path, Polygon, SVG } from '@wordpress/components';
 import classNames from 'classnames';
 
-export default ( { size = 24, className } ) => (
+export const JetpackLogo = ( { size = 24, className } ) => (
 	<SVG
 		className={ classNames( 'jetpack-logo', className ) }
 		width={ size }

--- a/extensions/shared/jetpack-plugin-sidebar.js
+++ b/extensions/shared/jetpack-plugin-sidebar.js
@@ -10,7 +10,7 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import './jetpack-plugin-sidebar.scss';
-import JetpackLogo from './jetpack-logo';
+import { JetpackLogo } from './icons';
 
 const { Fill, Slot } = createSlotFill( 'JetpackPluginSidebar' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Moves the shared Jetpack logo in a more generic `icons.js` file in preparation for #15717 adding more icons.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes existing Jetpack logo file
* Adds `icon.js` file with Jetpack logo
* Updates existing JetpackLogo imports.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the Editor
* Verify that the logo still works in the toolbar (top right)
* Open the block inserter and verify the logo still shows up next to the category.

#### Proposed changelog entry for your changes:
Not needed.