### PR TITLE
Cover: Only add filter if needed

### DIFF
--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -1,4 +1,3 @@
-
 /**
  * WordPress dependencies
  */
@@ -9,13 +8,13 @@ import { useContext, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isUpgradable, isVideoFile } from './utils';
+import { isVideoFile } from './utils';
 import { CoverMediaContext } from './components';
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
 		const { name } = useBlockEditContext();
-		if ( ! name || ! isUpgradable( name ) ) {
+		if ( 'core/cover' !== name ) {
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 
@@ -31,21 +30,25 @@ export default createHigherOrderComponent(
 		 * @param {Array} message - Error message provided by the callback.
 		 * @returns {*} Error handling.
 		 */
+		const uploadingErrorHandler = useCallback(
+			message => {
+				const filename = message?.[ 0 ]?.props?.children;
 
-		const uploadingErrorHandler = useCallback( ( message ) => {
-			const filename = message?.[ 0 ]?.props?.children;
-			if ( filename && isVideoFile( filename ) ) {
-				return onFilesUpload( [ filename ] );
-			}
-			return onError( message );
-		}, [ onFilesUpload, onError ] );
+				if ( isVideoFile( filename ) ) {
+					return onFilesUpload( [ filename ] );
+				}
+
+				return onError( message );
+			},
+			[ onFilesUpload, onError ]
+		);
 
 		return (
 			<div className="jetpack-cover-media-placeholder">
 				<CoreMediaPlaceholder
 					{ ...props }
 					onFilesPreUpload={ onFilesUpload }
-					onError = { uploadingErrorHandler }
+					onError={ uploadingErrorHandler }
 				/>
 			</div>
 		);

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -11,15 +11,23 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
-import isCurrentUserConnected from '../../is-current-user-connected';
 import jetpackCoverBlockEdit from './edit';
-
+import { isUpgradable } from './utils';
 import './editor.scss';
 
-if ( isCurrentUserConnected() ) {
-	// Take the control of MediaPlaceholder.
-	addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+const addVideoUploadPlanCheck = ( settings, name ) => {
+	if ( ! settings.isDeprecation && isUpgradable( name ) ) {
+		// Take the control of MediaPlaceholder.
+		addFilter(
+			'editor.MediaPlaceholder',
+			'jetpack/cover-edit-media-placeholder',
+			coverEditMediaPlaceholder
+		);
 
-	// Extend Core CoverEditBlock.
-	addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
-}
+		// Extend Core CoverEditBlock.
+		addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
+	}
+
+	return settings;
+};
+addFilter( 'blocks.registerBlockType', 'core/cover', addVideoUploadPlanCheck );

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -11,7 +11,7 @@ import getJetpackExtensionAvailability from '../../get-jetpack-extension-availab
 import getAllowedMimeTypesBySite, {
 	getAllowedVideoTypesByType,
 	pickFileExtensionsFromMimeTypes,
-} from "../../get-allowed-mime-types";
+} from '../../get-allowed-mime-types';
 
 /**
  * Check if the given file is a video.
@@ -38,7 +38,7 @@ export function isVideoFile( file ) {
 	}
 
 	if ( typeof file === 'object' ) {
-		return file.type && ( values( allowedVideoMimeTypes ) ).includes( file.type );
+		return file.type && values( allowedVideoMimeTypes ).includes( file.type );
 	}
 
 	return false;
@@ -53,7 +53,10 @@ export function isVideoFile( file ) {
 export function isUpgradable( name ) {
 	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
 
-	return name && name === 'core/cover' && // upgrade only for cover block
+	return (
+		name &&
+		name === 'core/cover' && // upgrade only for cover block
 		isSimpleSite() && // only for Simple sites
-		[ 'missing_plan', 'unknown' ].includes( unavailableReason );
+		[ 'missing_plan', 'unknown' ].includes( unavailableReason )
+	);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Suggestion to fix the `useBlockEditContext` regression for WordPress 5.3.

This emulates the way the VideoPress block is using `useBlockEditContext`, hidden behind an `isSimpleSite` and plan check.

Fixes #16233.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Moves environment checks into `index.js` to only filter the media placeholder when necessary.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a test environment that runs WordPress 5.3.4 with Jetpack master
* Open the editor and try inserting an Image Compare block 
* Make sure the block displays without error

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
