### PR TITLE
Remove usage of the Jetpack_Error class in the connection package

### DIFF
--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -159,7 +159,7 @@ class Jetpack_XMLRPC_Server {
 
 		if ( ! $user_id ) {
 			return $this->error(
-				new Jetpack_Error(
+				new \WP_Error(
 					'invalid_user',
 					__( 'Invalid user identifier.', 'jetpack' ),
 					400
@@ -172,7 +172,7 @@ class Jetpack_XMLRPC_Server {
 
 		if ( ! $user ) {
 			return $this->error(
-				new Jetpack_Error(
+				new \WP_Error(
 					'user_unknown',
 					__( 'User not found.', 'jetpack' ),
 					404
@@ -230,18 +230,18 @@ class Jetpack_XMLRPC_Server {
 		foreach ( array( 'secret', 'state', 'redirect_uri', 'code' ) as $required ) {
 			if ( ! isset( $request[ $required ] ) || empty( $request[ $required ] ) ) {
 				return $this->error(
-					new Jetpack_Error( 'missing_parameter', 'One or more parameters is missing from the request.', 400 ),
+					new \WP_Error( 'missing_parameter', 'One or more parameters is missing from the request.', 400 ),
 					'remote_authorize'
 				);
 			}
 		}
 
 		if ( ! $user ) {
-			return $this->error( new Jetpack_Error( 'user_unknown', 'User not found.', 404 ), 'remote_authorize' );
+			return $this->error( new \WP_Error( 'user_unknown', 'User not found.', 404 ), 'remote_authorize' );
 		}
 
 		if ( $this->connection->is_active() && $this->connection->is_user_connected( $request['state'] ) ) {
-			return $this->error( new Jetpack_Error( 'already_connected', 'User already connected.', 400 ), 'remote_authorize' );
+			return $this->error( new \WP_Error( 'already_connected', 'User already connected.', 400 ), 'remote_authorize' );
 		}
 
 		$verified = $this->verify_action( array( 'authorize', $request['secret'], $request['state'] ) );
@@ -293,7 +293,7 @@ class Jetpack_XMLRPC_Server {
 
 		if ( empty( $request['nonce'] ) ) {
 			return $this->error(
-				new Jetpack_Error(
+				new \WP_Error(
 					'nonce_missing',
 					__( 'The required "nonce" parameter is missing.', 'jetpack' ),
 					400
@@ -319,7 +319,7 @@ class Jetpack_XMLRPC_Server {
 			'OK' !== trim( wp_remote_retrieve_body( $response ) )
 		) {
 			return $this->error(
-				new Jetpack_Error(
+				new \WP_Error(
 					'invalid_nonce',
 					__( 'There was an issue validating this request.', 'jetpack' ),
 					400
@@ -338,7 +338,7 @@ class Jetpack_XMLRPC_Server {
 				return $this->error( $registered, 'remote_register' );
 			} elseif ( ! $registered ) {
 				return $this->error(
-					new Jetpack_Error(
+					new \WP_Error(
 						'registration_error',
 						__( 'There was an unspecified error registering the site', 'jetpack' ),
 						400
@@ -506,7 +506,7 @@ class Jetpack_XMLRPC_Server {
 	private function fetch_and_verify_local_user( $request ) {
 		if ( empty( $request['local_user'] ) ) {
 			return $this->error(
-				new Jetpack_Error(
+				new \WP_Error(
 					'local_user_missing',
 					__( 'The required "local_user" parameter is missing.', 'jetpack' ),
 					400
@@ -589,13 +589,13 @@ class Jetpack_XMLRPC_Server {
 		$user = wp_authenticate( 'username', 'password' );
 		if ( is_wp_error( $user ) ) {
 			if ( 'authentication_failed' === $user->get_error_code() ) { // Generic error could mean most anything.
-				$this->error = new Jetpack_Error( 'invalid_request', 'Invalid Request', 403 );
+				$this->error = new \WP_Error( 'invalid_request', 'Invalid Request', 403 );
 			} else {
 				$this->error = $user;
 			}
 			return false;
 		} elseif ( ! $user ) { // Shouldn't happen.
-			$this->error = new Jetpack_Error( 'invalid_request', 'Invalid Request', 403 );
+			$this->error = new \WP_Error( 'invalid_request', 'Invalid Request', 403 );
 			return false;
 		}
 

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -950,7 +950,7 @@ class Manager {
 	 * @since 2.6
 	 *
 	 * @param Mixed $response the response object, or the error object.
-	 * @return string|WP_Error A JSON object on success or Jetpack_Error on failures
+	 * @return string|WP_Error A JSON object on success or WP_Error on failures
 	 **/
 	protected function validate_remote_register_response( $response ) {
 		if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The `Jetpack_Error` class is defined here. As such, it's not available if a plugin is using the `jetpack-connection` package by itself. Since the `Jetpack_Error` class is just a subclass of `WP_Error` with no added logic, all usages of `Jetpack_Error` can be replaced with `WP_Error`. That's what I did.

I also checked that there's no code checking if the return value of a function is a `Jetpack_Error` specifically.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- Install the `Client-Example` plugin. DON'T install Jetpack.
- Connect your user and site to Jetpack.
- Change [this](https://github.com/Automattic/client-example/blob/8cb38966fb101cf8e91bc06bdca0f313a80df168/admin/simple-ui/class-connection-simple-ui-admin.php#L32) line in your `Client-Example` plugin to `$this->connected_state   = new Authorizing_State( $this );` . That way, you'll be able to go through the `authorize` flow even if Jetpack is already fully connected.
- Go to the `Client-Example` page, click `Authorize user`, and click the `Authorize` button in wordpress.com.

If you're using the published version of the `jetpack-connection` package, it won't work. If you use the `jetpack-connection` package with the changes made in this PR, it will.

#### Proposed changelog entry for your changes:
N/A