### PR TITLE
Memberships: Allow an `all` value for product type when querying membership status.

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -42,7 +42,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 							'type'              => 'string',
 							'required'          => false,
 							'validate_callback' => function( $param ) {
-								return in_array( $param, array( 'donation' ), true );
+								return in_array( $param, array( 'donation', 'all' ), true );
 							},
 						),
 					),


### PR DESCRIPTION
#16180 introduced a product `type` query arg to the memberships status endpoint. This PR expands the accepted values to include `all`, for returning all products regardless of their type.

#### Jetpack product discussion
* pbMlHh-kg-p2

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Apply D45314-code to a WP.com sandbox and sandbox the API.
* Make a `GET` request to `/sites/:site/memberships/status?type=all`.
* Verify the response does not include a `rest_invalid_param` error.

#### Proposed changelog entry for your changes:
* none, not applicable