### PR TITLE
Autoloader: add fallback check for plugin path in mu-plugins

### DIFF
--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -57,10 +57,10 @@ class Autoloader_Handler {
 		$active_plugins = $this->plugins_handler->get_all_active_plugins();
 
 		foreach ( $active_plugins as $plugin ) {
-			if ( 'jetpack' === $plugin ) {
-				$plugin_path = JETPACK__PLUGIN_DIR;
-			} else {
-				$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+
+			if ( ! file_exists( $plugin_path ) ) {
+				$plugin_path = trailingslashit( WPMU_PLUGIN_DIR ) . $plugin;
 			}
 
 			$classmap_path = trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';

--- a/packages/autoloader/src/class-classes-handler.php
+++ b/packages/autoloader/src/class-classes-handler.php
@@ -65,10 +65,10 @@ class Classes_Handler {
 	 * @return Array An array of plugin names and classmap paths.
 	 */
 	public function create_classmap_path_array( $plugin ) {
-		if ( 'jetpack' === $plugin ) {
-			$plugin_path = JETPACK__PLUGIN_DIR;
-		} else {
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+
+		if ( ! file_exists( $plugin_path ) ) {
+			$plugin_path = trailingslashit( WPMU_PLUGIN_DIR ) . $plugin;
 		}
 
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';

--- a/packages/autoloader/src/class-files-handler.php
+++ b/packages/autoloader/src/class-files-handler.php
@@ -65,10 +65,10 @@ class Files_Handler {
 	 * @return Array An array of plugin names and filemap paths.
 	 */
 	public function create_filemap_path_array( $plugin ) {
-		if ( 'jetpack' === $plugin ) {
-			$plugin_path = JETPACK__PLUGIN_DIR;
-		} else {
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
+
+		if ( ! file_exists( $plugin_path ) ) {
+			$plugin_path = trailingslashit( WPMU_PLUGIN_DIR ) . $plugin;
 		}
 
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_filemap.php';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

(hopefully) Fixes broken autoloader when loading from mu-plugins in VIP Go environments. 

Discussion here p1592963888441800-slack-jetpack-crew

This will be cleaned up as part of https://github.com/Automattic/jetpack/issues/16252

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Checks mu-plugins if it's not found in regular plugin path. This will be cleaned up tomorrow. See 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Make Jetpack an mu-plugin
- change the directory name to something like `jetpacks`
- This PR should load everything properly. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
