### PR TITLE
Cover: remove use block edit context

### DIFF
--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -1,0 +1,64 @@
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import UpgradeNudge from "../../components/upgrade-nudge";
+
+/**
+ * Nudge shows when the user tries to upload a video file.
+ * Unlike the core/video block, handled/extended by the videopress block,
+ * the nudge is not shown permanently.
+ * It's handled by the MediaPlaceholder component
+ * when the user tries to upload a video file.
+ * For this reason, we can't wrap the edit setting
+ * with the wrapPaidBlock() HOC, as the videopress does.
+ *
+ * @param {object}  props - Information about the user.
+ * @param {string}  props.name - Show the Nudge component.
+ * @param {boolean} props.show - Show the Nudge component.
+ * @returns {*} Nudge component or Null.
+ */
+export const JetpackCoverUpgradeNudge = ( { name, show, align } ) =>
+	show
+		? <div className="jetpack-upgrade-nudge-wrapper wp-block" data-align={ align }>
+			<UpgradeNudge
+				plan="value_bundle"
+				blockName={ name }
+				title={ {
+					knownPlan: __( 'To use a video in this block, upgrade to %(planName)s.', 'jetpack' ),
+					unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
+				} }
+				subtitle={ false }
+			/>
+		</div>
+		: null;
+
+/**
+ * Cover Media context
+ * Used to connect the CoverEdit with
+ * the Media Replace Flow.
+ */
+export const CoverMediaContext = createContext();
+
+/**
+ * Cover Media Provider will populate the properties
+ * from the CoverEdit to the Media Replace Flow component.
+ *
+ * @param {object}  props - Provider properties.
+ * @param {Function}  props.onFilesUpload - Callback function before to upload files.
+ * @param {boolean} props.children - Provider Children.
+ * @returns {*} Provider component.
+ */
+export const CoverMediaProvider = ( { onFilesUpload, children } ) => {
+	return (
+		<CoverMediaContext.Provider value={ onFilesUpload }>
+			{ children }
+		</CoverMediaContext.Provider>
+	);
+};

