### PR TITLE
Autoloader: Handle when JP is a mu-plugin

### DIFF
--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -57,10 +57,10 @@ class Autoloader_Handler {
 		$active_plugins = $this->plugins_handler->get_all_active_plugins();
 
 		foreach ( $active_plugins as $plugin ) {
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
-
-			if ( ! file_exists( $plugin_path ) ) {
-				$plugin_path = trailingslashit( WPMU_PLUGIN_DIR ) . $plugin;
+			if ( 'jetpack' === $plugin ) {
+				$plugin_path = JETPACK__PLUGIN_DIR;
+			} else {
+				$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 			}
 
 			$classmap_path = trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';

--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -57,12 +57,7 @@ class Autoloader_Handler {
 		$active_plugins = $this->plugins_handler->get_all_active_plugins();
 
 		foreach ( $active_plugins as $plugin ) {
-			if ( 'jetpack' === $plugin ) {
-				$plugin_path = JETPACK__PLUGIN_DIR;
-			} else {
-				$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
-			}
-
+			$plugin_path   = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 			$classmap_path = trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';
 
 			if ( file_exists( $classmap_path ) ) {

--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -73,11 +73,11 @@ class Autoloader_Handler {
 			}
 		}
 
-		// This would happen if Jetpack is loaded a mu-plugin and no other Jetpack ecosystem plugins are installed.
-		// @todo Handle the version global.
 		if ( ! $selected_autoloader_version || ! $selected_autoloader_path ) {
-			require $current_autoloader_path;
-			return;
+			// Something's wrong with the selected version or path, so just use this directory's autoloader.
+			// This would happen if Jetpack is loaded a mu-plugin and no other Jetpack ecosystem plugins are installed.
+			$selected_autoloader_version = $this->get_current_autoloader_version();
+			$selected_autoloader_path    = $current_autoloader_path;
 		}
 
 		$jetpack_autoloader_latest_version = $selected_autoloader_version;

--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -73,6 +73,13 @@ class Autoloader_Handler {
 			}
 		}
 
+		// This would happen if Jetpack is loaded a mu-plugin and no other Jetpack ecosystem plugins are installed.
+		// @todo Handle the version global.
+		if ( ! $selected_autoloader_version || ! $selected_autoloader_path ) {
+			require $current_autoloader_path;
+			return;
+		}
+
 		$jetpack_autoloader_latest_version = $selected_autoloader_version;
 		if ( $current_autoloader_path !== $selected_autoloader_path ) {
 			require $selected_autoloader_path;

--- a/packages/autoloader/src/class-classes-handler.php
+++ b/packages/autoloader/src/class-classes-handler.php
@@ -76,6 +76,15 @@ class Classes_Handler {
 		$active_plugins = $this->plugins_handler->get_all_active_plugins();
 		$plugins_paths  = array_map( array( $this, 'create_classmap_path_array' ), $active_plugins );
 
+		if ( empty( $plugins_paths ) ) {
+			// There may have been a problem generating the plugin paths.
+			// Try to add this directory's classmap as a last resort.
+			$classmap_path = trailingslashit( dirname( __FILE__ ) ) . 'composer/jetpack_autoload_classmap.php';
+			if ( is_readable( $classmap_path ) ) {
+				$plugins_paths = array( $classmap_path );
+			}
+		}
+
 		foreach ( $plugins_paths as $path ) {
 			if ( is_readable( $path ) ) {
 				$class_map = require $path;

--- a/packages/autoloader/src/class-classes-handler.php
+++ b/packages/autoloader/src/class-classes-handler.php
@@ -65,12 +65,7 @@ class Classes_Handler {
 	 * @return Array An array of plugin names and classmap paths.
 	 */
 	public function create_classmap_path_array( $plugin ) {
-		if ( 'jetpack' === $plugin ) {
-			$plugin_path = JETPACK__PLUGIN_DIR;
-		} else {
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
-		}
-
+		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';
 	}
 

--- a/packages/autoloader/src/class-classes-handler.php
+++ b/packages/autoloader/src/class-classes-handler.php
@@ -65,10 +65,10 @@ class Classes_Handler {
 	 * @return Array An array of plugin names and classmap paths.
 	 */
 	public function create_classmap_path_array( $plugin ) {
-		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
-
-		if ( ! file_exists( $plugin_path ) ) {
-			$plugin_path = trailingslashit( WPMU_PLUGIN_DIR ) . $plugin;
+		if ( 'jetpack' === $plugin ) {
+			$plugin_path = JETPACK__PLUGIN_DIR;
+		} else {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 		}
 
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_classmap.php';

--- a/packages/autoloader/src/class-files-handler.php
+++ b/packages/autoloader/src/class-files-handler.php
@@ -65,10 +65,10 @@ class Files_Handler {
 	 * @return Array An array of plugin names and filemap paths.
 	 */
 	public function create_filemap_path_array( $plugin ) {
-		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
-
-		if ( ! file_exists( $plugin_path ) ) {
-			$plugin_path = trailingslashit( WPMU_PLUGIN_DIR ) . $plugin;
+		if ( 'jetpack' === $plugin ) {
+			$plugin_path = JETPACK__PLUGIN_DIR;
+		} else {
+			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 		}
 
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_filemap.php';

--- a/packages/autoloader/src/class-files-handler.php
+++ b/packages/autoloader/src/class-files-handler.php
@@ -65,12 +65,7 @@ class Files_Handler {
 	 * @return Array An array of plugin names and filemap paths.
 	 */
 	public function create_filemap_path_array( $plugin ) {
-		if ( 'jetpack' === $plugin ) {
-			$plugin_path = JETPACK__PLUGIN_DIR;
-		} else {
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
-		}
-
+		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . $plugin;
 		return trailingslashit( $plugin_path ) . 'vendor/composer/jetpack_autoload_filemap.php';
 	}
 

--- a/packages/autoloader/src/class-files-handler.php
+++ b/packages/autoloader/src/class-files-handler.php
@@ -76,6 +76,15 @@ class Files_Handler {
 		$active_plugins = $this->plugins_handler->get_all_active_plugins();
 		$plugins_paths  = array_map( array( $this, 'create_filemap_path_array' ), $active_plugins );
 
+		if ( empty( $plugins_paths ) ) {
+			// There may have been a problem generating the plugin paths.
+			// Try to add this directory's filemap as a last resort.
+			$filemap_path = trailingslashit( dirname( __FILE__ ) ) . 'composer/jetpack_autoload_filemap.php';
+			if ( is_readable( $filemap_path ) ) {
+				$plugins_paths = array( $filemap_path );
+			}
+		}
+
 		foreach ( $plugins_paths as $path ) {
 			if ( is_readable( $path ) ) {
 				$file_map = require $path;


### PR DESCRIPTION
Follow-up to #16251 and #16252 

In cases where Jetpack is in a mu-plugin, we need to be able to still load the current executing version's packages.

#### Changes proposed in this Pull Request:
* Loads classmaps, etc from the executing version of the package if none are found in active plugins.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Add a built version of this branch to a site's mu-plugins directory (and be sure to load it from a mu-plugins level php file).
* Does it fatal?

#### Proposed changelog entry for your changes:
* n/a, part of the Autoloader 2.0 changelog.
