### PR TITLE
Podcast Player: add episode link and hide single episode track lists

### DIFF
--- a/extensions/blocks/podcast-player/components/header.js
+++ b/extensions/blocks/podcast-player/components/header.js
@@ -8,6 +8,11 @@ import classnames from 'classnames';
  */
 import { memo } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import { default as linkIcon } from '../icons/link';
+
 const Header = memo(
 	( {
 		playerId,
@@ -80,6 +85,14 @@ const Title = memo(
 					style={ { color: colors.primary.custom } }
 				>
 					{ track.title }
+					<a
+						className="jetpack-podcast-player__track-title-link"
+						href={ track.link || track.src }
+						target="_blank"
+						rel="noopener noreferrer nofollow"
+					>
+						{ linkIcon }
+					</a>
 				</span>
 			) }
 

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -21,23 +21,22 @@ const Playlist = memo( ( { playerId, tracks, selectTrack, currentTrack, playerSt
 			aria-labelledby={ `jetpack-podcast-player__tracklist-title--${ playerId }` }
 			aria-describedby={ `jetpack-podcast-player__tracklist-description--${ playerId }` }
 		>
-			{ tracks?.length > 1 &&
-				tracks.map( ( track, index ) => {
-					const isActive = currentTrack === index;
+			{ tracks.map( ( track, index ) => {
+				const isActive = currentTrack === index;
 
-					return (
-						<Track
-							key={ track.id }
-							index={ index }
-							track={ track }
-							selectTrack={ selectTrack }
-							isActive={ isActive }
-							isPlaying={ isActive && playerState === STATE_PLAYING }
-							isError={ isActive && playerState === STATE_ERROR }
-							colors={ colors }
-						/>
-					);
-				} ) }
+				return (
+					<Track
+						key={ track.id }
+						index={ index }
+						track={ track }
+						selectTrack={ selectTrack }
+						isActive={ isActive }
+						isPlaying={ isActive && playerState === STATE_PLAYING }
+						isError={ isActive && playerState === STATE_ERROR }
+						colors={ colors }
+					/>
+				);
+			} ) }
 		</ol>
 	);
 } );

--- a/extensions/blocks/podcast-player/components/playlist.js
+++ b/extensions/blocks/podcast-player/components/playlist.js
@@ -21,22 +21,23 @@ const Playlist = memo( ( { playerId, tracks, selectTrack, currentTrack, playerSt
 			aria-labelledby={ `jetpack-podcast-player__tracklist-title--${ playerId }` }
 			aria-describedby={ `jetpack-podcast-player__tracklist-description--${ playerId }` }
 		>
-			{ tracks.map( ( track, index ) => {
-				const isActive = currentTrack === index;
+			{ tracks?.length > 1 &&
+				tracks.map( ( track, index ) => {
+					const isActive = currentTrack === index;
 
-				return (
-					<Track
-						key={ track.id }
-						index={ index }
-						track={ track }
-						selectTrack={ selectTrack }
-						isActive={ isActive }
-						isPlaying={ isActive && playerState === STATE_PLAYING }
-						isError={ isActive && playerState === STATE_ERROR }
-						colors={ colors }
-					/>
-				);
-			} ) }
+					return (
+						<Track
+							key={ track.id }
+							index={ index }
+							track={ track }
+							selectTrack={ selectTrack }
+							isActive={ isActive }
+							isPlaying={ isActive && playerState === STATE_PLAYING }
+							isError={ isActive && playerState === STATE_ERROR }
+							colors={ colors }
+						/>
+					);
+				} ) }
 		</ol>
 	);
 } );

--- a/extensions/blocks/podcast-player/components/podcast-player.js
+++ b/extensions/blocks/podcast-player/components/podcast-player.js
@@ -300,14 +300,16 @@ export class PodcastPlayer extends Component {
 				>
 					{ __( 'Select an episode to play it in the audio player.', 'jetpack' ) }
 				</p>
-				<Playlist
-					playerId={ playerId }
-					playerState={ playerState }
-					currentTrack={ currentTrack }
-					tracks={ tracksToDisplay }
-					selectTrack={ this.selectTrack }
-					colors={ colors }
-				/>
+				{ tracksToDisplay.length > 1 && (
+					<Playlist
+						playerId={ playerId }
+						playerState={ playerState }
+						currentTrack={ currentTrack }
+						tracks={ tracksToDisplay }
+						selectTrack={ this.selectTrack }
+						colors={ colors }
+					/>
+				) }
 			</section>
 		);
 	}

--- a/extensions/blocks/podcast-player/icons/link.js
+++ b/extensions/blocks/podcast-player/icons/link.js
@@ -1,0 +1,17 @@
+/* eslint-disable jsdoc/check-tag-names */
+
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+/**
+ * @todo: Replace with `@wordpress/icons` when available
+ */
+const link = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />
+	</SVG>
+);
+
+export default link;

