### PR TITLE
Podcast Player: Fix initialization of podcast player on infinite scroll load

### DIFF
--- a/extensions/blocks/podcast-player/podcast-player.php
+++ b/extensions/blocks/podcast-player/podcast-player.php
@@ -119,7 +119,7 @@ function render_player( $player_data, $attributes ) {
 	);
 
 	// Generate a unique id for the block instance.
-	$instance_id             = wp_unique_id( 'jetpack-podcast-player-block-' );
+	$instance_id             = wp_unique_id( 'jetpack-podcast-player-block-' . get_the_ID() . '-' );
 	$player_data['playerId'] = $instance_id;
 
 	// Generate object to be used as props for PodcastPlayer.
@@ -180,15 +180,6 @@ function render_player( $player_data, $attributes ) {
 		<script type="application/json"><?php echo wp_json_encode( $player_props ); ?></script>
 		<?php endif; ?>
 	</div>
-	<?php if ( ! $is_amp ) : ?>
-	<script>
-		( function( instanceId ) {
-			document.getElementById( instanceId ).classList.remove( 'is-default' );
-			window.jetpackPodcastPlayers=(window.jetpackPodcastPlayers||[]);
-			window.jetpackPodcastPlayers.push( instanceId );
-		} )( <?php echo wp_json_encode( $instance_id ); ?> );
-	</script>
-	<?php endif; ?>
 	<?php
 	/**
 	 * Enqueue necessary scripts and styles.

--- a/extensions/blocks/podcast-player/view.js
+++ b/extensions/blocks/podcast-player/view.js
@@ -97,13 +97,9 @@ const initializeBlock = function( id ) {
 	block.setAttribute( 'data-jetpack-block-initialized', 'true' );
 };
 
-// Initialize queued players.
-if ( window.jetpackPodcastPlayers !== undefined ) {
-	jetpackPodcastPlayers.forEach( initializeBlock );
-}
-
-// Replace the queue with an immediate initialization for async loaded players.
-window.jetpackPodcastPlayers = {
-	push: initializeBlock,
-	playerInstances,
-};
+document
+	.querySelectorAll( '.wp-block-jetpack-podcast-player:not([data-jetpack-block-initialized])' )
+	.forEach( player => {
+		player.classList.remove( 'is-default' );
+		initializeBlock( player.id );
+	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Fix initialization of podcast player on infinite scroll load so that the audio player controls are created and the block does not unnecessarily default to static markup.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Does this pull request change what data or activity we track or use?
* No changes.

#### Testing instructions:
* Activate theme that has infinite scroll
* Visit Settings > Reading and set max posts to 2 and check infinite scroll behaviour option
* Set homepage to display latest posts instead of static page if needed
* Create three posts each containing a podcast player block
* Visit homepage and confirm initial two posts podcast players are initialized ok 
* Scroll down until infinite scroll is triggered. 
* Confirm new post's podcast player is initialized and no errors in console

#### Before
![podcast-player-before](https://user-images.githubusercontent.com/60436221/84007404-b3dbfb80-a9b3-11ea-9145-6a97994a69ce.gif)

#### After
![podcast-player-after](https://user-images.githubusercontent.com/60436221/84007426-bdfdfa00-a9b3-11ea-8c81-d3b5c2901910.gif)

#### Proposed changelog entry for your changes:
* Bug Fix: Ensure podcast players are initialized correctly when loaded via infinite scroll.
