### PR TITLE
Recurring Payments: Remove border on editor

### DIFF
--- a/extensions/shared/submit-button.js
+++ b/extensions/shared/submit-button.js
@@ -88,7 +88,7 @@ class SubmitButton extends Component {
 
 		const backgroundColor = backgroundButtonColor.color || fallbackBackgroundColor;
 		const color = textButtonColor.color || fallbackTextColor;
-		const buttonStyle = { border: 'none', backgroundColor, color };
+		const buttonStyle = { backgroundColor, color };
 		const buttonClasses = this.getButtonClasses();
 
 		return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes the border reset from the Recurring Payments button so the any border defined by themes is preserved.

Note that this was affecting only the editor view. Border was not being reset in the saved content.

View | Before | After
--- | --- | ---
Editor | <img width="288" alt="Screen Shot 2020-06-12 at 14 59 20" src="https://user-images.githubusercontent.com/1233880/84505627-5b13a800-acbe-11ea-9aa4-b85b8143d32e.png"> | <img width="293" alt="Screen Shot 2020-06-12 at 15 01 54" src="https://user-images.githubusercontent.com/1233880/84505649-61098900-acbe-11ea-9b95-4d57571a0081.png">
Published | <img width="287" alt="Screen Shot 2020-06-12 at 15 00 04" src="https://user-images.githubusercontent.com/1233880/84505667-69fa5a80-acbe-11ea-9427-4cef4e905d07.png"> | <img width="287" alt="Screen Shot 2020-06-12 at 15 00 04" src="https://user-images.githubusercontent.com/1233880/84505667-69fa5a80-acbe-11ea-9427-4cef4e905d07.png">

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?

Recurring Payments is an existing feature of Jetpack.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Switch to a theme that style buttons with borders (like the [Libretto theme for WP.com](https://public-api.wordpress.com/rest/v1/themes/download/libretto.zip)).
* Insert a Recurring Payments block.
* Make sure the Recurring Payments button is rendered with a border in both the editor and published view.

#### Proposed changelog entry for your changes:

Recurring Payments: Remove border on editor
