### PR TITLE
Instant Search: use our own decode function for query strings

### DIFF
--- a/modules/search/instant-search/lib/query-string-decode.js
+++ b/modules/search/instant-search/lib/query-string-decode.js
@@ -1,0 +1,37 @@
+// These two functions are a temporary addition while we wait for @jsnmoon's PR
+// to be merged into the qss package: https://github.com/lukeed/qss/pull/8
+function toValue( mix, tcBools, tcNumbers ) {
+	if ( ! mix ) {
+		return '';
+	}
+	const str = decodeURIComponent( mix );
+	if ( tcBools && str === 'false' ) {
+		return false;
+	}
+	if ( tcBools && str === 'true' ) {
+		return true;
+	}
+	return tcNumbers && +str * 0 === 0 ? +str : str;
+}
+
+export function decode( str, tcBools, tcNumbers ) {
+	let tmp, k;
+
+	const out = {},
+		arr = str.split( '&' );
+
+	tcBools = typeof tcBools !== 'undefined' ? tcBools : true;
+	tcNumbers = typeof tcNumbers !== 'undefined' ? tcNumbers : true;
+
+	while ( ( tmp = arr.shift() ) ) {
+		tmp = tmp.split( '=' );
+		k = tmp.shift();
+		if ( out[ k ] !== void 0 ) {
+			out[ k ] = [].concat( out[ k ], toValue( tmp.shift(), tcBools, tcNumbers ) );
+		} else {
+			out[ k ] = toValue( tmp.shift(), tcBools, tcNumbers );
+		}
+	}
+
+	return out;
+}

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import 'url-polyfill';
-import { decode, encode } from 'qss';
+import { encode } from 'qss';
 
 /**
  * Internal dependencies
@@ -15,11 +15,12 @@ import {
 	VALID_SORT_KEYS,
 } from './constants';
 import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
+import { decode } from './query-string-decode';
 
 const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
 
 function getQuery() {
-	return decode( window.location.search.substring( 1 ) );
+	return decode( window.location.search.substring( 1 ), false, false );
 }
 
 function pushQueryString( queryString, shouldEmitEvent = true ) {
@@ -47,6 +48,7 @@ export function setSearchQuery( searchValue ) {
 	} else {
 		query.s = searchValue;
 	}
+
 	pushQueryString( encode( query ) );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #14750.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Fixes an issue with Jetpack Search: you are currently unable to type a space after entering a query starting with a number.

@jsnmoon discovered earlier in the year that the issue was caused by our query string decoder, [qss](https://github.com/lukeed/qss), typecasting the search query as a number. He created a PR for a fix (https://github.com/lukeed/qss/pull/8) but there has been no activity for several months. In the short term, I suggest we include our own version of `decode()` directly and remove it later when our PR is merged.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply this change to your Jetpack installation with Jetpack Instant Search enabled.
* Perform a search starting with a number, e.g. "123 main street". Ensure that you are able to type the query and that it retrieves results.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixed an issue with Jetpack Instant Search that made it impossible to enter a space for searches beginning with a number.
