### PR TITLE
only display connection errors to allowed users

### DIFF
--- a/packages/connection/src/error-handlers/class-invalid-blog-token.php
+++ b/packages/connection/src/error-handlers/class-invalid-blog-token.php
@@ -62,6 +62,11 @@ class Invalid_Blog_Token {
 	 * @return void
 	 */
 	public function admin_notice() {
+
+		if ( ! current_user_can( 'jetpack_connect' ) ) {
+			return;
+		}
+
 		?>
 		<div class="notice notice-error is-dismissible jetpack-message jp-connect" style="display:block !important;">
 			<p><?php echo esc_html( $this->message ); ?></p>


### PR DESCRIPTION
This is a small fix to the XML-RPC error handling PR merged yesterday to only display the admin notice errors to users with permission to make connections.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only display connection error notices to users with permission to connect Jetpack to WordPress.com


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Same testing instructions as #16194 
* At the end, log in as a non-admin user and make sure the error message doesn't show up.

