### PR TITLE
Allow custom CSS to override [portfolio] shortcode styles

### DIFF
--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -630,7 +630,9 @@ class Jetpack_Portfolio {
 		}
 
 		// enqueue shortcode styles when shortcode is used
-		wp_enqueue_style( 'jetpack-portfolio-style', plugins_url( 'css/portfolio-shortcode.css', __FILE__ ), array(), '20140326' );
+		if ( ! wp_script_is( 'jetpack-portfolio-style', 'enqueued' ) ) {
+			wp_enqueue_style( 'jetpack-portfolio-style', plugins_url( 'css/portfolio-shortcode.css', __FILE__ ), array(), '20140326' );
+		}
 
 		return self::portfolio_shortcode_html( $atts );
 	}

--- a/modules/custom-post-types/portfolios.php
+++ b/modules/custom-post-types/portfolios.php
@@ -630,7 +630,7 @@ class Jetpack_Portfolio {
 		}
 
 		// enqueue shortcode styles when shortcode is used
-		if ( ! wp_script_is( 'jetpack-portfolio-style', 'enqueued' ) ) {
+		if ( ! wp_style_is( 'jetpack-portfolio-style', 'enqueued' ) ) {
 			wp_enqueue_style( 'jetpack-portfolio-style', plugins_url( 'css/portfolio-shortcode.css', __FILE__ ), array(), '20140326' );
 		}
 

--- a/modules/custom-post-types/testimonial.php
+++ b/modules/custom-post-types/testimonial.php
@@ -576,7 +576,9 @@ class Jetpack_Testimonial {
 		}
 
 		// enqueue shortcode styles when shortcode is used
-		wp_enqueue_style( 'jetpack-testimonial-style', plugins_url( 'css/testimonial-shortcode.css', __FILE__ ), array(), '20140326' );
+		if ( ! wp_style_is( 'jetpack-testimonial-style', 'enqueued' ) ) {
+			wp_enqueue_style( 'jetpack-testimonial-style', plugins_url( 'css/testimonial-shortcode.css', __FILE__ ), array(), '20140326' );
+		}
 
 		return self::jetpack_testimonial_shortcode_html( $atts );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15872

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

* Introduce a conditional check before loading the CSS styles required for the `[portfolio]` shortcode, this allows theme and plugin authors to register their own version of the styles like so:

```
	wp_enqueue_style( 'jetpack-portfolio-style', get_template_directory_uri() . '/portfolio.css', array(), '1.0' );
```

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Small improvement to custom content types shortcodes.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable custom post type support
* Create some posts and use the `[portfolio]` or `[testimonial]` shortcode
* See styled output of shortcode
* Add example snippet above to your theme at the correct hook for styles/scripts
* See custom styles applied to shortcode

#### Proposed changelog entry for your changes:

* N/A
