### PR TITLE
Recurring Payments: Add filter for hiding block controls

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -432,7 +432,7 @@ class MembershipsButtonEdit extends Component {
 			this.props.clientId
 		);
 
-		const inspectorControls = showControls ? (
+		const inspectorControls = (
 			<InspectorControls>
 				<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
 					<SelectControl
@@ -452,7 +452,7 @@ class MembershipsButtonEdit extends Component {
 					</ExternalLink>
 				</PanelBody>
 			</InspectorControls>
-		) : null;
+		);
 
 		return (
 			<Fragment>

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -421,23 +421,28 @@ class MembershipsButtonEdit extends Component {
 
 		const inspectorControls = (
 			<InspectorControls>
-				<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
-					<SelectControl
-						label={ __( 'Payment plan', 'jetpack' ) }
-						value={ this.props.attributes.planId }
-						onChange={ this.setMembershipAmount }
-						options={ products.map( product => ( {
-							label: this.renderAmount( product ),
-							value: product.id,
-							key: product.id,
-						} ) ) }
-					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Management', 'jetpack' ) }>
-					<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
-						{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
-					</ExternalLink>
-				</PanelBody>
+				<div
+					className="wp-block-jetpack-recurring-payments-inspector-controls"
+					data-block-id={ this.props.clientId }
+				>
+					<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
+						<SelectControl
+							label={ __( 'Payment plan', 'jetpack' ) }
+							value={ this.props.attributes.planId }
+							onChange={ this.setMembershipAmount }
+							options={ products.map( product => ( {
+								label: this.renderAmount( product ),
+								value: product.id,
+								key: product.id,
+							} ) ) }
+						/>
+					</PanelBody>
+					<PanelBody title={ __( 'Management', 'jetpack' ) }>
+						<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
+							{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
+						</ExternalLink>
+					</PanelBody>
+				</div>
 			</InspectorControls>
 		);
 

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -22,6 +22,7 @@ import {
 } from '@wordpress/components';
 import { InspectorControls, BlockIcon } from '@wordpress/block-editor';
 import { Fragment, Component } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -419,32 +420,39 @@ class MembershipsButtonEdit extends Component {
 
 		const stripeConnectUrl = this.getConnectUrl();
 
-		const inspectorControls = (
-			<InspectorControls>
-				<div
-					className="wp-block-jetpack-recurring-payments-inspector-controls"
-					data-block-id={ this.props.clientId }
-				>
-					<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
-						<SelectControl
-							label={ __( 'Payment plan', 'jetpack' ) }
-							value={ this.props.attributes.planId }
-							onChange={ this.setMembershipAmount }
-							options={ products.map( product => ( {
-								label: this.renderAmount( product ),
-								value: product.id,
-								key: product.id,
-							} ) ) }
-						/>
-					</PanelBody>
-					<PanelBody title={ __( 'Management', 'jetpack' ) }>
-						<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
-							{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
-						</ExternalLink>
-					</PanelBody>
-				</div>
-			</InspectorControls>
+		/**
+		 * Filters the flag that determines if the Recurring Payments block controls should be shown in the inspector.
+		 *
+		 * @param {bool} showControls Whether inspectors controls are shown.
+		 * @param {string} showControls Block ID.
+		 */
+		const showControls = applyFilters(
+			'jetpack.RecurringPayments.showControls',
+			products.length > 0,
+			this.props.clientId
 		);
+
+		const inspectorControls = showControls ? (
+			<InspectorControls>
+				<PanelBody title={ __( 'Payment plan', 'jetpack' ) }>
+					<SelectControl
+						label={ __( 'Payment plan', 'jetpack' ) }
+						value={ this.props.attributes.planId }
+						onChange={ this.setMembershipAmount }
+						options={ products.map( product => ( {
+							label: this.renderAmount( product ),
+							value: product.id,
+							key: product.id,
+						} ) ) }
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Management', 'jetpack' ) }>
+					<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
+						{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
+					</ExternalLink>
+				</PanelBody>
+			</InspectorControls>
+		) : null;
 
 		return (
 			<Fragment>
@@ -525,7 +533,7 @@ class MembershipsButtonEdit extends Component {
 							</Placeholder>
 						</div>
 					) }
-				{ products.length > 0 && inspectorControls }
+				{ showControls && inspectorControls }
 				{ ( ( ( this.hasUpgradeNudge || ! this.state.shouldUpgrade ) &&
 					connected !== API_STATE_LOADING ) ||
 					this.props.attributes.planId ) && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add a new filter for determining if the Recurring Payments block controls should be shown in the inspector. This will allow to hide them in cases where they are useless (such as when nested in a WP.com Premium Content block).

Controls enabled | Controls disabled
--- | ---
<img width="282" alt="Screen Shot 2020-06-29 at 13 57 34" src="https://user-images.githubusercontent.com/1233880/86002383-8e6d6b00-ba10-11ea-89ca-efd1095b6d01.png"> | <img width="295" alt="Screen Shot 2020-06-29 at 13 57 43" src="https://user-images.githubusercontent.com/1233880/86002390-90cfc500-ba10-11ea-8a74-c0e35da31fd9.png">

#### Jetpack product discussion

https://github.com/Automattic/wp-calypso/issues/43450#issuecomment-649535418

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:
* Insert a Recurring Payments block (known as just Payments in dev).
* Make sure the Payment plan and management block controls are shown by default (as long as there are Recurring Payments plan created).
* Type `wp.hooks.addFilter( 'jetpack.RecurringPayments.showControls', 'jetpack/test', () => false );` in the browser console.
* Confirm the block controls are no longer shown (unselect and select again the previously inserted block to make sure the filter is executed).
* You can also see the filter in action in https://github.com/Automattic/wp-calypso/pull/43684.

#### Proposed changelog entry for your changes:

Recurring Payments: Add filter for hiding block controls
