### PR TITLE
Do not show connection error notice to non-admins

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -200,6 +200,7 @@ class JetpackNotices extends React.Component {
 			<div aria-live="polite">
 				<NoticesList />
 				{ this.props.siteConnectionStatus &&
+					this.props.userCanConnectSite &&
 					( this.props.connectionErrors.length > 0 || siteDataErrors.length > 0 ) && (
 						<JetpackConnectionErrors
 							errors={ this.props.connectionErrors.concat( siteDataErrors ) }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #16304 and #16320 we added a new React notice when we see signs the connection is broken, with a CTA to reconnect the site. 

We should only be showing this notice to users that have the capability to reconnect. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-9q9-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Connect Jetpack as an admin
- Trigger the error by breaking the blog token. `Invalidate blog token` button in the Broken Token UI will do the trick. 
- Verify you see the notice in the Jetpack dashboard
- Create/log in as a secondary user that has an `editor` role, or any role lower than admin
- Navigate to the /settings tab as the user, and you should NOT see the notice anymore. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
