### PR TITLE
Cover: Handling site plan and its errors

### DIFF
--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -6,6 +6,7 @@ import './shared/block-category';
 import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
 import './shared/external-media';
+import './shared/blocks/cover';
 import analytics from '../_inc/client/lib/analytics';
 
 // @TODO Please make a shared analytics solution and remove this!

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -46,45 +46,42 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 		/>
 		: null;
 
-export default createHigherOrderComponent(
-	CoreMediaPlaceholder => props => {
-		const [ error, setError ] = useState( false );
-		const { name } = useBlockEditContext();
-		const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
-		if (
-			( ! name || name !== 'core/cover' ) || // extend only for cover block
-			! isSimpleSite() || // only for Simple sites
-			! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-		) {
-			return <CoreMediaPlaceholder { ...props } />;
-		}
+export default CoreMediaPlaceholder => props => {
+	const [ error, setError ] = useState( false );
+	const { name } = useBlockEditContext();
+	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
+	if (
+		( ! name || name !== 'core/cover' ) || // extend only for cover block
+		! isSimpleSite() || // only for Simple sites
+		! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
+	) {
+		return <CoreMediaPlaceholder { ...props } />;
+	}
 
-		const { onError } = props;
-		return (
-			<div className="jetpack-cover-media-placeholder">
-				<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
-				<CoreMediaPlaceholder
-					{ ...props }
-					multiple={ false }
-					onError = { ( message ) => {
-						// Try to pick up filename from the error message.
-						// We should find a better way to do it. Unstable.
-						const filename = message?.[0]?.props?.children;
-						if ( ! filename ) {
-							return onError( message );
-						}
+	const { onError } = props;
+	return (
+		<div className="jetpack-cover-media-placeholder">
+			<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
+			<CoreMediaPlaceholder
+				{ ...props }
+				multiple={ false }
+				onError = { ( message ) => {
+					// Try to pick up filename from the error message.
+					// We should find a better way to do it. Unstable.
+					const filename = message?.[0]?.props?.children;
+					if ( ! filename ) {
+						return onError( message );
+					}
 
-						const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
-						if ( ! videoFileExtensions.includes( fileExtension ) ) {
-							return onError( message );
-						}
+					const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
+					if ( ! videoFileExtensions.includes( fileExtension ) ) {
+						return onError( message );
+					}
 
-						return setError( message );
-					} }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-				/>
-			</div>
-		);
-	},
-	'JetpackCoverMediaPlaceholder'
-);
+					return setError( message );
+				} }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+			/>
+		</div>
+	);
+};

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -26,7 +26,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 			plan="value_bundle"
 			blockName={ name }
 			title={ {
-				knownPlan: __( 'To use a video in this block, upgrade to %(planName) plan.', 'jetpack' ),
+				knownPlan: __( 'To use a video in this block, upgrade to %(planName)s plan.', 'jetpack' ),
 				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
 			} }
 			subtitle={ __(

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -42,8 +42,8 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 
 const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
+		const { onError, allowedVideoFileExtensions } = props;
 		const [ error, setError ] = useState( false );
-		const { onError } = props;
 
 		return (
 			<Fragment>
@@ -55,7 +55,10 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 						// We should find a better way to do it. Unstable.
 						const filename = message?.[0]?.props?.children;
 						if ( filename ) {
-							return setError( message );
+							const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
+							if ( allowedVideoFileExtensions.includes( fileExtension ) ) {
+								return setError( message );
+							}
 						}
 						return onError( message );
 					} }
@@ -71,13 +74,12 @@ export default ( name ) => compose( [
 	withSelect( ( select ) => {
 		const { getEditorSettings } = select( 'core/editor' );
 		const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes || [];
-
-		const wpAllowedVideoMimeTypes = pickBy( wpAllowedMimeTypes, ( type ) => /^video\//.test( type ) );
-		const wpAllowedVideoFileExtensions = flatten( map( keys( wpAllowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
+		const allowedVideoMimeTypes = pickBy( wpAllowedMimeTypes, ( type ) => /^video\//.test( type ) );
+		const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
 
 		return {
-			wpAllowedVideoMimeTypes,
-			wpAllowedVideoFileExtensions,
+			allowedVideoMimeTypes,
+			allowedVideoFileExtensions,
 		};
 	} ),
 	JetpackCoverMediaPlaceholder( name )

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -40,16 +40,21 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 
 export default ( name ) => createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const [ uploadingError, setUploadingError ] = useState( false );
+		const [ error, setError ] = useState( false );
 		const { onError } = props;
 
 		return (
 			<Fragment>
-				<JetpackCoverUpgradeNudge name={ name } show={ uploadingError } />
+				<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
 				<CoreMediaPlaceholder
 					{ ...props }
 					onError = { ( message ) => {
-						setUploadingError( true );
+						// Try to pick up filename from the error message.
+						// We should find a better way to do it. Unstable.
+						const filename = message?.[0]?.props?.children;
+						if ( filename ) {
+							return setError( message );
+						}
 						return onError( message );
 					} }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -29,12 +29,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 				knownPlan: __( 'To use a video in this block, upgrade to %(planName)s plan.', 'jetpack' ),
 				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
 			} }
-			subtitle={ __(
-				'Upload unlimited videos to your website and \
-				display them using a fast, unbranded, \
-				customizable player.',
-				'jetpack'
-			) }
+			subtitle={ false }
 		/>
 		: null;
 

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -7,13 +7,37 @@
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { useBlockEditContext } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import UpgradeNudge from "../../components/upgrade-nudge";
 
 /**
  * Module Constants
  */
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
+const JetpackCoverUpgradeNudge = ( { name, show } ) =>
+	show
+		? <UpgradeNudge
+			plan="value_bundle"
+			blockName={ name }
+			title={ {
+				knownPlan: __( 'To use a video in this block, upgrade to %(planName) plan.', 'jetpack' ),
+				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
+			} }
+			subtitle={ __(
+				'Upload unlimited videos to your website and \
+				display them using a fast, unbranded, \
+				customizable player.',
+				'jetpack'
+			) }
+		/>
+		: null;
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
@@ -22,10 +46,18 @@ export default createHigherOrderComponent(
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 
+		const [ uploadingError, setUploadingError ] = useState( false );
+		const { onError } = props;
+
 		return (
 			<Fragment>
+				<JetpackCoverUpgradeNudge name={ name } show={ uploadingError } />
 				<CoreMediaPlaceholder
 					{ ...props }
+					onError = { ( message ) => {
+						setUploadingError( true );
+						return onError( message );
+					} }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 				/>
 			</Fragment>

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -48,6 +48,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
+		const [ error, setError ] = useState( false );
 		const { name } = useBlockEditContext();
 		const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 		if (
@@ -59,8 +60,6 @@ export default createHigherOrderComponent(
 		}
 
 		const { onError } = props;
-		const [ error, setError ] = useState( false );
-
 		return (
 			<div className="jetpack-cover-media-placeholder">
 				<JetpackCoverUpgradeNudge name={ name } show={ !! error } />

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -12,6 +12,8 @@ import { __ } from '@wordpress/i18n';
  */
 import UpgradeNudge from "../../components/upgrade-nudge";
 import { videoFileExtensions, videoFileMimeTypes } from './utils';
+import { isSimpleSite } from "../../site-type-utils";
+import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
 
 /**
  * Module Constants
@@ -39,7 +41,12 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
 		const { name } = useBlockEditContext();
-		if ( name !== 'core/cover' ) {
+		const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
+		if (
+			( ! name || name !== 'core/cover' ) || // extend only for cover block
+			! isSimpleSite() || // only for Simple sites
+			! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
+		) {
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -10,6 +10,11 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { useBlockEditContext } from '@wordpress/block-editor';
 
+/**
+ * Module Constants
+ */
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
+
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
 		const { name } = useBlockEditContext();
@@ -19,7 +24,10 @@ export default createHigherOrderComponent(
 
 		return (
 			<Fragment>
-				<CoreMediaPlaceholder { ...props } />
+				<CoreMediaPlaceholder
+					{ ...props }
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+				/>
 			</Fragment>
 		);
 	},

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -8,6 +8,7 @@ import { pickBy, keys, map, flatten, values } from 'lodash';
  * WordPress dependencies
  */
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
+import { useBlockEditContext } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { withSelect } from '@wordpress/data';
@@ -41,8 +42,13 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 		/>
 		: null;
 
-const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
+const JetpackCoverMediaPlaceholder = createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
+		const { name } = useBlockEditContext();
+		if ( name !== 'core/cover' ) {
+			return <CoreMediaPlaceholder { ...props } />;
+		}
+
 		const { onError } = props;
 		const [ error, setError ] = useState( false );
 
@@ -83,7 +89,7 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 	'JetpackCoverMediaPlaceholder'
 );
 
-export default ( name ) => compose( [
+export default compose( [
 	withSelect( ( select ) => {
 		const { getEditorSettings } = select( 'core/editor' );
 		const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes || [];
@@ -95,5 +101,5 @@ export default ( name ) => compose( [
 			allowedVideoFileExtensions,
 		};
 	} ),
-	JetpackCoverMediaPlaceholder( name )
+	JetpackCoverMediaPlaceholder
 ] );

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -20,6 +20,19 @@ import getJetpackExtensionAvailability from "../../get-jetpack-extension-availab
  */
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
+/**
+ * Nudge shows when the user tries to upload a video file.
+ * Unlike the core/video block, handled/extended by the videopress block,
+ * the nudge is not shown permanently.
+ * It's handled by the MediaPlaceholder component.
+ * For this reason, we can't wrap the edit setting
+ * with the wrapPaidBlock() HOC, as the videopress does.
+ *
+ * @param {object}  props - Information about the user.
+ * @param {string}  props.name - Show the Nudge component.
+ * @param {boolean} props.show - Show the Nudge component.
+ * @returns {*} Nudge component or Null.
+ */
 const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 	show
 		? <UpgradeNudge

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -1,17 +1,11 @@
 
 /**
- * External dependencies
- */
-import { pickBy, keys, map, flatten, values } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { createHigherOrderComponent, compose } from '@wordpress/compose';
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -42,7 +36,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 		/>
 		: null;
 
-const JetpackCoverMediaPlaceholder = createHigherOrderComponent(
+export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
 		const { name } = useBlockEditContext();
 		if ( name !== 'core/cover' ) {
@@ -88,18 +82,3 @@ const JetpackCoverMediaPlaceholder = createHigherOrderComponent(
 	},
 	'JetpackCoverMediaPlaceholder'
 );
-
-export default compose( [
-	withSelect( ( select ) => {
-		const { getEditorSettings } = select( 'core/editor' );
-		const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes || [];
-		const allowedVideoMimeTypes = pickBy( wpAllowedMimeTypes, ( type ) => /^video\//.test( type ) );
-		const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
-
-		return {
-			allowedVideoMimeTypes: values( allowedVideoMimeTypes ),
-			allowedVideoFileExtensions,
-		};
-	} ),
-	JetpackCoverMediaPlaceholder
-] );

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { filter } from 'lodash';
+import { pickBy, keys, map, flatten } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -70,10 +70,14 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 export default ( name ) => compose( [
 	withSelect( ( select ) => {
 		const { getEditorSettings } = select( 'core/editor' );
-		const wpAllowedVideoMimeTypes = filter( getEditorSettings().allowedMimeTypes, type => /^video\//.test( type ) );
+		const wpAllowedMimeTypes = getEditorSettings().allowedMimeTypes || [];
+
+		const wpAllowedVideoMimeTypes = pickBy( wpAllowedMimeTypes, ( type ) => /^video\//.test( type ) );
+		const wpAllowedVideoFileExtensions = flatten( map( keys( wpAllowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
 
 		return {
-			wpAllowedVideoMimeTypes
+			wpAllowedVideoMimeTypes,
+			wpAllowedVideoFileExtensions,
 		};
 	} ),
 	JetpackCoverMediaPlaceholder( name )

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -50,6 +50,7 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 				<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
 				<CoreMediaPlaceholder
 					{ ...props }
+					multiple={ false }
 					onError = { ( message ) => {
 						// Try to pick up filename from the error message.
 						// We should find a better way to do it. Unstable.

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -2,13 +2,15 @@
 /**
  * External dependencies
  */
+import { filter } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -38,7 +40,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 		/>
 		: null;
 
-export default ( name ) => createHigherOrderComponent(
+const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
 		const [ error, setError ] = useState( false );
 		const { onError } = props;
@@ -64,3 +66,15 @@ export default ( name ) => createHigherOrderComponent(
 	},
 	'JetpackCoverMediaPlaceholder'
 );
+
+export default ( name ) => compose( [
+	withSelect( ( select ) => {
+		const { getEditorSettings } = select( 'core/editor' );
+		const wpAllowedVideoMimeTypes = filter( getEditorSettings().allowedMimeTypes, type => /^video\//.test( type ) );
+
+		return {
+			wpAllowedVideoMimeTypes
+		};
+	} ),
+	JetpackCoverMediaPlaceholder( name )
+] );

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -53,6 +53,10 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 					{ ...props }
 					multiple={ false }
 					onFilesPreUpload={ ( files ) => {
+						// TRY/Experimental.
+						// Adding `onFilesPreUpload` prop hasn't been shiped yet.
+						// PR: https://github.com/WordPress/gutenberg/pull/22995
+						// Remove this code block in case the PR does isn't merged.
 						const fileMimeType = files?.[ 0 ].type;
 						if ( ! fileMimeType || ! videoFileMimeTypes.includes( fileMimeType ) ) {
 							return;

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -4,7 +4,7 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditContext } from '@wordpress/block-editor';
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -54,7 +54,7 @@ export default createHigherOrderComponent(
 		const [ error, setError ] = useState( false );
 
 		return (
-			<Fragment>
+			<div className="jetpack-cover-media-placeholder">
 				<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
 				<CoreMediaPlaceholder
 					{ ...props }
@@ -84,7 +84,7 @@ export default createHigherOrderComponent(
 					} }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 				/>
-			</Fragment>
+			</div>
 		);
 	},
 	'JetpackCoverMediaPlaceholder'

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -8,7 +8,6 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Fragment, useState } from '@wordpress/element';
-import { useBlockEditContext } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -39,13 +38,8 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 		/>
 		: null;
 
-export default createHigherOrderComponent(
+export default ( name ) => createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const { name } = useBlockEditContext();
-		if ( name !== 'core/cover' ) {
-			return <CoreMediaPlaceholder { ...props } />;
-		}
-
 		const [ uploadingError, setUploadingError ] = useState( false );
 		const { onError } = props;
 

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -20,7 +20,7 @@ import UpgradeNudge from "../../components/upgrade-nudge";
 /**
  * Module Constants
  */
-const ALLOWED_MEDIA_TYPES = [ 'image' ];
+const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
 const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 	show

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -70,13 +70,16 @@ export default createHigherOrderComponent(
 						// Try to pick up filename from the error message.
 						// We should find a better way to do it. Unstable.
 						const filename = message?.[0]?.props?.children;
-						if ( filename ) {
-							const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
-							if ( videoFileExtensions.includes( fileExtension ) ) {
-								return setError( message );
-							}
+						if ( ! filename ) {
+							return onError( message );
 						}
-						return onError( message );
+
+						const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
+						if ( ! videoFileExtensions.includes( fileExtension ) ) {
+							return onError( message );
+						}
+
+						return setError( message );
 					} }
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 				/>

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { pickBy, keys, map, flatten } from 'lodash';
+import { pickBy, keys, map, flatten, values } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -42,7 +42,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 
 const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const { onError, allowedVideoFileExtensions } = props;
+		const { onError, allowedVideoMimeTypes, allowedVideoFileExtensions } = props;
 		const [ error, setError ] = useState( false );
 
 		return (
@@ -51,6 +51,13 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 				<CoreMediaPlaceholder
 					{ ...props }
 					multiple={ false }
+					onFilesPreUpload={ ( files ) => {
+						const fileMimeType = files?.[ 0 ].type;
+						if ( ! fileMimeType || ! allowedVideoMimeTypes.includes( fileMimeType ) ) {
+							return;
+						}
+						return setError( true );
+					} }
 					onError = { ( message ) => {
 						// Try to pick up filename from the error message.
 						// We should find a better way to do it. Unstable.
@@ -79,7 +86,7 @@ export default ( name ) => compose( [
 		const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
 
 		return {
-			allowedVideoMimeTypes,
+			allowedVideoMimeTypes: values( allowedVideoMimeTypes ),
 			allowedVideoFileExtensions,
 		};
 	} ),

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -1,0 +1,27 @@
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+import { useBlockEditContext } from '@wordpress/block-editor';
+
+export default createHigherOrderComponent(
+	CoreMediaPlaceholder => props => {
+		const { name } = useBlockEditContext();
+		if ( name !== 'core/cover' ) {
+			return <CoreMediaPlaceholder { ...props } />;
+		}
+
+		return (
+			<Fragment>
+				<CoreMediaPlaceholder { ...props } />
+			</Fragment>
+		);
+	},
+	'JetpackCoverMediaPlaceholder'
+);

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -2,7 +2,6 @@
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -24,7 +23,8 @@ const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
  * Nudge shows when the user tries to upload a video file.
  * Unlike the core/video block, handled/extended by the videopress block,
  * the nudge is not shown permanently.
- * It's handled by the MediaPlaceholder component.
+ * It's handled by the MediaPlaceholder component
+ * when the user tries to upload a video file.
  * For this reason, we can't wrap the edit setting
  * with the wrapPaidBlock() HOC, as the videopress does.
  *
@@ -50,6 +50,7 @@ export default CoreMediaPlaceholder => props => {
 	const [ error, setError ] = useState( false );
 	const { name } = useBlockEditContext();
 	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
+
 	if (
 		( ! name || name !== 'core/cover' ) || // extend only for cover block
 		! isSimpleSite() || // only for Simple sites

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import UpgradeNudge from "../../components/upgrade-nudge";
-import { videoFileExtensions, videoFileMimeTypes } from './utils';
+import { videoFileExtensions } from './utils';
 import { isSimpleSite } from "../../site-type-utils";
 import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
 
@@ -59,17 +59,6 @@ export default createHigherOrderComponent(
 				<CoreMediaPlaceholder
 					{ ...props }
 					multiple={ false }
-					onFilesPreUpload={ ( files ) => {
-						// TRY/Experimental.
-						// Adding `onFilesPreUpload` prop hasn't been shiped yet.
-						// PR: https://github.com/WordPress/gutenberg/pull/22995
-						// Remove this code block in case the PR does isn't merged.
-						const fileMimeType = files?.[ 0 ].type;
-						if ( ! fileMimeType || ! videoFileMimeTypes.includes( fileMimeType ) ) {
-							return;
-						}
-						return setError( true );
-					} }
 					onError = { ( message ) => {
 						// Try to pick up filename from the error message.
 						// We should find a better way to do it. Unstable.

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -16,6 +16,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import UpgradeNudge from "../../components/upgrade-nudge";
+import { videoFileExtensions, videoFileMimeTypes } from './utils';
 
 /**
  * Module Constants
@@ -42,7 +43,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 
 const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const { onError, allowedVideoMimeTypes, allowedVideoFileExtensions } = props;
+		const { onError } = props;
 		const [ error, setError ] = useState( false );
 
 		return (
@@ -53,7 +54,7 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 					multiple={ false }
 					onFilesPreUpload={ ( files ) => {
 						const fileMimeType = files?.[ 0 ].type;
-						if ( ! fileMimeType || ! allowedVideoMimeTypes.includes( fileMimeType ) ) {
+						if ( ! fileMimeType || ! videoFileMimeTypes.includes( fileMimeType ) ) {
 							return;
 						}
 						return setError( true );
@@ -64,7 +65,7 @@ const JetpackCoverMediaPlaceholder = ( name ) => createHigherOrderComponent(
 						const filename = message?.[0]?.props?.children;
 						if ( filename ) {
 							const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
-							if ( allowedVideoFileExtensions.includes( fileExtension ) ) {
+							if ( videoFileExtensions.includes( fileExtension ) ) {
 								return setError( message );
 							}
 						}

--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -1,3 +1,12 @@
 .jetpack-cover-media-placeholder {
 	width: 100%;
+
+	// tweak Upgrade nudge.
+	.block-editor-warning__contents {
+		flex-wrap: initial;
+
+		.block-editor-warning__actions {
+			align-self: center;
+		}
+	}
 }

--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -1,0 +1,3 @@
+.jetpack-cover-media-placeholder {
+	width: 100%;
+}

--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -5,6 +5,7 @@
 	.block-editor-warning__contents {
 		flex-wrap: initial;
 
+		.jetpack-block-nudge__text-container,
 		.block-editor-warning__actions {
 			align-self: center;
 		}

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -13,13 +13,16 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import { isSimpleSite } from '../../site-type-utils';
+import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
 
 const extendCoreCoverBlock = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name } = props;
+		const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 		if (
 			( ! name || name !== 'core/cover' ) || // extend only for cover block
-			! isSimpleSite() // only for Simple sites
+			! isSimpleSite() || // only for Simple sites
+			! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
 		) {
 			return <BlockEdit { ...props } />;
 		}

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -6,37 +6,15 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
-import { isSimpleSite } from '../../site-type-utils';
-import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
 
-const extendCoreCoverBlock = createHigherOrderComponent(
-	( BlockEdit ) => ( props ) => {
-		const { name } = props;
-		const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
-		if (
-			( ! name || name !== 'core/cover' ) || // extend only for cover block
-			! isSimpleSite() || // only for Simple sites
-			! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-		) {
-			return <BlockEdit { ...props } />;
-		}
-
-		// Take the control of MediaPlaceholder.
-		addFilter(
-			'editor.MediaPlaceholder',
-			'jetpack/cover-edit-media-placeholder',
-			coverEditMediaPlaceholder
-		);
-
-		return <BlockEdit { ...props } />;
-	},
-	'JetpackCoverEdit'
+// Take the control of MediaPlaceholder.
+addFilter(
+	'editor.MediaPlaceholder',
+	'jetpack/cover-edit-media-placeholder',
+	coverEditMediaPlaceholder
 );
-
-addFilter( 'editor.BlockEdit', 'jetpack/cover', extendCoreCoverBlock );

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -6,15 +6,30 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 
-// Take the control of MediaPlaceholder.
-addFilter(
-	'editor.MediaPlaceholder',
-	'jetpack/cover-edit-media-placeholder',
-	coverEditMediaPlaceholder
+const extendCoreCoverBlock = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		const { name } = props;
+		if ( ! name || name !== 'core/cover' ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		// Take the control of MediaPlaceholder.
+		addFilter(
+			'editor.MediaPlaceholder',
+			'jetpack/cover-edit-media-placeholder',
+			coverEditMediaPlaceholder( name )
+		);
+
+		return <BlockEdit { ...props } />;
+	},
+	'JetpackCoverEdit'
 );
+
+addFilter( 'editor.BlockEdit', 'jetpack/cover', extendCoreCoverBlock );

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -11,6 +11,7 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
+import './editor.scss';
 
 // Take the control of MediaPlaceholder.
 addFilter(

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -12,11 +12,15 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
+import { isSimpleSite } from '../../site-type-utils';
 
 const extendCoreCoverBlock = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name } = props;
-		if ( ! name || name !== 'core/cover' ) {
+		if (
+			( ! name || name !== 'core/cover' ) || // extend only for cover block
+			! isSimpleSite() // only for Simple sites
+		) {
 			return <BlockEdit { ...props } />;
 		}
 

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -11,11 +11,14 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
+import isCurrentUserConnected from "../../is-current-user-connected";
 import './editor.scss';
 
-// Take the control of MediaPlaceholder.
-addFilter(
-	'editor.MediaPlaceholder',
-	'jetpack/cover-edit-media-placeholder',
-	coverEditMediaPlaceholder
-);
+if ( isCurrentUserConnected() ) {
+	// Take the control of MediaPlaceholder.
+	addFilter(
+		'editor.MediaPlaceholder',
+		'jetpack/cover-edit-media-placeholder',
+		coverEditMediaPlaceholder
+	);
+}

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import coverEditMediaPlaceholder from './cover-media-placeholder';
+
+// Take the control of MediaPlaceholder.
+addFilter(
+	'editor.MediaPlaceholder',
+	'jetpack/cover-edit-media-placeholder',
+	coverEditMediaPlaceholder
+);

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -31,7 +31,7 @@ const extendCoreCoverBlock = createHigherOrderComponent(
 		addFilter(
 			'editor.MediaPlaceholder',
 			'jetpack/cover-edit-media-placeholder',
-			coverEditMediaPlaceholder( name )
+			coverEditMediaPlaceholder
 		);
 
 		return <BlockEdit { ...props } />;

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -17,16 +17,3 @@ export const videoFileExtensions = [
 	'3gp',
 	'3g2',
 ];
-
-export const videoFileMimeTypes = [
-	'video/ogg',
-	'video/mp4',
-	'video/quicktime',
-	'video/x-ms-wmv',
-	'video/avi',
-	'video/mpeg',
-	'video/3gpp',
-	'video/3gpp2',
-	'video/3gpp',
-	'video/3gpp2',
-];

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -1,0 +1,32 @@
+
+export const videoFileExtensions = [
+	'ogv',
+	'mp4',
+	'm4v',
+	'mov',
+	'qt',
+	'wmv',
+	'avi',
+	'mpeg',
+	'mpg',
+	'mpe',
+	'3gp',
+	'3gpp',
+	'3g2',
+	'3gp2',
+	'3gp',
+	'3g2',
+];
+
+export const videoFileMimeTypes = [
+	'video/ogg',
+	'video/mp4',
+	'video/quicktime',
+	'video/x-ms-wmv',
+	'video/avi',
+	'video/mpeg',
+	'video/3gpp',
+	'video/3gpp2',
+	'video/3gpp',
+	'video/3gpp2',
+];

--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -30,7 +30,7 @@ export const BlockNudge = ( { autosaveAndRedirect, buttonLabel, href, icon, subt
 			{ icon }
 			<span className="jetpack-block-nudge__text-container">
 				<span className="jetpack-block-nudge__title">{ title }</span>
-				<span className="jetpack-block-nudge__message">{ subtitle }</span>
+				{ subtitle && <span className="jetpack-block-nudge__message">{ subtitle }</span> }
 			</span>
 		</span>
 	</Warning>

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -32,6 +32,21 @@ const getTitle = ( customTitle, planName ) => {
 		: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' );
 };
 
+const getSubtitle = ( subtitle ) => {
+	if ( subtitle === false ) {
+		return null;
+	}
+
+	if ( ! subtitle ) {
+		return __(
+			'You can try it out before upgrading, but only you will see it. It will be hidden from your visitors until you upgrade.',
+			'jetpack'
+		);
+	}
+
+	return subtitle;
+};
+
 export const UpgradeNudge = ( {
 	planName,
 	trackViewEvent,
@@ -61,14 +76,7 @@ export const UpgradeNudge = ( {
 			href={ upgradeUrl }
 			onClick={ trackClickEvent }
 			title={ getTitle( title, planName ) }
-			subtitle={
-				subtitle
-					? subtitle
-					: __(
-							'You can try it out before upgrading, but only you will see it. It will be hidden from your visitors until you upgrade.',
-							'jetpack'
-					  )
-			}
+			subtitle={ getSubtitle( subtitle ) }
 		/>
 	);
 };

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -32,6 +32,16 @@ const getTitle = ( customTitle, planName ) => {
 		: __( 'Upgrade to a paid plan to use this block on your site.', 'jetpack' );
 };
 
+/**
+ * Return the nudge description translated to the user language, or Null.
+ * `subtitle` param accepts three types:
+ * - A string, in which case it will translate and returned.
+ * - False (boolean), in which case it will return false
+ * - Undefined: it will return the default nudge description.
+ *
+ * @param {string|boolean} subtitle - Subtitle to translate, or False.
+ * @returns {string|null} Nudge description, or Null.
+ */
 const getSubtitle = ( subtitle ) => {
 	if ( subtitle === false ) {
 		return null;

--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -63,7 +63,7 @@
 }
 
 .contact-form label span {
-	color: #AAA;
+	font-size: 85%;
 	margin-left: 0.25em;
 	font-weight: normal;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR extends the MediaPlaceholder component for the `core/cover` block, to improve the messages to the users when try to upload different files, depending on the current site plan.

* not simple site: **no changes**
* paid plan: **no changes**
* simple site: free plan
  - The user tries to upload an image: **no changes**
  - The user tries to upload a no video file: **no changes**. It shows the regular error message
  - The user tries to upload a video: changes!!! It shows the upgrade nudge.

For the last condition, it worths mentioning it works either dropping the file as well as by clicking on the upload button.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* It adds a new (controversial) `/blocks` folder in `/share`. After testing I decided to put it there because it isn't a Jetpack block but is a core one. And also, it modifies the functionality of some pieces (and I think we are going to keep doing this soon). In this case, the MediaPlaceholder component.

#### Testing instructions:

**Jetpack site**
Nothing should change. Just create a cover block and update a video. It should work as usual.

**Simple site**

* Get Sandboxed
* Apply D44715-code

* Try to upload a video for a free site using the media placeholder. Confirm that it shows the upgrade nudge.

![image](https://user-images.githubusercontent.com/77539/84312445-54a8f300-ab3b-11ea-8d2c-8bbdb1646c1f.png)

* Try to upload an unsupported file, for instance, a pdf. You should see the proper error message:

![image](https://user-images.githubusercontent.com/77539/84262460-0d4b4400-aaf4-11ea-8540-b640e271f978.png)

* Try to upload a _weird_ file. You should see the _weird_ message. It's handled by the server-side:
![image](https://user-images.githubusercontent.com/77539/84262550-3075f380-aaf4-11ea-991f-2e84e2e7a9a3.png)

* Try to upload an image. Everything should be fine.
![image](https://user-images.githubusercontent.com/77539/84262636-51d6df80-aaf4-11ea-9306-f4cdc83924fe.png)


* Test using either the Upload button as well as dropping files in the placeholder area.
* Confirm the video block looks as exected. This PR touches shared code used by this component.



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Handling improvement for video files in the core/cover block.
