### PR TITLE
Adds information of active plugins using connection to the heartbeat

### DIFF
--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-heartbeat": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev"
 	},

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Connection;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Roles;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\Heartbeat;
 
 /**
  * The Jetpack Connection Manager class that is used as a single gateway between WordPress.com
@@ -99,6 +100,9 @@ class Manager {
 		);
 
 		add_action( 'plugins_loaded', __NAMESPACE__ . '\Plugin_Storage::configure', 100 );
+
+		Heartbeat::init();
+		add_filter( 'jetpack_heartbeat_stats_array', array( $manager, 'add_stats_to_heartbeat' ) );
 
 	}
 
@@ -2273,6 +2277,28 @@ class Manager {
 	 */
 	public function get_connected_plugins() {
 		return Plugin_Storage::get_all();
+	}
+
+	/**
+	 * If connection is active, add the list of plugins using connection to the heartbeat (except Jetpack itself)
+	 *
+	 * @param array $stats The Heartbeat stats array.
+	 * @return array $stats
+	 */
+	public function add_stats_to_heartbeat( $stats ) {
+
+		if ( ! $this->is_active() ) {
+			return $stats;
+		}
+
+		$active_plugins_using_connection = Plugin_Storage::get_all();
+		foreach ( $active_plugins_using_connection as $plugin_slug => $plugin_details ) {
+			if ( 'jetpack' !== $plugin_slug ) {
+				$stats_group           = isset( $active_plugins_using_connection['jetpack'] ) ? 'combined-connection' : 'standalone-connection';
+				$stats[ $stats_group ] = $plugin_slug;
+			}
+		}
+		return $stats;
 	}
 
 }


### PR DESCRIPTION
This PR adds information of active plugins using connection to the heartbeat, except jetpack itself.

If plugins are active alongside Jetpack, their slugs will be added to the `combined-connection` group. 

If Jetpack is not present, they will be added to the `standalone-connection` group.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 1146297891914257-as-1146297891914257

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
TBD

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
