### PR TITLE
Instant Search: Add support for configuring allowable post types in search widget configuration

### DIFF
--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -261,7 +261,7 @@ class Jetpack_Search_Template_Tags {
 
 		$fields_to_inject = array(
 			'orderby' => $orderby,
-			'order'   => $order
+			'order'   => $order,
 		);
 
 		// If the widget has specified post types to search within and IF the post types differ
@@ -276,6 +276,27 @@ class Jetpack_Search_Template_Tags {
 		echo '<div class="jetpack-search-form">';
 		echo $form;
 		echo '</div>';
+	}
+
+	/**
+	 * Renders the search box for the Instant Search version of the Jetpack Search widget on the frontend.
+	 *
+	 * @since 8.6.0
+	 *
+	 * @param array $post_types_whitelist Array of post types to limit search results to.
+	 */
+	public static function render_instant_widget_search_form( $post_types_whitelist ) {
+		$form = get_search_form( false );
+
+		if ( ! empty( $post_types_whitelist ) ) {
+			$form = str_replace(
+				'<form',
+				'<form data-post-type-whitelist=' . rawurlencode( wp_json_encode( $post_types_whitelist ) ),
+				$form
+			);
+		}
+
+		echo '<div class="jetpack-search-form">' . $form . '</div>'; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/modules/search/class.jetpack-search-template-tags.php
+++ b/modules/search/class.jetpack-search-template-tags.php
@@ -283,15 +283,15 @@ class Jetpack_Search_Template_Tags {
 	 *
 	 * @since 8.6.0
 	 *
-	 * @param array $post_types_whitelist Array of post types to limit search results to.
+	 * @param array $allowable_post_types Array of post types to limit search results to.
 	 */
-	public static function render_instant_widget_search_form( $post_types_whitelist ) {
+	public static function render_instant_widget_search_form( $allowable_post_types ) {
 		$form = get_search_form( false );
 
-		if ( ! empty( $post_types_whitelist ) ) {
+		if ( ! empty( $$allowable_post_types ) ) {
 			$form = str_replace(
 				'<form',
-				'<form data-post-type-whitelist=' . rawurlencode( wp_json_encode( $post_types_whitelist ) ),
+				'<form data-allowable-post-types=' . rawurlencode( wp_json_encode( $allowable_post_types ) ),
 				$form
 			);
 		}

--- a/modules/search/instant-search/components/preselected-search-filters.jsx
+++ b/modules/search/instant-search/components/preselected-search-filters.jsx
@@ -15,7 +15,7 @@ const PreselectedSearchFilters = props => {
 	const preselectedFilters = getPreselectedFilters( props.widgets, props.widgetsOutsideOverlay );
 
 	return (
-		<div className="jetpack-instant-search__testing">
+		<div className="jetpack-instant-search__preselected-filters">
 			{ preselectedFilters.length > 0 && (
 				<SearchFilters
 					loading={ props.isLoading }

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -136,6 +136,20 @@ class SearchApp extends Component {
 		return !! this.state.response.page_handle && ! this.state.hasError;
 	}
 
+	handleDatasetAttributes = form => {
+		try {
+			if ( 'postTypeWhitelist' in form.dataset ) {
+				setFilterQuery(
+					'post_types',
+					JSON.parse( decodeURIComponent( form.dataset.postTypeWhitelist ) )
+				);
+			}
+		} catch ( error ) {
+			// Unexpected value found at data-post-type-whitelist.
+			return;
+		}
+	};
+
 	handleSubmit = event => {
 		event.preventDefault();
 		this.handleInput.flush();
@@ -146,10 +160,14 @@ class SearchApp extends Component {
 		if ( event.inputType.includes( 'delete' ) || event.inputType.includes( 'format' ) ) {
 			return;
 		}
+		this.handleDatasetAttributes( event.target.form );
 		setSearchQuery( event.target.value );
 	}, 200 );
 
-	handleInputFocus = () => this.showResults();
+	handleInputFocus = () => {
+		this.handleDatasetAttributes( event.target.form );
+		this.showResults();
+	};
 
 	handleSortChange = event => {
 		setSortQuery( getSortKeyFromSortOption( event.target.value ) );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -138,14 +138,14 @@ class SearchApp extends Component {
 
 	handleDatasetAttributes = form => {
 		try {
-			if ( 'postTypeWhitelist' in form.dataset ) {
+			if ( 'allowablePostTypes' in form.dataset ) {
 				setFilterQuery(
 					'post_types',
-					JSON.parse( decodeURIComponent( form.dataset.postTypeWhitelist ) )
+					JSON.parse( decodeURIComponent( form.dataset.allowablePostTypes ) )
 				);
 			}
 		} catch ( error ) {
-			// Unexpected value found at data-post-type-whitelist.
+			// Unexpected value found at data-allowable-post-types.
 			return;
 		}
 	};

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -104,30 +104,27 @@ const filterKeyToEsFilter = new Map( [
 ] );
 
 function buildFilterObject( filterQuery, adminQueryFilter ) {
-	if ( ! filterQuery && ! adminQueryFilter ) {
-		return {};
-	}
-	if ( ! filterQuery ) {
-		return adminQueryFilter;
-	}
-
 	const filter = { bool: { must: [] } };
-	getFilterKeys()
-		.filter( key => isLengthyArray( filterQuery[ key ] ) )
-		.forEach( key => {
-			filterQuery[ key ].forEach( item => {
-				if ( filterKeyToEsFilter.has( key ) ) {
-					filter.bool.must.push( filterKeyToEsFilter.get( key )( item ) );
-				} else {
-					// If key is not in the standard map, assume to be a custom taxonomy
-					filter.bool.must.push( { term: { [ `taxonomy.${ key }.slug` ]: item } } );
-				}
+
+	if ( filterQuery ) {
+		getFilterKeys()
+			.filter( key => isLengthyArray( filterQuery[ key ] ) )
+			.forEach( key => {
+				filterQuery[ key ].forEach( item => {
+					if ( filterKeyToEsFilter.has( key ) ) {
+						filter.bool.must.push( filterKeyToEsFilter.get( key )( item ) );
+					} else {
+						// If key is not in the standard map, assume to be a custom taxonomy
+						filter.bool.must.push( { term: { [ `taxonomy.${ key }.slug` ]: item } } );
+					}
+				} );
 			} );
-		} );
+	}
 
 	if ( adminQueryFilter ) {
 		filter.bool.must.push( adminQueryFilter );
 	}
+
 	return filter;
 }
 

--- a/modules/search/instant-search/lib/filters.js
+++ b/modules/search/instant-search/lib/filters.js
@@ -24,7 +24,10 @@ const FILTER_KEYS = Object.freeze( [
 
 export function getFilterKeys() {
 	// Extract taxonomy names from server widget data
-	const taxonomies = window[ SERVER_OBJECT_NAME ].widgets
+	const taxonomies = [
+		...window[ SERVER_OBJECT_NAME ].widgets,
+		...window[ SERVER_OBJECT_NAME ].widgetsOutsideOverlay,
+	]
 		.map( w => w.filters )
 		.filter( filters => Array.isArray( filters ) )
 		.reduce( ( filtersA, filtersB ) => filtersA.concat( filtersB ), [] )

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -461,9 +461,10 @@ class Jetpack_Search_Widget extends WP_Widget {
 			do_action( 'jetpack_search_render_filters_widget_title', $title, $args['before_title'], $args['after_title'] );
 		}
 
-		// TODO: create new search box?
 		if ( ! empty( $instance['search_box_enabled'] ) ) {
-			Jetpack_Search_Template_Tags::render_widget_search_form( array(), '', '' );
+			Jetpack_Search_Template_Tags::render_instant_widget_search_form(
+				empty( $instance['post_types'] ) ? array() : $instance['post_types']
+			);
 		}
 
 		if ( $display_filters ) {


### PR DESCRIPTION
Split out from #15727.

#### Changes proposed in this Pull Request:
* Add support for configuring allowable post types in the search widget configuration

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Yes, it adds support for setting allowable post types in the search results

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this change to your site with a Jetpack Search subscription.
2. Add a Jetpack Search widget to a sidebar/footer while specifying allowable post types, like so:

<img width="299" alt="Screen Shot 2020-06-04 at 3 46 01 PM" src="https://user-images.githubusercontent.com/4044428/83813405-82dd8d00-a67a-11ea-9911-22db439e7cf3.png">

3. Interact with the Jetpack Search input created by the widget in step 2. The search overlay should appear and a post type filter should be automatically applied. Verify that the post type filter has been applied by checking for a `post_types=some-post-type` query string in your address bar.

#### Proposed changelog entry for your changes:
* Adds post types allowlist for the Jetpack Search overlay.
