### PR TITLE
Latest Instagram Posts: Don't try to reuse a connection if it doesn't exist anymore

### DIFF
--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -73,13 +73,13 @@ const InstagramGalleryEdit = props => {
 	} = useConnectInstagram( {
 		accessToken,
 		noticeOperations,
+		selectedAccount,
 		setAttributes,
 		setImages,
 		setSelectedAccount,
 	} );
 
 	const currentUserConnected = isCurrentUserConnected();
-	const hasUserConnections = userConnections.length > 0;
 	const unselectedCount = count > images.length ? images.length : count;
 
 	const showPlaceholder = ! isLoadingGallery && ( ! accessToken || isEmpty( images ) );
@@ -142,7 +142,7 @@ const InstagramGalleryEdit = props => {
 	};
 
 	const connectBlockToInstagram = () => {
-		if ( hasUserConnections && selectedAccount && NEW_INSTAGRAM_CONNECTION !== selectedAccount ) {
+		if ( selectedAccount && NEW_INSTAGRAM_CONNECTION !== selectedAccount ) {
 			setAttributes( {
 				accessToken: selectedAccount,
 				instagramUser: find( userConnections, { token: selectedAccount } ).username,
@@ -162,6 +162,7 @@ const InstagramGalleryEdit = props => {
 	};
 
 	const renderInstagramConnection = () => {
+		const hasUserConnections = userConnections.length > 0;
 		const radioOptions = [
 			...map( userConnections, connection => ( {
 				label: `@${ connection.username }`,

--- a/extensions/blocks/instagram-gallery/edit.js
+++ b/extensions/blocks/instagram-gallery/edit.js
@@ -79,6 +79,7 @@ const InstagramGalleryEdit = props => {
 	} );
 
 	const currentUserConnected = isCurrentUserConnected();
+	const hasUserConnections = userConnections.length > 0;
 	const unselectedCount = count > images.length ? images.length : count;
 
 	const showPlaceholder = ! isLoadingGallery && ( ! accessToken || isEmpty( images ) );
@@ -141,7 +142,7 @@ const InstagramGalleryEdit = props => {
 	};
 
 	const connectBlockToInstagram = () => {
-		if ( selectedAccount && NEW_INSTAGRAM_CONNECTION !== selectedAccount ) {
+		if ( hasUserConnections && selectedAccount && NEW_INSTAGRAM_CONNECTION !== selectedAccount ) {
 			setAttributes( {
 				accessToken: selectedAccount,
 				instagramUser: find( userConnections, { token: selectedAccount } ).username,
@@ -161,7 +162,6 @@ const InstagramGalleryEdit = props => {
 	};
 
 	const renderInstagramConnection = () => {
-		const hasUserConnections = userConnections.length > 0;
 		const radioOptions = [
 			...map( userConnections, connection => ( {
 				label: `@${ connection.username }`,

--- a/extensions/blocks/instagram-gallery/use-connect-instagram.js
+++ b/extensions/blocks/instagram-gallery/use-connect-instagram.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PopupMonitor from '@automattic/popup-monitor';
+import { find } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -10,9 +11,15 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { NEW_INSTAGRAM_CONNECTION } from './constants';
+
 export default function useConnectInstagram( {
 	accessToken,
 	noticeOperations,
+	selectedAccount,
 	setAttributes,
 	setImages,
 	setSelectedAccount,
@@ -37,6 +44,15 @@ export default function useConnectInstagram( {
 				setUserConnections( [] );
 			} );
 	}, [ accessToken ] );
+
+	useEffect( () => {
+		if (
+			NEW_INSTAGRAM_CONNECTION !== selectedAccount &&
+			! find( userConnections, { token: selectedAccount } )
+		) {
+			setSelectedAccount( undefined );
+		}
+	}, [ selectedAccount, setSelectedAccount, userConnections ] );
 
 	const connectToService = () => {
 		noticeOperations.removeAllNotices();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Don't try to reuse an Instagram connection if it doesn't exist anymore.

When permanently deleting an Instagram connection from Calypso, existing blocks won't be immediately aware of it.

After disconnecting the block (which now doesn't permanently delete the connection anymore), the block will try to automagically pre-select the old connection, with the reasoning that it hasn't been permanently deleted, so it still exists.
Though, the connection was deleted in Calypso.

When trying to re-connect the block, the block will use the pre-selected connection (instead of creating a new one), which will fail, because it doesn't exist.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Insert a Latest Instagram Posts block, and connect it to an Instagram account.
* In another tab, open Calypso -> Marketing -> Connections. Locate the Instagram connections and disconnect the one used for the block.
* Back in the editor, select the block and disconnect it from its sidebar.
* Wait for the block to fetch the Instagram connections.
* Make sure no connection is selected and the Connect button is disabled.
* Select something (existing connection or new), and make sure everything keeps working as expected.

Just for info, this is the broken behaviour:
* Disconnect the block, and wait for the Instagram connections fetch.
* Nothing is selected, but the Connect button is enabled.
* Try to click it: it will throw a console error because it cannot find [`username` of undefined](https://github.com/Automattic/jetpack/blob/e87551f16931c5d585e97b10ad841a92723129eb/extensions/blocks/instagram-gallery/edit.js#L147).

#### Proposed changelog entry for your changes:

* Latest Instagram Posts: Fix edge case of broken connection state when the connection is permanently deleted.
