### PR TITLE
Hide pre-connection JITM on the posts page when few posts are published

### DIFF
--- a/packages/jitm/src/class-pre-connection-jitm.php
+++ b/packages/jitm/src/class-pre-connection-jitm.php
@@ -63,6 +63,10 @@ class Pre_Connection_JITM extends JITM {
 				continue;
 			}
 
+			if ( 'jpsetup-posts' === $message['id'] && wp_count_posts()->publish < 5 ) {
+				continue;
+			}
+
 			$obj                 = new \stdClass();
 			$obj->CTA            = array( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				'message'   => $message['button_caption'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15945

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR changes the "edit post" preconnection JITM so that it only shows when there are 5 or more published posts.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. On a brand new site before connecting and before adding any posts, add the following to your wp-config.php:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/edit.php?post_type=post`. Verify that no pre-connection JITM shows.
3. Add posts until there are 5 or more.
4. Visit `/wp-admin/edit.php?post_type=post`. Verify that there is a pre-connection JITM.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None
