### PR TITLE
External Media: Update button class for styles to apply

### DIFF
--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -349,7 +349,7 @@ $grid-size: 8px;
 // Reset placeholder button margin.
 .components-placeholder__fieldset,
 .editor-post-featured-image {
-	.components-dropdown .jetpack-external-media-browse-button {
+	.components-dropdown .jetpack-external-media-button-menu {
 		margin-right: 8px;
 	}
 }


### PR DESCRIPTION
This PR fixes a rebasing regression introduced in #16069, where button margins for the External Media button would not be applied.

Fixes https://github.com/Automattic/jetpack/pull/16069#issuecomment-649476553
Fixes https://github.com/Automattic/jetpack/pull/16069#issuecomment-649509762

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Updates style class to apply to the correct element.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* After applying this PR and building extensions, open the Editor.
* Insert an image block and make sure the "Select Image" button has the proper margin
* Set a featured image and make sure the "Select Image" button has the proper margin

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
