### PR TITLE
Add missing closing curly brace for media at-rule

### DIFF
--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -114,7 +114,7 @@ class Admin_Bar_Notice {
 		}
 
 		// We might be showing the threats in the admin bar lets make sure that they look great!
-		$hide_wording_on_mobile = '#wp-admin-bar-jetpack-scan-notice .is-hidden { display:none; } @media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; }';
+		$hide_wording_on_mobile = '#wp-admin-bar-jetpack-scan-notice .is-hidden { display:none; } @media screen and (max-width: 959px ) { #wpadminbar #wp-admin-bar-jetpack-scan-notice { width:32px; } #wpadminbar #wp-admin-bar-jetpack-scan-notice a { color: transparent!important; } }';
 		$style                  = '#wp-admin-bar-jetpack-scan-notice svg { float:left; margin-top: 4px; margin-right: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;
 		if ( is_rtl() ) {
 			$style = '#wp-admin-bar-jetpack-scan-notice svg { float:right; margin-top: 4px; margin-left: 6px; width: 18px; height: 22px; }' . $hide_wording_on_mobile;


### PR DESCRIPTION
I noticed some bizzare issues with the admin bar in how some inline style rules added to the `admin-bar` would fail to apply. The issue turns out to be a missing closing curly brace for a `@media` at-rule added by Jetpack. 

Fixes regression introduced in #15795.

#### Changes proposed in this Pull Request:

* Fix CSS syntax error due to missing curly brace in media at-rule.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Copy contents of the `style#admin-bar-inline-css`  element and verify no CSS syntax errors are present.

#### Proposed changelog entry for your changes:

* Fix CSS syntax error due to missing curly brace in media at-rule.
