### PR TITLE
Connection: Fix issue where ABSPATH not included with register

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -856,6 +856,7 @@ class Manager {
 				'state'           => get_current_user_id(),
 				'site_created'    => $this->get_assumed_site_creation_date(),
 				'jetpack_version' => Constants::get_constant( 'JETPACK__VERSION' ),
+				'ABSPATH'         => Constants::get_constant( 'ABSPATH' ),
 			)
 		);
 


### PR DESCRIPTION
See pbtFPC-wo-p2 for context. 

In summary, when we moved to using the connection package for registering, we broke a partner-provisioning flow for setting SSH credentials that was added in #12788. The issue is that the register flow in the connection package does not send the ABSPATH value as part of the register process. 

#### Changes proposed in this Pull Request:

* Begins syncing ABSPATH when connecting via the connection package. This was previously begin sent when connecting via the Jetpack class.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Does this pull request change what data or activity we track or use?

pbtFPC-wo-p2

#### Testing instructions:

For a new site:

- Create JN site with beta
- Checkout this PR
- Click "Set Up Jetpack" button to start connection... but do not approve connection
- On WP.com side, ensure that the `jetpack_constant_ABSPATH` value is synced 

For an already connected site:

- Disconnect site
- Delete `jetpack_constant_ABSPATH` option for site on WP.com
- Register site, but do not approve the connection
- On WP.com side, ensure that the `jetpack_constant_ABSPATH` value is synced

#### Proposed changelog entry for your changes:

None
