### PR TITLE
External Media: Fix Modal focus loss on arrow keypress

### DIFF
--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -187,6 +187,9 @@ export default function withMedia() {
 				 * This handler makes sure that the keydown event doesn't propagate further,
 				 * which fixes the issue described above while still keeping arrow keys
 				 * functional inside the modal.
+				 *
+				 * This can be removed once
+				 * https://github.com/WordPress/gutenberg/issues/22940 is fixed.
 				 */
 				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
 					event.stopPropagation();

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -172,10 +172,6 @@ export default function withMedia() {
 				this.setState( { path }, cb );
 			};
 
-			stopPropagation( event ) {
-				event.stopPropagation();
-			}
-
 			stopArrowKeysPropagation = event => {
 				/**
 				 * When the External Media modal is open, pressing any arrow key causes
@@ -202,7 +198,7 @@ export default function withMedia() {
 
 				return (
 					// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-					<div onMouseDown={ this.stopPropagation } onKeyDown={ this.stopArrowKeysPropagation }>
+					<div onKeyDown={ this.stopArrowKeysPropagation }>
 						{ noticeUI }
 
 						<OriginalComponent

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -54,45 +54,6 @@ export default function withMedia() {
 				};
 			}
 
-			componentDidMount() {
-				this.removeArrowKeysPropagationHandler = this.attachArrowKeysPropagationHandler();
-			}
-
-			componentWillUnmount() {
-				if ( this.removeArrowKeysPropagationHandler ) {
-					this.removeArrowKeysPropagationHandler();
-				}
-			}
-
-			attachArrowKeysPropagationHandler = () => {
-				const eventListenerEl = document.querySelector( '.components-modal__content' );
-				if ( ! eventListenerEl ) {
-					return null;
-				}
-
-				eventListenerEl.addEventListener( 'keydown', this.stopArrowKeysPropagation );
-				return () => {
-					eventListenerEl.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
-				};
-			};
-
-			stopArrowKeysPropagation = event => {
-				/**
-				 * When the External Media modal is open, pressing any arrow key causes
-				 * it to close immediately. This is happening because the keydown event
-				 * propagates outside the modal, triggering a re-render and a blur event
-				 * eventually. We could avoid that by isolating the modal from the Image
-				 * block render scope, but it is not possible in current implementation.
-				 *
-				 * This handler makes sure that the keydown event doesn't propagate further,
-				 * which fixes the issue described above while still keeping arrow keys
-				 * functional inside the modal.
-				 */
-				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
-					event.stopPropagation();
-				}
-			};
-
 			setAuthenticated = isAuthenticated => this.setState( { isAuthenticated } );
 
 			mergeMedia( initial, media ) {
@@ -215,13 +176,30 @@ export default function withMedia() {
 				event.stopPropagation();
 			}
 
+			stopArrowKeysPropagation = event => {
+				/**
+				 * When the External Media modal is open, pressing any arrow key causes
+				 * it to close immediately. This is happening because the keydown event
+				 * propagates outside the modal, triggering a re-render and a blur event
+				 * eventually. We could avoid that by isolating the modal from the Image
+				 * block render scope, but it is not possible in current implementation.
+				 *
+				 * This handler makes sure that the keydown event doesn't propagate further,
+				 * which fixes the issue described above while still keeping arrow keys
+				 * functional inside the modal.
+				 */
+				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
+					event.stopPropagation();
+				}
+			};
+
 			renderContent() {
 				const { media, isLoading, nextHandle, isAuthenticated, path } = this.state;
 				const { noticeUI, allowedTypes, multiple = false } = this.props;
 
 				return (
 					// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-					<div onMouseDown={ this.stopPropagation }>
+					<div onMouseDown={ this.stopPropagation } onKeyDown={ this.stopArrowKeysPropagation }>
 						{ noticeUI }
 
 						<OriginalComponent

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -54,28 +54,20 @@ export default function withMedia() {
 				};
 			}
 
-			componentDidMount() {
-				this.arrowKeysPropagationHandler = this.attachArrowKeysPropagationHandler();
-			}
+			modalRef = el => {
+				if ( el ) {
+					// Find the modal wrapper.
+					this.modalElement = el.closest( '.jetpack-external-media-browser' );
 
-			componentWillUnmount() {
-				if ( this.arrowKeysPropagationHandler ) {
-					this.arrowKeysPropagationHandler.remove();
+					// Attach the listener if found.
+					if ( this.modalElement ) {
+						this.modalElement.addEventListener( 'keydown', this.stopArrowKeysPropagation );
+					}
+				} else if ( this.modalElement ) {
+					// Remove listeners when unmounting.
+					this.modalElement.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
+					this.modalElement = null;
 				}
-			}
-
-			attachArrowKeysPropagationHandler = () => {
-				const eventListenerEl = document.querySelector( '.jetpack-external-media-browser' );
-				if ( ! eventListenerEl ) {
-					return null;
-				}
-
-				eventListenerEl.addEventListener( 'keydown', this.stopArrowKeysPropagation );
-				return {
-					remove() {
-						eventListenerEl.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
-					},
-				};
 			};
 
 			stopArrowKeysPropagation = event => {
@@ -257,7 +249,9 @@ export default function withMedia() {
 						title={ isCopying ? __( 'Copying Media', 'jetpack' ) : __( 'Select Media', 'jetpack' ) }
 						className={ classes }
 					>
-						{ isCopying ? <CopyingMedia items={ isCopying } /> : this.renderContent() }
+						<div ref={ this.modalRef }>
+							{ isCopying ? <CopyingMedia items={ isCopying } /> : this.renderContent() }
+						</div>
 					</Modal>
 				);
 			}


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack/issues/15855

When the External Media modal is open, pressing any arrow key causes it to close immediately. 

To address this issue, I figured that a good thing to start with would be to handle the open/close toggle via the editor state (rather than re-rendering the whole thing every time content source changes). I've used other core implementations as an example - i.e.[ KeboardShortcutHelpModal](https://github.com/WordPress/gutenberg/blob/dbcaf38e886781d0bf5101db8cd04b5360ce2685/packages/edit-post/src/components/keyboard-shortcut-help-modal/index.js) or [OptionsModal](https://github.com/WordPress/gutenberg/blob/34ed2a6042d42fa18a5dcd0853d59bdff6a068d9/packages/edit-post/src/components/options-modal/index.js). I was hoping it would fix the issue, but that didn't happen, unfortunately. I'd still leave that change though, as it still improves the visibility toggle logic.

I've kept debugging and found out that `React` fires a `blur` event on the modal element right after the (arrow) `keydown` one. This happens probably during the re-render cycle of the Image block, which the modal component is a part of. The fun fact is that right after that, React actually tries to restore the focus to the modal element, but because the blur already happened, modal's [`withFocusOutside`](https://github.com/WordPress/gutenberg/blob/4857ad58c1241b3d63d21a6880c989b85746c3dc/packages/components/src/higher-order/with-focus-outside/index.js) handler thinks that [the outside of the modal was clicked](https://github.com/WordPress/gutenberg/blob/3b5bfa3964c336597687b62ac43906109c05f9aa/packages/components/src/modal/frame.js#L46) so it closes the modal anyway. So, I figured that we could fix that issue by completely isolating the modal from the Image block render scope. I was able to confirm this by triggering (via editor state) other (core) modals with the same button - when the modal component is outside the Image block render scope, blur is not being triggered, arrows are being contained and the focus stays within the modal. I've left [some commented out `openModal` calls](https://github.com/Automattic/jetpack/pull/16055/commits/2d6e89ec11a92a623d205548cf3b2db92bef19be#diff-b10daa55ee0c1b5a7218a11a0fe3b04bR34-R35) for testing purposes. To check it yourself just uncomment one of them and open the external media modal as you'd normally do. It will open the uncommented modal instead and you'll be able to see that arrow keys are being contained when pressed.

Unfortunately, I couldn't find a way to isolate the modal as mentioned above, so in https://github.com/Automattic/jetpack/pull/16055/commits/d9ec352830ff5f258f2f457905e50d755bc6396d I added a propagation handler for arrows `keydown` event. It makes sure that the `keydown` event doesn't propagate further, which fixes the https://github.com/Automattic/jetpack/issues/15855 while still keeping arrow keys functional inside the modal (i.e. when navigating inside Pexels search input text or choosing filter from one of the Google Photos filters' select dropdown). This solution is not ideal but it might be the best we can get now.

---

**Update:**

I've updated the code to include only the arrow keys handler. All the other changes were creating too many issues and weren't necessary ATM. This should be now easier to review and test.