### PR TITLE
Sitemaps: Do not use relative include.

### DIFF
--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( '1' == get_option( 'blog_public' ) ) { // loose comparison okay.
-	include_once 'sitemaps/sitemaps.php';
+	include_once __DIR__ . '/sitemaps/sitemaps.php';
 }
 
 add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_on_activate' );

--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -33,10 +33,10 @@ add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_on_activate' );
  */
 function jetpack_sitemap_on_activate() {
 	wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
-	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-constants.php';
-	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-buffer.php';
-	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-stylist.php';
-	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-librarian.php';
-	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-finder.php';
-	require_once dirname( __FILE__ ) . '/sitemaps/sitemap-builder.php';
+	require_once __DIR__ . '/sitemaps/sitemap-constants.php';
+	require_once __DIR__ . '/sitemaps/sitemap-buffer.php';
+	require_once __DIR__ . '/sitemaps/sitemap-stylist.php';
+	require_once __DIR__ . '/sitemaps/sitemap-librarian.php';
+	require_once __DIR__ . '/sitemaps/sitemap-finder.php';
+	require_once __DIR__ . '/sitemaps/sitemap-builder.php';
 }

--- a/modules/sitemaps/sitemap-builder.php
+++ b/modules/sitemaps/sitemap-builder.php
@@ -8,30 +8,30 @@
  */
 
 /* Include sitemap subclasses, if not already, and include proper buffer based on phpxml's availability. */
-require_once dirname( __FILE__ ) . '/sitemap-constants.php';
-require_once dirname( __FILE__ ) . '/sitemap-buffer.php';
+require_once __DIR__ . '/sitemap-constants.php';
+require_once __DIR__ . '/sitemap-buffer.php';
 
 if ( ! class_exists( 'DOMDocument' ) ) {
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-fallback.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-image-fallback.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-master-fallback.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-news-fallback.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-page-fallback.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-video-fallback.php';
+	require_once __DIR__ . '/sitemap-buffer-fallback.php';
+	require_once __DIR__ . '/sitemap-buffer-image-fallback.php';
+	require_once __DIR__ . '/sitemap-buffer-master-fallback.php';
+	require_once __DIR__ . '/sitemap-buffer-news-fallback.php';
+	require_once __DIR__ . '/sitemap-buffer-page-fallback.php';
+	require_once __DIR__ . '/sitemap-buffer-video-fallback.php';
 } else {
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-image.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-master.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-news.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-page.php';
-	require_once dirname( __FILE__ ) . '/sitemap-buffer-video.php';
+	require_once __DIR__ . '/sitemap-buffer-image.php';
+	require_once __DIR__ . '/sitemap-buffer-master.php';
+	require_once __DIR__ . '/sitemap-buffer-news.php';
+	require_once __DIR__ . '/sitemap-buffer-page.php';
+	require_once __DIR__ . '/sitemap-buffer-video.php';
 }
 
-require_once dirname( __FILE__ ) . '/sitemap-librarian.php';
-require_once dirname( __FILE__ ) . '/sitemap-finder.php';
-require_once dirname( __FILE__ ) . '/sitemap-state.php';
+require_once __DIR__ . '/sitemap-librarian.php';
+require_once __DIR__ . '/sitemap-finder.php';
+require_once __DIR__ . '/sitemap-state.php';
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-	require_once dirname( __FILE__ ) . '/sitemap-logger.php';
+	require_once __DIR__ . '/sitemap-logger.php';
 }
 
 /**
@@ -1319,7 +1319,7 @@ class Jetpack_Sitemap_Builder {
 
 		/** This filter is already documented in core/wp-includes/feed.php */
 		$content = apply_filters( 'the_content_feed', $content, 'rss2' );
-		
+
 		// Include thumbnails for VideoPress videos, use blank image for others
 		if ( 'complete' === get_post_meta( $post->ID, 'videopress_status', true ) && has_post_thumbnail( $post ) ) {
 			$video_thumbnail_url = get_the_post_thumbnail_url( $post );

--- a/modules/sitemaps/sitemap-librarian.php
+++ b/modules/sitemaps/sitemap-librarian.php
@@ -11,7 +11,7 @@
  */
 
 /* Ensure sitemap constants are available. */
-require_once dirname( __FILE__ ) . '/sitemap-constants.php';
+require_once __DIR__ . '/sitemap-constants.php';
 
 /**
  * This object handles any database interaction required

--- a/modules/sitemaps/sitemap-state.php
+++ b/modules/sitemaps/sitemap-state.php
@@ -8,11 +8,11 @@
  */
 
 /* Include standard constants and librarian. */
-require_once dirname( __FILE__ ) . '/sitemap-constants.php';
-require_once dirname( __FILE__ ) . '/sitemap-librarian.php';
+require_once __DIR__ . '/sitemap-constants.php';
+require_once __DIR__ . '/sitemap-librarian.php';
 
 if ( defined( 'WP_DEBUG' ) && ( true === WP_DEBUG ) ) {
-	require_once dirname( __FILE__ ) . '/sitemap-logger.php';
+	require_once __DIR__ . '/sitemap-logger.php';
 }
 
 /**

--- a/modules/sitemaps/sitemaps.php
+++ b/modules/sitemaps/sitemaps.php
@@ -32,15 +32,15 @@
  */
 
 /* Include all of the sitemap subclasses. */
-require_once dirname( __FILE__ ) . '/sitemap-constants.php';
-require_once dirname( __FILE__ ) . '/sitemap-buffer.php';
-require_once dirname( __FILE__ ) . '/sitemap-stylist.php';
-require_once dirname( __FILE__ ) . '/sitemap-librarian.php';
-require_once dirname( __FILE__ ) . '/sitemap-finder.php';
-require_once dirname( __FILE__ ) . '/sitemap-builder.php';
+require_once __DIR__ . '/sitemap-constants.php';
+require_once __DIR__ . '/sitemap-buffer.php';
+require_once __DIR__ . '/sitemap-stylist.php';
+require_once __DIR__ . '/sitemap-librarian.php';
+require_once __DIR__ . '/sitemap-finder.php';
+require_once __DIR__ . '/sitemap-builder.php';
 
 if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-	require_once dirname( __FILE__ ) . '/sitemap-logger.php';
+	require_once __DIR__ . '/sitemap-logger.php';
 }
 
 /**


### PR DESCRIPTION
In syncing files with WP.com, a commit failed as we prohibit relative include paths (e.g. `include 'sitemaps/sitemaps.php`).

Updating to use `__DIR__` in that instance plus updating Sitemaps to `__DIR__` over `dirname(__FILE__)` since we're no longer in need to support PHP 5.2.

#### Changes proposed in this Pull Request:
* Use absolute paths in the Sitemaps module since `__DIR__`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Confirm Sitemaps loads as usual.
*

#### Proposed changelog entry for your changes:
* None really needed, but can say something akin to "Sitemaps: Modernize code".
