### PR TITLE
Fix AMP Reader Mode sharing warning

### DIFF
--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -424,6 +424,11 @@ class Jetpack_AMP_Support {
 	 * For the AMP Reader mode template, include styles that we need.
 	 */
 	public static function amp_reader_sharing_css() {
+		// If sharing is not enabled, we should not proceed to render the CSS.
+		if ( ! defined( 'JETPACK_SOCIAL_LOGOS_DIR' ) || ! defined( 'WP_SHARING_PLUGIN_DIR' ) ) {
+			return;
+		}
+
 		/*
 		 * We'll need to output the full contents of the 2 files
 		 * in the head on AMP views. We can't rely on regular enqueues here.


### PR DESCRIPTION
If the sharing module is not active, the `WP_SHARING_PLUGIN_DIR` constant is not set. Only try load sharing styles for AMP Reader Mode if the constant is set and thus the module active.

Fixes #16259 

#### Testing instructions:

- Enable AMP Reader Mode using the AMP WordPress plugin
- Make sure Sharing is disabled
- Go to a WordPress post on the front end
- Make sure the following warning is not thrown in the error logs:

`PHP Warning:  Use of undefined constant WP_SHARING_PLUGIN_DIR - assumed 'WP_SHARING_PLUGIN_DIR' (this will throw an Error in a future version of PHP) in /wp-content/plugins/jetpack/3rd-party/class.jetpack-amp-support.php on line 435`
