### PR TITLE
External Media: Loading and disabled states for the copying state

### DIFF
--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -86,14 +86,27 @@ $grid-size: 8px;
 		&.is-transient img {
 			opacity: 0.3;
 		}
+	}
+
+	.jetpack-external-media-browser__media__copying_indicator {
+		display: flex;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		text-align: center;
 
 		.components-spinner {
-			position: absolute;
-			top: 50%;
-			right: 50%;
-			margin-top: -9px;
-			margin-right: -9px;
+			margin-bottom: $grid-size;
 		}
+	}
+
+	.jetpack-external-media-browser__media__copying_indicator__label {
+		font-size: 12px;
 	}
 
 	.jetpack-external-media-browser__media__folder {

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -121,7 +121,7 @@ function MediaBrowser( props ) {
 						isLarge
 						isSecondary
 						className="jetpack-external-media-browser__loadmore"
-						disabled={ isLoading }
+						disabled={ isLoading || isCopying }
 						onClick={ onLoadMoreClick }
 					>
 						{ __( 'Load More', 'jetpack' ) }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -34,7 +34,7 @@ function MediaItem( props ) {
 		'jetpack-external-media-browser__media__item': true,
 		'jetpack-external-media-browser__media__item__selected': isSelected,
 		'jetpack-external-media-browser__media__folder': type === 'folder',
-		'is-transient': isSelected && isCopying,
+		'is-transient': isCopying,
 	} );
 
 	const itemEl = useRef( null );

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -52,11 +52,12 @@ function MediaItem( props ) {
 		<li
 			ref={ itemEl }
 			className={ classes }
-			onClick={ onClick }
-			onKeyDown={ onKeyDown }
+			onClick={ ! isCopying && onClick }
+			onKeyDown={ ! isCopying && onKeyDown }
 			role="checkbox"
 			tabIndex="0"
 			aria-checked={ isSelected ? 'true' : 'false' }
+			aria-disabled={ !! isCopying }
 		>
 			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />
 

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
 
 function MediaItem( props ) {
 	const onClick = useCallback( () => {
@@ -68,7 +69,14 @@ function MediaItem( props ) {
 				</div>
 			) }
 
-			{ isSelected && isCopying && <Spinner /> }
+			{ true && ( //isSelected && isCopying &&
+				<div className="jetpack-external-media-browser__media__copying_indicator">
+					<Spinner />
+					<div className="jetpack-external-media-browser__media__copying_indicator__label">
+						{ __( 'Inserting Image…', 'jetpack' ) }
+					</div>
+				</div>
+			) }
 		</li>
 	);
 }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -69,7 +69,7 @@ function MediaItem( props ) {
 				</div>
 			) }
 
-			{ true && ( //isSelected && isCopying &&
+			{ isSelected && isCopying && (
 				<div className="jetpack-external-media-browser__media__copying_indicator">
 					<Spinner />
 					<div className="jetpack-external-media-browser__media__copying_indicator__label">

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -53,11 +53,11 @@ function MediaItem( props ) {
 		<li
 			ref={ itemEl }
 			className={ classes }
-			onClick={ ! isCopying && onClick }
-			onKeyDown={ ! isCopying && onKeyDown }
+			onClick={ isCopying ? undefined : onClick }
+			onKeyDown={ isCopying ? undefined : onKeyDown }
 			role="checkbox"
 			tabIndex="0"
-			aria-checked={ isSelected ? 'true' : 'false' }
+			aria-checked={ !! isSelected }
 			aria-disabled={ !! isCopying }
 		>
 			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />

--- a/extensions/shared/external-media/sources/google-photos/filter-view.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-view.js
@@ -44,7 +44,7 @@ function addFilter( existing, newFilter ) {
 
 function GoogleFilterView( props ) {
 	const [ currentFilter, setCurrentFilter ] = useState( getFirstFilter( [] ) );
-	const { isLoading, filters, canChangeMedia } = props;
+	const { isLoading, isCopying, filters, canChangeMedia } = props;
 	const remainingFilters = removeMediaType( getFilterOptions( filters ), canChangeMedia );
 	const setFilter = () => {
 		const newFilters = addFilter( filters, currentFilter );
@@ -62,12 +62,12 @@ function GoogleFilterView( props ) {
 			<SelectControl
 				label={ __( 'Filters', 'jetpack' ) }
 				value={ currentFilter }
-				disabled={ isLoading }
+				disabled={ isLoading || isCopying }
 				options={ remainingFilters }
 				onChange={ setCurrentFilter }
 			/>
 
-			<Button disabled={ isLoading } isSecondary isSmall onClick={ setFilter }>
+			<Button disabled={ isLoading || isCopying } isSecondary isSmall onClick={ setFilter }>
 				{ __( 'Add Filter', 'jetpack' ) }
 			</Button>
 		</Fragment>

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -86,7 +86,7 @@ function GooglePhotosMedia( props ) {
 					className="jetpack-external-media-header__select"
 					label={ __( 'View', 'jetpack' ) }
 					value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
-					disabled={ isLoading }
+					disabled={ isLoading || isCopying }
 					options={ PATH_OPTIONS }
 					onChange={ setPath }
 				/>

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -88,12 +88,15 @@ function PexelsMedia( props ) {
 					type="search"
 					value={ searchQuery }
 					onChange={ setSearchQuery }
+					disabled={ !! isCopying }
 				/>
 				<Button
 					isPrimary
 					onClick={ onSearch }
 					type="submit"
-					disabled={ ! searchQuery.length || searchQuery === previousSearchQueryValue.current }
+					disabled={
+						! searchQuery.length || searchQuery === previousSearchQueryValue.current || isCopying
+					}
 				>
 					{ __( 'Search', 'jetpack' ) }
 				</Button>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* This PR is addressing some feedback from #16081 

#### Testing instructions:
- Insert image using the External Media modal and observe the loading state:
  - you cannot interact with the image selection, buttons or filters
  - all images are visually faded-out
  - selected images (eg: those being copied) have a spinner on top of them, as well as "Inserting image…" label

#### Proposed changelog entry for your changes:
- none