### PR TITLE
Editor: Hide switch to classic link if in editor deprecation group

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -305,7 +305,7 @@ class Jetpack_WPCOM_Block_Editor {
 			'wpcomGutenberg',
 			array(
 				'switchToClassic' => array(
-					'isVisible' => $this->is_iframed_block_editor(),
+					'isVisible' => $this->is_iframed_block_editor() && ! isset( $_GET['in-editor-deprecation-group'] ), // phpcs:ignore WordPress.Security.NonceVerification
 					'label'     => __( 'Switch to Classic Editor', 'jetpack' ),
 					'url'       => Jetpack_Calypsoify::getInstance()->get_switch_to_classic_editor_url(),
 				),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Changes proposed in this Pull Request:
* Hides the Switch to Classic Editor link in More Tools menu if user is in editor deprecation group, identified by query string param set on Calypso iframe URL.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Activate this PR branch with Jetpack Beta plugin.
2. Checkout https://github.com/Automattic/wp-calypso/pull/43672 that passes query string param to iframed editor.
3. Ensure Calypso `config/development.json` has the `editor/after-deprecation` flag turned on and fire it up.
4. Login with user matching editor deprecation group requirements as per D44256-code or sandbox API and fudge `sites-gutenberg-v3.php` endpoint to return true for `in_editor_deprecation_group`.
5. In Calypso select the site using the Jetpack Beta plugin.
6. Edit a post using the block editor and inspect the page to ensure the iframe is given the `in-editor-deprecation-group` query string param.
7. Open the more tools menu from the top right of the editor and check that the "Switch to Classic Editor" link is not present.
8. Logout and back in with user that will not match the editor deprecation group requirements of D44256-code or undo changes to the sandboxed API endpoint.
9. Reload the page and check that the "Switch to Classic Editor" link is back in More Tools.

#### Proposed changelog entry for your changes:
* Do not show Switch to Classic Editor Link in More Tools for users in editor deprecation group.
