### PR TITLE
Connection: move connection custom caps to the Connection package

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1075,24 +1075,6 @@ class Jetpack {
 	public function jetpack_custom_caps( $caps, $cap, $user_id, $args ) {
 		$is_development_mode = ( new Status() )->is_development_mode();
 		switch ( $cap ) {
-			case 'jetpack_connect':
-			case 'jetpack_reconnect':
-				if ( $is_development_mode ) {
-					$caps = array( 'do_not_allow' );
-					break;
-				}
-				// Pass through. If it's not development mode, these should match disconnect.
-				// Let users disconnect if it's development mode, just in case things glitch.
-			case 'jetpack_disconnect':
-				/**
-				 * Filters the jetpack_disconnect capability.
-				 *
-				 * @since 8.7.0
-				 *
-				 * @param array An array containing the capability name.
-				 */
-				$caps = apply_filters( 'jetpack_disconnect_cap', array( 'manage_options' ) );
-				break;
 			case 'jetpack_manage_modules':
 			case 'jetpack_activate_modules':
 			case 'jetpack_deactivate_modules':
@@ -1121,13 +1103,6 @@ class Jetpack {
 				} else {
 					$caps = array( 'read' );
 				}
-				break;
-			case 'jetpack_connect_user':
-				if ( $is_development_mode ) {
-					$caps = array( 'do_not_allow' );
-					break;
-				}
-				$caps = array( 'read' );
 				break;
 		}
 		return $caps;

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -6,7 +6,8 @@
 	"require": {
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-roles": "@dev"
+		"automattic/jetpack-roles": "@dev",
+		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Connection;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Roles;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 use WP_Error;
 
@@ -100,6 +101,8 @@ class Manager {
 		}
 
 		add_action( 'plugins_loaded', __NAMESPACE__ . '\Plugin_Storage::configure', 100 );
+
+		add_filter( 'map_meta_cap', array( $manager, 'jetpack_connection_custom_caps' ), 1, 4 );
 	}
 
 	/**
@@ -1095,6 +1098,46 @@ class Manager {
 				break;
 			}
 		}
+	}
+
+	/**
+	 * Sets the Connection custom capabilities.
+	 *
+	 * @param string[] $caps    Array of the user's capabilities.
+	 * @param string   $cap     Capability name.
+	 * @param int      $user_id The user ID.
+	 * @param array    $args    Adds the context to the cap. Typically the object ID.
+	 */
+	public function jetpack_connection_custom_caps( $caps, $cap, $user_id, $args ) {
+		$is_development_mode = ( new Status() )->is_development_mode();
+		switch ( $cap ) {
+			case 'jetpack_connect':
+			case 'jetpack_reconnect':
+				if ( $is_development_mode ) {
+					$caps = array( 'do_not_allow' );
+					break;
+				}
+				// Pass through. If it's not development mode, these should match disconnect.
+				// Let users disconnect if it's development mode, just in case things glitch.
+			case 'jetpack_disconnect':
+				/**
+				 * Filters the jetpack_disconnect capability.
+				 *
+				 * @since 8.7.0
+				 *
+				 * @param array An array containing the capability name.
+				 */
+				$caps = apply_filters( 'jetpack_disconnect_cap', array( 'manage_options' ) );
+				break;
+			case 'jetpack_connect_user':
+				if ( $is_development_mode ) {
+					$caps = array( 'do_not_allow' );
+					break;
+				}
+				$caps = array( 'read' );
+				break;
+		}
+		return $caps;
 	}
 
 	/**

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -32,6 +32,8 @@ class ManagerTest extends TestCase {
 	 */
 	protected $arguments_stack = array();
 
+	const DEFAULT_TEST_CAPS = array( 'default_test_caps' );
+
 	/**
 	 * Initialize the object before running the test method.
 	 */
@@ -315,17 +317,65 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * Test the `jetpack_connection_custom_caps' method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::jetpack_connection_custom_caps
+	 * @dataProvider jetpack_connection_custom_caps_data_provider
+	 *
+	 * @param bool   $in_dev_mode Whether development mode is active.
+	 * @param string $custom_cap The custom capability that is being tested.
+	 * @param array  $expected_caps The expected output.
+	 */
+	public function test_jetpack_connection_custom_caps( $in_dev_mode, $custom_cap, $expected_caps ) {
+		// Mock the site_url call in Status::is_development_mode.
+		$this->mock_function( 'site_url', false, 'Automattic\Jetpack' );
+
+		// Mock the apply_filters( 'jetpack_development_mode', ) call in Status::is_development_mode.
+		$this->mock_function( 'apply_filters', $in_dev_mode, 'Automattic\Jetpack' );
+
+		// Mock the apply_filters( 'jetpack_disconnect_cap', ) call in jetpack_connection_custom_caps.
+		$this->mock_function( 'apply_filters', array( 'manage_options' ) );
+
+		$caps = $this->manager->jetpack_connection_custom_caps( self::DEFAULT_TEST_CAPS, $custom_cap, 1, array() );
+		$this->assertEquals( $expected_caps, $caps );
+	}
+
+	/**
+	 * Data provider test_jetpack_connection_custom_caps.
+	 *
+	 * The test data arrays contain:
+	 *    'in dev mode': Whether development mode is active.
+	 *    'custom cap': The custom capbability that is being tested.
+	 *    'expected caps': The expected output of the call to jetpack_connection_custom_caps. An array of strings.
+	 */
+	public function jetpack_connection_custom_caps_data_provider() {
+		return array(
+			'dev mode, jetpack_connect'          => array( true, 'jetpack_connect', array( 'do_not_allow' ) ),
+			'dev mode, jetpack_reconnect'        => array( true, 'jetpack_reconnect', array( 'do_not_allow' ) ),
+			'dev mode, jetpack_disconnect'       => array( true, 'jetpack_disconnect', array( 'manage_options' ) ),
+			'dev mode, jetpack_connect_user'     => array( true, 'jetpack_connect_user', array( 'do_not_allow' ) ),
+			'dev mode, unknown cap'              => array( true, 'unknown_cap', self::DEFAULT_TEST_CAPS ),
+			'not dev mode, jetpack_connect'      => array( false, 'jetpack_connect', array( 'manage_options' ) ),
+			'not dev mode, jetpack_reconnect'    => array( false, 'jetpack_reconnect', array( 'manage_options' ) ),
+			'not dev mode, jetpack_disconnect'   => array( false, 'jetpack_disconnect', array( 'manage_options' ) ),
+			'not dev mode, jetpack_connect_user' => array( false, 'jetpack_connect_user', array( 'read' ) ),
+			'not dev mode, unknown cap'          => array( false, 'unknown_cap', self::DEFAULT_TEST_CAPS ),
+		);
+	}
+
+	/**
 	 * Mock a global function and make it return a certain value.
 	 *
 	 * @param string $function_name Name of the function.
 	 * @param mixed  $return_value Return value of the function.
+	 * @param string $namespace The namespace of the function.
 	 *
 	 * @return Mock The mock object.
 	 * @throws MockEnabledException PHPUnit wasn't able to enable mock functions.
 	 */
-	protected function mock_function( $function_name, $return_value = null ) {
+	protected function mock_function( $function_name, $return_value = null, $namespace = __NAMESPACE__ ) {
 		$builder = new MockBuilder();
-		$builder->setNamespace( __NAMESPACE__ )
+		$builder->setNamespace( $namespace )
 			->setName( $function_name )
 			->setFunction(
 				function() use ( &$return_value ) {

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -343,12 +343,13 @@ class ManagerTest extends TestCase {
 	/**
 	 * Data provider test_jetpack_connection_custom_caps.
 	 *
-	 * The test data arrays contain:
-	 *    'in dev mode': Whether development mode is active.
-	 *    'custom cap': The custom capbability that is being tested.
-	 *    'expected caps': The expected output of the call to jetpack_connection_custom_caps. An array of strings.
+	 * Structure of the test data arrays:
+	 *     [0] => 'in_dev_mode'   boolean Whether development mode is active.
+	 *     [1] => 'custom_cap'    string The custom capability that is being tested.
+	 *     [2] => 'expected_caps' array The expected output of the call to jetpack_connection_custom_caps.
 	 */
 	public function jetpack_connection_custom_caps_data_provider() {
+
 		return array(
 			'dev mode, jetpack_connect'          => array( true, 'jetpack_connect', array( 'do_not_allow' ) ),
 			'dev mode, jetpack_reconnect'        => array( true, 'jetpack_reconnect', array( 'do_not_allow' ) ),


### PR DESCRIPTION
We'd like to[ move the connection owner deletion notice](https://github.com/Automattic/jetpack/issues/15568) to the Connection package. This will allow the notice to be displayed when the Connection package is used by a plugin and Jetpack is not installed. The notice uses the `jetpack_disconnect` capability. This PR moves the `jetpack_disconnect` capability, along with a few other connection-related capabilities, to the Connection package.

#### Changes proposed in this Pull Request:
* Move the connection-related custom capabilities to the Connection package.
This will allow the custom capabilities to be used when the package is used by
another plugin and Jetpack isn't installed.

* Add unit tests for the new `Manager::jetpack_connection_custom_caps` method.

* Add a new parameter, `$namespace`, to the `ManagerTest::mock_function` method. This will allow mocking of functions with different namespaces.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
These changes should not change any behavior, so testing will consist of verifying that Jetpack's functionality hasn't changed:
* Test the connection process on a previously unconnected site. Verify that the connection banners display as normal.
* Test the connection process for a secondary admin user.
* Test the disconnection process.
* Verify that the Jetpack dashboard operates normally.
* Anything else you can think of.

#### Proposed changelog entry for your changes:
* n/a
