### PR TITLE
React Reconnect Notice: Tracking the error code.

### DIFF
--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -20,6 +20,7 @@ export class ErrorNoticeCycleConnection extends React.Component {
 
 	static propTypes = {
 		text: PropTypes.string.isRequired,
+		errorCode: PropTypes.string,
 	};
 
 	render() {
@@ -30,7 +31,9 @@ export class ErrorNoticeCycleConnection extends React.Component {
 				status={ 'is-error' }
 				icon={ 'link-break' }
 			>
-				<NoticeActionDisconnect>{ __( 'Reconnect' ) }</NoticeActionDisconnect>
+				<NoticeActionDisconnect errorCode={ this.props.errorCode }>
+					{ __( 'Reconnect' ) }
+				</NoticeActionDisconnect>
 			</SimpleNotice>
 		);
 	}
@@ -42,7 +45,9 @@ export default class JetpackConnectionErrors extends React.Component {
 	};
 
 	actions = {
-		reconnect: message => <ErrorNoticeCycleConnection text={ message } />,
+		reconnect: ( message, code ) => (
+			<ErrorNoticeCycleConnection text={ message } errorCode={ code } />
+		),
 	};
 
 	isActionSupported( action ) {

--- a/_inc/client/components/jetpack-notices/notice-action-disconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-disconnect.jsx
@@ -15,13 +15,20 @@ import analytics from 'lib/analytics';
 class NoticeActionDisconnect extends React.Component {
 	static propTypes = {
 		icon: PropTypes.string,
+		errorCode: PropTypes.string,
 	};
 
 	handleDisconnectClick = () => {
-		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_click', {
+		const eventProps = {
 			location: 'dashboard',
 			purpose: 'reconnect',
-		} );
+		};
+
+		if ( this.props.errorCode ) {
+			eventProps.error_code = this.props.errorCode;
+		}
+
+		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_click', eventProps );
 
 		this.props.disconnectSite();
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
When an admin clicks "Reconnect" on the "Connection Error" notice bar, we track the event. This commit adds the error code to the tracking information.

#### Does this pull request change what data or activity we track or use?
Yes, adds a new prop to existing event.

#### Testing instructions:
1. Create the file `wp-content/plugins/jetpack-connection-message.php` with following content:
```
<?php
/** Plugin Name: Jetpack Connection Message Plugin */
add_filter( 'react_connection_errors_initial_state', function( $errors ) {
	$errors[] = array(
		'code' => 'invlaid_blog_token',
		'action' => 'reconnect',
		'message' => 'Connection Error'
	);

	return $errors;
} );
```
2. Load the Jetpack Dashboard, you should see the "Connection Error" notice.
3. Open the "Network" tab in your dev tools, enable "Persist Logs", and click on the "Reconnect" button.
4. An HTTP request should be sent to `https://pixel.wp.com/t.gif`.
5. Confirm the request has the GET-parameter: `error_code=invalid_blog_token`:
<img width="255" alt="Screen Shot 2020-06-30 at 10 01 18 AM" src="https://user-images.githubusercontent.com/1341249/86142458-d516a000-bab8-11ea-8df4-2909309510c3.png">

#### Proposed changelog entry for your changes:
n/a