### PR TITLE
New script that will revert the stable tag for Jetpack in wp.org svn. 

### DIFF
--- a/tools/revert-release.sh
+++ b/tools/revert-release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# CAUTION!
+# This script does one thing, which is to revert stable tag in WordPress.org svn to the prior tag.
+# It should only be used in extreme emergency cases.
+
+# Check for requirements. Using `jq` to easily parse json. Is there a simpler way to get the latest tags?
+if [ -z $(command -v jq) ]; then
+	echo "This script requires the jq library."
+	read -p "Do you want to install it on your system with Homebrew? [y/N]" -n 1 -r
+	if [[ $REPLY != "y" && $REPLY != "Y" ]]; then
+		exit 1;
+	else
+		brew install jq 2>/dev/null
+		echo "Done!"
+	fi
+fi
+
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NOCOLOR='\033[0m'
+
+# Current stable version
+CURRENT_STABLE_VERSION=$(curl -s http://api.wordpress.org/plugins/info/1.0/jetpack.json | jq -r .version)
+
+# Get all versions, strip anything with alpha characters such as -beta or trunk.
+LAST_STABLE_TAG=$(curl -s http://api.wordpress.org/plugins/info/1.0/jetpack.json | jq -r '.versions | delpaths([paths | select(.[] | test("[A-Za-z]+"; "i"))]) | keys[-2]' )
+
+echo -e "${RED}CAUTION${NOCOLOR}"
+echo -e "This script does one thing, which is to revert stable tag in WordPress.org svn to the prior tag."
+echo -e "It should only be used in extreme emergency cases."
+echo ""
+echo -e "${YELLOW}Current stable tag:${NOCOLOR} ${CURRENT_STABLE_VERSION}"
+echo -e "${YELLOW}Revert to tag:${NOCOLOR} ${LAST_STABLE_TAG}"
+
+read -p "Continue? [y/N]" -n 1 -r
+if [[ $REPLY != "y" && $REPLY != "Y" ]]; then
+    exit 1;
+fi
+echo ""
+
+JETPACK_SVN_DIR="/tmp/jetpack-revert"
+
+# Prep a home to drop our new files in. Just make it in /tmp so we can start fresh each time.
+rm -rf $JETPACK_SVN_DIR
+
+echo "Checking out SVN shallowly to $JETPACK_SVN_DIR"
+svn -q checkout https://plugins.svn.wordpress.org/jetpack/ --depth=empty $JETPACK_SVN_DIR
+echo "Done!"
+
+cd $JETPACK_SVN_DIR
+
+echo "Checking out SVN trunk to $JETPACK_SVN_DIR/trunk"
+svn -q up trunk
+echo "Done!"
+
+# Update trunk to point to the last stable tag.
+echo "Modifying 'Stable tag:' value in trunk readme.txt"
+perl -pi -e "s/Stable tag: .*/Stable tag: $LAST_STABLE_TAG/" trunk/readme.txt
+echo ""
+echo -e "${YELLOW}The diff you are about to commit:${NOCOLOR}"
+svn diff
+
+
+echo ""
+echo -e "${RED}WARNING:${NOCOLOR} "
+read -p "You are about to revert the stable tag for Jetpack via the diff above. Would you like to commit it now? [y/N]" -n 1 -r
+if [[ $REPLY != "y" && $REPLY != "Y" ]]; then
+    exit 1;
+else
+    svn ci -m "Revert stable tag"
+fi

--- a/tools/revert-release.sh
+++ b/tools/revert-release.sh
@@ -12,7 +12,8 @@ if [ -z $(command -v jq) ]; then
 		exit 1;
 	else
 		brew install jq 2>/dev/null
-		echo "Done!"
+		echo "Done! You can now run the script again to start the revert."
+		exit 1;
 	fi
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This adds a new script that does one thing only, which is to roll back the stable tag of the Jetpack plugin in the wp.org repo. It is only meant to be used in case of extreme emergency situations. 

We have discussed in depth internally about this. 

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Internal janitorial feature I guess? 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
**PLEASE BE CAREFUL WHEN TESTING**
There are a couple of confirmations along the way, and I suspect you still will need to input your svn creds in order for the commit to go through. But I have not dared to go beyond the last confirmation myself. 

I would like feedback on the following: 
- Whether we need more or less confirmations during the script
- The verbiage used
- If we should add more context in the description/text on when to use this

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
