### PR TITLE
Remove usage of Jetpack_Error

### DIFF
--- a/class.jetpack-error.php
+++ b/class.jetpack-error.php
@@ -1,3 +1,7 @@
 <?php
-
+/**
+ * Class Jetpack_Error
+ *
+ * This is deprecated.
+ */
 class Jetpack_Error extends WP_Error {}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3772,12 +3772,12 @@ p {
 				$response = $this->upload_handler( true );
 				break;
 			default:
-				$response = new Jetpack_Error( 'unknown_handler', 'Unknown Handler', 400 );
+				$response = new WP_Error( 'unknown_handler', 'Unknown Handler', 400 );
 				break;
 		}
 
 		if ( ! $response ) {
-			$response = new Jetpack_Error( 'unknown_error', 'Unknown Error', 400 );
+			$response = new WP_Error( 'unknown_error', 'Unknown Error', 400 );
 		}
 
 		if ( is_wp_error( $response ) ) {
@@ -3812,27 +3812,27 @@ p {
 	 */
 	function upload_handler( $update_media_item = false ) {
 		if ( 'POST' !== strtoupper( $_SERVER['REQUEST_METHOD'] ) ) {
-			return new Jetpack_Error( 405, get_status_header_desc( 405 ), 405 );
+			return new WP_Error( 405, get_status_header_desc( 405 ), 405 );
 		}
 
 		$user = wp_authenticate( '', '' );
 		if ( ! $user || is_wp_error( $user ) ) {
-			return new Jetpack_Error( 403, get_status_header_desc( 403 ), 403 );
+			return new WP_Error( 403, get_status_header_desc( 403 ), 403 );
 		}
 
 		wp_set_current_user( $user->ID );
 
 		if ( ! current_user_can( 'upload_files' ) ) {
-			return new Jetpack_Error( 'cannot_upload_files', 'User does not have permission to upload files', 403 );
+			return new WP_Error( 'cannot_upload_files', 'User does not have permission to upload files', 403 );
 		}
 
 		if ( empty( $_FILES ) ) {
-			return new Jetpack_Error( 'no_files_uploaded', 'No files were uploaded: nothing to process', 400 );
+			return new WP_Error( 'no_files_uploaded', 'No files were uploaded: nothing to process', 400 );
 		}
 
 		foreach ( array_keys( $_FILES ) as $files_key ) {
 			if ( ! isset( $_POST[ "_jetpack_file_hmac_{$files_key}" ] ) ) {
-				return new Jetpack_Error( 'missing_hmac', 'An HMAC for one or more files is missing', 400 );
+				return new WP_Error( 'missing_hmac', 'An HMAC for one or more files is missing', 400 );
 			}
 		}
 
@@ -3840,7 +3840,7 @@ p {
 
 		$token = Jetpack_Data::get_access_token( get_current_user_id() );
 		if ( ! $token || is_wp_error( $token ) ) {
-			return new Jetpack_Error( 'unknown_token', 'Unknown Jetpack token', 403 );
+			return new WP_Error( 'unknown_token', 'Unknown Jetpack token', 403 );
 		}
 
 		$uploaded_files = array();
@@ -3871,7 +3871,7 @@ p {
 
 			if ( $update_media_item ) {
 				if ( ! isset( $post_id ) || $post_id === 0 ) {
-					return new Jetpack_Error( 'invalid_input', 'Media ID must be defined.', 400 );
+					return new WP_Error( 'invalid_input', 'Media ID must be defined.', 400 );
 				}
 
 				$media_array = $_FILES['media'];

--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -517,7 +517,7 @@ class Jetpack_Subscriptions {
 	 * @param array  $post_ids (optional) defaults to 0 for blog posts only: array of post IDs to subscribe to blog's posts
 	 * @param bool   $async    (optional) Should the subscription be performed asynchronously?  Defaults to true.
 	 *
-	 * @return true|Jetpack_Error true on success
+	 * @return true|WP_Error true on success
 	 *	invalid_email   : not a valid email address
 	 *	invalid_post_id : not a valid post ID
 	 *	unknown_post_id : unknown post
@@ -530,7 +530,7 @@ class Jetpack_Subscriptions {
 	 */
 	function subscribe( $email, $post_ids = 0, $async = true, $extra_data = array() ) {
 		if ( !is_email( $email ) ) {
-			return new Jetpack_Error( 'invalid_email' );
+			return new WP_Error( 'invalid_email' );
 		}
 
 		if ( !$async ) {
@@ -540,9 +540,9 @@ class Jetpack_Subscriptions {
 		foreach ( (array) $post_ids as $post_id ) {
 			$post_id = (int) $post_id;
 			if ( $post_id < 0 ) {
-				return new Jetpack_Error( 'invalid_post_id' );
+				return new WP_Error( 'invalid_post_id' );
 			} else if ( $post_id && !$post = get_post( $post_id ) ) {
-				return new Jetpack_Error( 'unknown_post_id' );
+				return new WP_Error( 'unknown_post_id' );
 			}
 
 			if ( $async ) {
@@ -573,28 +573,28 @@ class Jetpack_Subscriptions {
 			}
 
 			if ( !is_array( $response[0] ) || empty( $response[0]['status'] ) ) {
-				$r[] = new Jetpack_Error( 'unknown' );
+				$r[] = new WP_Error( 'unknown' );
 				continue;
 			}
 
 			switch ( $response[0]['status'] ) {
 				case 'error':
-					$r[] = new Jetpack_Error( 'not_subscribed' );
+					$r[] = new WP_Error( 'not_subscribed' );
 					continue 2;
 				case 'disabled':
-					$r[] = new Jetpack_Error( 'disabled' );
+					$r[] = new WP_Error( 'disabled' );
 					continue 2;
 				case 'active':
-					$r[] = new Jetpack_Error( 'active' );
+					$r[] = new WP_Error( 'active' );
 					continue 2;
 				case 'confirming':
 					$r[] = true;
 					continue 2;
 				case 'pending':
-					$r[] = new Jetpack_Error( 'pending' );
+					$r[] = new WP_Error( 'pending' );
 					continue 2;
 				default:
-					$r[] = new Jetpack_Error( 'unknown_status', (string) $response[0]['status'] );
+					$r[] = new WP_Error( 'unknown_status', (string) $response[0]['status'] );
 					continue 2;
 			}
 		}


### PR DESCRIPTION
Continues on #16058

#### Changes proposed in this Pull Request:
* `Jetpack_Error` is extending `WP_Error` with zero changes. Let's use `WP_Error` instead.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
* There's no functional change.
*

#### Proposed changelog entry for your changes:
* Removes Jetpack_Error to use WP_Error directly.
