### PR TITLE
Instant Search: Start extracting translatable strings

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -211,8 +211,6 @@ gulp.task( 'languages:extract', function( done ) {
 			'_inc/client/**/*.jsx',
 			'_inc/blocks/*.js',
 			'_inc/blocks/**/*.js',
-			'modules/search/**/*.js',
-			'modules/search/**/*.jsx',
 		] )
 		.pipe(
 			tap( function( file ) {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -211,6 +211,8 @@ gulp.task( 'languages:extract', function( done ) {
 			'_inc/client/**/*.jsx',
 			'_inc/blocks/*.js',
 			'_inc/blocks/**/*.js',
+			'modules/search/**/*.js',
+			'modules/search/**/*.jsx',
 		] )
 		.pipe(
 			tap( function( file ) {

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -65,6 +65,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$script_version = self::get_asset_version( $script_relative_path );
 		$script_path    = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
 		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
+		wp_set_script_translations( 'jetpack-instant-search', 'jetpack' );
 		$this->load_and_initialize_tracks();
 		$this->inject_javascript_options();
 

--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const path = require( 'path' );
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
@@ -48,5 +49,9 @@ module.exports = [
 					maxEntrypointSize: 122880,
 					hints: 'error',
 			  },
+		plugins: [
+			...sharedWebpackConfig.plugins,
+			new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+		],
 	},
 ];


### PR DESCRIPTION
Fixes #15754 (I think?)

#### Changes proposed in this Pull Request:
* Adds instant search JS/JSX files to the `languages:extract` gulp job.
* Invoke `wp_set_script_translations` for the bundled JS file for instant search.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No, this is a bugfix for enabling translations in instant search.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Run `yarn build-production` and ensure that instant search related strings are added to `_inc/jetpack-strings.php`. 
* (I'm not sure how to test translations; for example, I know there are certain terms used in the instant search interface that have been [translated](https://translate.wordpress.org/projects/wp-plugins/jetpack/dev/ko/default/?filters%5Bterm%5D=relevance&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Apply+Filters&sort%5Bby%5D=priority&sort%5Bhow%5D=desc), but I don't know how to get them to appear. Would love some direction or guidance on this from @Automattic/jetpack-crew!)

#### Proposed changelog entry for your changes:
* Fixed translation issues for Jetpack Search.
