### PR TITLE
Memberships: Add a donations argument to the status endpoint.

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -41,10 +41,10 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 						'type'              => array(
 							'type'     => 'string',
 							'required' => false,
+							'validate_callback' => function( $param ) {
+								return in_array( $param, array( 'donation' ), true );
+							},
 						),
-						'validate_callback' => function( $param ) {
-							return in_array( $param, array( 'donation' ), true );
-						},
 					),
 				),
 			)

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -152,7 +152,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	/**
 	 * Get a status of connection for the site. If this is Jetpack, pass the request to wpcom.
 	 *
-	 * @param object $request - request passed from WP.
+	 * @param \WP_REST_Request $request - request passed from WP.
 	 *
 	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
 	 */
@@ -188,4 +188,3 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) || Jetpack::is_active() ) {
 	wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Memberships' );
 }
-

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -37,6 +37,15 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_status' ),
 					'permission_callback' => array( $this, 'get_status_permission_check' ),
+					'args'                => array(
+						'type'              => array(
+							'type'     => 'string',
+							'required' => false,
+						),
+						'validate_callback' => function( $param ) {
+							return in_array( $param, array( 'donation' ), true );
+						},
+					),
 				),
 			)
 		);

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -156,7 +156,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 *
 	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
 	 */
-	public function get_status( $request ) {
+	public function get_status( \WP_REST_Request $request ) {
 		$product_type = $request['type'];
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			jetpack_require_lib( 'memberships' );

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -38,9 +38,9 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_status' ),
 					'permission_callback' => array( $this, 'get_status_permission_check' ),
 					'args'                => array(
-						'type'              => array(
-							'type'     => 'string',
-							'required' => false,
+						'type' => array(
+							'type'              => 'string',
+							'required'          => false,
 							'validate_callback' => function( $param ) {
 								return in_array( $param, array( 'donation' ), true );
 							},
@@ -152,19 +152,22 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	/**
 	 * Get a status of connection for the site. If this is Jetpack, pass the request to wpcom.
 	 *
+	 * @param object $request - request passed from WP.
+	 *
 	 * @return WP_Error|array ['products','connected_account_id','connect_url','should_upgrade_to_access_memberships','upgrade_url']
 	 */
-	public function get_status() {
+	public function get_status( $request ) {
+		$product_type = $request['type'];
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			jetpack_require_lib( 'memberships' );
 			$blog_id = get_current_blog_id();
-			return (array) get_memberships_settings_for_site( $blog_id );
+			return (array) get_memberships_settings_for_site( $blog_id, $product_type );
 		} else {
 			$blog_id  = Jetpack_Options::get_option( 'id' );
 			$response = Client::wpcom_json_api_request_as_user(
 				"/sites/$blog_id/{$this->rest_base}/status",
 				'v2',
-				array(),
+				array( 'type' => $product_type ),
 				null
 			);
 			if ( is_wp_error( $response ) ) {


### PR DESCRIPTION
To support one-time donations through the Recurring Payments system, we need to be able to filter different types of membership products. Adding a `GET` argument will permit the type of product returned to be specified.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a `type` argument to the `memberships/status` endpoint to allow specifying only products of type `donation` should be returned in the response's `products` array.

#### Jetpack product discussion
* pbMlHh-kg-p2

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* TBD
* `/wp-json/wpcom/v2/memberships/status`

#### Proposed changelog entry for your changes:
* The `memberships/status` endpoint can now return only donation products.
