### PR TITLE
Form Block: Make sure the add block button is aligned correctly.

### DIFF
--- a/extensions/blocks/contact-form/editor.scss
+++ b/extensions/blocks/contact-form/editor.scss
@@ -49,6 +49,10 @@
 			}
 		}
 	}
+
+	.block-list-appender {
+		flex: 0 0 100%;
+	}
 }
 
 .jetpack-contact-form .components-placeholder {


### PR DESCRIPTION
Make sure the Add Block button for inner blocks is aligned to the right in the editor. Previously it was floating in the middle of the form.

<img width="708" alt="Screen Shot 2020-05-29 at 11 07 51 AM" src="https://user-images.githubusercontent.com/1464705/83291112-abf2af00-a19c-11ea-98d9-e51995f3440e.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a form block, check the button is on the right.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
