### PR TITLE
API: Add owns_site Capability to Sites Endpoint

### DIFF
--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -408,6 +408,8 @@ abstract class SAL_Site {
 	}
 
 	function get_capabilities() {
+		$is_wpcom_blog_owner = wpcom_get_blog_owner() === (int) get_current_user_id();
+
 		return array(
 			'edit_pages'          => current_user_can( 'edit_pages' ),
 			'edit_posts'          => current_user_can( 'edit_posts' ),
@@ -421,13 +423,13 @@ abstract class SAL_Site {
 			'manage_categories'   => current_user_can( 'manage_categories' ),
 			'manage_options'      => current_user_can( 'manage_options' ),
 			'moderate_comments'   => current_user_can( 'moderate_comments' ),
-			'activate_wordads'    => wpcom_get_blog_owner() === (int) get_current_user_id(),
+			'activate_wordads'    => $is_wpcom_blog_owner,
 			'promote_users'       => current_user_can( 'promote_users' ),
 			'publish_posts'       => current_user_can( 'publish_posts' ),
 			'upload_files'        => current_user_can( 'upload_files' ),
 			'delete_users'        => current_user_can( 'delete_users' ),
 			'remove_users'        => current_user_can( 'remove_users' ),
-			'owns_site'           => wpcom_get_blog_owner() === (int) get_current_user_id(),
+			'owns_site'           => $is_wpcom_blog_owner,
 			/**
 		 	 * Filter whether the Hosting section in Calypso should be available for site.
 			 *

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -429,7 +429,7 @@ abstract class SAL_Site {
 			'upload_files'        => current_user_can( 'upload_files' ),
 			'delete_users'        => current_user_can( 'delete_users' ),
 			'remove_users'        => current_user_can( 'remove_users' ),
-			'owns_site'           => $is_wpcom_blog_owner,
+			'own_site'            => $is_wpcom_blog_owner,
 			/**
 		 	 * Filter whether the Hosting section in Calypso should be available for site.
 			 *

--- a/sal/class.json-api-site-base.php
+++ b/sal/class.json-api-site-base.php
@@ -427,6 +427,7 @@ abstract class SAL_Site {
 			'upload_files'        => current_user_can( 'upload_files' ),
 			'delete_users'        => current_user_can( 'delete_users' ),
 			'remove_users'        => current_user_can( 'remove_users' ),
+			'owns_site'           => wpcom_get_blog_owner() === (int) get_current_user_id(),
 			/**
 		 	 * Filter whether the Hosting section in Calypso should be available for site.
 			 *


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Required for Automattic/wp-calypso#43520

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This capability does already exist under `activate_wordads`.

https://github.com/Automattic/jetpack/blob/2e190a1ffe33df32f19a0632d5e6f34589e79035/sal/class.json-api-site-base.php#L424

However, it also needs to be used in a wider context outside WordAds, and it was agreed that it'd be better to introduce a new check rather than relying on a feature which could change in the future. 

From https://github.com/Automattic/wp-calypso/pull/43520#issuecomment-647788436:

> It feels a bit fragile. If WordAds was changed or withdrawn for any reason, the feature may not work as expected. Let's try and find another way to identify that the current user is not the site owner.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I've primarily made this change based on looking at examples for adding different capabilities in the past. This seems consistent, but I recognise that there may be changes needed on the WordPress.com side that can't be added by myself. However, please verify that this is the correct way to add an additional capability! 

I should note that I wasn't exactly certain of an alternative name; `canCurrentUser(own_site)` does seem slightly odd, but less odd than `canCurrentUser(remove_owner)` considering that they are the owner...

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Probably not needed
