### PR TITLE
SAL: avoid notice with incomplete media items

### DIFF
--- a/sal/class.json-api-post-base.php
+++ b/sal/class.json-api-post-base.php
@@ -617,8 +617,11 @@ abstract class SAL_Post {
 
 		if ( in_array( $ext, array( 'mp3', 'm4a', 'wav', 'ogg' ) ) ) {
 			$metadata = wp_get_attachment_metadata( $media_item->ID );
-			$response['length'] = $metadata['length'];
-			$response['exif']   = $metadata;
+			if ( isset( $metadata['length'] ) ) {
+				$response['length'] = $metadata['length'];
+			}
+
+			$response['exif'] = $metadata;
 		}
 
 		if ( in_array( $ext, array( 'ogv', 'mp4', 'mov', 'wmv', 'avi', 'mpg', '3gp', '3g2', 'm4v' ) ) ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Noticed in my logs, it seems this can happen with some incomplete media. Let's check before we rely on `$metadata['length']`, just like we do a few lines below.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Not much to test here.

#### Proposed changelog entry for your changes:

* N/A
