### PR TITLE
SSO: Update types in `jetpack_sso_handle_login` action DocBlock

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -790,8 +790,8 @@ class Jetpack_SSO {
 		 *
 		 * @since 2.6.0
 		 *
-		 * @param array  $user      Local User information.
-		 * @param object $user_data WordPress.com User Login information.
+		 * @param WP_User|false|null $user      Local User information.
+		 * @param object             $user_data WordPress.com User Login information.
 		 */
 		do_action( 'jetpack_sso_handle_login', $user, $user_data );
 


### PR DESCRIPTION
At the moment, the type for the `$user` parameter passed to the `jetpack_sso_handle_login` action is listed as `array`. The parameter actually never is of this type - it is initialized as `null` and later set to either `WP_User` or `false` by calls to `get_user_by()`.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updated the DocBlock for the `jetpack_sso_handle_login` action.

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* No, just a DocBlock update.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
None.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
No changelog entry is needed.
