### PR TITLE
Unit Tests: Improve the Geolocation Test.

### DIFF
--- a/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
+++ b/tests/php/modules/geo-location/test_class.jetpack-geo-location.php
@@ -21,8 +21,9 @@ class WP_Test_Jetpack_Geo_Location extends WP_UnitTestCase {
 	public function setUp() {
 		global $post, $wp_query;
 
-		$post     = new stdClass();
-		$post->ID = 1;
+		$post            = new stdClass();
+		$post->ID        = 1;
+		$post->post_type = 'post';
 
 		$this->original_wp_query = $wp_query;
 	}


### PR DESCRIPTION
In https://core.trac.wordpress.org/changeset/48224, Core checks for `$post->post_type` anytime that the `$post` global is not empty.

In the Geolocation test, we make a very simple mock of `$post` with just the ID, so let's add `post_type` too to keep our testing flowing.

Requesting Core check for a WP_Post object in https://core.trac.wordpress.org/ticket/49927 to add a little defense for this if other people are doing something like we are.