### PR TITLE
Refactor currentUserConnected checks

### DIFF
--- a/extensions/blocks/instagram-gallery/constants.js
+++ b/extensions/blocks/instagram-gallery/constants.js
@@ -1,13 +1,2 @@
-/**
- * External dependencies
- */
-import { get } from 'lodash';
-
-export const IS_CURRENT_USER_CONNECTED_TO_WPCOM = get( window.Jetpack_Editor_Initial_State, [
-	'jetpack',
-	'is_current_user_connected',
-] );
-
 export const MAX_IMAGE_COUNT = 30;
-
 export const NEW_INSTAGRAM_CONNECTION = 'jetpack-new-instagram-connection';

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -28,16 +28,14 @@ import { __, sprintf, _n } from '@wordpress/i18n';
  * Internal dependencies
  */
 import defaultAttributes from './attributes';
-import {
-	IS_CURRENT_USER_CONNECTED_TO_WPCOM,
-	MAX_IMAGE_COUNT,
-	NEW_INSTAGRAM_CONNECTION,
-} from './constants';
+import { MAX_IMAGE_COUNT, NEW_INSTAGRAM_CONNECTION } from './constants';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import useConnectInstagram from './use-connect-instagram';
 import useConnectWpcom from './use-connect-wpcom';
 import useInstagramGallery from './use-instagram-gallery';
 import ImageTransition from './image-transition';
+import isCurrentUserConnected from '../../shared/is-current-user-connected';
+import { isCurrentUserLinked } from '../../../_inc/client/state/connection';
 import './editor.scss';
 
 const InstagramGalleryEdit = props => {
@@ -81,6 +79,7 @@ const InstagramGalleryEdit = props => {
 		setSelectedAccount,
 	} );
 
+	const currentUserConnected = isCurrentUserConnected();
 	const unselectedCount = count > images.length ? images.length : count;
 
 	const showPlaceholder = ! isLoadingGallery && ( ! accessToken || isEmpty( images ) );
@@ -154,7 +153,7 @@ const InstagramGalleryEdit = props => {
 	};
 
 	const renderPlaceholderInstructions = () => {
-		if ( ! IS_CURRENT_USER_CONNECTED_TO_WPCOM ) {
+		if ( ! currentUserConnected ) {
 			return __( "First, you'll need to connect to WordPress.com.", 'jetpack' );
 		}
 		if ( ! isRequestingUserConnections && ! userConnections.length ) {
@@ -215,7 +214,7 @@ const InstagramGalleryEdit = props => {
 					label={ __( 'Latest Instagram Posts', 'jetpack' ) }
 					notices={ noticeUI }
 				>
-					{ IS_CURRENT_USER_CONNECTED_TO_WPCOM ? (
+					{ currentUserConnected ? (
 						renderInstagramConnection()
 					) : (
 						<Button
@@ -260,7 +259,7 @@ const InstagramGalleryEdit = props => {
 								@{ instagramUser }
 							</ExternalLink>
 						</PanelRow>
-						{ IS_CURRENT_USER_CONNECTED_TO_WPCOM && (
+						{ currentUserConnected && (
 							<PanelRow>
 								<Button isDestructive isLink onClick={ () => disconnectFromService( accessToken ) }>
 									{ __( 'Disconnect your account', 'jetpack' ) }

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -35,7 +35,6 @@ import useConnectWpcom from './use-connect-wpcom';
 import useInstagramGallery from './use-instagram-gallery';
 import ImageTransition from './image-transition';
 import isCurrentUserConnected from '../../shared/is-current-user-connected';
-import { isCurrentUserLinked } from '../../../_inc/client/state/connection';
 import './editor.scss';
 
 const InstagramGalleryEdit = props => {

--- a/extensions/blocks/instagram-gallery/use-connect-wpcom.js
+++ b/extensions/blocks/instagram-gallery/use-connect-wpcom.js
@@ -9,7 +9,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { IS_CURRENT_USER_CONNECTED_TO_WPCOM } from './constants';
+import isCurrentUserConnected from '../../shared/is-current-user-connected';
 
 export default function useConnectWpcom() {
 	const { isAutoDraft } = useSelect( select => {
@@ -22,8 +22,10 @@ export default function useConnectWpcom() {
 	const [ wpcomConnectUrl, setWpcomConnectUrl ] = useState();
 	const [ isRequestingWpcomConnectUrl, setRequestingWpcomConnectUrl ] = useState( false );
 
+	const currentUserConnected = isCurrentUserConnected();
+
 	useEffect( () => {
-		if ( IS_CURRENT_USER_CONNECTED_TO_WPCOM || wpcomConnectUrl || isRequestingWpcomConnectUrl ) {
+		if ( currentUserConnected || wpcomConnectUrl || isRequestingWpcomConnectUrl ) {
 			return;
 		}
 
@@ -42,7 +44,13 @@ export default function useConnectWpcom() {
 			setWpcomConnectUrl( connectUrl );
 			setRequestingWpcomConnectUrl( false );
 		} );
-	}, [ isAutoDraft, isRequestingWpcomConnectUrl, savePost, wpcomConnectUrl ] );
+	}, [
+		isAutoDraft,
+		isRequestingWpcomConnectUrl,
+		savePost,
+		wpcomConnectUrl,
+		currentUserConnected,
+	] );
 
 	return { isRequestingWpcomConnectUrl, wpcomConnectUrl };
 }

--- a/extensions/blocks/instagram-gallery/use-connect-wpcom.js
+++ b/extensions/blocks/instagram-gallery/use-connect-wpcom.js
@@ -45,11 +45,11 @@ export default function useConnectWpcom() {
 			setRequestingWpcomConnectUrl( false );
 		} );
 	}, [
+		currentUserConnected,
 		isAutoDraft,
 		isRequestingWpcomConnectUrl,
 		savePost,
 		wpcomConnectUrl,
-		currentUserConnected,
 	] );
 
 	return { isRequestingWpcomConnectUrl, wpcomConnectUrl };

--- a/extensions/shared/is-current-user-connected.js
+++ b/extensions/shared/is-current-user-connected.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Return whether the current user is connected to WP.com.
+ *
+ * @returns {boolean} Whether the current user is connected.
+ */
+export default function isCurrentUserConnected() {
+	return get( getJetpackData(), [ 'jetpack', 'is_current_user_connected' ], false );
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Refactors the isCurrentUserConnect check into a shared utility function in preparation for #15717.

Follow up on https://github.com/Automattic/jetpack/pull/15470#discussion_r414754176

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Introduces `isCurrentUserConnected()` utility function to check if the current user is connected to dotcom
* Replaces all instances of the `IS_CURRENT_USER_CONNECTED_TO_WPCOM` constant with a call to the new function.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Run `yarn build-extensions`
* Go to the Editor and insert an Instagram Gallery block.
* Verify the check still works.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not necessary.
