### PR TITLE
Block Flamingo Plugin post types in Jetpack Sync

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -385,6 +385,9 @@ class Defaults {
 		'bwg_gallery',
 		'customize_changeset', // WP built-in post type for Customizer changesets.
 		'dn_wp_yt_log',
+		'flamingo_contact', // https://wordpress.org/plugins/flamingo/.
+		'flamingo_inbound',
+		'flamingo_outbound',
 		'http',
 		'idx_page',
 		'jetpack_migration',


### PR DESCRIPTION
Flamingo (https://wordpress.org/plugins/flamingo/) plugin stores email messages as post types. To minimize Search records and also reduce sync/backup requests we are adding them to the post_type blocklist.

Fixes #
[jpop-5477]

#### Changes proposed in this Pull Request:
* Adds flamingo_contact, flamingo_inbound and flamingo_outbound to post blaoklist

#### Jetpack product discussion
* https://wp.me/p1HpG7-9x6

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

* Apply this PR
* Ensure your test site is connected to WordPress.com
* Install and Activate the contact-form-7 and flamingo plugins to your site
* Add a contact-form-7 form to your site
* Submit the contact-form-7 form
* Verify a inbound/contact record is shown in your WP-Admin (Grab the post_id of the record)
* On your WP.com sandbox
* wp shell --url={SITE_DOMAIN}
* get_post( POST_ID)

Verify the post is not found on the sandbox (e.g. did not sync)

#### Proposed changelog entry for your changes:
* N/A - don't think post_type blocklists should be publicized. if so we can use
* Update the Jetpack Sync post_type blocklist to include Flamingo post_types.
