### PR TITLE
Dashboard: Reconnect Notice

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SimpleNotice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action.jsx';
+import NoticeActionDisconnect from './notice-action-disconnect.jsx';
 import { translate as __ } from 'i18n-calypso';
 import NoticesList from 'components/global-notices';
 import getRedirectUrl from 'lib/jp-redirect';
@@ -180,6 +181,25 @@ UserUnlinked.propTypes = {
 	connectUrl: PropTypes.string.isRequired,
 	siteConnected: PropTypes.bool.isRequired,
 };
+
+export class ErrorNoticeCycleConnection extends React.Component {
+	static propTypes = {
+		text: PropTypes.string.isRequired,
+	};
+
+	render() {
+		return (
+			<SimpleNotice
+				showDismiss={ false }
+				text={ this.props.text }
+				status={ 'is-error' }
+				icon={ 'link-break' }
+			>
+				<NoticeActionDisconnect>{ __( 'Reconnect' ) }</NoticeActionDisconnect>
+			</SimpleNotice>
+		);
+	}
+}
 
 class JetpackNotices extends React.Component {
 	static displayName = 'JetpackNotices';

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -183,6 +183,10 @@ UserUnlinked.propTypes = {
 };
 
 export class ErrorNoticeCycleConnection extends React.Component {
+	static defaultProps = {
+		text: 'Connection Error, please reconnect.',
+	};
+
 	static propTypes = {
 		text: PropTypes.string.isRequired,
 	};

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -184,7 +184,7 @@ UserUnlinked.propTypes = {
 
 export class ErrorNoticeCycleConnection extends React.Component {
 	static defaultProps = {
-		text: 'Connection Error, please reconnect.',
+		text: __( 'Connection Error, please reconnect.' ),
 	};
 
 	static propTypes = {

--- a/_inc/client/components/jetpack-notices/notice-action-disconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-disconnect.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
  */
 import NoticeAction from 'components/notice/notice-action';
 import { disconnectSite } from 'state/connection';
+import analytics from 'lib/analytics';
 
 class NoticeActionDisconnect extends React.Component {
 	static propTypes = {
@@ -17,6 +18,11 @@ class NoticeActionDisconnect extends React.Component {
 	};
 
 	handleDisconnectClick = () => {
+		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_click', {
+			location: 'dashboard',
+			purpose: 'reconnect',
+		} );
+
 		this.props.disconnectSite();
 	};
 

--- a/_inc/client/components/jetpack-notices/notice-action-disconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-disconnect.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import NoticeAction from './notice-action';
+import NoticeAction from 'components/notice/notice-action';
 import { disconnectSite } from 'state/connection';
 
 class NoticeActionDisconnect extends React.Component {

--- a/_inc/client/components/notice/notice-action-disconnect.jsx
+++ b/_inc/client/components/notice/notice-action-disconnect.jsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import NoticeAction from './notice-action';
+import { disconnectSite } from 'state/connection';
+
+class NoticeActionDisconnect extends React.Component {
+	static propTypes = {
+		icon: PropTypes.string,
+	};
+
+	handleDisconnectClick = () => {
+		this.props.disconnectSite();
+	};
+
+	render() {
+		return (
+			<NoticeAction icon={ this.props.icon } onClick={ this.handleDisconnectClick }>
+				{ this.props.children }
+			</NoticeAction>
+		);
+	}
+}
+
+export default connect( null, dispatch => {
+	return {
+		disconnectSite: () => {
+			return dispatch( disconnectSite( true ) );
+		},
+	};
+} )( NoticeActionDisconnect );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* React component `ErrorNoticeCycleConnection` to be used for displaying connection errors.
* React component `NoticeActionDisconnect` - a button to disconnect Jetpack within an error notice.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Open file `_inc/client/components/jetpack-notices/index.jsx`
* Find the component `JetpackNotices` and put following code inside the `render()` method: `<ErrorNoticeCycleConnection text={ 'Something went wrong' } />`
* Rebuild Jetpack, open the dashboard and confirm that the notice shows up:
<img width="480" alt="reconnect-notice" src="https://user-images.githubusercontent.com/1341249/85788173-29550500-b6f2-11ea-9622-5bc00c3f7a1d.png">
* Click "Reconnect" and confirm that Jetpack has been disconnected, the page should reload, "Set Up Jetpack" button should appear.
* The error notice will still show up after you're disconnected, that's fine.

#### Proposed changelog entry for your changes:
n/a
