### PR TITLE
External Media: Add arrow keys navigation

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -21,34 +21,32 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 	 * @var array
 	 */
 	public $media_schema = array(
-		'items' => array(
-			'type'       => 'object',
-			'required'   => true,
-			'properties' => array(
-				'caption' => array(
-					'type' => 'string',
-				),
-				'guid'    => array(
-					'items' => array(
-						'caption' => array(
-							'type' => 'string',
-						),
-						'name'    => array(
-							'type' => 'string',
-						),
-						'title'   => array(
-							'type' => 'string',
-						),
-						'url'     => array(
-							'format' => 'uri',
-							'type'   => 'string',
-						),
+		'type'       => 'object',
+		'required'   => true,
+		'properties' => array(
+			'caption' => array(
+				'type' => 'string',
+			),
+			'guid'    => array(
+				'items' => array(
+					'caption' => array(
+						'type' => 'string',
 					),
-					'type'  => 'array',
+					'name'    => array(
+						'type' => 'string',
+					),
+					'title'   => array(
+						'type' => 'string',
+					),
+					'url'     => array(
+						'format' => 'uri',
+						'type'   => 'string',
+					),
 				),
-				'title'   => array(
-					'type' => 'string',
-				),
+				'type'  => 'array',
+			),
+			'title'   => array(
+				'type' => 'string',
 			),
 		),
 	);
@@ -120,7 +118,7 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 				'args'                => array(
 					'media' => array(
 						'description'       => __( 'Media data to copy.', 'jetpack' ),
-						'items'             => array_values( $this->media_schema ),
+						'items'             => $this->media_schema,
 						'required'          => true,
 						'type'              => 'array',
 						'sanitize_callback' => array( $this, 'sanitize_media' ),

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -231,6 +231,14 @@ class WPCOM_REST_API_V2_Endpoint_External_Media extends WP_REST_Controller {
 				$response = json_decode( wp_remote_retrieve_body( $response ) );
 				break;
 
+			case 401:
+				$response = new WP_Error(
+					'authorization_required',
+					__( 'You are not connected to that service.', 'jetpack' ),
+					array( 'status' => 403 )
+				);
+				break;
+
 			case 403:
 				$error    = json_decode( wp_remote_retrieve_body( $response ) );
 				$response = new WP_Error( $error->code, $error->message, $error->data );

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -358,6 +358,9 @@ $grid-size: 8px;
 }
 
 // Reset placeholder button margin.
-.components-placeholder__fieldset .components-dropdown .components-button {
-	margin-right: 8px;
+.components-placeholder__fieldset,
+.editor-post-featured-image {
+	.components-dropdown .components-button {
+		margin-right: 8px;
+	}
 }

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -17,44 +17,20 @@ $grid-size: 8px;
 	}
 }
 
+.jetpack-external-media-browser--visually-hidden {
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect( 1px, 1px, 1px, 1px );
+	white-space: nowrap; /* added line */
+}
+
 /**
  * Media item container
  */
 
-.jetpack-external-media-browser__is-copying {
-	max-height: 20%;
-	max-width: 20%;
-	min-width: 480px;
-	min-height: 360px + 56px;
-
-	.jetpack-external-media-browser__single {
-		height: 300px;
-	}
-
-	.jetpack-external-media-browser__media {
-		height: 100%;
-	}
-
-	.is-transient {
-		border: 0;
-		background: 0;
-		padding: 0;
-		height: 100%;
-
-		&.jetpack-external-media-browser__media__item__selected {
-			box-shadow: none;
-			border-radius: 0;
-		}
-
-		img {
-			width: 100%;
-			height: 100%;
-			object-fit: contain;
-		}
-	}
-}
-
-.jetpack-external-media-browser:not( .jetpack-external-media-browser__is-copying ) {
+.jetpack-external-media-browser {
 	.is-error {
 		margin-bottom: 1em;
 		margin-left: 0;
@@ -71,29 +47,16 @@ $grid-size: 8px;
 	}
 }
 
-@media ( min-width: 600px ) {
-	.components-modal__content {
-		width: 90vw;
-		height: 90vh;
-	}
+.jetpack-external-media-browser--is-copying {
+	pointer-events: none;
 }
 
-.jetpack-external-media-browser__single {
-	position: relative;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+.components-modal__content {
+	width: 100%;
 
-	.is-transient img {
-		opacity: 0.3;
-	}
-
-	.components-spinner {
-		position: absolute;
-		top: 50%;
-		right: 50%;
-		margin-top: -9px;
-		margin-right: -9px;
+	@media ( min-width: 600px ) {
+		width: 90vw;
+		height: 90vh;
 	}
 }
 
@@ -132,14 +95,27 @@ $grid-size: 8px;
 		&.is-transient img {
 			opacity: 0.3;
 		}
+	}
+
+	.jetpack-external-media-browser__media__copying_indicator {
+		display: flex;
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		text-align: center;
 
 		.components-spinner {
-			position: absolute;
-			top: 50%;
-			right: 50%;
-			margin-top: -9px;
-			margin-right: -9px;
+			margin-bottom: $grid-size;
 		}
+	}
+
+	.jetpack-external-media-browser__media__copying_indicator__label {
+		font-size: 12px;
 	}
 
 	.jetpack-external-media-browser__media__folder {

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -27,6 +27,19 @@ $grid-size: 8px;
 }
 
 /**
+ * Media button menu
+ */
+
+/**
+ * Hide the menu when the modal is open. Hacky, but necessary to allow the focus
+ * to return to selected option when modal is closed. This is how it's currenly
+ * also implemented in Gutenberg's MediaReplaceFlow.
+ */
+.modal-open .jetpack-external-media-button-menu__options {
+	display: none;
+}
+
+/**
  * Media item container
  */
 

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -101,7 +101,7 @@ function MediaBrowser( props ) {
 
 	return (
 		<div className={ wrapper }>
-			<ul className={ classes }>
+			<div role="presentation" className={ classes }>
 				{ media.map( ( item, index ) => (
 					<MediaItem
 						item={ item }
@@ -115,19 +115,19 @@ function MediaBrowser( props ) {
 
 				{ media.length === 0 && ! isLoading && <EmptyResults /> }
 				{ isLoading && <MediaPlaceholder /> }
+			</div>
 
-				{ pageHandle && ! isLoading && (
-					<Button
-						isLarge
-						isSecondary
-						className="jetpack-external-media-browser__loadmore"
-						disabled={ isLoading || isCopying }
-						onClick={ onLoadMoreClick }
-					>
-						{ __( 'Load More', 'jetpack' ) }
-					</Button>
-				) }
-			</ul>
+			{ pageHandle && ! isLoading && (
+				<Button
+					isLarge
+					isSecondary
+					className="jetpack-external-media-browser__loadmore"
+					disabled={ isLoading }
+					onClick={ onLoadMoreClick }
+				>
+					{ __( 'Load More', 'jetpack' ) }
+				</Button>
+			) }
 
 			{ hasMediaItems && <SelectButton /> }
 		</div>

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -128,7 +128,7 @@ function MediaBrowser( props ) {
 
 	return (
 		<div className={ wrapper }>
-			<div role="presentation" className={ classes }>
+			<ul className={ classes }>
 				{ media.map( ( item, index ) => (
 					<MediaItem
 						item={ item }
@@ -148,7 +148,7 @@ function MediaBrowser( props ) {
 
 				{ media.length === 0 && ! isLoading && <EmptyResults /> }
 				{ isLoading && <MediaPlaceholder /> }
-			</div>
+			</ul>
 
 			{ pageHandle && ! isLoading && (
 				<Button

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -101,44 +101,34 @@ function MediaBrowser( props ) {
 		);
 	};
 
-	const handleArrowKeysNavigation = key => {
-		switch ( key ) {
+	const handleArrowKeysNavigation = ( keyCode, index ) => {
+		switch ( keyCode ) {
 			case LEFT:
-				if ( focused >= 1 ) {
-					setFocused( focused - 1 );
+				if ( index >= 1 ) {
+					setFocused( index - 1 );
 				}
 				break;
 			case RIGHT:
-				if ( focused < media.length ) {
-					setFocused( focused + 1 );
+				if ( index < media.length ) {
+					setFocused( index + 1 );
 				}
 				break;
 			case UP:
-				if ( focused >= 5 ) {
-					setFocused( focused - 5 );
+				if ( index >= 5 ) {
+					setFocused( index - 5 );
 				}
 				break;
 			case DOWN:
-				if ( focused < media.length - 5 ) {
-					setFocused( focused + 5 );
+				if ( index < media.length - 5 ) {
+					setFocused( index + 5 );
 				}
 				break;
-		}
-	};
-
-	const handleListKeyDown = event => {
-		if ( [ LEFT, RIGHT, UP, DOWN ].includes( event.keyCode ) ) {
-			handleArrowKeysNavigation( event.keyCode );
-			// ToDo: make only content scrollable, leave the form stick to top
-			event.target.scrollIntoView(); // this doesn't work well - needs a few style tweaks first
-			event.stopPropagation();
-			event.preventDefault();
 		}
 	};
 
 	return (
 		<div className={ wrapper }>
-			<div role="presentation" className={ classes } onKeyDown={ handleListKeyDown }>
+			<div role="presentation" className={ classes }>
 				{ media.map( ( item, index ) => (
 					<MediaItem
 						item={ item }
@@ -146,6 +136,9 @@ function MediaBrowser( props ) {
 						onClick={ image => {
 							onSelectImage( image );
 							setFocused( index );
+						} }
+						onKeyDown={ event => {
+							handleArrowKeysNavigation( event.keyCode, index );
 						} }
 						focus={ index === focused }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -39,6 +39,7 @@ function MediaBrowser( props ) {
 	} = props;
 	const [ selected, setSelected ] = useState( [] );
 	const [ focused, setFocused ] = useState( -1 );
+	const [ columns, setColumns ] = useState( 5 );
 
 	const onSelectImage = useCallback(
 		newlySelected => {
@@ -114,13 +115,13 @@ function MediaBrowser( props ) {
 				}
 				break;
 			case UP:
-				if ( index >= 5 ) {
-					setFocused( index - 5 );
+				if ( index >= columns ) {
+					setFocused( index - columns );
 				}
 				break;
 			case DOWN:
-				if ( index < media.length - 5 ) {
-					setFocused( index + 5 );
+				if ( index < media.length - columns ) {
+					setFocused( index + columns );
 				}
 				break;
 		}

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { memo, useCallback, useState, useRef } from '@wordpress/element';
+import { memo, useCallback, useState, useRef, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
@@ -39,7 +39,9 @@ function MediaBrowser( props ) {
 	} = props;
 	const [ selected, setSelected ] = useState( [] );
 	const [ focused, setFocused ] = useState( -1 );
-	const [ columns, setColumns ] = useState( 5 );
+	const [ columns, setColumns ] = useState( -1 );
+
+	const gridEl = useRef( null );
 
 	const onSelectImage = useCallback(
 		newlySelected => {
@@ -102,6 +104,31 @@ function MediaBrowser( props ) {
 		);
 	};
 
+	/**
+	 * Counts how many items are in a row by checking how many of the grid's child items have a matching offsetTop.
+	 */
+	const checkColumns = () => {
+		let perRow = 1;
+
+		const items = gridEl.current.children;
+
+		if ( items.length > 0 ) {
+			const firstOffset = items[ 0 ].offsetTop;
+
+			// Check how many items have a matching offsetTop.
+			// This will give us the total number of items in a row.
+			while ( perRow < items.length && items[ perRow ].offsetTop === firstOffset ) {
+				++perRow;
+			}
+		}
+
+		setColumns( perRow );
+	};
+
+	useEffect( () => {
+		checkColumns();
+	}, [ media ] );
+
 	const handleArrowKeysNavigation = ( keyCode, index ) => {
 		switch ( keyCode ) {
 			case LEFT:
@@ -129,7 +156,7 @@ function MediaBrowser( props ) {
 
 	return (
 		<div className={ wrapper }>
-			<ul className={ classes }>
+			<ul ref={ gridEl } className={ classes }>
 				{ media.map( ( item, index ) => (
 					<MediaItem
 						item={ item }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -25,7 +25,17 @@ const EmptyResults = memo( () => (
 ) );
 
 function MediaBrowser( props ) {
-	const { media, isLoading, pageHandle, className, multiple, setPath, nextPage, onCopy } = props;
+	const {
+		media,
+		isCopying,
+		isLoading,
+		pageHandle,
+		className,
+		multiple,
+		setPath,
+		nextPage,
+		onCopy,
+	} = props;
 	const [ selected, setSelected ] = useState( [] );
 
 	const onSelectImage = useCallback(
@@ -70,6 +80,25 @@ function MediaBrowser( props ) {
 		nextPage();
 	};
 
+	const SelectButton = () => {
+		const disabled = selected.length === 0 || isCopying;
+		const label = isCopying ? __( 'Inserting…', 'jetpack' ) : __( 'Select', 'jetpack' );
+
+		return (
+			<div className="jetpack-external-media-browser__media__toolbar">
+				<Button
+					isPrimary
+					isLarge
+					isBusy={ isCopying }
+					disabled={ disabled }
+					onClick={ onCopyAndInsert }
+				>
+					{ label }
+				</Button>
+			</div>
+		);
+	};
+
 	return (
 		<div className={ wrapper }>
 			<ul className={ classes }>
@@ -80,6 +109,7 @@ function MediaBrowser( props ) {
 						onClick={ onSelectImage }
 						focusOnMount={ !! prevMediaCount.current && index === prevMediaCount.current }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
+						isCopying={ isCopying }
 					/>
 				) ) }
 
@@ -91,7 +121,7 @@ function MediaBrowser( props ) {
 						isLarge
 						isSecondary
 						className="jetpack-external-media-browser__loadmore"
-						disabled={ isLoading }
+						disabled={ isLoading || isCopying }
 						onClick={ onLoadMoreClick }
 					>
 						{ __( 'Load More', 'jetpack' ) }
@@ -99,13 +129,7 @@ function MediaBrowser( props ) {
 				) }
 			</ul>
 
-			{ hasMediaItems && (
-				<div className="jetpack-external-media-browser__media__toolbar">
-					<Button isPrimary isLarge disabled={ selected.length === 0 } onClick={ onCopyAndInsert }>
-						{ __( 'Copy & Insert', 'jetpack' ) }
-					</Button>
-				</div>
-			) }
+			{ hasMediaItems && <SelectButton /> }
 		</div>
 	);
 }

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -58,8 +58,7 @@ function MediaBrowser( props ) {
 	} = props;
 	const [ selected, setSelected ] = useState( [] );
 	const [ focused, setFocused ] = useState( -1 );
-	const [ columns, setColumns ] = useState( -1 );
-
+	const columns = useRef( -1 );
 	const gridEl = useRef( null );
 
 	const select = useCallback(
@@ -107,13 +106,13 @@ function MediaBrowser( props ) {
 				}
 				break;
 			case UP:
-				if ( index >= columns ) {
-					setFocused( index - columns );
+				if ( index >= columns.current ) {
+					setFocused( index - columns.current );
 				}
 				break;
 			case DOWN:
-				if ( index < media.length - columns ) {
-					setFocused( index + columns );
+				if ( index < media.length - columns.current ) {
+					setFocused( index + columns.current );
 				}
 				break;
 		}
@@ -132,7 +131,7 @@ function MediaBrowser( props ) {
 			const firstOffset = items[ 0 ].offsetTop;
 
 			/**
-			 *Check how many items have a matching offsetTop. This will give us the
+			 * Check how many items have a matching offsetTop. This will give us the
 			 * total number of items in a row.
 			 */
 			while ( perRow < items.length && items[ perRow ].offsetTop === firstOffset ) {
@@ -140,7 +139,7 @@ function MediaBrowser( props ) {
 			}
 		}
 
-		setColumns( perRow );
+		columns.current = perRow;
 	};
 
 	useEffect( () => {

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -159,23 +159,6 @@ function MediaBrowser( props ) {
 		}
 	}, [ media ] );
 
-	const handleMediaItemClick = ( event, { item, index } ) => {
-		select( item, index );
-	};
-
-	const handleMediaItemKeyDown = ( event, { item, index } ) => {
-		if ( [ LEFT, RIGHT, UP, DOWN ].includes( event.keyCode ) ) {
-			navigate( event.keyCode, index );
-		}
-
-		if ( [ SPACE, ENTER ].includes( event.keyCode ) ) {
-			select( item, index );
-			event.preventDefault(); // Prevent space from scrolling the page down.
-		}
-
-		event.stopPropagation();
-	};
-
 	const handleLoadMoreButtonClick = () => {
 		if ( media.length ) {
 			setFocused( media.length );
@@ -186,6 +169,27 @@ function MediaBrowser( props ) {
 	const handleSelectButtonClick = useCallback( () => {
 		onCopy( selected );
 	}, [ selected, onCopy ] );
+
+	const handleMediaItemClick = ( event, { item, index } ) => {
+		select( item, index );
+	};
+
+	const handleMediaItemKeyDown = ( event, { item, index } ) => {
+		if ( [ LEFT, RIGHT, UP, DOWN ].includes( event.keyCode ) ) {
+			navigate( event.keyCode, index );
+		}
+
+		if ( SPACE === event.keyCode ) {
+			select( item, index );
+			event.preventDefault(); // Prevent space from scrolling the page down.
+		}
+
+		if ( ENTER === event.keyCode ) {
+			handleSelectButtonClick();
+		}
+
+		event.stopPropagation();
+	};
 
 	return (
 		<div className={ wrapper }>

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -196,7 +196,7 @@ function MediaBrowser( props ) {
 
 			{ hasMediaItems && (
 				<SelectButton
-					isCopying
+					isCopying={ isCopying }
 					disabled={ selected.length === 0 || isCopying }
 					onClick={ handleSelectButtonClick }
 				/>

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -178,15 +178,11 @@ function MediaBrowser( props ) {
 	const handleMediaItemKeyDown = ( event, { item, index } ) => {
 		if ( [ LEFT, RIGHT, UP, DOWN ].includes( event.keyCode ) ) {
 			navigate( event.keyCode, index );
-		}
-
-		if ( SPACE === event.keyCode ) {
+		} else if ( SPACE === event.keyCode ) {
 			select( item, index );
 			event.preventDefault(); // Prevent space from scrolling the page down.
-		}
-
-		if ( ENTER === event.keyCode ) {
-			handleSelectButtonClick();
+		} else if ( ENTER === event.keyCode ) {
+			select( item, index );
 		}
 
 		event.stopPropagation();

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -172,6 +172,8 @@ function MediaBrowser( props ) {
 			select( item, index );
 			event.preventDefault(); // Prevent space from scrolling the page down.
 		}
+
+		event.stopPropagation();
 	};
 
 	const handleLoadMoreButtonClick = () => {

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -63,7 +63,7 @@ function MediaBrowser( props ) {
 	const gridEl = useRef( null );
 
 	const select = useCallback(
-		( newlySelected, index ) => {
+		newlySelected => {
 			let newSelected = [ newlySelected ];
 
 			if ( newlySelected.type === 'folder' ) {
@@ -171,7 +171,7 @@ function MediaBrowser( props ) {
 	}, [ selected, onCopy ] );
 
 	const handleMediaItemClick = ( event, { item, index } ) => {
-		select( item, index );
+		select( item );
 		setFocused( index );
 	};
 
@@ -179,10 +179,10 @@ function MediaBrowser( props ) {
 		if ( [ LEFT, RIGHT, UP, DOWN ].includes( event.keyCode ) ) {
 			navigate( event.keyCode, index );
 		} else if ( SPACE === event.keyCode ) {
-			select( item, index );
+			select( item );
 			event.preventDefault(); // Prevent space from scrolling the page down.
 		} else if ( ENTER === event.keyCode ) {
-			select( item, index );
+			select( item );
 		}
 
 		event.stopPropagation();

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -142,8 +143,20 @@ function MediaBrowser( props ) {
 		columns.current = perRow;
 	};
 
+	const checkColumnsDebounced = debounce( checkColumns, 400 );
+
 	useEffect( () => {
-		checkColumns();
+		// Add listener on mount:
+		window.addEventListener( 'resize', checkColumnsDebounced );
+		return () => {
+			window.removeEventListener( 'resize', checkColumnsDebounced );
+		};
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect( () => {
+		if ( media.length ) {
+			checkColumns(); // Set columns value when media are loaded.
+		}
 	}, [ media ] );
 
 	const handleMediaItemClick = ( event, { item, index } ) => {

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -170,7 +170,7 @@ function MediaBrowser( props ) {
 
 		if ( [ SPACE, ENTER ].includes( event.keyCode ) ) {
 			select( item, index );
-			event.preventDefault(); // Prevent space from scrolling the page down;
+			event.preventDefault(); // Prevent space from scrolling the page down.
 		}
 	};
 

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -172,7 +172,6 @@ function MediaBrowser( props ) {
 
 	const handleMediaItemClick = ( event, { item, index } ) => {
 		select( item );
-		setFocused( index );
 	};
 
 	const handleMediaItemKeyDown = ( event, { item, index } ) => {

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -146,7 +146,7 @@ function MediaBrowser( props ) {
 	const checkColumnsDebounced = debounce( checkColumns, 400 );
 
 	useEffect( () => {
-		// Add listener on mount:
+		// Re-set columns on window resize:
 		window.addEventListener( 'resize', checkColumnsDebounced );
 		return () => {
 			window.removeEventListener( 'resize', checkColumnsDebounced );

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -154,8 +154,9 @@ function MediaBrowser( props ) {
 	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	useEffect( () => {
-		if ( media.length ) {
-			checkColumns(); // Set columns value when media are loaded.
+		// Set columns value once when media are loaded.
+		if ( media.length && columns.current === -1 ) {
+			checkColumns();
 		}
 	}, [ media ] );
 

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -79,7 +79,6 @@ function MediaBrowser( props ) {
 			}
 
 			setSelected( newSelected );
-			setFocused( index );
 		},
 		[ selected, multiple, setPath ]
 	);
@@ -173,6 +172,7 @@ function MediaBrowser( props ) {
 
 	const handleMediaItemClick = ( event, { item, index } ) => {
 		select( item, index );
+		setFocused( index );
 	};
 
 	const handleMediaItemKeyDown = ( event, { item, index } ) => {

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -50,7 +50,7 @@ function MediaItem( props ) {
 
 	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (
-		<li
+		<div
 			ref={ itemEl }
 			className={ classes }
 			onClick={ isCopying ? undefined : onClick }
@@ -77,7 +77,9 @@ function MediaItem( props ) {
 					<div className="jetpack-external-media-browser__media__count">{ children }</div>
 				</div>
 			) }
-		</li>
+
+			{ isSelected && isCopying && <Spinner /> }
+		</div>
 	);
 }
 

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -27,7 +27,7 @@ function MediaItem( props ) {
 		}
 	};
 
-	const { item, focusOnMount, isSelected, isCopying = false } = props;
+	const { item, focus, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;
 	const { medium = null, fmt_hd = null } = thumbnails;
 	const alt = title || caption || name;
@@ -41,12 +41,10 @@ function MediaItem( props ) {
 	const itemEl = useRef( null );
 
 	useEffect( () => {
-		if ( focusOnMount ) {
+		if ( focus ) {
 			itemEl.current.focus();
 		}
-		// Passing empty dependency array to focus on mount only.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ focus ] );
 
 	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -55,7 +55,7 @@ function MediaItem( props ) {
 
 	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (
-		<div
+		<li
 			ref={ itemEl }
 			className={ classes }
 			onClick={ isCopying ? undefined : onClick }
@@ -84,7 +84,7 @@ function MediaItem( props ) {
 			) }
 
 			{ isSelected && isCopying && <Spinner /> }
-		</div>
+		</li>
 	);
 }
 

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -18,14 +18,21 @@ function MediaItem( props ) {
 		}
 	}, [ props.onClick ] );
 
-	// Catch space and enter key presses.
-	const onKeyDown = event => {
-		if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
-			// Prevent spacebar from scrolling the page down.
-			event.preventDefault();
-			onClick( event );
-		}
-	};
+	const onKeyDown = useCallback(
+		event => {
+			// Catch space and enter key presses.
+			if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+				// Prevent spacebar from scrolling the page down.
+				event.preventDefault();
+				onClick( event );
+			}
+
+			if ( props.onKeyDown ) {
+				props.onKeyDown( event );
+			}
+		},
+		[ props.onKeyDown ]
+	);
 
 	const { item, focus, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { __ } from '@wordpress/i18n';
 
 function MediaItem( props ) {
 	const onClick = useCallback( () => {
@@ -34,7 +35,7 @@ function MediaItem( props ) {
 		'jetpack-external-media-browser__media__item': true,
 		'jetpack-external-media-browser__media__item__selected': isSelected,
 		'jetpack-external-media-browser__media__folder': type === 'folder',
-		'is-transient': isSelected && isCopying,
+		'is-transient': isCopying,
 	} );
 
 	const itemEl = useRef( null );
@@ -52,13 +53,23 @@ function MediaItem( props ) {
 		<li
 			ref={ itemEl }
 			className={ classes }
-			onClick={ onClick }
-			onKeyDown={ onKeyDown }
+			onClick={ isCopying ? undefined : onClick }
+			onKeyDown={ isCopying ? undefined : onKeyDown }
 			role="checkbox"
 			tabIndex="0"
-			aria-checked={ isSelected ? 'true' : 'false' }
+			aria-checked={ !! isSelected }
+			aria-disabled={ !! isCopying }
 		>
-			<img src={ medium || fmt_hd } alt={ alt } title={ alt } />
+			{ isSelected && isCopying && (
+				<div className="jetpack-external-media-browser__media__copying_indicator">
+					<Spinner />
+					<div className="jetpack-external-media-browser__media__copying_indicator__label">
+						{ __( 'Inserting Image…', 'jetpack' ) }
+					</div>
+				</div>
+			) }
+
+			<img src={ medium || fmt_hd } alt={ alt } />
 
 			{ type === 'folder' && (
 				<div className="jetpack-external-media-browser__media__info">
@@ -66,8 +77,6 @@ function MediaItem( props ) {
 					<div className="jetpack-external-media-browser__media__count">{ children }</div>
 				</div>
 			) }
-
-			{ isSelected && isCopying && <Spinner /> }
 		</li>
 	);
 }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -75,8 +75,6 @@ function MediaItem( props ) {
 					<div className="jetpack-external-media-browser__media__count">{ children }</div>
 				</div>
 			) }
-
-			{ isSelected && isCopying && <Spinner /> }
 		</li>
 	);
 }

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -6,33 +6,26 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
-import { ENTER, SPACE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 
 function MediaItem( props ) {
-	const onClick = useCallback( () => {
+	const onClick = event => {
+		const { item, index } = props;
+
 		if ( props.onClick ) {
-			props.onClick( props.item );
+			props.onClick( event, { item, index } );
 		}
-	}, [ props.onClick ] );
+	};
 
-	const onKeyDown = useCallback(
-		event => {
-			// Catch space and enter key presses.
-			if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
-				// Prevent spacebar from scrolling the page down.
-				event.preventDefault();
-				onClick( event );
-			}
+	const onKeyDown = event => {
+		const { item, index } = props;
 
-			if ( props.onKeyDown ) {
-				props.onKeyDown( event );
-			}
-		},
-		[ props.onKeyDown ]
-	);
+		if ( props.onKeyDown ) {
+			props.onKeyDown( event, { item, index } );
+		}
+	};
 
 	const { item, focus, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;

--- a/extensions/shared/external-media/media-button/index.js
+++ b/extensions/shared/external-media/media-button/index.js
@@ -33,7 +33,9 @@ function MediaButton( props ) {
 	};
 
 	return (
-		<>
+		// No added functionality, just capping event propagation.
+		// eslint-disable-next-line  jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+		<div onClick={ event => event.stopPropagation() }>
 			<MediaButtonMenu
 				{ ...props }
 				setSelectedSource={ setSelectedSource }
@@ -42,7 +44,7 @@ function MediaButton( props ) {
 			/>
 
 			{ ExternalLibrary && <ExternalLibrary onClose={ closeLibrary } { ...mediaProps } /> }
-		</>
+		</div>
 	);
 }
 

--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -27,19 +27,6 @@ function MediaButtonMenu( props ) {
 		);
 	}
 
-	const dropdownOpen = onToggle => {
-		onToggle();
-		open();
-	};
-	const changeSource = ( source, onToggle ) => {
-		setSelectedSource( source );
-		onToggle();
-	};
-	const openLibrary = onToggle => {
-		onToggle();
-		open();
-	};
-
 	let label = __( 'Select Image', 'jetpack' );
 
 	if ( mediaProps.multiple ) {
@@ -56,11 +43,12 @@ function MediaButtonMenu( props ) {
 
 			<Dropdown
 				position="bottom right"
+				contentClassName="jetpack-external-media-button-menu__options"
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
 						isTertiary={ ! isFeatured }
 						isPrimary={ isFeatured }
-						className="jetpack-external-media-browse-button"
+						className="jetpack-external-media-button-menu"
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
@@ -68,17 +56,14 @@ function MediaButtonMenu( props ) {
 						{ label }
 					</Button>
 				) }
-				renderContent={ ( { onToggle } ) => (
+				renderContent={ () => (
 					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
-							<MenuItem icon="admin-media" onClick={ () => openLibrary( onToggle ) }>
+							<MenuItem icon="admin-media" onClick={ open }>
 								{ __( 'Media Library', 'jetpack' ) }
 							</MenuItem>
 
-							<MediaSources
-								open={ () => dropdownOpen( onToggle ) }
-								setSource={ source => changeSource( source, onToggle ) }
-							/>
+							<MediaSources open={ open } setSource={ setSelectedSource } />
 						</MenuGroup>
 					</NavigableMenu>
 				) }

--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -13,6 +13,10 @@ function MediaButtonMenu( props ) {
 	const { mediaProps, open, setSelectedSource, isFeatured, isReplace } = props;
 	const originalComponent = mediaProps.render;
 
+	if ( isFeatured && mediaProps.value === undefined ) {
+		return originalComponent( { open } );
+	}
+
 	if ( isReplace ) {
 		return (
 			<MediaSources
@@ -36,9 +40,10 @@ function MediaButtonMenu( props ) {
 		open();
 	};
 
-	if ( isFeatured && mediaProps.value === undefined ) {
-		return originalComponent( { open } );
-	}
+	const label =
+		mediaProps.allowedTypes.length > 1
+			? __( 'Select Media', 'jetpack' )
+			: __( 'Select Image', 'jetpack' );
 
 	return (
 		<>
@@ -55,11 +60,11 @@ function MediaButtonMenu( props ) {
 						aria-expanded={ isOpen }
 						onClick={ onToggle }
 					>
-						{ __( 'Select Image', 'jetpack' ) }
+						{ label }
 					</Button>
 				) }
 				renderContent={ ( { onToggle } ) => (
-					<NavigableMenu aria-label={ __( 'Select Image', 'jetpack' ) }>
+					<NavigableMenu aria-label={ label }>
 						<MenuGroup>
 							<MenuItem icon="admin-media" onClick={ () => openLibrary( onToggle ) }>
 								{ __( 'Media Library', 'jetpack' ) }

--- a/extensions/shared/external-media/media-button/media-menu.js
+++ b/extensions/shared/external-media/media-button/media-menu.js
@@ -40,10 +40,15 @@ function MediaButtonMenu( props ) {
 		open();
 	};
 
-	const label =
-		mediaProps.allowedTypes.length > 1
-			? __( 'Select Media', 'jetpack' )
-			: __( 'Select Image', 'jetpack' );
+	let label = __( 'Select Image', 'jetpack' );
+
+	if ( mediaProps.multiple ) {
+		label = __( 'Select Images', 'jetpack' );
+	}
+
+	if ( mediaProps.allowedTypes.length > 1 ) {
+		label = __( 'Select Media', 'jetpack' );
+	}
 
 	return (
 		<>

--- a/extensions/shared/external-media/sources/google-photos/filter-view.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-view.js
@@ -44,7 +44,7 @@ function addFilter( existing, newFilter ) {
 
 function GoogleFilterView( props ) {
 	const [ currentFilter, setCurrentFilter ] = useState( getFirstFilter( [] ) );
-	const { isLoading, filters, canChangeMedia } = props;
+	const { isLoading, isCopying, filters, canChangeMedia } = props;
 	const remainingFilters = removeMediaType( getFilterOptions( filters ), canChangeMedia );
 	const setFilter = () => {
 		const newFilters = addFilter( filters, currentFilter );
@@ -62,12 +62,12 @@ function GoogleFilterView( props ) {
 			<SelectControl
 				label={ __( 'Filters', 'jetpack' ) }
 				value={ currentFilter }
-				disabled={ isLoading }
+				disabled={ isLoading || isCopying }
 				options={ remainingFilters }
 				onChange={ setCurrentFilter }
 			/>
 
-			<Button disabled={ isLoading } isSecondary isSmall onClick={ setFilter }>
+			<Button disabled={ isLoading || isCopying } isSecondary isSmall onClick={ setFilter }>
 				{ __( 'Add Filter', 'jetpack' ) }
 			</Button>
 		</Fragment>

--- a/extensions/shared/external-media/sources/google-photos/google-photos-auth.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-auth.js
@@ -20,8 +20,7 @@ import AuthInstructions from './auth-instructions';
 import AuthProgress from './auth-progress';
 
 function GooglePhotosAuth( props ) {
-	const { getMedia } = props;
-
+	const { setAuthenticated } = props;
 	const [ isAuthing, setIsAuthing ] = useState( false );
 
 	const onAuthorize = useCallback( () => {
@@ -39,15 +38,14 @@ function GooglePhotosAuth( props ) {
 				// Open authorize URL in a window and let it play out
 				requestExternalAccess( service.connect_URL, () => {
 					setIsAuthing( false );
-					const url = getApiUrl( 'list', SOURCE_GOOGLE_PHOTOS );
-					getMedia( url, true );
+					setAuthenticated( true );
 				} );
 			} )
 			.catch( () => {
 				// Not much we can tell the user at this point so let them try and auth again
 				setIsAuthing( false );
 			} );
-	}, [ getMedia ] );
+	}, [ setAuthenticated ] );
 
 	return (
 		<div className="jetpack-external-media-auth">

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -21,6 +21,7 @@ const isImageOnly = allowed => allowed && allowed.length === 1 && allowed[ 0 ] =
 function GooglePhotosMedia( props ) {
 	const {
 		media,
+		isCopying,
 		isLoading,
 		pageHandle,
 		multiple,
@@ -85,7 +86,7 @@ function GooglePhotosMedia( props ) {
 					className="jetpack-external-media-header__select"
 					label={ __( 'View', 'jetpack' ) }
 					value={ path.ID !== PATH_RECENT ? PATH_ROOT : PATH_RECENT }
-					disabled={ isLoading }
+					disabled={ isLoading || isCopying }
 					options={ PATH_OPTIONS }
 					onChange={ setPath }
 				/>
@@ -118,6 +119,7 @@ function GooglePhotosMedia( props ) {
 				className="jetpack-external-media-browser__google"
 				key={ listUrl }
 				media={ media }
+				isCopying={ isCopying }
 				isLoading={ isLoading }
 				nextPage={ getNextPage }
 				onCopy={ onCopy }

--- a/extensions/shared/external-media/sources/google-photos/index.js
+++ b/extensions/shared/external-media/sources/google-photos/index.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import withMedia from '../with-media';
@@ -11,7 +6,7 @@ import GooglePhotosAuth from './google-photos-auth';
 import GooglePhotosMedia from './google-photos-media';
 
 function GooglePhotos( props ) {
-	if ( props.requiresAuth ) {
+	if ( ! props.isAuthenticated ) {
 		return <GooglePhotosAuth { ...props } />;
 	}
 

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -15,7 +15,7 @@ import MediaBrowser from '../media-browser';
 import { getApiUrl } from './api';
 
 function PexelsMedia( props ) {
-	const { media, isLoading, pageHandle, multiple, copyMedia, getMedia } = props;
+	const { media, isCopying, isLoading, pageHandle, multiple, copyMedia, getMedia } = props;
 
 	const [ searchQuery, setSearchQuery ] = useState( sample( PEXELS_EXAMPLE_QUERIES ) );
 	const [ lastSearchQuery, setLastSearchQuery ] = useState( '' );
@@ -88,12 +88,15 @@ function PexelsMedia( props ) {
 					type="search"
 					value={ searchQuery }
 					onChange={ setSearchQuery }
+					disabled={ !! isCopying }
 				/>
 				<Button
 					isPrimary
 					onClick={ onSearch }
 					type="submit"
-					disabled={ ! searchQuery.length || searchQuery === previousSearchQueryValue.current }
+					disabled={
+						! searchQuery.length || searchQuery === previousSearchQueryValue.current || isCopying
+					}
 				>
 					{ __( 'Search', 'jetpack' ) }
 				</Button>
@@ -103,6 +106,7 @@ function PexelsMedia( props ) {
 				key={ lastSearchQuery }
 				className="jetpack-external-media-browser__pexels"
 				media={ media }
+				isCopying={ isCopying }
 				isLoading={ isLoading }
 				nextPage={ getNextPage }
 				onCopy={ onCopy }

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -39,6 +39,8 @@ export default function withMedia() {
 
 			modalRef = el => {
 				if ( el ) {
+					// Store modal content.
+					this.contentElement = el;
 					// Find the modal wrapper.
 					this.modalElement = el.closest( '.jetpack-external-media-browser' );
 
@@ -50,6 +52,7 @@ export default function withMedia() {
 					// Remove listeners when unmounting.
 					this.modalElement.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
 					this.modalElement = null;
+					this.contentElement = null;
 				}
 			};
 
@@ -68,7 +71,10 @@ export default function withMedia() {
 				 * This can be removed once
 				 * https://github.com/WordPress/gutenberg/issues/22940 is fixed.
 				 */
-				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
+				if (
+					[ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) &&
+					! this.contentElement.contains( event.target ) // Let event through to enable arrow keys navigation.
+				) {
 					event.stopPropagation();
 				}
 			};
@@ -236,7 +242,7 @@ export default function withMedia() {
 						aria={ { describedby } }
 						className={ classes }
 					>
-						<div ref={ this.modalRef }>
+						<div ref={ this.modalRef } className="jetpack-external-media-wrapper">
 							{ noticeUI }
 
 							<p id={ describedby } className="jetpack-external-media-browser--visually-hidden">

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -39,8 +39,6 @@ export default function withMedia() {
 
 			modalRef = el => {
 				if ( el ) {
-					// Store modal content.
-					this.contentElement = el;
 					// Find the modal wrapper.
 					this.modalElement = el.closest( '.jetpack-external-media-browser' );
 
@@ -52,7 +50,6 @@ export default function withMedia() {
 					// Remove listeners when unmounting.
 					this.modalElement.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
 					this.modalElement = null;
-					this.contentElement = null;
 				}
 			};
 
@@ -71,11 +68,8 @@ export default function withMedia() {
 				 * This can be removed once
 				 * https://github.com/WordPress/gutenberg/issues/22940 is fixed.
 				 */
-				if (
-					[ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) &&
-					! this.contentElement.contains( event.target ) // Let event through to enable arrow keys navigation.
-				) {
-					event.stopPropagation();
+				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
+					event.preventDefault();
 				}
 			};
 

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -48,10 +48,12 @@ export default function withMedia() {
 					nextHandle: false,
 					isLoading: false,
 					isCopying: null,
-					requiresAuth: false,
+					isAuthenticated: true,
 					path: { ID: PATH_RECENT },
 				};
 			}
+
+			setAuthenticated = isAuthenticated => this.setState( { isAuthenticated } );
 
 			mergeMedia( initial, media ) {
 				return uniqBy( initial.concat( media ), 'ID' );
@@ -88,7 +90,7 @@ export default function withMedia() {
 
 			handleApiError = error => {
 				if ( error.code === 'authorization_required' ) {
-					this.setState( { requiresAuth: true, isLoading: false, isCopying: false } );
+					this.setState( { isAuthenticated: false, isLoading: false, isCopying: false } );
 					return;
 				}
 
@@ -121,7 +123,7 @@ export default function withMedia() {
 				const path = this.getRequestUrl( url );
 				const method = 'GET';
 
-				this.setState( { requiresAuth: false } );
+				this.setAuthenticated( true );
 
 				apiFetch( {
 					path,
@@ -174,7 +176,7 @@ export default function withMedia() {
 			}
 
 			renderContent() {
-				const { media, isLoading, nextHandle, requiresAuth, path } = this.state;
+				const { media, isLoading, nextHandle, isAuthenticated, path } = this.state;
 				const { noticeUI, allowedTypes, multiple = false } = this.props;
 
 				return (
@@ -189,7 +191,8 @@ export default function withMedia() {
 							media={ media }
 							pageHandle={ nextHandle }
 							allowedTypes={ allowedTypes }
-							requiresAuth={ requiresAuth }
+							isAuthenticated={ isAuthenticated }
+							setAuthenticated={ this.setAuthenticated }
 							multiple={ multiple }
 							path={ path }
 							onChangePath={ this.onChangePath }

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -39,6 +39,8 @@ export default function withMedia() {
 
 			modalRef = el => {
 				if ( el ) {
+					// Store modal content.
+					this.contentElement = el;
 					// Find the modal wrapper.
 					this.modalElement = el.closest( '.jetpack-external-media-browser' );
 
@@ -50,6 +52,7 @@ export default function withMedia() {
 					// Remove listeners when unmounting.
 					this.modalElement.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
 					this.modalElement = null;
+					this.contentElement = null;
 				}
 			};
 
@@ -68,8 +71,11 @@ export default function withMedia() {
 				 * This can be removed once
 				 * https://github.com/WordPress/gutenberg/issues/22940 is fixed.
 				 */
-				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
-					event.preventDefault();
+				if (
+					[ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) &&
+					! this.contentElement.contains( event.target ) // Let event through to enable arrow keys navigation.
+				) {
+					event.stopPropagation();
 				}
 			};
 

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -11,35 +11,18 @@ import apiFetch from '@wordpress/api-fetch';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
 import { withNotices, Modal } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { PATH_RECENT } from '../constants';
-import MediaItem from '../media-browser/media-item';
-
-const CopyingMedia = ( { items } ) => {
-	const classname =
-		items.length === 1
-			? 'jetpack-external-media-browser__single'
-			: 'jetpack-external-media-browser';
-
-	return (
-		<div className={ classname }>
-			<div className="jetpack-external-media-browser__media">
-				{ items.map( item => (
-					<MediaItem item={ item } key={ item.ID } isSelected isCopying />
-				) ) }
-			</div>
-		</div>
-	);
-};
 
 export default function withMedia() {
 	return createHigherOrderComponent( OriginalComponent => {
-		// Grandfathered class as it was ported from an older codebase.
+		// Legacy class as it was ported from an older codebase.
 		class WithMediaComponent extends Component {
 			constructor( props ) {
 				super( props );
@@ -181,6 +164,24 @@ export default function withMedia() {
 				this.setState( { isCopying: items } );
 				this.props.noticeOperations.removeAllNotices();
 
+				// If we have a modal element set, focus it.
+				// Otherwise focus is reset to the body instead of staying within the Modal.
+				if ( this.modalElement ) {
+					this.modalElement.focus();
+				}
+
+				// Announce the action with appended string of all the images' alt text.
+				speak(
+					sprintf(
+						__( 'Inserting: %s', 'jetpack' ),
+						items
+							.map( item => item.title )
+							.filter( item => item )
+							.join( ', ' )
+					),
+					'polite'
+				);
+
 				apiFetch( {
 					path: apiUrl,
 					method: 'POST',
@@ -208,49 +209,54 @@ export default function withMedia() {
 				this.setState( { path }, cb );
 			};
 
-			renderContent() {
-				const { media, isLoading, nextHandle, isAuthenticated, path } = this.state;
-				const { noticeUI, allowedTypes, multiple = false } = this.props;
-
-				return (
-					// eslint-disable-next-line jsx-a11y/no-static-element-interactions
-					<div>
-						{ noticeUI }
-
-						<OriginalComponent
-							getMedia={ this.getMedia }
-							copyMedia={ this.copyMedia }
-							isLoading={ isLoading }
-							media={ media }
-							pageHandle={ nextHandle }
-							allowedTypes={ allowedTypes }
-							isAuthenticated={ isAuthenticated }
-							setAuthenticated={ this.setAuthenticated }
-							multiple={ multiple }
-							path={ path }
-							onChangePath={ this.onChangePath }
-						/>
-					</div>
-				);
-			}
-
 			render() {
-				const { isCopying } = this.state;
-				const { onClose } = this.props;
+				const { isAuthenticated, isCopying, isLoading, media, nextHandle, path } = this.state;
+				const { allowedTypes, multiple = false, noticeUI, onClose } = this.props;
 
+				const title = isCopying
+					? __( 'Inserting media', 'jetpack' )
+					: __( 'Select media', 'jetpack' );
+				const description = isCopying
+					? __(
+							'When the media is finished copying and inserting, you will be returned to the editor.',
+							'jetpack'
+					  )
+					: __( 'Select the media you would like to insert into the editor.', 'jetpack' );
+
+				const describedby = 'jetpack-external-media-browser__description';
 				const classes = classnames( {
 					'jetpack-external-media-browser': true,
-					'jetpack-external-media-browser__is-copying': isCopying,
+					'jetpack-external-media-browser--is-copying': isCopying,
 				} );
 
 				return (
 					<Modal
 						onRequestClose={ onClose }
-						title={ isCopying ? __( 'Copying Media', 'jetpack' ) : __( 'Select Media', 'jetpack' ) }
+						title={ title }
+						aria={ { describedby } }
 						className={ classes }
 					>
 						<div ref={ this.modalRef }>
-							{ isCopying ? <CopyingMedia items={ isCopying } /> : this.renderContent() }
+							{ noticeUI }
+
+							<p id={ describedby } className="jetpack-external-media-browser--visually-hidden">
+								{ description }
+							</p>
+
+							<OriginalComponent
+								getMedia={ this.getMedia }
+								copyMedia={ this.copyMedia }
+								isCopying={ isCopying }
+								isLoading={ isLoading }
+								media={ media }
+								pageHandle={ nextHandle }
+								allowedTypes={ allowedTypes }
+								isAuthenticated={ isAuthenticated }
+								setAuthenticated={ this.setAuthenticated }
+								multiple={ multiple }
+								path={ path }
+								onChangePath={ this.onChangePath }
+							/>
 						</div>
 					</Modal>
 				);

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -73,7 +73,7 @@ export default function withMedia() {
 				 */
 				if (
 					[ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) &&
-					! this.contentElement.contains( event.target ) // Let event through to enable arrow keys navigation.
+					! event.target.classList.contains( 'jetpack-external-media-browser__media__item' ) // Only let arrow key navigation on media grid items through. All others need to be stopped.
 				) {
 					event.stopPropagation();
 				}

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -37,7 +37,7 @@ export default function withMedia() {
 				};
 			}
 
-			modalRef = el => {
+			contentRef = el => {
 				if ( el ) {
 					// Store modal content.
 					this.contentElement = el;
@@ -242,7 +242,7 @@ export default function withMedia() {
 						aria={ { describedby } }
 						className={ classes }
 					>
-						<div ref={ this.modalRef } className="jetpack-external-media-wrapper">
+						<div ref={ this.contentRef } className="jetpack-external-media-wrapper">
 							{ noticeUI }
 
 							<p id={ describedby } className="jetpack-external-media-browser--visually-hidden">

--- a/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-external-media.php
+++ b/tests/php/core-api/wpcom-endpoints/test_class-wpcom-rest-api-v2-endpoint-external-media.php
@@ -1,0 +1,337 @@
+<?php // phpcs:ignore
+/**
+ * Tests for /wpcom/v2/external-media endpoints.
+ */
+
+require_once dirname( dirname( __DIR__ ) ) . '/lib/class-wp-test-jetpack-rest-testcase.php';
+
+/**
+ * Class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media
+ *
+ * @coversDefaultClass WPCOM_REST_API_V2_Endpoint_External_Media
+ */
+class WP_Test_WPCOM_REST_API_V2_Endpoint_External_Media extends WP_Test_Jetpack_REST_Testcase {
+
+	/**
+	 * Mock user ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id = 0;
+
+	/**
+	 * Name of test image.
+	 *
+	 * @var string
+	 */
+	private $image_name = 'example_image';
+
+	/**
+	 * Path to test image.
+	 *
+	 * @var string
+	 */
+	private static $image_path;
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$user_id    = $factory->user->create( array( 'role' => 'administrator' ) );
+		static::$image_path = dirname( dirname( __DIR__ ) ) . '/files/jetpack.jpg';
+	}
+
+	/**
+	 * Setup the environment for a test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( static::$user_id );
+
+		add_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );
+	}
+
+	/**
+	 * Reset the environment to its original state after the test.
+	 */
+	public function tearDown() {
+		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ) );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests empty list response.
+	 */
+	public function test_list_pexels_empty() {
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_list_pexels' ), 10, 3 );
+
+		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/external-media/list/pexels' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertObjectHasAttribute( 'found', $data );
+		$this->assertObjectHasAttribute( 'media', $data );
+		$this->assertObjectHasAttribute( 'meta', $data );
+		$this->assertObjectHasAttribute( 'next_page', $data->meta );
+		$this->assertEmpty( $data->media );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_list_pexels' ) );
+	}
+
+	/**
+	 * Tests list response with unauthenticated Google Photos.
+	 */
+	public function test_list_google_photos_unauthenticated() {
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_list_google_photos_unauthenticated' ), 10, 3 );
+
+		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/external-media/list/google_photos' );
+		$response = $this->server->dispatch( $request );
+		$error    = $response->get_data();
+
+		$this->assertObjectHasAttribute( 'code', $error );
+		$this->assertObjectHasAttribute( 'message', $error );
+		$this->assertObjectHasAttribute( 'data', $error );
+		$this->assertEquals( 'authorization_required', $error->code );
+		$this->assertEquals( 403, $error->data->status );
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_list_google_photos_unauthenticated' ) );
+	}
+
+	/**
+	 * Tests list response with unauthenticated Google Photos.
+	 */
+	public function test_copy_image() {
+		$tmp_name = $this->get_temp_name( static::$image_path );
+		if ( file_exists( $tmp_name ) ) {
+			unlink( $tmp_name );
+		}
+
+		add_filter( 'pre_http_request', array( $this, 'mock_image_data' ), 10, 3 );
+
+		add_filter(
+			'wp_handle_sideload_prefilter',
+			function( $file ) {
+				copy( static::$image_path, $file['tmp_name'] );
+
+				return $file;
+			}
+		);
+		add_filter(
+			'wp_check_filetype_and_ext',
+			function() {
+				return array(
+					'ext'             => 'jpg',
+					'type'            => 'image/jpeg',
+					'proper_filename' => basename( static::$image_path ),
+				);
+			}
+		);
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/external-media/copy/pexels' );
+		$request->set_body_params(
+			array(
+				'media' => array(
+					array(
+						'guid' => wp_json_encode(
+							array(
+								'url'  => static::$image_path,
+								'name' => $this->image_name,
+							)
+						),
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data()[0];
+		remove_filter( 'pre_http_request', array( $this, 'mock_image_data' ) );
+
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'caption', $data );
+		$this->assertArrayHasKey( 'alt', $data );
+		$this->assertArrayHasKey( 'type', $data );
+		$this->assertArrayHasKey( 'url', $data );
+		$this->assertEquals( 'image', $data['type'] );
+		$this->assertInternalType( 'int', $data['id'] );
+		$this->assertEmpty( $data['caption'] );
+		$this->assertEmpty( $data['alt'] );
+	}
+
+	/**
+	 * Tests connection response for Google Photos.
+	 */
+	public function test_connection_google_photos() {
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_connection_google_photos' ), 10, 3 );
+		$request  = wp_rest_request( Requests::GET, '/wpcom/v2/external-media/connection/google_photos' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'google_photos', $data->ID );
+		$this->assertNotEmpty( $data->connect_URL ); // phpcs:ignore
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_api_response_connection_google_photos' ) );
+	}
+
+	/**
+	 * Mock the user token.
+	 *
+	 * @return array
+	 */
+	public function mock_jetpack_private_options() {
+		return array(
+			'user_tokens' => array(
+				static::$user_id => 'pretend_this_is_valid.secret.' . static::$user_id,
+			),
+		);
+	}
+
+	/**
+	 * Validate the "list" Jetpack API request for Pexels and mock the response.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_list_pexels( $response, $args, $url ) {
+		$this->assertEquals( Requests::GET, $args['method'] );
+		$this->assertStringStartsWith( 'https://public-api.wordpress.com/wpcom/v2/meta/external-media/pexels', $url );
+
+		return array(
+			'headers'  => array(
+				'Allow' => 'GET',
+			),
+			'body'     => '{"found":0,"media":[],"meta":{"next_page":false}}',
+			'status'   => 200,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Validate the "list" Jetpack API request for Google Photos and mock the response.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_list_google_photos_unauthenticated( $response, $args, $url ) {
+		$this->assertEquals( Requests::GET, $args['method'] );
+		$this->assertStringStartsWith( 'https://public-api.wordpress.com/wpcom/v2/meta/external-media/google_photos', $url );
+
+		return array(
+			'headers'  => array(
+				'Allow' => 'GET',
+			),
+			'body'     => '{"code":"authorization_required","message":"You are not connected to that service.","data":{"status":403}}',
+			'status'   => 403,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Validate the "copy" Jetpack API request for Pexels and mock the response.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_image_data( $response, $args, $url ) {
+		$this->assertEquals( static::$image_path, $url );
+
+		return array(
+			'headers'  => array(
+				'Allow' => 'GET',
+			),
+			'status'   => 200,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Validate the "connection" Jetpack API request for Google Photos and mock the response.
+	 *
+	 * @param bool   $response Whether to preempt an HTTP request's return value. Default false.
+	 * @param array  $args     HTTP request arguments.
+	 * @param string $url      The request URL.
+	 * @return array
+	 */
+	public function mock_wpcom_api_response_connection_google_photos( $response, $args, $url ) {
+		$this->assertEquals( WP_REST_Server::READABLE, $args['method'] );
+		$this->assertEquals( 'https://public-api.wordpress.com/wpcom/v2/meta/external-media/connection/google_photos', $url );
+
+		return array(
+			'headers'  => array(
+				'Allow' => 'GET',
+			),
+			'body'     => '{"ID":"google_photos","label":"Google Photos","type":"other","description":"Access photos in your Google Account for use in posts and pages","genericon":{"class":"googleplus-alt","unicode":"\\f218"},"icon":"http:\/\/i.wordpress.com\/wp-content\/lib\/external-media-service\/icon\/google-photos-2x.png","connect_URL":"https:\/\/public-api.wordpress.com\/connect\/?action=request&kr_nonce=0&nonce=0&for=connect&service=google_photos&kr_blog_nonce=0&magic=keyring&blog=0","multiple_external_user_ID_support":false,"external_users_only":false,"jetpack_support":true}',
+			'status'   => 200,
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Re-creates a temporary file name so we can clean up after ourselves.
+	 *
+	 * @param string $filename File name.
+	 * @param string $dir      Temp directory. Dafault empty.
+	 *
+	 * @return string|string[]|null
+	 */
+	public function get_temp_name( $filename, $dir = '' ) {
+		if ( empty( $dir ) ) {
+			$dir = get_temp_dir();
+		}
+
+		if ( empty( $filename ) || in_array( $filename, array( '.', '/', '\\' ), true ) ) {
+			$filename = uniqid();
+		}
+
+		// Use the basename of the given file without the extension as the name for the temporary directory.
+		$temp_filename = basename( $filename );
+		$temp_filename = preg_replace( '|\.[^.]*$|', '', $temp_filename );
+
+		// If the folder is falsey, use its parent directory name instead.
+		if ( ! $temp_filename ) {
+			return wp_tempnam( dirname( $filename ), $dir );
+		}
+
+		// Suffix some random data to avoid filename conflicts.
+		$temp_filename .= '-' . wp_generate_password( 6, false );
+		$temp_filename .= '.tmp';
+
+		add_filter( 'wp_unique_filename', array( $this, 'get_file_name' ) );
+		$temp_filename = $dir . wp_unique_filename( $dir, $temp_filename );
+		remove_filter( 'wp_unique_filename', array( $this, 'get_file_name' ) );
+
+		return $temp_filename;
+	}
+
+	/**
+	 * Filter callback to provide a similar file name as in tested class.
+	 *
+	 * @see WPCOM_REST_API_V2_Endpoint_External_Media::tmp_name()
+	 *
+	 * @return string
+	 */
+	public function get_file_name() {
+		return $this->image_name;
+	}
+}


### PR DESCRIPTION
Adds arrow key navigation on media items in the external media browser modal. This brings it to have parity with the core Media Library image grid navigation.

![arrow-key-media-grid](https://user-images.githubusercontent.com/967608/84435242-1a049080-abf7-11ea-9e93-0ebd863a8729.gif)

#### Changes proposed in this Pull Request:
* Adds a `onKeyDown` prop to `MediaItem`
* Adds a `columns` ref and window resize listener to count and store the number of grid image columns. This is used to know where to send focus to when the up/down arrow keys are pressed.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a post and add an Image or Gallery block
* **Arrow key presses _should not close the modal_**. Focus different elements (search input, search button, etc) and press the arrow keys. It should never close the modal. Arrow keys should operate normally inside inputs (like the search input).
* **Media Grid image items should be able to navigate with arrow key presses**
* **Resize the browser to less than or greater than 600px so the images restack.** The `columns` number should be updated and up/down arrow keys should bring you to the correct image.
* **All other functionality should still work** (Selecting images via click, space, enter; load more, etc)
