### PR TITLE
Jetpack Soft Disconnect

### DIFF
--- a/_inc/client/components/jetpack-termination-dialog/features.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/features.jsx
@@ -153,8 +153,8 @@ class JetpackTerminationDialogFeatures extends Component {
 					<div className="jetpack-termination-dialog__generic-info">
 						<h2>
 							{ __(
-								'The Jetpack Connection is also used by another plugin, and it will lose connection.',
-								'The Jetpack Connection is also used by other plugins, and they will lose connection.',
+								'If you disconnect Jetpack, the website will still be connected to WordPress.com through the following plugin:',
+								'If you disconnect Jetpack, the website will still be connected to WordPress.com through the following plugins:',
 								{
 									count: connectedPlugins.length,
 								}

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -120,7 +120,16 @@ jQuery( document ).ready( function( $ ) {
 			loadingText.after( spinner );
 		},
 		handleConnectionSuccess: function( data ) {
-			jetpackConnectButton.fetchPlanType();
+			var isReconnected = data.hasOwnProperty( 'isReconnected' ) && data.isReconnected;
+
+			jetpackConnectButton.fetchPlanType(
+				isReconnected ? jetpackConnectButton.handleAuthorizationComplete : null
+			);
+
+			if ( isReconnected ) {
+				return;
+			}
+
 			window.addEventListener( 'message', jetpackConnectButton.receiveData );
 			jetpackConnectIframe.attr( 'src', data.authorizeUrl + '&from=' + connectButtonFrom );
 			jetpackConnectIframe.on( 'load', function() {
@@ -137,7 +146,7 @@ jQuery( document ).ready( function( $ ) {
 			link.href = jpConnect.preFetchScript;
 			document.head.appendChild( link );
 		},
-		fetchPlanType: function() {
+		fetchPlanType: function( callback ) {
 			$.ajax( {
 				url: jpConnect.apiBaseUrl + '/site',
 				type: 'GET',
@@ -148,6 +157,10 @@ jQuery( document ).ready( function( $ ) {
 					var siteData = JSON.parse( data.data );
 					jetpackConnectButton.isPaidPlan =
 						siteData.options.is_pending_plan || ! siteData.plan.is_free;
+
+					if ( callback ) {
+						callback();
+					}
 				},
 			} );
 		},

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1456,10 +1456,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 			return $response;
 		}
 
-		return rest_ensure_response(
-			array(
-				'authorizeUrl' => Jetpack::build_authorize_url( false, true )
-			) );
+		$response = array();
+
+		if ( Jetpack::is_active() ) {
+			// Jetpack has been softly reconnected, no need to re-authorize the user.
+			$response['isReconnected'] = true;
+		} else {
+			$response['authorizeUrl'] = Jetpack::build_authorize_url( false, true );
+		}
+
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -4,8 +4,9 @@ use Automattic\Jetpack\Assets\Logo as Jetpack_Logo;
 use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Connection\Utils as Connection_Utils;
+use Automattic\Jetpack\Connection\Plugin as Connection_Plugin;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
+use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Partner;
 use Automattic\Jetpack\Roles;
@@ -4048,9 +4049,7 @@ p {
 			&& self::is_active()
 		) {
 
-			$active_plugins_using_connection = Connection_Plugin_Storage::get_all();
-
-			if ( count( $active_plugins_using_connection ) > 1 ) {
+			if ( ! ( new Connection_Plugin( 'jetpack' ) )->is_only() ) {
 
 				add_thickbox();
 
@@ -4086,7 +4085,7 @@ p {
 					'deactivate_dialog',
 					array(
 						'title'            => __( 'Deactivate Jetpack', 'jetpack' ),
-						'deactivate_label' => __( 'Disconnect and Deactivate', 'jetpack' ),
+						'deactivate_label' => __( 'Deactivate', 'jetpack' ),
 						'tracksUserData'   => Jetpack_Tracks_Client::get_connected_user_tracks_identity(),
 					)
 				);

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3345,6 +3345,7 @@ p {
 
 		if ( $update_activated_state ) {
 			Jetpack_Options::update_option( 'activated', 4 );
+			$connection->disable_plugin();
 		}
 
 		if ( $jetpack_unique_connection = Jetpack_Options::get_option( 'unique_connection' ) ) {
@@ -3371,8 +3372,6 @@ p {
 
 		// Disable the Heartbeat cron
 		Jetpack_Heartbeat::init()->deactivate();
-
-		$connection->disable_plugin();
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -5,6 +5,7 @@
  * @package Jetpack
  */
 
+use Automattic\Jetpack\Connection\Plugin as Connection_Plugin;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Backup\Helper_Script_Manager;
 
@@ -24,6 +25,31 @@ if ( ! defined( 'JETPACK__PLUGIN_DIR' ) ) {
 }
 
 require JETPACK__PLUGIN_DIR . 'vendor/autoload_packages.php';
+
+if ( ! ( new Connection_Plugin( 'jetpack' ) )->is_only() ) {
+	$options_cleanup_filter = function( $options ) {
+		if ( ! is_array( $options ) ) {
+			_doing_it_wrong( 'jetpack_options_delete_all_ignore', '`$options` must be an array', '8.7.0' );
+			$options = array();
+		}
+
+		$options_to_add = array(
+			'private' => array( 'blog_token', 'user_token', 'user_tokens' ),
+			'compact' => array( 'master_user', 'time_diff', 'fallback_no_verify_ssl_certs' ),
+		);
+
+		foreach ( $options_to_add as $group => $keys ) {
+			if ( ! array_key_exists( $group, $options ) ) {
+				$options[ $group ] = array();
+			}
+			$options[ $group ] = array_unique( array_merge( $options[ $group ], $keys ) );
+		}
+
+		return $options;
+	};
+
+	add_filter( 'jetpack_options_delete_all_ignore', $options_cleanup_filter, 20 );
+}
 
 Jetpack_Options::delete_all_known_options();
 

--- a/views/admin/deactivation-dialog.php
+++ b/views/admin/deactivation-dialog.php
@@ -18,8 +18,8 @@
 			sprintf(
 				/* translators: %d is the number of additional plugins using the jetpack connection. */
 				_n(
-					'The Jetpack Connection is also used by %d other plugin, and it will lose connection.',
-					'The Jetpack Connection is also used by %d other plugins, and they will lose connection.',
+					'If you disconnect Jetpack, the website will still be connected to WordPress.com through the following plugin:',
+					'If you disconnect Jetpack, the website will still be connected to WordPress.com through the following plugins:',
 					count( $data ),
 					'jetpack'
 				),
@@ -51,7 +51,7 @@
 			<p><?php esc_html_e( 'Are you sure you want to deactivate?', 'jetpack' ); ?></p>
 			<div class="jetpack_deactivation_dialog_content__buttons">
 				<button type="button" id="jetpack_deactivation_dialog_content__button-cancel"><?php esc_html_e( 'Cancel', 'jetpack' ); ?></button>
-				<button type="button" id="jetpack_deactivation_dialog_content__button-deactivate"><?php esc_html_e( 'Disconnect and Deactivate', 'jetpack' ); ?></button>
+				<button type="button" id="jetpack_deactivation_dialog_content__button-deactivate"><?php esc_html_e( 'Deactivate', 'jetpack' ); ?></button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The PR proposes changes that let Jetpack utilizes the Soft Disconnect functionality introduced in the PR #15669.

When Jetpack gets disconnected, it will if any other plugins are still connected to WordPress.com, and if there are any, it will not remove any tokens, and only disconnect itself from the connection.

It will also deactivate Jetpack API endpoints as if the whole plugin was deactivated.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
`p9dueE-1nR-p2`

#### Ongoing To Do

- [x] Disconnect Jetpack softly
- [x] Allow easy reactivation of Jetpack after soft disconnect
- [x] Replace wording in Jetpack Disconnect modal ("Connection for other plugins will be preserved...")
- [x] Replace wording in the Jetpack Deactivate modal ("Connection for other plugins will be preserved...")
- [x] Softly disconnect Jetpack when the plugin is deactivated
- [x] Softly disconnect Jetpack when the plugin is uninstalled
- [x] Cover the changes with unit and integration tests
- [x] Make the "Reconnect" error notice always use hard disconnect

#### Does this pull request change what data or activity we track or use?
No, it doesn't.

#### Testing instructions

##### Unit Tests
1. Run `yarn docker:phpunit --filter="WP_Test_Jetpack::*"` and make sure there are no failures or errors.

##### Soft Disconnect and Reconnect
2. Install `client-example` plugin or pull the fresh copy from the `master` branch: https://github.com/Automattic/client-example
3. Connect Jetpack if needed. Go to the "Client Example" page and make sure it's connected too (`Woohoo! This site is registered with wpcom`)
4. Go to Jetpack Dashboard and click on "Manage site connection". You should see "Jetpack Client Example" in the list: <img width="314" alt="Screen Shot 2020-06-30 at 12 25 47 PM" src="https://user-images.githubusercontent.com/1341249/86167688-9eeb1780-badc-11ea-97a0-0c0a070347f7.png">
5. Click "Disconnect", Jetpack should disconnect.
6. Go to "Client Example" and make sure it's still connected (`Woohoo! This site is registered with wpcom`).
7. Go back to Jetpack Dashboard and click "Set up Jetpack". Jetpack should reconnect after the page reload, no questions asked (connection flow is skipped entirely).

##### Hard Disconnect and Reconnect
8. Go to "Client Example" and click "Soft Disconnect". Connection status should change to `Softly Disconnected`.
9. Go to Jetpack Dashboard and make sure it's still connected.
10. Click "Manage site connection" and confirm that you no longer see "Client Example" in the list of connected plugins. If there are no other connected plugins, the list should disappear entirely.
11. Click "Disconnect". Jetpack should disconnect.
12. Go to "Client Example", confirm that it's too disconnected (`Unregistered (Hard Disconnect)`).
13. Go to Jetpack Dashboard and click "Set up Jetpack". Make sure that you have to go through the full connection flow to reconnect. Jetpack should reconnect successfully.
14. Go to "Client Example" and confirm that it's back to the previous status of being softly disconnected.
15. Click "Reconnect this site", client-example should switch to the connected status (`Woohoo! This site is registered with wpcom`).

##### Deactivate Jetpack (Soft Disconnect)
16. Both Jetpack and Client Example are now connected. Go to the "Plugins", find Jetpack and click "Deactivate". You should see the "Deactivate" Modal. Make sure that "Client Example" is listed:
<img width="339" alt="Screen Shot 2020-06-30 at 2 33 42 PM" src="https://user-images.githubusercontent.com/1341249/86169152-ce028880-bade-11ea-84ce-87a2ba7ffbf6.png">
17. Click "Deactivate", Jetpack should deactivate.
18. Go to "Client Example" and confirm that it's still connected.
19. Enable Jetpack, go to Jetpack Dashboard, it should get connected automatically.

##### Deactivate Jetpack (Hard Disconnect)
17. Go to Client Example and click "Soft Disconnect".
18. Go to "Plugins" and deactivate Jetpack. You **should not** see the deactivation modal, Jetpack should get deactivated.
19. Enable Jetpack again, connect it. Ii should need to go through the regular connection flow to reconnect.
20. Go to "Client Example" and confirm that it's still "Softly Disconnected".

#### Proposed changelog entry for your changes:
* Disconnecting Jetpack no longer breaks connection for other plugins.
