### PR TITLE
Broken Tokens tool: clean up user token tests

### DIFF
--- a/docker/mu-plugins/jetpack-debug-helper/modules/class-broken-token.php
+++ b/docker/mu-plugins/jetpack-debug-helper/modules/class-broken-token.php
@@ -196,11 +196,11 @@ class Broken_Token {
 			<input type="submit" value="Clear blog token" class="button button-primary button-break-it">
 		</form>
 
-		<p><strong>Break the user token:</strong></p>
+		<p><strong>Break the user tokens:</strong></p>
 		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
 			<input type="hidden" name="action" value="clear_user_tokens">
 			<?php wp_nonce_field( 'clear-user-tokens' ); ?>
-			<input type="submit" value="Clear user token" class="button button-primary button-break-it">
+			<input type="submit" value="Clear user tokens" class="button button-primary button-break-it">
 		</form>
 		<br>
 		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
@@ -291,7 +291,7 @@ class Broken_Token {
 	public function admin_post_set_invalid_user_tokens() {
 		check_admin_referer( 'set-invalid-user-tokens' );
 		$this->notice_type = 'jetpack-broken';
-		foreach ( Jetpack_Options::get_option( 'user_tokens' ) as $id => $token ) {
+		foreach ( Jetpack_Options::get_option( 'user_tokens', array() ) as $id => $token ) {
 			Jetpack_Options::update_option( 'user_tokens', array( $id => $this->invalid_user_token ) );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:
A few small updates to clean up the user token tests:
 * Update the text to 'user tokens' because these tests affect all user tokens
 * Add a default value of an empty array to the `Jetpack_Options::get_option( 'user_tokens')` call. This will prevent warnings that occur when there are no user tokens to change.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Enable the broken token testing tool.
2. Clear the user tokens using the "Clear user tokens" button. There should be no user tokens in the current stored options.
3. Attempt to set invalid user tokens using the "Invalid user tokens" button. Confirm that no warnings have been generated in the debug log.

#### Proposed changelog entry for your changes:
* n/a
