### PR TITLE
IDC: remove remote killswitch

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6284,25 +6284,9 @@ endif;
 	public static function validate_sync_error_idc_option() {
 		$is_valid = false;
 
-		$idc_allowed = get_transient( 'jetpack_idc_allowed' );
-		if ( false === $idc_allowed ) {
-			$response = wp_remote_get( 'https://jetpack.com/is-idc-allowed/' );
-			if ( 200 === (int) wp_remote_retrieve_response_code( $response ) ) {
-				$json               = json_decode( wp_remote_retrieve_body( $response ) );
-				$idc_allowed        = isset( $json, $json->result ) && $json->result ? '1' : '0';
-				$transient_duration = HOUR_IN_SECONDS;
-			} else {
-				// If the request failed for some reason, then assume IDC is allowed and set shorter transient.
-				$idc_allowed        = '1';
-				$transient_duration = 5 * MINUTE_IN_SECONDS;
-			}
-
-			set_transient( 'jetpack_idc_allowed', $idc_allowed, $transient_duration );
-		}
-
 		// Is the site opted in and does the stored sync_error_idc option match what we now generate?
 		$sync_error = Jetpack_Options::get_option( 'sync_error_idc' );
-		if ( $idc_allowed && $sync_error && self::sync_idc_optin() ) {
+		if ( $sync_error && self::sync_idc_optin() ) {
 			$local_options = self::get_sync_error_idc_option();
 			// Ensure all values are set.
 			if ( isset( $sync_error['home'] ) && isset( $local_options['home'] ) && isset( $sync_error['siteurl'] ) && isset( $local_options['siteurl'] ) ) {
@@ -6321,7 +6305,7 @@ endif;
 		 */
 		$is_valid = (bool) apply_filters( 'jetpack_sync_error_idc_validation', $is_valid );
 
-		if ( ! $idc_allowed || ( ! $is_valid && $sync_error ) ) {
+		if ( ! $is_valid && $sync_error ) {
 			// Since the option exists, and did not validate, delete it
 			Jetpack_Options::delete_option( 'sync_error_idc' );
 		}

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -475,71 +475,6 @@ EXPECTED;
 		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
 	}
 
-	function test_sync_error_idc_validation_success_when_idc_allowed() {
-		add_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_is_allowed' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
-	function test_sync_error_idc_validation_fails_when_idc_disabled() {
-		add_filter( 'pre_http_request', array( $this, '__idc_is_disabled' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertFalse( Jetpack::validate_sync_error_idc_option() );
-		$this->assertFalse( Jetpack_Options::get_option( 'sync_error_idc' ) );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '0', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_is_disabled' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
-	function test_sync_error_idc_validation_success_when_idc_errored() {
-		add_filter( 'pre_http_request', array( $this, '__idc_check_errored' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_is_errored' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
-	function test_sync_error_idc_validation_success_when_idc_404() {
-		add_filter( 'pre_http_request', array( $this, '__idc_check_404' ) );
-		add_filter( 'jetpack_sync_idc_optin', '__return_true' );
-
-		Jetpack_Options::update_option( 'sync_error_idc', Jetpack::get_sync_error_idc_option() );
-		$this->assertTrue( Jetpack::validate_sync_error_idc_option() );
-
-		$this->assertNotEquals( false, get_transient( 'jetpack_idc_allowed' ) );
-		$this->assertEquals( '1', get_transient( 'jetpack_idc_allowed' ) );
-
-		// Cleanup
-		remove_filter( 'pre_http_request', array( $this, '__idc_check_404' ) );
-		remove_filter( 'jetpack_sync_idc_optin', '__return_true' );
-		delete_transient( 'jetpack_idc_allowed' );
-	}
-
 	function test_is_staging_site_true_when_sync_error_idc_is_valid() {
 		add_filter( 'jetpack_sync_error_idc_validation', '__return_true' );
 		$this->assertTrue( ( new Status() )->is_staging_site() );
@@ -917,37 +852,6 @@ EXPECTED;
 
 	function __return_string_1() {
 		return '1';
-	}
-
-	function __idc_is_allowed() {
-		return array(
-			'response' => array(
-				'code' => 200
-			),
-			'body' => '{"result":true}'
-		);
-	}
-
-	function __idc_is_disabled() {
-		return array(
-			'response' => array(
-				'code' => 200
-			),
-			'body' => '{"result":false}'
-		);
-	}
-
-	function __idc_check_errored() {
-		return new WP_Error( 'idc-request-failed' );
-	}
-
-	function __idc_check_404() {
-		return array(
-			'response' => array(
-				'code' => 404
-			),
-			'body' => '<div>some content</div>'
-		);
 	}
 
 	static function reset_tracking_of_module_activation() {


### PR DESCRIPTION
Fixes #16254

#### Changes proposed in this Pull Request:

* This essentially reverts #5464. We don't need that killswitch anymore.

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Not much to test imo. Let's just make sure IDCs still work

* Start from a site currently experiencing an IDC. See below for a quick and dirty way to force your site into an IDC.
* Open the dashboard while logged in as an admin, view the notice.

```php
// Opt in to IDC mitigation.
add_filter( 'jetpack_sync_idc_optin', '__return_true' );

/**
 * Trigger an update of IDC options from URL parameters in wp-admin
 */
function developing_jetapck_idc_query_strings() {
	if ( isset( $_GET['trigger-idc'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
		Jetpack_Options::update_option(
			'sync_error_idc',
			array_merge(
				Jetpack::get_sync_error_idc_option(),
				array(
					'home'    => 'fakehome.com',
					'siteurl' => 'fakesite.com',
				)
			)
		);
	} elseif ( isset( $_GET['clear-idc'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
		Jetpack_Options::delete_option( 'sync_error_idc' );
	}
}
add_action( 'admin_init', 'developing_jetapck_idc_query_strings' );

/**
 * Create a form to quickly trigger IDC query strings.
 */
function developing_jetapck_idc_test_form() {
	?>
	<div class="notice" id="idc-testing">
		<form action="" method="get">
			<button name="trigger-idc">
				Trigger IDC
			</button>
			<button name="clear-idc">
				Clear IDC
			</button>
		</form>
	</div>
	<?php
}
add_action( 'admin_notices', 'developing_jetapck_idc_test_form' );

/**
 * Move the form the bottom of wp-admin
 */
function idc_testing_styles() {
	?>
	<style>
		#idc-testing {
			position: fixed;
			bottom: 0;
			right: 0;
			background-color: #72af3a;
			z-index: 10000;
		}
	</style>
	<?php
}
add_action( 'admin_enqueue_scripts', 'idc_testing_styles' );
```

#### Proposed changelog entry for your changes:

* N/A
