### PR TITLE
Jetpack Sync: Update reference to `JETPACK_MASTER_USER` to not use the global constant

### DIFF
--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -329,7 +329,7 @@ class Actions {
 		$rpc = new \Jetpack_IXR_Client(
 			array(
 				'url'     => $url,
-				'user_id' => JETPACK_MASTER_USER,
+				'user_id' => Jetpack_Connection::JETPACK_MASTER_USER,
 				'timeout' => $query_args['timeout'],
 			)
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR updates the reference to `JETPACK_MASTER_USER` used in Jetpack Sync to point to point to `\Automattic\Jetpack\Connection\Manager::JETPACK_MASTER_USER`.

This is part 1 of many fixes to get Jetpack Sync working well as a separate composer module. 

#### Jetpack product discussion

P2 discussion: p9dueE-1wm-p2

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Checkout branch / PR
* Make sure Jetpack Sync is still able to sync things to WordPress.com's cache site.

#### Proposed changelog entry for your changes:

* None
