### PR TITLE
Cover: Catch and handle media replace flow

### DIFF
--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -1,0 +1,37 @@
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import UpgradeNudge from "../components/upgrade-nudge";
+
+/**
+ * Nudge shows when the user tries to upload a video file.
+ * Unlike the core/video block, handled/extended by the videopress block,
+ * the nudge is not shown permanently.
+ * It's handled by the MediaPlaceholder component
+ * when the user tries to upload a video file.
+ * For this reason, we can't wrap the edit setting
+ * with the wrapPaidBlock() HOC, as the videopress does.
+ *
+ * @param {object}  props - Information about the user.
+ * @param {string}  props.name - Show the Nudge component.
+ * @param {boolean} props.show - Show the Nudge component.
+ * @returns {*} Nudge component or Null.
+ */
+export const JetpackCoverUpgradeNudge = ( { name, show } ) =>
+	show
+		? <UpgradeNudge
+			plan="value_bundle"
+			blockName={ name }
+			title={ {
+				knownPlan: __( 'To use a video in this block, upgrade to %(planName)s.', 'jetpack' ),
+				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
+			} }
+			subtitle={ false }
+		/>
+		: null;

--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -24,17 +24,19 @@ import UpgradeNudge from "../../components/upgrade-nudge";
  * @param {boolean} props.show - Show the Nudge component.
  * @returns {*} Nudge component or Null.
  */
-export const JetpackCoverUpgradeNudge = ( { name, show } ) =>
+export const JetpackCoverUpgradeNudge = ( { name, show, align } ) =>
 	show
