### PR TITLE
Connection: Update XMLRPC overload

### DIFF
--- a/packages/connection/legacy/class-jetpack-ixr-client.php
+++ b/packages/connection/legacy/class-jetpack-ixr-client.php
@@ -49,10 +49,11 @@ class Jetpack_IXR_Client extends IXR_Client {
 	/**
 	 * Perform the IXR request.
 	 *
+	 * @param string[] ...$args IXR args.
+	 *
 	 * @return bool True if request succeeded, false otherwise.
 	 */
-	public function query() {
-		$args    = func_get_args();
+	public function query( ...$args ) {
 		$method  = array_shift( $args );
 		$request = new IXR_Request( $method, $args );
 		$xml     = trim( $request->getXml() );

--- a/packages/connection/legacy/class-jetpack-ixr-clientmulticall.php
+++ b/packages/connection/legacy/class-jetpack-ixr-clientmulticall.php
@@ -23,9 +23,10 @@ class Jetpack_IXR_ClientMulticall extends Jetpack_IXR_Client {
 	 * Add a IXR call to the client.
 	 * First argument is the method name.
 	 * The rest of the arguments are the params specified to the method.
+	 *
+	 * @param string[] ...$args IXR args.
 	 */
-	public function addCall() {
-		$args          = func_get_args();
+	public function addCall( ...$args ) {
 		$method_name   = array_shift( $args );
 		$struct        = array(
 			'methodName' => $method_name,
@@ -37,9 +38,11 @@ class Jetpack_IXR_ClientMulticall extends Jetpack_IXR_Client {
 	/**
 	 * Perform the IXR multicall request.
 	 *
+	 * @param string[] ...$args IXR args.
+	 *
 	 * @return bool True if request succeeded, false otherwise.
 	 */
-	public function query() {
+	public function query( ...$args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		usort( $this->calls, array( $this, 'sort_calls' ) );
 
 		// Prepare multicall, then call the parent::query() method.


### PR DESCRIPTION
In https://core.trac.wordpress.org/changeset/48204, Core has adopted the spread operator. As we're overloading the XMLRPC class, we need to match the parent methods.

#### Changes proposed in this Pull Request:
* Use the spread operator instead of `func_get_args` for the xmlrpc class implementations.

#### Jetpack product discussion
No.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* No functional change, though it is a very slight performance bump.
* Tests pass.

We may need to get creative with the older versions until our minimum is 5.5.

#### Proposed changelog entry for your changes:
* WordPress 5.5 compatibility 
