### PR TITLE
External Media: Show for empty galleries

### DIFF
--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -28,11 +28,11 @@ if ( isCurrentUserConnected() ) {
 		'editor.MediaUpload',
 		'external-media/replace-media-upload',
 		OriginalComponent => props => {
-			const { allowedTypes, gallery = false, value = false } = props;
+			const { allowedTypes, gallery = false, value = [] } = props;
 			let { render } = props;
 
 			// Only replace button for components that expect images, except existing galleries.
-			if ( allowedTypes.indexOf( 'image' ) > -1 && ! ( gallery && value ) ) {
+			if ( allowedTypes.indexOf( 'image' ) > -1 && ! ( gallery && value.length > 0 ) ) {
 				render = button => <MediaButton { ...button } mediaProps={ props } />;
 			}
 


### PR DESCRIPTION
This PR fixes a regression introduced in d2c4f68, where External Media would not be available for empty galleries.

Fixes https://github.com/Automattic/jetpack/pull/16069#issuecomment-649506487

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Always treat `value` like an array and check for the amount of items it contains.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* After applying this PR and building extensions, open the Editor.
* Insert any gallery-type block (gallery, tiled-galley, slideshow) and make sure External Media is available when the block is empty, and unavailable when it contains at least one image
* Insert any other image-type block (image, media/text, featured image, cover) and make sure External Media is always available, even when it contains an image.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
