### PR TITLE
React Connection Errors component.

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SimpleNotice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action.jsx';
-import NoticeActionDisconnect from './notice-action-disconnect.jsx';
 import { translate as __ } from 'i18n-calypso';
 import NoticesList from 'components/global-notices';
 import getRedirectUrl from 'lib/jp-redirect';
@@ -28,6 +27,7 @@ import DismissableNotices from './dismissable';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 import PlanConflictWarning from './plan-conflict-warning';
+import JetpackConnectionErrors from './jetpack-connection-errors';
 
 export class DevVersionNotice extends React.Component {
 	static displayName = 'DevVersionNotice';
@@ -182,29 +182,6 @@ UserUnlinked.propTypes = {
 	siteConnected: PropTypes.bool.isRequired,
 };
 
-export class ErrorNoticeCycleConnection extends React.Component {
-	static defaultProps = {
-		text: __( 'Connection Error, please reconnect.' ),
-	};
-
-	static propTypes = {
-		text: PropTypes.string.isRequired,
-	};
-
-	render() {
-		return (
-			<SimpleNotice
-				showDismiss={ false }
-				text={ this.props.text }
-				status={ 'is-error' }
-				icon={ 'link-break' }
-			>
-				<NoticeActionDisconnect>{ __( 'Reconnect' ) }</NoticeActionDisconnect>
-			</SimpleNotice>
-		);
-	}
-}
-
 class JetpackNotices extends React.Component {
 	static displayName = 'JetpackNotices';
 
@@ -212,6 +189,7 @@ class JetpackNotices extends React.Component {
 		return (
 			<div aria-live="polite">
 				<NoticesList />
+				{ this.props.siteConnectionStatus && <JetpackConnectionErrors /> }
 				<JetpackStateNotices />
 				<DevVersionNotice
 					isDevVersion={ this.props.isDevVersion }

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -22,7 +22,12 @@ import {
 	isCurrentUserLinked,
 	getConnectUrl as _getConnectUrl,
 } from 'state/connection';
-import { isDevVersion, userCanConnectSite, userIsSubscriber } from 'state/initial-state';
+import {
+	isDevVersion,
+	userCanConnectSite,
+	userIsSubscriber,
+	getConnectionErrors,
+} from 'state/initial-state';
 import DismissableNotices from './dismissable';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
@@ -189,7 +194,9 @@ class JetpackNotices extends React.Component {
 		return (
 			<div aria-live="polite">
 				<NoticesList />
-				{ this.props.siteConnectionStatus && <JetpackConnectionErrors /> }
+				{ this.props.siteConnectionStatus && this.props.connectionErrors && (
+					<JetpackConnectionErrors errors={ this.props.connectionErrors } />
+				) }
 				<JetpackStateNotices />
 				<DevVersionNotice
 					isDevVersion={ this.props.isDevVersion }
@@ -235,5 +242,6 @@ export default connect( state => {
 		siteDevMode: getSiteDevMode( state ),
 		isStaging: isStaging( state ),
 		isInIdentityCrisis: isInIdentityCrisis( state ),
+		connectionErrors: getConnectionErrors( state ),
 	};
 } )( JetpackNotices );

--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { translate as __ } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { getConnectionErrors } from 'state/initial-state';
+import SimpleNotice from 'components/notice';
+import NoticeActionDisconnect from './notice-action-disconnect';
+
+export class ErrorNoticeCycleConnection extends React.Component {
+	static defaultProps = {
+		text: __( 'Connection Error, please reconnect.' ),
+	};
+
+	static propTypes = {
+		text: PropTypes.string.isRequired,
+	};
+
+	render() {
+		return (
+			<SimpleNotice
+				showDismiss={ false }
+				text={ this.props.text }
+				status={ 'is-error' }
+				icon={ 'link-break' }
+			>
+				<NoticeActionDisconnect>{ __( 'Reconnect' ) }</NoticeActionDisconnect>
+			</SimpleNotice>
+		);
+	}
+}
+
+class JetpackConnectionErrors extends React.Component {
+	static propTypes = {
+		errors: PropTypes.array.isRequired,
+	};
+
+	actions = {
+		reconnect: message => <ErrorNoticeCycleConnection text={ message } />,
+	};
+
+	isActionSupported( action ) {
+		return (
+			this.actions.hasOwnProperty( action ) &&
+			{}.toString.call( this.actions[ action ] ) === '[object Function]'
+		);
+	}
+
+	renderOne( error ) {
+		if ( ! this.isActionSupported( error.action ) ) {
+			return '';
+		}
+
+		return (
+			<React.Fragment>
+				{ this.actions[ error.action ]( error.message, error.code ) }{ ' ' }
+			</React.Fragment>
+		);
+	}
+
+	render() {
+		return this.props.errors.map( error => this.renderOne( error ) );
+	}
+}
+
+export default connect( state => {
+	return {
+		errors: getConnectionErrors( state ),
+	};
+} )( JetpackConnectionErrors );

--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getConnectionErrors } from 'state/initial-state';
+
 import SimpleNotice from 'components/notice';
 import NoticeActionDisconnect from './notice-action-disconnect';
 
@@ -36,7 +36,7 @@ export class ErrorNoticeCycleConnection extends React.Component {
 	}
 }
 
-class JetpackConnectionErrors extends React.Component {
+export default class JetpackConnectionErrors extends React.Component {
 	static propTypes = {
 		errors: PropTypes.array.isRequired,
 	};
@@ -58,9 +58,7 @@ class JetpackConnectionErrors extends React.Component {
 		}
 
 		return (
-			<React.Fragment>
-				{ this.actions[ error.action ]( error.message, error.code ) }{ ' ' }
-			</React.Fragment>
+			<React.Fragment>{ this.actions[ error.action ]( error.message, error.code ) }</React.Fragment>
 		);
 	}
 
@@ -68,9 +66,3 @@ class JetpackConnectionErrors extends React.Component {
 		return this.props.errors.map( error => this.renderOne( error ) );
 	}
 }
-
-export default connect( state => {
-	return {
-		errors: getConnectionErrors( state ),
-	};
-} )( JetpackConnectionErrors );

--- a/_inc/client/state/initial-state/reducer.js
+++ b/_inc/client/state/initial-state/reducer.js
@@ -395,3 +395,15 @@ function getProductOptions( state, product, siteProducts ) {
 export function getInitialSetupWizardStatus( state ) {
 	return get( state.jetpack.initialState, 'setupWizardStatus', '' );
 }
+
+/**
+ * Get the connection errors.
+ *
+ * @param  {Object} state Global state tree.
+ * @returns {Array} Connection errors.
+ */
+export function getConnectionErrors( state ) {
+	return get( state.jetpack.initialState, [ 'connectionStatus', 'errors' ], [] ).filter( error =>
+		error.hasOwnProperty( 'action' )
+	);
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -252,6 +252,15 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isPublic'           => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
 				'sandboxDomain'      => JETPACK__SANDBOX_DOMAIN,
+
+				/**
+				 * Filter to add connection errors
+				 * Format: array( array( 'code' => '...', 'message' => '...', 'action' => '...' ), ... )
+				 *
+				 * @since 8.7.0
+				 *
+				 * @param array $errors Connection errors.
+				 */
 				'errors'             => apply_filters( 'react_connection_errors_initial_state', array() ),
 			),
 			'connectUrl'                  => false == $current_user_data['isConnected'] // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -252,6 +252,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isPublic'           => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),
 				'sandboxDomain'      => JETPACK__SANDBOX_DOMAIN,
+				'errors'             => apply_filters( 'react_connection_errors_initial_state', array() ),
 			),
 			'connectUrl'                  => false == $current_user_data['isConnected'] // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 				? Jetpack::init()->build_connect_url( true, false, false )


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- New filter`react_connection_errors_initial_state` is used to push connection errors into React Initial State.
- New `JetpackConnectionErrors` component that read the Initial State errors and displays them using `ErrorNoticeCycleConnection`.
- Existing `ErrorNoticeCycleConnection` component is moved alongside `JetpackConnectionErrors`, as it makes more sense being stored there.

#### Does this pull request change what data or activity we track or use?
No, it doesn't.

#### Testing instructions:
1. Create a plugin `jetpack-connection-test.php` with following code:
```php
<?php
/** Plugin Name: Jetpack Connection Message Plugin */
add_filter( 'react_connection_errors_initial_state', function( $errors ) {
	$errors[] = array(
		'message' => __('message'),
		'action' => 'reconnect'
	);

	$errors[] = array(
		'code' => 'invlaid_blog_token',
		'action' => 'reconnect'
	);

	$errors[] = array(
		'code' => 'invlaid_blog_token',
		'message' => __('message 3'),
	);

	return $errors;
} );
```
2. Activate the plugin, and open Jetpack Dashboard (connect if needed).

3. The messages on top the the dashboard should appear (third message is skipped because it's missing `action`):
<img width="1053" alt="Screen Shot 2020-06-26 at 4 26 34 PM" src="https://user-images.githubusercontent.com/1341249/85902520-d77fae00-b7c9-11ea-95b3-651dff08d412.png">

4. Click "Reconnect" on any one of the messages.

5. Jetpack should disconnect, dashboard should reload, messages should disappear.

6. Connect Jetpack again, go back to the Dashboard, make sure that the two messages show up again.

#### Proposed changelog entry for your changes:
* Displaying connection errors in Jetpack Dashboard.
