### PR TITLE
Widgets: Display Posts widget: Fetch less data when requesting posts from WPCOM

### DIFF
--- a/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget-base.php
+++ b/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget-base.php
@@ -563,7 +563,7 @@ abstract class Jetpack_Display_Posts_Widget__Base extends WP_Widget {
 				 *
 				 * @param string $args Extra parameters to filter posts returned from the WordPress.com REST API.
 				 */
-				apply_filters( 'jetpack_display_posts_widget_posts_params', '' )
+				apply_filters( 'jetpack_display_posts_widget_posts_params', '?fields=id,title,excerpt,URL,featured_image' )
 			)
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Set default parameters to the request we do to WordPress.com to only fetch thee data we need. They are still filterable as before, so this shouldn't introduce issues.
* Partial fix for #16253 

#### Jetpack product discussion

* pau2Xa-1rU-p2

#### Does this pull request change what data or activity we track or use?
 
No

#### Testing instructions:

* Go to the Jetpack dashboard, then down in Modules (in the footer)
* Enable `Extra Sidebar Widgets`
* Add a `Display WordPress Posts (Jetpack)` widget
* Enter the `en.blog.wordpress.com` blog URL.
* Save the widget
* Make sure the widget is showing the correct posts when saved.

#### Proposed changelog entry for your changes:

* Make the Display WordPress posts widget work a bit faster and fetch less data.
