### PR TITLE
Remove all instances of scrolling="no" from iFrames

### DIFF
--- a/extensions/blocks/google-calendar/edit.js
+++ b/extensions/blocks/google-calendar/edit.js
@@ -123,7 +123,7 @@ class GoogleCalendarEdit extends Component {
 
 		const iframeHeight = this.props.isMobile ? '300' : height;
 
-		const html = `<iframe src="${ url }" style="border:0" scrolling="no" frameborder="0" height="${ iframeHeight }"></iframe>`;
+		const html = `<iframe src="${ url }" style="border:0" frameborder="0" height="${ iframeHeight }"></iframe>`;
 
 		const permissionsLink = (
 			<ExternalLink href="https://en.support.wordpress.com/google-calendar/">

--- a/extensions/blocks/google-calendar/google-calendar.php
+++ b/extensions/blocks/google-calendar/google-calendar.php
@@ -51,14 +51,14 @@ function load_assets( $attr ) {
 
 	if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 		return sprintf(
-			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
+			'<div class="%1$s"><amp-iframe src="%2$s" frameborder="0" style="border:0" height="%3$d" sandbox="allow-scripts allow-same-origin" layout="responsive"></amp-iframe></div>',
 			esc_attr( $classes ),
 			esc_url( $url ),
 			absint( $height )
 		);
 	} else {
 		return sprintf(
-			'<div class="%1$s"><iframe src="%2$s" frameborder="0" style="border:0" scrolling="no" height="%3$d"></iframe></div>',
+			'<div class="%1$s"><iframe src="%2$s" frameborder="0" style="border:0" height="%3$d"></iframe></div>',
 			esc_attr( $classes ),
 			esc_url( $url ),
 			absint( $height )

--- a/extensions/blocks/google-calendar/test/utils.js
+++ b/extensions/blocks/google-calendar/test/utils.js
@@ -5,7 +5,7 @@ import { extractAttributesFromIframe } from '../utils';
 
 describe( 'extractAttributesFromIframe', () => {
 	it( 'should extract url, width and height from iframe embed', () => {
-		const iframeEmbed = '<iframe src="https://calendar.google.com/calendar/embed?src=test.user%40a8c.com&ctz=Pacific%2FAuckland" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>'
+		const iframeEmbed = '<iframe src="https://calendar.google.com/calendar/embed?src=test.user%40a8c.com&ctz=Pacific%2FAuckland" style="border: 0" width="800" height="600" frameborder="0"></iframe>'
 		expect( extractAttributesFromIframe( iframeEmbed ) ).toEqual( {
 			url: 'https://calendar.google.com/calendar/embed?src=test.user%40a8c.com&ctz=Pacific%2FAuckland',
 			height: '600',

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -144,7 +144,6 @@ function OpenTableEdit( {
 				<div className={ `${ defaultClassName }-overlay` }></div>
 				<iframe
 					title={ sprintf( __( 'Open Table Preview %s', 'jetpack' ), clientId ) }
-					scrolling="no"
 					src={ `https://www.opentable.com/widget/reservation/canvas?rid=${ join(
 						rid,
 						'%2C'

--- a/json-endpoints/class.wpcom-json-api-render-embed-reversal-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-render-embed-reversal-endpoint.php
@@ -28,7 +28,7 @@ new WPCOM_JSON_API_Render_Embed_Reversal_Endpoint( array(
 		),
 
 		'body' => array(
-			'maybe_embed' => '<iframe width="480" height="302" src="http://www.ustream.tv/embed/recorded/26370522/highlight/299667?v=3&amp;wmode=direct" scrolling="no" frameborder="0"></iframe>',
+			'maybe_embed' => '<iframe width="480" height="302" src="http://www.ustream.tv/embed/recorded/26370522/highlight/299667?v=3&amp;wmode=direct" frameborder="0"></iframe>',
 		)
 	),
 ) );

--- a/modules/contact-form/js/editor-view.js
+++ b/modules/contact-form/js/editor-view.js
@@ -66,7 +66,7 @@
 				$view = $tinyMCE_document.find( '.wpview.wpview-wrap' ).filter( function() {
 					return $( this ).attr( 'data-mce-selected' );
 				} ),
-				$editframe = $( '<iframe scrolling="no" class="inline-edit-contact-form" />' ),
+				$editframe = $( '<iframe class="inline-edit-contact-form" />' ),
 				index = 0,
 				named,
 				fields = '',

--- a/modules/likes.php
+++ b/modules/likes.php
@@ -540,7 +540,7 @@ class Jetpack_Likes {
 
 		$src = sprintf( 'https://widgets.wp.com/likes/#blog_id=%2$d&amp;post_id=%3$d&amp;origin=%1$s://%4$s', $protocol, $blog_id, $post_id, $domain );
 
-		$html = "<iframe class='admin-bar-likes-widget jetpack-likes-widget' scrolling='no' frameBorder='0' name='admin-bar-likes-widget' src='$src'></iframe>";
+		$html = "<iframe class='admin-bar-likes-widget jetpack-likes-widget' frameBorder='0' name='admin-bar-likes-widget' src='$src'></iframe>";
 
 		$node = array(
 				'id'   => 'admin-bar-likes-widget',

--- a/modules/likes/jetpack-likes-master-iframe.php
+++ b/modules/likes/jetpack-likes-master-iframe.php
@@ -32,7 +32,7 @@ function jetpack_likes_master_iframe() {
 	/* translators: The value of %d is not available at the time of output */
 	$likersText = wp_kses( __( '<span>%d</span> bloggers like this:', 'jetpack' ), array( 'span' => array() ) );
 	?>
-	<iframe src='<?php echo $src; ?>' scrolling='no' id='likes-master' name='likes-master' style='display:none;'></iframe>
+	<iframe src='<?php echo $src; ?>' id='likes-master' name='likes-master' style='display:none;'></iframe>
 	<div id='likes-other-gravatars'><div class="likes-text"><?php echo $likersText; ?></div><ul class="wpl-avatars sd-like-gravatars"></ul></div>
 	<?php
 }

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -862,7 +862,7 @@ class Share_Reddit extends Sharing_Source {
 
 	public function get_display( $post ) {
 		if ( $this->smart ) {
-			return '<div class="reddit_button"><iframe src="' . $this->http() . '://www.reddit.com/static/button/button1.html?newwindow=true&width=120&amp;url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&amp;title=' . rawurlencode( $this->get_share_title( $post->ID ) ) . '" height="22" width="120" scrolling="no" frameborder="0"></iframe></div>';
+			return '<div class="reddit_button"><iframe src="' . $this->http() . '://www.reddit.com/static/button/button1.html?newwindow=true&width=120&amp;url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&amp;title=' . rawurlencode( $this->get_share_title( $post->ID ) ) . '" height="22" width="120" frameborder="0"></iframe></div>';
 		} else {
 			return $this->get_link( $this->get_process_request_url( $post->ID ), _x( 'Reddit', 'share to', 'jetpack' ), __( 'Click to share on Reddit', 'jetpack' ), 'share=reddit' );
 		}

--- a/modules/shortcodes/crowdsignal.php
+++ b/modules/shortcodes/crowdsignal.php
@@ -550,7 +550,7 @@ if (
 							}
 
 							return sprintf(
-								'<iframe src="%1$s?iframe=1" frameborder="0" width="%2$d" height="%3$d" scrolling="auto" allowtransparency="true" marginheight="0" marginwidth="0">%4$s</iframe>',
+								'<iframe src="%1$s?iframe=1" frameborder="0" width="%2$d" height="%3$d" allowtransparency="true" marginheight="0" marginwidth="0">%4$s</iframe>',
 								esc_url( $survey_url ),
 								absint( $attributes['width'] ),
 								absint( $attributes['height'] ),

--- a/modules/shortcodes/dailymotion.php
+++ b/modules/shortcodes/dailymotion.php
@@ -257,13 +257,13 @@ function dailymotion_channel_shortcode( $atts ) {
 
 	switch ( $atts['type'] ) {
 		case 'grid':
-			$channel_iframe = '<iframe width="300px" height="264px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=grid' ) . '"></iframe>';
+			$channel_iframe = '<iframe width="300px" height="264px" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=grid' ) . '"></iframe>';
 			break;
 		case 'carousel':
-			$channel_iframe = '<iframe width="300px" height="360px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=carousel' ) . '"></iframe>';
+			$channel_iframe = '<iframe width="300px" height="360px" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username . '?type=carousel' ) . '"></iframe>';
 			break;
 		default:
-			$channel_iframe = '<iframe width="300px" height="78px" scrolling="no" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username ) . '"></iframe>';
+			$channel_iframe = '<iframe width="300px" height="78px" style="border:0;" src="' . esc_url( '//www.dailymotion.com/badge/user/' . $username ) . '"></iframe>';
 	}
 
 	return $channel_iframe;

--- a/modules/shortcodes/googlemaps.php
+++ b/modules/shortcodes/googlemaps.php
@@ -130,7 +130,7 @@ function jetpack_googlemaps_shortcode( $atts ) {
 
 		return sprintf(
 			'<div class="%1$s">
-				<iframe width="%2$d" height="%3$d" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" %5$s src="%4$s"></iframe>
+				<iframe width="%2$d" height="%3$d" frameborder="0" marginheight="0" marginwidth="0" %5$s src="%4$s"></iframe>
 			</div>',
 			esc_attr( $css_class ),
 			absint( $width ),

--- a/modules/shortcodes/hulu.php
+++ b/modules/shortcodes/hulu.php
@@ -155,7 +155,7 @@ function jetpack_hulu_shortcode( $atts ) {
 	$height     = round( ( $width / 640 ) * 360 );
 
 	$html = sprintf(
-		'<div class="embed-hulu" style="text-align: center;"><iframe src="%s" width="%s" height="%s" style="border:0;" scrolling="no" webkitAllowFullScreen
+		'<div class="embed-hulu" style="text-align: center;"><iframe src="%s" width="%s" height="%s" style="border:0;" webkitAllowFullScreen
 mozallowfullscreen allowfullscreen></iframe></div>',
 		esc_url( $iframe_url ),
 		esc_attr( $width ),

--- a/modules/shortcodes/scribd.php
+++ b/modules/shortcodes/scribd.php
@@ -70,7 +70,7 @@ function scribd_shortcode_markup( $atts ) {
 	);
 
 	return sprintf(
-		'<iframe class="scribd_iframe_embed" src="%1$s" %2$s data-auto-height="true" scrolling="no" id="scribd_%3$d" width="100%%" height="500" frameborder="0"></iframe>
+		'<iframe class="scribd_iframe_embed" src="%1$s" %2$s data-auto-height="true" id="scribd_%3$d" width="100%%" height="500" frameborder="0"></iframe>
 		<div style="font-size:10px;text-align:center;width:100%%"><a href="https://www.scribd.com/doc/%3$d" rel="noopener noreferrer" target="_blank">%4$s</a></div>',
 		$url,
 		$sandbox,

--- a/modules/shortcodes/soundcloud.php
+++ b/modules/shortcodes/soundcloud.php
@@ -151,7 +151,7 @@ function soundcloud_shortcode( $atts, $content = null ) {
 	);
 
 	return sprintf(
-		'<iframe width="%1$s" height="%2$d" scrolling="no" frameborder="no" src="%3$s"></iframe>',
+		'<iframe width="%1$s" height="%2$d" frameborder="no" src="%3$s"></iframe>',
 		esc_attr( $width ),
 		esc_attr( $height ),
 		$url

--- a/modules/shortcodes/twitchtv.php
+++ b/modules/shortcodes/twitchtv.php
@@ -67,7 +67,7 @@ function wpcom_twitchtv_shortcode( $atts ) {
 	$url = add_query_arg( $url_args, 'https://player.twitch.tv/' );
 
 	return sprintf(
-		'<iframe src="%s" width="%d" height="%d" frameborder="0" scrolling="no" allowfullscreen sandbox="allow-popups allow-scripts allow-same-origin allow-presentation"></iframe>',
+		'<iframe src="%s" width="%d" height="%d" frameborder="0" allowfullscreen sandbox="allow-popups allow-scripts allow-same-origin allow-presentation"></iframe>',
 		esc_url( $url ),
 		esc_attr( $width ),
 		esc_attr( $height )

--- a/modules/shortcodes/ustream.php
+++ b/modules/shortcodes/ustream.php
@@ -86,7 +86,7 @@ function ustream_shortcode( $atts ) {
 	);
 
 	$output = sprintf(
-		'<iframe src="%1$s" width="%2$d" height="%3$d" scrolling="no" style="border: 0 none transparent;"></iframe>',
+		'<iframe src="%1$s" width="%2$d" height="%3$d" style="border: 0 none transparent;"></iframe>',
 		esc_url( $url ),
 		absint( $atts['width'] ),
 		absint( $atts['height'] )
@@ -127,7 +127,7 @@ function ustreamsocial_shortcode( $atts ) {
 	$url = 'https://www.ustream.tv/socialstream/' . esc_attr( $atts['id'] );
 
 	return sprintf(
-		'<iframe id="SocialStream" src="%1$s" class="" name="SocialStream" width="%2$d" height="%3$d" scrolling="no" allowtransparency="true" style="visibility: visible; margin-top: 0; margin-bottom: 0; border: 0;"></iframe>',
+		'<iframe id="SocialStream" src="%1$s" class="" name="SocialStream" width="%2$d" height="%3$d" allowtransparency="true" style="visibility: visible; margin-top: 0; margin-bottom: 0; border: 0;"></iframe>',
 		esc_url( $url ),
 		absint( $atts['width'] ),
 		absint( $atts['height'] )

--- a/modules/shortcodes/wufoo.php
+++ b/modules/shortcodes/wufoo.php
@@ -94,7 +94,7 @@ function wufoo_shortcode( $atts ) {
 	 * iframe embed, loaded inside <noscript> tags.
 	 */
 	$iframe_embed = sprintf(
-		'<iframe height="%1$d" src="%2$s" allowTransparency="true" frameborder="0" scrolling="no" style="width:100%;border:none;">
+		'<iframe height="%1$d" src="%2$s" allowTransparency="true" frameborder="0" style="width:100%;border:none;">
 			<a href="%3$s" target="_blank" rel="noopener noreferrer">%4$s</a>
 		</iframe>',
 		absint( $attr['height'] ),

--- a/modules/wordads/wordads.php
+++ b/modules/wordads/wordads.php
@@ -702,7 +702,6 @@ HTML;
 			width="$width"
 			height="$height"
 			frameborder="0"
-			scrolling="no"
 			marginheight="0"
 			marginwidth="0">
 		</iframe>

--- a/tests/php/modules/shortcodes/test-class.googleapps.php
+++ b/tests/php/modules/shortcodes/test-class.googleapps.php
@@ -152,7 +152,7 @@ class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
 	}
 
 	function test_calendar_variation_1() {
-		$embed     = '<iframe src="https://www.google.com/calendar/embed?src=serjant%40gmail.com&ctz=Europe/Sofia" style="border: 0;" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+		$embed     = '<iframe src="https://www.google.com/calendar/embed?src=serjant%40gmail.com&ctz=Europe/Sofia" style="border: 0;" width="800" height="600" frameborder="0"></iframe>';
 		$shortcode = googleapps_embed_to_shortcode( $embed );
 
 		$expected_shortcode = '[googleapps domain="www" dir="calendar/embed" query="src=serjant%40gmail.com&amp;ctz=Europe/Sofia" width="800" height="600" /]';
@@ -170,7 +170,7 @@ class WP_Test_Jetpack_Shortcodes_GoogleApps extends WP_UnitTestCase {
 	}
 
 	function test_calendar_variation_3() {
-		$embed     = '<iframe src="https://calendar.google.com/calendar/embed?src=jb4bu80jirp0u11a6niie21pp4%40group.calendar.google.com&ctz=America/New_York" style="border: 0;" width="800" height="600" frameborder="0" scrolling="no"></iframe>';
+		$embed     = '<iframe src="https://calendar.google.com/calendar/embed?src=jb4bu80jirp0u11a6niie21pp4%40group.calendar.google.com&ctz=America/New_York" style="border: 0;" width="800" height="600" frameborder="0"></iframe>';
 		$shortcode = googleapps_embed_to_shortcode( $embed );
 
 		$expected_shortcode = '[googleapps domain="calendar" dir="calendar/embed" query="src=jb4bu80jirp0u11a6niie21pp4%40group.calendar.google.com&amp;ctz=America/New_York" width="800" height="600" /]';

--- a/tests/php/modules/shortcodes/test-class.googlemaps.php
+++ b/tests/php/modules/shortcodes/test-class.googlemaps.php
@@ -21,17 +21,17 @@ class WP_Test_Jetpack_Shortcodes_Googlemaps extends WP_UnitTestCase {
 			'non_amp'         => array(
 				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA&amp;w=640&amp;h=480]',
 				true,
-				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" sandbox="allow-popups allow-scripts allow-same-origin" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
+				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" marginheight="0" marginwidth="0" sandbox="allow-popups allow-scripts allow-same-origin" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
 			),
 			'amp'             => array(
 				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA&amp;w=640&amp;h=480]',
 				false,
-				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
+				'<div class="googlemaps"><iframe width="640" height="480" frameborder="0" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
 			),
 			'align_attribute' => array(
 				'[googlemaps https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA align="center"]',
 				false,
-				'<div class="googlemaps aligncenter"><iframe width="425" height="350" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
+				'<div class="googlemaps aligncenter"><iframe width="425" height="350" frameborder="0" marginheight="0" marginwidth="0" src="https://mapsengine.google.com/map/embed?mid=zbBhkou4wwtE.kUmp8K6QJ7SA"></iframe></div>',
 			),
 		);
 	}

--- a/tests/php/modules/shortcodes/test-class.hulu.php
+++ b/tests/php/modules/shortcodes/test-class.hulu.php
@@ -128,7 +128,7 @@ class WP_Test_Jetpack_Shortcodes_Hulu extends WP_UnitTestCase {
 
 
 	public function test_hulu_embed_to_shortcode() {
-		$embed     = '<iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=' . $this->video_eid . '&et=20&st=10&it=i11" frameborder="0" scrolling="no" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>';
+		$embed     = '<iframe width="512" height="288" src="http://www.hulu.com/embed.html?eid=' . $this->video_eid . '&et=20&st=10&it=i11" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowfullscreen></iframe>';
 		$shortcode = apply_filters( 'pre_kses', $embed, 'post', wp_allowed_protocols() );
 
 		$expected_shortcode = "[hulu id=$this->video_eid width=512 height=288 start_time=10 end_time=20 thumbnail_frame=11]";

--- a/tests/php/modules/shortcodes/test-class.scribd.php
+++ b/tests/php/modules/shortcodes/test-class.scribd.php
@@ -21,12 +21,12 @@ class WP_Test_Jetpack_Shortcodes_Scribd extends WP_UnitTestCase {
 			'non_amp' => array(
 				'[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]',
 				false,
-				'<iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe><div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" rel="noopener noreferrer" target="_blank">View this document on Scribd</a></div>',
+				'<iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" data-auto-height="true" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe><div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" rel="noopener noreferrer" target="_blank">View this document on Scribd</a></div>',
 			),
 			'amp'     => array(
 				'[scribd id=39027960 key=key-3kaiwcjqhtipf25m8tw mode=list]',
 				true,
-				'<iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" sandbox="allow-popups allow-scripts allow-same-origin" data-auto-height="true" scrolling="no" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe><div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" rel="noopener noreferrer" target="_blank">View this document on Scribd</a></div>',
+				'<iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/39027960/content?start_page=1&view_mode=list&access_key=key-3kaiwcjqhtipf25m8tw" sandbox="allow-popups allow-scripts allow-same-origin" data-auto-height="true" id="scribd_39027960" width="100%" height="500" frameborder="0"></iframe><div style="font-size:10px;text-align:center;width:100%"><a href="https://www.scribd.com/doc/39027960" rel="noopener noreferrer" target="_blank">View this document on Scribd</a></div>',
 			),
 		);
 	}

--- a/tests/php/modules/shortcodes/test-class.soundcloud.php
+++ b/tests/php/modules/shortcodes/test-class.soundcloud.php
@@ -97,7 +97,7 @@ class WP_Test_Jetpack_Shortcodes_Soundcloud extends WP_UnitTestCase {
 	 * Shortcode reversals.
 	 */
 	public function test_shortcodes_soundcloud_reversal_player() {
-		$content = '<iframe width="100%" height="450" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/4142297&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>';
+		$content = '<iframe width="100%" height="450" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/playlists/4142297&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false&amp;visual=true"></iframe>';
 
 		$shortcode_content = jetpack_soundcloud_embed_reversal( $content );
 		$shortcode_content = str_replace( "\n", '', $shortcode_content );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15736

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The `scrolling="no"` property is now obsolete on iFrames. This PR attempts to remove all instances of that property. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Mostly shortcodes and blocks

#### Does this pull request change what data or activity we track or use?

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable shortcode support
* Emebed some shortcodes (e.g. `[soundcloud url="https://soundcloud.com/kronopage/aaron-smith-dancin-remix-by"]`)
* Verify scrolling property has been removed
* Verify things are visually correct

I have only done very light testing on this and I have a hunch that older browsers may behave unexpectedly to this change. Having said that, YouTube no longer has this property present in the embed dialog:

```
<iframe width="560" height="315" src="https://www.youtube.com/embed/53kv-A4Wi_o" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

N/A
