### PR TITLE
Jetpack Debugger: Verifying the blog_token.

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -454,7 +454,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		}
 
 		$result       = json_decode( $body );
-		$is_connected = (bool) $result->connected;
+		$is_connected = ! empty( $result->connected );
 		$message      = $result->message . ': ' . wp_remote_retrieve_response_code( $response );
 
 		if ( $is_connected ) {

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -174,7 +174,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 
 		switch ( $code ) {
 			case 400:
-				return self::failing_test(
+				$result = self::failing_test(
 					array(
 						'name'              => __FUNCTION__,
 						'short_description' => __( 'Blog token is invalid.', 'jetpack' ),
@@ -182,23 +182,28 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 						'action_label'      => __( 'Disconnect your site from WordPress.com, and connect it again.', 'jetpack' ),
 					)
 				);
+				break;
 			case 429:
-				return self::skipped_test(
+				$result = self::skipped_test(
 					array(
 						'name'              => __FUNCTION__,
 						'short_description' => __( 'Token validation request failed: too many requests.', 'jetpack' ),
 					)
 				);
+				break;
 			case 200:
-				return self::passing_test( array( 'name' => __FUNCTION__ ) );
+				$result = self::passing_test( array( 'name' => __FUNCTION__ ) );
+				break;
 			default:
-				return self::skipped_test(
+				$result = self::skipped_test(
 					array(
 						'name'              => __FUNCTION__,
 						'short_description' => __( 'Token validation request failed: no response.', 'jetpack' ),
 					)
 				);
 		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
The commit adds verification that `blog_token` exists, and fixes an error that prevented it from being validated.

#### Changes proposed in this Pull Request:
* Make sure the `blog_token` exists before running the connection test
* If blog token is incorrect, and `display_errors` is enabled, displayed "warning" made the Debugger mark the whole "local testing suite" as "skipped". This PR fixes that issue, so if the blog token is invalid, the error will show up in the debugger.

#### Does this pull request change what data or activity we track or use?
No, it doesn't.

#### Testing instructions:
* Using the "Broken Token" plugin, clear the `blog_token`, but leave the other tokens in place.
* Run Jetpack Debugger, you should see an error: `error: test local testing suite`, `message: Blog token is missing.`.
* Using the "Broken Token" plugin, set an invalid `blog_token`.
* Run Jetpack Debugger again. You should see another error: `error: test local testing suite`, `message: It looks like your Jetpack connection is broken...`
* Restore the valid `blog_token`, or get a new one (disconnect Jetpack and connect it again).
* Run Jetpack Debugger, make sure that `Everything looks great!`

#### Proposed changelog entry for your changes:
* Blog token verification for Jetpack Debugger
