### PR TITLE
Slideshow: do not render markup when user doesn't select any images

### DIFF
--- a/extensions/blocks/slideshow/slideshow.js
+++ b/extensions/blocks/slideshow/slideshow.js
@@ -116,6 +116,12 @@ class Slideshow extends Component {
 
 	render() {
 		const { autoplay, className, delay, effect, images } = this.props;
+
+		// If user has not selected any images, don't print any markup.
+		if ( ! images.length ) {
+			return null;
+		}
+
 		// Note: React omits the data attribute if the value is null, but NOT if it is false.
 		// This is the reason for the unusual logic related to autoplay below.
 		/* eslint-disable jsx-a11y/anchor-is-valid */

--- a/extensions/blocks/slideshow/slideshow.js
+++ b/extensions/blocks/slideshow/slideshow.js
@@ -121,7 +121,6 @@ class Slideshow extends Component {
 		}
 
 		const { autoplay, className, delay, effect, images } = this.props;
-
 		// Note: React omits the data attribute if the value is null, but NOT if it is false.
 		// This is the reason for the unusual logic related to autoplay below.
 		/* eslint-disable jsx-a11y/anchor-is-valid */

--- a/extensions/blocks/slideshow/slideshow.js
+++ b/extensions/blocks/slideshow/slideshow.js
@@ -115,12 +115,12 @@ class Slideshow extends Component {
 	};
 
 	render() {
-		const { autoplay, className, delay, effect, images } = this.props;
-
 		// If user has not selected any images, don't print any markup.
-		if ( ! images.length ) {
+		if ( ! this.props?.images?.length ) {
 			return null;
 		}
+
+		const { autoplay, className, delay, effect, images } = this.props;
 
 		// Note: React omits the data attribute if the value is null, but NOT if it is false.
 		// This is the reason for the unusual logic related to autoplay below.

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -64,7 +64,7 @@ function render_amp( $attr ) {
 	);
 	$classes  = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, $extras );
 
-	return sprintf(
+	return empty( $ids ) ? null : sprintf(
 		'<div class="%1$s" id="wp-block-jetpack-slideshow__%2$d"><div class="wp-block-jetpack-slideshow_container swiper-container">%3$s%4$s%5$s</div></div>',
 		esc_attr( $classes ),
 		absint( $wp_block_jetpack_slideshow_id ),

--- a/extensions/blocks/slideshow/slideshow.php
+++ b/extensions/blocks/slideshow/slideshow.php
@@ -52,10 +52,14 @@ function load_assets( $attr, $content ) {
  * @return string
  */
 function render_amp( $attr ) {
+	if ( empty( $attr['ids'] ) ) {
+		return '';
+	}
+
 	static $wp_block_jetpack_slideshow_id = 0;
 	$wp_block_jetpack_slideshow_id++;
 
-	$ids      = empty( $attr['ids'] ) ? array() : $attr['ids'];
+	$ids      = $attr['ids'];
 	$autoplay = empty( $attr['autoplay'] ) ? false : true;
 	$extras   = array(
 		'wp-amp-block',
@@ -64,7 +68,7 @@ function render_amp( $attr ) {
 	);
 	$classes  = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, $extras );
 
-	return empty( $ids ) ? null : sprintf(
+	return sprintf(
 		'<div class="%1$s" id="wp-block-jetpack-slideshow__%2$d"><div class="wp-block-jetpack-slideshow_container swiper-container">%3$s%4$s%5$s</div></div>',
 		esc_attr( $classes ),
 		absint( $wp_block_jetpack_slideshow_id ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
This PR resolves #15273, where adding a slideshow block, without selecting any image, results to obsolete markup in the frontend. Especially, in the case of AMP rendering there was an extra **visible** markup.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Return null when images array is empty so that no obsolete markup is rendered both for normal and AMP rendering

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Setup local jetpack env with ngrok tunneling as per [instructions](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md) 
* Install the AMP plugin By AMP Project Contributors here /wp-admin/plugin-install.php?s=amp&tab=search&type=term
* Go to /wp-admin/post-new.php
* Add a slideshow block AND do not select any image
* Save and visit the above post
* Visit the the same post by appending `/amp` to the URL to inspect how AMP renders

**Before**
![CleanShot 2020-06-22 at 16 34 02](https://user-images.githubusercontent.com/12430020/85293590-3f6e8580-b4a6-11ea-89c5-d520b12aebe5.jpg)

**After**
![CleanShot 2020-06-22 at 16 36 09](https://user-images.githubusercontent.com/12430020/85293816-8a889880-b4a6-11ea-935b-4bc07d6b00b3.jpg)

**Before AMP**
![CleanShot 2020-06-22 at 16 37 13](https://user-images.githubusercontent.com/12430020/85293908-aa1fc100-b4a6-11ea-849a-905efbb2fe67.jpg)


**After AMP**
![CleanShot 2020-06-22 at 16 39 02](https://user-images.githubusercontent.com/12430020/85294125-ed7a2f80-b4a6-11ea-991e-4804217b7b29.jpg)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Slideshow: do not render markup when user doesn't select any images

#### Notices ####
The above changes will work for:
* new content both for normal and AMP rendering
* old content for AMP rendering

The above changes will **not** work for:
* old content for normal rendering