### PR TITLE
External Media: Improve Insert Flow

### DIFF
--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -17,6 +17,15 @@ $grid-size: 8px;
 	}
 }
 
+.jetpack-external-media-browser--visually-hidden {
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect( 1px, 1px, 1px, 1px );
+	white-space: nowrap; /* added line */
+}
+
 /**
  * Media item container
  */

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -21,7 +21,7 @@ $grid-size: 8px;
  * Media item container
  */
 
-.jetpack-external-media-browser:not( .jetpack-external-media-browser--is-copying ) {
+.jetpack-external-media-browser {
 	.is-error {
 		margin-bottom: 1em;
 		margin-left: 0;

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -21,39 +21,6 @@ $grid-size: 8px;
  * Media item container
  */
 
-.jetpack-external-media-browser__is-copying {
-	max-height: 20%;
-	max-width: 20%;
-	min-width: 480px;
-	min-height: 360px + 56px;
-
-	.jetpack-external-media-browser__single {
-		height: 300px;
-	}
-
-	.jetpack-external-media-browser__media {
-		height: 100%;
-	}
-
-	.is-transient {
-		border: 0;
-		background: 0;
-		padding: 0;
-		height: 100%;
-
-		&.jetpack-external-media-browser__media__item__selected {
-			box-shadow: none;
-			border-radius: 0;
-		}
-
-		img {
-			width: 100%;
-			height: 100%;
-			object-fit: contain;
-		}
-	}
-}
-
 .jetpack-external-media-browser:not( .jetpack-external-media-browser__is-copying ) {
 	.is-error {
 		margin-bottom: 1em;
@@ -71,29 +38,14 @@ $grid-size: 8px;
 	}
 }
 
+.jetpack-external-media-browser__is-copying {
+	pointer-events: none;
+}
+
 @media ( min-width: 600px ) {
 	.components-modal__content {
 		width: 90vw;
 		height: 90vh;
-	}
-}
-
-.jetpack-external-media-browser__single {
-	position: relative;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	.is-transient img {
-		opacity: 0.3;
-	}
-
-	.components-spinner {
-		position: absolute;
-		top: 50%;
-		right: 50%;
-		margin-top: -9px;
-		margin-right: -9px;
 	}
 }
 

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -21,7 +21,7 @@ $grid-size: 8px;
  * Media item container
  */
 
-.jetpack-external-media-browser:not( .jetpack-external-media-browser__is-copying ) {
+.jetpack-external-media-browser:not( .jetpack-external-media-browser--is-copying ) {
 	.is-error {
 		margin-bottom: 1em;
 		margin-left: 0;
@@ -38,12 +38,14 @@ $grid-size: 8px;
 	}
 }
 
-.jetpack-external-media-browser__is-copying {
+.jetpack-external-media-browser--is-copying {
 	pointer-events: none;
 }
 
-@media ( min-width: 600px ) {
-	.components-modal__content {
+.components-modal__content {
+	width: 100%;
+
+	@media ( min-width: 600px ) {
 		width: 90vw;
 		height: 90vh;
 	}

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -86,14 +86,27 @@ $grid-size: 8px;
 		&.is-transient img {
 			opacity: 0.3;
 		}
+	}
+
+	.jetpack-external-media-browser__media__copying_indicator {
+		display: flex;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		text-align: center;
 
 		.components-spinner {
-			position: absolute;
-			top: 50%;
-			right: 50%;
-			margin-top: -9px;
-			margin-right: -9px;
+			margin-bottom: $grid-size;
 		}
+	}
+
+	.jetpack-external-media-browser__media__copying_indicator__label {
+		font-size: 12px;
 	}
 
 	.jetpack-external-media-browser__media__folder {

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -121,7 +121,7 @@ function MediaBrowser( props ) {
 						isLarge
 						isSecondary
 						className="jetpack-external-media-browser__loadmore"
-						disabled={ isLoading }
+						disabled={ isLoading || isCopying }
 						onClick={ onLoadMoreClick }
 					>
 						{ __( 'Load More', 'jetpack' ) }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -25,7 +25,17 @@ const EmptyResults = memo( () => (
 ) );
 
 function MediaBrowser( props ) {
-	const { media, isLoading, pageHandle, className, multiple, setPath, nextPage, onCopy } = props;
+	const {
+		media,
+		isCopying,
+		isLoading,
+		pageHandle,
+		className,
+		multiple,
+		setPath,
+		nextPage,
+		onCopy,
+	} = props;
 	const [ selected, setSelected ] = useState( [] );
 
 	const onSelectImage = useCallback(
@@ -70,6 +80,25 @@ function MediaBrowser( props ) {
 		nextPage();
 	};
 
+	const SelectButton = () => {
+		const disabled = selected.length === 0 || isCopying;
+		const label = isCopying ? __( 'Inserting…', 'jetpack' ) : __( 'Select', 'jetpack' );
+
+		return (
+			<div className="jetpack-external-media-browser__media__toolbar">
+				<Button
+					isPrimary
+					isLarge
+					isBusy={ isCopying }
+					disabled={ disabled }
+					onClick={ onCopyAndInsert }
+				>
+					{ label }
+				</Button>
+			</div>
+		);
+	};
+
 	return (
 		<div className={ wrapper }>
 			<ul className={ classes }>
@@ -80,6 +109,7 @@ function MediaBrowser( props ) {
 						onClick={ onSelectImage }
 						focusOnMount={ !! prevMediaCount.current && index === prevMediaCount.current }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
+						isCopying={ isCopying }
 					/>
 				) ) }
 
@@ -99,13 +129,7 @@ function MediaBrowser( props ) {
 				) }
 			</ul>
 
-			{ hasMediaItems && (
-				<div className="jetpack-external-media-browser__media__toolbar">
-					<Button isPrimary isLarge disabled={ selected.length === 0 } onClick={ onCopyAndInsert }>
-						{ __( 'Copy & Insert', 'jetpack' ) }
-					</Button>
-				</div>
-			) }
+			{ hasMediaItems && <SelectButton /> }
 		</div>
 	);
 }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -60,21 +60,21 @@ function MediaItem( props ) {
 			aria-checked={ !! isSelected }
 			aria-disabled={ !! isCopying }
 		>
-			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />
-
-			{ type === 'folder' && (
-				<div className="jetpack-external-media-browser__media__info">
-					<div className="jetpack-external-media-browser__media__name">{ name }</div>
-					<div className="jetpack-external-media-browser__media__count">{ children }</div>
-				</div>
-			) }
-
 			{ isSelected && isCopying && (
 				<div className="jetpack-external-media-browser__media__copying_indicator">
 					<Spinner />
 					<div className="jetpack-external-media-browser__media__copying_indicator__label">
 						{ __( 'Inserting Image…', 'jetpack' ) }
 					</div>
+				</div>
+			) }
+
+			<img src={ medium || fmt_hd } alt={ alt } />
+
+			{ type === 'folder' && (
+				<div className="jetpack-external-media-browser__media__info">
+					<div className="jetpack-external-media-browser__media__name">{ name }</div>
+					<div className="jetpack-external-media-browser__media__count">{ children }</div>
 				</div>
 			) }
 		</li>

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
 
 function MediaItem( props ) {
 	const onClick = useCallback( () => {
@@ -34,7 +35,7 @@ function MediaItem( props ) {
 		'jetpack-external-media-browser__media__item': true,
 		'jetpack-external-media-browser__media__item__selected': isSelected,
 		'jetpack-external-media-browser__media__folder': type === 'folder',
-		'is-transient': isSelected && isCopying,
+		'is-transient': isCopying,
 	} );
 
 	const itemEl = useRef( null );
@@ -52,11 +53,12 @@ function MediaItem( props ) {
 		<li
 			ref={ itemEl }
 			className={ classes }
-			onClick={ onClick }
-			onKeyDown={ onKeyDown }
+			onClick={ isCopying ? undefined : onClick }
+			onKeyDown={ isCopying ? undefined : onKeyDown }
 			role="checkbox"
 			tabIndex="0"
-			aria-checked={ isSelected ? 'true' : 'false' }
+			aria-checked={ !! isSelected }
+			aria-disabled={ !! isCopying }
 		>
 			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />
 
@@ -67,7 +69,14 @@ function MediaItem( props ) {
 				</div>
 			) }
 
-			{ isSelected && isCopying && <Spinner /> }
+			{ isSelected && isCopying && (
+				<div className="jetpack-external-media-browser__media__copying_indicator">
+					<Spinner />
+					<div className="jetpack-external-media-browser__media__copying_indicator__label">
+						{ __( 'Inserting Image…', 'jetpack' ) }
+					</div>
+				</div>
+			) }
 		</li>
 	);
 }

--- a/extensions/shared/external-media/sources/google-photos/filter-view.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-view.js
@@ -44,7 +44,7 @@ function addFilter( existing, newFilter ) {
 
 function GoogleFilterView( props ) {
 	const [ currentFilter, setCurrentFilter ] = useState( getFirstFilter( [] ) );
-	const { isLoading, filters, canChangeMedia } = props;
+	const { isLoading, isCopying, filters, canChangeMedia } = props;
 	const remainingFilters = removeMediaType( getFilterOptions( filters ), canChangeMedia );
 	const setFilter = () => {
 		const newFilters = addFilter( filters, currentFilter );
@@ -62,12 +62,12 @@ function GoogleFilterView( props ) {
 			<SelectControl
 				label={ __( 'Filters', 'jetpack' ) }
 				value={ currentFilter }
-				disabled={ isLoading }
+				disabled={ isLoading || isCopying }
 				options={ remainingFilters }
 				onChange={ setCurrentFilter }
 			/>
 
-			<Button disabled={ isLoading } isSecondary isSmall onClick={ setFilter }>
+			<Button disabled={ isLoading || isCopying } isSecondary isSmall onClick={ setFilter }>
 				{ __( 'Add Filter', 'jetpack' ) }
 			</Button>
 		</Fragment>

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -86,7 +86,7 @@ function GooglePhotosMedia( props ) {
 					className="jetpack-external-media-header__select"
 					label={ __( 'View', 'jetpack' ) }
 					value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
-					disabled={ isLoading }
+					disabled={ isLoading || isCopying }
 					options={ PATH_OPTIONS }
 					onChange={ setPath }
 				/>

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -21,6 +21,7 @@ const isImageOnly = allowed => allowed && allowed.length === 1 && allowed[ 0 ] =
 function GooglePhotosMedia( props ) {
 	const {
 		media,
+		isCopying,
 		isLoading,
 		pageHandle,
 		multiple,
@@ -118,6 +119,7 @@ function GooglePhotosMedia( props ) {
 				className="jetpack-external-media-browser__google"
 				key={ listUrl }
 				media={ media }
+				isCopying={ isCopying }
 				isLoading={ isLoading }
 				nextPage={ getNextPage }
 				onCopy={ onCopy }

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -88,12 +88,15 @@ function PexelsMedia( props ) {
 					type="search"
 					value={ searchQuery }
 					onChange={ setSearchQuery }
+					disabled={ !! isCopying }
 				/>
 				<Button
 					isPrimary
 					onClick={ onSearch }
 					type="submit"
-					disabled={ ! searchQuery.length || searchQuery === previousSearchQueryValue.current }
+					disabled={
+						! searchQuery.length || searchQuery === previousSearchQueryValue.current || isCopying
+					}
 				>
 					{ __( 'Search', 'jetpack' ) }
 				</Button>

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -15,7 +15,7 @@ import MediaBrowser from '../media-browser';
 import { getApiUrl } from './api';
 
 function PexelsMedia( props ) {
-	const { media, isLoading, pageHandle, multiple, copyMedia, getMedia } = props;
+	const { media, isCopying, isLoading, pageHandle, multiple, copyMedia, getMedia } = props;
 
 	const [ searchQuery, setSearchQuery ] = useState( sample( PEXELS_EXAMPLE_QUERIES ) );
 	const [ lastSearchQuery, setLastSearchQuery ] = useState( '' );
@@ -103,6 +103,7 @@ function PexelsMedia( props ) {
 				key={ lastSearchQuery }
 				className="jetpack-external-media-browser__pexels"
 				media={ media }
+				isCopying={ isCopying }
 				isLoading={ isLoading }
 				nextPage={ getNextPage }
 				onCopy={ onCopy }

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -176,7 +176,7 @@ export default function withMedia() {
 
 				const classes = classnames( {
 					'jetpack-external-media-browser': true,
-					'jetpack-external-media-browser__is-copying': isCopying,
+					'jetpack-external-media-browser--is-copying': isCopying,
 				} );
 
 				return (

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -216,15 +216,32 @@ export default function withMedia() {
 				const title = isCopying
 					? __( 'Inserting media', 'jetpack' )
 					: __( 'Select media', 'jetpack' );
+				const description = isCopying
+					? __(
+							'When the media is finished copying and inserting, you will be returned to the editor.',
+							'jetpack'
+					  )
+					: __( 'Select the media you would like to insert into the editor.', 'jetpack' );
+
+				const describedby = 'jetpack-external-media-browser__description';
 				const classes = classnames( {
 					'jetpack-external-media-browser': true,
 					'jetpack-external-media-browser--is-copying': isCopying,
 				} );
 
 				return (
-					<Modal onRequestClose={ onClose } title={ title } className={ classes }>
+					<Modal
+						onRequestClose={ onClose }
+						title={ title }
+						aria={ { describedby } }
+						className={ classes }
+					>
 						<div ref={ this.modalRef }>
 							{ noticeUI }
+
+							<p id={ describedby } className="jetpack-external-media-browser--visually-hidden">
+								{ description }
+							</p>
 
 							<OriginalComponent
 								getMedia={ this.getMedia }

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -162,6 +162,12 @@ export default function withMedia() {
 
 			copyMedia = ( items, apiUrl ) => {
 				this.setState( { isCopying: items } );
+
+				// If we have a modal element set, focus it. Otherwise focus is reset to the body instead of staying within the Modal.
+				if ( this.modalElement ) {
+					this.modalElement.focus();
+				}
+
 				this.props.noticeOperations.removeAllNotices();
 
 				// Announce the action with appended string of all the images' alt text.
@@ -207,18 +213,16 @@ export default function withMedia() {
 				const { isAuthenticated, isCopying, isLoading, media, nextHandle, path } = this.state;
 				const { allowedTypes, multiple = false, noticeUI, onClose } = this.props;
 
-				const title = isCopying ? __( 'Inserting media', 'jetpack' ) : __( 'Select media', 'jetpack' );
+				const title = isCopying
+					? __( 'Inserting media', 'jetpack' )
+					: __( 'Select media', 'jetpack' );
 				const classes = classnames( {
 					'jetpack-external-media-browser': true,
 					'jetpack-external-media-browser--is-copying': isCopying,
 				} );
 
 				return (
-					<Modal
-						onRequestClose={ onClose }
-						title={ title }
-						className={ classes }
-					>
+					<Modal onRequestClose={ onClose } title={ title } className={ classes }>
 						<div ref={ this.modalRef }>
 							{ noticeUI }
 

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -162,13 +162,13 @@ export default function withMedia() {
 
 			copyMedia = ( items, apiUrl ) => {
 				this.setState( { isCopying: items } );
+				this.props.noticeOperations.removeAllNotices();
 
-				// If we have a modal element set, focus it. Otherwise focus is reset to the body instead of staying within the Modal.
+				// If we have a modal element set, focus it.
+				// Otherwise focus is reset to the body instead of staying within the Modal.
 				if ( this.modalElement ) {
 					this.modalElement.focus();
 				}
-
-				this.props.noticeOperations.removeAllNotices();
 
 				// Announce the action with appended string of all the images' alt text.
 				speak(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Improves the insert flow by not taking the user out of the media modal while inserting.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes Copy/Insert Modal
* Updates Insert button to say "Select" (like in media library) and be busy while inserting.
* Updates media items to show spinner while they're being copied.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Check out this PR and run `yarn run build-extensions`
* In the Editor, insert a media block (Cover, Media & Text, Image, Gallery)
* Click "Select [Image(s)|Media]" and chose either Pexels or Google Photos.
* Based on the block, select one or more images and click "Select".
* Observe the spinner overlay over the thumbnail images and the Select button now being busy and saying "Inserting…".

**After**
![image](https://user-images.githubusercontent.com/1398304/83928188-b46e5b00-a743-11ea-9f2a-afcaa0387c10.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
Not needed.

Closes #15867.
Fixes #15867.