### PR TITLE
Use new heartbeat package

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -132,6 +132,7 @@ class Jetpack_Heartbeat {
 	 * @return array $methods
 	 */
 	public static function jetpack_xmlrpc_methods( $methods ) {
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0', 'Automattic\\Jetpack\\Heartbeat::jetpack_xmlrpc_methods' );
 		return Heartbeat::jetpack_xmlrpc_methods( $methods );
 	}
 
@@ -145,6 +146,7 @@ class Jetpack_Heartbeat {
 	 * @return array $params all the stats that hearbeat handles.
 	 */
 	public static function xmlrpc_data_response( $params = array() ) {
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0', 'Automattic\\Jetpack\\Heartbeat::xmlrpc_data_response' );
 		return Heartbeat::xmlrpc_data_response( $params );
 	}
 

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\Jetpack\Connection\Manager;
+use Automattic\Jetpack\Heartbeat;
 
 class Jetpack_Heartbeat {
 
@@ -12,7 +13,13 @@ class Jetpack_Heartbeat {
 	 */
 	private static $instance = false;
 
-	private $cron_name = 'jetpack_v2_heartbeat';
+	/**
+	 * Holds the singleton instance of the proxied class
+	 *
+	 * @since 8.7.0
+	 * @var Automattic\Jetpack\Heartbeat
+	 */
+	private static $proxied_instance = false;
 
 	/**
 	 * Singleton
@@ -23,7 +30,8 @@ class Jetpack_Heartbeat {
 	 */
 	public static function init() {
 		if ( ! self::$instance ) {
-			self::$instance = new Jetpack_Heartbeat();
+			self::$instance         = new Jetpack_Heartbeat();
+			self::$proxied_instance = Heartbeat::init();
 		}
 
 		return self::$instance;
@@ -36,70 +44,22 @@ class Jetpack_Heartbeat {
 	 * @return Jetpack_Heartbeat
 	 */
 	private function __construct() {
-		if ( ! Jetpack::is_active() ) {
-			return;
-		}
-
-		// Schedule the task
-		add_action( $this->cron_name, array( $this, 'cron_exec' ) );
-
-		if ( ! wp_next_scheduled( $this->cron_name ) ) {
-			// Deal with the old pre-3.0 weekly one.
-			if ( $timestamp = wp_next_scheduled( 'jetpack_heartbeat' ) ) {
-				wp_unschedule_event( $timestamp, 'jetpack_heartbeat' );
-			}
-
-			wp_schedule_event( time(), 'daily', $this->cron_name );
-		}
-
-		add_filter( 'jetpack_xmlrpc_methods', array( __CLASS__, 'jetpack_xmlrpc_methods' ) );
+		add_filter( 'jetpack_heartbeat_stats_array', array( $this, 'add_stats_to_heartbeat' ) );
 	}
 
 	/**
 	 * Method that gets executed on the wp-cron call
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::cron_exec()
 	 *
 	 * @since 2.3.3
 	 * @global string $wp_version
 	 */
 	public function cron_exec() {
 
-		$jetpack = Jetpack::init();
+		return self::$proxied_instance->cron_exec();
 
-		/*
-		 * This should run daily.  Figuring in for variances in
-		 * WP_CRON, don't let it run more than every 23 hours at most.
-		 *
-		 * i.e. if it ran less than 23 hours ago, fail out.
-		 */
-		$last = (int) Jetpack_Options::get_option( 'last_heartbeat' );
-		if ( $last && ( $last + DAY_IN_SECONDS - HOUR_IN_SECONDS > time() ) ) {
-			return;
-		}
-
-		/*
-		 * Check for an identity crisis
-		 *
-		 * If one exists:
-		 * - Bump stat for ID crisis
-		 * - Email site admin about potential ID crisis
-		 */
-
-		// Coming Soon!
-
-		foreach ( self::generate_stats_array( 'v2-' ) as $key => $value ) {
-			$jetpack->stat( $key, $value );
-		}
-
-		Jetpack_Options::update_option( 'last_heartbeat', time() );
-
-		$jetpack->do_stats( 'server_side' );
-
-		/**
-		 * Fires when we synchronize all registered options on heartbeat.
-		 *
-		 * @since 3.3.0
-		 */
-		do_action( 'jetpack_heartbeat' );
 	}
 
 	/**
@@ -162,27 +122,63 @@ class Jetpack_Heartbeat {
 		return $return;
 	}
 
+	/**
+	 * Registers jetpack.getHeartbeatData xmlrpc method
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::jetpack_xmlrpc_methods()
+	 *
+	 * @param array $methods The list of methods to be filtered.
+	 * @return array $methods
+	 */
 	public static function jetpack_xmlrpc_methods( $methods ) {
-		$methods['jetpack.getHeartbeatData'] = array( __CLASS__, 'xmlrpc_data_response' );
-		return $methods;
+		return Heartbeat::jetpack_xmlrpc_methods( $methods );
 	}
 
+	/**
+	 * Handles the response for the jetpack.getHeartbeatData xmlrpc method
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::xmlrpc_data_response()
+	 *
+	 * @param array $params The parameters received in the request.
+	 * @return array $params all the stats that hearbeat handles.
+	 */
 	public static function xmlrpc_data_response( $params = array() ) {
-		// The WordPress XML-RPC server sets a default param of array()
-		// if no argument is passed on the request and the method handlers get this array in $params.
-		// generate_stats_array() needs a string as first argument.
-		$params = empty( $params ) ? '' : $params;
-		return self::generate_stats_array( $params );
+		return Heartbeat::xmlrpc_data_response( $params );
 	}
 
+	/**
+	 * Clear scheduled events
+	 *
+	 * @deprecated since 8.7.0
+	 * @see Automattic\Jetpack\Heartbeat::deactivate()
+	 *
+	 * @return void
+	 */
 	public function deactivate() {
-		// Deal with the old pre-3.0 weekly one.
-		if ( $timestamp = wp_next_scheduled( 'jetpack_heartbeat' ) ) {
-			wp_unschedule_event( $timestamp, 'jetpack_heartbeat' );
+		// Cronjobs are now handled by the Heartbeat package and we don't want to deactivate it here.
+		// We are adding jetpack stats to the heartbeat only if the connection is available. so we don't need to disable the cron when disconnecting.
+		_deprecated_function( __METHOD__, 'jetpack-8.7.0', 'Automattic\\Jetpack\\Heartbeat::deactivate' );
+	}
+
+	/**
+	 * Add Jetpack Stats array to Heartbeat if Jetpack is connected
+	 *
+	 * @since 8.7.0
+	 *
+	 * @param array $stats Jetpack Heartbeat stats.
+	 * @return array $stats
+	 */
+	public function add_stats_to_heartbeat( $stats ) {
+
+		if ( ! Jetpack::is_active() ) {
+			return $stats;
 		}
 
-		$timestamp = wp_next_scheduled( $this->cron_name );
-		wp_unschedule_event( $timestamp, $this->cron_name );
+		$jetpack_stats = self::generate_stats_array();
+
+		return array_merge( $stats, $jetpack_stats );
 	}
 
 }

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -16,7 +16,7 @@ class Jetpack_Heartbeat {
 	/**
 	 * Holds the singleton instance of the proxied class
 	 *
-	 * @since 8.7.0
+	 * @since 8.9.0
 	 * @var Automattic\Jetpack\Heartbeat
 	 */
 	private static $proxied_instance = false;
@@ -50,7 +50,7 @@ class Jetpack_Heartbeat {
 	/**
 	 * Method that gets executed on the wp-cron call
 	 *
-	 * @deprecated since 8.7.0
+	 * @deprecated since 8.9.0
 	 * @see Automattic\Jetpack\Heartbeat::cron_exec()
 	 *
 	 * @since 2.3.3
@@ -125,7 +125,7 @@ class Jetpack_Heartbeat {
 	/**
 	 * Registers jetpack.getHeartbeatData xmlrpc method
 	 *
-	 * @deprecated since 8.7.0
+	 * @deprecated since 8.9.0
 	 * @see Automattic\Jetpack\Heartbeat::jetpack_xmlrpc_methods()
 	 *
 	 * @param array $methods The list of methods to be filtered.
@@ -138,7 +138,7 @@ class Jetpack_Heartbeat {
 	/**
 	 * Handles the response for the jetpack.getHeartbeatData xmlrpc method
 	 *
-	 * @deprecated since 8.7.0
+	 * @deprecated since 8.9.0
 	 * @see Automattic\Jetpack\Heartbeat::xmlrpc_data_response()
 	 *
 	 * @param array $params The parameters received in the request.
@@ -151,7 +151,7 @@ class Jetpack_Heartbeat {
 	/**
 	 * Clear scheduled events
 	 *
-	 * @deprecated since 8.7.0
+	 * @deprecated since 8.9.0
 	 * @see Automattic\Jetpack\Heartbeat::deactivate()
 	 *
 	 * @return void
@@ -159,13 +159,13 @@ class Jetpack_Heartbeat {
 	public function deactivate() {
 		// Cronjobs are now handled by the Heartbeat package and we don't want to deactivate it here.
 		// We are adding jetpack stats to the heartbeat only if the connection is available. so we don't need to disable the cron when disconnecting.
-		_deprecated_function( __METHOD__, 'jetpack-8.7.0', 'Automattic\\Jetpack\\Heartbeat::deactivate' );
+		_deprecated_function( __METHOD__, 'jetpack-8.8.0', 'Automattic\\Jetpack\\Heartbeat::deactivate' );
 	}
 
 	/**
 	 * Add Jetpack Stats array to Heartbeat if Jetpack is connected
 	 *
-	 * @since 8.7.0
+	 * @since 8.9.0
 	 *
 	 * @param array $stats Jetpack Heartbeat stats.
 	 * @return array $stats

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -159,7 +159,7 @@ class Jetpack_Heartbeat {
 	public function deactivate() {
 		// Cronjobs are now handled by the Heartbeat package and we don't want to deactivate it here.
 		// We are adding jetpack stats to the heartbeat only if the connection is available. so we don't need to disable the cron when disconnecting.
-		_deprecated_function( __METHOD__, 'jetpack-8.8.0', 'Automattic\\Jetpack\\Heartbeat::deactivate' );
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0', 'Automattic\\Jetpack\\Heartbeat::deactivate' );
 	}
 
 	/**

--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -57,7 +57,7 @@ class Jetpack_Heartbeat {
 	 * @global string $wp_version
 	 */
 	public function cron_exec() {
-
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0', 'Automattic\\Jetpack\\Heartbeat::cron_exec' );
 		return self::$proxied_instance->cron_exec();
 
 	}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3310,8 +3310,6 @@ p {
 		// Delete all the sync related data. Since it could be taking up space.
 		Sender::get_instance()->uninstall();
 
-		// Disable the Heartbeat cron
-		Jetpack_Heartbeat::init()->deactivate();
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-error": "@dev",
+		"automattic/jetpack-heartbeat": "@dev",
 		"automattic/jetpack-jitm": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-options": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27b56a1f08be874fd86e89bc352eeaa2",
+    "content-hash": "37a9bed819dcf7bb749284d7a6957bc4",
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
@@ -333,6 +333,41 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Jetpack Error - a wrapper around WP_Error."
+        },
+        {
+            "name": "automattic/jetpack-heartbeat",
+            "version": "dev-use-new-heartbeat-package",
+            "dist": {
+                "type": "path",
+                "url": "./packages/heartbeat",
+                "reference": "ad4ce7ae64a1881dea8f09a7f94c789a02956f00"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-options": "@dev"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "This adds a cronjob that sends a batch of internal automattic stats to wp.com once a day",
+            "transport-options": {
+                "relative": true
+            }
         },
         {
             "name": "automattic/jetpack-jitm",
@@ -1084,6 +1119,7 @@
         "automattic/jetpack-constants": 20,
         "automattic/jetpack-device-detection": 20,
         "automattic/jetpack-error": 20,
+        "automattic/jetpack-heartbeat": 20,
         "automattic/jetpack-jitm": 20,
         "automattic/jetpack-logo": 20,
         "automattic/jetpack-options": 20,

--- a/tests/php/general/test_class.jetpack-heartbeat.php
+++ b/tests/php/general/test_class.jetpack-heartbeat.php
@@ -17,6 +17,8 @@ class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 	/**
 	 * @covers Jetpack_Heartbeat::cron_exec
 	 * @since 3.9.0
+	 *
+	 * @expectedDeprecated Jetpack_Heartbeat::cron_exec
 	 */
 	public function test_cron_exec() {
 		$this->heartbeat_action = false;

--- a/tests/php/general/test_class.jetpack-heartbeat.php
+++ b/tests/php/general/test_class.jetpack-heartbeat.php
@@ -49,6 +49,8 @@ class WP_Test_Jetpack_Heartbeat extends WP_UnitTestCase {
 	/**
 	 * @covers Jetpack_Heartbeat::jetpack_xmlrpc_methods
 	 * @since 3.9.0
+	 *
+	 * @expectedDeprecated Jetpack_Heartbeat::jetpack_xmlrpc_methods
 	 */
 	public function test_jetpack_xmlrpc_methods() {
 		$this->assertNotEmpty( Jetpack_Heartbeat::jetpack_xmlrpc_methods( array() ) );

--- a/tests/php/sync/test_class.jetpack-sync-modules-stats.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules-stats.php
@@ -3,6 +3,12 @@
 
 class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 
+	/**
+	 * Test sends stats data on heartbeat
+	 *
+	 * @expectedDeprecated Jetpack_Heartbeat::cron_exec
+	 * @return void
+	 */
 	function test_sends_stats_data_on_heartbeat() {
 		$heartbeat = Jetpack_Heartbeat::init();
 
@@ -17,6 +23,12 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( JETPACK__VERSION, $action->args[0]['version'] );
 	}
 
+	/**
+	 * Test dont send expensive data on heartbeat
+	 *
+	 * @expectedDeprecated Jetpack_Heartbeat::cron_exec
+	 * @return void
+	 */
 	function test_dont_send_expensive_data_on_heartbeat() {
 		$heartbeat = Jetpack_Heartbeat::init();
 		add_filter( 'pre_http_request', array( $this, 'pre_http_request_success' ) );
@@ -28,6 +40,12 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 		$this->assertFalse( isset( $action->args[0]['users'] ) );
 	}
 
+	/**
+	 * Test sends stats data on heartbeat on multisite
+	 *
+	 * @expectedDeprecated Jetpack_Heartbeat::cron_exec
+	 * @return void
+	 */
 	public function  test_sends_stats_data_on_heartbeat_on_multisite() {
 		global $wpdb;
 
@@ -56,7 +74,7 @@ class WP_Test_Jetpack_Sync_Module_Stats extends WP_Test_Jetpack_Sync_Base {
 		$this->sender->do_sync();
 
 		$action = $this->server_event_storage->get_most_recent_event( 'jetpack_sync_heartbeat_stats' );
-		
+
 		restore_current_blog();
 
 		$this->assertEquals( JETPACK__VERSION, $action->args[0]['version'] );


### PR DESCRIPTION
This PR makes jetpack uses the newly created Heartbeat package to handle the Heartbeat. It also creates a new CLI command to inspect the heartbeat

The approach here was to touch as little as possible the current heartbeat class, so everything still works as usual. `Jetpack_Heartbeat` class is now acting as a proxy class to the package, so you still can initialize and call its methods.

**Important** - There are some uses of the `generate_stats_array` method that are not related to the heartbeat itself. That's why we kept it as is and static. It's used, for example, by `wp jetpack status` CLI command.

That's why these stats are always returned by the static method. On the other hand, they are only added to the heartbeat stats batch if the connection is active. (Originally, the whole heartbeat was only initialized if the connection was active)

This PR depends on the new Heartbeat package -> #16276

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Uses Heartbeat package to handle heartbeat

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 1146297891914257-as-1146297891914257
* p9dueE-1tz-p2

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Nothing should change and heartbeat should work as usual, you have to manually debug the heartbeat to see if it's still working by adding debug functions in its `cron_exec`method.

Here's how to manually trigger the heart beat:
* `wp jetpack options update last_heartbeat 0` - to trick Jetpack into running the heartbeat on command.
* `wp cron event run jetpack_v2_heartbeat` - to run the heartbeat on command.

* Test the WP CLI command: `wp jetpack-heartbeat` and confirm it outputs all the blog details that are sent via heartbeat
