### PR TITLE
External Media: Google Photos Custom Date Range

### DIFF
--- a/extensions/shared/external-media/constants.js
+++ b/extensions/shared/external-media/constants.js
@@ -3,6 +3,8 @@
  */
 
 import { __ } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { map, range } from 'lodash';
 
 export const SOURCE_WORDPRESS = 'wordpress';
 export const SOURCE_GOOGLE_PHOTOS = 'google_photos';
@@ -162,9 +164,14 @@ export const GOOGLE_PHOTOS_DATE_PRESETS = [
 		value: DATE_RANGE_LAST_12_MONTHS,
 		label: __( 'Last 12 months', 'jetpack' ),
 	},
-	// TODO: Implement a UI for selecting month & year.
-	//{
-	//	value: DATE_RANGE_CUSTOM,
-	//	label: __( 'Custom Range', 'jetpack' ),
-	//},
+	{
+		value: DATE_RANGE_CUSTOM,
+		label: __( 'Specific Month', 'jetpack' ),
+	},
 ];
+
+export const MONTH_SELECT_OPTIONS = map( range( 0, 12 ), value => ( {
+	// Following call generates a new date object for the particular month and gets its name.
+	label: dateI18n( 'F', new Date( [ 0, value + 1 ] ) ),
+	value,
+} ) );

--- a/extensions/shared/external-media/constants.js
+++ b/extensions/shared/external-media/constants.js
@@ -166,12 +166,17 @@ export const GOOGLE_PHOTOS_DATE_PRESETS = [
 	},
 	{
 		value: DATE_RANGE_CUSTOM,
-		label: __( 'Specific Month', 'jetpack' ),
+		label: __( 'Specific Month/Year', 'jetpack' ),
 	},
 ];
 
-export const MONTH_SELECT_OPTIONS = map( range( 0, 12 ), value => ( {
-	// Following call generates a new date object for the particular month and gets its name.
-	label: dateI18n( 'F', new Date( [ 0, value + 1 ] ) ),
-	value,
-} ) );
+export const CURRENT_YEAR = new Date().getFullYear();
+
+export const MONTH_SELECT_OPTIONS = [
+	{ label: __( 'Any Month', 'jetpack' ), value: -1 },
+	...map( range( 0, 12 ), value => ( {
+		// Following call generates a new date object for the particular month and gets its name.
+		label: dateI18n( 'F', new Date( [ 0, value + 1 ] ) ),
+		value,
+	} ) ),
+];

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -229,17 +229,18 @@ $grid-size: 8px;
 	margin-bottom: 48px;
 	flex-direction: column;
 
+	@media only screen and ( min-width: 600px ) {
+		flex-direction: row;
+		align-items: center;
+	}
+
 	select {
 		max-width: 200px !important;
 	}
+
 	.components-base-control__field {
 		display: flex;
 		flex-direction: column;
-	}
-
-	input[type='number'] {
-		// this input holds only years, so 4 digits width is enough
-		width: 70px;
 	}
 }
 
@@ -261,6 +262,47 @@ $grid-size: 8px;
 	align-items: center;
 	flex-grow: 1;
 	justify-content: flex-start;
