### PR TITLE
Fix `jetpack sync start` CLI command

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Settings;
 
@@ -996,6 +997,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 							WP_CLI::log( __( 'Sent data to WordPress.com', 'jetpack' ) );
 						} else {
 							WP_CLI::log( __( 'Sent more data to WordPress.com', 'jetpack' ) );
+						}
+
+						// Immediate Full Sync does not wait for WP.com to process data so we need to enforce a wait.
+						if ( false !== strpos( get_class( Modules::get_module( 'full-sync' ) ), 'Full_Sync_Immediately' ) ) {
+							sleep( 10 );
 						}
 					}
 					$i++;

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -256,14 +256,24 @@ class Sender {
 	 * @return boolean|\WP_Error True if this sync sending was successful, error object otherwise.
 	 */
 	public function do_full_sync() {
-		if ( ! Modules::get_module( 'full-sync' ) ) {
+		$sync_module = Modules::get_module( 'full-sync' );
+		if ( ! $sync_module ) {
 			return;
 		}
 		if ( ! Settings::get_setting( 'full_sync_sender_enabled' ) ) {
 			return;
 		}
 		$this->continue_full_sync_enqueue();
-		return $this->do_sync_and_set_delays( $this->full_sync_queue );
+		// immediate full sync sends data in continue_full_sync_enqueue.
+		if ( false === strpos( get_class( $sync_module ), 'Full_Sync_Immediately' ) ) {
+			return $this->do_sync_and_set_delays( $this->full_sync_queue );
+		} else {
+			if ( $sync_module->get_status()['finished'] ) {
+				return false;
+			} else {
+				return true;
+			}
+		}
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -248,22 +248,16 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_queue_id_to_server() {
 		add_action( 'my_incremental_action', array( $this->listener, 'action_handler' ) );
-		add_action( 'my_full_sync_action', array( $this->listener, 'full_sync_action_handler' ) );
 
 		do_action( 'my_incremental_action' );
-		do_action( 'my_full_sync_action' );
 
 		$this->sender->do_sync();
-		$this->sender->do_full_sync();
 
 		$incremental_event = $this->server_event_storage->get_most_recent_event( 'my_incremental_action' );
-		$full_sync_event = $this->server_event_storage->get_most_recent_event( 'my_full_sync_action' );
 
 		$this->assertEquals( $incremental_event->queue, $this->listener->get_sync_queue()->id );
-		$this->assertEquals( $this->listener->get_full_sync_queue()->id, $full_sync_event->queue );
 
 		remove_action( 'my_incremental_action', array( $this->listener, 'action_handler' ) );
-		remove_action( 'my_full_sync_action', array( $this->listener, 'full_sync_action_handler' ) );
 	}
 
 	function test_reset_module_also_resets_full_sync_lock() {


### PR DESCRIPTION
As of Jetpack 8.3 the `jetpack sync start` cli command would initiate a Full Sync but would not continually send data. This update adds appropriate logic so that the command will run until the full sync has completed.

#### Changes proposed in this Pull Request:
* Adds a check for the Full Sync Module in use to properly send data until the Full Sync is complete when using `jetpack sync start`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Resolves an issue introduced in 8.3

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* execute `jetpack sync start` from the remote site's cli
* Verify that the command runs until complete "Success: Finished syncing to WordPress.com"

* Trigger a Full Sync from the jetpack Debugger
* Perform admin actions on the jetpack site (viewing pages is sufficient)
* Verify in the Debugger that the Full Sync processes until complete.

#### Proposed changelog entry for your changes:
* Jetpack CLI :: fix issue where `jetpack sync start` was triggering the error message "Sync error'd with code: empty_queue_full_sync"
