### PR TITLE
External Media: Only use in pre-approved blocks

### DIFF
--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
+import { useBlockEditContext } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -22,18 +23,35 @@ function insertExternalMediaBlocks( settings, name ) {
 	};
 }
 
-if ( isCurrentUserConnected() ) {
+if ( isCurrentUserConnected() && 'function' === typeof useBlockEditContext ) {
+	const isFeaturedImage = props =>
+		props.unstableFeaturedImageFlow ||
+		( props.modalClass && props.modalClass.indexOf( 'featured-image' ) > -1 );
+
 	// Register the new 'browse media' button.
 	addFilter(
 		'editor.MediaUpload',
 		'external-media/replace-media-upload',
 		OriginalComponent => props => {
-			const { allowedTypes, gallery = false, value = [] } = props;
+			const allowedBlocks = [
+				'core/image',
+				'core/gallery',
+				'core/media-text',
+				'jetpack/image-compare',
+				'jetpack/slideshow',
+				'jetpack/tiled-gallery',
+			];
+
+			const { name } = useBlockEditContext();
 			let { render } = props;
 
-			// Only replace button for components that expect images, except existing galleries.
-			if ( allowedTypes.indexOf( 'image' ) > -1 && ! ( gallery && value.length > 0 ) ) {
-				render = button => <MediaButton { ...button } mediaProps={ props } />;
+			if ( allowedBlocks.indexOf( name ) > -1 || isFeaturedImage( props ) ) {
+				const { allowedTypes, gallery = false, value = [] } = props;
+
+				// Only replace button for components that expect images, except existing galleries.
+				if ( allowedTypes.indexOf( 'image' ) > -1 && ! ( gallery && value.length > 0 ) ) {
+					render = button => <MediaButton { ...button } mediaProps={ props } />;
+				}
 			}
 
 			return <OriginalComponent { ...props } render={ render } />;


### PR DESCRIPTION
This limits the use of External Media to blocks that have been tested with it.
Avoids possible collisions with third-party media blocks.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a list of blocks the feature has been tested with
* Adds a check against that list, accounting for featured image.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* In the Editor, insert a block that is part of that list and make sure External Media is still available.
* Insert a CoBlocks gallery block (or any other third-party media block) and verify that only the Media library is available as a source.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed.
