### PR TITLE
External Media: Try adding module to disable feature

### DIFF
--- a/_inc/client/writing/writing-media.jsx
+++ b/_inc/client/writing/writing-media.jsx
@@ -27,11 +27,8 @@ import { isModuleFound as _isModuleFound } from 'state/search';
  * @returns {object} - Controls for carousel.
  */
 function WritingMedia( props ) {
-	const foundCarousel = props.isModuleFound( 'carousel' );
-
-	if ( ! foundCarousel ) {
-		return null;
-	}
+	const foundCarousel = props.isModuleFound( 'carousel' ),
+		foundExternalMedia = props.isModuleFound( 'external-media' );
 
 	const displayComments = props.getOptionValue( 'carousel_display_comments', 'carousel' );
 	const displayExif = props.getOptionValue( 'carousel_display_exif', 'carousel' );
@@ -65,75 +62,102 @@ function WritingMedia( props ) {
 		</CompactFormToggle>
 	);
 
+	const carouselSettings = (
+		<SettingsGroup
+			hasChild
+			module={ { module: 'carousel' } }
+			support={ {
+				link: getRedirectUrl( 'jetpack-support-carousel' ),
+			} }
+		>
+			<p>
+				{ __(
+					'Create full-screen carousel slideshows for the images in your ' +
+						'posts and pages. Carousel galleries are mobile-friendly and ' +
+						'encourage site visitors to interact with your photos.'
+				) }
+			</p>
+			<ModuleToggle
+				slug="carousel"
+				activated={ isCarouselActive }
+				toggling={ props.isSavingAnyOption( 'carousel' ) }
+				toggleModule={ props.toggleModuleNow }
+			>
+				<span className="jp-form-toggle-explanation">
+					{ __( 'Display images in a full-screen carousel gallery' ) }
+				</span>
+			</ModuleToggle>
+			<FormFieldset>
+				{ renderToggle(
+					displayExif,
+					'carousel_display_exif',
+					handleCarouselDisplayExifChange,
+					__( 'Show photo Exif metadata in carousel (when available)' )
+				) }
+				{ renderToggle(
+					displayComments,
+					'carousel_display_comments',
+					handleCarouselDisplayCommentsChange,
+					__( 'Show comments area in carousel' )
+				) }
+				<FormFieldset>
+					<p className="jp-form-setting-explanation">
+						{ __(
+							'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.'
+						) }
+					</p>
+				</FormFieldset>
+				<FormLabel>
+					<FormLegend className="jp-form-label-wide">{ __( 'Carousel color scheme' ) }</FormLegend>
+					<FormSelect
+						name={ 'carousel_background_color' }
+						value={ props.getOptionValue( 'carousel_background_color' ) }
+						disabled={
+							! isCarouselActive ||
+							props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] )
+						}
+						{ ...props }
+						validValues={ props.validValues( 'carousel_background_color', 'carousel' ) }
+					/>
+				</FormLabel>
+			</FormFieldset>
+		</SettingsGroup>
+	);
+
+	const externalMediaSettings = (
+		<SettingsGroup
+			module={ props.module( 'external-media' ) }
+			support={ {
+				text: 'External Media description',
+				link: getRedirectUrl( 'jetpack-support-shortcode-embeds' ),
+			} }
+		>
+			<FormFieldset>
+				<ModuleToggle
+					slug="external-media"
+					activated={ !! props.getOptionValue( 'external-media' ) }
+					toggling={ props.isSavingAnyOption( [ 'external-media' ] ) }
+					disabled={ props.isSavingAnyOption( [ 'external-media' ] ) }
+					toggleModule={ props.toggleModuleNow }
+				>
+					<span className="jp-form-toggle-explanation">
+						{ __( 'Use external media libraries' ) }
+					</span>
+				</ModuleToggle>
+			</FormFieldset>
+		</SettingsGroup>
+	);
+
 	return (
 		<SettingsCard
 			{ ...props }
 			module="media"
 			header={ __( 'Media' ) }
-			hideButton={ ! foundCarousel }
+			hideButton={ ! foundCarousel && ! foundExternalMedia }
 			saveDisabled={ props.isSavingAnyOption( 'carousel_background_color' ) }
 		>
-			<SettingsGroup
-				hasChild
-				module={ { module: 'carousel' } }
-				support={ {
-					link: getRedirectUrl( 'jetpack-support-carousel' ),
-				} }
-			>
-				<p>
-					{ __(
-						'Create full-screen carousel slideshows for the images in your ' +
-							'posts and pages. Carousel galleries are mobile-friendly and ' +
-							'encourage site visitors to interact with your photos.'
-					) }
-				</p>
-				<ModuleToggle
-					slug="carousel"
-					activated={ isCarouselActive }
-					toggling={ props.isSavingAnyOption( 'carousel' ) }
-					toggleModule={ props.toggleModuleNow }
-				>
-					<span className="jp-form-toggle-explanation">
-						{ __( 'Display images in a full-screen carousel gallery' ) }
-					</span>
-				</ModuleToggle>
-				<FormFieldset>
-					{ renderToggle(
-						displayExif,
-						'carousel_display_exif',
-						handleCarouselDisplayExifChange,
-						__( 'Show photo Exif metadata in carousel (when available)' )
-					) }
-					{ renderToggle(
-						displayComments,
-						'carousel_display_comments',
-						handleCarouselDisplayCommentsChange,
-						__( 'Show comments area in carousel' )
-					) }
-					<FormFieldset>
-						<p className="jp-form-setting-explanation">
-							{ __(
-								'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.'
-							) }
-						</p>
-					</FormFieldset>
-					<FormLabel>
-						<FormLegend className="jp-form-label-wide">
-							{ __( 'Carousel color scheme' ) }
-						</FormLegend>
-						<FormSelect
-							name={ 'carousel_background_color' }
-							value={ props.getOptionValue( 'carousel_background_color' ) }
-							disabled={
-								! isCarouselActive ||
-								props.isSavingAnyOption( [ 'carousel', 'carousel_background_color' ] )
-							}
-							{ ...props }
-							validValues={ props.validValues( 'carousel_background_color', 'carousel' ) }
-						/>
-					</FormLabel>
-				</FormFieldset>
-			</SettingsGroup>
+			{ foundCarousel && carouselSettings }
+			{ foundExternalMedia && externalMediaSettings }
 		</SettingsCard>
 	);
 }

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -6,6 +6,7 @@
 		"contact-form",
 		"contact-info",
 		"eventbrite",
