### PR TITLE
Actions: revert warning about Crew being away again

### DIFF
--- a/.github/workflows/needs-review.yml
+++ b/.github/workflows/needs-review.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches-ignore:
       - '**'
-  pull_request:
-    types: [labeled]
+  #pull_request:
+    #types: [labeled]
 
 jobs:
   comment:
@@ -21,5 +21,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Howdy! The Jetpack team has disappeared for a few days to recharge our batteries. As a result, your Pull Request may not be reviewed right away. Do not worry, we will be back on Monday, June 15 to look at your work! Thank you for your understanding.'
+              body: 'Howdy! The Jetpack team has disappeared for a few days to a secret island lair to concoct new ways to make Jetpack one hundred billion percent better. As a result, your Pull Request may not be reviewed right away. Do not worry, we will be back next week to look at your work! Thank you for your understanding.'
             })


### PR DESCRIPTION
This reverts commit d52a15c0eb66d8346fcc7b8a166adc19dc73ec99.

Reverts #16121

Should not be merged until Monday morning.

#### Changes proposed in this Pull Request:
* Crew is back so stop announcing we're away.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* n/a
