### PR TITLE
Feature/infinite scroll older twenty themes

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -42,6 +42,10 @@ class The_Neverending_Home_Page {
 		// Plugin compatibility
 		add_filter( 'grunion_contact_form_redirect_url', array( $this, 'filter_grunion_redirect_url' ) );
 
+		// AMP compatibility
+		// needs to happen after parse_query so that Jetpack_AMP_Support::is_amp_request() is ready.
+		add_action( 'wp', array( $this, 'amp_load_hooks' ) );
+
 		// Parse IS settings from theme
 		self::get_settings();
 	}
@@ -434,6 +438,11 @@ class The_Neverending_Home_Page {
 		// Check that we have an id.
 		if ( empty( $id ) )
 			return;
+
+		// AMP infinite scroll functionality will start on amp_load_hooks().
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
 
 		// Add our scripts.
 		wp_register_script(
@@ -1560,6 +1569,10 @@ class The_Neverending_Home_Page {
 	 * @return string or null
 	 */
 	function footer() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			return;
+		}
+
 		// Bail if theme requested footer not show
 		if ( false == self::get_settings()->footer )
 			return;
@@ -1678,6 +1691,182 @@ class The_Neverending_Home_Page {
 			}
 		}
 		return $scripts_data;
+	}
+
+	/**
+	 * Load AMP specific hooks.
+	 *
+	 * @return void
+	 */
+	public function amp_load_hooks() {
+		if ( Jetpack_AMP_Support::is_amp_request() ) {
+			$template = self::get_settings()->render;
+
+			add_filter( 'jetpack_infinite_scroll_load_scripts_and_styles', '__return_false' );
+
+			add_action( 'template_redirect', array( $this, 'amp_start_output_buffering' ), 0 );
+			add_action( 'shutdown', array( $this, 'amp_output_buffer' ), 1 );
+
+			if ( is_callable( "amp_{$template}_hooks" ) ) {
+				call_user_func( "amp_{$template}_hooks" );
+			}
+
+			// Warms up the amp next page markup.
+			// This should be done outside the output buffering callback started in the template_redirect.
+			$this->amp_get_footer_template();
+		}
+	}
+
+	/**
+	 * Start the AMP output buffering.
+	 *
+	 * @return void
+	 */
+	public function amp_start_output_buffering() {
+		ob_start( array( $this, 'amp_finish_output_buffering' ) );
+	}
+
+	/**
+	 * Flush the AMP output buffer.
+	 *
+	 * @return void
+	 */
+	public function amp_output_buffer() {
+		if ( ob_get_contents() ) {
+			ob_end_flush();
+		}
+	}
+
+	/**
+	 * Filter the AMP output buffer contents.
+	 *
+	 * @param string $buffer Contents of the output buffer.
+	 *
+	 * @return string|false
+	 */
+	public function amp_finish_output_buffering( $buffer ) {
+		// Hide WordPress admin bar on next page load.
+		$buffer = preg_replace(
+			'/id="wpadminbar"/',
+			'$0 next-page-hide',
+			$buffer
+		);
+
+		// Get the theme footers.
+		$footers = apply_filters( 'jetpack_amp_infinite_footers', array(), $buffer );
+
+		// Hook for themes to filter custom markup on next page load.
+		$buffer = apply_filters( 'jetpack_amp_infinite_output', $buffer );
+
+		// Add the amp next page markup.
+		$buffer = preg_replace(
+			'~</body>~',
+			$this->amp_get_footer_template( $footers ) . '$0',
+			$buffer
+		);
+
+		return $buffer;
+	}
+
+	/**
+	 * Get AMP next page markup with the custom footers.
+	 *
+	 * @param string[] $footers The theme footers.
+	 *
+	 * @return string
+	 */
+	protected function amp_get_footer_template( $footers = array() ) {
+		static $template = null;
+
+		if ( null === $template ) {
+			$template = $this->amp_footer_template();
+		}
+
+		if ( empty( $footers ) ) {
+			return $template;
+		}
+
+		return preg_replace(
+			'/%%footer%%/',
+			implode( '', $footers ),
+			$template
+		);
+	}
+
+	/**
+	 * AMP Next Page markup.
+	 *
+	 * @return string
+	 */
+	protected function amp_footer_template() {
+		ob_start();
+		?>
+<amp-next-page max-pages="<?php echo esc_attr( $this->amp_get_max_pages() ); ?>">
+	<script type="application/json">
+		[
+			<?php echo wp_json_encode( $this->amp_next_page() ); ?>
+		]
+	</script>
+	<div separator>
+		<?php echo wp_kses_post( apply_filters( 'jetpack_amp_infinite_separator', '' ) ); ?>
+	</div>
+	<div recommendation-box class="recommendation-box">
+		<template type="amp-mustache">
+			{{#pages}}
+			<?php echo wp_kses_post( apply_filters( 'jetpack_amp_infinite_older_posts', '' ) ); ?>
+			{{/pages}}
+		</template>
+	</div>
+	<div footer>
+		%%footer%%
+	</div>
+</amp-next-page>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Get the AMP next page information.
+	 *
+	 * @return array
+	 */
+	protected static function amp_next_page() {
+		$title = esc_html__( 'Home page', 'jetpack' );
+		$url   = home_url();
+		$image = '';
+
+		if ( ! static::amp_is_last_page() ) {
+			$title = esc_html__( 'Older posts', 'jetpack' );
+			$url   = get_next_posts_page_link();
+		}
+
+		$next_page = array(
+			'title' => $title,
+			'url'   => $url,
+			'image' => $image,
+		);
+
+		return apply_filters( 'jetpack_amp_infinite_next_page_data', $next_page );
+	}
+
+	/**
+	 * Get the number of pages left.
+	 *
+	 * @return int
+	 */
+	protected static function amp_get_max_pages() {
+		global $wp_query;
+
+		return (int) $wp_query->max_num_pages - $wp_query->query_vars['paged'];
+	}
+
+	/**
+	 * Is the last page.
+	 *
+	 * @return bool
+	 */
+	protected static function amp_is_last_page() {
+		return 0 === static::amp_get_max_pages();
 	}
 };
 

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -1830,7 +1830,7 @@ class The_Neverending_Home_Page {
 	 *
 	 * @return array
 	 */
-	protected static function amp_next_page() {
+	protected function amp_next_page() {
 		$title = esc_html__( 'Home page', 'jetpack' );
 		$url   = home_url();
 		$image = '';

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -440,7 +440,7 @@ class The_Neverending_Home_Page {
 			return;
 
 		// AMP infinite scroll functionality will start on amp_load_hooks().
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
 
@@ -1569,7 +1569,7 @@ class The_Neverending_Home_Page {
 	 * @return string or null
 	 */
 	function footer() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			return;
 		}
 
@@ -1699,7 +1699,7 @@ class The_Neverending_Home_Page {
 	 * @return void
 	 */
 	public function amp_load_hooks() {
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
+		if ( class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
 			$template = self::get_settings()->render;
 
 			add_filter( 'jetpack_infinite_scroll_load_scripts_and_styles', '__return_false' );

--- a/modules/infinite-scroll/themes/twentyeleven.css
+++ b/modules/infinite-scroll/themes/twentyeleven.css
@@ -43,3 +43,27 @@
 		padding-bottom: 40px;
 	}
 }
+
+#main {
+	overflow: hidden;
+}
+
+@media only screen and (max-device-width: 480px) and (min-device-width: 320px) {
+	#page {
+		margin: 0 auto;
+	}
+}
+
+@media (max-width: 800px) {
+	#main,
+	#secondary {
+		float: none;
+		margin: 0;
+		width: auto;
+	}
+
+	#secondary {
+		background-color: #fff;
+		padding: 0 7.6% 2em;
+	}
+}

--- a/modules/infinite-scroll/themes/twentyeleven.php
+++ b/modules/infinite-scroll/themes/twentyeleven.php
@@ -11,6 +11,7 @@
 function jetpack_twentyeleven_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container'      => 'content',
+		'render'         => 'twentyeleven_infinite_scroll_render',
 		'footer'         => 'page',
 		'footer_widgets' => jetpack_twentyeleven_has_footer_widgets(),
 	) );
@@ -18,12 +19,18 @@ function jetpack_twentyeleven_infinite_scroll_init() {
 add_action( 'init', 'jetpack_twentyeleven_infinite_scroll_init' );
 
 /**
+ * Needs to be defined so AMP logic kicks in.
+ */
+function twentyeleven_infinite_scroll_render() {}
+
+/**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
 function jetpack_twentyeleven_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
 		// Add theme specific styles.
-		wp_enqueue_style( 'infinity-twentyeleven', plugins_url( 'twentyeleven.css', __FILE__ ), array( 'the-neverending-homepage' ), '20121002' );
+		wp_enqueue_style( 'infinity-twentyeleven', plugins_url( 'twentyeleven.css', __FILE__ ), $dep, '20121002' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyeleven_infinite_scroll_enqueue_styles', 25 );
@@ -41,4 +48,115 @@ function jetpack_twentyeleven_has_footer_widgets() {
 		return true;
 
 	return false;
+}
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentyeleven_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentyeleven_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentyeleven_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentyeleven_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentyeleven_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<div id="secondary".*<!-- #secondary .widget-area -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentyeleven_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="branding"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide skip links on next page load.
+	$buffer = preg_replace(
+		'/<div class="skip-link"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide pagination on next page load.
+	$buffer = preg_replace(
+		'/<nav id="nav-above"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	$buffer = preg_replace(
+		'/<nav id="nav-below"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the sidebar as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<div id="secondary".*<!-- #secondary .widget-area -->/s',
+		'',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentyeleven_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" style="background-color: #fff; padding: 1em 7.6%">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
 }

--- a/modules/infinite-scroll/themes/twentyeleven.php
+++ b/modules/infinite-scroll/themes/twentyeleven.php
@@ -70,7 +70,7 @@ function amp_twentyeleven_infinite_scroll_render_hooks() {
  * @return mixed
  */
 function twentyeleven_amp_infinite_footers( $footers, $buffer ) {
-	// Collect the footer wrapper.
+	// Collect the sidebar wrapper.
 	preg_match(
 		'/<div id="secondary".*<!-- #secondary .widget-area -->/s',
 		$buffer,
@@ -78,6 +78,7 @@ function twentyeleven_amp_infinite_footers( $footers, $buffer ) {
 	);
 	$footers[] = reset( $footer );
 
+	// Collect the footer wrapper.
 	preg_match(
 		'/<footer id="colophon".*<!-- #colophon -->/s',
 		$buffer,

--- a/modules/infinite-scroll/themes/twentyfifteen.php
+++ b/modules/infinite-scroll/themes/twentyfifteen.php
@@ -11,18 +11,116 @@
 function jetpack_twentyfifteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'main',
+		'render'    => 'twentyfifteen_infinite_scroll_render',
 		'footer'    => 'page',
 	) );
 }
 add_action( 'after_setup_theme', 'jetpack_twentyfifteen_infinite_scroll_init' );
 
 /**
+ * Needs to be defined so AMP logic kicks in.
+ */
+function twentyfifteen_infinite_scroll_render() {}
+
+/**
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function jetpack_twentyfifteen_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
-		wp_enqueue_style( 'infinity-twentyfifteen', plugins_url( 'twentyfifteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20141022' );
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
+		wp_enqueue_style( 'infinity-twentyfifteen', plugins_url( 'twentyfifteen.css', __FILE__ ), $dep, '20141022' );
 		wp_style_add_data( 'infinity-twentyfifteen', 'rtl', 'replace' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyfifteen_infinite_scroll_enqueue_styles', 25 );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentyfifteen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentyfifteen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentyfifteen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentyfifteen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentyfifteen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- .site-footer -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentyfifteen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide skip link.
+	$buffer = preg_replace(
+		'/<a class="skip-link screen-reader-text"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Hide below nav bar.
+	$buffer = preg_replace(
+		'/<nav class="navigation pagination"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- .site-footer -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentyfifteen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/infinite-scroll/themes/twentyfourteen.php
+++ b/modules/infinite-scroll/themes/twentyfourteen.php
@@ -54,7 +54,6 @@ function jetpack_twentyfourteen_infinite_scroll_enqueue_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyfourteen_infinite_scroll_enqueue_styles', 25 );
 
-
 /**
  * Load AMP theme specific hooks for infinite scroll.
  *

--- a/modules/infinite-scroll/themes/twentyfourteen.php
+++ b/modules/infinite-scroll/themes/twentyfourteen.php
@@ -11,11 +11,17 @@
 function jetpack_twentyfourteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container'      => 'content',
+		'render'         => 'twentyfourteen_infinite_scroll_render',
 		'footer'         => 'page',
 		'footer_widgets' => jetpack_twentyfourteen_has_footer_widgets(),
 	) );
 }
 add_action( 'after_setup_theme', 'jetpack_twentyfourteen_infinite_scroll_init' );
+
+/**
+ * Needs to be defined so AMP logic kicks in.
+ */
+function twentyfourteen_infinite_scroll_render() {}
 
 /**
  * Switch to the "click to load" type IS with the following cases
@@ -41,8 +47,109 @@ function jetpack_twentyfourteen_has_footer_widgets() {
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function jetpack_twentyfourteen_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
-		wp_enqueue_style( 'infinity-twentyfourteen', plugins_url( 'twentyfourteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20131118' );
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
+		wp_enqueue_style( 'infinity-twentyfourteen', plugins_url( 'twentyfourteen.css', __FILE__ ), $dep, '20131118' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyfourteen_infinite_scroll_enqueue_styles', 25 );
+
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentyfourteen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentyfourteen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentyfourteen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentyfourteen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentyfourteen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the sidebar wrapper.
+	preg_match(
+		'/<div id="secondary".*<!-- #secondary -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentyfourteen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Remove the sidebar as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<div id="secondary".*<!-- #secondary -->/s',
+		'',
+		$buffer
+	);
+
+	// Hide below nav bar.
+	$buffer = preg_replace(
+		'/<nav class="navigation paging-navigation"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentyfourteen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/infinite-scroll/themes/twentyseventeen.css
+++ b/modules/infinite-scroll/themes/twentyseventeen.css
@@ -122,6 +122,14 @@
 	display: block;
 }
 
+amp-next-page {
+	background-color: #fff;
+}
+
+#secondary {
+	padding: 1em 2em 2em;
+}
+
 @media screen and (min-width: 44.375em) {
 	#infinite-handle {
 		margin: 0 0 1em 0;

--- a/modules/infinite-scroll/themes/twentyseventeen.php
+++ b/modules/infinite-scroll/themes/twentyseventeen.php
@@ -50,9 +50,116 @@ function jetpack_twentyseventeen_has_footer_widgets() {
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function jetpack_twentyseventeen_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
-		wp_enqueue_style( 'infinity-twentyseventeen', plugins_url( 'twentyseventeen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20161219' );
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
+		wp_enqueue_style( 'infinity-twentyseventeen', plugins_url( 'twentyseventeen.css', __FILE__ ), $dep, '20161219' );
 		wp_style_add_data( 'infinity-twentyseventeen', 'rtl', 'replace' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentyseventeen_infinite_scroll_enqueue_styles', 25 );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_jetpack_twentyseventeen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentyseventeen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentyseventeen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentyseventeen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentyseventeen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the sidebar wrapper.
+	preg_match(
+		'/<aside id="secondary".*<!-- #secondary -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentyseventeen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide skip link.
+	$buffer = preg_replace(
+		'/<a class="skip-link screen-reader-text"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the sidebar as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<aside id="secondary".*<!-- #secondary -->/s',
+		'',
+		$buffer
+	);
+
+	// Hide below nav bar.
+	$buffer = preg_replace(
+		'/<nav class="navigation pagination"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentyseventeen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/infinite-scroll/themes/twentysixteen.css
+++ b/modules/infinite-scroll/themes/twentysixteen.css
@@ -34,6 +34,7 @@
 	clear: both;
 	margin-right: 7.6923%;
 	margin-left: 7.6923%;
+	margin-bottom: 3.5em;
 	text-align: center;
 }
 
@@ -53,6 +54,11 @@
 #infinite-handle span:hover,
 #infinite-handle span:focus {
 	background: #007acc;
+}
+
+#infinite-handle button {
+	display: block;
+	width: 100%;
 }
 
 #infinite-handle button:focus {
@@ -158,4 +164,8 @@ body #infinite-footer .blog-credits a:focus {
 	.site-main .infinite-loader {
 		margin-bottom: 7.0em;
 	}
+}
+
+body {
+	background-color: #fff;
 }

--- a/modules/infinite-scroll/themes/twentysixteen.php
+++ b/modules/infinite-scroll/themes/twentysixteen.php
@@ -35,9 +35,116 @@ function jetpack_twentysixteen_infinite_scroll_render() {
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function jetpack_twentysixteen_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
-		wp_enqueue_style( 'infinity-twentysixteen', plugins_url( 'twentysixteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20151102' );
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
+		wp_enqueue_style( 'infinity-twentysixteen', plugins_url( 'twentysixteen.css', __FILE__ ), $dep, '20151102' );
 		wp_style_add_data( 'infinity-twentysixteen', 'rtl', 'replace' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentysixteen_infinite_scroll_enqueue_styles', 25 );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_jetpack_twentysixteen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentysixteen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentysixteen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentysixteen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentysixteen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the sidebar wrapper.
+	preg_match(
+		'/<aside id="secondary".*<!-- .sidebar .widget-area -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- .site-footer -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentysixteen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide skip link.
+	$buffer = preg_replace(
+		'/<a class="skip-link screen-reader-text"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the sidebar as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<aside id="secondary".*<!-- .sidebar .widget-area -->/s',
+		'',
+		$buffer
+	);
+
+	// Hide below nav bar.
+	$buffer = preg_replace(
+		'/<nav class="navigation pagination"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- .site-footer -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentysixteen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/infinite-scroll/themes/twentyten.php
+++ b/modules/infinite-scroll/themes/twentyten.php
@@ -53,3 +53,100 @@ function jetpack_twentyten_has_footer_widgets() {
 
 	return false;
 }
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_jetpack_twentyten_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentyten_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentyten_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentyten_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentyten_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<div id="footer" role="contentinfo".*<!-- #footer -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = '<div style="background: #fff; margin: 0 auto; padding: 0 20px; width: 940px;">' . reset( $footer ) . '</div>';
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentyten_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<div id="header"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide sidebar on next page load.
+	$buffer = preg_replace(
+		'/<div id="primary"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide pagination on next page load.
+	$buffer = preg_replace(
+		'/<div id="nav-above" class="navigation"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	$buffer = preg_replace(
+		'/<div id="nav-below" class="navigation"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<div id="footer" role="contentinfo".*<!-- #footer -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentyten_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" style="background: #fff; margin: 0 auto; padding: 0 20px 20px; width: 940px;">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/infinite-scroll/themes/twentythirteen.css
+++ b/modules/infinite-scroll/themes/twentythirteen.css
@@ -88,3 +88,7 @@
 		padding-left: 0;
 	}
 }
+
+#infinite-handle button {
+	border-bottom: none;
+}

--- a/modules/infinite-scroll/themes/twentythirteen.php
+++ b/modules/infinite-scroll/themes/twentythirteen.php
@@ -11,6 +11,7 @@
 function jetpack_twentythirteen_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container'      => 'content',
+		'render'         => 'twentythirteen_infinite_scroll_render',
 		'footer'         => 'page',
 		'footer_widgets' => array( 'sidebar-1' ),
 	) );
@@ -18,11 +19,101 @@ function jetpack_twentythirteen_infinite_scroll_init() {
 add_action( 'after_setup_theme', 'jetpack_twentythirteen_infinite_scroll_init' );
 
 /**
+ * Needs to be defined so AMP logic kicks in.
+ */
+function twentythirteen_infinite_scroll_render() {}
+
+/**
  * Enqueue CSS stylesheet with theme styles for Infinite Scroll.
  */
 function jetpack_twentythirteen_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
-		wp_enqueue_style( 'infinity-twentythirteen', plugins_url( 'twentythirteen.css', __FILE__ ), array( 'the-neverending-homepage' ), '20130409' );
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
+		wp_enqueue_style( 'infinity-twentythirteen', plugins_url( 'twentythirteen.css', __FILE__ ), $dep, '20130409' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentythirteen_infinite_scroll_enqueue_styles', 25 );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentythirteen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentythirteen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentythirteen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentythirteen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentythirteen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentythirteen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide below nav bar.
+	$buffer = preg_replace(
+		'/<nav class="navigation paging-navigation"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentythirteen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/infinite-scroll/themes/twentytwelve.css
+++ b/modules/infinite-scroll/themes/twentytwelve.css
@@ -31,3 +31,12 @@
 		padding-bottom: 3.428571429rem;
 	}
 }
+
+#secondary,
+#colophon {
+	margin: 0 1.714285714rem;
+}
+
+#colophon {
+	padding: 1.714285714rem 0;
+}

