### PR TITLE
WooCommerce Analytics: avoid 404 error when enqueuing script

### DIFF
--- a/packages/assets/src/class-assets.php
+++ b/packages/assets/src/class-assets.php
@@ -89,7 +89,7 @@ class Assets {
 	 * Given a minified path, and a non-minified path, will return
 	 * a minified or non-minified file URL based on whether SCRIPT_DEBUG is set and truthy.
 	 *
-	 * Both `$min_base` and `$non_min_base` are expected to be relative to the
+	 * Both `$min_base` and `$non_min_base` can be either full URLs, or are expected to be relative to the
 	 * root Jetpack directory.
 	 *
 	 * @since 5.6.0
@@ -103,7 +103,16 @@ class Assets {
 			? $non_min_path
 			: $min_path;
 
-		$url = plugins_url( $path, Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) );
+		/*
+		 * If the path is actually a full URL, keep that.
+		 * We look for a host value, since enqueues are sometimes without a scheme.
+		 */
+		$file_parts = wp_parse_url( $path );
+		if ( ! empty( $file_parts['host'] ) ) {
+				$url = $path;
+		} else {
+			$url = plugins_url( $path, Jetpack_Constants::get_constant( 'JETPACK__PLUGIN_FILE' ) );
+		}
 
 		/**
 		 * Filters the URL for a file passed through the get_file_url_for_environment function.

--- a/packages/assets/tests/php/test-assets.php
+++ b/packages/assets/tests/php/test-assets.php
@@ -1,4 +1,9 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for Automattic\Jetpack\Assets methods
+ *
+ * @package automattic/jetpack-assets
+ */
 
 namespace Automattic\Jetpack;
 
@@ -7,10 +12,34 @@ use Automattic\Jetpack\Constants as Jetpack_Constants;
 use Brain\Monkey;
 use Brain\Monkey\Filters;
 
+/**
+ * Retrieves a URL within the plugins or mu-plugins directory.
+ *
+ * @param string $path        Extra path appended to the end of the URL, including the relative directory if $plugin is supplied.
+ * @param string $plugin_path A full path to a file inside a plugin or mu-plugin.
+ *                            The URL will be relative to its directory.
+ *                            Typically this is done by passing __FILE__ as the argument.
+ */
 function plugins_url( $path, $plugin_path ) {
 	return $plugin_path . $path;
 }
 
+/**
+ * Enqueue a script.
+ *
+ * Registers the script if $src provided (does NOT overwrite), and enqueues it.
+ *
+ * @param string           $handle    Name of the script. Should be unique.
+ * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                    Default empty.
+ * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                    as a query string for cache busting purposes. If version is set to false, a version
+ *                                    number is automatically added equal to current installed WordPress version.
+ *                                    If set to null, no version is added.
+ * @param bool             $in_footer Optional. Whether to enqueue the script before </body> instead of in the <head>.
+ *                                    Default 'false'.
+ */
 function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $in_footer = false ) {
 	$GLOBALS['_was_called_wp_enqueue_script'][] = array( $handle, $src, $deps, $ver, $in_footer );
 }
@@ -27,8 +56,14 @@ function wp_parse_url( $url, $component = -1 ) { // phpcs:ignore VariableAnalysi
 	return parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
 }
 
