### PR TITLE
Editor: Update visibility of Switch To Classic Editor link

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -281,25 +281,23 @@ class Jetpack_WPCOM_Block_Editor {
 		);
 
 		/**
+		 * Whether to show the Switch To Classic Editor link for a user that
+		 * isn't in the editor deprecation group. Can be forced to display
+		 * by setting query string param.
+		 */
+		$switch_visible = $this->is_iframed_block_editor() || isset( $_GET['editor/show-classic-link'] ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		/**
 		 * Offer an option to switch to the classic editor when the following
-		 * criteria are met:
-		 * - The editor/after-deprecation query string param is present (Temporary requirement).
+		 * criteria are met for a user in editor deprecation rollout group:
+		 * - The editor/after-deprecation query string param is present.
 		 * - In the iFramed block editor.
 		 * - The classic editor plugin is installed but not active.
 		 * - User has permission to activate plugins e.g. admins.
 		 */
-		$switch_visible = $this->is_iframed_block_editor()
-			&& isset( $_GET['editor/after-deprecation'] ) // phpcs:ignore WordPress.Security.NonceVerification
-			&& file_exists( WP_PLUGIN_DIR . 'classic-editor/classic-editor.php' )
-			&& is_plugin_inactive( 'classic-editor/classic-editor.php' )
-			&& current_user_can( 'activate_plugin' );
-
-		/**
-		 * Due to difficulties in being able test with an iFramed editor, the
-		 * following has been added so that requirement can be worked around.
-		 */
-		if ( isset( $_GET['editor/after-deprecation'] ) && 'show' === $_GET['editor/after-deprecation'] ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$switch_visible = file_exists( WP_PLUGIN_DIR . '/classic-editor/classic-editor.php' )
+		if ( isset( $_GET['editor/after-deprecation'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$switch_visible = $switch_visible
+				&& file_exists( WP_PLUGIN_DIR . '/classic-editor/classic-editor.php' )
 				&& is_plugin_inactive( 'classic-editor/classic-editor.php' )
 				&& current_user_can( 'activate_plugin' );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
As we are rolling out the editor deprecation to users in stages, we need to allow for the original conditions for the display of the Switch To Classic Editor link.

- If the user is not part of the editor deprecation rollout group the only condition required is that they are in the iframed block editor.
- If they are in the rollout group then we need to also check for the presence of the classic editor plugin, that its inactive and the user has permissions to activate plugins.
- Only users that get passed the `editor/after-deprecation` query param will be within the rollout group.
- Due to difficulty testing iframed block editor locally ability to force display with query string param has been added as well.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Due to difficulties testing iframed block editor locally the ability to skip that requirement has been added via setting a query string param `editor/show-classic-link`

1. Ensure you have the classic editor plugin installed but inactive
2. Edit a post using the block editor
3. Open "More Tools" menu from the top right of the editor and confirm no Switch To Classic link
4. Add `editor/show-classic-link` query string param and reload
5. Confirm the Switch To Classic Editor link is visible and has had `set-editor=classic` added to it
6. Add `editor/after-deprecation` query string param to current url and reload
7. Confirm the Switch To Classic Editor link is shown and follow it
8. Should be taken to WP admin classic editor with the plugin now activated

#### Proposed changelog entry for your changes:
* Editor: Update visibility of Switch To Classic Editor link for staged rollout of editor deprecation.
