### PR TITLE
API: Add filter to /sites/$blog-id/roles

### DIFF
--- a/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -135,9 +135,9 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 		 *
 		 * @module json-api
 		 *
-		 * @since 5.4.2
+		 * @since 8.7.0
 		 *
-		 * @param array List of role objects available to the site.
+		 * @param array $roles List of role objects available to the site.
 		 */
 		$roles = apply_filters( 'wpcom_api_site_roles', $roles );
 

--- a/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -130,6 +130,8 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// Sort the array so roles with the most number of capabilities comes first, then the next role, and so on
 		usort( $roles, array( 'self', 'role_sort' ) );
 
+		$roles = apply_filters( 'wpcom_api_site_roles', $roles );
+
 		return array( 'roles' => $roles );
 	}
 }

--- a/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-roles-endpoint.php
@@ -130,6 +130,15 @@ class WPCOM_JSON_API_List_Roles_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// Sort the array so roles with the most number of capabilities comes first, then the next role, and so on
 		usort( $roles, array( 'self', 'role_sort' ) );
 
+		/**
+		 * Filter for curating the list of roles available for a wpcom site.
+		 *
+		 * @module json-api
+		 *
+		 * @since 5.4.2
+		 *
+		 * @param array List of role objects available to the site.
+		 */
 		$roles = apply_filters( 'wpcom_api_site_roles', $roles );
 
 		return array( 'roles' => $roles );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a filter for roles returned by the `/sites/<blog-id>/roles` endpoint. 

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
No.

Partial fix for 462-gh-p2 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* D44865-code adds a filter for roles returned by `/sites/<blog-id>/roles`

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Changes here should not affect non-P2 (wpforteams) sites.
* Using the WP.COM dev api console (v1 GET), verify that `sites/<P2-SITE-ID>/roles` does not return the contributor role.
* Using the WP.COM dev api console (v1 GET), verify that `sites/<NON-P2-SITE-ID>/roles` returns the contributor role.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds filter for roles returned by sites/$blog-id/roles api endpoint. 