+/**
+ * Assets test suite.
+ */
 class AssetsTest extends TestCase {
 
+	/**
+	 * Test setup.
+	 */
 	public function setUp() {
 		Monkey\setUp();
 		$plugin_file = dirname( dirname( dirname( dirname( __DIR__ ) ) ) ) . '/jetpack.php';
@@ -45,14 +80,22 @@ class AssetsTest extends TestCase {
 	}
 
 	/**
+	 * Test get_file_url_for_environment
+	 *
 	 * @author ebinnion goldsounds
 	 * @dataProvider get_file_url_for_environment_data_provider
+	 *
+	 * @param string $min_path        minified path.
+	 * @param string $non_min_path    non-minified path.
+	 * @param bool   $is_script_debug Is SCRIPT_DEBUG enabled.
+	 * @param string $expected        Expected result.
+	 * @param string $not_expected    Non expected result.
 	 */
-	function test_get_file_url_for_environment( $min_path, $non_min_path, $is_script_debug, $expected, $not_expected ) {
+	public function test_get_file_url_for_environment( $min_path, $non_min_path, $is_script_debug, $expected, $not_expected ) {
 		Constants::set_constant( 'SCRIPT_DEBUG', $is_script_debug );
 		$file_url = Assets::get_file_url_for_environment( $min_path, $non_min_path );
 
-		// note the double-$$ here, $(non_)min_path is referenced by var name
+		// note the double-$$ here, $(non_)min_path is referenced by var name.
 		$this->assertContains( $$expected, $file_url );
 		$this->assertNotContains( $$not_expected, $file_url );
 	}
@@ -83,7 +126,10 @@ class AssetsTest extends TestCase {
 		$this->assertContains( 'special-test.js', $file_url );
 	}
 
-	function get_file_url_for_environment_data_provider() {
+	/**
+	 * Possible values for test_get_file_url_for_environment.
+	 */
+	public function get_file_url_for_environment_data_provider() {
 		return array(
 			'script-debug-true'  => array(
 				'_inc/build/shortcodes/js/instagram.js',

--- a/packages/assets/tests/php/test_Assets.php
+++ b/packages/assets/tests/php/test_Assets.php
@@ -15,6 +15,18 @@ function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $
 	$GLOBALS['_was_called_wp_enqueue_script'][] = array( $handle, $src, $deps, $ver, $in_footer );
 }
 
+/**
+ * A wrapper for PHP's parse_url()
+ *
+ * @param string $url       The URL to parse.
+ * @param int    $component The specific component to retrieve. Use one of the PHP
+ *                          predefined constants to specify which one.
+ *                          Defaults to -1 (= return all parts as an array).
+ */
+function wp_parse_url( $url, $component = -1 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	return parse_url( $url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+}
+
 class AssetsTest extends TestCase {
 
 	public function setUp() {
@@ -43,6 +55,18 @@ class AssetsTest extends TestCase {
 		// note the double-$$ here, $(non_)min_path is referenced by var name
 		$this->assertContains( $$expected, $file_url );
 		$this->assertNotContains( $$not_expected, $file_url );
+	}
+
+	/**
+	 * Test that get_file_url_for_environment returns a full URL when given a full URL
+	 *
+	 * @author jeherve
+	 */
+	public function test_get_file_url_for_environment_full_url() {
+		$path     = 'https://jetpack.com';
+		$file_url = Assets::get_file_url_for_environment( $path, $path );
+
+		$this->assertEquals( $path, $file_url );
 	}
 
 	/**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This was introduced in #15795. While `Assets::get_file_url_for_environment()` was previously only used with relative paths, we started using it with full URLs as well, such as the URL enqueued here:
https://github.com/Automattic/jetpack/blob/d6211b1e30d5905e61608d61f12fa34757fc3293/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php#L75-L81

As a result, since we always went through `plugins_url` in all paths processed by `Assets::get_file_url_for_environment()`, this was breaking the enqueue above.

This PR rectifies that, adds a test to cover this new use case, and fixes all phpcs errors that stopped me from committing the new test cleanly.

This may be a candidate for a point release. If we choose to include this change in a point release, we'll need to update the Assets package version. It's worth noting that the Assets package is also a dependency of the JITM package, so we'd need to bump the version of that package as well.

Until the problem is solved in a new version of Jetpack, folks running into the issue can fix the problem on their site by adding the following code snippet to their site [using a functionality plugin](https://jetpack.com/support/adding-code-snippets/):

```php
/**
 * Fix the path of Woo script.
 *
 * @param string $url The URL to the file.
 * @param string $min_path The minified path.
 * @param string $non_min_path The non-minified path.
 */
function jetpackcom_fix_woo_script_path( $url, $min_path, $non_min_path ) {
	if ( wp_startswith( $min_path, 'https://stats.wp.com/s-' ) ) {
		return $min_path;
	}

	return $url;
}
add_filter( 'jetpack_get_file_for_environment', 'jetpackcom_fix_woo_script_path', 10, 3 );
```
 

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Do the tests pass?

* Install and activate the WooCommerce plugin.
* Create a new product.
* In an incognito window, load the product page.
* In your browser's network tab, ensure that `https://stats.wp.com/s-202023.js` is properly called.

#### Proposed changelog entry for your changes:

* WooCommerce compatibility: avoid broken resources when using the WooCommerce plugin alongside Jetpack.