--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -160,6 +160,7 @@ function render_player( $player_data, $attributes ) {
 				)
 			);
 			?>
+			<?php if ( count( $player_data['tracks'] ) > 1 ) : ?>
 			<ol class="jetpack-podcast-player__tracks">
 				<?php foreach ( $player_data['tracks'] as $track_index => $attachment ) : ?>
 					<?php
@@ -175,6 +176,7 @@ function render_player( $player_data, $attributes ) {
 					?>
 				<?php endforeach; ?>
 			</ol>
+			<?php endif; ?>
 		</section>
 		<?php if ( ! $is_amp ) : ?>
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -294,6 +294,7 @@ $jetpack-podcast-player-error: $alert-red;
 		}
 
 		svg {
+			display: block;
 			width: $current-track-title-icon-size;
 			height: $current-track-title-icon-size;
 			fill: currentColor;

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -8,6 +8,7 @@ $gutter-m: 15px;
 $gutter-l: 24px;
 $cover-image-size: 80px;
 $current-track-title-font-size: 24px;
+$current-track-title-icon-size: 27px;
 $track-status-icon-size: 22px;
 $jetpack-podcast-player-primary: $black;
 $jetpack-podcast-player-secondary: $dark-gray-300;
@@ -272,6 +273,20 @@ $jetpack-podcast-player-error: $alert-red;
 	.jetpack-podcast-player__track-title {
 		flex-grow: 1;
 		padding: 0 $gutter-m;
+	}
+
+	.jetpack-podcast-player__track-title-link {
+		display: inline-block;
+		height: $current-track-title-icon-size;
+		margin-left: $gutter-s / 2;
+		vertical-align: top;
+		color: currentColor;
+
+		svg {
+			width: $current-track-title-icon-size;
+			height: $current-track-title-icon-size;
+			fill: currentColor;
+		}
 	}
 
 	.jetpack-podcast-player__track-duration {

--- a/extensions/blocks/podcast-player/style.scss
+++ b/extensions/blocks/podcast-player/style.scss
@@ -280,7 +280,18 @@ $jetpack-podcast-player-error: $alert-red;
 		height: $current-track-title-icon-size;
 		margin-left: $gutter-s / 2;
 		vertical-align: top;
-		color: currentColor;
+
+		&,
+		&:active,
+		&:visited {
+			color: currentColor;
+		}
+
+		&:hover,
+		&:focus {
+			color: inherit;
+			color: var( --jetpack-podcast-player-secondary );
+		}
 
 		svg {
 			width: $current-track-title-icon-size;

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -17,6 +17,7 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  */
 
 $track_title    = $attachment['title'];
+$track_link     = empty( $attachment['link'] ) ? $attachment['src'] : $attachment['link'];
 $track_duration = ! empty( $attachment['duration'] ) ? $attachment['duration'] : '';
 
 $class = 'jetpack-podcast-player__track ' . $secondary_colors['class'];
@@ -34,7 +35,7 @@ if ( $is_active ) {
 >
 	<a
 		class="jetpack-podcast-player__track-link jetpack-podcast-player__link"
-		href="<?php echo esc_url( empty( $attachment['link'] ) ? $attachment['src'] : $attachment['link'] ); ?>"
+		href="<?php echo esc_url( $track_link ); ?>"
 		role="button"
 		<?php echo $is_active ? 'aria-current="track"' : ''; ?>
 	>

--- a/extensions/blocks/podcast-player/templates/playlist-track.php
+++ b/extensions/blocks/podcast-player/templates/playlist-track.php
@@ -34,7 +34,7 @@ if ( $is_active ) {
 >
 	<a
 		class="jetpack-podcast-player__track-link jetpack-podcast-player__link"
-		href="<?php echo esc_url( $attachment['link'] ); ?>"
+		href="<?php echo esc_url( empty( $attachment['link'] ) ? $attachment['src'] : $attachment['link'] ); ?>"
 		role="button"
 		<?php echo $is_active ? 'aria-current="track"' : ''; ?>
 	>

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -23,7 +23,7 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 ?>
 
 <h2 id="<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
-	<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $track['link'] ) && isset( $track['src'] ) ) : ?>
+	<?php if ( isset( $track['title'], $track['link'], $track['src'] ) ) : ?>
 		<span
 			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
 			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -19,26 +19,35 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 	return;
+} elseif ( isset( $track['link'] ) && ! empty( $track['link'] ) ) {
+	$track_link = $track['link'];
+} elseif ( isset( $track['src'] ) && ! empty( $track['src'] ) ) {
+	$track_link = $track['src'];
 }
+
 ?>
 
+
+
 <h2 id="<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
-	<?php if ( isset( $track['title'], $track['link'], $track['src'] ) ) : ?>
+	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
 		<span
 			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
 			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
 		>
 			<?php echo esc_html( $track['title'] ); ?>
-			<a
-				class="jetpack-podcast-player__track-title-link"
-				href="<?php echo esc_url( empty( $track['link'] ) ? $track['src'] : $track['link'] ); ?>"
-				target="_blank"
-				rel="noopener noreferrer nofollow"
-			>
-				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-					<path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />
-				</svg>
-			</a>
+			<?php if ( isset( $track_link ) ) : ?>
+				<a
+					class="jetpack-podcast-player__track-title-link"
+					href="<?php echo esc_url( $track_link ); ?>"
+					target="_blank"
+					rel="noopener noreferrer nofollow"
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+						<path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />
+					</svg>
+				</a>
+			<?php endif; ?>
 		</span>
 	<?php endif; ?>
 

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -25,8 +25,6 @@ $track_link = empty( $track['link'] ) ? $track['src'] : $track['link'];
 
 ?>
 
-
-
 <h2 id="<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
 	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
 		<span

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -17,41 +17,39 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
  * @var array  $primary_colors
  */
 
-if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
+if ( ! isset( $title ) && empty( $track['title'] ) ) {
 	return;
 }
 
 $track_link = empty( $track['link'] ) ? $track['src'] : $track['link'];
-
 ?>
 
 <h2 id="<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
-	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
-		<span
-			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
-			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
-		>
-			<?php echo esc_html( $track['title'] ); ?>
-			<?php if ( isset( $track_link ) ) : ?>
-				<a
-					class="jetpack-podcast-player__track-title-link"
-					href="<?php echo esc_url( $track_link ); ?>"
-					target="_blank"
-					rel="noopener noreferrer nofollow"
-				>
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-						<path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />
-					</svg>
-				</a>
-			<?php endif; ?>
-		</span>
-	<?php endif; ?>
+	<span
+		class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
+		<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
+	>
+		<?php
+		echo esc_html( $track['title'] );
+		if ( ! empty( $track_link ) ) :
+			// Prevent whitespace between title and link to cause a jump when JS kicks in.
+			?>
+			<a
+				class="jetpack-podcast-player__track-title-link"
+				href="<?php echo esc_url( $track_link ); ?>"
+				target="_blank"
+				rel="noopener noreferrer nofollow"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+					<path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />
+				</svg>
+			</a>
+		<?php endif; ?>
+	</span>
 
-	<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $title ) ) : ?>
+	<?php if ( ! empty( $title ) ) : ?>
 		<span class="jetpack-podcast-player--visually-hidden"> - </span>
