### PR TITLE
Check blog token when computing is_registered

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -519,8 +519,8 @@ class Manager {
 	 * @return bool
 	 */
 	public function is_registered() {
-		$has_blog_id    = ! ! \Jetpack_Options::get_option( 'id' );
-		$has_blog_token = ! ! $this->get_access_token( false );
+		$has_blog_id    = (bool) \Jetpack_Options::get_option( 'id' );
+		$has_blog_token = (bool) $this->get_access_token( false );
 		return $has_blog_id && $has_blog_token;
 	}
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -519,9 +519,9 @@ class Manager {
 	 * @return bool
 	 */
 	public function is_registered() {
-		$blog_id   = \Jetpack_Options::get_option( 'id' );
-		$has_token = $this->is_active();
-		return $blog_id && $has_token;
+		$has_blog_id    = ! ! \Jetpack_Options::get_option( 'id' );
+		$has_blog_token = ! ! $this->get_access_token( false );
+		return $has_blog_id && $has_blog_token;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16056

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Check blog token when computing $manager->is_registered()

#### Testing instructions:
* Register, but do not activate a site
* `(new Connection_Manager())->is_registered()` should return true
* `(new Connection_Manager())->is_active()` should return false
