### PR TITLE
Search: Sync minor change from wp.com

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -134,7 +134,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'homeUrl'               => home_url(),
 			'locale'                => str_replace( '_', '-', Jetpack_Search_Helpers::is_valid_locale( get_locale() ) ? get_locale() : 'en_US' ),
 			'postsPerPage'          => $posts_per_page,
-			'siteId'                => Jetpack::get_option( 'id' ),
+			'siteId'                => $this->jetpack_blog_id,
 
 			'postTypes'             => $post_type_labels,
 			'widgets'               => array_values( $widgets ),


### PR DESCRIPTION
This change made deploying on wp.com a little easier and we already set the jetpack blog id in the parent class: https://github.com/Automattic/jetpack/blob/master/modules/search/class.jetpack-search.php#L177

To test, just try out instant search on an existing site and verify that it works