-		? <UpgradeNudge
-			plan="value_bundle"
-			blockName={ name }
-			title={ {
-				knownPlan: __( 'To use a video in this block, upgrade to %(planName)s.', 'jetpack' ),
-				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
-			} }
-			subtitle={ false }
-		/>
+		? <div className="jetpack-upgrade-nudge-wrapper wp-block" data-align={ align }>
+			<UpgradeNudge
+				plan="value_bundle"
+				blockName={ name }
+				title={ {
+					knownPlan: __( 'To use a video in this block, upgrade to %(planName)s.', 'jetpack' ),
+					unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
+				} }
+				subtitle={ false }
+			/>
+		</div>
 		: null;
 
 /**

--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -3,11 +3,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { createContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import UpgradeNudge from "../components/upgrade-nudge";
+import UpgradeNudge from "../../components/upgrade-nudge";
 
 /**
  * Nudge shows when the user tries to upload a video file.
@@ -35,3 +36,29 @@ export const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 			subtitle={ false }
 		/>
 		: null;
+
+/**
+ * Cover Media context
+ * Used to connect the CoverEdit with
+ * the Media Replace Flow.
+ */
+export const CoverMediaContext = createContext();
+
+/**
+ * Cover Media Provider will populate the properties
+ * from the CoverEdit to the Media Replace Flow component.
+ *
+ * @param {object}  props - Provider properties.
+ * @param {string}  props.onFilesUpload - Callback function before to upload files.
+ * @param {boolean} props.children - Provider Children.
+ * @returns {*} Provider component.
+ */
+export const CoverMediaProvider = ( { onFilesUpload, children } ) => {
+	return (
+		<CoverMediaContext.Provider value={ {
+			onFilesUpload,
+		} }>
+			{ children }
+		</CoverMediaContext.Provider>
+	);
+};

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import UpgradeNudge from "../../components/upgrade-nudge";
-import { videoFileExtensions, isUpgradable } from './utils';
+import { isUpgradable, isVideoFile } from './utils';
 
 /**
  * Module Constants
@@ -63,16 +63,10 @@ export default CoreMediaPlaceholder => props => {
 					// Try to pick up filename from the error message.
 					// We should find a better way to do it. Unstable.
 					const filename = message?.[0]?.props?.children;
-					if ( ! filename ) {
-						return onError( message );
+					if ( filename && isVideoFile( filename ) ) {
+						return setError( message );
 					}
-
-					const fileExtension = ( filename.split( '.' ) )?.[ 1 ];
-					if ( ! videoFileExtensions.includes( fileExtension ) ) {
-						return onError( message );
-					}
-
-					return setError( message );
+					return onError( message );
 				} }
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 			/>

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -4,12 +4,11 @@
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import UpgradeNudge from "../../components/upgrade-nudge";
+import { JetpackCoverUpgradeNudge } from './components';
 import { isUpgradable, isVideoFile } from './utils';
 
 /**
@@ -17,32 +16,6 @@ import { isUpgradable, isVideoFile } from './utils';
  */
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
-/**
- * Nudge shows when the user tries to upload a video file.
- * Unlike the core/video block, handled/extended by the videopress block,
- * the nudge is not shown permanently.
- * It's handled by the MediaPlaceholder component
- * when the user tries to upload a video file.
- * For this reason, we can't wrap the edit setting
- * with the wrapPaidBlock() HOC, as the videopress does.
- *
- * @param {object}  props - Information about the user.
- * @param {string}  props.name - Show the Nudge component.
- * @param {boolean} props.show - Show the Nudge component.
- * @returns {*} Nudge component or Null.
- */
-export const JetpackCoverUpgradeNudge = ( { name, show } ) =>
-	show
-		? <UpgradeNudge
-			plan="value_bundle"
-			blockName={ name }
-			title={ {
-				knownPlan: __( 'To use a video in this block, upgrade to %(planName)s.', 'jetpack' ),
-				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
-			} }
-			subtitle={ false }
-		/>
-		: null;
 
 export default CoreMediaPlaceholder => props => {
 	const [ error, setError ] = useState( false );

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -3,46 +3,50 @@
  * WordPress dependencies
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import { JetpackCoverUpgradeNudge } from './components';
 import { isUpgradable, isVideoFile } from './utils';
+import { CoverMediaContext } from './components';
 
 /**
  * Module Constants
  */
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
+export default createHigherOrderComponent(
+	CoreMediaPlaceholder => props => {
+		const { name } = useBlockEditContext();
+		if ( ! isUpgradable( name ) ) {
+			return <CoreMediaPlaceholder { ...props } />;
+		}
 
-export default CoreMediaPlaceholder => props => {
-	const [ error, setError ] = useState( false );
-
-	const { name } = useBlockEditContext();
-	if ( ! isUpgradable( name ) ) {
-		return <CoreMediaPlaceholder { ...props } />;
-	}
-
-	const { onError } = props;
-	return (
-		<div className="jetpack-cover-media-placeholder">
-			<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
-			<CoreMediaPlaceholder
-				{ ...props }
-				multiple={ false }
-				onError = { ( message ) => {
-					// Try to pick up filename from the error message.
-					// We should find a better way to do it. Unstable.
-					const filename = message?.[0]?.props?.children;
-					if ( filename && isVideoFile( filename ) ) {
-						return setError( message );
-					}
-					return onError( message );
-				} }
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
-			/>
-		</div>
-	);
-};
+		const { onError } = props;
+		return (
+			<div className="jetpack-cover-media-placeholder">
+				<CoverMediaContext.Consumer>
+					{ ( { onFilesUpload } ) => (
+						<CoreMediaPlaceholder
+							{ ...props }
+							onFilesPreUpload={ onFilesUpload }
+							multiple={ false }
+							onError = { ( message ) => {
+								// Try to pick up filename from the error message.
+								// We should find a better way to do it. Unstable.
+								const filename = message?.[0]?.props?.children;
+								if ( filename && isVideoFile( filename ) ) {
+									return onFilesUpload( [ filename ] );
+								}
+								return onError( message );
+							} }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+						/>
+					) }
+				</CoverMediaContext.Consumer>
+			</div>
+		);
+	},
+	'JepackCoverMediaPlaceholder'
+);

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -48,5 +48,5 @@ export default createHigherOrderComponent(
 			</div>
 		);
 	},
-	'JepackCoverMediaPlaceholder'
+	'JetpackCoverMediaPlaceholder'
 );

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -31,7 +31,7 @@ const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
  * @param {boolean} props.show - Show the Nudge component.
  * @returns {*} Nudge component or Null.
  */
