### PR TITLE
Autoloader: set latest autoloader version value if find_latest_autoloader fails

### DIFF
--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -79,7 +79,7 @@ class Autoloader_Handler {
 		}
 
 		$jetpack_autoloader_latest_version = $selected_autoloader_version;
-		if ( $current_autoloader_path !== $selected_autoloader_path ) {
+		if ( $current_autoloader_path !== $selected_autoloader_path && file_exists( $selected_autoloader_path ) ) {
 			require $selected_autoloader_path;
 		}
 	}

--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -86,6 +86,11 @@ function set_up_autoloader() {
 
 	$current_autoloader_version = $autoloader_handler->get_current_autoloader_version();
 
+	if ( ! $jetpack_autoloader_latest_version ) {
+		// Set the lastest version if it hasn't been set yet.
+		$jetpack_autoloader_latest_version = $current_autoloader_version;
+	}
+
 	// This is the latest autoloader, so generate the classmap and filemap and register the autoloader function.
 	if ( empty( $jetpack_packages_classmap ) && $current_autoloader_version === $jetpack_autoloader_latest_version ) {
 		enqueue_files( $plugins_handler, $version_selector );


### PR DESCRIPTION
These changes should solve a problem where `Autoloader_Handler::find_latest_autoloader` can't load a `autoload_packages.php` file.


#### Changes proposed in this Pull Request:
* In `Autoloader_Handler::find_latest_autoloader,` check that the `autoload_packages.php`
file in the latest autoloader package exists before requiring it.

* In `set_up_autoloader()`, set the value of `$jetpack_autoloader_latest_version` to the
current autoloader version if the latest version wasn't found by `Autoloader_Handler::find_latest_autoloader`.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
* Make sure that Jetpack still works.

#### Proposed changelog entry for your changes:
* n/a
