### PR TITLE
Make Slideshare shortcode to be compatible with AMP

### DIFF
--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -91,7 +91,9 @@ function slideshare_shortcode( $atts ) {
 		$player .= " frameborder='" . intval( $attr['fb'] ) . "'";
 	}
 
-	if ( class_exists( 'Jetpack_AMP_Support' ) && ! Jetpack_AMP_Support::is_amp_request() ) {
+	$is_amp = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ? true : false;
+
+	if ( ! $is_amp ) {
 		// check the margin width; if not empty, cast as int.
 		if ( ( ! empty( $attr['mw'] ) || '0' === $attr['mw'] ) ) {
 			$player .= " marginwidth='" . intval( $attr['mw'] ) . "'";

--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -91,14 +91,16 @@ function slideshare_shortcode( $atts ) {
 		$player .= " frameborder='" . intval( $attr['fb'] ) . "'";
 	}
 
-	// check the margin width; if not empty, cast as int.
-	if ( ( ! empty( $attr['mw'] ) || '0' === $attr['mw'] ) && ! Jetpack_AMP_Support::is_amp_request() ) {
-		$player .= " marginwidth='" . intval( $attr['mw'] ) . "'";
-	}
+	if ( class_exists( 'Jetpack_AMP_Support' ) && ! Jetpack_AMP_Support::is_amp_request() ) {
+		// check the margin width; if not empty, cast as int.
+		if ( ( ! empty( $attr['mw'] ) || '0' === $attr['mw'] ) ) {
+			$player .= " marginwidth='" . intval( $attr['mw'] ) . "'";
+		}
 
-	// check the margin height, if not empty, cast as int.
-	if ( ( ! empty( $attr['mh'] ) || '0' === $attr['mh'] ) && ! Jetpack_AMP_Support::is_amp_request() ) {
-		$player .= " marginheight='" . intval( $attr['mh'] ) . "'";
+		// check the margin height, if not empty, cast as int.
+		if ( ( ! empty( $attr['mh'] ) || '0' === $attr['mh'] ) ) {
+			$player .= " marginheight='" . intval( $attr['mh'] ) . "'";
+		}
 	}
 
 	if ( ! empty( $attr['style'] ) ) {

--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -91,7 +91,7 @@ function slideshare_shortcode( $atts ) {
 		$player .= " frameborder='" . intval( $attr['fb'] ) . "'";
 	}
 
-	$is_amp = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ? true : false;
+	$is_amp = ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() );
 
 	if ( ! $is_amp ) {
 		// check the margin width; if not empty, cast as int.

--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -92,12 +92,12 @@ function slideshare_shortcode( $atts ) {
 	}
 
 	// check the margin width; if not empty, cast as int.
-	if ( ! empty( $attr['mw'] ) || '0' === $attr['mw'] ) {
+	if ( ( ! empty( $attr['mw'] ) || '0' === $attr['mw'] ) && ! Jetpack_AMP_Support::is_amp_request() ) {
 		$player .= " marginwidth='" . intval( $attr['mw'] ) . "'";
 	}
 
 	// check the margin height, if not empty, cast as int.
-	if ( ! empty( $attr['mh'] ) || '0' === $attr['mh'] ) {
+	if ( ( ! empty( $attr['mh'] ) || '0' === $attr['mh'] ) && ! Jetpack_AMP_Support::is_amp_request() ) {
 		$player .= " marginheight='" . intval( $attr['mh'] ) . "'";
 	}
 

--- a/modules/shortcodes/slideshare.php
+++ b/modules/shortcodes/slideshare.php
@@ -114,7 +114,7 @@ function slideshare_shortcode( $atts ) {
 		}
 	}
 
-	$player .= ' allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>';
+	$player .= ' sandbox="allow-popups allow-scripts allow-same-origin allow-presentation" allowfullscreen webkitallowfullscreen mozallowfullscreen></iframe>';
 
 	/**
 	 * Filter the returned SlideShare shortcode.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #
- Remove AMP errors
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Remove the `marginwidth` and `marginheight` attributes to the `iframe` in the shortcode output for AMP requests.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This modifies the output of the Slideshare shortcode

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure you have AMP Plugin installed and activated.
* Create a new post/page or edit a existing post/page
* Add the Slideshare shortcode:
![](https://user-images.githubusercontent.com/51013565/83712508-9392f200-a5eb-11ea-8fa3-ea7d322a0b14.jpg)
* Check the shortcode output:
![](https://user-images.githubusercontent.com/51013565/83712950-80345680-a5ec-11ea-8d59-aa0e897a9bb0.jpg)
* Check the shortcode output for AMP:
![](https://user-images.githubusercontent.com/51013565/83712988-9c37f800-a5ec-11ea-9a91-7bfcb720c8eb.jpg)
* Go to AMP Validated URL pages (WP Dashborad > AMP > Validated URLs), on the list click the URL of the post/page the shortcode was added in.
* Press the `Recheck` button
![](https://user-images.githubusercontent.com/51013565/83713209-1ec0b780-a5ed-11ea-9673-1966ae4dc768.jpg)
* Make sure that there is no AMP errors in the Errors table.

Note: Please try different parameter combinations in the shortcode.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve AMP compatibility for Slideshare shortcode.
