### PR TITLE
Add and expose allowed_mime_types prop

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -770,9 +770,9 @@ class Jetpack_Gutenberg {
 					'is_active'                 => Jetpack::is_active(),
 					'is_current_user_connected' => $is_current_user_connected,
 				),
-				'siteFragment'       => $site_fragment,
-				'tracksUserData'     => $user_data,
-				'wpcomBlogId'        => $blog_id,
+				'siteFragment'     => $site_fragment,
+				'tracksUserData'   => $user_data,
+				'wpcomBlogId'      => $blog_id,
 				'allowedMimeTypes' => wp_get_mime_types(),
 			)
 		);


### PR DESCRIPTION
This PR adds and exposes a list of allowed mime types to the global Initial state.

![image](https://user-images.githubusercontent.com/77539/84277740-45f61800-ab0a-11ea-9a2c-f2aef822ff44.png)

#### Changes proposed in this Pull Request:

* Add and expose a list of allowed mime types to the global Initial state.

#### Testing instructions:

Confirm that these values are present in the window object in the client-side.

#### Proposed changelog entry for your changes:

<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add and expose a list of allowed mime types to the global Initial state.
