### PR TITLE
Fix PHP notice in infinite scroll

### DIFF
--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -829,7 +829,7 @@ class The_Neverending_Home_Page {
 
 			// Check if the taxonomy is attached to one post type only and use its plural name.
 			// If not, use "Posts" without confusing the users.
-			if ( count( $taxonomy->object_type ) < 2 ) {
+			if ( $taxonomy && count( $taxonomy->object_type ) < 2 ) {
 				$post_type = $taxonomy->object_type[0];
 			}
 		}

--- a/modules/infinite-scroll/infinity.php
+++ b/modules/infinite-scroll/infinity.php
@@ -829,7 +829,11 @@ class The_Neverending_Home_Page {
 
 			// Check if the taxonomy is attached to one post type only and use its plural name.
 			// If not, use "Posts" without confusing the users.
-			if ( $taxonomy && count( $taxonomy->object_type ) < 2 ) {
+			if (
+				is_a( $taxonomy, 'WP_Taxonomy' )
+				&& is_countable( $taxonomy->object_type )
+				&& count( $taxonomy->object_type ) < 2
+			) {
 				$post_type = $taxonomy->object_type[0];
 			}
 		}


### PR DESCRIPTION
https://github.com/Automattic/jetpack/pull/6584/ introduced a PHP notice in some circumstances:

```[24-Jun-2020 17:24:07 UTC] Warning: count(): Parameter must be an array or an object that implements Countable in /home/wpcom/public_html/wp-content/mu-plugins/infinity/infinity.php on line 832 ```

I can't figure out when this happens, but this should fix it :)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Test that $taxonomy exists before we look for its size

#### Jetpack product discussion
p1593019484077200-vip-devs

#### Testing instructions:
?!

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no change log
