### PR TITLE
Recurring Payments: Keep custom text on plan change

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -340,11 +340,20 @@ class MembershipsButtonEdit extends Component {
 		return formatCurrency( parseFloat( product.price ), product.currency );
 	};
 
-	setMembershipAmount = id =>
+	setMembershipAmount = id => {
+		const currentPlanId = this.props.attributes.planId;
+		const currentText = this.props.attributes.submitButtonText;
+		const defaultTextForNewPlan =
+			this.getFormattedPriceByProductId( id ) + __( ' Contribution', 'jetpack' );
+		const defaultTextForCurrentPlan = currentPlanId
+			? this.getFormattedPriceByProductId( currentPlanId ) + __( ' Contribution', 'jetpack' )
+			: undefined;
+		const text = currentText === defaultTextForCurrentPlan ? defaultTextForNewPlan : currentText;
 		this.props.setAttributes( {
 			planId: id,
-			submitButtonText: this.getFormattedPriceByProductId( id ) + __( ' Contribution', 'jetpack' ),
+			submitButtonText: text,
 		} );
+	};
 
 	renderMembershipAmounts = () => (
 		<div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Ensures any custom text entered in a Recurring Payments button is preserved when plan changes.

Before | After
--- | ---
![Jun-12-2020 13-52-23](https://user-images.githubusercontent.com/1233880/84500160-49c59e00-acb4-11ea-818b-92e92bb029bb.gif) | ![Jun-12-2020 13-45-28](https://user-images.githubusercontent.com/1233880/84500174-4e8a5200-acb4-11ea-84bf-dd522a843365.gif)


#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Recurring Payments is an existing feature of Jetpack.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Insert a Recurring Payments block.
* Select a plan.
* Makes sure the button label changes to `<Plan Amount> Contribution`.
* Change the plan.
* Makes sure the button label changes to `<New Plan Amount> Contribution`.
* Change the button label to a custom text such as "Subscribe".
* Change the plan.
* Makes sure the custom text previously entered is preserved.

#### Proposed changelog entry for your changes:

Recurring Payments: Keep custom text on plan change