+		"external-media",
 		"gathering-tweetstorms",
 		"gif",
 		"google-calendar",

--- a/modules/external-media.php
+++ b/modules/external-media.php
@@ -1,0 +1,61 @@
+<?php // phpcs:ignore
+/**
+ * Module Name: External Media
+ * Module Description: Jetpack’s External Media integrates Google Photos and Pexels free photos into your image blocks.
+ * Sort Order: 28
+ * Recommendation Order: 10
+ * First Introduced: 8.7
+ * Requires Connection: Yes
+ * Auto Activate: Yes
+ * Module Tags: Recommended
+ * Feature: Media
+ * Additional Search Queries:
+ */
+
+/**
+ * Class Jetpack_External_Media.
+ */
+class Jetpack_External_Media {
+	/**
+	 * Module slug.
+	 *
+	 * @var string
+	 */
+	public $module = 'external-media';
+
+	/**
+	 * Jetpack_External_Media constructor.
+	 */
+	public function __construct() {
+		add_action( 'jetpack_activate_module_external-media', array( $this, 'activate_module' ) );
+		add_action( 'jetpack_deactivate_module_external-media', array( $this, 'deactivate_module' ) );
+		add_action( 'jetpack_register_gutenberg_extensions', array( $this, 'register_extension' ) );
+	}
+
+	/**
+	 * Activates module.
+	 */
+	public function activate_module() {
+		\Jetpack_Gutenberg::set_extension_available( $this->module );
+	}
+
+	/**
+	 * Deactivates module.
+	 */
+	public function deactivate_module() {
+		\Jetpack_Gutenberg::set_extension_unavailable( $this->module, 'missing_module' );
+	}
+
+	/**
+	 * Registers extension.
+	 */
+	public function register_extension() {
+		$is_wpcom = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+		if ( $is_wpcom || Jetpack::is_module_active( $this->module ) ) {
+			$this->activate_module();
+		} else {
+			$this->deactivate_module();
+		}
+	}
+}

--- a/modules/module-headings.php
+++ b/modules/module-headings.php
@@ -52,6 +52,11 @@ function jetpack_get_module_i18n( $key ) {
 				'description' => _x( 'Increase reach and traffic.', 'Module Description', 'jetpack' ),
 			),
 
+			'external-media'        => array(
+				'name'        => _x( 'External Media', 'Module Name', 'jetpack' ),
+				'description' => _x( 'Jetpack’s External Media integrates Google Photos and Pexels free photos into your image blocks.', 'Module Description', 'jetpack' ),
+			),
+
 			'google-analytics' => array(
 				'name' => _x( 'Google Analytics', 'Module Name', 'jetpack' ),
 				'description' => _x( 'Set up Google Analytics without touching a line of code.', 'Module Description', 'jetpack' ),
@@ -296,6 +301,7 @@ function jetpack_get_module_i18n_tag( $key ) {
 			'Developers' =>_x( 'Developers', 'Module Tag', 'jetpack' ),
 
 			// Modules with `Recommended` tag:
+			// - modules/external-media.php
 			//  - modules/lazy-images.php
 			//  - modules/monitor.php
 			//  - modules/photon-cdn.php


### PR DESCRIPTION
@marekhrabe suggested adding a setting that lets users disable External Media in case it's taking over media library buttons in custom blocks that happen to be incompatible with the Core API.

This is a first attempt of adding a Jetpack module that allows users to do that.
So far I have not fully grok'd how the modules API works with the extensions and how extensions can be made available or not based on whether a certain module is active.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds an External Media module in the Media settings, allowing to disable External Media.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* TBD

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
