### PR TITLE
Connection: use heartbeat to send connected plugins info

### DIFF
--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-heartbeat": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev",
 		"automattic/jetpack-status": "@dev",

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2698,8 +2698,8 @@ class Manager {
 		$active_plugins_using_connection = Plugin_Storage::get_all();
 		foreach ( array_keys( $active_plugins_using_connection ) as $plugin_slug ) {
 			if ( 'jetpack' !== $plugin_slug ) {
-				$stats_group           = isset( $active_plugins_using_connection['jetpack'] ) ? 'combined-connection' : 'standalone-connection';
-				$stats[ $stats_group ] = $plugin_slug;
+				$stats_group             = isset( $active_plugins_using_connection['jetpack'] ) ? 'combined-connection' : 'standalone-connection';
+				$stats[ $stats_group ][] = $plugin_slug;
 			}
 		}
 		return $stats;

--- a/packages/heartbeat/src/class-heartbeat.php
+++ b/packages/heartbeat/src/class-heartbeat.php
@@ -106,7 +106,13 @@ class Heartbeat {
 		// Coming Soon!
 
 		foreach ( self::generate_stats_array( 'v2-' ) as $key => $value ) {
-			$a8c_mc_stats->add( $key, $value );
+			if ( is_array( $value ) ) {
+				foreach ( $value as $v ) {
+					$a8c_mc_stats->add( $key, (string) $v );
+				}
+			} else {
+				$a8c_mc_stats->add( $key, (string) $value );
+			}
 		}
 
 		Jetpack_Options::update_option( 'last_heartbeat', time() );

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -934,6 +934,7 @@ EXPECTED;
 		$allowed = array(
 			'jetpack.subscriptions.subscribe',
 			'jetpack.updatePublicizeConnections',
+			'jetpack.getHeartbeatData',
 		);
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
@@ -988,6 +989,7 @@ EXPECTED;
 		$allowed = array(
 			'jetpack.subscriptions.subscribe',
 			'jetpack.updatePublicizeConnections',
+			'jetpack.getHeartbeatData',
 		);
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );


### PR DESCRIPTION
This PR adds information of active plugins using connection to the heartbeat, except jetpack itself.

If plugins are active alongside Jetpack, their slugs will be added to the `combined-connection` group. 

If Jetpack is not present, they will be added to the `standalone-connection` group.

~This PR depends on the new Heartbeat package -> #16285~

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
* 1146297891914257-as-1146297891914257

#### Does this pull request change what data or activity we track or use?
Yes, it tracks if there are any other active plugin using the Jetpack connection

#### Testing instructions:
* Connect jetpack
* Install the Client Example plugin
* run `wp jetpack-heartbeat`
* Check that there is an entry of `combined-connection -> client-example`

Note, you might need to copy the contents of the connection package inside the `vendor/automattic` folder of the client example plugin if you want to test the `standalone` situation.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Tracks active plugins using Jetpack connection
