### PR TITLE
Dev Tools: Broken Token Helper

### DIFF
--- a/docker/mu-plugins/.gitignore
+++ b/docker/mu-plugins/.gitignore
@@ -1,4 +1,7 @@
-*
+/*
 !.gitignore
 !debug.php
 !avoid-plugin-deletion.php
+!jetpack-debug-helper-loader.php
+!/jetpack-debug-helper
+

--- a/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/docker/mu-plugins/avoid-plugin-deletion.php
@@ -22,13 +22,11 @@ $jetpack_docker_avoided_plugins = array(
  *                              'deactivate', and 'delete'. With Multisite active this can also include
  *                              'network_active' and 'network_only' items.
  * @param string   $plugin_file Path to the plugin file relative to the plugins directory.
- * @param array    $plugin_data An array of plugin data. See `get_plugin_data()`.
- * @param string   $context     The plugin context. By default this can include 'all', 'active', 'inactive',
  *                              'recently_activated', 'upgrade', 'mustuse', 'dropins', and 'search'.
  *
  * @return mixed
  */
-function jetpack_docker_disable_plugin_deletion_link( $actions, $plugin_file, $plugin_data, $context ) {
+function jetpack_docker_disable_plugin_deletion_link( $actions, $plugin_file ) {
 	global $jetpack_docker_avoided_plugins;
 	if (
 		array_key_exists( 'delete', $actions ) &&
@@ -42,7 +40,7 @@ function jetpack_docker_disable_plugin_deletion_link( $actions, $plugin_file, $p
 	}
 	return $actions;
 }
-add_filter( 'plugin_action_links', 'jetpack_docker_disable_plugin_deletion_link', 10, 4 );
+add_filter( 'plugin_action_links', 'jetpack_docker_disable_plugin_deletion_link', 10, 2 );
 
 /**
  * Fail deletion attempts of our important plugins

--- a/docker/mu-plugins/jetpack-debug-helper-loader.php
+++ b/docker/mu-plugins/jetpack-debug-helper-loader.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Plugin Name: Jetpack Debug Helper Loader
+ * Description: Give me a Jetpack and I'll help you break it.
+ * Author: Automattic - Jetpack Crew
+ * Version: 1.0
+ * Text Domain: jetpack
+ *
+ * @package Jetpack
+ */
+
+define( 'JETPACK_DEBUG_HELPER_VERSION', '1.0.0' ); // Used for enqueuing assets.
+
+/**
+ * Require the plugin.
+ */
+require_once 'jetpack-debug-helper/plugin.php';

--- a/docker/mu-plugins/jetpack-debug-helper/class-broken-token.php
+++ b/docker/mu-plugins/jetpack-debug-helper/class-broken-token.php
@@ -1,0 +1,459 @@
+<?php // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
+/**
+ * Plugin Name: Broken Token
+ * Description: Give me a Jetpack connection, and I'll break it every way possible.
+ * Author: Bestpack
+ * Version: 1.0
+ * Text Domain: jetpack
+ *
+ * @package Jetpack
+ */
+
+/**
+ * Require the XMLRPC functionality.
+ */
+require 'inc/class-broken-token-xmlrpc.php';
+
+/**
+ * Class Broken_Token
+ */
+class Broken_Token {
+	/**
+	 * Notice type.
+	 *
+	 * @var mixed|string
+	 */
+	public $notice_type = '';
+
+	/**
+	 * Blog token.
+	 *
+	 * @var bool|mixed
+	 */
+	public $blog_token;
+
+	/**
+	 * User token.
+	 *
+	 * @var bool|mixed
+	 */
+	public $user_tokens;
+
+	/**
+	 * Jetpack Primary User.
+	 *
+	 * @var bool|mixed
+	 */
+	public $master_user;
+
+	/**
+	 * Site ID.
+	 *
+	 * @var bool|mixed
+	 */
+	public $id;
+
+	/**
+	 * Options.
+	 *
+	 * PHP 7.1+
+	 */
+	public const STORED_OPTIONS_KEY = 'broken_token_stored_options'; // phpcs:ignore PHPCompatibility.Classes.NewConstVisibility.Found
+
+	/**
+	 * Token name.
+	 *
+	 * @var string
+	 */
+	public $invalid_blog_token = 'broken.token';
+
+	/**
+	 * User token name.
+	 *
+	 * @var string
+	 */
+	public $invalid_user_token = 'broken.token.1';
+
+	/**
+	 * Broken_Token constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'broken_token_register_submenu_page' ), 1000 );
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+		// Stored options.
+		add_action( 'admin_post_clear_stored_options', array( $this, 'admin_post_clear_stored_options' ) );
+		add_action( 'admin_post_store_current_options', array( $this, 'admin_post_store_current_options' ) );
+		add_action( 'admin_post_restore_from_stored_options', array( $this, 'admin_post_restore_from_stored_options' ) );
+
+		// Break stuff.
+		add_action( 'admin_post_set_invalid_blog_token', array( $this, 'admin_post_set_invalid_blog_token' ) );
+		add_action( 'admin_post_set_invalid_user_tokens', array( $this, 'admin_post_set_invalid_user_tokens' ) );
+		add_action( 'admin_post_clear_blog_token', array( $this, 'admin_post_clear_blog_token' ) );
+		add_action( 'admin_post_clear_user_tokens', array( $this, 'admin_post_clear_user_tokens' ) );
+		add_action( 'admin_post_randomize_master_user', array( $this, 'admin_post_randomize_master_user' ) );
+		add_action( 'admin_post_clear_master_user', array( $this, 'admin_post_clear_master_user' ) );
+		add_action( 'admin_post_randomize_blog_id', array( $this, 'admin_post_randomize_blog_id' ) );
+		add_action( 'admin_post_clear_blog_id', array( $this, 'admin_post_clear_blog_id' ) );
+
+		$this->blog_token  = Jetpack_Options::get_option( 'blog_token' );
+		$this->user_tokens = Jetpack_Options::get_option( 'user_tokens' );
+		$this->master_user = Jetpack_Options::get_option( 'master_user' );
+		$this->id          = Jetpack_Options::get_option( 'id' );
+
+		if ( isset( $_GET['notice'] ) && check_admin_referer( 'jetpack_debug_broken_token_admin_notice', 'nonce' ) ) {
+			$this->notice_type = $_GET['notice'];
+			add_action( 'admin_notices', array( $this, 'render_admin_notice' ) );
+		}
+	}
+
+	/**
+	 * Enqueue scripts.
+	 *
+	 * @param string $hook Called hook.
+	 */
+	public function enqueue_scripts( $hook ) {
+		if ( strpos( $hook, 'jetpack_page_broken-token' ) === 0 ) {
+			wp_enqueue_style( 'broken_token_style', plugin_dir_url( __FILE__ ) . '/css/style.css', array(), JETPACK_DEBUG_HELPER_VERSION );
+		}
+	}
+
+	/**
+	 * Register's submenu.
+	 */
+	public function broken_token_register_submenu_page() {
+		add_submenu_page(
+			'jetpack',
+			'Broken Token',
+			'Broken Token',
+			'manage_options',
+			'broken-token',
+			array( $this, 'render_ui' ),
+			99
+		);
+	}
+
+	/**
+	 * Render UI.
+	 */
+	public function render_ui() {
+		$stored_options = $this->get_stored_connection_options();
+		?>
+		<h1>Broken Token 😱!</h1>
+		<p>This plugin will help you break the Jetpack connection in various ways.</p>
+		<p>All instances of breaking only involve modifying the local DB options. Nothing done here will alter tokens stored in wp.com</p>
+		<hr>
+
+		<h2>Current token options being used by Jetpack:</h2>
+		<p>Blog Token: <?php echo esc_html( $this->blog_token ); ?></p>
+		<p>User Tokens: <?php print_r( $this->user_tokens ); ?></p>
+		<p>Primary User: <?php echo esc_html( $this->master_user ); ?></p>
+		<p>Blog ID: <?php echo esc_html( $this->id ); ?></p>
+
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="store_current_options">
+			<?php wp_nonce_field( 'store-current-options' ); ?>
+			<input type="submit" value="Store these options" class="button button-primary">
+		</form>
+		<br>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="restore_from_stored_options">
+			<?php wp_nonce_field( 'restore-stored-options' ); ?>
+			<input type="submit" value="Restore from stored options" class="button button-primary <?php echo empty( $stored_options ) ? 'disabled' : ''; ?>">
+		</form>
+
+		<?php
+		echo '<h2>Stored connection options.</h2>';
+		echo '<p>Might be useful to store valid connection options before breaking it, so you can restore later.</p>';
+		if ( empty( $stored_options ) ) {
+			echo '<p>No connection options are currently stored!</p>';
+		} else {
+			echo '<pre>';
+			print_r( $stored_options );
+			echo '</pre>';
+		}
+		?>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="clear_stored_options">
+			<?php wp_nonce_field( 'clear-stored-options' ); ?>
+			<input type="submit" value="Clear stored options" class="button button-primary <?php echo empty( $stored_options ) ? 'disabled' : ''; ?>">
+		</form>
+
+		<hr>
+
+		<h2>Break some stuff:</h2>
+		<p><strong>Break the blog token:</strong></p>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="set_invalid_blog_token">
+			<?php wp_nonce_field( 'set-invalid-blog-token' ); ?>
+			<input type="submit" value="Set invalid blog token" class="button button-primary button-break-it">
+		</form>
+		<br>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="clear_blog_token">
+			<?php wp_nonce_field( 'clear-blog-token' ); ?>
+			<input type="submit" value="Clear blog token" class="button button-primary button-break-it">
+		</form>
+
+		<p><strong>Break the user token:</strong></p>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="clear_user_tokens">
+			<?php wp_nonce_field( 'clear-user-tokens' ); ?>
+			<input type="submit" value="Clear user token" class="button button-primary button-break-it">
+		</form>
+		<br>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="set_invalid_user_tokens">
+			<?php wp_nonce_field( 'set-invalid-user-tokens' ); ?>
+			<input type="submit" value="Set invalid user tokens" class="button button-primary button-break-it">
+		</form>
+
+		<p><strong>Break the Primary User:</strong></p>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="randomize_master_user">
+			<?php wp_nonce_field( 'randomize-master-user' ); ?>
+			<input type="submit" value="Randomize Primary User ID" class="button button-primary button-break-it">
+		</form>
+		<br>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="clear_master_user">
+			<?php wp_nonce_field( 'clear-master-user' ); ?>
+			<input type="submit" value="Clear the Primary User" class="button button-primary button-break-it">
+		</form>
+
+		<p><strong>Break the blog ID:</strong></p>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="randomize_blog_id">
+			<?php wp_nonce_field( 'randomize-blog-id' ); ?>
+			<input type="submit" value="Randomize Blog ID" class="button button-primary button-break-it">
+		</form>
+		<br>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="clear_blog_id">
+			<?php wp_nonce_field( 'clear-blog-id' ); ?>
+			<input type="submit" value="Clear the Blog ID" class="button button-primary button-break-it">
+		</form>
+		<?php
+	}
+
+	/**
+	 * Store options.
+	 */
+	public function admin_post_store_current_options() {
+		check_admin_referer( 'store-current-options' );
+		$this->notice_type = 'store-options';
+		$this->store_current_options();
+
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Clear options.
+	 */
+	public function admin_post_clear_stored_options() {
+		check_admin_referer( 'clear-stored-options' );
+		$this->clear_stored_options();
+
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Restore from options.
+	 */
+	public function admin_post_restore_from_stored_options() {
+		check_admin_referer( 'restore-stored-options' );
+		$this->notice_type = 'restore-options';
+		foreach ( $this->get_stored_connection_options() as $key => $value ) {
+			if ( empty( $value ) ) {
+				continue;
+			}
+			Jetpack_Options::update_option( $key, $value );
+		}
+
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Set invalid blog token.
+	 */
+	public function admin_post_set_invalid_blog_token() {
+		check_admin_referer( 'set-invalid-blog-token' );
+		$this->notice_type = 'jetpack-broken';
+		Jetpack_Options::update_option( 'blog_token', $this->invalid_blog_token );
+
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Set invalid user token.
+	 */
+	public function admin_post_set_invalid_user_tokens() {
+		check_admin_referer( 'set-invalid-user-tokens' );
+		$this->notice_type = 'jetpack-broken';
+		foreach ( Jetpack_Options::get_option( 'user_tokens' ) as $id => $token ) {
+			Jetpack_Options::update_option( 'user_tokens', array( $id => $this->invalid_user_token ) );
+		}
+
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Clear blog token.
+	 */
+	public function admin_post_clear_blog_token() {
+		check_admin_referer( 'clear-blog-token' );
+		$this->notice_type = 'jetpack-broken';
+		Jetpack_Options::delete_option( 'blog_token' );
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Clear user token.
+	 */
+	public function admin_post_clear_user_tokens() {
+		check_admin_referer( 'clear-user-tokens' );
+		$this->notice_type = 'jetpack-broken';
+		Jetpack_Options::delete_option( 'user_tokens' );
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Randomize master user.
+	 */
+	public function admin_post_randomize_master_user() {
+		check_admin_referer( 'randomize-master-user' );
+		$this->notice_type = 'jetpack-broken';
+		$current_id        = Jetpack_Options::get_option( 'master_user' );
+		Jetpack_Options::update_option( 'master_user', wp_rand( $current_id + 1, $current_id + 100 ) );
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Clear master user.
+	 */
+	public function admin_post_clear_master_user() {
+		check_admin_referer( 'clear-master-user' );
+		$this->notice_type = 'jetpack-broken';
+		Jetpack_Options::delete_option( 'master_user' );
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Randomize blog ID.
+	 */
+	public function admin_post_randomize_blog_id() {
+		check_admin_referer( 'randomize-blog-id' );
+		$this->notice_type = 'jetpack-broken';
+		Jetpack_Options::update_option( 'id', wp_rand( 100, 10000 ) );
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Clear blog ID.
+	 */
+	public function admin_post_clear_blog_id() {
+		check_admin_referer( 'clear-blog-id' );
+		$this->notice_type = 'jetpack-broken';
+		Jetpack_Options::delete_option( 'id' );
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Stores a backup of the current Jetpack connection options.
+	 */
+	public function store_current_options() {
+		update_option(
+			$this::STORED_OPTIONS_KEY,
+			array(
+				'blog_token'  => $this->blog_token,
+				'user_tokens' => $this->user_tokens,
+				'master_user' => $this->master_user,
+				'id'          => $this->id,
+			)
+		);
+	}
+
+	/**
+	 * Retrieves the stored connection options.
+	 *
+	 * @return array
+	 */
+	public function get_stored_connection_options() {
+		return get_option( $this::STORED_OPTIONS_KEY );
+	}
+
+	/**
+	 * Clears all stored connection option values.
+	 */
+	public function clear_stored_options() {
+		delete_option( $this::STORED_OPTIONS_KEY );
+	}
+
+	/**
+	 * Just redirects back to the referrer. Keeping it DRY.
+	 */
+	public function admin_post_redirect_referrer() {
+		if ( wp_get_referer() ) {
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						'notice' => $this->notice_type,
+						'nonce'  => wp_create_nonce( 'jetpack_debug_broken_token_admin_notice' ),
+					),
+					wp_get_referer()
+				)
+			);
+		} else {
+			wp_safe_redirect( get_home_url() );
+		}
+	}
+
+	/**
+	 * Displays an admin notice...
+	 */
+	public function render_admin_notice() {
+		switch ( $this->notice_type ) {
+			case 'jetpack-broken':
+				$message = 'Nice! You broke Jetpack!';
+				break;
+			case 'store-options':
+				$message = 'Success! Backup of the connection options stored safely.';
+				break;
+			case 'restore-options':
+				$message = 'Success! You\'ve restored the connection options. I hope things are working well now.';
+				break;
+			default:
+				$message = 'Setting saved!';
+				break;
+		}
+
+		printf( '<div class="notice notice-success"><p>%s</p></div>', esc_html( $message ) );
+	}
+}
+
+add_action( 'plugins_loaded', 'register_broken_token', 1000 );
+
+
+/**
+ * Load the brokenness.
+ */
+function register_broken_token() {
+	if ( class_exists( 'Jetpack' ) ) {
+		new Broken_Token();
+		if ( class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
+			new Broken_Token_XmlRpc();
+		}
+	} else {
+		add_action( 'admin_notices', 'broken_token_jetpack_not_active' );
+	}
+}
+
+/**
+ * Notice for if Jetpack is not active.
+ */
+function broken_token_jetpack_not_active() {
+	echo '<div class="notice info"><p>Jetpack needs to be active and installed for the Broken Token plugin.</p></div>';
+}
+
+// phpcs:enable

--- a/docker/mu-plugins/jetpack-debug-helper/css/style.css
+++ b/docker/mu-plugins/jetpack-debug-helper/css/style.css
@@ -1,0 +1,22 @@
+/**
+Styles for miles
+ */
+
+.button-break-it {
+    background-color: red !important;
+    border-color: red !important;
+}
+
+pre {
+	max-height: 200px;
+	overflow: scroll;
+	max-width: 800px;
+}
+
+#make_xmlrpc_requests {
+	float: right;
+}
+
+#current_xmlrpc_errors {
+	float: left;
+}

--- a/docker/mu-plugins/jetpack-debug-helper/inc/class-broken-token-xmlrpc.php
+++ b/docker/mu-plugins/jetpack-debug-helper/inc/class-broken-token-xmlrpc.php
@@ -1,0 +1,132 @@
+<?php // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r
+/**
+ * XMLRPC Brokeness.
+ *
+ * @package Jetpack.
+ */
+
+use Automattic\Jetpack\Connection\Error_Handler;
+
+/**
+ * Class Broken_Token_XmlRpc
+ */
+class Broken_Token_XmlRpc {
+
+	/**
+	 * Broken_Token_XmlRpc constructor.
+	 */
+	public function __construct() {
+
+		add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
+
+		add_action( 'admin_post_clear_all_xmlrpc_errors', array( $this, 'admin_post_clear_all_xmlrpc_errors' ) );
+
+		$this->error_manager = new Error_Handler();
+		$this->stored_errors = $this->error_manager->get_stored_errors();
+		$this->dev_debug_on  = defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG;
+	}
+
+	/**
+	 * Register submenu page.
+	 */
+	public function register_submenu_page() {
+		add_submenu_page(
+			'jetpack',
+			'XML-RPC Errors',
+			'XML-RPC Errors',
+			'manage_options',
+			'broken-token-xmlrpc-errors',
+			array( $this, 'render_ui' ),
+			99
+		);
+	}
+
+	/**
+	 * Render UI.
+	 */
+	public function render_ui() {
+		?>
+			<h1>XML-RPC errors</h1>
+			<p>
+				This page helps you to trigger XML-RPC requests with invalid signatures.
+			</p>
+			<?php if ( $this->dev_debug_on ) : ?>
+				<div class="notice notice-success">
+					<p>JETPACK_DEV_DEBUG constant is ON. This means every xml-rpc error will be reported. You're good to test.</p>
+				</div>
+			<?php else : ?>
+				<div class="notice notice-warning">
+					<p>JETPACK_DEV_DEBUG constant is OFF. This means xml-rpc error will only be reported once evey hour. Set it to true so you can test it.</p>
+				</div>
+			<?php endif; ?>
+
+			<p>
+				Now head to <a href="https://jetpack.com/debug/?url=<?php echo esc_url_raw( get_home_url() ); ?>">Jetpack Debugger</a> and trigger some requests!
+			</p>
+
+			<div id="current_xmlrpc_errors">
+
+
+				<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+					<input type="hidden" name="action" value="clear_all_xmlrpc_errors">
+					<?php wp_nonce_field( 'clear-xmlrpc-errors' ); ?>
+					<h2>
+						Current Unverified Errors
+						<input type="submit" value="Clear all unverified errors" class="button button-primary">
+					</h2>
+				</form>
+				<div id="stored-xmlrpc-error">
+					<?php $this->print_current_errors(); ?>
+				</div>
+			</div>
+
+		<?php
+	}
+
+	/**
+	 * Print current errors.
+	 */
+	public function print_current_errors() {
+		foreach ( $this->stored_errors as $error_code => $error_group ) {
+
+			echo '<h4>' . esc_html( $error_code ) . '</h4>';
+
+			foreach ( $error_group as $user_id => $error ) {
+				?>
+				<b>User: <?php echo esc_html( $user_id ); ?></b>
+				<pre><?php print_r( $error ); ?></pre>
+				<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+					<input type="hidden" name="action" value="verify_error">
+					<input type="hidden" name="nonce" value="<?php echo esc_attr( $error['error_data']['nonce'] ); ?>">
+					<?php wp_nonce_field( 'verify-error' ); ?>
+					<input type="submit" value="Verify error" class="button button-primary">
+				</form>
+				<hr />
+				<?php
+			}
+		}
+	}
+
+	/**
+	 * Clear all XMLRPC Errors.
+	 */
+	public function admin_post_clear_all_xmlrpc_errors() {
+		check_admin_referer( 'clear-xmlrpc-errors' );
+		$this->error_manager->delete_stored_errors();
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Just redirects back to the referrer. Keeping it DRY.
+	 */
+	public function admin_post_redirect_referrer() {
+		if ( wp_get_referer() ) {
+			wp_safe_redirect( wp_get_referer() );
+		} else {
+			wp_safe_redirect( get_home_url() );
+		}
+	}
+
+}
+
+// phpcs:enable

--- a/docker/mu-plugins/jetpack-debug-helper/plugin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/plugin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: Jetpack Debug Tools
+ * Description: Give me a Jetpack connection, and I'll break it every way possible.
+ * Author: Automattic - Jetpack Crew
+ * Version: 1.0
+ * Text Domain: jetpack
+ *
+ * @package Jetpack.
+ */
+
+/**
+ * List "plugins" from the src directory here.
+ */
+require_once plugin_dir_path( __FILE__ ) . 'class-broken-token.php';


### PR DESCRIPTION
Per our team call today, bringing over @dereksmart's broken token testing tool.

Changed from the original source:
* Various coding standard improvements, including output sanitation and all that.
* Built into a more general helper plugin to give us a framework to add more.

#### Changes proposed in this Pull Request:
* Adds a helper mu-plugin to our Docker instance to assist with connection testing.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Via our Docker container, kick off Jetpack.
* Notice new mu-plugin that adds a "Broken Token" menu to the Jetpack nav menu of WP.
* Play with it.

#### Proposed changelog entry for your changes:
* Not sure we need one.
