### PR TITLE
Eventbrite Block: Center the button when the parent block is center aligned

### DIFF
--- a/extensions/blocks/eventbrite/editor.scss
+++ b/extensions/blocks/eventbrite/editor.scss
@@ -5,3 +5,7 @@
 		margin-top: 1em;
 	}
 }
+
+[data-type='jetpack/eventbrite'][data-align='center'] {
+	text-align: center;
+}

--- a/extensions/blocks/eventbrite/style.scss
+++ b/extensions/blocks/eventbrite/style.scss
@@ -11,4 +11,8 @@
 	iframe {
 		height: 425px;
 	}
+
+	&.aligncenter {
+		text-align: center;
+	}
 }


### PR DESCRIPTION
Fixes #15761

#### Changes proposed in this Pull Request:

* When the Eventbrite block is center aligned, make sure the inner button is center aligned as well.

| Before | After |
| - | - |
| <img width="628" alt="Screenshot 2020-06-22 at 12 09 43" src="https://user-images.githubusercontent.com/2070010/85281089-5058d000-b481-11ea-99f9-290a7e22627f.png"> | <img width="626" alt="Screenshot 2020-06-22 at 12 09 07" src="https://user-images.githubusercontent.com/2070010/85281094-5484ed80-b481-11ea-80d8-a86ed3de5930.png"> |
| <img width="620" alt="Screenshot 2020-06-22 at 12 09 32" src="https://user-images.githubusercontent.com/2070010/85281112-5c449200-b481-11ea-9cd3-d22fa6bc9134.png"> | <img width="643" alt="Screenshot 2020-06-22 at 12 09 15" src="https://user-images.githubusercontent.com/2070010/85281117-5f3f8280-b481-11ea-99d0-ba2452d1d13b.png"> |

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

⚠️ Perform the following test **with and without the Gutenberg plugin**.

* Insert an Eventbrite block and connect it to an Eventbrite event.
* Set the block alignment to "center".
* Switch the block's embed type to "Button & Modal".
* Make sure the button is centered in the Eventbrite block.
* Save and preview the post.
* Make sure the button is centered in the front end as well.

#### Proposed changelog entry for your changes:

* Eventbrite Block: Fix button center alignment.