### PR TITLE
P2 sites: Exclude 'contributor' from roles in sites/$blog-id/roles

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -86,6 +86,8 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 
 	// /sites/%s/roles/ -> $blog_id
 	function callback( $path = '', $blog_id = 0 ) {
+		require_lib( 'wpforteams' );
+
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );
 		if ( is_wp_error( $blog_id ) ) {
 			return $blog_id;
@@ -127,9 +129,19 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 			}
 		}
 
+		if ( WPForTeams\is_wpforteams_site( $blog_id ) ) {
+			$roles = $this->get_wpforteams_roles( $roles );
+		}
+
 		// Sort the array so roles with the most number of capabilities comes first, then the next role, and so on
 		usort( $roles, array( 'self', 'role_sort' ) );
 
 		return array( 'roles' => $roles );
+	}
+
+	private function get_wpforteams_roles( $roles ) {
+		return array_filter( (array) $roles, function( $role ) {
+			return $role->name !== 'contributor';
+		});
 	}
 }


### PR DESCRIPTION
Summary:
Add logic to `/sites/$blog-id/roles` to remove 'contributor' from list of roles available for P2 (wpforteams) sites.  This is the endpoint Calypso is hitting to populate its list of roles for a site. Adding this here will eliminate the need to add isWPForTeams checks everywhere else (inside Calypso and other places that use this endpoint).

Fixes 462-gh-p2

Test Plan:
1. Sandbox public-api.
2. Go to the WP.COM dev api console. Select WP.COM API, v1, and GET.
3. Test `/sites/<regular-blog-id>/roles. It should give you administrator, author, editor and contributor.
4. Test `/sites/<wpforteams-blog-id>/roles. It should give you administrator, author, and editor (no contributor).
5. Optionally, test Calypso (https://wordpress.com/people/new/YOUR-P2-SITE) by verifying that the Invite Link role dropdown does not include Contributor.

NOTE: A8C P2s are not included in P2 sites' role curation.

{F6752902}

Reviewers: #lighthouse_team, 0mirka00

Reviewed By: #lighthouse_team, 0mirka00

Subscribers: 0mirka00

Tags: #touches_jetpack_files

Differential Revision: D44636-code

This commit syncs r208865-wpcom.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
No.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes contributor role if site is a P2 site (wpforteams).

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Sandbox public-api.
2. Go to the WP.COM dev api console. Select WP.COM API, v1, and GET.
3. Test `/sites/<regular-blog-id>/roles. It should give you administrator, author, editor and contributor.
4. Test `/sites/<wpforteams-blog-id>/roles. It should give you administrator, author, and editor (no contributor).
5. Optionally, test Calypso (https://wordpress.com/people/new/YOUR-P2-SITE) by verifying that the Invite Link role dropdown does not include Contributor.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove Contributor role for P2 (wpforteams) sites.