-const JetpackCoverUpgradeNudge = ( { name, show } ) =>
+export const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 	show
 		? <UpgradeNudge
 			plan="value_bundle"

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -10,9 +10,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import UpgradeNudge from "../../components/upgrade-nudge";
-import { videoFileExtensions } from './utils';
-import { isSimpleSite } from "../../site-type-utils";
-import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
+import { videoFileExtensions, isUpgradable } from './utils';
 
 /**
  * Module Constants
@@ -48,14 +46,9 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 
 export default CoreMediaPlaceholder => props => {
 	const [ error, setError ] = useState( false );
-	const { name } = useBlockEditContext();
-	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
-	if (
-		( ! name || name !== 'core/cover' ) || // extend only for cover block
-		! isSimpleSite() || // only for Simple sites
-		! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-	) {
+	const { name } = useBlockEditContext();
+	if ( ! isUpgradable( name ) ) {
 		return <CoreMediaPlaceholder { ...props } />;
 	}
 

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -1,0 +1,23 @@
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useBlockEditContext } from '@wordpress/block-editor';
+import { isUpgradable } from "./utils";
+
+export default createHigherOrderComponent(
+	MediaReplaceFlow => props => {
+		const { name } = useBlockEditContext();
+		if ( ! isUpgradable( name ) ) {
+			return <MediaReplaceFlow { ...props } />;
+		}
+
+		return <MediaReplaceFlow { ...props } />;
+	},
+	'coverMediaReplaceFlow'
+);

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -6,18 +6,22 @@
 /**
  * WordPress dependencies
  */
-import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { isUpgradable } from "./utils";
 
-export default createHigherOrderComponent(
-	MediaReplaceFlow => props => {
-		const { name } = useBlockEditContext();
-		if ( ! isUpgradable( name ) ) {
-			return <MediaReplaceFlow { ...props } />;
-		}
-
+export default ( onNotice ) => ( MediaReplaceFlow => props => {
+	const { name } = useBlockEditContext();
+	if ( ! isUpgradable( name ) ) {
 		return <MediaReplaceFlow { ...props } />;
-	},
-	'coverMediaReplaceFlow'
-);
+	}
+
+	const { createNotice } = props;
+
+	return <MediaReplaceFlow
+		{ ...props }
+		createNotice={ ( status, msg, options ) => {
+			onNotice( status, msg, options );
+			createNotice( status, msg, options );
+		} }
+	/>;
+} );

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -12,22 +12,28 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { CoverMediaContext } from './index';
 import { isUpgradable } from "./utils";
 
