### PR TITLE
Latest Instagram Posts: Stop caching the gallery if the fetch failed

### DIFF
--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -49,7 +49,10 @@ class Jetpack_Instagram_Gallery_Helper {
 
 			$encoded_gallery = wp_json_encode( $gallery );
 
-			set_transient( $transient_key, $encoded_gallery, HOUR_IN_SECONDS );
+			// Avoid caching the gallery if the fetch failed for unknown reasons.
+			if ( property_exists( $gallery, 'images' ) && 'ERROR' !== $gallery->images ) {
+				set_transient( $transient_key, $encoded_gallery, HOUR_IN_SECONDS );
+			}
 
 			// Make sure the gallery is an object.
 			return json_decode( $encoded_gallery );

--- a/_inc/lib/class-jetpack-instagram-gallery-helper.php
+++ b/_inc/lib/class-jetpack-instagram-gallery-helper.php
@@ -49,13 +49,15 @@ class Jetpack_Instagram_Gallery_Helper {
 
 			$encoded_gallery = wp_json_encode( $gallery );
 
+			// Make sure the gallery is an object.
+			$gallery_object = json_decode( $encoded_gallery );
+
 			// Avoid caching the gallery if the fetch failed for unknown reasons.
-			if ( property_exists( $gallery, 'images' ) && 'ERROR' !== $gallery->images ) {
+			if ( property_exists( $gallery_object, 'images' ) && 'ERROR' !== $gallery_object->images ) {
 				set_transient( $transient_key, $encoded_gallery, HOUR_IN_SECONDS );
 			}
 
-			// Make sure the gallery is an object.
-			return json_decode( $encoded_gallery );
+			return $gallery_object;
 		}
 
 		$response = Client::wpcom_json_api_request_as_blog(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Avoid caching the gallery if the fetch failed for unknown reasons.

When requesting an Instagram gallery through the Keyring, on failure it returns: `[ 'images' => 'ERROR' ]` (see `lib/instagram-gallery-helper.php` on WPCOM).
The response is formatted correctly, so this `ERROR` string ends up cached as gallery.
This is then handled correctly by the block, but it will still log a PHP warning when retrieving the cache, as it attempts to `count( $cached_gallery->images )`.

I'm not entirely sure how to trigger a Keyring error.
As far as I could see, it might happen when the request to Instagram times out.
Speaking of, in D45419-code I've increased the timeout from 5 to 10 seconds.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Smoke test the Latest Instagram Posts block, especially on WPCOM.

#### Proposed changelog entry for your changes:

* Latest Instagram Block: Avoid caching the gallery if the fetch failed for unknown reasons.
