### PR TITLE
Twitter Cards: avoid PHP notices when no image width / height info

### DIFF
--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -93,7 +93,11 @@ class Jetpack_Twitter_Cards {
 			);
 			if ( ! empty( $post_image ) && is_array( $post_image ) ) {
 				// 4096 is the maximum size for an image per https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary .
-				if ( (int) $post_image['src_width'] <= 4096 && (int) $post_image['src_height'] <= 4096 ) {
+				if (
+					isset( $post_image['src_width'], $post_image['src_height'] )
+					&& (int) $post_image['src_width'] <= 4096
+					&& (int) $post_image['src_height'] <= 4096
+				) {
 					// 300x157 is the minimum size for a summary_large_image per https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary-card-with-large-image .
 					if ( (int) $post_image['src_width'] >= 300 && (int) $post_image['src_height'] >= 157 ) {
 						$card_type                = 'summary_large_image';


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Follow-up from #15608 
* In some scenarios, we may not have enough info from the image. Let's avoid notices like the ones that follow when that happens:

```
PHP Notice:  Undefined index: src_height in wp-content/plugins/jetpack-dev/class.jetpack-twitter-cards.php on line 96
PHP Notice:  Undefined index: src_width in wp-content/plugins/jetpack-dev/class.jetpack-twitter-cards.php on line 98
```

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much testing to do here.

#### Proposed changelog entry for your changes:

* Sharing: avoid PHP notices when we do not have enough information about an image.
