### PR TITLE
Add/use heartbeat package

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Heartbeat;
 
 class Jetpack_Heartbeat {
 
@@ -12,7 +13,13 @@ class Jetpack_Heartbeat {
 	 */
 	private static $instance = false;
 
-	private $cron_name = 'jetpack_v2_heartbeat';
+	/**
+	 * Holds the singleton instance of the proxied class
+	 *
+	 * @since 8.7.0
+	 * @var Automattic\Jetpack\Heartbeat
+	 */
+	private static $proxied_instance = false;
 
 	/**
 	 * Singleton
@@ -23,7 +30,8 @@ class Jetpack_Heartbeat {
 	 */
 	public static function init() {
 		if ( ! self::$instance ) {
-			self::$instance = new Jetpack_Heartbeat();
+			self::$instance         = new Jetpack_Heartbeat();
+			self::$proxied_instance = Heartbeat::init();
 		}
 
 		return self::$instance;
@@ -36,70 +44,22 @@ class Jetpack_Heartbeat {
 	 * @return Jetpack_Heartbeat
 	 */
 	private function __construct() {
-		if ( ! Jetpack::is_active() ) {
-			return;
-		}
-
-		// Schedule the task
-		add_action( $this->cron_name, array( $this, 'cron_exec' ) );
-
-		if ( ! wp_next_scheduled( $this->cron_name ) ) {
-			// Deal with the old pre-3.0 weekly one.
-			if ( $timestamp = wp_next_scheduled( 'jetpack_heartbeat' ) ) {
-				wp_unschedule_event( $timestamp, 'jetpack_heartbeat' );
-			}
-
-			wp_schedule_event( time(), 'daily', $this->cron_name );
-		}
-
-		add_filter( 'jetpack_xmlrpc_methods', array( __CLASS__, 'jetpack_xmlrpc_methods' ) );
+		add_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_stats_to_heartbeat' ) );
 	}
 
 	/**
 	 * Method that gets executed on the wp-cron call
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::cron_exec()
 	 *
 	 * @since 2.3.3
 	 * @global string $wp_version
 	 */
 	public function cron_exec() {
 
-		$jetpack = Jetpack::init();
+		return self::$proxied_instance->cron_exec();
 
-		/*
-		 * This should run daily.  Figuring in for variances in
-		 * WP_CRON, don't let it run more than every 23 hours at most.
-		 *
-		 * i.e. if it ran less than 23 hours ago, fail out.
-		 */
-		$last = (int) Jetpack_Options::get_option( 'last_heartbeat' );
-		if ( $last && ( $last + DAY_IN_SECONDS - HOUR_IN_SECONDS > time() ) ) {
-			return;
-		}
-
-		/*
-		 * Check for an identity crisis
-		 *
-		 * If one exists:
-		 * - Bump stat for ID crisis
-		 * - Email site admin about potential ID crisis
-		 */
-
-		// Coming Soon!
-
-		foreach ( self::generate_stats_array( 'v2-' ) as $key => $value ) {
-			$jetpack->stat( $key, $value );
-		}
-
-		Jetpack_Options::update_option( 'last_heartbeat', time() );
-
-		$jetpack->do_stats( 'server_side' );
-
-		/**
-		 * Fires when we synchronize all registered options on heartbeat.
-		 *
-		 * @since 3.3.0
-		 */
-		do_action( 'jetpack_heartbeat' );
 	}
 
 	/**
@@ -162,27 +122,63 @@ class Jetpack_Heartbeat {
 		return $return;
 	}
 
+	/**
+	 * Registers jetpack.getHeartbeatData xmlrpc method
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::jetpack_xmlrpc_methods()
+	 *
+	 * @param array $methods The list of methods to be filtered.
+	 * @return array $methods
+	 */
 	public static function jetpack_xmlrpc_methods( $methods ) {
-		$methods['jetpack.getHeartbeatData'] = array( __CLASS__, 'xmlrpc_data_response' );
-		return $methods;
+		return Heartbeat::jetpack_xmlrpc_methods( $methods );
 	}
 
+	/**
+	 * Handles the response for the jetpack.getHeartbeatData xmlrpc method
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::xmlrpc_data_response()
+	 *
+	 * @param array $params The parameters received in the request.
+	 * @return array $params all the stats that hearbeat handles.
+	 */
 	public static function xmlrpc_data_response( $params = array() ) {
-		// The WordPress XML-RPC server sets a default param of array()
-		// if no argument is passed on the request and the method handlers get this array in $params.
-		// generate_stats_array() needs a string as first argument.
-		$params = empty( $params ) ? '' : $params;
-		return self::generate_stats_array( $params );
+		return Heartbeat::xmlrpc_data_response( $params );
 	}
 
+	/**
+	 * Clear scheduled events
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::deactivate()
+	 *
+	 * @return void
+	 */
 	public function deactivate() {
-		// Deal with the old pre-3.0 weekly one.
-		if ( $timestamp = wp_next_scheduled( 'jetpack_heartbeat' ) ) {
-			wp_unschedule_event( $timestamp, 'jetpack_heartbeat' );
+		// Cronjobs are now handled by the Heartbeat package and we don't want to deactivate it here.
+		// We are adding jetpack stats to the heartbeat only if the connection is available. so we don't need to disable the cron when disconnecting.
+		_deprecated_function( __METHOD__, 'jetpack-8.7.0', 'Automattic\\Jetpack\\Heartbeat::deactivate' );
+	}
+
+	/**
+	 * Add Jetpack Stats array to Heartbeat if Jetpack is connected
+	 *
+	 * @since 8.7.0
+	 *
+	 * @param array $stats Jetpack Heartbeat stats.
+	 * @return array $stats
+	 */
+	public function add_stats_to_heartbeat( $stats ) {
+
+		if ( ! Jetpack::is_active() ) {
+			return $stats;
 		}
 
-		$timestamp = wp_next_scheduled( $this->cron_name );
-		wp_unschedule_event( $timestamp, $this->cron_name );
+		$jetpack_stats = self::generate_stats_array();
+
+		return array_merge( $stats, $jetpack_stats );
 	}
 
 }

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3404,9 +3404,6 @@ p {
 
 		// Delete all the sync related data. Since it could be taking up space.
 		Sender::get_instance()->uninstall();
-
-		// Disable the Heartbeat cron
-		Jetpack_Heartbeat::init()->deactivate();
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-error": "@dev",
+		"automattic/jetpack-heartbeat": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-options": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76b0cce3e2c32a81a3cce4d8d3ed0665",
+    "content-hash": "a628559f1c9cb575be1cc3c443e3e3ef",
     "packages": [
         {
             "name": "automattic/jetpack-abtest",
@@ -274,6 +274,38 @@
             "description": "Jetpack Error - a wrapper around WP_Error."
         },
         {
+            "name": "automattic/jetpack-heartbeat",
+            "version": "dev-add/stats-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/heartbeat",
+                "reference": "95035cf019b0f50e599ace5f2c2cc6ec2732fce9"
+            },
+            "require": {
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-stats": "@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "This adds a cronjob that sends a batch of stats to wp.com once a day"
+        },
+        {
             "name": "automattic/jetpack-jitm",
             "version": "dev-retry/phpcs-changed",
             "dist": {
@@ -453,6 +485,34 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Utilities, related with user roles and capabilities."
+        },
+        {
+            "name": "automattic/jetpack-stats",
+            "version": "dev-add/stats-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/stats",
+                "reference": "e3a93a090bf12666c2953425852a16b1357f1dd2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to bump stats using http://pixel.wp.com/g.gif."
         },
         {
             "name": "automattic/jetpack-status",
@@ -912,16 +972,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "version": "3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
             "require": {
@@ -959,7 +1019,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "time": "2020-04-17T01:09:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1019,6 +1079,7 @@
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-error": 20,
+        "automattic/jetpack-heartbeat": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-options": 20,
@@ -1037,6 +1098,5 @@
         "ext-json": "*",
         "ext-openssl": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform-dev": []
 }


### PR DESCRIPTION
This PR makes jetpack uses the newly created Heartbeat package to handle the Heartbeat.

The approach here was to touch as little as possible the current heartbeat class, so everything still works as usual. `Jetpack_Heartbeat` class is now acting as a proxy class to the package, so you still can initialize and call its methods.

**Important** - There are some uses of the `generate_stats_array` method that are not related to the heartbeat itself. That's why we kept it as is and static. It's used, for example, by `wp jetpack status` CLI command.

That's why these stats are always returned by the static method. On the other hand, they are only added to the heartbeat stats batch if the connection is active. (Originally, the whole heartbeat was only initialized if the connection was active)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Uses Heartbeat package to handle heartbeat

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 1146297891914257-as-1146297891914257

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
TBD

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
