### PR TITLE
External Media: Better reflect accepted media types

### DIFF
--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -13,6 +13,10 @@ function MediaButtonMenu( props ) {
 	const { mediaProps, open, setSelectedSource, isFeatured, isReplace } = props;
 	const originalComponent = mediaProps.render;
 
+	if ( isFeatured && mediaProps.value === undefined ) {
+		return originalComponent( { open } );
+	}
+
 	if ( isReplace ) {
 		return (
 			<MediaSources
@@ -36,9 +40,10 @@ function MediaButtonMenu( props ) {
 		open();
 	};
 
-	if ( isFeatured && mediaProps.value === undefined ) {
-		return originalComponent( { open } );
-	}
+	const label =
+		mediaProps.allowedTypes.length > 1
+			? __( 'Select Media', 'jetpack' )
+			: __( 'Select Image', 'jetpack' );
 
 	return (
 		<>
@@ -55,11 +60,11 @@ function MediaButtonMenu( props ) {
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
 					>
-						{ __( 'Select Image', 'jetpack' ) }
+						{ label }
 					</Button>
 				) }
 				renderContent={ ( { onToggle } ) => (
-					<NavigableMenu aria-label={ __( 'Select Image', 'jetpack' ) }>
+					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
 							<MenuItem icon="admin-media" onClick={ () => openLibrary( onToggle ) }>
 								{ __( 'Media Library', 'jetpack' ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Alternates dropdown button text based on whether the current block accepts media types other than `image`.

Fixes #16064.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Display "Select Media" if the amount of accepted media types are more than one. (We only ever get this far if the block accepts at least `image`.
* Moves up `mediaProps.value` check to return quicker.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this PR and run `yarn run build-extensions`
* In the editor, insert a media block (Cover, Media & Text, Image, Gallery)
* Check that the dropdown button shows the expected button text.
* Note that it says "Select Image" in the featured image pane.

**After** 
![Screen Shot 2020-06-04 at 2 04 24 PM](https://user-images.githubusercontent.com/1398304/83810827-9df5d000-a66d-11ea-9fb5-2ba91a1b6976.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.