### PR TITLE
Fix color contrast ratio accessibility issue with "required" text on forms

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -63,7 +63,7 @@
 }
 
 .contact-form label span {
-	color: #AAA;
+	font-size: 85%;
 	margin-left: 0.25em;
 	font-weight: normal;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #3228

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

From the original issue:

> The color contrast ratio between for the text (#aaaaaa) and its background (#F8F8F8 for Twenty Fifteen) is not at least 4.5 to 1.

* To fix these we can use font-size and weight rather than color to differentiate between label and required label on Jetpack forms. This should increase theme compatibility for these labels.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

* A11y fix for Jetpack forms

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Pull this PR
* Insert a Jetpack form with required fields
* Check the contrast ratio on the "required" label next to form fields

**Before:**

![Screenshot 2020-06-09 at 16 34 37](https://user-images.githubusercontent.com/411945/84161041-bf3c2f00-aa66-11ea-9a67-7e1043953a78.png)

**After:**

![Screenshot 2020-06-09 at 16 28 47](https://user-images.githubusercontent.com/411945/84160957-a6cc1480-aa66-11ea-9c5f-2f6c2fee0af3.png)

Tested on Twenty Fifteen.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
