### PR TITLE
External Media: Disable for existing galleries

### DIFF
--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -31,7 +31,7 @@ if ( isCurrentUserConnected() ) {
 			const { addToGallery = false, allowedTypes } = props;
 			let { render } = props;
 
-			// Only replace button for components that expect images.
+			// Only replace button for components that expect images, except existing galleries.
 			if ( allowedTypes.indexOf( 'image' ) > -1 && ! addToGallery ) {
 				render = button => <MediaButton { ...button } mediaProps={ props } />;
 			}

--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -28,10 +28,11 @@ if ( isCurrentUserConnected() ) {
 		'editor.MediaUpload',
 		'external-media/replace-media-upload',
 		OriginalComponent => props => {
+			const { addToGallery = false, allowedTypes } = props;
 			let { render } = props;
 
 			// Only replace button for components that expect images.
-			if ( props.allowedTypes.indexOf( 'image' ) > -1 ) {
+			if ( allowedTypes.indexOf( 'image' ) > -1 && ! addToGallery ) {
 				render = button => <MediaButton { ...button } mediaProps={ props } />;
 			}
 

--- a/extensions/shared/external-media/media-button/index.js
+++ b/extensions/shared/external-media/media-button/index.js
@@ -33,9 +33,7 @@ function MediaButton( props ) {
 	};
 
 	return (
-		// No added functionality, just capping event propagation.
-		// eslint-disable-next-line  jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-		<div onClick={ event => event.stopPropagation() }>
+		<>
 			<MediaButtonMenu
 				{ ...props }
 				setSelectedSource={ setSelectedSource }
@@ -44,7 +42,7 @@ function MediaButton( props ) {
 			/>
 
 			{ ExternalLibrary && <ExternalLibrary onClose={ closeLibrary } { ...mediaProps } /> }
-		</div>
+		</>
 	);
 }
 


### PR DESCRIPTION
Disables External Media for existing galleries. Users won't be able to add more images after they selected an initial set of images.

Fixes #16126.
Fixes #16165.
Reverts #16124.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a check whether we're adding to a gallery and fails if so
* Removes now-unneeded click propagation cap.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the Editor, add a new Gallery block.
* Add an image to the Gallery, from either an external library or the media library
* After that, try adding more images to the gallery. Note how external libraries are not an option any longer
* All images should display correctly, no errors in the console.
* Make sure remaining media blocks still work as expected. (image, media/text, cover blocks, and featured image all still accept external media.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
