### PR TITLE
Add a trailing / to jetpack.com/redirect URLs.

### DIFF
--- a/_inc/client/lib/jp-redirect/index.js
+++ b/_inc/client/lib/jp-redirect/index.js
@@ -1,9 +1,9 @@
 /**
- * Builds an URL using the jetpack.com/redirect service
+ * Builds an URL using the jetpack.com/redirect/ service
  *
- * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
+ * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect/?source=slug
  *
- * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
+ * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect/?url=https://wordpress.com
  *
  * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
  *

--- a/composer.lock
+++ b/composer.lock
@@ -423,7 +423,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "description": "Utilities to build URLs to the jetpack.com/redirect service"
+            "description": "Utilities to build URLs to the jetpack.com/redirect/ service"
         },
         {
             "name": "automattic/jetpack-roles",

--- a/packages/redirect/README.md
+++ b/packages/redirect/README.md
@@ -1,6 +1,6 @@
 # Jetpack Redirect package
 
-A package containing functionality to generate URLs to the jetpack.com/redirect service
+A package containing functionality to generate URLs to the jetpack.com/redirect/ service
 
 ### Usage TODO
 

--- a/packages/redirect/composer.json
+++ b/packages/redirect/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "automattic/jetpack-redirect",
-	"description": "Utilities to build URLs to the jetpack.com/redirect service",
+	"description": "Utilities to build URLs to the jetpack.com/redirect/ service",
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"require-dev": {

--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -37,7 +37,7 @@ class Redirect {
 	 *
 	 * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect/?source=slug
 	 *
-	 * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirec/t?url=https://wordpress.com
+	 * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect/?url=https://wordpress.com
 	 *
 	 * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
 	 *

--- a/packages/redirect/src/class-redirect.php
+++ b/packages/redirect/src/class-redirect.php
@@ -33,11 +33,11 @@ class Redirect {
 	}
 
 	/**
-	 * Builds and returns an URL using the jetpack.com/redirect service
+	 * Builds and returns an URL using the jetpack.com/redirect/ service
 	 *
-	 * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect?source=slug
+	 * If $source is a simple slug, it will be sent using the source query parameter. e.g. jetpack.com/redirect/?source=slug
 	 *
-	 * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirect?url=https://wordpress.com
+	 * If $source is a full URL, starting with https://, it will be sent using the url query parameter. e.g. jetpack.com/redirec/t?url=https://wordpress.com
 	 *
 	 * Note: if using full URL, query parameters and anchor must be passed in $args. Any querystring of url fragment in the URL will be discarded.
 	 *
@@ -55,7 +55,7 @@ class Redirect {
 	 */
 	public static function get_url( $source, $args = array() ) {
 
-		$url           = 'https://jetpack.com/redirect';
+		$url           = 'https://jetpack.com/redirect/';
 		$args          = wp_parse_args( $args, array( 'site' => self::build_raw_urls( get_home_url() ) ) );
 		$accepted_args = array( 'site', 'path', 'query', 'anchor' );
 

--- a/packages/redirect/tests/php/test_Redirect.php
+++ b/packages/redirect/tests/php/test_Redirect.php
@@ -15,55 +15,55 @@ class RedirectTest extends TestCase {
 	public function test_get_url() {
 
 		$url = Redirect::get_url( 'simple' );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org', $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org', $url );
 
 		// Test invalid parameter.
 		$url = Redirect::get_url( 'simple', array( 'invalid' => 'value' ) );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org', $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org', $url );
 
 		// Test path.
 		$url = Redirect::get_url( 'simple', array( 'path' => 'value' ) );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&path=value', $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org&path=value', $url );
 
 		// Test path special chars.
 		$url = Redirect::get_url( 'simple', array( 'path' => 'weird value!' ) );
 		$v   = rawurlencode( 'weird value!' );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&path=' . $v, $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org&path=' . $v, $url );
 
 		// Test query.
 		$url = Redirect::get_url( 'simple', array( 'query' => 'value' ) );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&query=value', $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org&query=value', $url );
 
 		// Test query special chars.
 		$url = Redirect::get_url( 'simple', array( 'query' => 'key=value&key2=value2' ) );
 		$v   = rawurlencode( 'key=value&key2=value2' );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&query=' . $v, $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org&query=' . $v, $url );
 
 		// Test anchor.
 		$url = Redirect::get_url( 'simple', array( 'anchor' => 'value' ) );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&anchor=value', $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org&anchor=value', $url );
 
 		// Test anchor special chars.
 		$url = Redirect::get_url( 'simple', array( 'anchor' => 'key=value&key2=value2' ) );
 		$v   = rawurlencode( 'key=value&key2=value2' );
-		$this->assertEquals( 'https://jetpack.com/redirect?source=simple&site=example.org&anchor=' . $v, $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?source=simple&site=example.org&anchor=' . $v, $url );
 
 		// Test informing URL.
 		$url = Redirect::get_url( 'https://wordpress.com/support' );
 		$v   = rawurlencode( 'https://wordpress.com/support' );
-		$this->assertEquals( 'https://jetpack.com/redirect?url=' . $v . '&site=example.org', $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?url=' . $v . '&site=example.org', $url );
 
 		// Test URL and query.
 		$url   = Redirect::get_url( 'https://wordpress.com/support', array( 'query' => 'key=value&key2=value2' ) );
 		$v     = rawurlencode( 'key=value&key2=value2' );
 		$v_url = rawurlencode( 'https://wordpress.com/support' );
-		$this->assertEquals( 'https://jetpack.com/redirect?url=' . $v_url . '&site=example.org&query=' . $v, $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?url=' . $v_url . '&site=example.org&query=' . $v, $url );
 
 		// Test URL and query, discarding info from url.
 		$url   = Redirect::get_url( 'https://wordpress.com/support?this=that#super', array( 'query' => 'key=value&key2=value2' ) );
 		$v     = rawurlencode( 'key=value&key2=value2' );
 		$v_url = rawurlencode( 'https://wordpress.com/support' );
-		$this->assertEquals( 'https://jetpack.com/redirect?url=' . $v_url . '&site=example.org&query=' . $v, $url );
+		$this->assertEquals( 'https://jetpack.com/redirect/?url=' . $v_url . '&site=example.org&query=' . $v, $url );
 
 	}
 


### PR DESCRIPTION
`https://jetpack.com/redirect` just redirects requests to `https://jetpack.com/redirect/`. Adding the trailing `/` means that redirect links avoid an extra round trip just for that redirect.

For me, this PR saves 300ms per redirect, which (assuming an average of 10 redirect URLs visited a day), will pay back the hour it took to investigate and write this fix in just 3 years!

I also updated the comments which referred to the URL without the trailing `/`, as that may have contributed to the bug getting in originally.

#### Changes proposed in this Pull Request:
* Update `Redirect::get_url()` to return a redirect URL with a trailing `/`.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Bug fix.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Open dev tools in your browser, go the Network tab, and ensure it's set to keep logs between page loads.
* Visit https://jetpack.com/redirect?url=https://wordpress.com/support, and note the additional redirect.

#### Proposed changelog entry for your changes:
* Improve performance of redirect URLs.
