### PR TITLE
Renaming Earn features

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -881,7 +881,7 @@ const features = {
 
 			return {
 				feature: 'simple-payments-block',
-				title: __( 'Pay with PayPal Button' ),
+				title: __( 'Pay with PayPal' ),
 				details: __( 'A simple way to accept payments.' ),
 				checked: inCurrentPlan,
 				isDisabled: inCurrentPlan,

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -881,8 +881,8 @@ const features = {
 
 			return {
 				feature: 'simple-payments-block',
-				title: __( 'Simple Payments Block' ),
-				details: __( 'A simple way to accept payments.' ),
+				title: __( 'Pay with PayPal Button' ),
+				details: __( 'A simple way to accept PayPal payments.' ),
 				checked: inCurrentPlan,
 				isDisabled: inCurrentPlan,
 				isPaid: true,

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -882,7 +882,7 @@ const features = {
 			return {
 				feature: 'simple-payments-block',
 				title: __( 'Pay with PayPal Button' ),
-				details: __( 'A simple way to accept PayPal payments.' ),
+				details: __( 'A simple way to accept payments.' ),
 				checked: inCurrentPlan,
 				isDisabled: inCurrentPlan,
 				isPaid: true,

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -78,7 +78,7 @@ class MembershipsButtonEdit extends Component {
 			editedProductPriceValid: true,
 			editedProductTitle: '',
 			editedProductTitleValid: true,
-			editedProductRenewInterval: '1 month',
+			editedProductRenewInterval: 'one-time',
 		};
 		this.timeout = null;
 
@@ -248,7 +248,7 @@ class MembershipsButtonEdit extends Component {
 					isLarge
 					onClick={ () => this.setState( { addingMembershipAmount: PRODUCT_FORM } ) }
 				>
-					{ __( 'Add a plan', 'jetpack' ) }
+					{ __( 'Add a payment plan', 'jetpack' ) }
 				</Button>
 			);
 		}
@@ -310,6 +310,10 @@ class MembershipsButtonEdit extends Component {
 							label: __( 'Yearly', 'jetpack' ),
 							value: '1 year',
 						},
+						{
+							label: __( 'One-Time Payment', 'jetpack' ),
+							value: 'one-time',
+						},
 					] }
 					value={ this.state.editedProductRenewInterval }
 				/>
@@ -320,7 +324,7 @@ class MembershipsButtonEdit extends Component {
 						className="membership-button__field-button membership-button__add-amount"
 						onClick={ this.saveProduct }
 					>
-						{ __( 'Add this plan', 'jetpack' ) }
+						{ __( 'Add this payment plan', 'jetpack' ) }
 					</Button>
 					<Button
 						isLarge
@@ -375,7 +379,7 @@ class MembershipsButtonEdit extends Component {
 		return (
 			<div className="membership-button__disclaimer">
 				<ExternalLink href="https://en.support.wordpress.com/recurring-payments-button/#related-fees">
-					{ __( 'Read more about Recurring Payments and related fees.', 'jetpack' ) }
+					{ __( 'Read more about Payments and related fees.', 'jetpack' ) }
 				</ExternalLink>
 			</div>
 		);
@@ -417,7 +421,7 @@ class MembershipsButtonEdit extends Component {
 
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Product', 'jetpack' ) }>
+				<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
 					<SelectControl
 						label={ __( 'Payment plan', 'jetpack' ) }
 						value={ this.props.attributes.planId }
@@ -431,7 +435,7 @@ class MembershipsButtonEdit extends Component {
 				</PanelBody>
 				<PanelBody title={ __( 'Management', 'jetpack' ) }>
 					<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
-						{ __( 'See your earnings, subscriber list, and products.', 'jetpack' ) }
+						{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
 					</ExternalLink>
 				</PanelBody>
 			</InspectorControls>
@@ -449,10 +453,10 @@ class MembershipsButtonEdit extends Component {
 					<div className="wp-block-jetpack-recurring-payments">
 						<Placeholder
 							icon={ <BlockIcon icon={ icon } /> }
-							label={ __( 'Recurring Payments', 'jetpack' ) }
+							label={ __( 'Payments', 'jetpack' ) }
 							notices={ notices }
 							instructions={ __(
-								"You'll need to upgrade your plan to use the Recurring Payments button.",
+								"You'll need to upgrade your plan to use the Payments block.",
 								'jetpack'
 							) }
 						>
@@ -477,7 +481,7 @@ class MembershipsButtonEdit extends Component {
 						<div className="wp-block-jetpack-recurring-payments">
 							<Placeholder
 								icon={ <BlockIcon icon={ icon } /> }
-								label={ __( 'Recurring Payments', 'jetpack' ) }
+								label={ __( 'Payments', 'jetpack' ) }
 								notices={ notices }
 							>
 								<div className="components-placeholder__instructions">
@@ -498,7 +502,7 @@ class MembershipsButtonEdit extends Component {
 						<div className="wp-block-jetpack-recurring-payments">
 							<Placeholder
 								icon={ <BlockIcon icon={ icon } /> }
-								label={ __( 'Recurring Payments', 'jetpack' ) }
+								label={ __( 'Payments', 'jetpack' ) }
 								notices={ notices }
 							>
 								<div className="components-placeholder__instructions">

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -378,7 +378,7 @@ class MembershipsButtonEdit extends Component {
 	renderDisclaimer = () => {
 		return (
 			<div className="membership-button__disclaimer">
-				<ExternalLink href="https://en.support.wordpress.com/recurring-payments-button/#related-fees">
+				<ExternalLink href="https://wordpress.com/support/wordpress-editor/blocks/payments/#related-fees">
 					{ __( 'Read more about Payments and related fees.', 'jetpack' ) }
 				</ExternalLink>
 			</div>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -78,7 +78,7 @@ class MembershipsButtonEdit extends Component {
 			editedProductPriceValid: true,
 			editedProductTitle: '',
 			editedProductTitleValid: true,
-			editedProductRenewInterval: 'one-time',
+			editedProductRenewInterval: '1 month',
 		};
 		this.timeout = null;
 

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -25,13 +25,14 @@ export const icon = (
 );
 
 export const settings = {
-	title: __( 'Recurring Payments', 'jetpack' ),
+	title: __( 'Payments', 'jetpack' ),
 	icon,
-	description: __( 'Button allowing you to sell subscription products.', 'jetpack' ),
+	description: __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ),
 	category: supportsCollections() ? 'earn' : 'jetpack',
 	keywords: [
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'subscriptions', 'block search term', 'jetpack' ),
+		_x( 'product', 'block search term', 'jetpack' ),
 		'stripe',
 		_x( 'memberships', 'block search term', 'jetpack' ),
 	],

--- a/extensions/blocks/recurring-payments/view.js
+++ b/extensions/blocks/recurring-payments/view.js
@@ -56,7 +56,7 @@ const initializeMembershipButtonBlocks = () => {
 			activateSubscription( block, checkoutURL );
 		} catch ( err ) {
 			// eslint-disable-next-line no-console
-			console.error( 'Problem activating Recurring Payments ' + checkoutURL, err );
+			console.error( 'Problem activating Payments ' + checkoutURL, err );
 		}
 
 		block.setAttribute( 'data-jetpack-block-initialized', 'true' );

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -29,7 +29,7 @@ export const name = 'simple-payments';
 const supportLink =
 	isSimpleSite() || isAtomicSite()
 		? 'https://wordpress.com/support/pay-with-paypal-button/'
-		: 'http://jetpack.com/support/jetpack-blocks/pay-with-paypal-button/';
+		: 'https://jetpack.com/support/jetpack-blocks/pay-with-paypal-button/';
 
 export const settings = {
 	title: __( 'Pay with PayPal button', 'jetpack' ),

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -28,8 +28,8 @@ export const name = 'simple-payments';
 
 const supportLink =
 	isSimpleSite() || isAtomicSite()
-		? 'https://wordpress.com/support/pay-with-paypal-button/'
-		: 'https://jetpack.com/support/jetpack-blocks/pay-with-paypal-button/';
+		? 'https://wordpress.com/support/pay-with-paypal/'
+		: 'https://jetpack.com/support/jetpack-blocks/pay-with-paypal/';
 
 export const settings = {
 	title: __( 'Pay with PayPal', 'jetpack' ),

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -28,11 +28,11 @@ export const name = 'simple-payments';
 
 const supportLink =
 	isSimpleSite() || isAtomicSite()
-		? 'https://support.wordpress.com/simple-payments/'
-		: 'https://jetpack.com/support/jetpack-blocks/simple-payments-block/';
+		? 'https://wordpress.com/support/pay-with-paypal-button/'
+		: 'http://jetpack.com/support/jetpack-blocks/pay-with-paypal-button/';
 
 export const settings = {
-	title: __( 'Simple Payments', 'jetpack' ),
+	title: __( 'Pay with PayPal button', 'jetpack' ),
 
 	description: (
 		<Fragment>

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -32,7 +32,7 @@ const supportLink =
 		: 'https://jetpack.com/support/jetpack-blocks/pay-with-paypal-button/';
 
 export const settings = {
-	title: __( 'Pay with PayPal button', 'jetpack' ),
+	title: __( 'Pay with PayPal', 'jetpack' ),
 
 	description: (
 		<Fragment>

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -65,6 +65,8 @@ export const settings = {
 		_x( 'purchase', 'block search term', 'jetpack' ),
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'shop', 'block search term', 'jetpack' ),
+		_x( 'simple', 'block search term', 'jetpack' ),
+		_x( 'payments', 'block search term', 'jetpack' ),
 		'PayPal',
 	],
 

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -10,9 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 	/**
-	 * Pay with PayPal Button (aka Simple Payments)
+	 * Pay with PayPal (aka Simple Payments)
 	 *
-	 * Display a Pay with PayPal Button as a Widget.
+	 * Display a Pay with PayPal button as a Widget.
 	 */
 	class Jetpack_Simple_Payments_Widget extends WP_Widget {
 		/**
@@ -24,7 +24,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/modules/simple-payments/simple-payments.php#L386-L415
 		 *
 		 * Indian Rupee (INR) is listed here for backwards compatibility with previously added widgets.
-		 * It's not supported by Pay with PayPal Button because at the time of the creation of this file
+		 * It's not supported by Pay with PayPal because at the time of the creation of this file
 		 * because it's limited to in-country PayPal India accounts only.
 		 * Discussion: https://github.com/Automattic/wp-calypso/pull/28236
 		 */
@@ -62,10 +62,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			parent::__construct(
 				'jetpack_simple_payments_widget',
 				/** This filter is documented in modules/widgets/facebook-likebox.php */
-				apply_filters( 'jetpack_widget_name', __( 'Pay with PayPal Button', 'jetpack' ) ),
+				apply_filters( 'jetpack_widget_name', __( 'Pay with PayPal', 'jetpack' ) ),
 				array(
 					'classname'                   => 'jetpack-simple-payments',
-					'description'                 => __( 'Add a Pay with PayPal Button as a Widget.', 'jetpack' ),
+					'description'                 => __( 'Add a Pay with PayPal button as a Widget.', 'jetpack' ),
 					'customize_selective_refresh' => true,
 				)
 			);

--- a/modules/widgets/simple-payments.php
+++ b/modules/widgets/simple-payments.php
@@ -10,9 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 	/**
-	 * Simple Payments Button
+	 * Pay with PayPal Button (aka Simple Payments)
 	 *
-	 * Display a Simple Payments Button as a Widget.
+	 * Display a Pay with PayPal Button as a Widget.
 	 */
 	class Jetpack_Simple_Payments_Widget extends WP_Widget {
 		/**
@@ -24,7 +24,7 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 		 * @link https://github.com/Automattic/jetpack/blob/31efa189ad223c0eb7ad085ac0650a23facf9ef5/modules/simple-payments/simple-payments.php#L386-L415
 		 *
 		 * Indian Rupee (INR) is listed here for backwards compatibility with previously added widgets.
-		 * It's not supported by Simple Payments because at the time of the creation of this file
+		 * It's not supported by Pay with PayPal Button because at the time of the creation of this file
 		 * because it's limited to in-country PayPal India accounts only.
 		 * Discussion: https://github.com/Automattic/wp-calypso/pull/28236
 		 */
@@ -62,10 +62,10 @@ if ( ! class_exists( 'Jetpack_Simple_Payments_Widget' ) ) {
 			parent::__construct(
 				'jetpack_simple_payments_widget',
 				/** This filter is documented in modules/widgets/facebook-likebox.php */
-				apply_filters( 'jetpack_widget_name', __( 'Simple Payments', 'jetpack' ) ),
+				apply_filters( 'jetpack_widget_name', __( 'Pay with PayPal Button', 'jetpack' ) ),
 				array(
 					'classname'                   => 'jetpack-simple-payments',
-					'description'                 => __( 'Add a Simple Payments Button as a Widget.', 'jetpack' ),
+					'description'                 => __( 'Add a Pay with PayPal Button as a Widget.', 'jetpack' ),
 					'customize_selective_refresh' => true,
 				)
 			);

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -2,8 +2,8 @@
 	<p>
 		<?php
 			$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-				? 'https://wordpress.com/support/pay-with-paypal-button/'
-				: 'https://jetpack.com/support/pay-with-paypal-button/';
+				? 'https://wordpress.com/support/pay-with-paypal/'
+				: 'https://jetpack.com/support/pay-with-paypal/';
 			printf(
 				wp_kses(
 					__( 'Your plan doesn\'t include Pay with PayPal. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -2,11 +2,11 @@
 	<p>
 		<?php
 			$support_url = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
-				? 'https://support.wordpress.com/simple-payments/'
-				: 'https://jetpack.com/support/simple-payment-button/';
+				? 'https://wordpress.com/support/pay-with-paypal-button/'
+				: 'https://jetpack.com/support/pay-with-paypal-button/';
 			printf(
 				wp_kses(
-					__( 'Your plan doesn\'t include Simple Payments. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+					__( 'Your plan doesn\'t include Pay with PayPal Button. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
 					array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
 				),
 				esc_url( $support_url )

--- a/modules/widgets/simple-payments/admin-warning.php
+++ b/modules/widgets/simple-payments/admin-warning.php
@@ -6,7 +6,7 @@
 				: 'https://jetpack.com/support/pay-with-paypal-button/';
 			printf(
 				wp_kses(
-					__( 'Your plan doesn\'t include Pay with PayPal Button. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
+					__( 'Your plan doesn\'t include Pay with PayPal. <a href="%s" rel="noopener noreferrer" target="_blank">Learn more and upgrade</a>.', 'jetpack' ),
 					array( 'a' => array( 'href' => array(), 'rel' => array(), 'target' => array() ) )
 				),
 				esc_url( $support_url )

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Display the Simple Payments Form.
+ * Display the Pay with PayPal button Form.
  *
  * @package Jetpack
  */
@@ -19,7 +19,7 @@
 </p>
 <p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>">
-		<?php esc_html_e( 'Select a Simple Payments Button:', 'jetpack' ); ?>
+		<?php esc_html_e( 'Select a Pay with PayPal Button:', 'jetpack' ); ?>
 	</label>
 	<select
 		class="widefat jetpack-simple-payments-products"

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Display the Pay with PayPal button Form.
+ * Display the Pay with PayPal Form.
  *
  * @package Jetpack
  */

--- a/modules/widgets/simple-payments/form.php
+++ b/modules/widgets/simple-payments/form.php
@@ -19,7 +19,7 @@
 </p>
 <p class="jetpack-simple-payments-products-fieldset" <?php if ( empty( $product_posts ) ) { echo 'style="display:none;"'; } ?>>
 	<label for="<?php echo esc_attr( $this->get_field_id( 'product_post_id' ) ); ?>">
-		<?php esc_html_e( 'Select a Pay with PayPal Button:', 'jetpack' ); ?>
+		<?php esc_html_e( 'Select a Pay with PayPal button:', 'jetpack' ); ?>
 	</label>
 	<select
 		class="widefat jetpack-simple-payments-products"

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Display the Pay with PayPal button Widget.
+ * Display the Pay with PayPal Widget.
  *
  * @package Jetpack
  */

--- a/modules/widgets/simple-payments/widget.php
+++ b/modules/widgets/simple-payments/widget.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Display the Simple Payments Widget.
+ * Display the Pay with PayPal button Widget.
  *
  * @package Jetpack
  */

--- a/tests/e2e/lib/blocks/simple-payments.js
+++ b/tests/e2e/lib/blocks/simple-payments.js
@@ -16,7 +16,7 @@ export default class SimplePaymentBlock {
 	}
 
 	static title() {
-		return 'Simple Payments';
+		return 'Pay with PayPal Button';
 	}
 
 	async fillDetails( {

--- a/tests/e2e/lib/blocks/simple-payments.js
+++ b/tests/e2e/lib/blocks/simple-payments.js
@@ -16,7 +16,7 @@ export default class SimplePaymentBlock {
 	}
 
 	static title() {
-		return 'Pay with PayPal Button';
+		return 'Pay with PayPal';
 	}
 
 	async fillDetails( {

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -51,7 +51,7 @@ describe( 'Paid blocks', () => {
 		let blockEditor;
 		let blockInfo;
 
-		await step( 'Can visit the block editor and add a Pay with PayPal button', async () => {
+		await step( 'Can visit the block editor and add a Pay with PayPal block', async () => {
 			blockEditor = await BlockEditorPage.visit( page );
 			await blockEditor.waitForAvailableBlock( SimplePaymentBlock.name() );
 
@@ -61,13 +61,13 @@ describe( 'Paid blocks', () => {
 			);
 		} );
 
-		await step( 'Can fill details of Pay with PayPal button', async () => {
+		await step( 'Can fill details of Pay with PayPal block', async () => {
 			const spBlock = new SimplePaymentBlock( blockInfo, page );
 			await spBlock.fillDetails();
 		} );
 
 		await step(
-			'Can publish a post and assert that Pay with PayPal button is rendered',
+			'Can publish a post and assert that Pay with PayPal block is rendered',
 			async () => {
 				await blockEditor.focus();
 				await blockEditor.publishPost();

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -47,11 +47,11 @@ describe( 'Paid blocks', () => {
 		} );
 	} );
 
-	it( 'Simple Payment block', async () => {
+	it( 'Pay with PayPal', async () => {
 		let blockEditor;
 		let blockInfo;
 
-		await step( 'Can visit the block editor and add a Simple Payment block', async () => {
+		await step( 'Can visit the block editor and add a Pay with PayPal button', async () => {
 			blockEditor = await BlockEditorPage.visit( page );
 			await blockEditor.waitForAvailableBlock( SimplePaymentBlock.name() );
 
@@ -61,12 +61,12 @@ describe( 'Paid blocks', () => {
 			);
 		} );
 
-		await step( 'Can fill details of Simple Payment block', async () => {
+		await step( 'Can fill details of Pay with PayPal button', async () => {
 			const spBlock = new SimplePaymentBlock( blockInfo, page );
 			await spBlock.fillDetails();
 		} );
 
-		await step( 'Can publish a post and assert that Simple Payment block is rendered', async () => {
+		await step( 'Can publish a post and assert that Pay with PayPal button is rendered', async () => {
 			await blockEditor.focus();
 			await blockEditor.publishPost();
 			await blockEditor.viewPost();

--- a/tests/e2e/specs/pro-blocks.test.js
+++ b/tests/e2e/specs/pro-blocks.test.js
@@ -66,14 +66,17 @@ describe( 'Paid blocks', () => {
 			await spBlock.fillDetails();
 		} );
 
-		await step( 'Can publish a post and assert that Pay with PayPal button is rendered', async () => {
-			await blockEditor.focus();
-			await blockEditor.publishPost();
-			await blockEditor.viewPost();
+		await step(
+			'Can publish a post and assert that Pay with PayPal button is rendered',
+			async () => {
+				await blockEditor.focus();
+				await blockEditor.publishPost();
+				await blockEditor.viewPost();
 
-			const frontend = await PostFrontendPage.init( page );
-			await frontend.isRenderedBlockPresent( SimplePaymentBlock );
-		} );
+				const frontend = await PostFrontendPage.init( page );
+				await frontend.isRenderedBlockPresent( SimplePaymentBlock );
+			}
+		);
 	} );
 
 	it( 'WordAds block', async () => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/42860
Part of https://github.com/Automattic/wp-calypso/issues/42861
Part of https://github.com/Automattic/wp-calypso/issues/42862

#### Changes proposed in this Pull Request:

* Adds a one-time payment feature to Recurring Payments and rename the entire Recurring Payments feature to “Payments”. The bet is that this will simplify the user experience and increase usage, as customers will now have only one place to go when they want to accept payments.
* “Simple Payments” as a feature will still be available to customers already utilizing it, but it's renamed to "Pay with PayPal"

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

pbMlHh-hn-p2

#### Does this pull request change what data or activity we track or use?
Not applicable.

#### Testing instructions:

* The Simple Payments block should now be called Pay with PayPal - verify this by creating a post with block editor and adding a Pay with PayPal block.

<img width="215" alt="icon" src="https://user-images.githubusercontent.com/5560595/84370950-e151c080-abd0-11ea-8696-447c621f7393.png">
<img width="321" alt="shortcut" src="https://user-images.githubusercontent.com/5560595/84370952-e1ea5700-abd0-11ea-8f55-1c22da66c301.png">
<img width="656" alt="esc-block" src="https://user-images.githubusercontent.com/5560595/84370955-e282ed80-abd0-11ea-8434-cbdcd8856290.png">
<img width="286" alt="block-description" src="https://user-images.githubusercontent.com/5560595/84370962-e3b41a80-abd0-11ea-8b0a-44c19fc3801c.png">

* Make sure the block still appear in the block inserter when searching for "Simple Payments".

* Confirm that the Simple Payments widget is also named Pay with PayPal.
<img width="408" alt="widget-form" src="https://user-images.githubusercontent.com/5560595/84371092-0c3c1480-abd1-11ea-8fca-6025c81c3592.png">
<img width="283" alt="widget-title" src="https://user-images.githubusercontent.com/5560595/84371093-0cd4ab00-abd1-11ea-86df-5e9fba52032a.png">

* Verify the Recurring Payments block has been renamed to Payments.

<img width="659" alt="Zrzut ekranu 2020-06-8 o 16 46 44" src="https://user-images.githubusercontent.com/3775068/84045596-4925c280-a9a9-11ea-9d71-5a7a4d0792a8.png">

<img width="742" alt="Zrzut ekranu 2020-06-8 o 16 46 56" src="https://user-images.githubusercontent.com/3775068/84045612-4cb94980-a9a9-11ea-8638-f7f6d6a3516c.png">

* Create a new payments plan, with the "One time" option.
* Publish the post and visit it while logged out.
* Go through checkout.

<img width="988" alt="Zrzut ekranu 2020-06-8 o 16 48 11" src="https://user-images.githubusercontent.com/3775068/84045618-4fb43a00-a9a9-11ea-94b4-7efc1891f040.png">

#### Proposed changelog entry for your changes:
Rename Earn features (Simple Payments > Pay with PayPal, Recurring Payments > Payments).
