### PR TITLE
Jetpack_XMLRPC_Server: set up jsonAPI and testConnection endpoint when Jetpack is active

### DIFF
--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -56,12 +56,15 @@ class Jetpack_XMLRPC_Server {
 	 */
 	public function xmlrpc_methods( $core_methods ) {
 		$jetpack_methods = array(
-			'jetpack.jsonAPI'         => array( $this, 'json_api' ),
 			'jetpack.verifyAction'    => array( $this, 'verify_action' ),
 			'jetpack.getUser'         => array( $this, 'get_user' ),
 			'jetpack.remoteRegister'  => array( $this, 'remote_register' ),
 			'jetpack.remoteProvision' => array( $this, 'remote_provision' ),
 		);
+
+		if ( class_exists( 'Jetpack' ) ) {
+			$jetpack_methods['jetpack.jsonAPI'] = array( $this, 'json_api' );
+		}
 
 		$this->user = $this->login();
 
@@ -69,7 +72,6 @@ class Jetpack_XMLRPC_Server {
 			$jetpack_methods = array_merge(
 				$jetpack_methods,
 				array(
-					'jetpack.testConnection'    => array( $this, 'test_connection' ),
 					'jetpack.testAPIUserCode'   => array( $this, 'test_api_user_code' ),
 					'jetpack.featuresAvailable' => array( $this, 'features_available' ),
 					'jetpack.featuresEnabled'   => array( $this, 'features_enabled' ),
@@ -78,6 +80,10 @@ class Jetpack_XMLRPC_Server {
 					'jetpack.idcUrlValidation'  => array( $this, 'validate_urls_for_idc_mitigation' ),
 				)
 			);
+
+			if ( class_exists( 'Jetpack' ) ) {
+				$jetpack_methods['jetpack.testConnection'] = array( $this, 'test_connection' );
+			}
 
 			if ( isset( $core_methods['metaWeblog.editPost'] ) ) {
 				$jetpack_methods['metaWeblog.newMediaObject']      = $core_methods['metaWeblog.newMediaObject'];

--- a/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -72,17 +72,17 @@ class Jetpack_XMLRPC_Server {
 			$jetpack_methods = array_merge(
 				$jetpack_methods,
 				array(
-					'jetpack.testAPIUserCode'   => array( $this, 'test_api_user_code' ),
-					'jetpack.featuresAvailable' => array( $this, 'features_available' ),
-					'jetpack.featuresEnabled'   => array( $this, 'features_enabled' ),
-					'jetpack.disconnectBlog'    => array( $this, 'disconnect_blog' ),
-					'jetpack.unlinkUser'        => array( $this, 'unlink_user' ),
-					'jetpack.idcUrlValidation'  => array( $this, 'validate_urls_for_idc_mitigation' ),
+					'jetpack.testAPIUserCode'  => array( $this, 'test_api_user_code' ),
+					'jetpack.disconnectBlog'   => array( $this, 'disconnect_blog' ),
+					'jetpack.unlinkUser'       => array( $this, 'unlink_user' ),
+					'jetpack.idcUrlValidation' => array( $this, 'validate_urls_for_idc_mitigation' ),
 				)
 			);
 
 			if ( class_exists( 'Jetpack' ) ) {
-				$jetpack_methods['jetpack.testConnection'] = array( $this, 'test_connection' );
+				$jetpack_methods['jetpack.testConnection']    = array( $this, 'test_connection' );
+				$jetpack_methods['jetpack.featuresAvailable'] = array( $this, 'features_available' );
+				$jetpack_methods['jetpack.featuresEnabled']   = array( $this, 'features_enabled' );
 			}
 
 			if ( isset( $core_methods['metaWeblog.editPost'] ) ) {

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -886,7 +886,6 @@ EXPECTED;
 	 */
 	private function assertXMLRPCMethodsComply( $required, $allowed, $actual ) {
 		$this->assertArraySubset( $required, $actual );
-
 		$this->assertEquals( [], array_diff( $actual, $required, $allowed ) );
 	}
 
@@ -899,11 +898,11 @@ EXPECTED;
 		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
 
 		$required = [
-			'jetpack.jsonAPI',
 			'jetpack.verifyAction',
 			'jetpack.getUser',
 			'jetpack.remoteRegister',
 			'jetpack.remoteProvision',
+			'jetpack.jsonAPI',
 		];
 
 		// Nothing else is allowed.
@@ -921,19 +920,19 @@ EXPECTED;
 		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
 
 		$required = [
-			'jetpack.jsonAPI',
 			'jetpack.verifyAction',
 			'jetpack.getUser',
 			'jetpack.remoteRegister',
 			'jetpack.remoteProvision',
+			'jetpack.jsonAPI',
 
-			'jetpack.testConnection',
 			'jetpack.testAPIUserCode',
-			'jetpack.featuresAvailable',
-			'jetpack.featuresEnabled',
 			'jetpack.disconnectBlog',
 			'jetpack.unlinkUser',
 			'jetpack.idcUrlValidation',
+			'jetpack.testConnection',
+			'jetpack.featuresAvailable',
+			'jetpack.featuresEnabled',
 
 			'jetpack.syncObject',
 		];
@@ -961,19 +960,19 @@ EXPECTED;
 		] );
 
 		$required = [
-			'jetpack.jsonAPI',
 			'jetpack.verifyAction',
 			'jetpack.getUser',
 			'jetpack.remoteRegister',
 			'jetpack.remoteProvision',
+			'jetpack.jsonAPI',
 
-			'jetpack.testConnection',
 			'jetpack.testAPIUserCode',
-			'jetpack.featuresAvailable',
-			'jetpack.featuresEnabled',
 			'jetpack.disconnectBlog',
 			'jetpack.unlinkUser',
 			'jetpack.idcUrlValidation',
+			'jetpack.testConnection',
+			'jetpack.featuresAvailable',
+			'jetpack.featuresEnabled',
 
 			'metaWeblog.newMediaObject',
 			'jetpack.updateAttachmentParent',


### PR DESCRIPTION
Fixes #16060

#### Changes proposed in this Pull Request:
* The `jetpack.json_api` and `jetpack.testConnection` endpoints should only be available when the Jetpack plugin is active. Check whether the Jetpack class exists before setting up these endpoints.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:

##### Test with Jetpack active
1. Install, active, and connect Jetpack.
2. Confirm that  the `jetpack.json_api` and `jetpack.testConnection` endpoints are available by making requests to these endpoints. For example, use the Jetpack debugger or access Calypso.

##### Test without Jetpack active
1. Deactivate Jetpack and activate the client-example plugin.
2. Copy the changes in this branch to the connection package in client-example.
3. Follow the test instructions in Issue #16060, and confirm that no errors or warnings are generated.

#### Proposed changelog entry for your changes:
* tbd
