### PR TITLE
Instant Search: Use full width of overlay if sidebar is empty

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -144,6 +144,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
 
 			// widget info.
+			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,
 			'widgets'               => array_values( $widgets ),
 			'widgetsOutsideOverlay' => array_values( $widgets_outside_overlay ),
 		);

--- a/modules/search/instant-search/components/jetpack-colophon.scss
+++ b/modules/search/instant-search/components/jetpack-colophon.scss
@@ -8,7 +8,6 @@
 	align-items: center;
 	color: inherit;
 	display: flex;
-	justify-content: center;
 	text-decoration: none;
 }
 

--- a/modules/search/instant-search/components/overlay.jsx
+++ b/modules/search/instant-search/components/overlay.jsx
@@ -14,7 +14,8 @@ const closeOnEscapeKey = callback => event => {
 	event.key === 'Escape' && callback();
 };
 
-const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) => {
+const Overlay = props => {
+	const { children, closeOverlay, colorTheme, hasOverlayWidgets, isVisible, opacity } = props;
 	useEffect( () => {
 		window.addEventListener( 'keydown', closeOnEscapeKey( closeOverlay ) );
 		return () => {
@@ -28,6 +29,7 @@ const Overlay = ( { children, closeOverlay, colorTheme, isVisible, opacity } ) =
 			className={ [
 				'jetpack-instant-search__overlay',
 				`jetpack-instant-search__overlay--${ colorTheme }`,
+				hasOverlayWidgets ? '' : 'jetpack-instant-search__overlay--no-sidebar',
 				isVisible ? '' : 'is-hidden',
 			].join( ' ' ) }
 			style={ { opacity: isVisible ? opacity / 100 : 0 } }

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -1,3 +1,5 @@
+$overlay-vertical-padding: 3em;
+
 .jetpack-instant-search__overlay {
 	position: fixed;
 	top: 0;
@@ -5,8 +7,8 @@
 	z-index: 9999999999999;
 	width: 100vw;
 	height: 100vh;
-	padding: 3em 1em;
-	background: rgba(255, 255, 255, 0.975);
+	padding: $overlay-vertical-padding 1em;
+	background: rgba( 255, 255, 255, 0.975 );
 	overflow-y: auto;
 	overflow-x: hidden;
 	transition: opacity 0.15s ease-in-out;
@@ -24,7 +26,9 @@
 		background: #131313;
 	}
 
-	*, *:before, *:after {
+	*,
+	*:before,
+	*:after {
 		box-sizing: inherit;
 	}
 }
@@ -46,7 +50,7 @@
 
 	@include break-medium() {
 		position: absolute;
-		top: -22px;
+		top: -$overlay-vertical-padding;
 		right: 8px;
 		width: 64px;
 		height: 64px;

--- a/modules/search/instant-search/components/overlay.scss
+++ b/modules/search/instant-search/components/overlay.scss
@@ -1,4 +1,4 @@
-$overlay-vertical-padding: 3em;
+$overlay-vertical-padding: 3.5em;
 
 .jetpack-instant-search__overlay {
 	position: fixed;

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -261,6 +261,7 @@ class SearchApp extends Component {
 				closeColor={ this.state.overlayOptions.closeColor }
 				closeOverlay={ this.hideResults }
 				colorTheme={ this.state.overlayOptions.colorTheme }
+				hasOverlayWidgets={ this.props.hasOverlayWidgets }
 				isVisible={ this.state.showResults }
 				opacity={ this.state.overlayOptions.opacity }
 			>

--- a/modules/search/instant-search/components/search-results.scss
+++ b/modules/search/instant-search/components/search-results.scss
@@ -47,8 +47,12 @@
 
 	@include break-medium() {
 		margin-right: 4em;
+		.jetpack-instant-search__overlay--no-sidebar & {
+			margin-right: 0;
+		}
 	}
 }
+
 .jetpack-instant-search__search-results-secondary {
 	display: none;
 
@@ -62,6 +66,9 @@
 		border: 0;
 		border-radius: 0;
 		box-shadow: none;
+		.jetpack-instant-search__overlay--no-sidebar & {
+			display: none;
+		}
 	}
 }
 

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -23,7 +23,7 @@ const injectSearchApp = () => {
 				...window[ SERVER_OBJECT_NAME ].widgets,
 				...window[ SERVER_OBJECT_NAME ].widgetsOutsideOverlay,
 			] ) }
-			hasOverlayWidgets={ window[ SERVER_OBJECT_NAME ].widgets?.length > 0 }
+			hasOverlayWidgets={ !! window[ SERVER_OBJECT_NAME ].hasOverlayWidgets }
 			initialHref={ window.location.href }
 			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			// NOTE: initialShowResults is only used in the customizer. See lib/customize.js.

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -23,6 +23,7 @@ const injectSearchApp = () => {
 				...window[ SERVER_OBJECT_NAME ].widgets,
 				...window[ SERVER_OBJECT_NAME ].widgetsOutsideOverlay,
 			] ) }
+			hasOverlayWidgets={ window[ SERVER_OBJECT_NAME ].widgets?.length > 0 }
 			initialHref={ window.location.href }
 			initialOverlayOptions={ window[ SERVER_OBJECT_NAME ].overlayOptions }
 			// NOTE: initialShowResults is only used in the customizer. See lib/customize.js.


### PR DESCRIPTION
Fixes #15996.

#### Changes proposed in this Pull Request:
* When the overlay sidebar is empty, the search result section will use the full width of the overlay.

<img width="1034" alt="Screen Shot 2020-06-19 at 2 21 51 PM" src="https://user-images.githubusercontent.com/4044428/85176948-3c6e5d80-b238-11ea-823d-5f0809d13202.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Apply this change to your Jetpack installation.
* Move all widgets out of the Jetpack Search overlay sidebar.
* Search the site. Ensure that the wide layout is used.
* Move the widgets back into the overlay sidebar.
* Search the site. Ensure that the 70/30 layout is used.

#### Proposed changelog entry for your changes:
* None.