### PR TITLE
Improve AMP compatibility for the TwitchTV shortcodes.

### DIFF
--- a/modules/shortcodes/twitchtv.php
+++ b/modules/shortcodes/twitchtv.php
@@ -67,7 +67,7 @@ function wpcom_twitchtv_shortcode( $atts ) {
 	$url = add_query_arg( $url_args, 'https://player.twitch.tv/' );
 
 	return sprintf(
-		'<iframe src="%s" width="%d" height="%d" frameborder="0" scrolling="no" allowfullscreen></iframe>',
+		'<iframe src="%s" width="%d" height="%d" frameborder="0" scrolling="no" allowfullscreen sandbox="allow-popups allow-scripts allow-same-origin allow-presentation"></iframe>',
 		esc_url( $url ),
 		esc_attr( $width ),
 		esc_attr( $height )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* In the `[twitchtv]` and `[twitch]` shortcodes, adds a `sandbox` attribute which allows opening links in a new window and fixes a console error on page load.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* This enhances an existing feature.

#### Testing instructions:
* Ensure the AMP plugin is active
* In AMP Settings, select 'Transitional' mode
* In Jetpack > Settings > Writing, ensure 'Compose using shortcodes' option is toggled on
* Add a shortcode block with: `[twitchtv url="https://www.twitch.tv/xaryu" height='378' width='620']` or `[twitch url="https://www.twitch.tv/xaryu" height='378' width='620']`
* View the page with `?amp` in the query string
* Click a link inside the Twitch TV embed
* Expected: Link opens up in a new window/tab, and does not throw a console error

#### Proposed changelog entry for your changes:
* Improved Twitch TV shortcode AMP compatibility