-export default ( onNudgeShow ) => createHigherOrderComponent( MediaReplaceFlow => props => {
+export default createHigherOrderComponent( MediaReplaceFlow => props => {
 	const { name } = useBlockEditContext();
 	if ( ! isUpgradable( name ) ) {
 		return <MediaReplaceFlow { ...props } />;
 	}
 
 	const { createNotice } = props;
-
-	return <MediaReplaceFlow
-		{ ...props }
-		createNotice={ ( status, msg, options ) => {
-			onNudgeShow( status, msg, options );
-			createNotice( status, msg, options );
-		} }
-	/>;
+	return (
+		<CoverMediaContext.Consumer>
+			{ ( { onFilesUpload } ) => (
+				<MediaReplaceFlow
+					{ ...props }
+					onFilesUpload={ onFilesUpload }
+					createNotice={ ( status, msg, options ) => {
+						createNotice( status, msg, options );
+					} }
+				/>
+			) }
+		</CoverMediaContext.Consumer>
+	);
 }, 'withNudgeHandling' );
 

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -35,5 +35,5 @@ export default createHigherOrderComponent( MediaReplaceFlow => props => {
 			) }
 		</CoverMediaContext.Consumer>
 	);
-}, 'withNudgeHandling' );
+}, 'JetpackCoverMediaReplaceFlow' );
 

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -8,15 +8,17 @@
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { CoverMediaContext } from './components';
-import { isUpgradable } from "./utils";
+import { isUpgradable, isVideoFile } from "./utils";
 
 export default createHigherOrderComponent( MediaReplaceFlow => props => {
 	const { name } = useBlockEditContext();
+	const preUploadFile = useRef();
 	if ( ! isUpgradable( name ) ) {
 		return <MediaReplaceFlow { ...props } />;
 	}
@@ -27,8 +29,15 @@ export default createHigherOrderComponent( MediaReplaceFlow => props => {
 			{ ( { onFilesUpload } ) => (
 				<MediaReplaceFlow
 					{ ...props }
-					onFilesUpload={ onFilesUpload }
+					onFilesUpload={ ( files ) => {
+						preUploadFile.current = files?.length ? files[ 0 ] : null;
+						onFilesUpload( files );
+					} }
 					createNotice={ ( status, msg, options ) => {
+						// Detect video file from callback and reference instance.
+						if ( isVideoFile( preUploadFile.current ) ) {
+							return null;
+						}
 						createNotice( status, msg, options );
 					} }
 				/>

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -38,6 +38,12 @@ export default createHigherOrderComponent( MediaReplaceFlow => props => {
 						if ( isVideoFile( preUploadFile.current ) ) {
 							return null;
 						}
+
+						// Try to pick file type from notice message.
+						// Unstable. Not reliable. Fallback.
+						if ( isVideoFile( msg.split( ':' )[ 0 ] ) ) {
+							return null;
+						}
 						createNotice( status, msg, options );
 					} }
 				/>

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -12,7 +12,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { CoverMediaContext } from './index';
+import { CoverMediaContext } from './components';
 import { isUpgradable } from "./utils";
 
 export default createHigherOrderComponent( MediaReplaceFlow => props => {

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -7,9 +7,14 @@
  * WordPress dependencies
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
 import { isUpgradable } from "./utils";
 
-export default ( onNotice ) => ( MediaReplaceFlow => props => {
+export default ( onNudgeShow ) => createHigherOrderComponent( MediaReplaceFlow => props => {
 	const { name } = useBlockEditContext();
 	if ( ! isUpgradable( name ) ) {
 		return <MediaReplaceFlow { ...props } />;
@@ -20,8 +25,9 @@ export default ( onNotice ) => ( MediaReplaceFlow => props => {
 	return <MediaReplaceFlow
 		{ ...props }
 		createNotice={ ( status, msg, options ) => {
-			onNotice( status, msg, options );
+			onNudgeShow( status, msg, options );
 			createNotice( status, msg, options );
 		} }
 	/>;
-} );
+}, 'withNudgeHandling' );
+

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -1,0 +1,51 @@
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockEditContext } from '@wordpress/block-editor';
+import { useEffect, useState, Fragment } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { isUpgradable, isVideoFile } from "./utils";
+import { CoverMediaProvider, JetpackCoverUpgradeNudge } from "./components";
+
+export default createHigherOrderComponent(
+	BlockEdit => props => {
+		const { name } = useBlockEditContext();
+		const [ showNudge, setShowNudge ] = useState( false );
+
+		// Remove Nudge if the block changes its attributes.
+		const { attributes } = props;
+		const { align } = attributes;
+		useEffect( () => setShowNudge( false ), [ attributes ] );
+
+		if ( ! isUpgradable( name ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const handleFilesPreUpload = ( files ) => {
+			if ( ! files?.length ) {
+				return;
+			}
+
+			if ( ! isVideoFile( files[ 0 ] ) ) {
+				return;
+			}
+
+			setShowNudge( true );
+		};
+
+		return (
+			<Fragment>
+				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
+					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ align } />
+					<BlockEdit { ...props } />
+				</CoverMediaProvider>
+			</Fragment>
+		);
+	},
+	'JetpackCoverBlockEdit'
+);

--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -1,7 +1,5 @@
-.jetpack-cover-media-placeholder {
-	width: 100%;
-
-	// tweak Upgrade nudge.
+// tweak Upgrade nudge.
+.jetpack-upgrade-nudge-wrapper.wp-block {
 	.block-editor-warning__contents {
 		flex-wrap: initial;
 
@@ -9,5 +7,10 @@
 		.block-editor-warning__actions {
 			align-self: center;
 		}
+	}
+
+	.jetpack-block-nudge {
+		width: 100%;
+		min-width: 100%;
 	}
 }

--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -1,3 +1,8 @@
+// Stretch Cover MediaPlaceholder element.
+.jetpack-cover-media-placeholder {
+	width: 100%;
+}
+
 // tweak Upgrade nudge.
 .jetpack-upgrade-nudge-wrapper.wp-block {
 	.block-editor-warning__contents {

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -7,7 +7,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { useBlockEditContext } from '@wordpress/block-editor';
-import { useEffect, useState, Fragment, createContext } from '@wordpress/element';
+import { useEffect, useState, Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,39 +15,15 @@ import { useEffect, useState, Fragment, createContext } from '@wordpress/element
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import isCurrentUserConnected from "../../is-current-user-connected";
 import coverMediaReplaceFlow from './cover-replace-control-button';
-import { JetpackCoverUpgradeNudge } from './components';
+import { JetpackCoverUpgradeNudge, CoverMediaProvider } from './components';
 import { isUpgradable, isVideoFile } from "./utils";
+
 import './editor.scss';
-
-/**
- * Cover Media context
- * Used to connect the CoverEdit with
- * the Media Replace Flow.
- */
-export const CoverMediaContext = createContext();
-
-/**
- * Cover Media Provider will populate the properties
- * from the CoverEdit to the Media Replace Flow component.
- *
- * @param {object}  props - Provider properties.
- * @param {string}  props.onFilesUpload - Callback function before to upload files.
- * @param {boolean} props.children - Provider Children.
- * @returns {*} Provider component.
- */
-const CoverMediaProvider = ( { onFilesUpload, children } ) => {
-	return (
-		<CoverMediaContext.Provider value={ {
-			onFilesUpload,
-		} }>
-			{ children }
-		</CoverMediaContext.Provider>
-	);
-};
 
 const jetpackEditBlock = BlockEdit => props => {
 	const { name } = useBlockEditContext();
 	const [ showNudge, setShowNudge ] = useState( false );
+	console.log( { name } );
 
 	// Remove Nudge if the block changes its attributes.
 	const { attributes } = props;

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -12,9 +12,10 @@ import { useEffect, useState, Fragment, createContext } from '@wordpress/element
 /**
  * Internal dependencies
  */
-import coverEditMediaPlaceholder, { JetpackCoverUpgradeNudge } from './cover-media-placeholder';
+import coverEditMediaPlaceholder from './cover-media-placeholder';
 import isCurrentUserConnected from "../../is-current-user-connected";
 import coverMediaReplaceFlow from './cover-replace-control-button';
+import { JetpackCoverUpgradeNudge } from './components';
 import { isUpgradable, isVideoFile } from "./utils";
 import './editor.scss';
 

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -8,6 +8,8 @@
 import { addFilter } from '@wordpress/hooks';
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { useEffect, useState, Fragment } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
 
 /**
  * Internal dependencies
@@ -20,40 +22,42 @@ import { isUpgradable, isVideoFile } from "./utils";
 
 import './editor.scss';
 
-const jetpackEditBlock = BlockEdit => props => {
-	const { name } = useBlockEditContext();
-	const [ showNudge, setShowNudge ] = useState( false );
-	console.log( { name } );
+const jetpackEditBlock = createHigherOrderComponent(
+	BlockEdit => props => {
+		const { name } = useBlockEditContext();
+		const [ showNudge, setShowNudge ] = useState( false );
 
-	// Remove Nudge if the block changes its attributes.
-	const { attributes } = props;
-	useEffect( () => setShowNudge( false ), [ attributes ] );
+		// Remove Nudge if the block changes its attributes.
+		const { attributes } = props;
+		useEffect( () => setShowNudge( false ), [ attributes ] );
 
-	if ( ! isUpgradable( name ) ) {
-		return <BlockEdit { ...props } />;
-	}
-
-	const handleFilesPreUpload = ( files ) => {
-		if ( ! files?.length ) {
-			return;
+		if ( ! isUpgradable( name ) ) {
+			return <BlockEdit { ...props } />;
 		}
 
-		if ( ! isVideoFile( files[ 0 ] ) ) {
-			return;
-		}
+		const handleFilesPreUpload = ( files ) => {
+			if ( ! files?.length ) {
+				return;
+			}
 
-		setShowNudge( true );
-	};
+			if ( ! isVideoFile( files[ 0 ] ) ) {
+				return;
+			}
 
-	return (
-		<Fragment>
-			<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
-				<JetpackCoverUpgradeNudge show={ showNudge } name={ name } />
-				<BlockEdit { ...props } />
-			</CoverMediaProvider>
-		</Fragment>
-	);
-};
+			setShowNudge( true );
+		};
+
+		return (
+			<Fragment>
+				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
+					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } />
+					<BlockEdit { ...props } />
+				</CoverMediaProvider>
+			</Fragment>
+		);
+	},
+	'JetpackCoverEdit'
+);
 
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -6,67 +6,25 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { useBlockEditContext } from '@wordpress/block-editor';
-import { useEffect, useState, Fragment } from '@wordpress/element';
-import { createHigherOrderComponent } from '@wordpress/compose';
-
 
 /**
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
-import isCurrentUserConnected from "../../is-current-user-connected";
 import coverMediaReplaceFlow from './cover-replace-control-button';
-import { JetpackCoverUpgradeNudge, CoverMediaProvider } from './components';
-import { isUpgradable, isVideoFile } from "./utils";
+import jetpackCoverBlockEdit from './edit';
+
+import isCurrentUserConnected from "../../is-current-user-connected";
 
 import './editor.scss';
 
-const jetpackEditBlock = createHigherOrderComponent(
-	BlockEdit => props => {
-		const { name } = useBlockEditContext();
-		const [ showNudge, setShowNudge ] = useState( false );
-
-		// Remove Nudge if the block changes its attributes.
-		const { attributes } = props;
-		const { align } = attributes;
-		useEffect( () => setShowNudge( false ), [ attributes ] );
-
-		if ( ! isUpgradable( name ) ) {
-			return <BlockEdit { ...props } />;
-		}
-
-		const handleFilesPreUpload = ( files ) => {
-			if ( ! files?.length ) {
-				return;
-			}
-
-			if ( ! isVideoFile( files[ 0 ] ) ) {
-				return;
-			}
-
-			setShowNudge( true );
-		};
-
-		return (
-			<Fragment>
-				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
-					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ align } />
-					<BlockEdit { ...props } />
-				</CoverMediaProvider>
-			</Fragment>
-		);
-	},
-	'JetpackCoverEdit'
-);
-
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
-	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-media-placeholder', coverEditMediaPlaceholder );
 
 	// Take the control of the Replace block button control.
-	addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-edit-media-placeholder', coverMediaReplaceFlow );
+	addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );
 
 	// Extend CoverEdit.
-	addFilter( 'editor.BlockEdit', 'jetpack/handle-upgrade-nudge', jetpackEditBlock );
+	addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
 }

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -7,7 +7,7 @@
  */
 import { addFilter } from '@wordpress/hooks';
 import { useBlockEditContext } from '@wordpress/block-editor';
-import { useEffect, useState, Fragment } from '@wordpress/element';
+import { useEffect, useState, Fragment, createContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,51 +15,76 @@ import { useEffect, useState, Fragment } from '@wordpress/element';
 import coverEditMediaPlaceholder, { JetpackCoverUpgradeNudge } from './cover-media-placeholder';
 import isCurrentUserConnected from "../../is-current-user-connected";
 import coverMediaReplaceFlow from './cover-replace-control-button';
-import { isUpgradable } from "./utils";
+import { isUpgradable, isVideoFile } from "./utils";
 import './editor.scss';
 
+/**
+ * Cover Media context
+ * Used to connect the CoverEdit with
+ * the Media Replace Flow.
+ */
+export const CoverMediaContext = createContext();
+
+/**
+ * Cover Media Provider will populate the properties
+ * from the CoverEdit to the Media Replace Flow component.
+ *
+ * @param {object}  props - Provider properties.
+ * @param {string}  props.onFilesUpload - Callback function before to upload files.
+ * @param {boolean} props.children - Provider Children.
+ * @returns {*} Provider component.
+ */
+const CoverMediaProvider = ( { onFilesUpload, children } ) => {
+	return (
+		<CoverMediaContext.Provider value={ {
+			onFilesUpload,
+		} }>
+			{ children }
+		</CoverMediaContext.Provider>
+	);
+};
+
+const jetpackEditBlock = BlockEdit => props => {
+	const { name } = useBlockEditContext();
+	const [ showNudge, setShowNudge ] = useState( false );
+
+	// Remove Nudge if the block changes its attributes.
+	const { attributes } = props;
+	useEffect( () => setShowNudge( false ), [ attributes ] );
+
+	if ( ! isUpgradable( name ) ) {
+		return <BlockEdit { ...props } />;
+	}
+
+	const handleFilesPreUpload = ( files ) => {
+		if ( ! files?.length ) {
+			return;
+		}
+
+		if ( ! isVideoFile( files[ 0 ] ) ) {
+			return;
+		}
+
+		setShowNudge( true );
+	};
+
+	return (
+		<Fragment>
+			<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
+				<JetpackCoverUpgradeNudge show={ showNudge } name={ name } />
+				<BlockEdit { ...props } />
+			</CoverMediaProvider>
+		</Fragment>
+	);
+};
 
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
-	addFilter(
-		'editor.MediaPlaceholder',
-		'jetpack/cover-edit-media-placeholder',
-		coverEditMediaPlaceholder
-	);
+	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
 
-	const jetpackEditBlock = BlockEdit => props => {
-		const { name } = useBlockEditContext();
-		const [ showNudge, setShowNudge ] = useState( false );
+	// Take the control of the Replace block button control.
+	addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-edit-media-placeholder', coverMediaReplaceFlow );
 
-		// Remove Nudge of the block changes its attributes.
-		const { attributes } = props;
-		useEffect( () => {
-			if ( ! isUpgradable( name ) ) {
-				return;
-			}
-			setShowNudge( false );
-		}, [ attributes, name ] );
-
-		useEffect( () => {
-			// Take the control of the Replace block button control.
-			addFilter(
-				'editor.MediaReplaceFlow',
-				'jetpack/cover-edit-media-placeholder',
-				coverMediaReplaceFlow( ( data ) => setShowNudge( !! data ) )
-			);
-		}, [ name ] );
-
-		if ( ! isUpgradable( name ) ) {
-			return <BlockEdit { ...props } />;
-		}
-
-		return (
-			<Fragment>
-				<JetpackCoverUpgradeNudge show={ showNudge } name={ name } />
-				<BlockEdit { ...props } />
-			</Fragment>
-		);
-	};
-
+	// Extend CoverEdit.
 	addFilter( 'editor.BlockEdit', 'jetpack/handle-upgrade-nudge', jetpackEditBlock );
 }

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -29,6 +29,7 @@ const jetpackEditBlock = createHigherOrderComponent(
 
 		// Remove Nudge if the block changes its attributes.
 		const { attributes } = props;
+		const { align } = attributes;
 		useEffect( () => setShowNudge( false ), [ attributes ] );
 
 		if ( ! isUpgradable( name ) ) {
@@ -50,7 +51,7 @@ const jetpackEditBlock = createHigherOrderComponent(
 		return (
 			<Fragment>
 				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
-					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } />
+					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ align } />
 					<BlockEdit { ...props } />
 				</CoverMediaProvider>
 			</Fragment>

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -13,6 +13,7 @@ import { addFilter } from '@wordpress/hooks';
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import isCurrentUserConnected from "../../is-current-user-connected";
 import './editor.scss';
+import coverMediaReplaceFlow from './cover-replace-control-button';
 
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
@@ -20,5 +21,12 @@ if ( isCurrentUserConnected() ) {
 		'editor.MediaPlaceholder',
 		'jetpack/cover-edit-media-placeholder',
 		coverEditMediaPlaceholder
+	);
+
+// Take the control of the Replace block button control.
+	addFilter(
+		'editor.MediaReplaceFlow',
+		'jetpack/cover-edit-media-placeholder',
+		coverMediaReplaceFlow
 	);
 }

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -18,6 +18,7 @@ import coverMediaReplaceFlow from './cover-replace-control-button';
 import { isUpgradable } from "./utils";
 import './editor.scss';
 
+
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
 	addFilter(
@@ -29,6 +30,15 @@ if ( isCurrentUserConnected() ) {
 	const jetpackEditBlock = BlockEdit => props => {
 		const { name } = useBlockEditContext();
 		const [ showNudge, setShowNudge ] = useState( false );
+
+		// Remove Nudge of the block changes its attributes.
+		const { attributes } = props;
+		useEffect( () => {
+			if ( ! isUpgradable( name ) ) {
+				return;
+			}
+			setShowNudge( false );
+		}, [ attributes, name ] );
 
 		useEffect( () => {
 			// Take the control of the Replace block button control.

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -1,4 +1,10 @@
 
+/**
+ * Internal dependencies
+ */
+import { isSimpleSite } from "../../site-type-utils";
+import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
+
 export const videoFileExtensions = [
 	'ogv',
 	'mp4',
@@ -17,3 +23,17 @@ export const videoFileExtensions = [
 	'3gp',
 	'3g2',
 ];
+
+/**
+ * Check if the cover block should show the upgrade nudge.
+ *
+ * @param {string} name - Block name.
+ * @returns {boolean} True if it should show the nudge. Otherwise, False.
+ */
+export function isUpgradable( name ) {
+	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
+
+	return name && name === 'core/cover' && // upgrade only for cover block
+		isSimpleSite() && // only for Simple sites
+		[ 'missing_plan', 'unknown' ].includes( unavailableReason );
+}

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -1,28 +1,48 @@
 
 /**
+ * External dependencies
+ */
+import { pickBy, flatten, map, keys, values } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { isSimpleSite } from "../../site-type-utils";
 import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
 
-export const videoFileExtensions = [
-	'ogv',
-	'mp4',
-	'm4v',
-	'mov',
-	'qt',
-	'wmv',
-	'avi',
-	'mpeg',
-	'mpg',
-	'mpe',
-	'3gp',
-	'3gpp',
-	'3g2',
-	'3gp2',
-	'3gp',
-	'3g2',
-];
+/**
+ * Check if the given file is a video.
+ *
+ * @param   {string|object} file - file to check.
+ * @returns {boolean}       True if it's a video file. Otherwise, False.
+ */
+export function isVideoFile( file ) {
+	// Pick up allowed mime types from the window object.
+	const allowedMimeTypes = window?.Jetpack_Editor_Initial_State?.allowedMimeTypes;
+	if ( ! allowedMimeTypes ) {
+		return false;
+	}
+
+	if ( ! file ) {
+		return false;
+	}
+
+	let allowedVideoMimeTypes = pickBy( allowedMimeTypes, ( type ) => /^video\//.test( type ) );
+	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
+
+	if ( typeof file === 'string' ) {
+		const fileExtension = ( file.split( '.' ) )?.[ 1 ];
+		return fileExtension && allowedVideoFileExtensions.includes( fileExtension );
+	}
+
+	allowedVideoMimeTypes = values( allowedVideoMimeTypes );
+
+	if ( typeof file === 'object' ) {
+		return file.type && allowedVideoMimeTypes.includes( file.type );
+	}
+
+	return false;
+}
 
 /**
  * Check if the cover block should show the upgrade nudge.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR handles how and when to show an upgrade nudge for the core/cover block when it's a simple site and has a free plan.
It refactorizes part of the current implementation for the MediaPlaceholder.
This PR will be split out in smaller ones in order to do the merging process less painful.

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