-	<?php endif; ?>
 
-	<?php if ( isset( $title ) ) : ?>
 		<?php
 		render(
 			'podcast-title',

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -19,11 +19,9 @@ namespace Automattic\Jetpack\Extensions\Podcast_Player;
 
 if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 	return;
-} elseif ( isset( $track['link'] ) && ! empty( $track['link'] ) ) {
-	$track_link = $track['link'];
-} elseif ( isset( $track['src'] ) && ! empty( $track['src'] ) ) {
-	$track_link = $track['src'];
 }
+
+$track_link = empty( $track['link'] ) ? $track['src'] : $track['link'];
 
 ?>
 

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -23,12 +23,22 @@ if ( ! isset( $title ) && empty( $track ) && ! isset( $track['title'] ) ) {
 ?>
 
 <h2 id="<?php echo esc_attr( $player_id ); ?>__title" class="jetpack-podcast-player__title">
-	<?php if ( ! empty( $track ) && isset( $track['title'] ) ) : ?>
+	<?php if ( ! empty( $track ) && isset( $track['title'] ) && isset( $track['link'] ) && isset( $track['src'] ) ) : ?>
 		<span
 			class="jetpack-podcast-player__current-track-title <?php echo esc_attr( $primary_colors['class'] ); ?>"
 			<?php echo isset( $primary_colors['style'] ) ? 'style="' . esc_attr( $primary_colors['style'] ) . '"' : ''; ?>
 		>
 			<?php echo esc_html( $track['title'] ); ?>
+			<a
+				class="jetpack-podcast-player__track-title-link"
+				href="<?php echo esc_url( empty( $track['link'] ) ? $track['src'] : $track['link'] ); ?>"
+				target="_blank"
+				rel="noopener noreferrer nofollow"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+					<path d="M15.6 7.2H14v1.5h1.6c2 0 3.7 1.7 3.7 3.7s-1.7 3.7-3.7 3.7H14v1.5h1.6c2.8 0 5.2-2.3 5.2-5.2 0-2.9-2.3-5.2-5.2-5.2zM4.7 12.4c0-2 1.7-3.7 3.7-3.7H10V7.2H8.4c-2.9 0-5.2 2.3-5.2 5.2 0 2.9 2.3 5.2 5.2 5.2H10v-1.5H8.4c-2 0-3.7-1.7-3.7-3.7zm4.6.9h5.3v-1.5H9.3v1.5z" />
+				</svg>
+			</a>
 		</span>
 	<?php endif; ?>
 

--- a/extensions/blocks/podcast-player/templates/podcast-header-title.php
+++ b/extensions/blocks/podcast-player/templates/podcast-header-title.php
@@ -33,8 +33,7 @@ $track_link = empty( $track['link'] ) ? $track['src'] : $track['link'];
 		echo esc_html( $track['title'] );
 		if ( ! empty( $track_link ) ) :
 			// Prevent whitespace between title and link to cause a jump when JS kicks in.
-			?>
-			<a
+			?><a
 				class="jetpack-podcast-player__track-title-link"
 				href="<?php echo esc_url( $track_link ); ?>"
 				target="_blank"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### This PR introduces the following three changes to the Podcast Player: 

1. Add an external link to the main episode title
2. Hide the track list if there is only one episode 
3. Fix an issue in the original no-js implementation where the links in the track list would be empty if `link` was not set. It now falls back to `src` in that case.

Fixes https://github.com/Automattic/jetpack/issues/15803

| Before  | After |
| ------------- | ------------- |
| <img width="803" alt="Screenshot 2020-06-03 at 19 37 46" src="https://user-images.githubusercontent.com/1562646/83669469-ebbcfa80-a5d1-11ea-895a-7103ea50cab0.png"> | <img width="812" alt="Screenshot 2020-06-03 at 19 36 51" src="https://user-images.githubusercontent.com/1562646/83669425-de077500-a5d1-11ea-91e8-65c4d6db08f7.png"> |

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

For all:
* Create a new post and add the `Podcast Player` block.
* Add a Podcast URL e.g. [Distributed](https://distributed.blog/category/podcast/feed/) (`link` set) or [Dissect](https://anchor.fm/dissect) (only `src` set)

For 1.:
* Confirm that you can see the new external link next to the main episode title both in the editor and the Frontend.
* In the Frontend disable JavaScript and confirm that you can see the new external link in the static version as well.
* Change the colors (primary and secondary) and confirm that the changes apply as expected (primary for default color, secondary for hover/focus).

For 2.:
* In the `Podcast Settings` reduce the `Number of items` to 1.
* Confirm that track list is not showing anymore in the editor and Frontend.
* In the Frontend disable JavaScript and confirm that the track list is not showing anymore.

For 3.:
* Use both [Distributed](https://distributed.blog/category/podcast/feed/) (`link` set) and [Dissect](https://anchor.fm/dissect) (only `src` set) to test this.
* In the Frontend disable JavaScript.
* Confirm that the first is still working as expected.
* Confirm that the second now links out to the source files (instead of empty links like before).

