### PR TITLE
External Media: Screen Reader accessible states for Insert flow

### DIFF
--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -17,6 +17,15 @@ $grid-size: 8px;
 	}
 }
 
+.jetpack-external-media-browser--visually-hidden {
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect( 1px, 1px, 1px, 1px );
+	white-space: nowrap; /* added line */
+}
+
 /**
  * Media item container
  */

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -60,21 +60,21 @@ function MediaItem( props ) {
 			aria-checked={ !! isSelected }
 			aria-disabled={ !! isCopying }
 		>
-			<img src={ medium || fmt_hd } alt={ alt } />
-
-			{ type === 'folder' && (
-				<div className="jetpack-external-media-browser__media__info">
-					<div className="jetpack-external-media-browser__media__name">{ name }</div>
-					<div className="jetpack-external-media-browser__media__count">{ children }</div>
-				</div>
-			) }
-
 			{ isSelected && isCopying && (
 				<div className="jetpack-external-media-browser__media__copying_indicator">
 					<Spinner />
 					<div className="jetpack-external-media-browser__media__copying_indicator__label">
 						{ __( 'Inserting Image…', 'jetpack' ) }
 					</div>
+				</div>
+			) }
+
+			<img src={ medium || fmt_hd } alt={ alt } />
+
+			{ type === 'folder' && (
+				<div className="jetpack-external-media-browser__media__info">
+					<div className="jetpack-external-media-browser__media__name">{ name }</div>
+					<div className="jetpack-external-media-browser__media__count">{ children }</div>
 				</div>
 			) }
 		</li>

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -60,7 +60,7 @@ function MediaItem( props ) {
 			aria-checked={ !! isSelected }
 			aria-disabled={ !! isCopying }
 		>
-			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />
+			<img src={ medium || fmt_hd } alt={ alt } />
 
 			{ type === 'folder' && (
 				<div className="jetpack-external-media-browser__media__info">

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -216,6 +216,14 @@ export default function withMedia() {
 				const title = isCopying
 					? __( 'Inserting media', 'jetpack' )
 					: __( 'Select media', 'jetpack' );
+				const description = isCopying
+					? __(
+							'When the media is finished copying and inserting, you will be returned to the editor.',
+							'jetpack'
+					  )
+					: __( 'Select the media you would like to insert into the editor.', 'jetpack' );
+
+				const describedby = 'jetpack-external-media-browser__description';
 				const classes = classnames( {
 					'jetpack-external-media-browser': true,
 					'jetpack-external-media-browser--is-copying': isCopying,
@@ -225,24 +233,14 @@ export default function withMedia() {
 					<Modal
 						onRequestClose={ onClose }
 						title={ title }
-						aria={ {
-							describedby: 'jetpack-external-media-browser__description',
-						} }
+						aria={ { describedby } }
 						className={ classes }
 					>
 						<div ref={ this.modalRef }>
 							{ noticeUI }
 
-							<p
-								id="jetpack-external-media-browser__description"
-								class="jetpack-external-media-browser--visually-hidden"
-							>
-								{ isCopying
-									? __(
-											'When the media is finished copying and inserting, you will be returned to the editor.',
-											'jetpack'
-									  )
-									: __( 'Select the media you would like to insert into the editor.', 'jetpack' ) }
+							<p id={ describedby } className="jetpack-external-media-browser--visually-hidden">
+								{ description }
 							</p>
 
 							<OriginalComponent

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -207,7 +207,9 @@ export default function withMedia() {
 				const { isAuthenticated, isCopying, isLoading, media, nextHandle, path } = this.state;
 				const { allowedTypes, multiple = false, noticeUI, onClose } = this.props;
 
-				const title = isCopying ? __( 'Inserting media', 'jetpack' ) : __( 'Select media', 'jetpack' );
+				const title = isCopying
+					? __( 'Inserting media', 'jetpack' )
+					: __( 'Select media', 'jetpack' );
 				const classes = classnames( {
 					'jetpack-external-media-browser': true,
 					'jetpack-external-media-browser--is-copying': isCopying,
@@ -217,10 +219,25 @@ export default function withMedia() {
 					<Modal
 						onRequestClose={ onClose }
 						title={ title }
+						aria={ {
+							describedby: 'jetpack-external-media-browser__description',
+						} }
 						className={ classes }
 					>
 						<div ref={ this.modalRef }>
 							{ noticeUI }
+
+							<p
+								id="jetpack-external-media-browser__description"
+								class="jetpack-external-media-browser--visually-hidden"
+							>
+								{ isCopying
+									? __(
+											'When the media is finished copying and inserting, you will be returned to the editor.',
+											'jetpack'
+									  )
+									: __( 'Select the media you would like to insert into the editor.', 'jetpack' ) }
+							</p>
 
 							<OriginalComponent
 								getMedia={ this.getMedia }


### PR DESCRIPTION
Implements screen reader accessible states and descriptions to communicate what is happening during the insertion flow. Tasks and reasons [originally outlined in this comment](https://github.com/Automattic/jetpack/pull/16103#issuecomment-641347935), but I'll provide a recap here.

#### Changes proposed in this Pull Request:
- [x] Add a visually hidden description using `aria-describedby` to communicate the default and inserting states.
- [x] Moves the Inserting Image... text to before the image so the announcement is `Inserting Image... [alt text]` instead of `[image alt text] Inserting Image...`. I debated this one for awhile, considering using an `aria-describedby` element for the `Inserting Image...` text, but after testing, this felt like the nicest state. Definitely open for changing or discussion. 
- [x] Bonus: Removes the `title` from the `<img>` src as the title isn't necessary, and titles in general are not recommended.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert an image or gallery block
* Commenting out the lines in `with-media.js` that actually copied and closed the modal were helpful for testing (lines 191 - 197)
* Select some images and click Insert
* Use VoiceOver or test the HTML for:
  - The aria-describedby on the modal
  - That Inserting Image... appears before the image in the source order
  - The `title` attribute is not present on any images
