### PR TITLE
Calypsoify: Add check for cookies to enable breaking out of iframe if 3rd party cookies blocked

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -24,8 +24,28 @@ class Jetpack_Calypsoify {
 
 	private function __construct() {
 		add_action( 'wp_loaded', array( $this, 'setup' ) );
+		add_action( 'login_init', array( $this, 'check_iframe_cookie_setting') );
 	}
 
+	/**
+	 * Checks to see if cookie can be set in current context. If 3rd party cookie blocking
+	 * is enabled the editor can't load in iFrame, so emiting X-Frame-Options: DENY will
+	 * force the editor to break out of the iFrame.
+	 */
+	function check_iframe_cookie_setting() {
+		if ( ! strpos($_GET['redirect_to'], 'calypsoify=1&block-editor=1' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
+			return;
+		}
+	
+		if ( ! isset( $_GET['calypsoify_cookie_check'] ) ) {
+			header( 'Location: ' . $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' );
+			exit;
+		}
+	
+		header('X-Frame-Options: DENY');
+		exit;
+	 }
+	 
 	public static function getInstance() {
 		if ( ! self::$instance ) {
 			self::$instance = new self();

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -24,33 +24,7 @@ class Jetpack_Calypsoify {
 
 	private function __construct() {
 		add_action( 'wp_loaded', array( $this, 'setup' ) );
-		add_action( 'login_init', array( $this, 'check_iframe_cookie_setting') );
 	}
-
-	/**
-	 * Checks to see if cookie can be set in current context. If 3rd party cookie blocking
-	 * is enabled the editor can't load in iFrame, so emiting X-Frame-Options: DENY will
-	 * force the editor to break out of the iFrame.
-	 */
-	function check_iframe_cookie_setting() {
-		var_dump( 'check_iframe_cookie_setting' );
-		var_dump( strpos($_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) );
-		var_dump( isset( $_COOKIE['wordpress_test_cookie'] ) );
-		var_dump( $_GET['calypsoify_cookie_check'] );
-		var_dump( $_SERVER['REQUEST_URI'] );
-		exit;
-		if ( ! strpos($_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
-			return;
-		}
-
-		if ( ! $_GET['calypsoify_cookie_check'] ) {
-			header( 'Location: ' . $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' );
-			exit;
-		}
-
-		header('X-Frame-Options: DENY');
-		exit;
-	 }
 
 	public static function getInstance() {
 		if ( ! self::$instance ) {

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -33,13 +33,11 @@ class Jetpack_Calypsoify {
 	 * force the editor to break out of the iFrame.
 	 */
 	function check_iframe_cookie_setting() {
-		echo 'here!';
-		exit;
-		if ( ! strpos($_GET['redirect_to'], 'calypsoify=1&block-editor=1' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
+		if ( ! strpos($_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
 			return;
 		}
 	
-		if ( ! isset( $_GET['calypsoify_cookie_check'] ) ) {
+		if ( ! $_GET['calypsoify_cookie_check'] ) {
 			header( 'Location: ' . $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' );
 			exit;
 		}

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -33,19 +33,25 @@ class Jetpack_Calypsoify {
 	 * force the editor to break out of the iFrame.
 	 */
 	function check_iframe_cookie_setting() {
+		var_dump( 'check_iframe_cookie_setting' );
+		var_dump( strpos($_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) );
+		var_dump( isset( $_COOKIE['wordpress_test_cookie'] ) );
+		var_dump( $_GET['calypsoify_cookie_check'] );
+		var_dump( $_SERVER['REQUEST_URI'] );
+		exit;
 		if ( ! strpos($_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
 			return;
 		}
-	
+
 		if ( ! $_GET['calypsoify_cookie_check'] ) {
 			header( 'Location: ' . $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' );
 			exit;
 		}
-	
+
 		header('X-Frame-Options: DENY');
 		exit;
 	 }
-	 
+
 	public static function getInstance() {
 		if ( ! self::$instance ) {
 			self::$instance = new self();

--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -33,6 +33,8 @@ class Jetpack_Calypsoify {
 	 * force the editor to break out of the iFrame.
 	 */
 	function check_iframe_cookie_setting() {
+		echo 'here!';
+		exit;
 		if ( ! strpos($_GET['redirect_to'], 'calypsoify=1&block-editor=1' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
 			return;
 		}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -110,12 +110,12 @@ class Jetpack_WPCOM_Block_Editor {
 	 * while trying to access the block editor from wordpress.com.
 	 */
 	public function allow_block_editor_login() {
-		$this->check_iframe_cookie_setting();
-
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( empty( $_REQUEST['redirect_to'] ) ) {
 			return;
 		}
+
+		$this->check_iframe_cookie_setting();
 
 		// phpcs:ignore WordPress.Security.NonceVerification
 		$query = wp_parse_url( urldecode( $_REQUEST['redirect_to'] ), PHP_URL_QUERY );

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -92,8 +92,6 @@ class Jetpack_WPCOM_Block_Editor {
 	 * force the editor to break out of the iFrame.
 	 */
 	private function check_iframe_cookie_setting() {
-		var_dump( 'die' );
-		die;
 		if ( ! strpos( $_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
 			return;
 		}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -92,7 +92,7 @@ class Jetpack_WPCOM_Block_Editor {
 	 * force the editor to break out of the iFrame.
 	 */
 	private function check_iframe_cookie_setting() {
-		if ( ! strpos( $_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
+		if ( ! isset( $_SERVER['QUERY_STRING'] ) || ! strpos( $_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
 			return;
 		}
 

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -92,6 +92,8 @@ class Jetpack_WPCOM_Block_Editor {
 	 * force the editor to break out of the iFrame.
 	 */
 	private function check_iframe_cookie_setting() {
+		var_dump( 'die' );
+		die;
 		if ( ! strpos( $_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
 			return;
 		}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -87,10 +87,31 @@ class Jetpack_WPCOM_Block_Editor {
 	}
 
 	/**
+	 * Checks to see if cookie can be set in current context. If 3rd party cookie blocking
+	 * is enabled the editor can't load in iFrame, so emiting X-Frame-Options: DENY will
+	 * force the editor to break out of the iFrame.
+	 */
+	private function check_iframe_cookie_setting() {
+		if ( ! strpos( $_SERVER['QUERY_STRING'], 'calypsoify%3D1%26block-editor' ) || isset( $_COOKIE['wordpress_test_cookie'] ) ) {
+			return;
+		}
+
+		if ( ! $_GET['calypsoify_cookie_check'] ) {
+			header( 'Location: ' . $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' );
+			exit;
+		}
+
+		header( 'X-Frame-Options: DENY' );
+		exit;
+	}
+
+	/**
 	 * Allows to iframe the login page if a user is logged out
 	 * while trying to access the block editor from wordpress.com.
 	 */
 	public function allow_block_editor_login() {
+		$this->check_iframe_cookie_setting();
+
 		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( empty( $_REQUEST['redirect_to'] ) ) {
 			return;

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -96,8 +96,8 @@ class Jetpack_WPCOM_Block_Editor {
 			return;
 		}
 
-		if ( ! $_GET['calypsoify_cookie_check'] ) {
-			header( 'Location: ' . $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' );
+		if ( ! $_GET['calypsoify_cookie_check'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			header( 'Location: ' . esc_url_raw( $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' ) );
 			exit;
 		}
 


### PR DESCRIPTION
Adds a check for cookies to enable breaking out of iframe if 3rd party cookies blocked

Part of fixe for: https://github.com/Automattic/wp-calypso/issues/43068

#### Changes proposed in this Pull Request:
* If a redirect to login from calypso iframe is detected a check is done to make sure cookies can be set, if not code exits with an `X-Frame-Options: DENY` header. This prevents an endless auth loop between wpcom and jetpack and makes the editor break out of the iframe. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* Adds functionality to an existing feature.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

- Add Jetpack Beta to an Atomic site and install this branch
- Go direct to the atomic site wp-admin and login
- Load WP.com and switch to the same Atomic site in safari with `Prevent Cross Site Tracking` enabled, and load editor
- It should do a redirect to wpadmin and return to editor with authWpAdmin=true param set
- Now delete all the data/cookies just for this  domain from Safari, but make sure there is still a Session Storage value for wordpress.com for `gutenframe_{site_id}_is_authenticated` for that site
- Try loading the editor again and it should go break out of the iframe and redirect top wpadmin fr site

#### Proposed changelog entry for your changes:
* No changelog entry needed
