### PR TITLE
Sitemaps: Disable Core's sitemap

### DIFF
--- a/modules/sitemaps.php
+++ b/modules/sitemaps.php
@@ -22,6 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( '1' == get_option( 'blog_public' ) ) { // loose comparison okay.
 	include_once __DIR__ . '/sitemaps/sitemaps.php';
+
+	// Disable WordPress 5.5-era sitemaps.
+	add_filter( 'wp_sitemaps_is_enabled', '__return_false' );
 }
 
 add_action( 'jetpack_activate_module_sitemaps', 'jetpack_sitemap_on_activate' );


### PR DESCRIPTION
Supports #15388

WordPress 5.5 adds a new default sitemap feature. While a future PR will investigate expanding upon that feature when 5.5 is our supported minimum, in the short term, we should short-circuit the Core sitemap to prevent duplicative sitemaps from loading.

This PR would disable the Core sitemap whenever the Jetpack sitemap modules is enabled. Since it is only adding a filter, this can land without version checks.

#### Changes proposed in this Pull Request:
* Disables the Core's sitemaps added via https://core.trac.wordpress.org/changeset/48072

#### Jetpack product discussion
p9dueE-1eG-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* On WordPress nightly.
* Connected Jetpack with default modules.
* Visit example.com/wp-sitemap.xml and see Core's sitemap.
* visit example.com/robots.txt and see wp-sitemap.xml noted.
* Visit example.com/sitemap.xml and see the redirect to wp-sitemap.xml.
* Enable the Sitemaps module via Jetpack settings.
* Before this patch, all of the above will still happen except the sitemap.xml will show Jetpack's instead of redirecting. Notice that robots.txt include reference to both sitemaps.
* After the patch, confirm robots.txt only shows the Jetpack URL.
* After the patch, confirms that wp-sitemap.xml 404s.
* After the patch, confirm Jetpack sitemap still works.

#### Proposed changelog entry for your changes:
* Sitemaps: WordPress 5.5 Compatibility
