### PR TITLE
Image Compare: fix issue with editing two blocks in a post

### DIFF
--- a/extensions/blocks/image-compare/view.js
+++ b/extensions/blocks/image-compare/view.js
@@ -531,7 +531,7 @@ domReady( function() {
 		);
 	};
 
-	//Enable HTML Implementation
+	// Scan page and add juxtapose sliders.
 	juxtapose.scanPage = function() {
 		const elements = document.querySelectorAll( '.juxtapose' );
 		for ( let i = 0; i < elements.length; i++ ) {
@@ -541,4 +541,7 @@ domReady( function() {
 
 	juxtapose.JXSlider = JXSlider;
 	window.juxtapose = juxtapose;
+
+	// Required for front-end.
+	juxtapose.scanPage();
 } );

--- a/extensions/blocks/image-compare/view.js
+++ b/extensions/blocks/image-compare/view.js
@@ -309,6 +309,9 @@ domReady( function() {
 				this.imgAfter.loaded === true
 			) {
 				this.wrapper = document.querySelector( this.selector );
+				if ( ! this.wrapper ) {
+					return;
+				}
 				addClass( this.wrapper, 'juxtapose' );
 
 				this.wrapper.style.width = this.imgBefore.image.naturalWidth;
@@ -475,6 +478,11 @@ domReady( function() {
 		const w = element;
 
 		const images = w.querySelectorAll( 'img' );
+		// Bail if two images not found, they are required to build slider.
+		// This potentially happens with different load states in React.
+		if ( images.length < 2 ) {
+			return;
+		}
 
 		const options = {};
 		// don't set empty string into options, that's a false false.
@@ -533,6 +541,4 @@ domReady( function() {
 
 	juxtapose.JXSlider = JXSlider;
 	window.juxtapose = juxtapose;
-
-	juxtapose.scanPage();
 } );


### PR DESCRIPTION
Due to the way React `useLayoutEffect` works, the `scanPage` function is called multiple times, with the component in various states of ready. The load and execution order of the scripts change based on different environments, for example due to `concat_js` behavior on WPCOM.

This ends up causing problems if one of the states is not rendered how the script expects. This PR adds a couple of additional checks to make sure it is in a valid state to avoid errors.

~Additionally, the initial `scanPage` call at the end is no longer needed and was removed.~
Updated: scanPage function is required for front-end rendering.

Fixes #16117

#### Changes proposed in this Pull Request:

* Add check for `this.wrapper` and bail if not defined.
* Add check for two images in element and bail if not found.
* ~Remove initial `scanPage` call, not needed since done in `useLayoutEffect`~

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

No, fixes issue with Image Compare block released in 8.6

#### Does this pull request change what data or activity we track or use?

No, no data or activity change.

#### Testing instruction

See instructions at #16117 confirm this change fixes that issue.


#### Proposed changelog entry for your changes:

* Fix issue with two Image Compare blocks in the same post.
