### PR TITLE
updates jetpack product topic on pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,9 @@ Fixes #
 <!--- Explain what functional changes your PR includes -->
 *
 
-#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
-* If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here.
+#### Jetpack product discussion
+<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
+<!-- Make sure any changes to existing products have been discussed and agreed upon -->
 
 #### Does this pull request change what data or activity we track or use?
 <!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->


### PR DESCRIPTION
Updates the PR template to include a more clear section on Jetpack product discussion.

The background here is: It's important to make sure that any change to the Jetpack as a product must have a related internal discussion so we know all the stakeholders are aware of the change.

Before this PR, the question was:

```
Is this a new feature or does it add/remove features to an existing part of Jetpack?
```

So it looked like the main concern there was to know whether the PR was something new or changed anything. But what we really want is to know if this was properly discussed and a link to the discussion.

This PR proposes to put this in the format of a topic, and not a question:

```
#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
```