### PR TITLE
Autoloader: use JETPACK__PLUGIN_DIR when looking for the jetpack plugin directory

### DIFF
--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -57,7 +57,12 @@ class Autoloader_Handler {
 		$active_plugins = $this->plugins_handler->get_all_active_plugins();
 
 		foreach ( $active_plugins as $plugin ) {
-			$plugin_path   = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+			if ( 'jetpack' === $plugin ) {
+				$plugin_path = JETPACK__PLUGIN_DIR;
+			} else {
+				$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+			}
+
 			$classmap_path = trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';
 
 			if ( file_exists( $classmap_path ) ) {

--- a/packages/autoloader/src/class-classes-handler.php
+++ b/packages/autoloader/src/class-classes-handler.php
@@ -65,7 +65,12 @@ class Classes_Handler {
 	 * @return Array An array of plugin names and classmap paths.
 	 */
 	public function create_classmap_path_array( $plugin ) {
-		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		if ( 'jetpack' === $plugin ) {
+			$plugin_path = JETPACK__PLUGIN_DIR;
+		} else {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		}
+
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';
 	}
 

--- a/packages/autoloader/src/class-files-handler.php
+++ b/packages/autoloader/src/class-files-handler.php
@@ -65,7 +65,12 @@ class Files_Handler {
 	 * @return Array An array of plugin names and filemap paths.
 	 */
 	public function create_filemap_path_array( $plugin ) {
-		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		if ( 'jetpack' === $plugin ) {
+			$plugin_path = JETPACK__PLUGIN_DIR;
+		} else {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		}
+
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_filemap.php';
 	}
 


### PR DESCRIPTION
This is a temporary fix to a site with Jetpack installed in the mu-plugins folder.


#### Jetpack product discussion
- n/a

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Test on a site with Jetpack installed in the mu-plugins folder.

#### Proposed changelog entry for your changes:
* n/a
