### PR TITLE
External Media: Account for multiple images

### DIFF
--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -40,10 +40,15 @@ function MediaButtonMenu( props ) {
 		open();
 	};
 
-	const label =
-		mediaProps.allowedTypes.length > 1
-			? __( 'Select Media', 'jetpack' )
-			: __( 'Select Image', 'jetpack' );
+	let label = __( 'Select Image', 'jetpack' );
+
+	if ( mediaProps.multiple ) {
+		label = __( 'Select Images', 'jetpack' );
+	}
+
+	if ( mediaProps.allowedTypes.length > 1 ) {
+		label = __( 'Select Media', 'jetpack' );
+	}
 
 	return (
 		<>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Adds dropdown button text alternative based on whether the current block accepts multiple entities.

See https://github.com/Automattic/jetpack/pull/16071#issuecomment-639367271

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Displays "Select Images" when the block accepts multiple entities and only one media type.
* Display "Select Media" if the amount of accepted media types are more than one, regardless of how many entities the block accepts. Media is already plural.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this PR and run `yarn run build-extensions`
* In the editor, insert a media block (Cover, Media & Text, Image, Gallery)
* Check that the dropdown button shows the expected button text.

**After** 
![image](https://user-images.githubusercontent.com/1398304/83900167-7dca1d80-a70e-11ea-96ef-f3473b69fa3f.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.