+
+	@media only screen and ( min-width: 600px ) {
+		border-left: 1px solid $light-gray-secondary;
+		margin-left: $grid-size * 2;
+		padding-left: $grid-size * 2;
+	}
+
+	.jetpack-external-media-date-filter {
+		display: flex;
+		flex-wrap: wrap;
+
+		button {
+			// Adjust button to match the size and position of inputs.
+			margin-top: 27px;
+			height: 40px;
+
+			@media only screen and ( min-width: 783px ) {
+				height: 30px;
+			}
+		}
+
+		.components-base-control {
+			.components-input-control__label {
+				margin-bottom: 3px;
+			}
+
+			.components-input-control__backdrop {
+				border-color: $dark-gray-200;
+				border-radius: 3px;
+			}
+
+			.components-input-control__input {
+				height: 40px;
+				width: 70px; // This input holds only years, so 4 digits width is enough.
+
+				@media only screen and ( min-width: 783px ) {
+					height: 30px;
+				}
+			}
+		}
+	}
 }
 
 .jetpack-external-media-header__pexels {
@@ -343,39 +385,5 @@ $grid-size: 8px;
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
 		margin-right: 8px;
-	}
-}
-
-.jetpack-external-media-date-filter {
-	display: flex;
-	flex-wrap: wrap;
-
-	button {
-		// Adjust button to match the size and position of inputs.
-		margin-top: 23px;
-		height: 40px;
-	}
-
-	.components-text-control__input {
-		margin: 1px;
-	}
-}
-
-@media only screen and ( min-width: 600px ) {
-	.jetpack-external-media-header__filter {
-		border-left: 1px solid $light-gray-secondary;
-		margin-left: $grid-size * 2;
-		padding-left: $grid-size * 2;
-	}
-
-	.jetpack-external-media-header__view {
-		flex-direction: row;
-		align-items: center;
-	}
-}
-
-@media only screen and ( min-width: 783px ) {
-	.jetpack-external-media-date-filter button {
-		height: 30px;
 	}
 }

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -339,6 +339,12 @@ $grid-size: 8px;
 
 .jetpack-external-media-date-filter {
 	display: flex;
+
+	button {
+		// Adjust button to match the size and position of inputs.
+		margin-top: 22px;
+		height: 40px;
+	}
 }
 
 @media only screen and ( min-width: 600px ) {
@@ -351,5 +357,11 @@ $grid-size: 8px;
 	.jetpack-external-media-header__view {
 		flex-direction: row;
 		align-items: center;
+	}
+}
+
+@media only screen and ( min-width: 783px ) {
+	.jetpack-external-media-date-filter button {
+		height: 30px;
 	}
 }

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -239,7 +239,7 @@ $grid-size: 8px;
 
 	input[type='number'] {
 		// this input holds only years, so 4 digits width is enough
-		width: 50px;
+		width: 70px;
 	}
 }
 

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -224,9 +224,10 @@ $grid-size: 8px;
 
 .jetpack-external-media-header__view {
 	display: flex;
-	align-items: center;
+	align-items: start;
 	justify-content: flex-start;
 	margin-bottom: 48px;
+	flex-direction: column;
 
 	select {
 		max-width: 200px !important;
@@ -243,32 +244,14 @@ $grid-size: 8px;
 		padding-right: $grid-size;
 		margin-bottom: 0;
 	}
-
-	.components-base-control__label {
-		margin-bottom: 0;
-	}
-
-	.components-base-control__field {
-		display: flex;
-		align-items: center;
-		margin-bottom: 0;
-	}
-
-	.components-base-control + .components-base-control {
-		padding-left: $grid-size * 2;
-	}
 }
 
 .jetpack-external-media-header__filter {
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
-
-	.jetpack-external-media-googlephotos-filter {
-		display: flex;
-		align-items: center;
-		margin-right: 7px;
-	}
+	flex-grow: 1;
+	justify-content: flex-start;
 }
 
 .jetpack-external-media-header__pexels {
@@ -351,5 +334,22 @@ $grid-size: 8px;
 .editor-post-featured-image {
 	.components-dropdown .jetpack-external-media-button-menu {
 		margin-right: 8px;
+	}
+}
+
+.jetpack-external-media-date-filter {
+	display: flex;
+}
+
+@media only screen and ( min-width: 600px ) {
+	.jetpack-external-media-header__filter {
+		border-left: 1px solid $light-gray-secondary;
+		margin-left: $grid-size * 2;
+		padding-left: $grid-size * 2;
+	}
+
+	.jetpack-external-media-header__view {
+		flex-direction: row;
+		align-items: center;
 	}
 }

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -232,6 +232,15 @@ $grid-size: 8px;
 	select {
 		max-width: 200px !important;
 	}
+	.components-base-control__field {
+		display: flex;
+		flex-direction: column;
+	}
+
+	input[type='number'] {
+		// this input holds only years, so 4 digits width is enough
+		width: 50px;
+	}
 }
 
 .jetpack-external-media-header__filter,
