### PR TITLE
Make Comics CPT validate for AMP

### DIFF
--- a/modules/custom-post-types/comics.php
+++ b/modules/custom-post-types/comics.php
@@ -172,29 +172,35 @@ class Jetpack_Comic {
 	public function register_scripts() {
 		wp_enqueue_style( 'jetpack-comics-style', plugins_url( 'comics/comics.css', __FILE__ ) );
 		wp_style_add_data( 'jetpack-comics-style', 'rtl', 'replace' );
-		wp_enqueue_script(
-			'jetpack-comics',
-			Assets::get_file_url_for_environment(
-				'_inc/build/custom-post-types/comics/comics.min.js',
-				'modules/custom-post-types/comics/comics.js'
-			),
-			array( 'jquery', 'jquery.spin' )
-		);
 
-		$options = array(
-			'nonce' => wp_create_nonce( 'jetpack_comic_upload_nonce' ),
-			'writeURL' => admin_url( 'admin-ajax.php?action=jetpack_comic_upload' ),
-			'labels' => array(
-				'dragging' => __( 'Drop images to upload', 'jetpack' ),
-				'uploading' => __( 'Uploading...', 'jetpack' ),
-				'processing' => __( 'Processing...', 'jetpack' ),
-				'unsupported' => __( "Sorry, your browser isn't supported. Upgrade at browsehappy.com.", 'jetpack' ),
-				'invalidUpload' => __( 'Only images can be uploaded here.', 'jetpack' ),
-				'error' => __( "Your upload didn't complete; try again later or cross your fingers and try again right now.", 'jetpack' ),
-			)
-		);
+		$is_amp = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+		if ( ! $is_amp ) {
+			wp_enqueue_script(
+				'jetpack-comics',
+				Assets::get_file_url_for_environment(
+					'_inc/build/custom-post-types/comics/comics.min.js',
+					'modules/custom-post-types/comics/comics.js'
+				),
+				array( 'jquery', 'jquery.spin' ),
+				JETPACK__VERSION,
+				false
+			);
 
-		wp_localize_script( 'jetpack-comics', 'Jetpack_Comics_Options', $options );
+			$options = array(
+				'nonce'    => wp_create_nonce( 'jetpack_comic_upload_nonce' ),
+				'writeURL' => admin_url( 'admin-ajax.php?action=jetpack_comic_upload' ),
+				'labels'   => array(
+					'dragging'      => __( 'Drop images to upload', 'jetpack' ),
+					'uploading'     => __( 'Uploading...', 'jetpack' ),
+					'processing'    => __( 'Processing...', 'jetpack' ),
+					'unsupported'   => __( "Sorry, your browser isn't supported. Upgrade at browsehappy.com.", 'jetpack' ),
+					'invalidUpload' => __( 'Only images can be uploaded here.', 'jetpack' ),
+					'error'         => __( "Your upload didn't complete; try again later or cross your fingers and try again right now.", 'jetpack' ),
+				),
+			);
+
+			wp_localize_script( 'jetpack-comics', 'Jetpack_Comics_Options', $options );
+		}
 	}
 
 	public function admin_enqueue_scripts() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The comic CPT doesn't validate on AMP because of the `jetpack-comics` script that gets enqueued. This change conditionally loads it for non-AMP only. 

<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Don't load `jetpack-comics` on AMP pages

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
No.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install AMP plugin if necessary
* In the AMP plugin settings, select Transitional mode
* In your theme, add `add_theme_support( 'jetpack-comic' );` to `after_setup_theme`
* In wp-admin, create a comic (/wp-admin/post-new.php?post_type=jetpack-comic)
* View the post in AMP mode and non-AMP mode
  * If the post returns a 404, switch to a different theme, and then back to the previous theme
* Confirm that the post renders correctly and that there are no validation errors

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* AMP support for comic CPT
