### PR TITLE
Cover: Handle upgrade nudge when replace background

### DIFF
--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -19,7 +19,7 @@ import { isUpgradable, isVideoFile } from "./utils";
 export default createHigherOrderComponent( MediaReplaceFlow => props => {
 	const { name } = useBlockEditContext();
 	const preUploadFile = useRef();
-	if ( ! isUpgradable( name ) ) {
+	if ( 'core/cover' !== name ) {
 		return <MediaReplaceFlow { ...props } />;
 	}
 

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -14,7 +14,7 @@ import { useRef, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { CoverMediaContext } from './components';
-import { isUpgradable, isVideoFile } from "./utils";
+import { isVideoFile } from './utils';
 
 export default createHigherOrderComponent( MediaReplaceFlow => props => {
 	const { name } = useBlockEditContext();

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -1,0 +1,46 @@
+
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockEditContext } from '@wordpress/block-editor';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useRef, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CoverMediaContext } from './components';
+import { isUpgradable, isVideoFile } from "./utils";
+
+export default createHigherOrderComponent( MediaReplaceFlow => props => {
+	const { name } = useBlockEditContext();
+	const preUploadFile = useRef();
+	if ( ! isUpgradable( name ) ) {
+		return <MediaReplaceFlow { ...props } />;
+	}
+
+	const onFilesUpload = useContext( CoverMediaContext );
+
+	return (
+		<MediaReplaceFlow
+			{ ...props }
+			onFilesUpload={ ( files ) => {
+				preUploadFile.current = files?.length ? files[ 0 ] : null;
+				onFilesUpload( files );
+			} }
+			createNotice={ ( status, msg, options ) => {
+				// Detect video file from callback and reference instance.
+				if ( isVideoFile( preUploadFile.current ) ) {
+					preUploadFile.current = null; // clean up the file reference.
+					return null;
+				}
+
+				props.createNotice( status, msg, options );
+			} }
+		/>
+	);
+}, 'JetpackCoverMediaReplaceFlow' );

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -11,6 +11,7 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import coverEditMediaPlaceholder from './cover-media-placeholder';
+import coverMediaReplaceFlow from './cover-replace-control-button';
 import jetpackCoverBlockEdit from './edit';
 import { isUpgradable } from './utils';
 import './editor.scss';
@@ -22,6 +23,13 @@ const addVideoUploadPlanCheck = ( settings, name ) => {
 			'editor.MediaPlaceholder',
 			'jetpack/cover-edit-media-placeholder',
 			coverEditMediaPlaceholder
+		);
+
+		// Take the control of the Replace block button control.
+		addFilter(
+			'editor.MediaReplaceFlow',
+			'jetpack/cover-media-replace-flow',
+			coverMediaReplaceFlow
 		);
 
 		// Extend Core CoverEditBlock.


### PR DESCRIPTION
~IMPORTANT~
~PR branched off from https://github.com/Automattic/jetpack/pull/16271~

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR extends the media to replace flow in order to deal with paid plans. Basically, the UI allows the user to upload a video when it's a simple site even with a free plan. This PR shows an upgrade nudge when the user tries to upload a video to the `cover` block.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Handle upgrade nudge when uploading video for cover block.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
1) Test with _Gutenberg v8.4.0_ (it uses the editor.MediaReplaceFlow filter, added [here](https://github.com/WordPress/gutenberg/pull/22995))
2) Apply these changes (D45422-code)
3) Create a cover block in a simple site with a free plan
4) Set the background (color or image)
5) Try to replace the background uploading a video.
6) Confirm that you get the upgrade nudge.

![image](https://user-images.githubusercontent.com/77539/85581542-0e5f9380-b613-11ea-88cc-0bb5d3e7699b.png)

7) Confirm that the Notice is not shown
8) Try to load an unsupported image. You should see the notice error (tested with a pdf):

![image](https://user-images.githubusercontent.com/77539/85581804-46ff6d00-b613-11ea-9b8e-e86882139d53.png)

9) Try to upload an image. It should work.


#### Proposed changelog entry for your changes:
* Handle media replace flow for free simple sites.
