### PR TITLE
Jetpack Live Branches: Fix Jurassic Ninja link update on DOM re-render

### DIFF
--- a/tools/jetpack-live-branches/jetpack-live-branches.user.js
+++ b/tools/jetpack-live-branches/jetpack-live-branches.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Jetpack Live Branches
 // @namespace    https://wordpress.com/
-// @version      1.13
+// @version      1.14
 // @description  Adds links to PRs pointing to Jurassic Ninja sites for live-testing a changeset
 // @require      https://code.jquery.com/jquery-3.3.1.min.js
 // @match        https://github.com/Automattic/jetpack/pull/*
@@ -171,11 +171,18 @@
 				`<h2>Jetpack Live Branches</h2> ${ contents }`
 			);
 			$el.append( liveBranches );
-			$el.find( 'input[type=checkbox]' ).change( function( e ) {
-				e.stopPropagation();
-				e.preventDefault();
-				updateLink();
-			} );
+			$( 'body' ).on( 'change', $el.find( 'input[type=checkbox]' ), onInputChanged );
+		}
+
+		function onInputChanged( e ) {
+			e.stopPropagation();
+			e.preventDefault();
+			if ( e.target.checked ) {
+				e.target.setAttribute( 'checked', true );
+			} else {
+				e.target.removeAttribute( 'checked' );
+			}
+			updateLink();
 		}
 
 		function updateLink() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR fixes a bug in the Jetpack Live Branches userscript related to the script's unexpected behaviour on DOM re-rendering, for example when the script coexists with the Github Highlighter script which does exactly that.

In more detail, before these changes, the way the script was attaching the onchange event on the corresponding checkboxes resulted in the event not being fired when the corresponding DOM nodes where re-rendered ( caused by the Github Highlighter ).

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions

**Prerequisites**: 
- Tampermonkey with `Jetpack Live Branches` and `Github Highlighter` scripts active

**Testing:**
- Try viewing a Jetpack PR with both the `Jetpack Live Branches` and `Github Highlighter` scripts active in Tampermonkey
- Verify the "Before" behaviour as seen in the screencast below, aka checking on a checkbox doesn't update the Jurassic Ninja link nor persists the `checked` state on the corresponding checkbox.
- Replace your `Github Highlighter` script in Tampermonkey with the one introduced in this PR
- Verify the issue is fixed, as presented in the "After" screencast below

#### Before: 
![Screen Capture on 2020-06-19 at 11-30-58](https://user-images.githubusercontent.com/1758399/85113783-82b7c280-b220-11ea-958a-1b56a5cabe58.gif)

#### After:
![Screen Capture on 2020-06-19 at 11-52-17](https://user-images.githubusercontent.com/1758399/85114882-71bc8080-b223-11ea-893c-83e363826d98.gif)

#### Proposed changelog entry for your changes:
* Jetpack Live Branches: Fix Jurassic Ninja link update on DOM re-render
