### PR TITLE
External Media: Maintain existing gallery images

### DIFF
--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -10,8 +10,8 @@ import classnames from 'classnames';
 import { speak } from '@wordpress/a11y';
 import apiFetch from '@wordpress/api-fetch';
 import { withNotices, Modal } from '@wordpress/components';
-import { createHigherOrderComponent } from '@wordpress/compose';
-import { select } from '@wordpress/data';
+import { compose, createHigherOrderComponent } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
@@ -162,10 +162,16 @@ export default function withMedia() {
 			};
 
 			copyMedia = ( items, apiUrl ) => {
-				const { addToGallery, multiple, noticeOperations, onClose, onSelect, value } = this.props;
-				const galleryImages = addToGallery
-					? value.map( id => select( 'core' ).getMedia( Number( id ) ) )
-					: [];
+				const {
+					addToGallery,
+					getMediaById,
+					multiple,
+					noticeOperations,
+					onClose,
+					onSelect,
+					value,
+				} = this.props;
+				const galleryImages = addToGallery ? value.map( getMediaById ) : [];
 
 				this.setState( { isCopying: items } );
 				noticeOperations.removeAllNotices();
@@ -268,6 +274,11 @@ export default function withMedia() {
 			}
 		}
 
-		return withNotices( WithMediaComponent );
+		return compose( [
+			withNotices,
+			withSelect( select => ( {
+				getMediaById: id => select( 'core' ).getMedia( Number( id ) ),
+			} ) ),
+		] )( WithMediaComponent );
 	} );
 }

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -7,12 +7,13 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
-import { createHigherOrderComponent } from '@wordpress/compose';
-import { Component } from '@wordpress/element';
-import { withNotices, Modal } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
+import apiFetch from '@wordpress/api-fetch';
+import { withNotices, Modal } from '@wordpress/components';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { select } from '@wordpress/data';
+import { Component } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
@@ -161,8 +162,13 @@ export default function withMedia() {
 			};
 
 			copyMedia = ( items, apiUrl ) => {
+				const { addToGallery, multiple, noticeOperations, onClose, onSelect, value } = this.props;
+				const galleryImages = addToGallery
+					? value.map( id => select( 'core' ).getMedia( Number( id ) ) )
+					: [];
+
 				this.setState( { isCopying: items } );
-				this.props.noticeOperations.removeAllNotices();
+				noticeOperations.removeAllNotices();
 
 				// If we have a modal element set, focus it.
 				// Otherwise focus is reset to the body instead of staying within the Modal.
@@ -194,13 +200,12 @@ export default function withMedia() {
 					},
 				} )
 					.then( result => {
-						const { value, addToGallery, multiple } = this.props;
 						const media = multiple ? result : result[ 0 ];
 
-						this.props.onClose();
+						onClose();
 
 						// Select the image(s). This will close the modal
-						this.props.onSelect( addToGallery ? value.concat( result ) : media );
+						onSelect( addToGallery ? galleryImages.concat( result ) : media );
 					} )
 					.catch( this.handleApiError );
 			};


### PR DESCRIPTION
Queries image data for existing gallery images prior to returning the new set of images. This _should_ not result in actual API requests since those images have been loaded with the post.

This fixes a bug where the Gallery block expects to receive full image objects but only image IDs are supplied. 

Fixes #16126.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Grabs image data from store for all existing gallery images.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the Editor, add a new Gallery block.
* Add an image to the Gallery, from either an external library or the media library
* After that, add additional images from an external library
* All images should display correctly, no errors in the console.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
