### PR TITLE
Infinite scroll for AMP

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1864,7 +1864,13 @@ class The_Neverending_Home_Page {
 		$image = '';
 
 		if ( ! static::amp_is_last_page() ) {
-			$title = esc_html__( 'Older posts', 'jetpack' );
+			$title = sprintf(
+				'%s - %s %d - %s',
+				wp_title( '', false ),
+				__( 'Page', 'jetpack' ),
+				max( get_query_var( 'paged', 1 ), 1 ) + 1,
+				get_bloginfo( 'name' )
+			);
 			$url   = get_next_posts_page_link();
 		}
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -440,7 +440,7 @@ class The_Neverending_Home_Page {
 			return;
 
 		// AMP infinite scroll functionality will start on amp_load_hooks().
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
 
@@ -1597,7 +1597,7 @@ class The_Neverending_Home_Page {
 	 * @return string or null
 	 */
 	function footer() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
 
@@ -1727,7 +1727,7 @@ class The_Neverending_Home_Page {
 	 * @return void
 	 */
 	public function amp_load_hooks() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			$template = self::get_settings()->render;
 
 			add_filter( 'jetpack_infinite_scroll_load_scripts_and_styles', '__return_false' );

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1859,8 +1859,8 @@ class The_Neverending_Home_Page {
 	 * @return array
 	 */
 	protected function amp_next_page() {
-		$title = esc_html__( 'Home page', 'jetpack' );
-		$url   = home_url();
+		$title = '';
+		$url   = '';
 		$image = '';
 
 		if ( ! static::amp_is_last_page() ) {

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1858,7 +1858,7 @@ class The_Neverending_Home_Page {
 	 *
 	 * @return array
 	 */
-	protected static function amp_next_page() {
+	protected function amp_next_page() {
 		$title = esc_html__( 'Home page', 'jetpack' );
 		$url   = home_url();
 		$image = '';

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -42,6 +42,10 @@ class The_Neverending_Home_Page {
 		// Plugin compatibility
 		add_filter( 'grunion_contact_form_redirect_url', array( $this, 'filter_grunion_redirect_url' ) );
 
+		// AMP compatibility
+		// needs to happen after parse_query so that Jetpack_AMP_Support::is_amp_request() is ready.
+		add_action( 'wp', array( $this, 'amp_load_hooks' ) );
+
 		// Parse IS settings from theme
 		self::get_settings();
 	}
@@ -434,6 +438,11 @@ class The_Neverending_Home_Page {
 		// Check that we have an id.
 		if ( empty( $id ) )
 			return;
+
+		// AMP infinite scroll functionality will start on amp_load_hooks().
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
 
 		// Add our scripts.
 		wp_register_script(
@@ -1588,6 +1597,10 @@ class The_Neverending_Home_Page {
 	 * @return string or null
 	 */
 	function footer() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		// Bail if theme requested footer not show
 		if ( false == self::get_settings()->footer )
 			return;
@@ -1706,6 +1719,182 @@ class The_Neverending_Home_Page {
 			}
 		}
 		return $scripts_data;
+	}
+
+	/**
+	 * Load AMP specific hooks.
+	 *
+	 * @return void
+	 */
+	public function amp_load_hooks() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			$template = self::get_settings()->render;
+
+			add_filter( 'jetpack_infinite_scroll_load_scripts_and_styles', '__return_false' );
+
+			add_action( 'template_redirect', array( $this, 'amp_start_output_buffering' ), 0 );
+			add_action( 'shutdown', array( $this, 'amp_output_buffer' ), 1 );
+
+			if ( is_callable( "amp_{$template}_hooks" ) ) {
+				call_user_func( "amp_{$template}_hooks" );
+			}
+
+			// Warms up the amp next page markup.
+			// This should be done outside the output buffering callback started in the template_redirect.
+			$this->amp_get_footer_template();
+		}
+	}
+
+	/**
+	 * Start the AMP output buffering.
+	 *
+	 * @return void
+	 */
+	public function amp_start_output_buffering() {
+		ob_start( array( $this, 'amp_finish_output_buffering' ) );
+	}
+
+	/**
+	 * Flush the AMP output buffer.
+	 *
+	 * @return void
+	 */
+	public function amp_output_buffer() {
+		if ( ob_get_contents() ) {
+			ob_end_flush();
+		}
+	}
+
+	/**
+	 * Filter the AMP output buffer contents.
+	 *
+	 * @param string $buffer Contents of the output buffer.
+	 *
+	 * @return string|false
+	 */
+	public function amp_finish_output_buffering( $buffer ) {
+		// Hide WordPress admin bar on next page load.
+		$buffer = preg_replace(
+			'/id="wpadminbar"/',
+			'$0 next-page-hide',
+			$buffer
+		);
+
+		// Get the theme footers.
+		$footers = apply_filters( 'jetpack_amp_infinite_footers', array(), $buffer );
+
+		// Hook for themes to filter custom markup on next page load.
+		$buffer = apply_filters( 'jetpack_amp_infinite_output', $buffer );
+
+		// Add the amp next page markup.
+		$buffer = preg_replace(
+			'~</body>~',
+			$this->amp_get_footer_template( $footers ) . '$0',
+			$buffer
+		);
+
+		return $buffer;
+	}
+
+	/**
+	 * Get AMP next page markup with the custom footers.
+	 *
+	 * @param string[] $footers The theme footers.
+	 *
+	 * @return string
+	 */
+	protected function amp_get_footer_template( $footers = array() ) {
+		static $template = null;
+
+		if ( null === $template ) {
+			$template = $this->amp_footer_template();
+		}
+
+		if ( empty( $footers ) ) {
+			return $template;
+		}
+
+		return preg_replace(
+			'/%%footer%%/',
+			implode( '', $footers ),
+			$template
+		);
+	}
+
+	/**
+	 * AMP Next Page markup.
+	 *
+	 * @return string
+	 */
+	protected function amp_footer_template() {
+		ob_start();
+		?>
+<amp-next-page max-pages="<?php echo esc_attr( $this->amp_get_max_pages() ); ?>">
+	<script type="application/json">
+		[
+			<?php echo wp_json_encode( $this->amp_next_page() ); ?>
+		]
+	</script>
+	<div separator>
+		<?php echo wp_kses_post( apply_filters( 'jetpack_amp_infinite_separator', '' ) ); ?>
+	</div>
+	<div recommendation-box class="recommendation-box">
+		<template type="amp-mustache">
+			{{#pages}}
+			<?php echo wp_kses_post( apply_filters( 'jetpack_amp_infinite_older_posts', '' ) ); ?>
+			{{/pages}}
+		</template>
+	</div>
+	<div footer>
+		%%footer%%
+	</div>
+</amp-next-page>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Get the AMP next page information.
+	 *
+	 * @return array
+	 */
+	protected static function amp_next_page() {
+		$title = esc_html__( 'Home page', 'jetpack' );
+		$url   = home_url();
+		$image = '';
+
+		if ( ! static::amp_is_last_page() ) {
+			$title = esc_html__( 'Older posts', 'jetpack' );
+			$url   = get_next_posts_page_link();
+		}
+
+		$next_page = array(
+			'title' => $title,
+			'url'   => $url,
+			'image' => $image,
+		);
+
+		return apply_filters( 'jetpack_amp_infinite_next_page_data', $next_page );
+	}
+
+	/**
+	 * Get the number of pages left.
+	 *
+	 * @return int
+	 */
+	protected static function amp_get_max_pages() {
+		global $wp_query;
+
+		return (int) $wp_query->max_num_pages - $wp_query->query_vars['paged'];
+	}
+
+	/**
+	 * Is the last page.
+	 *
+	 * @return bool
+	 */
+	protected static function amp_is_last_page() {
+		return 0 === static::amp_get_max_pages();
 	}
 };
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1785,7 +1785,7 @@ class The_Neverending_Home_Page {
 		 *
 		 * @module infinite-scroll
 		 *
-		 * @since 8.9.1
+		 * @since 9.0.0
 		 *
 		 * @param array  array() An array to store multiple markup entries to be added to the footer.
 		 * @param string $buffer The contents of the output buffer.
@@ -1798,7 +1798,7 @@ class The_Neverending_Home_Page {
 		 *
 		 * @module infinite-scroll
 		 *
-		 * @since 8.9.1
+		 * @since 9.0.0
 		 *
 		 * @param string $buffer The contents of the output buffer.
 		 */
@@ -1861,7 +1861,7 @@ class The_Neverending_Home_Page {
 			 *
 			 * @module infinite-scroll
 			 *
-			 * @since 8.9.1
+			 * @since 9.0.0
 			 *
 			 * @param string '' The markup for the next page separator.
 			 */
@@ -1879,7 +1879,7 @@ class The_Neverending_Home_Page {
 				 *
 				 * @module infinite-scroll
 				 *
-				 * @since 8.9.1
+				 * @since 9.0.0
 				 *
 				 * @param string '' The markup for the older posts/next page.
 				 */
@@ -1933,7 +1933,7 @@ class The_Neverending_Home_Page {
 		 *
 		 * @module infinite-scroll
 		 *
-		 * @since 8.9.1
+		 * @since 9.0.0
 		 *
 		 * @param array $next_page The contents of the output buffer.
 		 */

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1780,10 +1780,28 @@ class The_Neverending_Home_Page {
 			$buffer
 		);
 
-		// Get the theme footers.
+		/**
+		 * Get the theme footers.
+		 *
+		 * @module infinite-scroll
+		 *
+		 * @since 8.9.1
+		 *
+		 * @param array  array() An array to store multiple markup entries to be added to the footer.
+		 * @param string $buffer The contents of the output buffer.
+		 */
 		$footers = apply_filters( 'jetpack_amp_infinite_footers', array(), $buffer );
 
-		// Hook for themes to filter custom markup on next page load.
+		/**
+		 * Filter the output buffer.
+		 * Themes can leverage this hook to add custom markup on next page load.
+		 *
+		 * @module infinite-scroll
+		 *
+		 * @since 8.9.1
+		 *
+		 * @param string $buffer The contents of the output buffer.
+		 */
 		$buffer = apply_filters( 'jetpack_amp_infinite_output', $buffer );
 
 		// Add the amp next page markup.
@@ -1836,12 +1854,38 @@ class The_Neverending_Home_Page {
 		]
 	</script>
 	<div separator>
-		<?php echo wp_kses_post( apply_filters( 'jetpack_amp_infinite_separator', '' ) ); ?>
+		<?php
+		echo wp_kses_post(
+			/**
+			 * AMP infinite scroll separator.
+			 *
+			 * @module infinite-scroll
+			 *
+			 * @since 8.9.1
+			 *
+			 * @param string '' The markup for the next page separator.
+			 */
+			apply_filters( 'jetpack_amp_infinite_separator', '' )
+		);
+		?>
 	</div>
 	<div recommendation-box class="recommendation-box">
 		<template type="amp-mustache">
 			{{#pages}}
-			<?php echo wp_kses_post( apply_filters( 'jetpack_amp_infinite_older_posts', '' ) ); ?>
+			<?php
+			echo wp_kses_post(
+				/**
+				 * AMP infinite scroll older posts markup.
+				 *
+				 * @module infinite-scroll
+				 *
+				 * @since 8.9.1
+				 *
+				 * @param string '' The markup for the older posts/next page.
+				 */
+				apply_filters( 'jetpack_amp_infinite_older_posts', '' )
+			);
+			?>
 			{{/pages}}
 		</template>
 	</div>
@@ -1880,6 +1924,19 @@ class The_Neverending_Home_Page {
 			'image' => $image,
 		);
 
+		/**
+		 * The next page settings.
+		 * An array containing:
+		 *  - title => The title to be featured on the browser tab.
+		 *  - url   => The URL of next page.
+		 *  - image => The image URL. A required AMP setting, not in use currently. Themes are welcome to leverage.
+		 *
+		 * @module infinite-scroll
+		 *
+		 * @since 8.9.1
+		 *
+		 * @param array $next_page The contents of the output buffer.
+		 */
 		return apply_filters( 'jetpack_amp_infinite_next_page_data', $next_page );
 	}
 

--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -200,7 +200,7 @@ function twentynineteen_amp_infinite_older_posts() {
 	<span>
 		<a href="{{url}}">
 			<button>
-				{{title}}
+				<?php esc_html_e( 'Older posts', 'jetpack' ); ?>
 			</button>
 		</a>
 	</span>

--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -124,3 +124,87 @@ function twentynineteen_jetpack_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'twentynineteen_jetpack_body_classes' );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentynineteen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentynineteen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentynineteen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentynineteen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentynineteen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentynineteen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide pagination on next page load.
+	$buffer = preg_replace(
+		'/class=".*navigation pagination.*"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentynineteen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" style="text-align: center;">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/theme-tools/compat/twentytwenty.css
+++ b/modules/theme-tools/compat/twentytwenty.css
@@ -294,3 +294,7 @@ iframe#wpnt-notes-iframe2.wide {
 .admin-bar {
 	position: unset !important;
 }
+
+.screen-reader-text {
+	position: absolute;
+}

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -160,3 +160,114 @@ function twentytwenty_infinity_accent_color_css() {
 	wp_add_inline_style( 'twentytwenty-jetpack', $custom_css );
 }
 add_action( 'wp_enqueue_scripts', 'twentytwenty_infinity_accent_color_css' );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentytwenty_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentytwenty_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentytwenty_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_separator', 'twentytwenty_amp_infinite_separator' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentytwenty_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentytwenty_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<div class="footer-nav-widgets-wrapper.*<!-- .footer-nav-widgets-wrapper -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="site-footer".*<!-- #site-footer -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentytwenty_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/id="site-header"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide pagination on next page load.
+	$buffer = preg_replace(
+		'/class=".*pagination-wrapper.*"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<div class="footer-nav-widgets-wrapper.*<!-- .footer-nav-widgets-wrapper -->/s',
+		'',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="site-footer".*<!-- #site-footer -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll separator
+ *
+ * @return string
+ */
+function twentytwenty_amp_infinite_separator() {
+	ob_start();
+	?>
+<hr class="post-separator styled-separator is-style-wide section-inner" aria-hidden="true">
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentytwenty_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" class="read-more-button-wrap">
+	<span>
+		<a href="{{url}}" class="more-link" rel="amphtml">
+			<span class="faux-button">{{title}}</span>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -264,7 +264,9 @@ function twentytwenty_amp_infinite_older_posts() {
 <div id="infinite-handle" class="read-more-button-wrap">
 	<span>
 		<a href="{{url}}" class="more-link" rel="amphtml">
-			<span class="faux-button">{{title}}</span>
+			<span class="faux-button">
+				<?php esc_html_e( 'Older posts', 'jetpack' ); ?>
+			</span>
 		</a>
 	</span>
 </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds the foundations for AMP compatibility for Infinite Scroll and support for `twentynineteen` and `twentytwenty` themes.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR adds support for Infinite Scroll on AMP via `amp-next-page`;
* This PR adds support for `twentynineteen` and `twentytwenty` themes;

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This adds support for Infinite Scroll on AMP requests;

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure the [AMP](https://wordpress.org/plugins/amp/) plugin is installed and enabled;
1. On Jetpack Settings > Writing  > Theme Enhancements > Infinite Scroll, set the radio to either `Load more posts in page with a button` or `Load more posts as the reader scrolls down`. Due to [AMP implementation](https://amp.dev/documentation/components/amp-next-page/#recommendation-box-(more-suggested-links)) of the functionality, the next page will always be autoloaded and still show the Older Posts button, if the user scrolls faster then the next page loads;
1. Enable `twentynineteen` or `twentytwenty` theme;
1. Make sure you have enough posts to enable pagination;
1. Visit the home page or an archive page;
1. Scroll to the footer. The next page should be loaded by then, or you can click the older posts button;


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds support for Infinite Scroll on `twentynineteen` and `twentytwenty` themes for AMP requests;
* Add the following filters to allow extending support to other themes:
    * `jetpack_amp_infinite_footers`
get the theme footers to be added to `amp-next-page` footer component;
    * `jetpack_amp_infinite_output`
filters the output buffer to allow inserting `next-page-hide` attributes and remove the filtered footers from the standard output;
    * `jetpack_amp_infinite_separator`
filters the `amp-next-page` separator markup;
    * `jetpack_amp_infinite_older_posts`
filters the `amp-next-page` older posts button markup;
    * `jetpack_amp_infinite_next_page_data`
filters the `amp-next-page` data (title, url and image);