### PR TITLE
Memberships: Add a route for generating products.

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -15,6 +15,33 @@ use Automattic\Jetpack\Connection\Client;
 class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 
 	/**
+	 * Currencies should be supported by Stripe.
+	 *
+	 * @link https://stripe.com/docs/currencies
+	 *
+	 * List has to be in sync with the Recurring Payments block in Jetpack and the Memberships library in WP.com.
+	 */
+	const SUPPORTED_CURRENCIES = array(
+		'USD',
+		'AUD',
+		'BRL',
+		'CAD',
+		'CHF',
+		'DKK',
+		'EUR',
+		'GBP',
+		'HKD',
+		'INR',
+		'JPY',
+		'MXN',
+		'NOK',
+		'NZD',
+		'PLN',
+		'SEK',
+		'SGD',
+	);
+
+	/**
 	 * WPCOM_REST_API_V2_Endpoint_Memberships constructor.
 	 */
 	public function __construct() {
@@ -98,29 +125,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 							'type'              => 'string',
 							'required'          => false,
 							'validate_callback' => function( $param ) {
-								return in_array(
-									$param,
-									array(
-										'USD',
-										'AUD',
-										'BRL',
-										'CAD',
-										'CHF',
-										'DKK',
-										'EUR',
-										'GBP',
-										'HKD',
-										'INR',
-										'JPY',
-										'MXN',
-										'NOK',
-										'NZD',
-										'PLN',
-										'SEK',
-										'SGD',
-									),
-									true
-								);
+								return in_array( $param, self::SUPPORTED_CURRENCIES, true );
 							},
 						),
 					),

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -174,7 +174,12 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			if ( ! $connected_destination_account_id ) {
 				return new WP_Error( 'no-destination-account', __( 'Please set up a Stripe account for this site first', 'jetpack' ) );
 			}
