### PR TITLE
Recurring Payments -> Payments block + one-time option

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -78,7 +78,7 @@ class MembershipsButtonEdit extends Component {
 			editedProductPriceValid: true,
 			editedProductTitle: '',
 			editedProductTitleValid: true,
-			editedProductRenewInterval: '1 month',
+			editedProductRenewInterval: 'one-time',
 		};
 		this.timeout = null;
 
@@ -248,7 +248,7 @@ class MembershipsButtonEdit extends Component {
 					isLarge
 					onClick={ () => this.setState( { addingMembershipAmount: PRODUCT_FORM } ) }
 				>
-					{ __( 'Add a plan', 'jetpack' ) }
+					{ __( 'Add a payment plan', 'jetpack' ) }
 				</Button>
 			);
 		}
@@ -310,6 +310,10 @@ class MembershipsButtonEdit extends Component {
 							label: __( 'Yearly', 'jetpack' ),
 							value: '1 year',
 						},
+						{
+							label: __( 'One-Time Payment', 'jetpack' ),
+							value: 'one-time',
+						},
 					] }
 					value={ this.state.editedProductRenewInterval }
 				/>
@@ -320,7 +324,7 @@ class MembershipsButtonEdit extends Component {
 						className="membership-button__field-button membership-button__add-amount"
 						onClick={ this.saveProduct }
 					>
-						{ __( 'Add this plan', 'jetpack' ) }
+						{ __( 'Add this payment plan', 'jetpack' ) }
 					</Button>
 					<Button
 						isLarge
@@ -366,7 +370,7 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<div className="membership-button__disclaimer">
 				<ExternalLink href="https://en.support.wordpress.com/recurring-payments-button/#related-fees">
-					{ __( 'Read more about Recurring Payments and related fees.', 'jetpack' ) }
+					{ __( 'Read more about Payments and related fees.', 'jetpack' ) }
 				</ExternalLink>
 			</div>
 		);
@@ -408,7 +412,7 @@ class MembershipsButtonEdit extends Component {
 
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Product', 'jetpack' ) }>
+				<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
 					<SelectControl
 						label={ __( 'Payment plan', 'jetpack' ) }
 						value={ this.props.attributes.planId }
@@ -422,7 +426,7 @@ class MembershipsButtonEdit extends Component {
 				</PanelBody>
 				<PanelBody title={ __( 'Management', 'jetpack' ) }>
 					<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
-						{ __( 'See your earnings, subscriber list, and products.', 'jetpack' ) }
+						{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
 					</ExternalLink>
 				</PanelBody>
 			</InspectorControls>
@@ -440,10 +444,10 @@ class MembershipsButtonEdit extends Component {
 					<div className="wp-block-jetpack-recurring-payments">
 						<Placeholder
 							icon={ <BlockIcon icon={ icon } /> }
-							label={ __( 'Recurring Payments', 'jetpack' ) }
+							label={ __( 'Payments', 'jetpack' ) }
 							notices={ notices }
 							instructions={ __(
-								"You'll need to upgrade your plan to use the Recurring Payments button.",
+								"You'll need to upgrade your plan to use the Payments block.",
 								'jetpack'
 							) }
 						>
@@ -468,7 +472,7 @@ class MembershipsButtonEdit extends Component {
 						<div className="wp-block-jetpack-recurring-payments">
 							<Placeholder
 								icon={ <BlockIcon icon={ icon } /> }
-								label={ __( 'Recurring Payments', 'jetpack' ) }
+								label={ __( 'Payments', 'jetpack' ) }
 								notices={ notices }
 							>
 								<div className="components-placeholder__instructions">
@@ -489,7 +493,7 @@ class MembershipsButtonEdit extends Component {
 						<div className="wp-block-jetpack-recurring-payments">
 							<Placeholder
 								icon={ <BlockIcon icon={ icon } /> }
-								label={ __( 'Recurring Payments', 'jetpack' ) }
+								label={ __( 'Payments', 'jetpack' ) }
 								notices={ notices }
 							>
 								<div className="components-placeholder__instructions">

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -25,13 +25,14 @@ export const icon = (
 );
 
 export const settings = {
-	title: __( 'Recurring Payments', 'jetpack' ),
+	title: __( 'Payments', 'jetpack' ),
 	icon,
-	description: __( 'Button allowing you to sell subscription products.', 'jetpack' ),
+	description: __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ),
 	category: supportsCollections() ? 'earn' : 'jetpack',
 	keywords: [
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'subscriptions', 'block search term', 'jetpack' ),
+		_x( 'product', 'block search term', 'jetpack' ),
 		'stripe',
 		_x( 'memberships', 'block search term', 'jetpack' ),
 	],

--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -56,7 +56,7 @@ const initializeMembershipButtonBlocks = () => {
 			activateSubscription( block, checkoutURL );
 		} catch ( err ) {
 			// eslint-disable-next-line no-console
-			console.error( 'Problem activating Recurring Payments ' + checkoutURL, err );
+			console.error( 'Problem activating Payments ' + checkoutURL, err );
 		}
 
 		block.setAttribute( 'data-jetpack-block-initialized', 'true' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/42862 and https://github.com/Automattic/wp-calypso/issues/42860

Copy reviewed in https://github.com/Automattic/wp-calypso/pull/42848

#### Changes proposed in this Pull Request:
* Rename labels of `Recurring Payments` to `Payments`
* Provide consistency across product/plan and settle on `payment plan` per https://github.com/Automattic/wp-calypso/pull/42848#issuecomment-639548972
* Introduce "One-time" option

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* pbMlHh-hn-p2#comment-329

#### Does this pull request change what data or activity we track or use?
- nope

#### Testing instructions:
- Pick a site with active stripe connection
- Search for "Payments" block
- Insert
- Create new payments plan, with the "One time" option
- publish
- click the button, go throuph checkout

#### Proposed changelog entry for your changes:
* Recurring Payments block is now "Payments", providing a consistent experience for selling products and subscriptions alike.

### Screenshots

<img width="659" alt="Zrzut ekranu 2020-06-8 o 16 46 44" src="https://user-images.githubusercontent.com/3775068/84045596-4925c280-a9a9-11ea-9d71-5a7a4d0792a8.png">

<img width="742" alt="Zrzut ekranu 2020-06-8 o 16 46 56" src="https://user-images.githubusercontent.com/3775068/84045612-4cb94980-a9a9-11ea-8638-f7f6d6a3516c.png">

<img width="988" alt="Zrzut ekranu 2020-06-8 o 16 48 11" src="https://user-images.githubusercontent.com/3775068/84045618-4fb43a00-a9a9-11ea-94b4-7efc1891f040.png">


