### PR TITLE
Adds error message for broken REST API calls to jetpack/v4/site

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -195,12 +195,12 @@ class JetpackNotices extends React.Component {
 		return (
 			<div aria-live="polite">
 				<NoticesList />
-				{ this.props.siteConnectionStatus && this.props.connectionErrors && (
-					<JetpackConnectionErrors errors={ this.props.connectionErrors } />
-				) }
-				{ this.props.siteConnectionStatus && this.props.siteDataErrors && (
-					<JetpackConnectionErrors errors={ this.props.siteDataErrors } />
-				) }
+				{ this.props.siteConnectionStatus &&
+					( this.props.connectionErrors || this.props.siteDataErrors ) && (
+						<JetpackConnectionErrors
+							errors={ this.props.connectionErrors.concat( this.props.siteDataErrors ) }
+						/>
+					) }
 				<JetpackStateNotices />
 				<DevVersionNotice
 					isDevVersion={ this.props.isDevVersion }

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -192,13 +192,17 @@ class JetpackNotices extends React.Component {
 	static displayName = 'JetpackNotices';
 
 	render() {
+		const siteDataErrors = this.props.siteDataErrors.filter( error =>
+			error.hasOwnProperty( 'action' )
+		);
+
 		return (
 			<div aria-live="polite">
 				<NoticesList />
 				{ this.props.siteConnectionStatus &&
-					( this.props.connectionErrors || this.props.siteDataErrors ) && (
+					( this.props.connectionErrors.length > 0 || siteDataErrors.length > 0 ) && (
 						<JetpackConnectionErrors
-							errors={ this.props.connectionErrors.concat( this.props.siteDataErrors ) }
+							errors={ this.props.connectionErrors.concat( siteDataErrors ) }
 						/>
 					) }
 				<JetpackStateNotices />

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -28,6 +28,7 @@ import {
 	userIsSubscriber,
 	getConnectionErrors,
 } from 'state/initial-state';
+import { getSiteDataErrors } from 'state/site';
 import DismissableNotices from './dismissable';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
@@ -197,6 +198,9 @@ class JetpackNotices extends React.Component {
 				{ this.props.siteConnectionStatus && this.props.connectionErrors && (
 					<JetpackConnectionErrors errors={ this.props.connectionErrors } />
 				) }
+				{ this.props.siteConnectionStatus && this.props.siteDataErrors && (
+					<JetpackConnectionErrors errors={ this.props.siteDataErrors } />
+				) }
 				<JetpackStateNotices />
 				<DevVersionNotice
 					isDevVersion={ this.props.isDevVersion }
@@ -243,5 +247,6 @@ export default connect( state => {
 		isStaging: isStaging( state ),
 		isInIdentityCrisis: isInIdentityCrisis( state ),
 		connectionErrors: getConnectionErrors( state ),
+		siteDataErrors: getSiteDataErrors( state ),
 	};
 } )( JetpackNotices );

--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -63,6 +63,15 @@ export default class JetpackConnectionErrors extends React.Component {
 	}
 
 	render() {
-		return this.props.errors.map( error => this.renderOne( error ) );
+		const errorsToDisplay = {};
+		const errors = this.props.errors.filter( error => error.hasOwnProperty( 'action' ) );
+
+		for ( const error of errors ) {
+			if ( ! errorsToDisplay.hasOwnProperty( error.action ) ) {
+				errorsToDisplay[ error.action ] = error;
+			}
+		}
+
+		return Object.values( errorsToDisplay ).map( error => this.renderOne( error ) );
 	}
 }

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -3,6 +3,7 @@
  */
 import { combineReducers } from 'redux';
 import { assign, find, get, merge } from 'lodash';
+import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -120,10 +121,36 @@ export const requests = ( state = initialRequestsState, action ) => {
 	}
 };
 
+export const errors = ( state = {}, action ) => {
+	switch ( action.type ) {
+		case JETPACK_SITE_DATA_FETCH_FAIL:
+			return assign( {}, state, {
+				message: __(
+					'There seems to be a problem with your connection to WordPress.com. If the problem persists, try reconnecting.'
+				),
+				action: 'reconnect',
+				code: 'fetch_site_data_fail',
+			} );
+		default:
+			return state;
+	}
+};
+
 export const reducer = combineReducers( {
 	data,
 	requests,
+	errors,
 } );
+
+/**
+ * Returns an object of the siteData errors
+ *
+ * @param  {Object}  state Global state tree
+ * @return {Object}        Error object
+ */
+export function getSiteDataErrors( state ) {
+	return [ get( state.jetpack.siteData, [ 'errors' ], [] ) ];
+}
 
 /**
  * Returns true if currently requesting site data. Otherwise false.

--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -3,7 +3,6 @@
  */
 import { combineReducers } from 'redux';
 import { assign, find, get, merge } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -125,11 +124,9 @@ export const errors = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SITE_DATA_FETCH_FAIL:
 			return assign( {}, state, {
-				message: __(
-					'There seems to be a problem with your connection to WordPress.com. If the problem persists, try reconnecting.'
-				),
+				message: action.error.response.message,
 				action: 'reconnect',
-				code: 'fetch_site_data_fail',
+				code: action.error.response.code,
 			} );
 		default:
 			return state;

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1728,7 +1728,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 		if ( $site_data->get_error_code() === 'site_data_fetch_failed' ) {
-			return new WP_Error( 'site_data_fetch_failed', esc_html__( 'Connection to WordPress.com failed. If the problem persists, try reconnecting', 'jetpack' ), array( 'status' => 400 ) );
+			return new WP_Error( 'site_data_fetch_failed', esc_html__( 'Failed fetching site data from WordPress.com. If the problem persists, try reconnecting Jetpack.', 'jetpack' ), array( 'status' => 400 ) );
 		}
 
 		if ( $site_data->get_error_code() === 'site_id_missing' ) {

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1728,7 +1728,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 			);
 		}
 		if ( $site_data->get_error_code() === 'site_data_fetch_failed' ) {
-			return new WP_Error( 'site_data_fetch_failed', esc_html__( 'Failed fetching site data. Try again later.', 'jetpack' ), array( 'status' => 400 ) );
+			return new WP_Error( 'site_data_fetch_failed', esc_html__( 'Connection to WordPress.com failed. If the problem persists, try reconnecting', 'jetpack' ), array( 'status' => 400 ) );
 		}
 
 		if ( $site_data->get_error_code() === 'site_id_missing' ) {


### PR DESCRIPTION
Add user feedback then the request to the `jetpack/v4/site` endpoint returns an error.

Up until https://github.com/Automattic/jetpack/pull/16184, if the `site` endpoint returned an error, the whole React dashboard would break. 

Now that we fixed that, we can display a helpful error message to the user. One of the reasons this endpoint return an error is because of a broken connection, so we are displaying a "Connection Error" message with a CTA to Reconnect jetpack.


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-9q9-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a connected Jetpack site
* Use the "Broken token" plugin to break your connection (this is available in the `mu-plugins` folder and activated on your docker environment)
* Go to Jetpack > Broken tokens
* Now choose "Set invalid blog token"and break the connection. 
* Visit the Jetpack Dashboard
* Confirm you see the connection error message:

![Captura de Tela 2020-06-29 às 17 53 16](https://user-images.githubusercontent.com/971483/86054948-71955f80-ba31-11ea-9944-d4c8e95276c1.png)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Better user feedback for broken connections on the React Dashboard
