### PR TITLE
Facebook: avoid relying on jQuery for the official button

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1163,7 +1163,7 @@ class Share_Facebook extends Sharing_Source {
 			?><div id="fb-root"></div>
 			<script>(function(d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (d.getElementById(id)) return; js = d.createElement(s); js.id = id; js.src = 'https://connect.facebook.net/<?php echo $locale; ?>/sdk.js#xfbml=1<?php echo $fb_app_id; ?>&version=v2.3'; fjs.parentNode.insertBefore(js, fjs); }(document, 'script', 'facebook-jssdk'));</script>
 			<script>
-			jQuery( document.body ).on( 'post-load', function() {
+			document.body.addEventListener( 'post-load', function() {
 				if ( 'undefined' !== typeof FB ) {
 					FB.XFBML.parse();
 				}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Jetpack's Sharing feature does not rely on jQuery, and not all sites load jQuery via their theme or other plugins so we cannot expect it to be available.

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Start with a site that uses the Twenty Twenty theme, and no other plugin. This will ensure that jQuery is not loaded on the frontend of your site by default.
* Activate and connect Jetpack to WordPress.com.
* Go to Jetpack > Settings > Sharing and enable the sharing buttons.
* Go to Settings > Sharing and switch to the official sharing buttons. Also ensure the button is loaded on the home page as well.
* View a post. You'll notice that the Facebook official button does not load. You'll see a JavaScript error in the console instead.
* Switch to this branch.
* The button should now load.
* Make sure it loads when viewing single posts, a list of posts (the home page), or on page 2 if you have several posts on your site, have activated Infinite Scroll under Jetpack > Settings, and scroll down when on the home page.

#### Proposed changelog entry for your changes:

* Sharing: avoid relying on jQuery for the official Facebook button.
