### PR TITLE
Shortcodes: Twitch: Add required parent query param to embed

### DIFF
--- a/modules/shortcodes/twitchtv.php
+++ b/modules/shortcodes/twitchtv.php
@@ -65,7 +65,10 @@ function wpcom_twitchtv_shortcode( $atts ) {
 	}
 
 	// See https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956.
-	$url_args['parent'] = $_SERVER['HTTP_HOST'];
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$url_args['parent'] = isset( $_SERVER['HTTP_HOST'] )
+		? rawurlencode( wp_unslash( $_SERVER['HTTP_HOST'] ) ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		: '';
 
 	$url = add_query_arg( $url_args, 'https://player.twitch.tv/' );
 

--- a/modules/shortcodes/twitchtv.php
+++ b/modules/shortcodes/twitchtv.php
@@ -64,6 +64,9 @@ function wpcom_twitchtv_shortcode( $atts ) {
 		$url_args['channel'] = $user_id;
 	}
 
+	// See https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956.
+	$url_args['parent'] = $_SERVER['HTTP_HOST'];
+
 	$url = add_query_arg( $url_args, 'https://player.twitch.tv/' );
 
 	return sprintf(


### PR DESCRIPTION
On June 10th, Twitch deployed some changes that required the parent query arg be added to all iframe embeds. The value of the parent query param is supposed to be the the domain that the player is embedded on. See https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956

This patch has already been shipped to WPCOM in r208936-wpcom.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes broken embeds after a change on Twitch's side that began being enforced on June 10

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes

#### Testing instructions:
* Checkout PR
* Create new post with a shortcode block
* Inside the shortcode block, use something like this: `[twitchtv url="https://www.twitch.tv/thinnd" width="1080" height="720" autoplay="false" muted="true"]` (feel free to substitute your own favorite streamer)
* Preview post and verify embed work

#### Proposed changelog entry for your changes:
* We updated our Twitch shortcode to work after some [requirements were added to embeds](https://discuss.dev.twitch.tv/t/twitch-embedded-player-updates-in-2020/23956). To test, embed any Twitch URL with the `twitchtv` shortcode and ensure that the video is playable.
