### PR TITLE
External Media: Render Media after authentication

### DIFF
--- a/extensions/shared/external-media/sources/google-photos/google-photos-auth.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-auth.js
@@ -20,8 +20,7 @@ import AuthInstructions from './auth-instructions';
 import AuthProgress from './auth-progress';
 
 function GooglePhotosAuth( props ) {
-	const { getMedia } = props;
-
+	const { setAuthenticated } = props;
 	const [ isAuthing, setIsAuthing ] = useState( false );
 
 	const onAuthorize = useCallback( () => {
@@ -39,15 +38,14 @@ function GooglePhotosAuth( props ) {
 				// Open authorize URL in a window and let it play out
 				requestExternalAccess( service.connect_URL, () => {
 					setIsAuthing( false );
-					const url = getApiUrl( 'list', SOURCE_GOOGLE_PHOTOS );
-					getMedia( url, true );
+					setAuthenticated( true );
 				} );
 			} )
 			.catch( () => {
 				// Not much we can tell the user at this point so let them try and auth again
 				setIsAuthing( false );
 			} );
-	}, [ getMedia ] );
+	}, [ setAuthenticated ] );
 
 	return (
 		<div className="jetpack-external-media-auth">

--- a/extensions/shared/external-media/sources/google-photos/index.js
+++ b/extensions/shared/external-media/sources/google-photos/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import withMedia from '../with-media';
@@ -11,7 +6,7 @@ import GooglePhotosAuth from './google-photos-auth';
 import GooglePhotosMedia from './google-photos-media';
 
 function GooglePhotos( props ) {
-	if ( props.requiresAuth ) {
+	if ( ! props.isAuthenticated ) {
 		return <GooglePhotosAuth { ...props } />;
 	}
 

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -48,10 +48,12 @@ export default function withMedia() {
 					nextHandle: false,
 					isLoading: false,
 					isCopying: null,
-					requiresAuth: false,
+					isAuthenticated: true,
 					path: { ID: PATH_RECENT },
 				};
 			}
+
+			setAuthenticated = isAuthenticated => this.setState( { isAuthenticated } );
 
 			mergeMedia( initial, media ) {
 				return uniqBy( initial.concat( media ), 'ID' );
@@ -88,7 +90,7 @@ export default function withMedia() {
 
 			handleApiError = error => {
 				if ( error.code === 'authorization_required' ) {
-					this.setState( { requiresAuth: true, isLoading: false, isCopying: false } );
+					this.setState( { isAuthenticated: false, isLoading: false, isCopying: false } );
 					return;
 				}
 
@@ -121,7 +123,7 @@ export default function withMedia() {
 				const path = this.getRequestUrl( url );
 				const method = 'GET';
 
-				this.setState( { requiresAuth: false } );
+				this.setAuthenticated( true );
 
 				apiFetch( {
 					path,
@@ -174,7 +176,7 @@ export default function withMedia() {
 			}
 
 			renderContent() {
-				const { media, isLoading, nextHandle, requiresAuth, path } = this.state;
+				const { media, isLoading, nextHandle, isAuthenticated, path } = this.state;
 				const { noticeUI, allowedTypes, multiple = false } = this.props;
 
 				return (
@@ -189,7 +191,8 @@ export default function withMedia() {
 							media={ media }
 							pageHandle={ nextHandle }
 							allowedTypes={ allowedTypes }
-							requiresAuth={ requiresAuth }
+							isAuthenticated={ isAuthenticated }
+							setAuthenticated={ this.setAuthenticated }
 							multiple={ multiple }
 							path={ path }
 							onChangePath={ this.onChangePath }


### PR DESCRIPTION
Fixes a bug where the first query after authenticating with Google would show Albums instead of the most recent photos.

See https://github.com/Automattic/jetpack/pull/15717#pullrequestreview-418201700

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Swaps authentication variable to make state clearer.
* Passes a authentication state update function to original components.
* Authentication component updates auth state now instead of populating the modal.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go through the Google Photos authentication flow
* Make sure the flow fires when there is no connection
* Make sure it doesn't as for authentication when Google Photos is already authenticated
* Check that after authenticating the initial results are recent photos

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None needed.