### PR TITLE
Site Purchases: Return an error if the response from the API is not 200

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php
@@ -75,6 +75,10 @@ class Jetpack_Core_API_Site_Endpoint {
 			return self::get_failed_fetch_error();
 		}
 
+		if ( 200 !== intval( wp_remote_retrieve_response_code( $response ) ) ) {
+			return self::get_failed_fetch_error();
+		}
+
 		// Decode the results.
 		$results = json_decode( $response['body'], true );
 


### PR DESCRIPTION
Fixes #16067

#### Changes proposed in this Pull Request:
* Return an error code if the API response is not 200.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Connect Jetpack.
* On WP.com, set the `blog_public` option to `-1` for the cache site.
* Attempt to load the Jetpack dashboard.

Before the patch, WSOD. After, the dashboard loads.

This is due to #16068 which should be separately fixed where we'd assumed the response would be an array if it was returned successfully. This fixes the reason the response was not an array, but we should still tackle 16068 to future-proof this more.

#### Proposed changelog entry for your changes:
* REST API: Minor fix to ensure an accurate fix for the site purchase endpoint.

cc: @nickdaugherty 
