### PR TITLE
API: Add Connection Owner Name to Endpoint

### DIFF
--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -527,3 +527,17 @@ function jetpack_current_user_data() {
 
 	return $current_user_data;
 }
+
+/**
+ * Return the username of the Jetpack connection's owner.
+ *
+ * @since 7.8.0
+ *
+ * @return array
+ */
+function jetpack_connection_owner_name() {
+	$owner_user      = Jetpack_Options::get_option( 'master_user' );
+	$owner_user_data = new WP_User( $owner_user );
+	
+	return $owner_user_data->display_name;
+}

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -527,17 +527,3 @@ function jetpack_current_user_data() {
 
 	return $current_user_data;
 }
-
-/**
- * Return the username of the Jetpack connection's owner.
- *
- * @since 7.8.0
- *
- * @return array
- */
-function jetpack_connection_owner_name() {
-	$owner_user      = Jetpack_Options::get_option( 'master_user' );
-	$owner_user_data = new WP_User( $owner_user );
-	
-	return $owner_user_data->display_name;
-}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1501,7 +1501,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$response = array(
 //			'othersLinked'    => Jetpack::get_other_linked_admins(),
 			'currentUser'     => jetpack_current_user_data(),
-			'connectionOwner' => jetpack_connection_owner_name(),
+			'connectionOwner' => ( new Connection_Manager() )->get_connection_owner()->data->display_name,
 		);
 		return rest_ensure_response( $response );
 	}

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1499,8 +1499,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 		require_once( JETPACK__PLUGIN_DIR . '_inc/lib/admin-pages/class.jetpack-react-page.php' );
 
 		$response = array(
-//			'othersLinked' => Jetpack::get_other_linked_admins(),
-			'currentUser'  => jetpack_current_user_data(),
+//			'othersLinked'    => Jetpack::get_other_linked_admins(),
+			'currentUser'     => jetpack_current_user_data(),
+			'connectionOwner' => jetpack_connection_owner_name(),
 		);
 		return rest_ensure_response( $response );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Required for Automattic/wp-calypso#43788

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds the Jetpack connection owner's username to the API response

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See Automattic/wp-calypso#25812 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
I don't think so, but this data isn't accessible in Calypso currently.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to `/settings/manage-connection/site` in Calypso
* Inspect the call to `?http_envelope=1&path=%2Fjetpack%2Fv4%2Fconnection%2Fdata%2F&locale=en-gb`
* Verify the response includes the connection owner's name

<img width="452" alt="Screenshot 2020-06-30 at 10 52 52" src="https://user-images.githubusercontent.com/43215253/86112468-eadb9380-babf-11ea-8868-347a65cb5ed2.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Probably not needed since this is a change in Calypso
