### PR TITLE
Connection: add the api_constant filter before setup_xmlrpc_handlers called

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -74,6 +74,13 @@ class Manager {
 	public static function configure() {
 		$manager = new self();
 
+		add_filter(
+			'jetpack_constant_default_value',
+			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
+			10,
+			2
+		);
+
 		$manager->setup_xmlrpc_handlers(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$manager->is_active(),
@@ -91,15 +98,7 @@ class Manager {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		}
 
-		add_filter(
-			'jetpack_constant_default_value',
-			__NAMESPACE__ . '\Utils::jetpack_api_constant_filter',
-			10,
-			2
-		);
-
 		add_action( 'plugins_loaded', __NAMESPACE__ . '\Plugin_Storage::configure', 100 );
-
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Move the `add_filter( 'jetpack_constant_default_value'` call so that it precedes the `Manager::setup_xmlrpc_handlers()` call.

##### Why this is necessary:
* The `jetpack_constant_default_filter` sets default values of Jetpack API constants if they haven't already been set.
* The `JETPACK__API_VERSION` constant is used in `Manager:: internal_verify_xml_rpc_signature()`, which is called in the arguments for
`Manager::setup_xmlrpc_handlers()`. So, the hook should be added before `Manager::setup_xmlrpc_handlers()` is called.

This bug and the changes in this PR should not affect the Jetpack plugin. Jetpack sets the value of the API constants. So, the default values are only needed when the Connection package is used by another plugin and Jetpack is not activated.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This changes an existing part of Jetpack.

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:
##### Test site
* This branch of Jetpack must be installed.
* The client-example plugin must be installed.
* Debug logging must be enabled.

##### Test steps
Jetpack - Test that the Jetpack connection works.

1. Start with a disconnected site (deactivate Jetpack if the site is already connected).
2. Connect Jetpack (both site registration and user authorization).
3. Disconnect Jetpack.
4. Verify that no errors/warnings/notices were generated in the debug.log.

Client-example - Test that the connection works without Jetpack.

1. Deactivate Jetpack.
2. Connect using the Calypso connection flow in the client-example plugin (both site registration and user authorization). The connection should successfully complete.
3. An error should be generated in the debug log when you land in Calypso after user authorization. The issue described in #16060 should generate this error:

   `PHP Fatal error:  require_once(): Failed opening required 'JETPACK__PLUGIN_DIRclass.json-api.php'`

That error will be fixed in a separate PR.

#### Proposed changelog entry for your changes:
* tbd
