### PR TITLE
External Media: Restore focus on modal close

### DIFF
--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -18,6 +18,19 @@ $grid-size: 8px;
 }
 
 /**
+ * Media button menu
+ */
+
+/**
+ * Hide the menu when the modal is open. Hacky, but necessary to allow the focus
+ * to return to selected option when modal is closed. This is how it's currenly
+ * also implemented in Gutenberg's MediaReplaceFlow.
+ */
+.modal-open .jetpack-external-media-button-menu__options {
+	display: none;
+}
+
+/**
  * Media item container
  */
 

--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -27,19 +27,6 @@ function MediaButtonMenu( props ) {
 		);
 	}
 
-	const dropdownOpen = onToggle => {
-		onToggle();
-		open();
-	};
-	const changeSource = ( source, onToggle ) => {
-		setSelectedSource( source );
-		onToggle();
-	};
-	const openLibrary = onToggle => {
-		onToggle();
-		open();
-	};
-
 	let label = __( 'Select Image', 'jetpack' );
 
 	if ( mediaProps.multiple ) {
@@ -56,11 +43,12 @@ function MediaButtonMenu( props ) {
 
 			<Dropdown
 				position="bottom right"
+				contentClassName="jetpack-external-media-button-menu__options"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
 						isTertiary={ ! isFeatured }
 						isPrimary={ isFeatured }
-						className="jetpack-external-media-browse-button"
+						className="jetpack-external-media-button-menu"
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
@@ -68,17 +56,14 @@ function MediaButtonMenu( props ) {
 						{ label }
 					</Button>
 				) }
-				renderContent={ ( { onToggle } ) => (
+				renderContent={ () => (
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
-							<MenuItem icon="admin-media" onClick={ () => openLibrary( onToggle ) }>
+							<MenuItem icon="admin-media" onClick={ open }>
 								{ __( 'Media Library', 'jetpack' ) }
 							</MenuItem>
 
-							<MediaSources
-								open={ () => dropdownOpen( onToggle ) }
-								setSource={ source => changeSource( source, onToggle ) }
-							/>
+							<MediaSources open={ open } setSource={ setSelectedSource } />
 						</MenuGroup>
 					</NavigableMenu>
 				) }


### PR DESCRIPTION
Fixes #15828

#### Changes proposed in this Pull Request:

Fixes issue where after closing the External Media modal the focus is not restored to the selected media option.

#### Testing instructions:

- Add the ExternalMedia block,
- Click `Select Media` button and select any option,
- Close the modal,
- The focus should be restored to the selected media menu option,
- Repeat for each media option.

#### Proposed changelog entry for your changes:
* no changelog entry needed