--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -3,7 +3,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createContext } from '@wordpress/element';
+import { createContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -52,12 +52,15 @@ export const CoverMediaContext = createContext();
  *
  * @param {object}  props - Provider properties.
  * @param {Function}  props.onFilesUpload - Callback function before to upload files.
+ * @param {string}  props.blockName - Block name.
  * @param {boolean} props.children - Provider Children.
  * @returns {*} Provider component.
  */
-export const CoverMediaProvider = ( { onFilesUpload, children } ) => {
+export const CoverMediaProvider = ( { onFilesUpload, blockName, children } ) => {
+	const memoContextProperties = useMemo( () => ( { onFilesUpload, blockName } ), [ onFilesUpload, blockName ] );
+
 	return (
-		<CoverMediaContext.Provider value={ onFilesUpload }>
+		<CoverMediaContext.Provider value={ memoContextProperties }>
 			{ children }
 		</CoverMediaContext.Provider>
 	);

--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -8,7 +8,7 @@ import { createContext } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import UpgradeNudge from "../../components/upgrade-nudge";
+import UpgradeNudge from '../../components/upgrade-nudge';
 
 /**
  * Nudge shows when the user tries to upload a video file.

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -1,10 +1,5 @@
 
 /**
- * External dependencies
- */
-import { noop } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useBlockEditContext } from '@wordpress/block-editor';

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -32,7 +32,7 @@ export default createHigherOrderComponent(
 		return (
 			<div className="jetpack-cover-media-placeholder">
 				<CoverMediaContext.Consumer>
-					{ ( onFilesUpload = noop ) => (
+					{ ( onFilesUpload ) => (
 						<CoreMediaPlaceholder
 							{ ...props }
 							onFilesPreUpload={ onFilesUpload }

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import UpgradeNudge from "../../components/upgrade-nudge";
+import UpgradeNudge from '../../components/upgrade-nudge';
 import { isUpgradable, isVideoFile } from './utils';
 
 /**

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -1,73 +1,57 @@
+
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
 /**
  * WordPress dependencies
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import UpgradeNudge from '../../components/upgrade-nudge';
 import { isUpgradable, isVideoFile } from './utils';
+import { CoverMediaContext } from './components';
 
 /**
  * Module Constants
  */
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
-/**
- * Nudge shows when the user tries to upload a video file.
- * Unlike the core/video block, handled/extended by the videopress block,
- * the nudge is not shown permanently.
- * It's handled by the MediaPlaceholder component
- * when the user tries to upload a video file.
- * For this reason, we can't wrap the edit setting
- * with the wrapPaidBlock() HOC, as the videopress does.
- *
- * @param {object}  props - Information about the user.
- * @param {string}  props.name - Show the Nudge component.
- * @param {boolean} props.show - Show the Nudge component.
- * @returns {*} Nudge component or Null.
- */
-const JetpackCoverUpgradeNudge = ( { name, show } ) =>
-	show ? (
-		<UpgradeNudge
-			plan="value_bundle"
-			blockName={ name }
-			title={ {
-				knownPlan: __( 'To use a video in this block, upgrade to %(planName)s.', 'jetpack' ),
-				unknownPlan: __( 'To use a video in this block, upgrade to a paid plan.', 'jetpack' ),
-			} }
-			subtitle={ false }
-		/>
-	) : null;
+export default createHigherOrderComponent(
+	CoreMediaPlaceholder => props => {
+		const { name } = useBlockEditContext();
+		if ( ! name || ! isUpgradable( name ) ) {
+			return <CoreMediaPlaceholder { ...props } />;
+		}
 
-export default CoreMediaPlaceholder => props => {
-	const [ error, setError ] = useState( false );
-	const { name } = useBlockEditContext();
-	if ( ! name || ! isUpgradable( name ) ) {
-		return <CoreMediaPlaceholder { ...props } />;
-	}
-
-	const { onError } = props;
-	return (
-		<div className="jetpack-cover-media-placeholder">
-			<JetpackCoverUpgradeNudge name={ name } show={ !! error } />
-			<CoreMediaPlaceholder
-				{ ...props }
-				multiple={ false }
-				onError={ message => {
-					// Try to pick up filename from the error message.
-					// We should find a better way to do it. Unstable.
-					const filename = message?.[ 0 ]?.props?.children;
-					if ( filename && isVideoFile( filename ) ) {
-						return setError( message );
-					}
-					return onError( message );
-				} }
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
-			/>
-		</div>
-	);
-};
+		const { onError } = props;
+		return (
+			<div className="jetpack-cover-media-placeholder">
+				<CoverMediaContext.Consumer>
+					{ ( onFilesUpload = noop ) => (
+						<CoreMediaPlaceholder
+							{ ...props }
+							onFilesPreUpload={ onFilesUpload }
+							multiple={ false }
+							onError = { ( message ) => {
+								// Try to pick up filename from the error message.
+								// We should find a better way to do it. Unstable.
+								const filename = message?.[ 0 ]?.props?.children;
+								if ( filename && isVideoFile( filename ) ) {
+									return onFilesUpload( [ filename ] );
+								}
+								return onError( message );
+							} }
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+						/>
+					) }
+				</CoverMediaContext.Consumer>
+			</div>
+		);
+	},
+	'JetpackCoverMediaPlaceholder'
+);

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -26,6 +26,7 @@ export default createHigherOrderComponent(
 		 * On Uploading error handler.
 		 * Try to pick up filename from the error message.
 		 * We should find a better way to do it. Unstable.
+		 * This act as a fallback of `onFilesPreUpload()`.
 		 *
 		 * @param {Array} message - Error message provided by the callback.
 		 * @returns {*} Error handling.

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -4,17 +4,13 @@
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { isUpgradable, isVideoFile } from './utils';
 import { CoverMediaContext } from './components';
-
-/**
- * Module Constants
- */
-const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
@@ -23,28 +19,24 @@ export default createHigherOrderComponent(
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 
+		const onFilesUpload = useContext( CoverMediaContext );
 		const { onError } = props;
+
 		return (
 			<div className="jetpack-cover-media-placeholder">
-				<CoverMediaContext.Consumer>
-					{ ( onFilesUpload ) => (
-						<CoreMediaPlaceholder
-							{ ...props }
-							onFilesPreUpload={ onFilesUpload }
-							multiple={ false }
-							onError = { ( message ) => {
-								// Try to pick up filename from the error message.
-								// We should find a better way to do it. Unstable.
-								const filename = message?.[ 0 ]?.props?.children;
-								if ( filename && isVideoFile( filename ) ) {
-									return onFilesUpload( [ filename ] );
-								}
-								return onError( message );
-							} }
-							allowedTypes={ ALLOWED_MEDIA_TYPES }
-						/>
-					) }
-				</CoverMediaContext.Consumer>
+				<CoreMediaPlaceholder
+					{ ...props }
+					onFilesPreUpload={ onFilesUpload }
+					onError = { ( message ) => {
+						// Try to pick up filename from the error message.
+						// We should find a better way to do it. Unstable.
+						const filename = message?.[ 0 ]?.props?.children;
+						if ( filename && isVideoFile( filename ) ) {
+							return onFilesUpload( [ filename ] );
+						}
+						return onError( message );
+					} }
+				/>
 			</div>
 		);
 	},

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -1,5 +1,10 @@
 
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -13,10 +18,22 @@ import { CoverMediaContext } from './components';
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const { onFilesUpload, blockName: name } = useContext( CoverMediaContext );
+		/*
+		 * Data provided by the cover media context
+		 * could be undefined.
+		 * We need to check data exists before proceeding.
+		 */
+		const coverMediaProvidedData = useContext( CoverMediaContext );
+		if ( ! coverMediaProvidedData ) {
+			return <CoreMediaPlaceholder { ...props } />;
+		}
+
+		// Check if the block is upgradable before to proceeding.
+		const { onFilesUpload, blockName: name } = coverMediaProvidedData;
 		if ( ! name || ! isUpgradable( name ) ) {
 			return <CoreMediaPlaceholder { ...props } />;
 		}
+
 		const { onError } = props;
 
 		/**

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -2,7 +2,6 @@
 /**
  * WordPress dependencies
  */
-import { useBlockEditContext } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useContext, useCallback } from '@wordpress/element';
 
@@ -14,12 +13,10 @@ import { CoverMediaContext } from './components';
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const { name } = useBlockEditContext();
+		const { onFilesUpload, blockName: name } = useContext( CoverMediaContext );
 		if ( ! name || ! isUpgradable( name ) ) {
 			return <CoreMediaPlaceholder { ...props } />;
 		}
-
-		const onFilesUpload = useContext( CoverMediaContext );
 		const { onError } = props;
 
 		/**

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 
 /**
  * WordPress dependencies

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -22,20 +22,28 @@ export default createHigherOrderComponent(
 		const onFilesUpload = useContext( CoverMediaContext );
 		const { onError } = props;
 
+		/**
+		 * On Uploading error handler.
+		 * Try to pick up filename from the error message.
+		 * We should find a better way to do it. Unstable.
+		 *
+		 * @param {Array} message - Error message provided by the callback.
+		 * @returns {*} Error handling.
+		 */
+		const uploadingErrorHandler = ( message ) => {
+			const filename = message?.[ 0 ]?.props?.children;
+			if ( filename && isVideoFile( filename ) ) {
+				return onFilesUpload( [ filename ] );
+			}
+			return onError( message );
+		};
+
 		return (
 			<div className="jetpack-cover-media-placeholder">
 				<CoreMediaPlaceholder
 					{ ...props }
 					onFilesPreUpload={ onFilesUpload }
-					onError = { ( message ) => {
-						// Try to pick up filename from the error message.
-						// We should find a better way to do it. Unstable.
-						const filename = message?.[ 0 ]?.props?.children;
-						if ( filename && isVideoFile( filename ) ) {
-							return onFilesUpload( [ filename ] );
-						}
-						return onError( message );
-					} }
+					onError = { uploadingErrorHandler }
 				/>
 			</div>
 		);

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -34,8 +34,6 @@ export default createHigherOrderComponent(
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 
-		const { onError } = props;
-
 		/**
 		 * On Uploading error handler.
 		 * Try to pick up filename from the error message.
@@ -51,8 +49,8 @@ export default createHigherOrderComponent(
 			if ( filename && isVideoFile( filename ) ) {
 				return onFilesUpload( [ filename ] );
 			}
-			return onError( message );
-		}, [ onFilesUpload, onError ] );
+			return props.onError( message );
+		}, [ onFilesUpload, props.onError ] );
 
 		return (
 			<div className="jetpack-cover-media-placeholder">

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -4,7 +4,7 @@
  */
 import { useBlockEditContext } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useContext } from '@wordpress/element';
+import { useContext, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,13 +30,14 @@ export default createHigherOrderComponent(
 		 * @param {Array} message - Error message provided by the callback.
 		 * @returns {*} Error handling.
 		 */
-		const uploadingErrorHandler = ( message ) => {
+
+		const uploadingErrorHandler = useCallback( ( message ) => {
 			const filename = message?.[ 0 ]?.props?.children;
 			if ( filename && isVideoFile( filename ) ) {
 				return onFilesUpload( [ filename ] );
 			}
 			return onError( message );
-		};
+		}, [ onFilesUpload, onError ] );
 
 		return (
 			<div className="jetpack-cover-media-placeholder">

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -8,10 +8,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import UpgradeNudge from '../../components/upgrade-nudge';
-import { videoFileExtensions } from './utils';
-import { isSimpleSite } from '../../site-type-utils';
-import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
+import UpgradeNudge from "../../components/upgrade-nudge";
+import { isUpgradable, isVideoFile } from './utils';
 
 /**
  * Module Constants
@@ -48,14 +46,7 @@ const JetpackCoverUpgradeNudge = ( { name, show } ) =>
 export default CoreMediaPlaceholder => props => {
 	const [ error, setError ] = useState( false );
 	const { name } = useBlockEditContext();
-	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
-
-	if (
-		! name ||
-		name !== 'core/cover' || // extend only for cover block
-		! isSimpleSite() || // only for Simple sites
-		! [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-	) {
+	if ( ! name || ! isUpgradable( name ) ) {
 		return <CoreMediaPlaceholder { ...props } />;
 	}
 
@@ -70,16 +61,10 @@ export default CoreMediaPlaceholder => props => {
 					// Try to pick up filename from the error message.
 					// We should find a better way to do it. Unstable.
 					const filename = message?.[ 0 ]?.props?.children;
-					if ( ! filename ) {
-						return onError( message );
+					if ( filename && isVideoFile( filename ) ) {
+						return setError( message );
 					}
-
-					const fileExtension = filename.split( '.' )?.[ 1 ];
-					if ( ! videoFileExtensions.includes( fileExtension ) ) {
-						return onError( message );
-					}
-
-					return setError( message );
+					return onError( message );
 				} }
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 			/>

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockEditContext } from '@wordpress/block-editor';
+import { useEffect, useState, Fragment, useCallback } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { isUpgradable, isVideoFile } from "./utils";
+import { CoverMediaProvider, JetpackCoverUpgradeNudge } from "./components";
+
+export default createHigherOrderComponent(
+	BlockEdit => props => {
+		const { name } = useBlockEditContext();
+		if ( ! isUpgradable( name ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		const [ showNudge, setShowNudge ] = useState( false );
+
+		const { attributes } = props;
+
+		// Remove Nudge if the block changes its attributes.
+		useEffect( () => setShowNudge( false ), [ attributes ] );
+
+		const handleFilesPreUpload = useCallback( ( files ) => {
+			if ( ! files?.length || ! isVideoFile( files[ 0 ] ) ) {
+				return;
+			}
+			setShowNudge( true );
+		} );
+
+		return (
+			<Fragment>
+				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
+					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ attributes.align } />
+					<BlockEdit { ...props } />
+				</CoverMediaProvider>
+			</Fragment>
+		);
+	},
+	'JetpackCoverBlockEdit'
+);

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -13,11 +13,6 @@ import { CoverMediaProvider, JetpackCoverUpgradeNudge } from "./components";
 
 export default createHigherOrderComponent(
 	BlockEdit => props => {
-		const { name } = useBlockEditContext();
-		if ( ! isUpgradable( name ) ) {
-			return <BlockEdit { ...props } />;
-		}
-
 		const [ showNudge, setShowNudge ] = useState( false );
 
 		const { attributes } = props;
@@ -31,6 +26,11 @@ export default createHigherOrderComponent(
 			}
 			setShowNudge( true );
 		} );
+
+		const { name } = useBlockEditContext();
+		if ( ! isUpgradable( name ) ) {
+			return <BlockEdit { ...props } />;
+		}
 
 		return (
 			<Fragment>

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -8,8 +8,8 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { isUpgradable, isVideoFile } from "./utils";
-import { CoverMediaProvider, JetpackCoverUpgradeNudge } from "./components";
+import { isUpgradable, isVideoFile } from './utils';
+import { CoverMediaProvider, JetpackCoverUpgradeNudge } from './components';
 
 export default createHigherOrderComponent(
 	BlockEdit => props => {

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -27,7 +27,7 @@ const JetpackCoverBlockEdit = ( blockName ) => createHigherOrderComponent(
 
 		return (
 			<Fragment>
-				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
+				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload } blockName={ blockName }>
 					<JetpackCoverUpgradeNudge show={ showNudge } name={ blockName } align={ attributes.align } />
 					<CoverBlockEdit { ...props } />
 				</CoverMediaProvider>

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useBlockEditContext } from '@wordpress/block-editor';
 import { useEffect, useState, Fragment, useCallback } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
@@ -11,10 +10,9 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { isUpgradable, isVideoFile } from './utils';
 import { CoverMediaProvider, JetpackCoverUpgradeNudge } from './components';
 
-export default createHigherOrderComponent(
-	BlockEdit => props => {
+const JetpackCoverBlockEdit = ( blockName ) => createHigherOrderComponent(
+	( CoverBlockEdit ) => props => {
 		const [ showNudge, setShowNudge ] = useState( false );
-
 		const { attributes } = props;
 
 		// Remove Nudge if the block changes its attributes.
@@ -27,19 +25,25 @@ export default createHigherOrderComponent(
 			setShowNudge( true );
 		} );
 
-		const { name } = useBlockEditContext();
-		if ( ! isUpgradable( name ) ) {
-			return <BlockEdit { ...props } />;
-		}
-
 		return (
 			<Fragment>
 				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
-					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ attributes.align } />
-					<BlockEdit { ...props } />
+					<JetpackCoverUpgradeNudge show={ showNudge } name={ blockName } align={ attributes.align } />
+					<CoverBlockEdit { ...props } />
 				</CoverMediaProvider>
 			</Fragment>
 		);
 	},
 	'JetpackCoverBlockEdit'
 );
+
+export default ( settings, name ) => {
+	if ( ! isUpgradable( name ) ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: JetpackCoverBlockEdit( name )( settings.edit ),
+	};
+};

--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -1,7 +1,11 @@
+
+// Stretch Cover MediaPlaceholder element.
 .jetpack-cover-media-placeholder {
 	width: 100%;
+}
 
-	// tweak Upgrade nudge.
+// tweak Upgrade nudge.
+.jetpack-upgrade-nudge-wrapper.wp-block {
 	.block-editor-warning__contents {
 		flex-wrap: initial;
 
@@ -9,5 +13,10 @@
 		.block-editor-warning__actions {
 			align-self: center;
 		}
+	}
+
+	.jetpack-block-nudge {
+		width: 100%;
+		min-width: 100%;
 	}
 }

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -12,13 +12,14 @@ import { addFilter } from '@wordpress/hooks';
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import isCurrentUserConnected from '../../is-current-user-connected';
+import jetpackCoverBlockEdit from './edit';
+
 import './editor.scss';
 
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
-	addFilter(
-		'editor.MediaPlaceholder',
-		'jetpack/cover-edit-media-placeholder',
-		coverEditMediaPlaceholder
-	);
+	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+
+	// Extend Core CoverEditBlock.
+	addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
 }

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -18,8 +18,8 @@ import './editor.scss';
 
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
-	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+	// addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
 
 	// Extend Core CoverEditBlock.
-	addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
+	addFilter( 'blocks.registerBlockType', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
 }

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -18,7 +18,7 @@ import './editor.scss';
 
 if ( isCurrentUserConnected() ) {
 	// Take the control of MediaPlaceholder.
-	// addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
 
 	// Extend Core CoverEditBlock.
 	addFilter( 'blocks.registerBlockType', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -8,7 +8,10 @@ import { flatten, map, keys, values } from 'lodash';
  */
 import { isSimpleSite } from '../../site-type-utils';
 import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
-import getAllowedMimeTypesBySite, { getAllowedVideoTypesByType } from "../../get-allowed-mime-types";
+import getAllowedMimeTypesBySite, {
+	getAllowedVideoTypesByType,
+	pickFileExtensionsFromMimeTypes,
+} from "../../get-allowed-mime-types";
 
 /**
  * Check if the given file is a video.
@@ -27,7 +30,7 @@ export function isVideoFile( file ) {
 	}
 
 	let allowedVideoMimeTypes = getAllowedVideoTypesByType( 'video' );
-	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ( ext ) => ext.split( '|' ) ) );
+	const allowedVideoFileExtensions = pickFileExtensionsFromMimeTypes( allowedVideoMimeTypes );
 
 	if ( typeof file === 'string' ) {
 		const fileExtension = file.split( '.' ).pop();
@@ -36,7 +39,7 @@ export function isVideoFile( file ) {
 
 	if ( typeof file === 'object' ) {
 		allowedVideoMimeTypes = values( allowedVideoMimeTypes );
-		return file.type && allowedVideoMimeTypes.includes( file.type );
+		return file.type && ( allowedVideoMimeTypes ).includes( file.type );
 	}
 
 	return false;

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -30,7 +30,7 @@ export function isVideoFile( file ) {
 	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
 
 	if ( typeof file === 'string' ) {
-		const fileExtension = ( file.split( '.' ) )?.[ 1 ];
+		const fileExtension = file.split( '.' ).pop();
 		return fileExtension && allowedVideoFileExtensions.includes( fileExtension );
 	}
 

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -27,7 +27,7 @@ export function isVideoFile( file ) {
 	}
 
 	let allowedVideoMimeTypes = pickBy( allowedMimeTypes, ( type ) => /^video\//.test( type ) );
-	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
+	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ( ext ) => ext.split( '|' ) ) );
 
 	if ( typeof file === 'string' ) {
 		const fileExtension = file.split( '.' ).pop();

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flatten, map, keys, values } from 'lodash';
+import { values } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ export function isVideoFile( file ) {
 		return false;
 	}
 
-	let allowedVideoMimeTypes = getAllowedVideoTypesByType( 'video' );
+	const allowedVideoMimeTypes = getAllowedVideoTypesByType( 'video' );
 	const allowedVideoFileExtensions = pickFileExtensionsFromMimeTypes( allowedVideoMimeTypes );
 
 	if ( typeof file === 'string' ) {
@@ -38,8 +38,7 @@ export function isVideoFile( file ) {
 	}
 
 	if ( typeof file === 'object' ) {
-		allowedVideoMimeTypes = values( allowedVideoMimeTypes );
-		return file.type && ( allowedVideoMimeTypes ).includes( file.type );
+		return file.type && ( values( allowedVideoMimeTypes ) ).includes( file.type );
 	}
 
 	return false;

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -16,13 +16,13 @@ import getJetpackExtensionAvailability from '../../get-jetpack-extension-availab
  * @returns {boolean}       True if it's a video file. Otherwise, False.
  */
 export function isVideoFile( file ) {
-	// Pick up allowed mime types from the window object.
-	const allowedMimeTypes = window?.Jetpack_Editor_Initial_State?.allowedMimeTypes;
-	if ( ! allowedMimeTypes ) {
+	if ( ! file ) {
 		return false;
 	}
 
-	if ( ! file ) {
+	// Pick up allowed mime types from the window object.
+	const allowedMimeTypes = window?.Jetpack_Editor_Initial_State?.allowedMimeTypes;
+	if ( ! allowedMimeTypes ) {
 		return false;
 	}
 

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -6,8 +6,8 @@ import { pickBy, flatten, map, keys, values } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isSimpleSite } from "../../site-type-utils";
-import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
+import { isSimpleSite } from '../../site-type-utils';
+import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
 
 /**
  * Check if the given file is a video.

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -1,18 +1,58 @@
-export const videoFileExtensions = [
-	'ogv',
-	'mp4',
-	'm4v',
-	'mov',
-	'qt',
-	'wmv',
-	'avi',
-	'mpeg',
-	'mpg',
-	'mpe',
-	'3gp',
-	'3gpp',
-	'3g2',
-	'3gp2',
-	'3gp',
-	'3g2',
-];
+/**
+ * External dependencies
+ */
+import { pickBy, flatten, map, keys, values } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { isSimpleSite } from "../../site-type-utils";
+import getJetpackExtensionAvailability from "../../get-jetpack-extension-availability";
+
+/**
+ * Check if the given file is a video.
+ *
+ * @param   {string|object} file - file to check.
+ * @returns {boolean}       True if it's a video file. Otherwise, False.
+ */
+export function isVideoFile( file ) {
+	// Pick up allowed mime types from the window object.
+	const allowedMimeTypes = window?.Jetpack_Editor_Initial_State?.allowedMimeTypes;
+	if ( ! allowedMimeTypes ) {
+		return false;
+	}
+
+	if ( ! file ) {
+		return false;
+	}
+
+	let allowedVideoMimeTypes = pickBy( allowedMimeTypes, ( type ) => /^video\//.test( type ) );
+	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ext => ext.split( '|' ) ) );
+
+	if ( typeof file === 'string' ) {
+		const fileExtension = ( file.split( '.' ) )?.[ 1 ];
+		return fileExtension && allowedVideoFileExtensions.includes( fileExtension );
+	}
+
+	allowedVideoMimeTypes = values( allowedVideoMimeTypes );
+
+	if ( typeof file === 'object' ) {
+		return file.type && allowedVideoMimeTypes.includes( file.type );
+	}
+
+	return false;
+}
+
+/**
+ * Check if the cover block should show the upgrade nudge.
+ *
+ * @param {string} name - Block name.
+ * @returns {boolean} True if it should show the nudge. Otherwise, False.
+ */
+export function isUpgradable( name ) {
+	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
+
+	return name && name === 'core/cover' && // upgrade only for cover block
+		isSimpleSite() && // only for Simple sites
+		[ 'missing_plan', 'unknown' ].includes( unavailableReason );
+}

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { pickBy, flatten, map, keys, values } from 'lodash';
+import { flatten, map, keys, values } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { isSimpleSite } from '../../site-type-utils';
 import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
+import getAllowedMimeTypesBySite, { getAllowedVideoTypesByType } from "../../get-allowed-mime-types";
 
 /**
  * Check if the given file is a video.
@@ -20,13 +21,12 @@ export function isVideoFile( file ) {
 		return false;
 	}
 
-	// Pick up allowed mime types from the window object.
-	const allowedMimeTypes = window?.Jetpack_Editor_Initial_State?.allowedMimeTypes;
+	const allowedMimeTypes = getAllowedMimeTypesBySite();
 	if ( ! allowedMimeTypes ) {
 		return false;
 	}
 
-	let allowedVideoMimeTypes = pickBy( allowedMimeTypes, ( type ) => /^video\//.test( type ) );
+	let allowedVideoMimeTypes = getAllowedVideoTypesByType( 'video' );
 	const allowedVideoFileExtensions = flatten( map( keys( allowedVideoMimeTypes ), ( ext ) => ext.split( '|' ) ) );
 
 	if ( typeof file === 'string' ) {
@@ -34,9 +34,8 @@ export function isVideoFile( file ) {
 		return fileExtension && allowedVideoFileExtensions.includes( fileExtension );
 	}
 
-	allowedVideoMimeTypes = values( allowedVideoMimeTypes );
-
 	if ( typeof file === 'object' ) {
+		allowedVideoMimeTypes = values( allowedVideoMimeTypes );
 		return file.type && allowedVideoMimeTypes.includes( file.type );
 	}
 

--- a/extensions/shared/get-allowed-mime-types.js
+++ b/extensions/shared/get-allowed-mime-types.js
@@ -7,7 +7,7 @@ import { get, pickBy, startsWith, flatten, map, keys } from 'lodash';
 /**
  * Internal dependencies
  */
-import getJetpackData from "./get-jetpack-data";
+import getJetpackData from './get-jetpack-data';
 
 /**
  * Return an object with the allowed mime types for the site,

--- a/extensions/shared/get-allowed-mime-types.js
+++ b/extensions/shared/get-allowed-mime-types.js
@@ -1,0 +1,35 @@
+
+/**
+ * External dependencies
+ */
+import { get, pickBy, startsWith } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getJetpackData from "./get-jetpack-data";
+
+/**
+ * Return an object with the allowed mime types for the site,
+ * filtered vy the given mime type argument.
+ * It allows `video, `audio`, ...
+ *
+ * @param {string} mimeType - File mime type.
+ * @returns {object} Filtered allowed mime types.
+ */
+export function getAllowedVideoTypesByType( mimeType ) {
+	if ( ! mimeType ) {
+		return [];
+	}
+	return pickBy( getAllowedMimeTypesBySite(), ( type ) => startsWith( type, `${ mimeType }/` ) );
+}
+
+/**
+ * Return the allowed file mime types for the site.
+ *
+ * @returns {object} Allowed Mime Types.
+ */
+export default function getAllowedMimeTypesBySite() {
+	return get( getJetpackData(), [ 'allowedMimeTypes' ], [] );
+}
+

--- a/extensions/shared/get-allowed-mime-types.js
+++ b/extensions/shared/get-allowed-mime-types.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, pickBy, startsWith } from 'lodash';
+import { get, pickBy, startsWith, flatten, map, keys } from 'lodash';
 
 /**
  * Internal dependencies
@@ -19,9 +19,26 @@ import getJetpackData from "./get-jetpack-data";
  */
 export function getAllowedVideoTypesByType( mimeType ) {
 	if ( ! mimeType ) {
-		return [];
+		return {};
 	}
 	return pickBy( getAllowedMimeTypesBySite(), ( type ) => startsWith( type, `${ mimeType }/` ) );
+}
+
+/**
+ * Given the mime types object, return an Array with the all file extensions.
+ * The keys of the Mime types object provided by the server
+ * can define more than one file extension per key.
+ * For instance: { 3g2|3gp2: "video/3gpp2" }. This function
+ * pick up both extensions `3g2` and `3gp2` and populate the returned array.
+ *
+ * @param {object} mimeTypesObject - Object mime types.
+ * @returns {Array} File extensions.
+ */
+export function pickFileExtensionsFromMimeTypes( mimeTypesObject ) {
+	if ( ! mimeTypesObject ) {
+		return [];
+	}
+	return flatten( map( keys( mimeTypesObject ), ( ext ) => ext.split( '|' ) ) );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

IMPORTANT
------------

This branch as branched off https://github.com/Automattic/jetpack/pull/16171. DO NOT MERGE before to `#16171`.

This PR stop using the `useBlockEditContext` hook and populates the block name through the media cover context. This hook has been added in WP 5.4 which means it isn't available for newer versions triggering a fatal error when invoked.
Although it isn't a valid reason to stop using it, I suggest propagating the block name in the through the context and getting rid of the hook in favor of a better and global implementation.

The cover media context allows implementing communication among all pieces of the block. These pieces are the CoverEdit and the MediaPlaceholder, and soon we will need to deal with the `Replace` control button.

This PR is another alternative to fix #16233 besides https://github.com/Automattic/jetpack/pull/16241

Fixes https://github.com/Automattic/jetpack/issues/16233

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Propagate block name through of cover media context.

#### Testing instructions:


1) Test the feature in a site with WP smaller version than 5.4
2) Start to create a cover block
3) Confirm that the block is broken without these changes
4) Switch to this branch
5) Confirm it fixes the bug and the blocks are rendered properly.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Propagate block name through of cover media context.
