### PR TITLE
Blog Stats Widget: Update Label on Hits Text Field

### DIFF
--- a/modules/widgets/blog-stats.php
+++ b/modules/widgets/blog-stats.php
@@ -94,7 +94,7 @@ class Jetpack_Blog_Stats_Widget extends WP_Widget {
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['title'] ); ?>" />
 		</p>
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>"><?php echo number_format_i18n( '12345' ); ?></label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>"><?php esc_html_e( 'Pageview Description:', 'jetpack' ); ?></label>
 			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'hits' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'hits' ) ); ?>" type="text" value="<?php echo esc_attr( $instance['hits'] ); ?>" />
 		</p>
 		<p><?php esc_html_e( 'Hit counter is delayed by up to 60 seconds.', 'jetpack' ); ?></p>


### PR DESCRIPTION
Fixes #16182

#### Changes proposed in this Pull Request:
* Replace the Hits text field in Blog Stats Widget from "12,345" to "Pageview Description"

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Ensure Site Stats module is active
- Navigate to Customize > Widgets > WIDGET LOCATION
- Click on "Add a Widget"
- Select the Blog Stats widget to add
- Confirm the Hits text field's label is now "Pageview Description"

#### Before
![before](https://user-images.githubusercontent.com/1758399/85281800-4c35ae00-b493-11ea-980a-a0c0b8208010.png)

#### After
![Screenshot 2020-06-22 at 2 18 30 PM](https://user-images.githubusercontent.com/1758399/85281820-59529d00-b493-11ea-9a57-e9a575a3a52c.png)

#### Proposed changelog entry for your changes:
Blog Stats Widget: Update Label on Hits Text Field
