### PR TITLE
Remove widget sort option for instant search widgets

### DIFF
--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -277,7 +277,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 			(array) $instance,
 			array(
 				'title'      => '',
-				'sort'       => self::DEFAULT_SORT,
 				'filters'    => array(),
 				'post_types' => array(),
 			)
@@ -857,22 +856,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 						<?php echo esc_html( $post_type->label ); ?>
 					</label>
 				<?php endforeach; ?>
-			</p>
-
-			<!-- Default sort order control -->
-			<p>
-				<label>
-					<?php esc_html_e( 'Default sort order:', 'jetpack' ); ?>
-					<select
-						name="<?php echo esc_attr( $this->get_field_name( 'sort' ) ); ?>"
-						class="widefat jetpack-search-filters-widget__sort-order">
-						<?php foreach ( $this->get_sort_types() as $sort_type => $label ) { ?>
-							<option value="<?php echo esc_attr( $sort_type ); ?>" <?php selected( $instance['sort'], $sort_type ); ?>>
-								<?php echo esc_html( $label ); ?>
-							</option>
-						<?php } ?>
-					</select>
-				</label>
 			</p>
 
 			<!-- Filters control -->


### PR DESCRIPTION
Fixes #15324.

#### Changes proposed in this Pull Request:
* Removes sort select when configuring Jetpack Search widgets with Instant Search enabled. Default sort order can be set site-wide via #16017 for Instant Search.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this change to your local Jetpack installation.
2. Ensure that you have a Jetpack Search subscription for the site. 
3. Ensure that instant search has been enabled in Jetpack performance settings.
4. Navigate to a Jetpack Search widget in the customizer. 
5. Ensure that the "Default Sort Order" select input has been removed.
6. Try disabling instant search.
7. Repeat steps 4; the "Default Sort Order" select should be restored.
8. Try adding and removing the Jetpack Search widget with instant search enabled. Ensure that the widget behaves as expected.

### Before and After

Before:

<img width="408" alt="Screen Shot 2020-06-24 at 2 17 42 PM" src="https://user-images.githubusercontent.com/4044428/85623401-9c447a00-b625-11ea-9c6a-2d3aacd7b4dd.png">

After:

<img width="408" alt="Screen Shot 2020-06-24 at 2 18 23 PM" src="https://user-images.githubusercontent.com/4044428/85623388-95b60280-b625-11ea-8875-13acb2ab8f7d.png">

#### Proposed changelog entry for your changes:
* None.