--- a/modules/infinite-scroll/themes/twentytwelve.php
+++ b/modules/infinite-scroll/themes/twentytwelve.php
@@ -11,6 +11,7 @@
 function jetpack_twentytwelve_infinite_scroll_init() {
 	add_theme_support( 'infinite-scroll', array(
 		'container'      => 'content',
+		'render'         => 'twentytwelve_infinite_scroll_render',
 		'footer'         => 'page',
 		'footer_widgets' => jetpack_twentytwelve_has_footer_widgets(),
 	) );
@@ -18,12 +19,18 @@ function jetpack_twentytwelve_infinite_scroll_init() {
 add_action( 'after_setup_theme', 'jetpack_twentytwelve_infinite_scroll_init' );
 
 /**
+ * Needs to be defined so AMP logic kicks in.
+ */
+function twentytwelve_infinite_scroll_render() {}
+
+/**
  * Enqueue CSS stylesheet with theme styles for infinity.
  */
 function jetpack_twentytwelve_infinite_scroll_enqueue_styles() {
-	if ( wp_script_is( 'the-neverending-homepage' ) ) {
+	if ( wp_script_is( 'the-neverending-homepage' ) || class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request() ) {
+		$dep = wp_script_is( 'the-neverending-homepage' ) ? array( 'the-neverending-homepage' ) : array();
 		// Add theme specific styles.
-		wp_enqueue_style( 'infinity-twentytwelve', plugins_url( 'twentytwelve.css', __FILE__ ), array( 'the-neverending-homepage' ), '20120817' );
+		wp_enqueue_style( 'infinity-twentytwelve', plugins_url( 'twentytwelve.css', __FILE__ ), $dep, '20120817' );
 	}
 }
 add_action( 'wp_enqueue_scripts', 'jetpack_twentytwelve_infinite_scroll_enqueue_styles', 25 );
@@ -40,4 +47,103 @@ function jetpack_twentytwelve_has_footer_widgets() {
 	}
 
 	return false;
+}
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentytwelve_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentytwelve_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentytwelve_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentytwelve_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentytwelve_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the sidebar wrapper.
+	preg_match(
+		'/<div id="secondary".*<!-- #secondary -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentytwelve_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/<header id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide below nav bar.
+	$buffer = preg_replace(
+		'/<nav id="nav-below"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the sidebar as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<div id="secondary".*<!-- #secondary -->/s',
+		'',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentytwelve_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" style="padding: 1.714285714rem 0; margin: 0 1.714285714rem;">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
 }

--- a/modules/theme-tools/compat/twentynineteen.php
+++ b/modules/theme-tools/compat/twentynineteen.php
@@ -124,3 +124,87 @@ function twentynineteen_jetpack_body_classes( $classes ) {
 	return $classes;
 }
 add_filter( 'body_class', 'twentynineteen_jetpack_body_classes' );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentynineteen_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentynineteen_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentynineteen_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentynineteen_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentynineteen_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentynineteen_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/id="masthead"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide pagination on next page load.
+	$buffer = preg_replace(
+		'/class=".*navigation pagination.*"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="colophon".*<!-- #colophon -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentynineteen_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" style="text-align: center;">
+	<span>
+		<a href="{{url}}">
+			<button>
+				{{title}}
+			</button>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}

--- a/modules/theme-tools/compat/twentytwenty.php
+++ b/modules/theme-tools/compat/twentytwenty.php
@@ -160,3 +160,114 @@ function twentytwenty_infinity_accent_color_css() {
 	wp_add_inline_style( 'twentytwenty-jetpack', $custom_css );
 }
 add_action( 'wp_enqueue_scripts', 'twentytwenty_infinity_accent_color_css' );
+
+/**
+ * Load AMP theme specific hooks for infinite scroll.
+ *
+ * @return void
+ */
+function amp_twentytwenty_infinite_scroll_render_hooks() {
+	add_filter( 'jetpack_amp_infinite_footers', 'twentytwenty_amp_infinite_footers', 10, 2 );
+	add_filter( 'jetpack_amp_infinite_output', 'twentytwenty_amp_infinite_output' );
+	add_filter( 'jetpack_amp_infinite_separator', 'twentytwenty_amp_infinite_separator' );
+	add_filter( 'jetpack_amp_infinite_older_posts', 'twentytwenty_amp_infinite_older_posts' );
+}
+
+/**
+ * Get the theme specific footers.
+ *
+ * @param array  $footers The footers of the themes.
+ * @param string $buffer  Contents of the output buffer.
+ *
+ * @return mixed
+ */
+function twentytwenty_amp_infinite_footers( $footers, $buffer ) {
+	// Collect the footer wrapper.
+	preg_match(
+		'/<div class="footer-nav-widgets-wrapper.*<!-- .footer-nav-widgets-wrapper -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	// Collect the footer wrapper.
+	preg_match(
+		'/<footer id="site-footer".*<!-- #site-footer -->/s',
+		$buffer,
+		$footer
+	);
+	$footers[] = reset( $footer );
+
+	return $footers;
+}
+
+/**
+ * Hide and remove various elements from next page load.
+ *
+ * @param string $buffer Contents of the output buffer.
+ *
+ * @return string
+ */
+function twentytwenty_amp_infinite_output( $buffer ) {
+	// Hide site header on next page load.
+	$buffer = preg_replace(
+		'/id="site-header"/',
+		'$0 next-page-hide',
+		$buffer
+	);
+
+	// Hide pagination on next page load.
+	$buffer = preg_replace(
+		'/class=".*pagination-wrapper.*"/',
+		'$0 next-page-hide hidden',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<div class="footer-nav-widgets-wrapper.*<!-- .footer-nav-widgets-wrapper -->/s',
+		'',
+		$buffer
+	);
+
+	// Remove the footer as it will be added back to amp next page footer.
+	$buffer = preg_replace(
+		'/<footer id="site-footer".*<!-- #site-footer -->/s',
+		'',
+		$buffer
+	);
+
+	return $buffer;
+}
+
+/**
+ * Filter the AMP infinite scroll separator
+ *
+ * @return string
+ */
+function twentytwenty_amp_infinite_separator() {
+	ob_start();
+	?>
+<hr class="post-separator styled-separator is-style-wide section-inner" aria-hidden="true">
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Filter the AMP infinite scroll older posts button
+ *
+ * @return string
+ */
+function twentytwenty_amp_infinite_older_posts() {
+	ob_start();
+	?>
+<div id="infinite-handle" class="read-more-button-wrap">
+	<span>
+		<a href="{{url}}" class="more-link" rel="amphtml">
+			<span class="faux-button">{{title}}</span>
+		</a>
+	</span>
+</div>
+	<?php
+	return ob_get_clean();
+}


### PR DESCRIPTION
This PR extends the AMP Infinite Scroll support #16048 for older `twenty` themes.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR extends mobile AMP Infinite Scroll support for older `twenty` themes.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
* This extends support for Infinite Scroll on AMP requests;

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
* No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure the AMP plugin is installed and enabled;
1. On Jetpack Settings > Writing > Theme Enhancements > Infinite Scroll, set the radio to either `Load more posts on a page with a button` or `Load more posts as the reader scrolls down`. Due to[ AMP implementation](https://amp.dev/documentation/components/amp-next-page/#recommendation-box-(more-suggested-links)) of the functionality, the next page will always be autoloaded and still show the Older Posts button, if the user scrolls faster then the next page loads;
1. Enable an older `twenty` theme;
1. Make sure you have enough posts to enable pagination;
1. Visit the home page or an archive page on mobile mode;
1. Scroll to the footer. The next page should be loaded by then, or you can click the older posts button;
#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Adds mobile support for Infinite Scroll on older `twenty` themes for AMP requests:
  * `twentyten`;
  * `twentyeleven`;
  * `twentytwelve`;
  * `twentythirteen`;
  * `twentyfourteen`;
  * `twentyfifteen`;
  * `tweentysixteen`;
  * `twentyseventeen`;
* Due to technical limitations, there are significant markup changes that sacrifice the desktop experience with these themes.
