### PR TITLE
Search: add Atomic support for Search product

### DIFF
--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -19,7 +19,7 @@ import Card from 'components/card';
 import JetpackBanner from 'components/jetpack-banner';
 import { isDevMode } from 'state/connection';
 import { getSitePlan, hasActiveSearchPurchase, isFetchingSitePurchases } from 'state/site';
-import { getUpgradeUrl, isAtomicSite } from 'state/initial-state';
+import { getUpgradeUrl } from 'state/initial-state';
 
 /**
  * Displays a card for Search based on the props given.
@@ -74,11 +74,6 @@ class DashSearch extends Component {
 	};
 
 	render() {
-		// NOTE: Jetpack Search currently does not support atomic sites.
-		if ( this.props.isAtomicSite ) {
-			return null;
-		}
-
 		if ( this.props.isFetching ) {
 			return renderCard( {
 				status: '',
@@ -171,7 +166,6 @@ class DashSearch extends Component {
 
 export default connect( state => {
 	return {
-		isAtomicSite: isAtomicSite( state ),
 		isBusinessPlan: 'is-business-plan' === getPlanClass( getSitePlan( state ).product_slug ),
 		isDevMode: isDevMode( state ),
 		isFetching: isFetchingSitePurchases( state ),

--- a/_inc/client/components/plans/plan-icon/index.jsx
+++ b/_inc/client/components/plans/plan-icon/index.jsx
@@ -26,6 +26,8 @@ import {
 	PLAN_VIP,
 	PLAN_JETPACK_SEARCH,
 	PLAN_JETPACK_SEARCH_MONTHLY,
+	PLAN_WPCOM_SEARCH,
+	PLAN_WPCOM_SEARCH_MONTHLY,
 	getPlanClass,
 } from 'lib/plans/constants';
 
@@ -225,6 +227,8 @@ export default class PlanIcon extends Component {
 				return this.getBusinessIcon();
 			case PLAN_JETPACK_SEARCH:
 			case PLAN_JETPACK_SEARCH_MONTHLY:
+			case PLAN_WPCOM_SEARCH:
+			case PLAN_WPCOM_SEARCH_MONTHLY:
 				return this.getSearchIcon();
 			default:
 				return this.getDefaultIcon();

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -30,7 +30,6 @@ import {
 import {
 	getSiteAdminUrl,
 	getUpgradeUrl,
-	isAtomicSite,
 	isMultisite,
 	userCanManageModules,
 } from 'state/initial-state';
@@ -189,8 +188,7 @@ export const SettingsCard = props => {
 				);
 
 			case FEATURE_SEARCH_JETPACK:
-				// NOTE: Jetpack Search currently does not support atomic sites.
-				if ( props.hasActiveSearchPurchase || props.isAtomicSite ) {
+				if ( props.hasActiveSearchPurchase ) {
 					return '';
 				}
 
@@ -390,6 +388,5 @@ export default connect( state => {
 		spamUpgradeUrl: getUpgradeUrl( state, 'settings-spam' ),
 		multisite: isMultisite( state ),
 		hasActiveSearchPurchase: hasActiveSearchPurchase( state ),
-		isAtomicSite: isAtomicSite( state ),
 	};
 } )( SettingsCard );

--- a/_inc/client/lib/plans/constants.js
+++ b/_inc/client/lib/plans/constants.js
@@ -30,6 +30,8 @@ export const PLAN_JETPACK_BACKUP_REALTIME = 'jetpack_backup_realtime';
 export const PLAN_JETPACK_BACKUP_REALTIME_MONTHLY = 'jetpack_backup_realtime_monthly';
 export const PLAN_JETPACK_SEARCH = 'jetpack_search';
 export const PLAN_JETPACK_SEARCH_MONTHLY = 'jetpack_search_monthly';
+export const PLAN_WPCOM_SEARCH = 'wpcom_search';
+export const PLAN_WPCOM_SEARCH_MONTHLY = 'wpcom_search_monthly';
 export const PLAN_JETPACK_SCAN = 'jetpack_scan';
 export const PLAN_JETPACK_SCAN_MONTHLY = 'jetpack_scan_monthly';
 export const PLAN_HOST_BUNDLE = 'host-bundle';
@@ -52,7 +54,12 @@ export const JETPACK_BACKUP_PRODUCTS = [
 	PLAN_JETPACK_BACKUP_REALTIME_MONTHLY,
 ];
 
-export const JETPACK_SEARCH_PRODUCTS = [ PLAN_JETPACK_SEARCH, PLAN_JETPACK_SEARCH_MONTHLY ];
+export const JETPACK_SEARCH_PRODUCTS = [
+	PLAN_JETPACK_SEARCH,
+	PLAN_JETPACK_SEARCH_MONTHLY,
+	PLAN_WPCOM_SEARCH,
+	PLAN_WPCOM_SEARCH_MONTHLY,
+];
 
 export const JETPACK_SCAN_PRODUCTS = [ PLAN_JETPACK_SCAN, PLAN_JETPACK_SCAN_MONTHLY ];
 
@@ -193,6 +200,8 @@ export function getPlanClass( plan ) {
 			return 'is-realtime-backup-plan';
 		case PLAN_JETPACK_SEARCH:
 		case PLAN_JETPACK_SEARCH_MONTHLY:
+		case PLAN_WPCOM_SEARCH:
+		case PLAN_WPCOM_SEARCH_MONTHLY:
 			return 'is-search-plan';
 		case PLAN_JETPACK_SCAN:
 		case PLAN_JETPACK_SCAN_MONTHLY:

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -18,7 +18,6 @@ import { FormFieldset } from 'components/forms';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FEATURE_SEARCH_JETPACK, getPlanClass } from 'lib/plans/constants';
 import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
-import { isAtomicSite } from 'state/initial-state';
 import { hasUpdatedSetting, isSettingActivated, isUpdatingSetting } from 'state/settings';
 import {
 	getSitePlan,
@@ -92,27 +91,24 @@ function Search( props ) {
 							{ __( 'Enable Search' ) }
 						</ModuleToggle>
 
-						{ ! props.isAtomicSite && (
-							// NOTE: Jetpack Search currently does not support atomic sites.
-							<FormFieldset>
-								<CompactFormToggle
-									checked={ isInstantSearchEnabled }
-									disabled={ ! props.hasActiveSearchPurchase || ! isModuleEnabled }
-									onChange={ toggleInstantSearch }
-									toggling={ props.isSavingAnyOption( 'instant_search_enabled' ) }
-								>
-									<span className="jp-form-toggle-explanation">
-										{ __( 'Enable instant search experience (recommended)' ) }
-									</span>
-								</CompactFormToggle>
-								<p className="jp-form-setting-explanation jp-form-search-setting-explanation">
-									{ __(
-										'Instant search will allow your visitors to get search results as soon as they start typing. ' +
-											'If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.'
-									) }
-								</p>
-							</FormFieldset>
-						) }
+						<FormFieldset>
+							<CompactFormToggle
+								checked={ isInstantSearchEnabled }
+								disabled={ ! props.hasActiveSearchPurchase || ! isModuleEnabled }
+								onChange={ toggleInstantSearch }
+								toggling={ props.isSavingAnyOption( 'instant_search_enabled' ) }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Enable instant search experience (recommended)' ) }
+								</span>
+							</CompactFormToggle>
+							<p className="jp-form-setting-explanation jp-form-search-setting-explanation">
+								{ __(
+									'Instant search will allow your visitors to get search results as soon as they start typing. ' +
+										'If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.'
+								) }
+							</p>
+						</FormFieldset>
 					</Fragment>
 				) }
 			</SettingsGroup>
@@ -144,7 +140,6 @@ function Search( props ) {
 export default connect( state => {
 	const planClass = getPlanClass( getSitePlan( state ).product_slug );
 	return {
-		isAtomicSite: isAtomicSite( state ),
 		isLoading: isFetchingSitePurchases( state ),
 		hasActiveSearchPurchase: selectHasActiveSearchPurchase( state ),
 		isBusinessPlan: 'is-business-plan' === planClass,


### PR DESCRIPTION
Enables support for WP.com Search Add-on product in Jetpack so that it can run on Atomic sites properly.

To work this requires some changes to Calypso that are still getting implemented. Currently this is just fixing the things that obviously would be broken.

Testing:
- Start up an atomic site
- Upload the jetpack beta plugin to it
- Use this branch on it
- Using https://github.com/Automattic/wp-calypso/pull/43545 purchase and test adding the new search plans from `/checkout/../wpcom_search` (there are some bugs in the Calypso PR, may need to go back into /checkout after the product gets added)
- Go to the wp-admin dashboard of your atomic site and see that the plan is there

<img width="1120" alt="Screen Shot 2020-06-26 at 2 01 27 PM" src="https://user-images.githubusercontent.com/820871/85896549-e5c3cf00-b7b5-11ea-9dfa-fc0c0a4d6dac.png">

<img width="1071" alt="Screen Shot 2020-06-26 at 2 00 47 PM" src="https://user-images.githubusercontent.com/820871/85896558-ea888300-b7b5-11ea-901e-f9e1244251ad.png">