@@ -339,11 +348,16 @@ $grid-size: 8px;
 
 .jetpack-external-media-date-filter {
 	display: flex;
+	flex-wrap: wrap;
 
 	button {
 		// Adjust button to match the size and position of inputs.
-		margin-top: 22px;
+		margin-top: 23px;
 		height: 40px;
+	}
+
+	.components-text-control__input {
+		margin: 1px;
 	}
 }
 

--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -224,7 +224,7 @@ $grid-size: 8px;
 
 .jetpack-external-media-header__view {
 	display: flex;
-	align-items: start;
+	align-items: flex-start;
 	justify-content: flex-start;
 	margin-bottom: 48px;
 	flex-direction: column;

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -86,13 +86,7 @@ function MediaBrowser( props ) {
 
 		return (
 			<div className="jetpack-external-media-browser__media__toolbar">
-				<Button
-					isPrimary
-					isLarge
-					isBusy={ isCopying }
-					disabled={ disabled }
-					onClick={ onCopyAndInsert }
-				>
+				<Button isPrimary isBusy={ isCopying } disabled={ disabled } onClick={ onCopyAndInsert }>
 					{ label }
 				</Button>
 			</div>
@@ -118,7 +112,6 @@ function MediaBrowser( props ) {
 
 				{ pageHandle && ! isLoading && (
 					<Button
-						isLarge
 						isSecondary
 						className="jetpack-external-media-browser__loadmore"
 						disabled={ isLoading || isCopying }

--- a/extensions/shared/external-media/sources/google-photos/filter-option.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-option.js
@@ -23,8 +23,6 @@ import {
 	CURRENT_YEAR,
 } from '../../constants';
 
-console.log( { BlockEditorNumberControl } );
-
 /**
  * This uses the experimental NumberControl from the block editor where available,
  * otherwise it falls back to a standard TextControl, limited to numbers.

--- a/extensions/shared/external-media/sources/google-photos/filter-option.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-option.js
@@ -59,7 +59,7 @@ function DateOption( { value, updateFilter } ) {
 				onChange={ range => updateFilter( { range } ) }
 			/>
 			{ selectedRange === DATE_RANGE_CUSTOM && (
-				<Fragment className="jetpack-external-media-custom-date-filter">
+				<Fragment>
 					<SelectControl
 						label={ __( 'Month', 'jetpack' ) }
 						value={ month }

--- a/extensions/shared/external-media/sources/google-photos/filter-option.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-option.js
@@ -23,6 +23,8 @@ import {
 	CURRENT_YEAR,
 } from '../../constants';
 
+console.log( { BlockEditorNumberControl } );
+
 /**
  * This uses the experimental NumberControl from the block editor where available,
  * otherwise it falls back to a standard TextControl, limited to numbers.
@@ -67,6 +69,7 @@ function DateOption( { value, updateFilter } ) {
 						onChange={ setMonth }
 					/>
 					<NumberControl
+						className="components-base-control"
 						label={ __( 'Year', 'jetpack' ) }
 						value={ year }
 						min={ 1970 }

--- a/extensions/shared/external-media/sources/google-photos/filter-option.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-option.js
@@ -20,6 +20,7 @@ import {
 	DATE_RANGE_ANY,
 	DATE_RANGE_CUSTOM,
 	MONTH_SELECT_OPTIONS,
+	CURRENT_YEAR,
 } from '../../constants';
 
 /**
@@ -46,8 +47,8 @@ function CategoryOption( { value, updateFilter } ) {
 function DateOption( { value, updateFilter } ) {
 	const selectedRange = value?.range || DATE_RANGE_ANY;
 
-	const [ month, setMonth ] = useState( 0 );
-	const [ year, setYear ] = useState( 2020 );
+	const [ month, setMonth ] = useState( -1 );
+	const [ year, setYear ] = useState( CURRENT_YEAR );
 
 	return (
 		<div className="jetpack-external-media-date-filter">
@@ -73,6 +74,7 @@ function DateOption( { value, updateFilter } ) {
 					/>
 					<Button
 						isSecondary
+						disabled={ value?.month === month && value?.year === year }
 						onClick={ () => {
 							updateFilter( { range: selectedRange, month, year } );
 						} }

--- a/extensions/shared/external-media/sources/google-photos/filter-request.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-request.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import moment from 'moment';
+import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,23 +35,29 @@ export default function getFilterRequest( filters ) {
 
 	if ( date ) {
 		let startDate = null;
-		let endDate = TODAY;
+		let endDate = null;
 		switch ( date.range ) {
 			case DATE_RANGE_LAST_7_DAYS:
 				startDate = moment( TODAY ).subtract( 7, 'days' );
+				endDate = TODAY;
 				break;
 			case DATE_RANGE_LAST_30_DAYS:
 				startDate = moment( TODAY ).subtract( 30, 'days' );
+				endDate = TODAY;
 				break;
 			case DATE_RANGE_LAST_6_MONTHS:
 				startDate = moment( TODAY ).subtract( 6, 'months' );
+				endDate = TODAY;
 				break;
 			case DATE_RANGE_LAST_12_MONTHS:
 				startDate = moment( TODAY ).subtract( 1, 'year' );
+				endDate = TODAY;
 				break;
 			case DATE_RANGE_CUSTOM:
-				if ( date.year && date.month ) {
-					startDate = moment( [ date.year, date.month - 1 ] );
+				const month = parseInt( date.month );
+				const year = parseInt( date.year );
+				if ( ! isNaN( month ) && ! isNaN( year ) ) {
+					startDate = moment( [ year, month ] );
 					endDate = moment( startDate ).endOf( 'month' );
 				}
 				break;

--- a/extensions/shared/external-media/sources/google-photos/filter-request.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-request.js
@@ -57,8 +57,15 @@ export default function getFilterRequest( filters ) {
 				const month = parseInt( date.month );
 				const year = parseInt( date.year );
 				if ( ! isNaN( month ) && ! isNaN( year ) ) {
-					startDate = moment( [ year, month ] );
-					endDate = moment( startDate ).endOf( 'month' );
+					if ( month === -1 ) {
+						// Whole year.
+						startDate = moment( [ year, 0 ] );
+						endDate = moment( startDate ).endOf( 'year' );
+					} else {
+						// Specific month.
+						startDate = moment( [ year, month ] );
+						endDate = moment( startDate ).endOf( 'month' );
+					}
 				}
 				break;
 		}

--- a/extensions/shared/external-media/sources/google-photos/filter-request.js
+++ b/extensions/shared/external-media/sources/google-photos/filter-request.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import moment from 'moment';
-import { isNumber } from 'lodash';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Adds a new option for filtering data by specified month and styles the filter area to match the new design https://github.com/Automattic/jetpack/issues/15880#issuecomment-647611492

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* on a connected JP site, `yarn run build-extensions`
* insert an image block and open the Google Photos media modal
* set date filter to "Specific Month/Year"
* update inputs and hit Apply
* observe results and confirm they are correct
* apply button is disabled when the input selection is equal to what's already shows in results
 
You can watch the Network devtools for API requests to see how your selection of inputs translates to the date range. It's always encoded in the URL. Variants:
- pick "any month" and 2020 year - the date range in the API request URL will be "2020-01-01 to 2020-12-31"
- pick "february" and 2020 year - date range "2020-02-01 to 2020-02-29"

#### Proposed changelog entry for your changes:
* External Media: added ability to show google photos for a specific month or year
