### PR TITLE
Fix accessibility of verbose related posts

### DIFF
--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -157,7 +157,7 @@
 						'" width="' +
 						post.img.width +
 						'" alt="' +
-						post.title +
+						post.img.alt_text +
 						'" />' +
 						anchor[ 1 ];
 				} else {

--- a/modules/related-posts/related-posts.js
+++ b/modules/related-posts/related-posts.js
@@ -58,10 +58,6 @@
 
 		getAnchor: function( post, classNames ) {
 			var anchor_title = post.title;
-			if ( '' !== '' + post.excerpt ) {
-				anchor_title += '\n\n' + post.excerpt;
-			}
-
 			var anchor = $( '<a>' );
 
 			anchor.attr( {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #12811

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This PR improves the screen reader accessibility of the related posts feature. It does this by:

* Removing excerpts from link titles - they are long and verbose
* Using the actual image alt text if there is one assigned to the image. This stops the post title being read out again and again and again. 

We could consider removing the `title` attribute from the links completely, however this announces an empty link on the image.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

It modifies the related posts feature to improve navigation via screen reader. It doesn't go as far as implementing all recommendations in the original issue. For now we have not:

* Used a single link element for the title, image and meta - changing the markup/layout of the feature in this way risks breaking existing themes/css
* Changed headings from `H3` elements to `span`s. Once again this is a risk to existing users and their themes.

For advanced customisation, we do provide hooks and filters which would allow someone to achieve the correct flow of headings:

https://jetpack.com/support/related-posts/customize-related-posts/

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to cusomize site -> related posts
* Navigate to a single post
* Use a screen reader on the generated related posts section

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve accessibility of related posts
