### PR TITLE
Latest Instagram Posts: Delete cache after permanently deleting the connection

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -57,7 +57,26 @@ class Jetpack_Instagram_Gallery_Helper {
 			return $site_id;
 		}
 
+		// Check if the connection exists before trying to retrieve the cached gallery.
+		$connections       = self::get_instagram_connections();
+		$connection_exists = false;
+		foreach ( $connections as $connection ) {
+			if ( $access_token === $connection['token'] ) {
+				$connection_exists = true;
+				break;
+			}
+		}
+
 		$transient_key = self::TRANSIENT_KEY_PREFIX . $access_token;
+
+		if ( ! $connection_exists ) {
+			delete_transient( $transient_key );
+			return new WP_Error(
+				'instagram_connection_unavailable',
+				__( 'The requested Instagram connection is not available anymore.', 'jetpack' ),
+				403
+			);
+		}
 
 		$cached_gallery = get_transient( $transient_key );
 		if ( $cached_gallery ) {

--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -145,4 +145,5 @@ class Jetpack_Instagram_Gallery_Helper {
 	 */
 	private static function is_wpcom() {
 		return defined( 'IS_WPCOM' ) && IS_WPCOM;
-	}}
+	}
+}

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -123,26 +123,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 	 * @return mixed
 	 */
 	public function get_instagram_connections() {
-		if ( $this->is_wpcom ) {
-			return WPCOM_Instagram_Gallery_Helper::get_connections();
-		}
-
-		$response = Client::wpcom_json_api_request_as_user( '/me/connections' );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-		$body = json_decode( wp_remote_retrieve_body( $response ) );
-
-		$connections = array();
-		foreach ( $body->connections as $connection ) {
-			if ( 'instagram-basic-display' === $connection->service && 'ok' === $connection->status ) {
-				$connections[] = array(
-					'token'    => (string) $connection->ID,
-					'username' => $connection->external_name,
-				);
-			}
-		}
-		return $connections;
+		return Jetpack_Instagram_Gallery_Helper::get_instagram_connections();
 	}
 
 	/**

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -69,13 +69,20 @@ function render_block( $attributes, $content ) {
 	$gallery = Jetpack_Instagram_Gallery_Helper::get_instagram_gallery( $access_token, $count );
 
 	if ( is_wp_error( $gallery ) || ! property_exists( $gallery, 'images' ) || 'ERROR' === $gallery->images ) {
-		if ( current_user_can( 'edit_post', get_the_ID() ) ) {
-			$message = esc_html__( 'An error occurred in the Latest Instagram Posts block. Please try again later.', 'jetpack' )
-				. '<br />'
-				. esc_html__( '(Only administrators and the post author will see this message.)', 'jetpack' );
-			return Jetpack_Gutenberg::notice( $message, 'error', Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ) );
+		if ( ! current_user_can( 'edit_post', get_the_ID() ) ) {
+			return '';
 		}
-		return '';
+
+		$connection_unavailable = is_wp_error( $gallery ) && 'instagram_connection_unavailable' === $gallery->get_error_code();
+
+		$error_message = $connection_unavailable
+			? $gallery->get_error_message()
+			: esc_html__( 'An error occurred in the Latest Instagram Posts block. Please try again later.', 'jetpack' );
+
+		$message = $error_message
+			. '<br />'
+			. esc_html__( '(Only administrators and the post author will see this message.)', 'jetpack' );
+		return Jetpack_Gutenberg::notice( $message, 'error', Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes ) );
 	}
 
 	if ( empty( $gallery->images ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Move the `get_instagram_connections` logic to the Instagram helper in order to be easily reused where needed.
* Check if the Instagram connection is valid before using the gallery cache; if it's not valid, delete the cache.
* If the block's connection is not valid, show a descriptive error message on the front end.

<img width="602" alt="Screenshot 2020-06-24 at 14 48 35" src="https://user-images.githubusercontent.com/2070010/85568700-d1eb6200-b629-11ea-9b85-f6fff2de0100.png">

To properly support multiple Instagram connections, we decided to stop permanently deleting a connection when disconnecting a block. This is still possible from Calypso (Marketing -> Connections).

Since the gallery is cached on the site, deleting a connection from Calypso won't also automatically delete the cache as well. For this reason, galleries are still visible for up to 1 hour after their connection has been deleted.

The solution proposed here is to check if the block's connection exists before attempting to retrieve the cached gallery.
If it doesn't exist, we delete the cached gallery and return an error.
In the front end, we display that error message to the site admins.
In the editor, we simply ignore the error and show the block's placeholder, prompting to create a new connection.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Insert a Latest Instagram Posts block, and connect it to an Instagram account.
* Save the post.
* Head to Calypso (Marketing -> Connection) and delete the Instagram connection.
* View the post in the front end: make sure it shows a "connection unavailable" error message (only for site admins)
* Reload the editor: make sure the block loads up in placeholder, prompting to create a new connection (or to select a different one, if possible).

#### Proposed changelog entry for your changes:

* Latest Instagram Posts Block: Stop showing cached galleries after the Instagram connection has been deleted.
