### PR TITLE
Mailchimp Block: Replace submit button with inner button block

### DIFF
--- a/extensions/blocks/mailchimp/deprecated/v1/index.js
+++ b/extensions/blocks/mailchimp/deprecated/v1/index.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { isEmpty, omit, pick, some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+const deprecatedAttributes = [
+	'submitButtonText',
+	'backgroundButtonColor',
+	'textButtonColor',
+	'submitButtonClasses',
+	'customBackgroundButtonColor',
+	'customTextButtonColor',
+];
+
+const migrateAttributes = oldAttributes => ( {
+	text: oldAttributes.submitButtonText || __( 'Join my email list', 'jetpack' ),
+	textColor: oldAttributes.textButtonColor,
+	customTextColor: oldAttributes.customTextButtonColor,
+	backgroundColor: oldAttributes.backgroundButtonColor,
+	customBackgroundColor: oldAttributes.customBackgroundButtonColor,
+} );
+
+export default {
+	attributes: {
+		emailPlaceholder: {
+			type: 'string',
+			default: __( 'Enter your email', 'jetpack' ),
+		},
+		submitButtonText: {
+			type: 'string',
+			default: __( 'Join my email list', 'jetpack' ),
+		},
+		backgroundButtonColor: {
+			type: 'string',
+		},
+		textButtonColor: {
+			type: 'string',
+		},
+		submitButtonClasses: {
+			type: 'string',
+		},
+		customBackgroundButtonColor: {
+			type: 'string',
+		},
+		customTextButtonColor: {
+			type: 'string',
+		},
+		consentText: {
+			type: 'string',
+			default: __(
+				'By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.',
+				'jetpack'
+			),
+		},
+		interests: {
+			type: 'array',
+			default: [],
+		},
+		processingLabel: {
+			type: 'string',
+			default: __( 'Processing…', 'jetpack' ),
+		},
+		signupFieldTag: {
+			type: 'string',
+		},
+		signupFieldValue: {
+			type: 'string',
+		},
+		successLabel: {
+			type: 'string',
+			default: __( "Success! You're on the list.", 'jetpack' ),
+		},
+		errorLabel: {
+			type: 'string',
+			default: __(
+				"Whoops! There was an error and we couldn't process your subscription. Please reload the page and try again.",
+				'jetpack'
+			),
+		},
+		preview: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	migrate: attributes => {
+		const newAttributes = omit( attributes, deprecatedAttributes );
+		const buttonAttributes = migrateAttributes( attributes );
+		const newInnerBlocks = [
+			createBlock( 'jetpack/button', {
+				element: 'button',
+				uniqueId: 'mailchimp-widget-id',
+				...buttonAttributes,
+			} ),
+		];
+
+		return [ newAttributes, newInnerBlocks ];
+	},
+	isEligible: ( attributes, innerBlocks ) =>
+		isEmpty( innerBlocks ) || some( pick( attributes, deprecatedAttributes ), Boolean ),
+	save: () => null,
+};

--- a/extensions/blocks/mailchimp/edit.js
+++ b/extensions/blocks/mailchimp/edit.js
@@ -14,13 +14,13 @@ import {
 	TextControl,
 	withNotices,
 } from '@wordpress/components';
-import { InspectorControls, RichText } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, RichText } from '@wordpress/block-editor';
 import { Fragment, Component } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { icon } from '.';
+import { icon, innerButtonBlock } from '.';
 import MailchimpGroups from './mailchimp-groups';
 
 const API_STATE_LOADING = 0;
@@ -250,7 +250,10 @@ class MailchimpSubscribeEdit extends Component {
 					title={ __( 'You can edit the email placeholder in the sidebar.', 'jetpack' ) }
 					type="email"
 				/>
-				<SubmitButton { ...this.props } />
+				<InnerBlocks
+					template={ [ [ innerButtonBlock.name, innerButtonBlock.attributes ] ] }
+					templateLock="all"
+				/>
 				<RichText
 					tagName="p"
 					placeholder={ __( 'Write consent text', 'jetpack' ) }

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { Path, SVG, G } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import './editor.scss';
 import { supportsCollections } from '../../shared/block-category';
@@ -29,6 +31,15 @@ export const icon = (
 	</SVG>
 );
 
+export const innerButtonBlock = {
+	name: 'jetpack/button',
+	attributes: {
+		element: 'button',
+		text: __( 'Join my email list', 'jetpack' ),
+		uniqueId: 'mailchimp-widget-id',
+	},
+};
+
 export const settings = {
 	title: __( 'Mailchimp', 'jetpack' ),
 	icon,
@@ -43,25 +54,6 @@ export const settings = {
 		emailPlaceholder: {
 			type: 'string',
 			default: __( 'Enter your email', 'jetpack' ),
-		},
-		submitButtonText: {
-			type: 'string',
-			default: __( 'Join my email list', 'jetpack' ),
-		},
-		backgroundButtonColor: {
-			type: 'string',
-		},
-		textButtonColor: {
-			type: 'string',
-		},
-		submitButtonClasses: {
-			type: 'string',
-		},
-		customBackgroundButtonColor: {
-			type: 'string',
-		},
-		customTextButtonColor: {
-			type: 'string',
 		},
 		consentText: {
 			type: 'string',
@@ -101,10 +93,12 @@ export const settings = {
 		},
 	},
 	edit,
-	save: () => null,
+	save: () => <InnerBlocks.Content />,
 	example: {
 		attributes: {
 			preview: true,
 		},
+		innerBlocks: [ innerButtonBlock ],
 	},
+	deprecated: [ deprecatedV1 ],
 };

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -40,67 +40,25 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 /**
  * Mailchimp block registration/dependency declaration.
  *
- * @param array $attr - Array containing the map block attributes.
+ * @param array  $attr - Array containing the Mailchimp block attributes.
+ * @param string $content - Mailchimp block content.
  *
  * @return string
  */
-function load_assets( $attr ) {
+function load_assets( $attr, $content ) {
 
 	if ( ! verify_connection() ) {
 		return null;
 	}
 
-	$values  = array();
+	$values  = get_attributes_with_defaults( $attr );
 	$blog_id = ( defined( 'IS_WPCOM' ) && IS_WPCOM )
 		? get_current_blog_id()
 		: Jetpack_Options::get_option( 'id' );
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-	$defaults = array(
-		'emailPlaceholder' => esc_html__( 'Enter your email', 'jetpack' ),
-		'submitButtonText' => esc_html__( 'Join my email list', 'jetpack' ),
-		'consentText'      => esc_html__( 'By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.', 'jetpack' ),
-		'processingLabel'  => esc_html__( 'Processing…', 'jetpack' ),
-		'successLabel'     => esc_html__( 'Success! You\'re on the list.', 'jetpack' ),
-		'errorLabel'       => esc_html__( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
-		'interests'        => array(),
-		'signupFieldTag'   => '',
-		'signupFieldValue' => '',
-	);
-	foreach ( $defaults as $id => $default ) {
-		$values[ $id ] = isset( $attr[ $id ] ) ? $attr[ $id ] : $default;
-	}
-
-	$values['submitButtonText'] = empty( $values['submitButtonText'] ) ? $defaults['submitButtonText'] : $values['submitButtonText'];
-
-	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
-
-	$button_styles = array();
-	if ( ! empty( $attr['customBackgroundButtonColor'] ) ) {
-		array_push(
-			$button_styles,
-			sprintf(
-				'background-color: %s',
-				sanitize_hex_color( $attr['customBackgroundButtonColor'] )
-			)
-		);
-	}
-	if ( ! empty( $attr['customTextButtonColor'] ) ) {
-		array_push(
-			$button_styles,
-			sprintf(
-				'color: %s',
-				sanitize_hex_color( $attr['customTextButtonColor'] )
-			)
-		);
-	}
-	$button_styles   = implode( ';', $button_styles );
+	$classes         = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr );
 	$amp_form_action = sprintf( 'https://public-api.wordpress.com/rest/v1.1/sites/%s/email_follow/amp/subscribe/', $blog_id );
 	$is_amp_request  = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
-
-	$button_classes = 'components-button is-button is-primary ';
-	if ( ! empty( $attr['submitButtonClasses'] ) ) {
-		$button_classes .= $attr['submitButtonClasses'];
-	}
 
 	ob_start();
 	?>
@@ -114,9 +72,7 @@ function load_assets( $attr ) {
 					method="post"
 					id="mailchimp_form"
 					target="_top"
-					<?php if ( $is_amp_request ) : ?>
 					on="submit-success:AMP.setState( { mailing_list_status: 'subscribed', mailing_list_email: event.response.email } )"
-					<?php endif; ?>
 				<?php endif; ?>
 			>
 				<p>
@@ -150,11 +106,7 @@ function load_assets( $attr ) {
 						value="<?php echo esc_attr( $values['signupFieldValue'] ); ?>"
 					/>
 				<?php endif; ?>
-				<p>
-					<button type="submit" class="<?php echo esc_attr( $button_classes ); ?>" style="<?php echo esc_attr( $button_styles ); ?>">
-						<?php echo wp_kses_post( $values['submitButtonText'] ); ?>
-					</button>
-				</p>
+				<?php echo render_button( $attr, $content ); // phpcs:ignore ?>
 				<p id="wp-block-jetpack-mailchimp_consent-text">
 					<?php echo wp_kses_post( $values['consentText'] ); ?>
 				</p>
@@ -221,4 +173,94 @@ function verify_connection() {
 		return false;
 	}
 	return isset( $data['follower_list_id'], $data['keyring_id'] );
+}
+
+/**
+ * Builds complete set of attributes using default values where needed.
+ *
+ * @param array $attr Saved set of attributes for the Mailchimp block.
+ * @return array
+ */
+function get_attributes_with_defaults( $attr ) {
+	$values   = array();
+	$defaults = array(
+		'emailPlaceholder' => esc_html__( 'Enter your email', 'jetpack' ),
+		'consentText'      => esc_html__( 'By clicking submit, you agree to share your email address with the site owner and Mailchimp to receive marketing, updates, and other emails from the site owner. Use the unsubscribe link in those emails to opt out at any time.', 'jetpack' ),
+		'processingLabel'  => esc_html__( 'Processing…', 'jetpack' ),
+		'successLabel'     => esc_html__( 'Success! You\'re on the list.', 'jetpack' ),
+		'errorLabel'       => esc_html__( 'Whoops! There was an error and we couldn\'t process your subscription. Please reload the page and try again.', 'jetpack' ),
+		'interests'        => array(),
+		'signupFieldTag'   => '',
+		'signupFieldValue' => '',
+	);
+
+	foreach ( $defaults as $id => $default ) {
+		$values[ $id ] = isset( $attr[ $id ] ) ? $attr[ $id ] : $default;
+	}
+
+	return $values;
+}
+
+/**
+ * Renders the Mailchimp block button using inner block content if available
+ * otherwise generating the HTML button from deprecated attributes.
+ *
+ * @param array  $attr Attributes for the Mailchimp block.
+ * @param string $content Mailchimp block content.
+ *
+ * @return string
+ */
+function render_button( $attr, $content ) {
+	if ( ! empty( $content ) ) {
+		$block_id = wp_unique_id( 'mailchimp-button-block-' );
+		return str_replace( 'mailchimp-widget-id', $block_id, $content );
+	}
+
+	return render_deprecated_button( $attr );
+}
+
+/**
+ * Renders HTML button from deprecated Mailchimp block attributes.
+ *
+ * @param array $attr Mailchimp block attributes.
+ * @return string
+ */
+function render_deprecated_button( $attr ) {
+	$default       = esc_html__( 'Join my email list', 'jetpack' );
+	$text          = empty( $attr['submitButtonText'] ) ? $default : $attr['submitButtonText'];
+	$button_styles = array();
+
+	if ( ! empty( $attr['customBackgroundButtonColor'] ) ) {
+		array_push(
+			$button_styles,
+			sprintf(
+				'background-color: %s',
+				sanitize_hex_color( $attr['customBackgroundButtonColor'] )
+			)
+		);
+	}
+
+	if ( ! empty( $attr['customTextButtonColor'] ) ) {
+		array_push(
+			$button_styles,
+			sprintf(
+				'color: %s',
+				sanitize_hex_color( $attr['customTextButtonColor'] )
+			)
+		);
+	}
+
+	$button_styles  = implode( ';', $button_styles );
+	$button_classes = 'components-button is-button is-primary ';
+
+	if ( ! empty( $attr['submitButtonClasses'] ) ) {
+		$button_classes .= $attr['submitButtonClasses'];
+	}
+
+	return sprintf(
+		'<p><button type="submit" class="%s" style="%s">%s</button></p>',
+		esc_attr( $button_classes ),
+		esc_attr( $button_styles ),
+		wp_kses_post( $text )
+	);
 }

--- a/extensions/blocks/mailchimp/mailchimp.php
+++ b/extensions/blocks/mailchimp/mailchimp.php
@@ -106,7 +106,7 @@ function load_assets( $attr, $content ) {
 						value="<?php echo esc_attr( $values['signupFieldValue'] ); ?>"
 					/>
 				<?php endif; ?>
-				<?php echo render_button( $attr, $content ); // phpcs:ignore ?>
+				<?php echo render_button( $attr, $content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<p id="wp-block-jetpack-mailchimp_consent-text">
 					<?php echo wp_kses_post( $values['consentText'] ); ?>
 				</p>

--- a/extensions/blocks/mailchimp/view.scss
+++ b/extensions/blocks/mailchimp/view.scss
@@ -8,6 +8,10 @@
 		}
 	}
 
+	.wp-block-jetpack-button {
+		margin-bottom: 1em;
+	}
+
 	.wp-block-jetpack-mailchimp_notification {
 		display: none;
 		margin-bottom: $jetpack-block-margin-bottom;


### PR DESCRIPTION
Fixes #15712

#### Changes proposed in this Pull Request:
* Replace the SubmitButton in the Mailchimp block with new shared Button block.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No.

#### Does this pull request change what data or activity we track or use?
* No.

#### Prerequisites:
* Mailchimp account
* Site with Mailchimp connection setup
* Post with Mailchimp block created prior to applying this PR's changes

#### Testing instructions:
1. Apply this PR
2. On the frontend, visit the post containing the previous version of Mailchimp block
3. Confirm that the block displays and functions as it did before
4. Edit the post
5. Confirm Mailchimp block displays and has correct settings
6. Update the Mailchimp block's button using new settings controls provided by button block
7. Save the post
8. Re-visit the post on the frontend and confirm display and function of block.

#### Before:
<img width="1225" alt="Screen Shot 2020-06-16 at 5 23 05 pm" src="https://user-images.githubusercontent.com/60436221/84747298-6b978b80-affa-11ea-8082-a1155c6dd272.png">

#### After:
<img width="1284" alt="Screen Shot 2020-06-16 at 5 44 07 pm" src="https://user-images.githubusercontent.com/60436221/84747341-7a7e3e00-affa-11ea-95b5-bee786d70f57.png">

#### Proposed changelog entry for your changes:
* Update Mailchimp block to use new shared Button block.