-			return Memberships_Product::generate_default_products( get_current_blog_id(), $request['type'], $request['currency'], $connected_destination_account_id );
+			$result = Memberships_Product::generate_default_products( get_current_blog_id(), $request['type'], $request['currency'], $connected_destination_account_id );
+			if ( is_wp_error( $result ) ) {
+				$status = 'invalid_param' === $result->get_error_code() ? 400 : 500;
+				return new WP_Error( $result->get_error_code(), $result->get_error_message(), array( 'status' => $status ) );
+			}
+			return $result;
 		} else {
 			$blog_id  = Jetpack_Options::get_option( 'id' );
 			$response = Client::wpcom_json_api_request_as_user(

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -87,11 +87,40 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'callback'            => array( $this, 'create_products' ),
 					'permission_callback' => array( $this, 'get_status_permission_check' ),
 					'args'                => array(
-						'type' => array(
+						'type'     => array(
 							'type'              => 'string',
 							'required'          => true,
 							'validate_callback' => function( $param ) {
 								return in_array( $param, array( 'donation' ), true );
+							},
+						),
+						'currency' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'validate_callback' => function( $param ) {
+								return in_array(
+									$param,
+									array(
+										'USD',
+										'AUD',
+										'BRL',
+										'CAD',
+										'CHF',
+										'DKK',
+										'EUR',
+										'GBP',
+										'HKD',
+										'INR',
+										'JPY',
+										'MXN',
+										'NOK',
+										'NZD',
+										'PLN',
+										'SEK',
+										'SGD',
+									),
+									true
+								);
 							},
 						),
 					),
@@ -183,7 +212,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			if ( ! $connected_destination_account_id ) {
 				return new WP_Error( 'no-destination-account', __( 'Please set up a Stripe account for this site first', 'jetpack' ) );
 			}
-			return Memberships_Product::generate_default_products( get_current_blog_id(), $request['type'], $connected_destination_account_id );
+			return Memberships_Product::generate_default_products( get_current_blog_id(), $request['type'], $request['currency'], $connected_destination_account_id );
 		} else {
 			$blog_id  = Jetpack_Options::get_option( 'id' );
 			$response = Client::wpcom_json_api_request_as_user(

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -238,8 +238,8 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			}
 			$data = isset( $response['body'] ) ? json_decode( $response['body'], true ) : null;
 			// If endpoint returned error, we have to detect it.
-			if ( 200 !== $response['response']['code'] && $data['code'] && $data['message'] ) {
-				return new WP_Error( $data['code'], $data['message'], 401 );
+			if ( 200 !== $response['response']['code'] && $data['code'] ) {
+				return new WP_Error( $data['code'], $data['message'] ? $data['message'] : '', 401 );
 			}
 			return $data;
 		}

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -20,6 +20,8 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 * @link https://stripe.com/docs/currencies
 	 *
 	 * List has to be in sync with the Recurring Payments block in Jetpack and the Memberships library in WP.com.
+	 * @link https://github.com/Automattic/jetpack/blob/2e7e2c4dbe6348933075cef0a8ca75dd21b20657/extensions/blocks/recurring-payments/index.js#L81
+	 * @see Memberships_Product::SUPPORTED_CURRENCIES
 	 */
 	const SUPPORTED_CURRENCIES = array(
 		'USD',

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -15,35 +15,6 @@ use Automattic\Jetpack\Connection\Client;
 class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 
 	/**
-	 * Currencies should be supported by Stripe.
-	 *
-	 * @link https://stripe.com/docs/currencies
-	 *
-	 * List has to be in sync with the Recurring Payments block in Jetpack and the Memberships library in WP.com.
-	 * @link https://github.com/Automattic/jetpack/blob/2e7e2c4dbe6348933075cef0a8ca75dd21b20657/extensions/blocks/recurring-payments/index.js#L81
-	 * @see Memberships_Product::SUPPORTED_CURRENCIES
-	 */
-	const SUPPORTED_CURRENCIES = array(
-		'USD',
-		'AUD',
-		'BRL',
-		'CAD',
-		'CHF',
-		'DKK',
-		'EUR',
-		'GBP',
-		'HKD',
-		'INR',
-		'JPY',
-		'MXN',
-		'NOK',
-		'NZD',
-		'PLN',
-		'SEK',
-		'SGD',
-	);
-
-	/**
 	 * WPCOM_REST_API_V2_Endpoint_Memberships constructor.
 	 */
 	public function __construct() {
@@ -115,22 +86,6 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'create_products' ),
 					'permission_callback' => array( $this, 'get_status_permission_check' ),
-					'args'                => array(
-						'type'     => array(
-							'type'              => 'string',
-							'required'          => true,
-							'validate_callback' => function( $param ) {
-								return in_array( $param, array( 'donation' ), true );
-							},
-						),
-						'currency' => array(
-							'type'              => 'string',
-							'required'          => false,
-							'validate_callback' => function( $param ) {
-								return in_array( $param, self::SUPPORTED_CURRENCIES, true );
-							},
-						),
-					),
 				),
 			)
 		);

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -189,7 +189,8 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'method' => 'POST',
 				),
 				array(
-					'type' => $request['type'],
+					'type'     => $request['type'],
+					'currency' => $request['currency'],
 				)
 			);
 			if ( is_wp_error( $response ) ) {

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -72,7 +72,9 @@ export const settings = {
 /**
  * Currencies we support and Stripe's minimum amount for a transaction in that currency.
  *
- * https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+ * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
+ *
+ * List has to be in sync with the Memberships API endpoint in Jetpack and the Memberships library in WP.com.
  *
  * @type { [currency: string]: number }
  */

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -74,8 +74,7 @@ export const settings = {
  *
  * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
  *
- * List has to be in sync with the Memberships API endpoint in Jetpack and the Memberships library in WP.com.
- * @link https://github.com/Automattic/jetpack/blob/2e7e2c4dbe6348933075cef0a8ca75dd21b20657/_inc/lib/core-api/wpcom-endpoints/memberships.php#L24
+ * List has to be in sync with the Memberships library in WP.com.
  * @see Memberships_Product::SUPPORTED_CURRENCIES
  *
  * @type { [currency: string]: number }

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -75,6 +75,8 @@ export const settings = {
  * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
  *
  * List has to be in sync with the Memberships API endpoint in Jetpack and the Memberships library in WP.com.
+ * @link https://github.com/Automattic/jetpack/blob/2e7e2c4dbe6348933075cef0a8ca75dd21b20657/_inc/lib/core-api/wpcom-endpoints/memberships.php#L24
+ * @see Memberships_Product::SUPPORTED_CURRENCIES
  *
  * @type { [currency: string]: number }
  */


### PR DESCRIPTION
Part of adding support for the Donations block will be automatically generating default plan products for the three tabbed options: one-time, monthly, and yearly. This PR adds a route to the memberships endpoint for `POST`ing that a certain type of product have its defaults generated (and returned). The only type to be immediately supported will be the `donation` type.

<img width="1069" alt="Screen Shot 2020-06-22 at 4 46 55 PM" src="https://user-images.githubusercontent.com/349751/85347184-bd358f80-b4ac-11ea-86fc-90d5f8aaede1.png">


#### Changes proposed in this Pull Request:
* This PR adds a `create_posts` callback for a new `memberships/products` route which, server-side on WP.com, will generate default products for a given product type via the `Memberships_Product` library.

#### Jetpack product discussion
* pbMlHh-kg-p2

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

_WordPress.com_
* On a WP.com sandbox, apply D45327-code, D45328-code, and sandbox the API and store.
* Use the [WP.com developer console](https://developer.wordpress.com/docs/api/console/) to `POST` to `WP REST API wpcom/v2 /sites/:site-with-store-access/memberships/products?type=donation`.
* Verify the response includes the 3 default USD donation-type plans that have been just created, one for each interval: one-time, monthly, annually.
* Repeat the call but set an explicit currency this time such as EUR (`/wpcom/v2 /sites/:site-with-store-access/memberships/products?type=donation&currency=EUR`).
* Verify the response includes now the 3 default EUR donation-type plans that have been just created.
* Repeat any of the 2 requests and verify no plans are created (it should return the ones created previously).

_Jetpack_
* TBD (the WP.com developer console cannot be used as it doesn't hit the JP site directly (it calls `public-api.wordpress.com`).

#### Proposed changelog entry for your changes:
* New `/memberships/products` route for generating default products automatically.
