### PR TITLE
Fix Latest Instagram Posts Images on AMP pages

### DIFF
--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -10,6 +10,7 @@
 namespace Automattic\Jetpack\Extensions\Instagram_Gallery;
 
 use Jetpack;
+use Jetpack_AMP_Support;
 use Jetpack_Gutenberg;
 use Jetpack_Instagram_Gallery_Helper;
 
@@ -86,6 +87,8 @@ function render_block( $attributes, $content ) {
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
+	$is_amp_request = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+
 	ob_start();
 	?>
 
@@ -101,6 +104,7 @@ function render_block( $attributes, $content ) {
 				<img
 					alt="<?php echo esc_attr( $image->title ? $image->title : $image->link ); ?>"
 					src="<?php echo esc_url( $image->url ); ?>"
+					<?php echo $is_amp_request ? 'layout="responsive"' : ''; ?>
 				/>
 			</a>
 		<?php endforeach; ?>

--- a/extensions/blocks/instagram-gallery/instagram-gallery.php
+++ b/extensions/blocks/instagram-gallery/instagram-gallery.php
@@ -85,13 +85,19 @@ function render_block( $attributes, $content ) {
 
 	$images = array_slice( $gallery->images, 0, $count );
 
-	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
-
 	$is_amp_request = class_exists( 'Jetpack_AMP_Support' ) && Jetpack_AMP_Support::is_amp_request();
+
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
 	ob_start();
 	?>
-
+	<?php if ( $is_amp_request ) : ?>
+		<style>
+			.wp-block-jetpack-instagram-gallery__grid .wp-block-jetpack-instagram-gallery__grid-post amp-img img {
+				object-fit: cover;
+			}
+		</style>
+	<?php endif; ?>
 	<div class="<?php echo esc_attr( $grid_classes ); ?>" style="<?php echo esc_attr( $grid_style ); ?>">
 		<?php foreach ( $images as $image ) : ?>
 			<a
@@ -104,7 +110,6 @@ function render_block( $attributes, $content ) {
 				<img
 					alt="<?php echo esc_attr( $image->title ? $image->title : $image->link ); ?>"
 					src="<?php echo esc_url( $image->url ); ?>"
-					<?php echo $is_amp_request ? 'layout="responsive"' : ''; ?>
 				/>
 			</a>
 		<?php endforeach; ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #
- Fix the images style layout of the Latest Instagram Posts block on AMPpages.
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Apply object-fit CSS rule to images of the block

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure AMP plugin is activated
* Create or edit a new post and add a `Latest Instagram Posts` block:
![Selección_045](https://user-images.githubusercontent.com/51013565/85809508-c7aa9000-b71d-11ea-8cd2-fbbb97a02390.jpg)
* Connect the block with your Instagram account. If you already connected the block with instagram, then choose a account:
![](https://user-images.githubusercontent.com/51013565/85809560-fc1e4c00-b71d-11ea-92a6-2f5eb4479bbb.jpg)
* You should see a grid with the posts from your instagram account:
![](https://user-images.githubusercontent.com/51013565/85809598-1f48fb80-b71e-11ea-860d-7d443adbc048.jpg)
* Save the post and check the output on normal pages and then on AMP pages:

Normal Pages:
![Normal pages](https://user-images.githubusercontent.com/51013565/85810141-b6628300-b71f-11ea-824c-645ac6d6650b.jpg)
AMP Pages:
![AMP Pages](https://user-images.githubusercontent.com/51013565/85810174-cd08da00-b71f-11ea-823c-dcdf7fbcbbda.jpg)

Before:
![Before Fix](https://user-images.githubusercontent.com/51013565/85810196-e742b800-b71f-11ea-8630-d4d837f8c22b.jpg)




#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix image layout for Latest Instagram Posts block
