### PR TITLE
Blocks: Switch new Whatsapp block to production

### DIFF
--- a/extensions/index.json
+++ b/extensions/index.json
@@ -24,6 +24,8 @@
 		"related-posts",
 		"repeat-visitor",
 		"revue",
+		"send-a-message",
+		"send-a-message/whatsapp-button",
 		"sharing",
 		"shortlinks",
 		"simple-payments",
@@ -33,7 +35,7 @@
 		"videopress",
 		"wordads"
 	],
-	"beta": [ "amazon", "send-a-message", "send-a-message/whatsapp-button" ],
+	"beta": [ "amazon" ],
 	"experimental": [ "seo" ],
 	"no-post-editor": [
 		"business-hours",


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Let's move this block to production since it will go out with Jetpack 8.7

Related PR: #15050 

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* With Jetpack Beta blocks disabled, go to Posts > Add New and search for the Send a Message block.
* Do you see it? 🎉 

#### Proposed changelog entry for your changes:

* N/A
