### PR TITLE
OpenTable Block: Allow for custom css classes

### DIFF
--- a/extensions/blocks/opentable/deprecated/v1/index.js
+++ b/extensions/blocks/opentable/deprecated/v1/index.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { defaultAttributes } from '../../attributes';
+
+export default {
+	attributes: defaultAttributes,
+	supports: {
+		align: true,
+		html: false,
+	},
+	save: ( { attributes: { rid } } ) => (
+		<>
+			{ rid.map( restaurantId => (
+				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
+					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
+				</a>
+			) ) }
+		</>
+	),
+};

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -8,6 +8,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { defaultAttributes } from './attributes';
+import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import icon from './icon';
 
@@ -37,13 +38,13 @@ export const settings = {
 	},
 	edit,
 	save: ( { attributes: { rid } } ) => (
-		<>
+		<div>
 			{ rid.map( restaurantId => (
 				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
 					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
 				</a>
 			) ) }
-		</>
+		</div>
 	),
 	attributes: defaultAttributes,
 	example: {
@@ -72,4 +73,5 @@ export const settings = {
 			},
 		],
 	},
+	deprecated: [ deprecatedV1 ],
 };


### PR DESCRIPTION
Fixes #15639

#### Changes proposed in this Pull Request:
Update OpenTable block so additional CSS classes are maintained between edits. 

Previously, reloading the editor after saving an additional CSS class under the block's Advanced settings, loses the CSS class from that field. Saving the post again causes the CSS class to be removed from the block's saved content as the Additional CSS Classes field is blank.

#### Pending Issue With This Solution
_I haven't been able to find a means of getting the `className` value for the OpenTable block at the time of migrating a deprecated block. This means that I can't prevent the issue this PR addresses until the block has been migrated and the custom CSS class re-added._

_Open to suggestions on how to tackle this, if anyone has any? I believe the use of this block is rather low as well, so it might not be worth the time wrestling further with this problem._

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
* Checkout this PR branch
* Create a new post, adding OpenTable blocks to it
* Add custom CSS classes for the OpenTable blocks under their Advanced settings
* Save the post
* View post on the frontend and inspect to confirm css classes are present.
* Switch back to the editor and reload the page
* Confirm that the CSS classes are still present under the Additional CSS Field

#### Proposed changelog entry for your changes:
* Bug fix: Ensure OpenTable block additional CSS classes are populated correctly.
