### PR TITLE
Adds Jetpack products and Cloud eligibility to site API

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -144,6 +144,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'import_engine',
 		'is_wpforteams_site',
 		'site_creation_flow',
+		'is_cloud_eligible',
 	);
 
 	protected static $jetpack_response_field_additions = array(
@@ -154,6 +155,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 	protected static $jetpack_response_field_member_additions = array(
 		'capabilities',
 		'plan',
+		'products',
 	);
 
 	protected static $jetpack_response_option_additions = array(
@@ -392,6 +394,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			case 'plan' :
 				$response[ $key ] = $this->site->get_plan();
 				break;
+			case 'products' :
+				$response[ $key ] = $this->site->get_products();
+				break;
 			case 'quota' :
 				$response[ $key ] = $this->site->get_quota();
 				break;
@@ -619,6 +624,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$options[ $key ] = $site_creation_flow;
 					}
 					break;
+				case 'is_cloud_eligible':
+					$options[ $key ] = $site->is_cloud_eligible();
+					break;
 			}
 		}
 
@@ -676,6 +684,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			unset( $response->user_can_manage );
 			unset( $response->is_multisite );
 			unset( $response->plan );
+			unset( $response->products );
 		}
 
 		// render additional options

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -149,6 +149,14 @@ abstract class SAL_Site {
 		return false;
 	}
 
+	public function is_cloud_eligible() {
+		return false;
+	}
+
+	public function get_products() {
+		return [];
+	}
+
 	public function get_post_by_id( $post_id, $context ) {
 		$post = get_post( $post_id, OBJECT, $context );
 

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -154,7 +154,7 @@ abstract class SAL_Site {
 	}
 
 	public function get_products() {
-		return [];
+		return array();
 	}
 
 	public function get_post_by_id( $post_id, $context ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This adds fields for `products` and `is_cloud_eligible` to site info API endpoints.

#### Is this a new feature, or does it add/remove elements to an existing part of Jetpack?
Differential Revision: D44303-code

This commit syncs r208626-wpcom.

#### Does this pull request change what data or activity we track or use?
None that I can see.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that the context you are working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be beneficial when the change is visual. -->

Test the following endpoints:

  - /me/sites
  - /sites/[id]

Site data should have a field for products with existing products for JP sites, and under `options` should be `is_cloud_eligible`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None, I believe!