### PR TITLE
Autoloader: fix the fatal that occurs during plugin update

### DIFF
--- a/packages/autoloader/src/class-plugins-handler.php
+++ b/packages/autoloader/src/class-plugins-handler.php
@@ -156,44 +156,4 @@ class Plugins_Handler {
 	public function get_current_plugin_dir() {
 		return explode( '/', plugin_basename( __FILE__ ) )[0];
 	}
-
-	/**
-	 * Resets the autoloader after a plugin update.
-	 *
-	 * @param bool  $response   Installation response.
-	 * @param array $hook_extra Extra arguments passed to hooked filters.
-	 * @param array $result     Installation result data.
-	 *
-	 * @return bool The passed in $response param.
-	 */
-	public function reset_maps_after_update( $response, $hook_extra, $result ) {
-		global $jetpack_autoloader_latest_version;
-		global $jetpack_packages_classmap;
-
-		if ( isset( $hook_extra['plugin'] ) ) {
-			$plugin = $hook_extra['plugin'];
-
-			if ( ! $this->is_directory_plugin( $plugin ) ) {
-				// Single-file plugins don't use packages, so bail.
-				return $response;
-			}
-
-			if ( ! is_plugin_active( $plugin ) ) {
-				// The updated plugin isn't active, so bail.
-				return $response;
-			}
-
-			$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . trailingslashit( explode( '/', $plugin )[0] );
-
-			if ( is_readable( $plugin_path . 'vendor/autoload_functions.php' ) ) {
-				// The plugin has a v2.x autoloader, so reset it.
-				$jetpack_autoloader_latest_version = null;
-				$jetpack_packages_classmap         = array();
-
-				require $plugin_path . 'vendor/autoload_packages.php';
-			}
-		}
-
-		return $response;
-	}
 }

--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -90,7 +90,55 @@ function set_up_autoloader() {
 	if ( empty( $jetpack_packages_classmap ) && $current_autoloader_version === $jetpack_autoloader_latest_version ) {
 		enqueue_files( $plugins_handler, $version_selector );
 		$autoloader_handler->update_autoloader_chain();
-		add_filter( 'upgrader_post_install', array( $plugins_handler, 'reset_maps_after_update' ), 0, 3 );
+		add_filter( 'upgrader_post_install', __NAMESPACE__ . '\reset_maps_after_update', 0, 3 );
 	}
+}
+
+/**
+ * Resets the autoloader after a plugin update.
+ *
+ * @param bool  $response   Installation response.
+ * @param array $hook_extra Extra arguments passed to hooked filters.
+ * @param array $result     Installation result data.
+ *
+ * @return bool The passed in $response param.
+ */
+function reset_maps_after_update( $response, $hook_extra, $result ) {
+	global $jetpack_autoloader_latest_version;
+	global $jetpack_packages_classmap;
+
+	if ( isset( $hook_extra['plugin'] ) ) {
+		/*
+		 * $hook_extra['plugin'] is the path to the plugin file relative to the plugins directory:
+		 * https://core.trac.wordpress.org/browser/tags/5.4/src/wp-admin/includes/class-wp-upgrader.php#L701
+		 */
+		$plugin = $hook_extra['plugin'];
+
+		if ( false === strpos( $plugin, '/', 1 ) ) {
+			// Single-file plugins don't use packages, so bail.
+			return $response;
+		}
+
+		if ( ! is_plugin_active( $plugin ) ) {
+			// The updated plugin isn't active, so bail.
+			return $response;
+		}
+
+		/*
+		 * $plugin is the path to the plugin file relative to the plugins directory.
+		 * What if this plugin is not in the plugins directory, for example an mu plugin?
+		 */
+		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . trailingslashit( explode( '/', $plugin )[0] );
+
+		if ( is_readable( $plugin_path . 'vendor/autoload_functions.php' ) ) {
+			// The plugin has a v2.x autoloader, so reset it.
+			$jetpack_autoloader_latest_version = null;
+			$jetpack_packages_classmap         = array();
+
+			set_up_autoloader();
+		}
+	}
+
+	return $response;
 }
 


### PR DESCRIPTION
Fix the fatal that occurs during plugin update. The fatal occurs because, during a plugin update, a function in the just-installed version of `autoload_functions.php` is called. However, that file had already been loaded, so the just-installed version of  the file isn't available.

Fixes #16273

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Move the `upgrader_post_install` callback function, `reset_maps_after_update`, to the `autoload_functions.php` file.
* In `reset_maps_after_update`, call `set_up_autoloader` to reset the autoloader after a plugin update.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* n/a

#### Testing instructions:

##### Cause a fatal error during a plugin update
1. Install the Jetpack beta plugin.
2. Install and activate the master branch.
3. Delete the existing `jetpack` folder and rename the `jetpack-dev` folder to `jetpack`.
4. Decrease the plugin version in the plugin header of the `jetpack.php` file to < 8.6.1.
5. Connect Jetpack.
6. Add this snippet to your site. It does two things:
   * Uses a class from a Jetpack package when the `upgrader_process_complete` hook fires. Note that the snippet uses the `Pre_Connection_JITM` class, which is not loaded when Jetpack is connected.
   * Sets the source file for the Jetpack plugin update to `wp-content/plugins/jetpack.zip`.

```
add_action( 'upgrader_process_complete', 'load_package_class', 1 );

function load_package_class() {
	$class = new \Automattic\Jetpack\JITMS\Pre_Connection_JITM();
}

add_action( 'upgrader_package_options', 'set_plugin_path' );

function set_plugin_path( $options ) {
	if( 'jetpack/jetpack.php' === $options['hook_extra']['plugin'] ) {
		$options['package'] = WP_PLUGIN_DIR . '/jetpack.zip';
	}
	return $options;
}
```

7. Create the source zip file for the Jetpack update using a command like `zip -r jetpack.zip jetpack`. The file name and location must match the source zip file in the `upgrader_package_options` hook callback. If you use the snippet in step 5, the source file path must be `wp-content/plugins/jetpack.zip`.

8. In `jetpack/vendor/composer/jetpack_autoload_classmap.php`, change the file name for the `Pre_Connection_JITM` class.
   * Note that this file is in the original location in the jetpack.zip file. This change allows us to simulate the file being moved.

9. Change the namespace of the autoloader files. Get the namespace from the `vendor/autoload_functions.php` file. It will be something like:

   `namespace Automattic\Jetpack\Autoloader\jp659a3ca3ee216d6e4c3d3ab24194e47z;`

      * You can use something like the command below to change the namespace in all of the generated autoloader files. This should be run from the vendor directory. Change the strings to match your current and changed namespaces.

`find . -type f -exec sed -i 's/jp659a3ca3ee216d6e4c3d3ab24194e47z/jp659a3ca3ee216d6e4c3d3ab24194e47a/g' {}  +`

10. Navigate to wp-admin -> Plugins. An update should be available for Jetpack. Click update now.

11. The update should fail and a fatal error should be generated in the debug log because the set_up_autoloader() function in the newly installed namespace can't be found. The error should look like:

`[24-Jun-2020 15:00:11 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function Automattic\Jetpack\Autoloader\jpc74400305ae47f17074763a083b7f93f\set_up_autoloader() in wp-content/plugins/jetpack-dev/vendor/autoload_packages.php:14`

##### Test the fix

1. Install this branch.
2. Use the same steps as above, and the update should complete successfully.


#### Proposed changelog entry for your changes:
* n/a
