### PR TITLE
Sync: Add test to verify do_full_sync returns error when existing lock

### DIFF
--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -466,6 +466,28 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( $user_id, $decoded_object->ID );
 	}
 
+	/**
+	 * This test was created in response to the 8.6 launch that caused performance issues due to looping.
+	 * For more context see p1HpG7-9pe-p2.
+	 *
+	 * @return void
+	 */
+	public function test_do_full_sync_returns_error_if_lock() {
+		$sender = $this->getMockBuilder( 'Automattic\Jetpack\Sync\Sender' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'do_sync_and_set_delays' ) )
+			->getMock();
+
+		$sender
+			->expects( $this->once() )
+			->method( 'do_sync_and_set_delays' )
+			->willReturn( new \WP_Error( 'unclosed_buffer', 'There is an unclosed buffer' ) );
+
+		$result = $sender->do_full_sync();
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+	}
+
 	function run_filter( $data ) {
 		$this->filter_ran = true;
 		return $data;

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -522,7 +522,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 			'progress' => array(),
 			'config'   => array(),
 		);
-		\Jetpack_Options::update_raw_option('jetpack_sync_full_status', $settings );
+		\Jetpack_Options::update_raw_option( 'jetpack_sync_full_status', $settings );
 
 		$result = $this->sender->do_full_sync();
 
@@ -546,7 +546,7 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 			'progress' => array(),
 			'config'   => array(),
 		);
-		\Jetpack_Options::update_raw_option('jetpack_sync_full_status', $settings );
+		\Jetpack_Options::update_raw_option( 'jetpack_sync_full_status', $settings );
 
 		// establish lock.
 		$this->assertTrue( ( new Lock() )->attempt( 'full_sync' ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See p1HpG7-9pe-p2 for context. In short, we release an 8.6.1 release after we found a looping issue in 8.6.0. We were able to replicate the issue when:

- A full sync was being processed via CLI
- Another full sync was triggered via cron

After debugging this, the issue seems to be that #16010 had changed the behavior of #16010 such that it always returned true if we hadn't completed a full sync. Before #16010, would've returned a `WP_Error` instance if there was an existing lock. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a test to ensure that `do_full_sync` returns an instance of WP_Error if there is an existing lock.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

p1HpG7-9pe-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No changes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout patch
* Run `yarn docker:phpunit --filter=test_do_full_sync_returns_error_if_lock` and ensure tests pass
* Checkout 8.6 tag
* Run `yarn docker:phpunit --filter=test_do_full_sync_returns_error_if_lock` and ensure tests fails
* Ensure Travis CI tests pass

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
- No changelog entry need
