### PR TITLE
Remove whitelist/blacklist from files in the Jetpack root directory

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -598,7 +598,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				$new_ip        = $args[1];
 				$current_allow = get_site_option( 'jetpack_protect_whitelist', array() ); // @todo Update the option name.
 
-				// Build array of IPs that are already whitelisted.
+				// Build array of IPs that are already on the allowed list.
 				// Re-build manually instead of using jetpack_protect_format_whitelist() so we can easily get
 				// low & high range params for jetpack_protect_ip_address_is_in_range();
 				foreach ( $current_allow as $allowed ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -563,20 +563,20 @@ class Jetpack_CLI extends WP_CLI_Command {
 	 *
 	 * ## OPTIONS
 	 *
-	 * whitelist: Whitelist an IP address.  You can also read or clear the whitelist.
+	 * allow: Add an IP address to an always allow list.  You can also read or clear the allow list.
 	 *
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp jetpack protect whitelist <ip address>
-	 * wp jetpack protect whitelist list
-	 * wp jetpack protect whitelist clear
+	 * wp jetpack protect allow <ip address>
+	 * wp jetpack protect allow list
+	 * wp jetpack protect allow clear
 	 *
-	 * @synopsis <whitelist> [<ip|ip_low-ip_high|list|clear>]
+	 * @synopsis <allow> [<ip|ip_low-ip_high|list|clear>]
 	 */
 	public function protect( $args, $assoc_args ) {
 		$action = isset( $args[0] ) ? $args[0] : 'prompt';
-		if ( ! in_array( $action, array( 'whitelist' ) ) ) {
+		if ( ! in_array( $action, array( 'whitelist', 'allow' ), true ) ) { // Still allow "whitelist" for legacy support.
 			/* translators: %s is a command like "prompt" */
 			WP_CLI::error( sprintf( __( '%s is not a valid command.', 'jetpack' ), $action ) );
 		}
@@ -585,96 +585,96 @@ class Jetpack_CLI extends WP_CLI_Command {
 			/* translators: %s is a module name */
 			WP_CLI::error( sprintf( _x( '%1$s is not active. You can activate it with "wp jetpack module activate %2$s"', '"wp jetpack module activate" is a command - do not translate', 'jetpack' ), __FUNCTION__, __FUNCTION__ ) );
 		}
-		if ( in_array( $action, array( 'whitelist' ) ) ) {
+		if ( in_array( $action, array( 'allow', 'whitelist' ), true ) ) {
 			if ( isset( $args[1] ) ) {
-				$action = 'whitelist';
+				$action = 'allow';
 			} else {
 				$action = 'prompt';
 			}
 		}
 		switch ( $action ) {
-			case 'whitelist':
-				$whitelist         = array();
-				$new_ip            = $args[1];
-				$current_whitelist = get_site_option( 'jetpack_protect_whitelist', array() );
+			case 'allow':
+				$allow         = array();
+				$new_ip        = $args[1];
+				$current_allow = get_site_option( 'jetpack_protect_whitelist', array() ); // @todo Update the option name.
 
 				// Build array of IPs that are already whitelisted.
 				// Re-build manually instead of using jetpack_protect_format_whitelist() so we can easily get
 				// low & high range params for jetpack_protect_ip_address_is_in_range();
-				foreach ( $current_whitelist as $whitelisted ) {
+				foreach ( $current_allow as $allowed ) {
 
 					// IP ranges
-					if ( $whitelisted->range ) {
+					if ( $allowed->range ) {
 
-						// Is it already whitelisted?
-						if ( jetpack_protect_ip_address_is_in_range( $new_ip, $whitelisted->range_low, $whitelisted->range_high ) ) {
+						// Is it already on the allowed list?
+						if ( jetpack_protect_ip_address_is_in_range( $new_ip, $allowed->range_low, $allowed->range_high ) ) {
 							/* translators: %s is an IP address */
-							WP_CLI::error( sprintf( __( '%s has already been whitelisted', 'jetpack' ), $new_ip ) );
+							WP_CLI::error( sprintf( __( '%s is already on the always allow list.', 'jetpack' ), $new_ip ) );
 							break;
 						}
-						$whitelist[] = $whitelisted->range_low . ' - ' . $whitelisted->range_high;
+						$allow[] = $allowed->range_low . ' - ' . $allowed->range_high;
 
 					} else { // Individual IPs
 
-						// Check if the IP is already whitelisted (single IP only)
-						if ( $new_ip == $whitelisted->ip_address ) {
+						// Check if the IP is already on the allow list (single IP only).
+						if ( $new_ip === $allowed->ip_address ) {
 							/* translators: %s is an IP address */
-							WP_CLI::error( sprintf( __( '%s has already been whitelisted', 'jetpack' ), $new_ip ) );
+							WP_CLI::error( sprintf( __( '%s is already on the always allow list.', 'jetpack' ), $new_ip ) );
 							break;
 						}
-						$whitelist[] = $whitelisted->ip_address;
+						$allow[] = $allowed->ip_address;
 
 					}
 				}
 
 				/*
-				 * List the whitelist
-				 * Done here because it's easier to read the $whitelist array after it's been rebuilt
+				 * List the allowed IPs.
+				 * Done here because it's easier to read the $allow array after it's been rebuilt.
 				 */
 				if ( isset( $args[1] ) && 'list' == $args[1] ) {
-					if ( ! empty( $whitelist ) ) {
-						WP_CLI::success( __( 'Here are your whitelisted IPs:', 'jetpack' ) );
-						foreach ( $whitelist as $ip ) {
+					if ( ! empty( $allow ) ) {
+						WP_CLI::success( __( 'Here are your always allowed IPs:', 'jetpack' ) );
+						foreach ( $allow as $ip ) {
 							WP_CLI::line( "\t" . str_pad( $ip, 24 ) );
 						}
 					} else {
-						WP_CLI::line( __( 'Whitelist is empty.', 'jetpack' ) );
+						WP_CLI::line( __( 'Always allow list is empty.', 'jetpack' ) );
 					}
 					break;
 				}
 
 				/*
-				 * Clear the whitelist
+				 * Clear the always allow list.
 				 */
 				if ( isset( $args[1] ) && 'clear' == $args[1] ) {
-					if ( ! empty( $whitelist ) ) {
-						$whitelist = array();
-						jetpack_protect_save_whitelist( $whitelist );
-						WP_CLI::success( __( 'Cleared all whitelisted IPs', 'jetpack' ) );
+					if ( ! empty( $allow ) ) {
+						$allow = array();
+						jetpack_protect_save_whitelist( $allow ); // @todo Need to update function name in the Protect module.
+						WP_CLI::success( __( 'Cleared all IPs from the always allow list.', 'jetpack' ) );
 					} else {
-						WP_CLI::line( __( 'Whitelist is empty.', 'jetpack' ) );
+						WP_CLI::line( __( 'Always allow list is empty.', 'jetpack' ) );
 					}
 					break;
 				}
 
-				// Append new IP to whitelist array
-				array_push( $whitelist, $new_ip );
+				// Append new IP to allow array.
+				array_push( $allow, $new_ip );
 
-				// Save whitelist if there are no errors
-				$result = jetpack_protect_save_whitelist( $whitelist );
+				// Save allow list if there are no errors.
+				$result = jetpack_protect_save_whitelist( $allow ); // @todo Need to update function name in the Protect module.
 				if ( is_wp_error( $result ) ) {
 					WP_CLI::error( $result );
 				}
 
 				/* translators: %s is an IP address */
-				WP_CLI::success( sprintf( __( '%s has been whitelisted.', 'jetpack' ), $new_ip ) );
+				WP_CLI::success( sprintf( __( '%s has been added to the always allowed list.', 'jetpack' ), $new_ip ) );
 				break;
 			case 'prompt':
 				WP_CLI::error(
 					__( 'No command found.', 'jetpack' ) . "\n" .
-					__( 'Please enter the IP address you want to whitelist.', 'jetpack' ) . "\n" .
-					_x( 'You can save a range of IPs {low_range}-{high_range}. No spaces allowed.  (example: 1.1.1.1-2.2.2.2)', 'Instructions on how to whitelist IP ranges - low_range/high_range should be translated.', 'jetpack' ) . "\n" .
-					_x( "You can also 'list' or 'clear' the whitelist.", "'list' and 'clear' are commands and should not be translated", 'jetpack' ) . "\n"
+					__( 'Please enter the IP address you want to always allow.', 'jetpack' ) . "\n" .
+					_x( 'You can save a range of IPs {low_range}-{high_range}. No spaces allowed.  (example: 1.1.1.1-2.2.2.2)', 'Instructions on how to add IP ranges - low_range/high_range should be translated.', 'jetpack' ) . "\n" .
+					_x( "You can also 'list' or 'clear' the always allowed list.", "'list' and 'clear' are commands and should not be translated", 'jetpack' ) . "\n"
 				);
 				break;
 		}

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -102,7 +102,7 @@ class Jetpack_Gutenberg {
 	/**
 	 * Only these extensions can be registered. Used to control availability of beta blocks.
 	 *
-	 * @var array Extensions whitelist
+	 * @var array Extensions allowed list.
 	 */
 	private static $extensions = array();
 
@@ -312,7 +312,7 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Set up a whitelist of allowed block editor extensions
+	 * Set up a list of allowed block editor extensions
 	 *
 	 * @return void
 	 */
@@ -344,7 +344,7 @@ class Jetpack_Gutenberg {
 		}
 
 		/**
-		 * Filter the whitelist of block editor extensions that are available through Jetpack.
+		 * Filter the list of block editor extensions that are available through Jetpack.
 		 *
 		 * @since 7.0.0
 		 *
@@ -353,7 +353,7 @@ class Jetpack_Gutenberg {
 		self::$extensions = apply_filters( 'jetpack_set_available_extensions', self::get_available_extensions() );
 
 		/**
-		 * Filter the whitelist of block editor plugins that are available through Jetpack.
+		 * Filter the list of block editor plugins that are available through Jetpack.
 		 *
 		 * @deprecated 7.0.0 Use jetpack_set_available_extensions instead
 		 *
@@ -364,7 +364,7 @@ class Jetpack_Gutenberg {
 		self::$extensions = apply_filters( 'jetpack_set_available_blocks', self::$extensions );
 
 		/**
-		 * Filter the whitelist of block editor plugins that are available through Jetpack.
+		 * Filter the list of block editor plugins that are available through Jetpack.
 		 *
 		 * @deprecated 7.0.0 Use jetpack_set_available_extensions instead
 		 *
@@ -429,11 +429,11 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Returns a whitelist of Jetpack Gutenberg extensions (blocks and plugins), based on index.json
+	 * Returns a list of Jetpack Gutenberg extensions (blocks and plugins), based on index.json
 	 *
 	 * @return array A list of blocks: eg [ 'publicize', 'markdown' ]
 	 */
-	public static function get_jetpack_gutenberg_extensions_whitelist() {
+	public static function get_jetpack_gutenberg_extensions_allowed_list() {
 		$preset_extensions_manifest = self::preset_exists( 'index' )
 			? self::get_preset( 'index' )
 			: (object) array();
@@ -443,17 +443,29 @@ class Jetpack_Gutenberg {
 	}
 
 	/**
-	 * Returns a diff from a combined list of whitelisted extensions and extensions determined to be excluded
+	 * Returns a list of Jetpack Gutenberg extensions (blocks and plugins), based on index.json
 	 *
-	 * @param  array $whitelisted_extensions An array of whitelisted extensions.
+	 * @deprecated 8.7.0 Use get_jetpack_gutenberg_extensions_allowed_list()
+	 *
+	 * @return array A list of blocks: eg [ 'publicize', 'markdown' ]
+	 */
+	public static function get_jetpack_gutenberg_extensions_whitelist() {
+		_deprecated_function( __FUNCTION__, 'jetpack-8.7.0', 'Jetpack_Gutenberg::get_jetpack_gutenberg_extensions_allowed_list' );
+		return self::get_jetpack_gutenberg_extensions_allowed_list();
+	}
+
+	/**
+	 * Returns a diff from a combined list of allowed extensions and extensions determined to be excluded
+	 *
+	 * @param  array $allowed_extensions An array of allowed extensions.
 	 *
 	 * @return array A list of blocks: eg array( 'publicize', 'markdown' )
 	 */
-	public static function get_available_extensions( $whitelisted_extensions = null ) {
-		$exclusions             = get_option( 'jetpack_excluded_extensions', array() );
-		$whitelisted_extensions = is_null( $whitelisted_extensions ) ? self::get_jetpack_gutenberg_extensions_whitelist() : $whitelisted_extensions;
+	public static function get_available_extensions( $allowed_extensions = null ) {
+		$exclusions         = get_option( 'jetpack_excluded_extensions', array() );
+		$allowed_extensions = is_null( $allowed_extensions ) ? self::get_jetpack_gutenberg_extensions_allowed_list() : $allowed_extensions;
 
-		return array_diff( $whitelisted_extensions, $exclusions );
+		return array_diff( $allowed_extensions, $exclusions );
 	}
 
 	/**
@@ -956,7 +968,7 @@ class Jetpack_Gutenberg {
 		}
 
 		/*
-		 * If we're using a whitelist of hosts,
+		 * If we're using an allowed list of hosts,
 		 * check if the URL belongs to one of the domains allowed for that block.
 		 */
 		if (

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3655,7 +3655,7 @@ p {
 		add_filter( 'plugin_action_links_' . plugin_basename( JETPACK__PLUGIN_DIR . 'jetpack.php' ), array( $this, 'plugin_action_links' ) );
 
 		if ( self::is_active() || $is_development_mode ) {
-			// Artificially throw errors in certain whitelisted cases during plugin activation
+			// Artificially throw errors in certain specific cases during plugin activation.
 			add_action( 'activate_plugin', array( $this, 'throw_error_on_activate_plugin' ) );
 		}
 
@@ -3680,7 +3680,7 @@ p {
 
 	/**
 	 * Sometimes a plugin can activate without causing errors, but it will cause errors on the next page load.
-	 * This function artificially throws errors for such cases (whitelisted).
+	 * This function artificially throws errors for such cases (per a specific list).
 	 *
 	 * @param string $plugin The activated plugin.
 	 */
@@ -4219,7 +4219,7 @@ p {
 		}
 
 		if ( isset( $_GET['connect_url_redirect'] ) ) {
-			// @todo: Add validation against a known whitelist
+			// @todo: Add validation against a known allowed list.
 			$from = ! empty( $_GET['from'] ) ? $_GET['from'] : 'iframe';
 			// User clicked in the iframe to link their accounts
 			if ( ! self::is_user_connected() ) {
@@ -5214,7 +5214,7 @@ endif;
 			'/jetpack/v4/settings',
 		);
 
-		// Whitelist the action
+		// Only allow valid actions.
 		if ( ! in_array( $action, $valid_actions ) ) {
 			return false;
 		}
@@ -5990,11 +5990,11 @@ endif;
 		} else {
 			$domain = $host;
 		}
-		// Array of Automattic domains
-		$domain_whitelist = array( 'wordpress.com', 'wp.com' );
+		// Array of Automattic domains.
+		$domains_allowed = array( 'wordpress.com', 'wp.com' );
 
-		// Return $url if not an Automattic domain
-		if ( ! in_array( $domain, $domain_whitelist ) ) {
+		// Return $url if not an Automattic domain.
+		if ( ! in_array( $domain, $domains_allowed, true ) ) {
 			return $url;
 		}
 
@@ -6054,7 +6054,7 @@ endif;
 		update_user_meta( $user->ID, 'jetpack_json_api_' . $this->json_api_authorization_request['client_id'], $token );
 	}
 
-	// Add public-api.wordpress.com to the safe redirect whitelist - only added when someone allows API access
+	// Add public-api.wordpress.com to the safe redirect allowed list - only added when someone allows API access.
 	function allow_wpcom_public_api_domain( $domains ) {
 		$domains[] = 'public-api.wordpress.com';
 		return $domains;
@@ -6064,7 +6064,7 @@ endif;
 		return preg_match( '/https?%3A%2F%2F/i', $redirect_url ) > 0;
 	}
 
-	// Add all wordpress.com environments to the safe redirect whitelist
+	// Add all wordpress.com environments to the safe redirect allowed list.
 	function allow_wpcom_environments( $domains ) {
 		$domains[] = 'wordpress.com';
 		$domains[] = 'wpcalypso.wordpress.com';
@@ -6279,12 +6279,12 @@ endif;
 	}
 
 	/**
-	 * Checks whether the home and siteurl specifically are whitelisted
+	 * Checks whether the home and siteurl specifically are allowed.
 	 * Written so that we don't have re-check $key and $value params every time
-	 * we want to check if this site is whitelisted, for example in footer.php
+	 * we want to check if this site is allowed, for example in footer.php
 	 *
 	 * @since  3.8.0
-	 * @return bool True = already whitelisted False = not whitelisted
+	 * @return bool True = already allowed False = not on the allowed list.
 	 */
 	public static function is_staging_site() {
 		_deprecated_function( 'Jetpack::is_staging_site', 'jetpack-8.1', '/Automattic/Jetpack/Status->is_staging_site' );

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -154,7 +154,7 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 	if ( ! apply_filters( 'jetpack_photon_any_extension_for_domain', false, $image_url_parts['host'] ) ) {
 		// Photon doesn't support query strings so we ignore them and look only at the path.
 		// However some source images are served via PHP so check the no-query-string extension.
-		// For future proofing, this is a blacklist of common issues rather than a whitelist.
+		// For future proofing, this is an excluded list of common issues rather than an allow list.
 		$extension = pathinfo( $image_url_parts['path'], PATHINFO_EXTENSION );
 		if ( empty( $extension ) || in_array( $extension, array( 'php', 'ashx' ), true ) ) {
 			return $image_url;


### PR DESCRIPTION
Supports #16099

#### Changes proposed in this Pull Request:
* Update Jetpack CLI, Gutenberg class, and the main Jetpack class to remove most references to whitelist/blacklist.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* pb6Nl-duS-p2

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:
* Test `jetpack protect allow` function. It should function the same as the pre-existing `whitelist` function. `whitelist` will still work in case there are partners who have scripted this CLI command in their systems, but not advertised.

#### Proposed changelog entry for your changes:
* Removed instances of "whitelist" and "blacklist" from the Jetpack codebase.
