### PR TITLE
Plugin Search Hints: Remove status request to wp.com.

### DIFF
--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -18,7 +18,8 @@ if (
 	/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 	apply_filters( 'jetpack_show_promotions', true ) &&
 	// Disable feature hints when plugins cannot be installed.
-	! Constants::is_true( 'DISALLOW_FILE_MODS' )
+	! Constants::is_true( 'DISALLOW_FILE_MODS' ) &&
+	jetpack_is_psh_active()
 ) {
 	Jetpack_Plugin_Search::init();
 }
@@ -537,4 +538,22 @@ class Jetpack_Plugin_Search {
 		return $links;
 	}
 
+}
+
+/**
+ * Master control that checks if Plugin search hints is active.
+ *
+ * @since 7.1.1
+ *
+ * @return bool True if PSH is active.
+ */
+function jetpack_is_psh_active() {
+	/**
+	 * Disables the Plugin Search Hints feature found when searching the plugins page.
+	 *
+	 * @since 8.7.0
+	 *
+	 * @param bool Set false to disable the feature.
+	 */
+	return apply_filters( 'jetpack_psh_active', true );
 }

--- a/modules/plugin-search.php
+++ b/modules/plugin-search.php
@@ -18,8 +18,7 @@ if (
 	/** This filter is documented in _inc/lib/admin-pages/class.jetpack-react-page.php */
 	apply_filters( 'jetpack_show_promotions', true ) &&
 	// Disable feature hints when plugins cannot be installed.
-	! Constants::is_true( 'DISALLOW_FILE_MODS' ) &&
-	jetpack_is_psh_active()
+	! Constants::is_true( 'DISALLOW_FILE_MODS' )
 ) {
 	Jetpack_Plugin_Search::init();
 }
@@ -538,62 +537,4 @@ class Jetpack_Plugin_Search {
 		return $links;
 	}
 
-}
-
-/**
- * Master control that checks if Plugin search hints is active.
- *
- * @since 7.1.1
- *
- * @return bool True if PSH is active.
- */
-function jetpack_is_psh_active() {
-	// false means unset, 1 means active, 0 means inactive.
-	$status = get_transient( 'jetpack_psh_status' );
-
-	if ( false === $status ) {
-		$error = false;
-		$status = jetpack_get_remote_is_psh_active( $error );
-		set_transient(
-			'jetpack_psh_status',
-			// Cache as int
-			(int) $status,
-			// If there was an error, still cache but for a shorter time
-			( $error ? 5 : 15 ) * MINUTE_IN_SECONDS
-		);
-	}
-
-	return (bool) $status;
-}
-
-/**
- * Makes remote request to determine if Plugin search hints is active.
- *
- * @since 7.1.1
- * @internal
- *
- * @param bool &$error Did the remote request result in an error?
- * @return bool True if PSH is active.
- */
-function jetpack_get_remote_is_psh_active( &$error ) {
-	$response = wp_remote_get( 'https://jetpack.com/psh-status/' );
-	if ( is_wp_error( $response ) ) {
-		$error = true;
-		return true;
-	}
-
-	$body = wp_remote_retrieve_body( $response );
-	if ( empty( $body ) ) {
-		$error = true;
-		return true;
-	}
-
-	$json = json_decode( $body );
-	if ( ! isset( $json->active ) ) {
-		$error = true;
-		return true;
-	}
-
-	$error = false;
-	return (bool) $json->active;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

We've never needed to use this remote switch, and I can't think of a reason today where we'd need to turn them off. Removes unnecessary requests, as the transient time was set pretty short. 

I added a new filter which specifically will disable this feature all together. This can also be disabled via the `jetpack_show_promotions` filter that already exists. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Brought up here: 
p9dueE-1xX-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Head to `/wp-admin/plugin-install.php` and search for the term `photon` or some other Jetpack feature.
- Set the filter to `false`, make sure plugin search hints do not display

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
New filter for disabling Plugin Search Hints feature. 
