### PR TITLE
Core Compat: Site Environment

### DIFF
--- a/_inc/client/README.md
+++ b/_inc/client/README.md
@@ -121,7 +121,7 @@ Action types dispatched during the UI lifecycle are listed in `state/action-type
 * **getSettings( state )**
 * **getSiteAdminUrl( state )**
 * **getSiteConnectionStatus( state )**
-* **getSiteDevMode( state )**
+* **getSiteOfflineMode( state )**
 * **getSitePlan( state )**
 * **getSiteRawUrl( state )**
 * **getSiteRoles( state )**

--- a/_inc/client/at-a-glance/activity.jsx
+++ b/_inc/client/at-a-glance/activity.jsx
@@ -14,24 +14,24 @@ import Card from 'components/card';
 import DashItem from 'components/dash-item';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getSitePlan } from 'state/site';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 //import { PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_VIP } from 'lib/plans/constants';
 
 class DashActivity extends Component {
 	static propTypes = {
-		inDevMode: PropTypes.bool.isRequired,
+		inOfflineMode: PropTypes.bool.isRequired,
 		siteRawUrl: PropTypes.string.isRequired,
 		sitePlan: PropTypes.object.isRequired,
 	};
 
 	static defaultProps = {
-		inDevMode: false,
+		inOfflineMode: false,
 		siteRawUrl: '',
 		sitePlan: '',
 	};
 
 	render() {
-		const { inDevMode } = this.props;
+		const { inOfflineMode } = this.props;
 		// const sitePlan = get( this.props.sitePlan, 'product_slug', 'jetpack_free' );
 		// const hasBackups = includes( [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY, PLAN_VIP ], sitePlan );
 		// const maybeUpgrade = hasBackups
@@ -59,12 +59,14 @@ class DashActivity extends Component {
 					label={ __( 'Activity', 'jetpack' ) }
 					isModule={ false }
 					className={ classNames( {
-						'jp-dash-item__is-inactive': inDevMode,
+						'jp-dash-item__is-inactive': inOfflineMode,
 					} ) }
 					pro={ false }
 				>
 					<p className="jp-dash-item__description">
-						{ inDevMode ? __( 'Unavailable in Dev Mode.', 'jetpack' ) : activityLogOnlyText }
+						{ inOfflineMode
+							? __( 'Unavailable in Offline Mode.', 'jetpack' )
+							: activityLogOnlyText }
 					</p>
 				</DashItem>
 				<Card
@@ -82,5 +84,5 @@ class DashActivity extends Component {
 
 export default connect( state => ( {
 	sitePlan: getSitePlan( state ),
-	inDevMode: isDevMode( state ),
+	inOfflineMode: isOfflineMode( state ),
 } ) )( DashActivity );

--- a/_inc/client/at-a-glance/akismet.jsx
+++ b/_inc/client/at-a-glance/akismet.jsx
@@ -21,7 +21,7 @@ import restApi from 'rest-api';
 import QueryAkismetData from 'components/data/query-akismet-data';
 import { getAkismetData } from 'state/at-a-glance';
 import { getSitePlan } from 'state/site';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { getApiNonce, getUpgradeUrl } from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
 
@@ -32,7 +32,7 @@ class DashAkismet extends Component {
 
 		// Connected props
 		akismetData: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ).isRequired,
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		upgradeUrl: PropTypes.string.isRequired,
 	};
 
@@ -40,7 +40,7 @@ class DashAkismet extends Component {
 		siteRawUrl: '',
 		siteAdminUrl: '',
 		akismetData: 'N/A',
-		isDevMode: '',
+		isOfflineMode: '',
 	};
 
 	trackActivateClick() {
@@ -186,7 +186,7 @@ class DashAkismet extends Component {
 					{ _x( 'Spam comments blocked.', 'Example: "412 Spam comments blocked"', 'jetpack' ) }
 				</p>
 			</DashItem>,
-			! this.props.isDevMode && (
+			! this.props.isOfflineMode && (
 				<Card
 					key="moderate-comments"
 					className="jp-dash-item__manage-in-wpcom"
@@ -212,7 +212,7 @@ class DashAkismet extends Component {
 export default connect( state => ( {
 	akismetData: getAkismetData( state ),
 	sitePlan: getSitePlan( state ),
-	isDevMode: isDevMode( state ),
+	isOfflineMode: isOfflineMode( state ),
 	upgradeUrl: getUpgradeUrl( state, 'aag-akismet' ),
 	nonce: getApiNonce( state ),
 } ) )( DashAkismet );

--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -20,7 +20,7 @@ import getRedirectUrl from 'lib/jp-redirect';
 import { getSitePlan } from 'state/site';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressData } from 'state/at-a-glance';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { getUpgradeUrl, showBackups } from 'state/initial-state';
 
 /**
@@ -58,7 +58,7 @@ class DashBackups extends Component {
 		// Connected props
 		vaultPressData: PropTypes.any.isRequired,
 		sitePlan: PropTypes.object.isRequired,
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		isVaultPressInstalled: PropTypes.bool.isRequired,
 		upgradeUrl: PropTypes.string.isRequired,
 	};
@@ -68,7 +68,7 @@ class DashBackups extends Component {
 		getOptionValue: noop,
 		vaultPressData: '',
 		sitePlan: '',
-		isDevMode: false,
+		isOfflineMode: false,
 		isVaultPressInstalled: false,
 		rewindStatus: '',
 	};
@@ -217,13 +217,13 @@ class DashBackups extends Component {
 			return null;
 		}
 
-		if ( this.props.isDevMode ) {
+		if ( this.props.isOfflineMode ) {
 			return (
 				<div className="jp-dash-item__interior">
 					{ renderCard( {
 						className: 'jp-dash-item__is-inactive',
 						status: 'no-pro-uninstalled-or-inactive',
-						content: __( 'Unavailable in Dev Mode.', 'jetpack' ),
+						content: __( 'Unavailable in Offline Mode.', 'jetpack' ),
 					} ) }
 				</div>
 			);
@@ -249,7 +249,7 @@ export default connect( state => {
 		vaultPressData: getVaultPressData( state ),
 		sitePlan,
 		planClass: getPlanClass( sitePlan ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		showBackups: showBackups( state ),
 		upgradeUrl: getUpgradeUrl( state, 'aag-backups' ),

--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -13,7 +13,7 @@ import { __, sprintf, _x } from '@wordpress/i18n';
 import {
 	getSiteConnectionStatus,
 	isCurrentUserLinked,
-	isDevMode,
+	isOfflineMode,
 	isFetchingUserData as _isFetchingUserData,
 	getConnectedWpComUser as _getConnectedWpComUser,
 } from 'state/connection';
@@ -40,7 +40,7 @@ export class DashConnections extends Component {
 	siteConnection() {
 		let cardContent = '';
 
-		if ( this.props.isDevMode ) {
+		if ( this.props.isOfflineMode ) {
 			cardContent = (
 				<div className="jp-connection-settings__info">
 					{ this.props.siteIcon ? (
@@ -101,7 +101,7 @@ export class DashConnections extends Component {
 
 	/*
 	 * Render a card for user linking. If it's connected, show the currently linked user.
-	 * Show an alternative message if site is in Dev Mode.
+	 * Show an alternative message if site is in Offline Mode.
 	 *
 	 * @returns {string}
 	 */
@@ -112,7 +112,7 @@ export class DashConnections extends Component {
 
 		let cardContent = '';
 
-		if ( this.props.isDevMode ) {
+		if ( this.props.isOfflineMode ) {
 			// return nothing if this is an account connection card
 			return (
 				<div className="jp-connection-settings__info">
@@ -220,7 +220,7 @@ export class DashConnections extends Component {
 
 DashConnections.propTypes = {
 	siteConnectionStatus: PropTypes.any.isRequired,
-	isDevMode: PropTypes.bool.isRequired,
+	isOfflineMode: PropTypes.bool.isRequired,
 	userCanDisconnectSite: PropTypes.bool.isRequired,
 	userIsMaster: PropTypes.bool.isRequired,
 	isLinked: PropTypes.bool.isRequired,
@@ -231,7 +231,7 @@ DashConnections.propTypes = {
 export default connect( state => {
 	return {
 		siteConnectionStatus: getSiteConnectionStatus( state ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		userCanDisconnectSite: userCanDisconnectSite( state ),
 		userIsMaster: userIsMaster( state ),
 		userGravatar: getUserGravatar( state ),

--- a/_inc/client/at-a-glance/connections.jsx
+++ b/_inc/client/at-a-glance/connections.jsx
@@ -33,7 +33,7 @@ import MobileMagicLink from 'components/mobile-magic-link';
 export class DashConnections extends Component {
 	/*
 	 * Render a card for site connection. If it's connected, indicate if user is the connection owner.
-	 * Show alternative message if site is in development mode.
+	 * Show alternative message if site is in offline mode.
 	 *
 	 * @returns {string}
 	 */
@@ -56,7 +56,7 @@ export class DashConnections extends Component {
 					) }
 					<div className="jp-connection-settings__text">
 						{ __(
-							'Your site is in Development Mode, so it can not be connected to WordPress.com.',
+							'Your site is in Offline Mode, so it can not be connected to WordPress.com.',
 							'jetpack'
 						) }
 					</div>

--- a/_inc/client/at-a-glance/index.jsx
+++ b/_inc/client/at-a-glance/index.jsx
@@ -31,7 +31,7 @@ import {
 	userCanViewStats,
 	userIsSubscriber,
 } from 'state/initial-state';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { getModuleOverride } from 'state/modules';
 
 const renderPairs = layout =>
@@ -65,11 +65,11 @@ class AtAGlance extends Component {
 				label={ __( 'Security', 'jetpack' ) }
 				settingsPath={ this.props.userCanManageModules ? '#security' : undefined }
 				externalLink={
-					this.props.isDevMode || ! this.props.userCanManageModules
+					this.props.isOfflineMode || ! this.props.userCanManageModules
 						? ''
 						: __( 'Manage security settings', 'jetpack' )
 				}
-				externalLinkPath={ this.props.isDevMode ? '' : '#/security' }
+				externalLinkPath={ this.props.isOfflineMode ? '' : '#/security' }
 				externalLinkClick={ this.trackSecurityClick }
 			/>
 		);
@@ -184,7 +184,7 @@ export default connect( state => {
 		userCanManageModules: userCanManageModules( state ),
 		userCanViewStats: userCanViewStats( state ),
 		userIsSubscriber: userIsSubscriber( state ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
 		multisite: isMultisite( state ),
 	};

--- a/_inc/client/at-a-glance/monitor.jsx
+++ b/_inc/client/at-a-glance/monitor.jsx
@@ -13,12 +13,12 @@ import { __ } from '@wordpress/i18n';
 import analytics from 'lib/analytics';
 import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleAvailable } from 'state/modules';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import DashItem from 'components/dash-item';
 
 class DashMonitor extends Component {
 	static propTypes = {
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
 	};
 
@@ -63,8 +63,8 @@ class DashMonitor extends Component {
 				className="jp-dash-item__is-inactive"
 			>
 				<p className="jp-dash-item__description">
-					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode.', 'jetpack' )
+					{ this.props.isOfflineMode
+						? __( 'Unavailable in Offline Mode.', 'jetpack' )
 						: jetpackCreateInterpolateElement(
 								__(
 									'<a>Activate Monitor</a> to receive email notifications if your site goes down.',
@@ -85,6 +85,6 @@ class DashMonitor extends Component {
 }
 
 export default connect( state => ( {
-	isDevMode: isDevMode( state ),
+	isOfflineMode: isOfflineMode( state ),
 	isModuleAvailable: isModuleAvailable( state, 'monitor' ),
 } ) )( DashMonitor );

--- a/_inc/client/at-a-glance/photon.jsx
+++ b/_inc/client/at-a-glance/photon.jsx
@@ -13,11 +13,11 @@ import { __ } from '@wordpress/i18n';
 import DashItem from 'components/dash-item';
 import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleAvailable } from 'state/modules';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 
 class DashPhoton extends Component {
 	static propTypes = {
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
 	};
 
@@ -55,8 +55,8 @@ class DashPhoton extends Component {
 				className="jp-dash-item__is-inactive"
 			>
 				<p className="jp-dash-item__description">
-					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode', 'jetpack' )
+					{ this.props.isOfflineMode
+						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: jetpackCreateInterpolateElement(
 								__(
 									"<a>Activate</a> to optimize image sizes and load images from Jetpack's fast global network of servers. This improves your site's performance on desktop and mobile devices.",
@@ -77,6 +77,6 @@ class DashPhoton extends Component {
 }
 
 export default connect( state => ( {
-	isDevMode: isDevMode( state ),
+	isOfflineMode: isOfflineMode( state ),
 	isModuleAvailable: isModuleAvailable( state, 'photon' ),
 } ) )( DashPhoton );

--- a/_inc/client/at-a-glance/plugins.jsx
+++ b/_inc/client/at-a-glance/plugins.jsx
@@ -19,11 +19,11 @@ import DashItem from 'components/dash-item';
 import getRedirectUrl from 'lib/jp-redirect';
 import QueryPluginUpdates from 'components/data/query-plugin-updates';
 import { getPluginUpdates } from 'state/at-a-glance';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 
 class DashPluginUpdates extends Component {
 	static propTypes = {
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		siteRawUrl: PropTypes.string.isRequired,
 		siteAdminUrl: PropTypes.string.isRequired,
 		pluginUpdates: PropTypes.any.isRequired,
@@ -82,7 +82,7 @@ class DashPluginUpdates extends Component {
 									pluginUpdates.count,
 									'jetpack'
 								) + ' ',
-								! this.props.isDevMode &&
+								! this.props.isOfflineMode &&
 									jetpackCreateInterpolateElement(
 										__( '<a>Turn on plugin autoupdates.</a>', 'jetpack' ),
 										{
@@ -93,7 +93,7 @@ class DashPluginUpdates extends Component {
 						: __( 'All plugins are up-to-date. Awesome work!', 'jetpack' ) }
 				</p>
 			</DashItem>,
-			! this.props.isDevMode && (
+			! this.props.isOfflineMode && (
 				<Card
 					key="manage-plugins"
 					className="jp-dash-item__manage-in-wpcom"
@@ -120,5 +120,5 @@ class DashPluginUpdates extends Component {
 
 export default connect( state => ( {
 	pluginUpdates: getPluginUpdates( state ),
-	isDevMode: isDevMode( state ),
+	isOfflineMode: isOfflineMode( state ),
 } ) )( DashPluginUpdates );

--- a/_inc/client/at-a-glance/protect.jsx
+++ b/_inc/client/at-a-glance/protect.jsx
@@ -14,13 +14,13 @@ import { __ } from '@wordpress/i18n';
 import DashItem from 'components/dash-item';
 import { getProtectCount } from 'state/at-a-glance';
 import getRedirectUrl from 'lib/jp-redirect';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { isModuleAvailable } from 'state/modules';
 import QueryProtectCount from 'components/data/query-dash-protect';
 
 class DashProtect extends Component {
 	static propTypes = {
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		protectCount: PropTypes.any.isRequired,
 		isModuleAvailable: PropTypes.bool.isRequired,
 	};
@@ -79,8 +79,8 @@ class DashProtect extends Component {
 				className="jp-dash-item__is-inactive"
 			>
 				<p className="jp-dash-item__description">
-					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode', 'jetpack' )
+					{ this.props.isOfflineMode
+						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: jetpackCreateInterpolateElement(
 								__(
 									'<a>Activate Protect</a> to keep your site protected from malicious sign in attempts.',
@@ -109,6 +109,6 @@ class DashProtect extends Component {
 
 export default connect( state => ( {
 	protectCount: getProtectCount( state ),
-	isDevMode: isDevMode( state ),
+	isOfflineMode: isOfflineMode( state ),
 	isModuleAvailable: isModuleAvailable( state, 'protect' ),
 } ) )( DashProtect );

--- a/_inc/client/at-a-glance/scan.jsx
+++ b/_inc/client/at-a-glance/scan.jsx
@@ -18,7 +18,7 @@ import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getScanStatus, isFetchingScanStatus } from 'state/scan';
 import { isPluginInstalled } from 'state/site/plugins';
 import { getVaultPressScanThreatCount, getVaultPressData } from 'state/at-a-glance';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import DashItem from 'components/dash-item';
 import { get, isArray } from 'lodash';
 import { getUpgradeUrl, showBackups } from 'state/initial-state';
@@ -85,7 +85,7 @@ class DashScan extends Component {
 		vaultPressData: PropTypes.any.isRequired,
 		scanThreats: PropTypes.any.isRequired,
 		sitePlan: PropTypes.object.isRequired,
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		isVaultPressInstalled: PropTypes.bool.isRequired,
 		fetchingSiteData: PropTypes.bool.isRequired,
 		upgradeUrl: PropTypes.string.isRequired,
@@ -96,7 +96,7 @@ class DashScan extends Component {
 		vaultPressData: '',
 		scanThreats: 0,
 		sitePlan: '',
-		isDevMode: false,
+		isOfflineMode: false,
 		isVaultPressInstalled: false,
 		fetchingSiteData: false,
 	};
@@ -278,10 +278,10 @@ class DashScan extends Component {
 			return null;
 		}
 
-		if ( this.props.isDevMode ) {
+		if ( this.props.isOfflineMode ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
-				content: __( 'Unavailable in Dev Mode.', 'jetpack' ),
+				content: __( 'Unavailable in Offline Mode.', 'jetpack' ),
 			} );
 		}
 
@@ -317,7 +317,7 @@ export default connect( state => {
 		scanThreats: getVaultPressScanThreatCount( state ),
 		sitePlan,
 		planClass: getPlanClass( get( sitePlan, 'product_slug', '' ) ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		isVaultPressInstalled: isPluginInstalled( state, 'vaultpress/vaultpress.php' ),
 		fetchingSiteData: isFetchingSiteData( state ),
 		showBackups: showBackups( state ),

--- a/_inc/client/at-a-glance/search.jsx
+++ b/_inc/client/at-a-glance/search.jsx
@@ -18,7 +18,7 @@ import { getPlanClass, PLAN_JETPACK_SEARCH } from 'lib/plans/constants';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getSitePlan, hasActiveSearchPurchase, isFetchingSitePurchases } from 'state/site';
 import { getUpgradeUrl } from 'state/initial-state';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import JetpackBanner from 'components/jetpack-banner';
 import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
 
@@ -51,12 +51,12 @@ class DashSearch extends Component {
 		getOptionValue: PropTypes.func.isRequired,
 
 		// Connected props
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 	};
 
 	static defaultProps = {
 		getOptionValue: noop,
-		isDevMode: false,
+		isOfflineMode: false,
 	};
 
 	trackSearchLink() {
@@ -82,12 +82,12 @@ class DashSearch extends Component {
 			} );
 		}
 
-		if ( this.props.isDevMode ) {
+		if ( this.props.isOfflineMode ) {
 			return renderCard( {
 				className: 'jp-dash-item__is-inactive',
 				status: 'no-pro-uninstalled-or-inactive',
 				pro_inactive: true,
-				content: __( 'Unavailable in Dev Mode', 'jetpack' ),
+				content: __( 'Unavailable in Offline Mode', 'jetpack' ),
 			} );
 		}
 
@@ -169,7 +169,7 @@ class DashSearch extends Component {
 export default connect( state => {
 	return {
 		isBusinessPlan: 'is-business-plan' === getPlanClass( getSitePlan( state ).product_slug ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		isFetching: isFetchingSitePurchases( state ),
 		hasSearchProduct: hasActiveSearchPurchase( state ),
 		upgradeUrl: getUpgradeUrl( state, 'aag-search' ),

--- a/_inc/client/at-a-glance/stats/index.jsx
+++ b/_inc/client/at-a-glance/stats/index.jsx
@@ -23,7 +23,7 @@ import { getInitialStateStatsData } from 'state/initial-state';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getStatsData, statsSwitchTab, fetchStatsData, getActiveStatsTab } from 'state/at-a-glance';
 import { imagePath } from 'constants/urls';
-import { isDevMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
+import { isOfflineMode, isCurrentUserLinked, getConnectUrl } from 'state/connection';
 import { isModuleAvailable, getModuleOverride } from 'state/modules';
 import ModuleOverriddenBanner from 'components/module-overridden-banner';
 import QueryStatsData from 'components/data/query-stats-data';
@@ -31,7 +31,7 @@ import Spinner from 'components/spinner';
 
 export class DashStats extends Component {
 	static propTypes = {
-		isDevMode: PropTypes.bool.isRequired,
+		isOfflineMode: PropTypes.bool.isRequired,
 		siteRawUrl: PropTypes.string.isRequired,
 		siteAdminUrl: PropTypes.string.isRequired,
 		statsData: PropTypes.any.isRequired,
@@ -231,8 +231,8 @@ export class DashStats extends Component {
 					/>
 				</div>
 				<div className="jp-at-a-glance__stats-inactive-text">
-					{ this.props.isDevMode
-						? __( 'Unavailable in Dev Mode', 'jetpack' )
+					{ this.props.isOfflineMode
+						? __( 'Unavailable in Offline Mode', 'jetpack' )
 						: jetpackCreateInterpolateElement(
 								__(
 									'<a>Activate Site Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
@@ -250,7 +250,7 @@ export class DashStats extends Component {
 								}
 						  ) }
 				</div>
-				{ ! this.props.isDevMode && (
+				{ ! this.props.isOfflineMode && (
 					<div className="jp-at-a-glance__stats-inactive-button">
 						<Button onClick={ this.activateStats } primary>
 							{ __( 'Activate Site Stats', 'jetpack' ) }
@@ -343,7 +343,7 @@ export class DashStats extends Component {
 					</DashSectionHeader>
 					<Card
 						className={
-							'jp-at-a-glance__stats-card ' + ( this.props.isDevMode ? 'is-inactive' : '' )
+							'jp-at-a-glance__stats-card ' + ( this.props.isOfflineMode ? 'is-inactive' : '' )
 						}
 					>
 						{ this.renderStatsArea() }
@@ -358,7 +358,7 @@ export default connect(
 	state => ( {
 		isModuleAvailable: isModuleAvailable( state, 'stats' ),
 		activeTab: getActiveStatsTab( state ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		isLinked: isCurrentUserLinked( state ),
 		connectUrl: getConnectUrl( state ),
 		statsData: isEmpty( getStatsData( state ) )

--- a/_inc/client/at-a-glance/stats/test/component.js
+++ b/_inc/client/at-a-glance/stats/test/component.js
@@ -56,7 +56,7 @@ describe( 'Dashboard Stats', () => {
 				day: undefined,
 			},
 			isModuleAvailable: true,
-			isDevMode: false,
+			isOfflineMode: false,
 			moduleList: { stats: {} },
 			activeTab: 'day',
 			isLinked: true,

--- a/_inc/client/at-a-glance/test/component.js
+++ b/_inc/client/at-a-glance/test/component.js
@@ -13,7 +13,7 @@ import { DashConnections } from '../connections';
 describe( 'Connections', () => {
 	let testProps = {
 		siteConnectionStatus: true,
-		isDevMode: false,
+		isOfflineMode: false,
 		userCanDisconnectSite: true,
 		userIsMaster: true,
 		isLinked: true,
@@ -63,9 +63,9 @@ describe( 'Connections', () => {
 
 	} );
 
-	describe( 'when site is in Dev Mode', () => {
+	describe( 'when site is in Offline Mode', () => {
 
-		const wrapper = shallow( <DashConnections { ...testProps } siteConnectionStatus={ false } isDevMode={ true } /> );
+		const wrapper = shallow( <DashConnections { ...testProps } siteConnectionStatus={ false } isOfflineMode={ true } /> );
 
 		it( 'does not show a disconnection link', () => {
 			expect( wrapper.find( 'Connect(ConnectButton)' ) ).to.have.length( 0 );

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -17,7 +17,7 @@ import Card from 'components/card';
 import { getModule as _getModule } from 'state/modules';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { ModuleToggle } from 'components/module-toggle';
 import ProStatus from 'pro-status';
 import SectionHeader from 'components/section-header';
@@ -77,7 +77,7 @@ export class DashItem extends Component {
 					[ 'monitor', 'protect', 'photon', 'vaultpress', 'scan', 'backups', 'akismet', 'search' ],
 					this.props.module
 				) &&
-					this.props.isDevMode ) ||
+					this.props.isOfflineMode ) ||
 				// Avoid toggle for manage as it's no longer a module
 				'manage' === this.props.module ? (
 					''
@@ -96,7 +96,7 @@ export class DashItem extends Component {
 					toggle = (
 						<a
 							href={
-								this.props.isDevMode
+								this.props.isOfflineMode
 									? this.props.siteAdminUrl + 'update-core.php'
 									: getRedirectUrl( 'calypso-plugins-manage', { site: this.props.siteRawUrl } )
 							}
@@ -119,7 +119,7 @@ export class DashItem extends Component {
 			}
 		}
 
-		if ( this.props.pro && ! this.props.isDevMode ) {
+		if ( this.props.pro && ! this.props.isOfflineMode ) {
 			proButton = (
 				<Button onClick={ this.trackPaidBtnClick } compact={ true } href="#/plans">
 					{ _x(
@@ -166,7 +166,7 @@ export class DashItem extends Component {
 export default connect( state => {
 	return {
 		getModule: module_name => _getModule( state, module_name ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		userCanToggle: userCanManageModules( state ),
 		siteRawUrl: getSiteRawUrl( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),

--- a/_inc/client/components/dash-item/test/component.js
+++ b/_inc/client/components/dash-item/test/component.js
@@ -20,7 +20,7 @@ describe( 'DashItem', () => {
 		statusText: '',
 		disabled: true,
 		pro: true,
-		isDevMode: false,
+		isOfflineMode: false,
 		href: getRedirectUrl( 'jetpack' ),
 		userCanToggle: true,
 		siteAdminUrl: 'https://example.org/wp-admin/',
@@ -140,15 +140,15 @@ describe( 'DashItem', () => {
 
 	} );
 
-	describe( 'when site is in Dev Mode, not a PRO module, user can not toggle', () => {
+	describe( 'when site is in Offline Mode, not a PRO module, user can not toggle', () => {
 
 		testProps = Object.assign( testProps, {
-			isDevMode: true
+			isOfflineMode: true
 		} );
 
 		const wrapper = shallow( <DashItem { ...testProps } /> );
 
-		it( 'does not display the PRO button linked to #/plans when site is in Dev Mode', () => {
+		it( 'does not display the PRO button linked to #/plans when site is in Offline Mode', () => {
 			expect( wrapper.find( 'SectionHeader' ).props().cardBadge ).to.have.length( 0 );
 		} );
 
@@ -165,7 +165,7 @@ describe( 'DashItem', () => {
 			module: 'manage',
 			status: 'is-warning',
 			pro: false,
-			isDevMode: false,
+			isOfflineMode: false,
 			userCanToggle: true,
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			siteRawUrl: 'example.org',
@@ -196,7 +196,7 @@ describe( 'DashItem', () => {
 			label: 'Monitor',
 			status: '',
 			pro: false,
-			isDevMode: false,
+			isOfflineMode: false,
 			userCanToggle: true,
 			siteAdminUrl: 'https://example.org/wp-admin/',
 			siteRawUrl: 'example.org',

--- a/_inc/client/components/data/query-connect-url/index.jsx
+++ b/_inc/client/components/data/query-connect-url/index.jsx
@@ -7,11 +7,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { fetchConnectUrl, isFetchingConnectUrl, isDevMode } from 'state/connection';
+import { fetchConnectUrl, isFetchingConnectUrl, isOfflineMode } from 'state/connection';
 
 export class QueryConnectUrl extends React.Component {
 	UNSAFE_componentWillMount() {
-		if ( ! ( this.props.isFetchingConnectUrl || this.props.isDevMode ) ) {
+		if ( ! ( this.props.isFetchingConnectUrl || this.props.isOfflineMode ) ) {
 			this.props.fetchConnectUrl();
 		}
 	}
@@ -25,7 +25,7 @@ export default connect(
 	state => {
 		return {
 			isFetchingConnectUrl: isFetchingConnectUrl( state ),
-			isDevMode: isDevMode( state ),
+			isOfflineMode: isOfflineMode( state ),
 		};
 	},
 	dispatch => {

--- a/_inc/client/components/data/query-rewind-status/index.js
+++ b/_inc/client/components/data/query-rewind-status/index.js
@@ -10,23 +10,23 @@ import { connect } from 'react-redux';
  */
 import { fetchRewindStatus, isFetchingRewindStatus } from 'state/rewind';
 import { getSitePlan } from 'state/site';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 
 class QueryRewindStatus extends Component {
 	static propTypes = {
 		isFetchingRewindStatus: PropTypes.bool,
-		isDevMode: PropTypes.bool,
+		isOfflineMode: PropTypes.bool,
 		sitePlan: PropTypes.object,
 	};
 
 	static defaultProps = {
 		isFetchingRewindStatus: false,
-		isDevMode: false,
+		isOfflineMode: false,
 		sitePlan: {},
 	};
 
 	UNSAFE_componentWillMount() {
-		if ( ! this.props.isFetchingRewindStatus && ! this.props.isDevMode ) {
+		if ( ! this.props.isFetchingRewindStatus && ! this.props.isOfflineMode ) {
 			this.props.fetchRewind();
 		}
 	}
@@ -40,7 +40,7 @@ export default connect(
 	state => {
 		return {
 			isFetchingRewindStatus: isFetchingRewindStatus( state ),
-			isDevMode: isDevMode( state ),
+			isOfflineMode: isOfflineMode( state ),
 			sitePlan: getSitePlan( state ),
 		};
 	},

--- a/_inc/client/components/data/query-scan-status/index.jsx
+++ b/_inc/client/components/data/query-scan-status/index.jsx
@@ -9,21 +9,21 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { fetchScanStatus, isFetchingScanStatus } from 'state/scan';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 
 class QueryScanStatus extends Component {
 	static propTypes = {
 		isFetchingScanStatus: PropTypes.bool,
-		isDevMode: PropTypes.bool,
+		isOfflineMode: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isFetchingScanStatus: false,
-		isDevMode: false,
+		isOfflineMode: false,
 	};
 
 	UNSAFE_componentWillMount() {
-		if ( ! this.props.isFetchingScanStatus && ! this.props.isDevMode ) {
+		if ( ! this.props.isFetchingScanStatus && ! this.props.isOfflineMode ) {
 			this.props.fetchScan();
 		}
 	}
@@ -37,7 +37,7 @@ export default connect(
 	state => {
 		return {
 			isFetchingScanStatus: isFetchingScanStatus( state ),
-			isDevMode: isDevMode( state ),
+			isOfflineMode: isOfflineMode( state ),
 		};
 	},
 	dispatch => {

--- a/_inc/client/components/data/query-setup-wizard-questionnaire/index.jsx
+++ b/_inc/client/components/data/query-setup-wizard-questionnaire/index.jsx
@@ -12,21 +12,21 @@ import {
 	fetchSetupWizardQuestionnaire,
 	isFetchingSetupWizardQuestionnaire,
 } from 'state/setup-wizard';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 
 class QuerySetupWizardQuestionnaire extends Component {
 	static propTypes = {
 		isFetchingSetupWizardQuestionnaire: PropTypes.bool,
-		isDevMode: PropTypes.bool,
+		isOfflineMode: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isFetchingScanStatus: false,
-		isDevMode: false,
+		isOfflineMode: false,
 	};
 
 	componentDidMount() {
-		if ( ! this.props.isFetchingSetupWizardQuestionnaire && ! this.props.isDevMode ) {
+		if ( ! this.props.isFetchingSetupWizardQuestionnaire && ! this.props.isOfflineMode ) {
 			this.props.fetchSetupWizardQuestionnaire();
 		}
 	}
@@ -40,7 +40,7 @@ export default connect(
 	state => {
 		return {
 			isFetchingSetupWizardQuestionnaire: isFetchingSetupWizardQuestionnaire( state ),
-			isDevMode: isDevMode( state ),
+			isOfflineMode: isOfflineMode( state ),
 		};
 	},
 	dispatch => {

--- a/_inc/client/components/data/query-site/index.jsx
+++ b/_inc/client/components/data/query-site/index.jsx
@@ -17,25 +17,25 @@ import {
 	isFetchingSiteData,
 	getSitePlan,
 } from 'state/site';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 
 class QuerySite extends Component {
 	static propTypes = {
 		isFetchingSiteData: PropTypes.bool,
-		isDevMode: PropTypes.bool,
+		isOfflineMode: PropTypes.bool,
 		sitePlan: PropTypes.object,
 	};
 
 	static defaultProps = {
 		isFetchingSiteData: false,
-		isDevMode: false,
+		isOfflineMode: false,
 		sitePlan: {},
 	};
 
 	UNSAFE_componentWillMount() {
 		if (
 			! this.props.isFetchingSiteData &&
-			! this.props.isDevMode &&
+			! this.props.isOfflineMode &&
 			isEmpty( this.props.sitePlan )
 		) {
 			this.props.fetchSiteData();
@@ -54,7 +54,7 @@ export default connect(
 	state => {
 		return {
 			isFetchingSiteData: isFetchingSiteData( state ),
-			isDevMode: isDevMode( state ),
+			isOfflineMode: isOfflineMode( state ),
 			sitePlan: getSitePlan( state ),
 		};
 	},

--- a/_inc/client/components/data/query-user-connection/index.jsx
+++ b/_inc/client/components/data/query-user-connection/index.jsx
@@ -7,11 +7,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { fetchUserConnectionData, isFetchingUserData, isDevMode } from 'state/connection';
+import { fetchUserConnectionData, isFetchingUserData, isOfflineMode } from 'state/connection';
 
 export class QueryUserConnectionData extends React.Component {
 	UNSAFE_componentWillMount() {
-		if ( ! ( this.props.isFetchingUserData || this.props.isDevMode ) ) {
+		if ( ! ( this.props.isFetchingUserData || this.props.isOfflineMode ) ) {
 			this.props.fetchUserConnectionData();
 		}
 	}
@@ -25,7 +25,7 @@ export default connect(
 	state => {
 		return {
 			isFetchingUserData: isFetchingUserData( state ),
-			isDevMode: isDevMode( state ),
+			isOfflineMode: isOfflineMode( state ),
 		};
 	},
 	dispatch => {

--- a/_inc/client/components/foldable-card/style2.scss
+++ b/_inc/client/components/foldable-card/style2.scss
@@ -2,7 +2,7 @@
 
 .dops-foldable-card.dops-card {
 
-	&.devmode-disabled {
+	&.offlinemode-disabled {
 		.dops-foldable-card__summary,
 		.dops-foldable-card__summary_expanded {
 			width: 100px;

--- a/_inc/client/components/forms/styles.scss
+++ b/_inc/client/components/forms/styles.scss
@@ -133,7 +133,7 @@ button.jp-form-input-suffix {
 	height: 100%;
 }
 
-.jp-form-devmode-message.is-compact {
+.jp-form-offlinemode-message.is-compact {
 	width: 100%;
 	padding: 0 1rem;
 	position: absolute;

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -104,7 +104,22 @@ export class OfflineModeNotice extends React.Component {
 				reasons.push( __( 'The jetpack_development_mode filter is active', 'jetpack' ) );
 			}
 			if ( offlineMode.constant ) {
-				reasons.push( __( 'The JETPACK_DEV_DEBUG constant is defined', 'jetpack' ) );
+				reasons.push(
+					sprintf(
+						/* translators: placeholder is a constant, such as WP_LOCAL_DEV. */
+						__( 'The %s constant is defined', 'jetpack' ),
+						'JETPACK_DEV_DEBUG'
+					)
+				);
+			}
+			if ( offlineMode.wpLocalConstant ) {
+				reasons.push(
+					sprintf(
+						/* translators: placeholder is a constant, such as WP_LOCAL_DEV. */
+						__( 'The %s constant is defined', 'jetpack' ),
+						'WP_LOCAL_DEV'
+					)
+				);
 			}
 			if ( offlineMode.url ) {
 				reasons.push( __( 'Your site URL lacks a dot (e.g. http://localhost)', 'jetpack' ) );

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -122,7 +122,9 @@ export class OfflineModeNotice extends React.Component {
 				);
 			}
 			if ( offlineMode.url ) {
-				reasons.push( __( 'Your site URL lacks a dot (e.g. http://localhost)', 'jetpack' ) );
+				reasons.push(
+					__( 'Your site URL is a known local development environment URL', 'jetpack' )
+				);
 			}
 
 			const text = jetpackCreateInterpolateElement(

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -15,7 +15,7 @@ import DismissableNotices from './dismissable';
 import getRedirectUrl from 'lib/jp-redirect';
 import {
 	getSiteConnectionStatus,
-	getSiteDevMode,
+	getSiteOfflineMode,
 	isStaging,
 	isInIdentityCrisis,
 	isCurrentUserLinked,
@@ -92,21 +92,21 @@ StagingSiteNotice.propTypes = {
 	isInIdentityCrisis: PropTypes.bool.isRequired,
 };
 
-export class DevModeNotice extends React.Component {
-	static displayName = 'DevModeNotice';
+export class OfflineModeNotice extends React.Component {
+	static displayName = 'OfflineModeNotice';
 
 	render() {
-		if ( this.props.siteConnectionStatus === 'dev' ) {
-			const devMode = this.props.siteDevMode,
+		if ( this.props.siteConnectionStatus === 'offline' ) {
+			const offlineMode = this.props.siteOfflineMode,
 				reasons = [];
 
-			if ( devMode.filter ) {
+			if ( offlineMode.filter ) {
 				reasons.push( __( 'The jetpack_development_mode filter is active', 'jetpack' ) );
 			}
-			if ( devMode.constant ) {
+			if ( offlineMode.constant ) {
 				reasons.push( __( 'The JETPACK_DEV_DEBUG constant is defined', 'jetpack' ) );
 			}
-			if ( devMode.url ) {
+			if ( offlineMode.url ) {
 				reasons.push( __( 'Your site URL lacks a dot (e.g. http://localhost)', 'jetpack' ) );
 			}
 
@@ -147,9 +147,9 @@ export class DevModeNotice extends React.Component {
 	}
 }
 
-DevModeNotice.propTypes = {
+OfflineModeNotice.propTypes = {
 	siteConnectionStatus: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ).isRequired,
-	siteDevMode: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
+	siteOfflineMode: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
 };
 
 export class UserUnlinked extends React.Component {
@@ -207,9 +207,9 @@ class JetpackNotices extends React.Component {
 					isDevVersion={ this.props.isDevVersion }
 					userIsSubscriber={ this.props.userIsSubscriber }
 				/>
-				<DevModeNotice
+				<OfflineModeNotice
 					siteConnectionStatus={ this.props.siteConnectionStatus }
-					siteDevMode={ this.props.siteDevMode }
+					siteOfflineMode={ this.props.siteOfflineMode }
 				/>
 				<StagingSiteNotice
 					isStaging={ this.props.isStaging }
@@ -245,7 +245,7 @@ export default connect( state => {
 		userIsSubscriber: userIsSubscriber( state ),
 		isLinked: isCurrentUserLinked( state ),
 		isDevVersion: isDevVersion( state ),
-		siteDevMode: getSiteDevMode( state ),
+		siteOfflineMode: getSiteOfflineMode( state ),
 		isStaging: isStaging( state ),
 		isInIdentityCrisis: isInIdentityCrisis( state ),
 		connectionErrors: getConnectionErrors( state ),

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -111,9 +111,9 @@ export class DevModeNotice extends React.Component {
 			}
 
 			const text = jetpackCreateInterpolateElement(
-				/* translators: reasons is an unordered list of reasons why a site may be in Development mode. */
+				/* translators: reasons is an unordered list of reasons why a site may be in Offline mode. */
 				__(
-					'Currently in <a>Development Mode</a> (some features are disabled) because: <reasons/>',
+					'Currently in <a>Offline Mode</a> (some features are disabled) because: <reasons/>',
 					'jetpack'
 				),
 				{

--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -51,7 +51,8 @@ export class Masthead extends React.Component {
 	};
 
 	render() {
-		const devNotice = this.props.siteConnectionStatus === 'dev' ? <code>Dev Mode</code> : '',
+		const offlineNotice =
+				this.props.siteConnectionStatus === 'offline' ? <code>Offline Mode</code> : '',
 			sandboxedBadge = this.props.sandboxDomain ? (
 				<code
 					id="sandbox-domain-badge"
@@ -81,7 +82,7 @@ export class Masthead extends React.Component {
 						<a onClick={ this.trackLogoClick } className="jp-masthead__logo-link" href="#dashboard">
 							<JetpackLogo className="jetpack-logo__masthead" />
 						</a>
-						{ devNotice }
+						{ offlineNotice }
 						{ sandboxedBadge }
 					</div>
 					{ this.props.userCanEditPosts && ! hideNav && (

--- a/_inc/client/components/masthead/test/component.js
+++ b/_inc/client/components/masthead/test/component.js
@@ -22,12 +22,12 @@ describe( 'Masthead', () => {
 		expect( component.find( '.jp-masthead' ) ).to.have.length( 1 );
 	} );
 
-	it( 'does not display the Dev Mode badge when connected', () => {
+	it( 'does not display the Offline Mode badge when connected', () => {
 		expect( component.find( 'code' ) ).to.have.length( 0 );
 	} );
 
-	it( 'displays the badge in Dev Mode', () => {
-		component = shallow( <Masthead siteConnectionStatus="dev"/> );
+	it( 'displays the badge in Offline Mode', () => {
+		component = shallow( <Masthead siteConnectionStatus="offline"/> );
 		expect( component.find( 'code' ) ).to.have.length( 1 );
 	} );
 } );

--- a/_inc/client/components/module-settings/inline-module-toggle.jsx
+++ b/_inc/client/components/module-settings/inline-module-toggle.jsx
@@ -22,7 +22,7 @@ class ModuleSettingsComponent extends Component {
 		const module = this.props.module( this.props.module_slug );
 		return (
 			<div className="jp-upgrade-notice__enable-module">
-				<SettingsGroup hasChild disableInDevMode module={ module }>
+				<SettingsGroup hasChild disableInOfflineMode module={ module }>
 					<ModuleToggle
 						slug={ this.props.module_slug }
 						disabled={ false }

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -11,7 +11,7 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import { isCurrentUserLinked, isDevMode } from 'state/connection';
+import { isCurrentUserLinked, isOfflineMode } from 'state/connection';
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
@@ -55,7 +55,7 @@ export class Navigation extends React.Component {
 					>
 						{ _x( 'At a Glance', 'Navigation item.', 'jetpack' ) }
 					</NavItem>
-					{ ! this.props.isDevMode && this.props.isLinked && (
+					{ ! this.props.isOfflineMode && this.props.isLinked && (
 						<NavItem
 							path="#/my-plan"
 							onClick={ this.trackMyPlanClick }
@@ -64,7 +64,7 @@ export class Navigation extends React.Component {
 							{ _x( 'My Plan', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
-					{ ! this.props.isDevMode && this.props.isLinked && (
+					{ ! this.props.isOfflineMode && this.props.isLinked && (
 						<NavItem
 							path="#/plans"
 							onClick={ this.trackPlansClick }
@@ -99,7 +99,7 @@ export class Navigation extends React.Component {
 
 Navigation.propTypes = {
 	routeName: PropTypes.string.isRequired,
-	isDevMode: PropTypes.bool.isRequired,
+	isOfflineMode: PropTypes.bool.isRequired,
 };
 
 export default connect( state => {
@@ -107,7 +107,7 @@ export default connect( state => {
 		userCanManageModules: _userCanManageModules( state ),
 		userCanViewStats: _userCanViewStats( state ),
 		isModuleActivated: module_name => _isModuleActivated( state, module_name ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		isLinked: isCurrentUserLinked( state ),
 	};
 } )( withRouter( Navigation ) );

--- a/_inc/client/components/settings-group/index.jsx
+++ b/_inc/client/components/settings-group/index.jsx
@@ -12,7 +12,7 @@ import { includes, noop } from 'lodash';
  * Internal dependencies
  */
 import SupportInfo from 'components/support-info';
-import { isDevMode, isUnavailableInDevMode, isCurrentUserLinked } from 'state/connection';
+import { isOfflineMode, isUnavailableInOfflineMode, isCurrentUserLinked } from 'state/connection';
 import { userCanManageModules, isSitePublic, userCanEditPosts } from 'state/initial-state';
 import { isModuleActivated } from 'state/modules';
 
@@ -29,8 +29,9 @@ export const SettingsGroup = props => {
 		return <span />;
 	}
 
-	const disableInDevMode = props.disableInDevMode && props.isUnavailableInDevMode( module.module );
-	let displayFadeBlock = disableInDevMode;
+	const disableInOfflineMode =
+		props.disableInOfflineMode && props.isUnavailableInOfflineMode( module.module );
+	let displayFadeBlock = disableInOfflineMode;
 
 	if ( 'post-by-email' === module.module && ! props.isLinked ) {
 		displayFadeBlock = true;
@@ -41,7 +42,7 @@ export const SettingsGroup = props => {
 			<Card
 				className={ classNames( {
 					'jp-form-has-child': props.hasChild,
-					'jp-form-settings-disable': disableInDevMode,
+					'jp-form-settings-disable': disableInOfflineMode,
 				} ) }
 			>
 				{ displayFadeBlock && <div className="jp-form-block-fade" /> }
@@ -55,35 +56,35 @@ export const SettingsGroup = props => {
 SettingsGroup.propTypes = {
 	support: PropTypes.object,
 	module: PropTypes.object,
-	disableInDevMode: PropTypes.bool.isRequired,
-	isDevMode: PropTypes.bool.isRequired,
+	disableInOfflineMode: PropTypes.bool.isRequired,
+	isOfflineMode: PropTypes.bool.isRequired,
 	isSitePublic: PropTypes.bool.isRequired,
 	userCanManageModules: PropTypes.bool.isRequired,
 	isLinked: PropTypes.bool.isRequired,
-	isUnavailableInDevMode: PropTypes.func.isRequired,
+	isUnavailableInOfflineMode: PropTypes.func.isRequired,
 	className: PropTypes.string,
 };
 
 SettingsGroup.defaultProps = {
 	support: { text: '', link: '' },
 	module: {},
-	disableInDevMode: false,
-	isDevMode: false,
+	disableInOfflineMode: false,
+	isOfflineMode: false,
 	isSitePublic: true,
 	userCanManageModules: false,
 	isLinked: false,
-	isUnavailableInDevMode: noop,
+	isUnavailableInOfflineMode: noop,
 	className: '',
 };
 
 export default connect( state => {
 	return {
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		isSitePublic: isSitePublic( state ),
 		userCanManageModules: userCanManageModules( state ),
 		userCanEditPosts: userCanEditPosts( state ),
 		isLinked: isCurrentUserLinked( state ),
 		isModuleActivated: module => isModuleActivated( state, module ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 	};
 } )( SettingsGroup );

--- a/_inc/client/components/settings-group/test/component.js
+++ b/_inc/client/components/settings-group/test/component.js
@@ -59,11 +59,11 @@ describe( 'SettingsGroup', () => {
 			text: 'Help text about Protect',
 			link: getRedirectUrl( 'jetpack-support-protect' ),
 		},
-		isDevMode: false,
+		isOfflineMode: false,
 		isSitePublic: true,
 		userCanManageModules: true,
 		isLinked: true,
-		isUnavailableInDevMode: () => false
+		isUnavailableInOfflineMode: () => false
 	};
 
 	const settingsGroup = shallow( <SettingsGroup support={ testProps.info } hasChild /> );
@@ -82,10 +82,10 @@ describe( 'SettingsGroup', () => {
 
 	describe( 'has a fading layer', () => {
 
-		it( 'visible in in Dev Mode', () => {
+		it( 'visible in in Offline Mode', () => {
 			const disabled = {
-				disableInDevMode: true,
-				isUnavailableInDevMode: () => true
+				disableInOfflineMode: true,
+				isUnavailableInOfflineMode: () => true
 			};
 			expect( shallow( <SettingsGroup { ...disabled } /> ).find( '.jp-form-block-fade' ) ).to.have.length( 1 );
 		} );

--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -55,14 +55,14 @@ class CommentsComponent extends React.Component {
 			return null;
 		}
 
-		const { isUnavailableInDevMode, getOptionValue } = this.props;
+		const { isUnavailableInOfflineMode: isUnavailableInOfflineMode, getOptionValue } = this.props;
 
 		const comments = this.props.getModule( 'comments' ),
 			isCommentsActive = this.props.getOptionValue( 'comments' ),
-			commentsUnavailableInDevMode = this.props.isUnavailableInDevMode( 'comments' ),
+			commentsUnavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'comments' ),
 			gravatar = this.props.getModule( 'gravatar-hovercards' ),
 			markdown = this.props.getModule( 'markdown' ),
-			commentLikesUnavailable = isUnavailableInDevMode( 'comment-likes' ),
+			commentLikesUnavailable = isUnavailableInOfflineMode( 'comment-likes' ),
 			commentLikesActive = getOptionValue( 'comment-likes' );
 
 		return (
@@ -78,7 +78,7 @@ class CommentsComponent extends React.Component {
 				{ foundComments && (
 					<SettingsGroup
 						hasChild
-						disableInDevMode
+						disableInOfflineMode
 						module={ comments }
 						support={ {
 							text: __(
@@ -91,7 +91,7 @@ class CommentsComponent extends React.Component {
 						<ModuleToggle
 							slug="comments"
 							compact
-							disabled={ commentsUnavailableInDevMode }
+							disabled={ commentsUnavailableInOfflineMode }
 							activated={ this.props.getOptionValue( 'comments' ) }
 							toggling={ this.props.isSavingAnyOption( 'comments' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -108,7 +108,7 @@ class CommentsComponent extends React.Component {
 									value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
 									disabled={
 										! isCommentsActive ||
-										commentsUnavailableInDevMode ||
+										commentsUnavailableInOfflineMode ||
 										this.props.isSavingAnyOption( 'highlander_comment_form_prompt' )
 									}
 									onChange={ this.props.onOptionChange }
@@ -124,7 +124,7 @@ class CommentsComponent extends React.Component {
 									value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
 									disabled={
 										! isCommentsActive ||
-										commentsUnavailableInDevMode ||
+										commentsUnavailableInOfflineMode ||
 										this.props.isSavingAnyOption( 'jetpack_comment_form_color_scheme' )
 									}
 									onChange={ this.props.onOptionChange }

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -12,8 +12,8 @@ import Card from 'components/card';
 import { getModule, getModuleOverride } from 'state/modules';
 import { getSettings } from 'state/settings';
 import {
-	isDevMode,
-	isUnavailableInDevMode,
+	isOfflineMode,
+	isUnavailableInOfflineMode,
 	isCurrentUserLinked,
 	getConnectUrl,
 } from 'state/connection';
@@ -29,8 +29,8 @@ export class Discussion extends React.Component {
 		const commonProps = {
 			settings: this.props.settings,
 			getModule: this.props.module,
-			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isOfflineMode: this.props.isOfflineMode,
+			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 		};
 
 		const foundComments = this.props.isModuleFound( 'comments' ),
@@ -89,8 +89,8 @@ export default connect( state => {
 	return {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
-		isDevMode: isDevMode( state ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isOfflineMode: isOfflineMode( state ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		connectUrl: getConnectUrl( state ),
 		isLinked: isCurrentUserLinked( state ),

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -57,10 +57,10 @@ class SubscriptionsComponent extends React.Component {
 	render() {
 		const subscriptions = this.props.getModule( 'subscriptions' ),
 			isSubscriptionsActive = this.props.getOptionValue( 'subscriptions' ),
-			unavailableInDevMode = this.props.isUnavailableInDevMode( 'subscriptions' );
+			unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'subscriptions' );
 
 		const getSubClickableCard = () => {
-			if ( unavailableInDevMode || ! isSubscriptionsActive ) {
+			if ( unavailableInOfflineMode || ! isSubscriptionsActive ) {
 				return '';
 			}
 
@@ -90,7 +90,7 @@ class SubscriptionsComponent extends React.Component {
 			<SettingsCard { ...this.props } hideButton module="subscriptions">
 				<SettingsGroup
 					hasChild
-					disableInDevMode
+					disableInOfflineMode
 					module={ subscriptions }
 					support={ {
 						text: __(
@@ -102,7 +102,7 @@ class SubscriptionsComponent extends React.Component {
 				>
 					<ModuleToggle
 						slug="subscriptions"
-						disabled={ unavailableInDevMode }
+						disabled={ unavailableInOfflineMode }
 						activated={ isSubscriptionsActive }
 						toggling={ this.props.isSavingAnyOption( 'subscriptions' ) }
 						toggleModule={ this.props.toggleModuleNow }
@@ -115,7 +115,7 @@ class SubscriptionsComponent extends React.Component {
 								checked={ this.state.stb_enabled }
 								disabled={
 									! isSubscriptionsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'subscriptions', 'stb_enabled' ] )
 								}
 								onChange={ this.handleSubscribeToBlogToggleChange }
@@ -128,7 +128,7 @@ class SubscriptionsComponent extends React.Component {
 								checked={ this.state.stc_enabled }
 								disabled={
 									! isSubscriptionsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'subscriptions', 'stc_enabled' ] )
 								}
 								onChange={ this.handleSubscribeToCommentToggleChange }

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -154,9 +154,9 @@ class Main extends React.Component {
 				current_version: this.props.currentVersion,
 			} );
 
-		// Not taking into account development mode here because changing the connection
+		// Not taking into account offline mode here because changing the connection
 		// status without reloading is possible only by disconnecting a live site not
-		// in development mode.
+		// in offline mode.
 		if ( prevProps.siteConnectionStatus !== this.props.siteConnectionStatus ) {
 			const $items = jQuery( '#toplevel_page_jetpack' ).find( 'ul.wp-submenu li' );
 			$items.find( 'a[href$="#/settings"]' ).hide();

--- a/_inc/client/my-plan/index.jsx
+++ b/_inc/client/my-plan/index.jsx
@@ -25,8 +25,8 @@ export function MyPlan( props ) {
 	let sitePlan = props.sitePlan.product_slug || '',
 		availableFeatures = props.availableFeatures,
 		activeFeatures = props.activeFeatures;
-	if ( 'dev' === props.getSiteConnectionStatus( props ) ) {
-		sitePlan = 'dev';
+	if ( 'offline' === props.getSiteConnectionStatus( props ) ) {
+		sitePlan = 'offline';
 		availableFeatures = {};
 		activeFeatures = {};
 	}

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -80,7 +80,7 @@ class MyPlanBody extends React.Component {
 
 	render() {
 		let planCard = '';
-		const planClass = 'dev' !== this.props.plan ? getPlanClass( this.props.plan ) : 'dev';
+		const planClass = 'offline' !== this.props.plan ? getPlanClass( this.props.plan ) : 'offline';
 		const premiumThemesActive = includes(
 				this.props.activeFeatures,
 				FEATURE_UNLIMITED_PREMIUM_THEMES
@@ -617,7 +617,7 @@ class MyPlanBody extends React.Component {
 			case 'is-daily-backup-plan':
 			case 'is-realtime-backup-plan':
 			case 'is-search-plan':
-			case 'dev':
+			case 'offline':
 				planCard = (
 					<div className="jp-landing__plan-features">
 						{ jetpackBackupCard }

--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getModule, getModuleOverride } from 'state/modules';
-import { isUnavailableInDevMode } from 'state/connection';
+import { isUnavailableInOfflineMode } from 'state/connection';
 import { isModuleFound } from 'state/search';
 import Card from 'components/card';
 import QuerySite from 'components/data/query-site';
@@ -24,7 +24,7 @@ class Performance extends Component {
 	render() {
 		const commonProps = {
 			getModule: this.props.module,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			isModuleFound: this.props.isModuleFound,
 			getModuleOverride: this.props.getModuleOverride,
 		};
@@ -66,7 +66,7 @@ class Performance extends Component {
 export default connect( state => {
 	return {
 		module: module_name => getModule( state, module_name ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 		getModuleOverride: module_name => getModuleOverride( state, module_name ),
 	};

--- a/_inc/client/performance/media.jsx
+++ b/_inc/client/performance/media.jsx
@@ -34,7 +34,7 @@ class Media extends React.Component {
 		const videoPressSettings = includes( [ 'is-premium-plan', 'is-business-plan' ], planClass ) && (
 			<SettingsGroup
 				hasChild
-				disableInDevMode
+				disableInOfflineMode
 				module={ videoPress }
 				support={ {
 					link: getRedirectUrl( 'jetpack-support-videopress' ),
@@ -50,7 +50,7 @@ class Media extends React.Component {
 				</p>
 				<ModuleToggle
 					slug="videopress"
-					disabled={ this.props.isUnavailableInDevMode( 'videopress' ) }
+					disabled={ this.props.isUnavailableInOfflineMode( 'videopress' ) }
 					activated={ this.props.getOptionValue( 'videopress' ) }
 					toggling={ this.props.isSavingAnyOption( 'videopress' ) }
 					toggleModule={ this.props.toggleModuleNow }

--- a/_inc/client/performance/speed-up-site.jsx
+++ b/_inc/client/performance/speed-up-site.jsx
@@ -262,7 +262,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 								{ foundPhoton && (
 									<ModuleToggle
 										slug="photon"
-										disabled={ this.props.isUnavailableInDevMode( 'photon' ) }
+										disabled={ this.props.isUnavailableInOfflineMode( 'photon' ) }
 										activated={ this.props.getOptionValue( 'photon' ) }
 										toggling={ this.props.isSavingAnyOption( 'photon' ) }
 										toggleModule={ this.toggleModule }
@@ -304,7 +304,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 							</p>
 							<ModuleToggle
 								slug="lazy-images"
-								disabled={ this.props.isUnavailableInDevMode( 'lazy-images' ) }
+								disabled={ this.props.isUnavailableInOfflineMode( 'lazy-images' ) }
 								activated={ this.props.getOptionValue( 'lazy-images' ) }
 								toggling={ this.props.isSavingAnyOption( 'lazy-images' ) }
 								toggleModule={ this.toggleModule }

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -26,7 +26,7 @@ import {
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getRewindStatus } from 'state/rewind';
 import { getScanStatus } from 'state/scan';
-import { isDevMode } from 'state/connection';
+import { isOfflineMode } from 'state/connection';
 import { isFetchingPluginsData, isPluginActive, isPluginInstalled } from 'state/site/plugins';
 import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
@@ -296,7 +296,7 @@ class ProStatus extends React.Component {
 				<QuerySitePlugins />
 				<QueryAkismetKeyCheck />
 				<QueryVaultPressData />
-				{ ! this.props.isDevMode &&
+				{ ! this.props.isOfflineMode &&
 					getStatus(
 						this.props.proFeature,
 						this.props.pluginActive( pluginSlug ),
@@ -322,7 +322,7 @@ export default connect( state => {
 		fetchingPluginsData: isFetchingPluginsData( state ),
 		pluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
 		pluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),
-		isDevMode: isDevMode( state ),
+		isOfflineMode: isOfflineMode( state ),
 		fetchingSiteData: isFetchingSiteData( state ),
 		isAkismetKeyValid: isAkismetKeyValid( state ),
 		fetchingAkismetData: isFetchingAkismetData( state ),

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -17,7 +17,7 @@ import { isModuleFound } from 'state/search';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { userCanManageModules } from 'state/initial-state';
-import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { isOfflineMode, isUnavailableInOfflineMode } from 'state/connection';
 
 export const SearchableModules = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -44,10 +44,13 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 				results = [];
 			forEach( allModules, ( moduleData, slug ) => {
 				if ( this.props.isModuleFound( slug ) && includes( safelist, slug ) ) {
-					// Not available in dev mode
-					if ( this.props.isDevMode && this.props.isUnavailableInDevMode( moduleData.module ) ) {
+					// Not available in offline mode.
+					if (
+						this.props.isOfflineMode &&
+						this.props.isUnavailableInOfflineMode( moduleData.module )
+					) {
 						return results.push(
-							<ActiveCard key={ slug } moduleData={ moduleData } devMode={ true } />
+							<ActiveCard key={ slug } moduleData={ moduleData } offlineMode={ true } />
 						);
 					}
 
@@ -86,12 +89,12 @@ SearchableModules.defaultProps = {
 class ActiveCard extends Component {
 	render() {
 		const m = this.props.moduleData,
-			devMode = this.props.devMode;
+			offlineMode = this.props.offlineMode;
 
 		return (
 			<SettingsCard module={ m.module } header={ m.name } action={ m.module } hideButton>
 				<SettingsGroup
-					disableInDevMode={ devMode }
+					disableInOfflineMode={ offlineMode }
 					module={ { module: m.module } }
 					support={ { link: m.learn_more_button } }
 				>
@@ -107,7 +110,7 @@ export default connect( state => {
 		modules: getModules( state ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 		canManageModules: userCanManageModules( state ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
-		isDevMode: isDevMode( state ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
+		isOfflineMode: isOfflineMode( state ),
 	};
 } )( SearchableModules );

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -35,7 +35,7 @@ class LoadingCard extends Component {
 				action="scan"
 			>
 				<SettingsGroup
-					disableInDevMode
+					disableInOfflineMode
 					module={ { module: 'backups' } }
 					support={ {
 						text: __(
@@ -54,13 +54,13 @@ class LoadingCard extends Component {
 
 class BackupsScanRewind extends Component {
 	static propTypes = {
-		isDevMode: PropTypes.bool,
+		isOfflineMode: PropTypes.bool,
 		siteRawUrl: PropTypes.string,
 		rewindState: PropTypes.string,
 	};
 
 	static defaultProps = {
-		isDevMode: false,
+		isOfflineMode: false,
 		siteRawUrl: '',
 		rewindState: '',
 	};
@@ -110,8 +110,8 @@ class BackupsScanRewind extends Component {
 	}
 
 	getCardText = () => {
-		if ( this.props.isDevMode ) {
-			return __( 'Unavailable in Dev Mode.', 'jetpack' );
+		if ( this.props.isOfflineMode ) {
+			return __( 'Unavailable in Offline Mode.', 'jetpack' );
 		}
 
 		const { title, icon, description, url } = this.getRewindMessage();
@@ -163,8 +163,8 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				planClass = getPlanClass( this.props.sitePlan.product_slug );
 			let cardText = '';
 
-			if ( this.props.isDevMode ) {
-				return __( 'Unavailable in Dev Mode.', 'jetpack' );
+			if ( this.props.isOfflineMode ) {
+				return __( 'Unavailable in Offline Mode.', 'jetpack' );
 			}
 
 			// We check if the features are active first, rather than the plan because it's possible the site is on a
@@ -261,7 +261,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				>
 					<QueryRewindStatus />
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						module={ { module: 'backups' } }
 						support={ {
 							text: __(
@@ -273,7 +273,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					>
 						{ this.getCardText() }
 					</SettingsGroup>
-					{ ! this.props.isUnavailableInDevMode( 'backups' ) && scanEnabled && (
+					{ ! this.props.isUnavailableInOfflineMode( 'backups' ) && scanEnabled && (
 						<Card
 							compact
 							className="jp-settings-card__configure-link"

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
 import Card from 'components/card';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
-import { isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { isOfflineMode, isUnavailableInOfflineMode } from 'state/connection';
 import { getVaultPressData } from 'state/at-a-glance';
 import { isModuleFound } from 'state/search';
 import { isPluginActive, isPluginInstalled } from 'state/site/plugins';
@@ -65,8 +65,8 @@ export class Security extends Component {
 		const commonProps = {
 			settings: this.props.settings,
 			getModule: this.props.module,
-			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isOfflineMode: this.props.isOfflineMode,
+			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			rewindStatus: this.props.rewindStatus,
 			siteRawUrl: this.props.siteRawUrl,
 		};
@@ -142,8 +142,8 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
 		sitePlan: getSitePlan( state ),
-		isDevMode: isDevMode( state ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isOfflineMode: isOfflineMode( state ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 		isPluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
 		isPluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -56,7 +56,7 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 					header={ _x( 'Auto-update plugins', 'Settings header', 'jetpack' ) }
 					hideButton
 				>
-					<SettingsGroup disableInDevMode module={ this.props.getModule( 'manage' ) }>
+					<SettingsGroup disableInOfflineMode module={ this.props.getModule( 'manage' ) }>
 						<div>
 							{ __(
 								'With Jetpack you can choose to have your plugins auto-updated with each new plugin release. You’ll get the latest security and bug fixes right away, ensuring your site stays secure.',

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -23,7 +23,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 
 		render() {
 			const isMonitorActive = this.props.getOptionValue( 'monitor' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'monitor' );
+				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'monitor' );
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -33,7 +33,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 				>
 					<SettingsGroup
 						hasChild
-						disableInDevMode
+						disableInOfflineMode
 						module={ this.props.getModule( 'monitor' ) }
 						support={ {
 							text: __(
@@ -45,7 +45,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 					>
 						<ModuleToggle
 							slug="monitor"
-							disabled={ unavailableInDevMode }
+							disabled={ unavailableInOfflineMode }
 							activated={ isMonitorActive }
 							toggling={ this.props.isSavingAnyOption( 'monitor' ) }
 							toggleModule={ this.props.toggleModuleNow }

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -75,12 +75,12 @@ export const Protect = withModuleSettingsFormHelpers(
 
 		render() {
 			const isProtectActive = this.props.getOptionValue( 'protect' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'protect' ),
+				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'protect' ),
 				toggle = (
 					<ModuleToggle
 						slug="protect"
 						compact
-						disabled={ unavailableInDevMode }
+						disabled={ unavailableInOfflineMode }
 						activated={ isProtectActive }
 						toggling={ this.props.isSavingAnyOption( 'protect' ) }
 						toggleModule={ this.props.toggleModuleNow }
@@ -100,11 +100,11 @@ export const Protect = withModuleSettingsFormHelpers(
 					<FoldableCard
 						onOpen={ this.trackOpenCard }
 						header={ toggle }
-						className={ classNames( { 'jp-foldable-settings-disable': unavailableInDevMode } ) }
+						className={ classNames( { 'jp-foldable-settings-disable': unavailableInOfflineMode } ) }
 					>
 						<SettingsGroup
 							hasChild
-							disableInDevMode
+							disableInOfflineMode
 							module={ this.props.getModule( 'protect' ) }
 							support={ {
 								text: __(
@@ -128,7 +128,7 @@ export const Protect = withModuleSettingsFormHelpers(
 											<Button
 												disabled={
 													! isProtectActive ||
-													unavailableInDevMode ||
+													unavailableInOfflineMode ||
 													this.currentIpIsSafelisted() ||
 													this.props.isSavingAnyOption( [
 														'protect',
@@ -147,7 +147,7 @@ export const Protect = withModuleSettingsFormHelpers(
 									<Textarea
 										disabled={
 											! isProtectActive ||
-											unavailableInDevMode ||
+											unavailableInOfflineMode ||
 											this.props.isSavingAnyOption( [
 												'protect',
 												'jetpack_protect_global_whitelist',

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -54,7 +54,7 @@ export const SSO = withModuleSettingsFormHelpers(
 
 		render() {
 			const isSSOActive = this.props.getOptionValue( 'sso' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'sso' );
+				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'sso' );
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -64,7 +64,7 @@ export const SSO = withModuleSettingsFormHelpers(
 				>
 					<SettingsGroup
 						hasChild
-						disableInDevMode
+						disableInOfflineMode
 						module={ this.props.getModule( 'sso' ) }
 						support={ {
 							text: __(
@@ -82,7 +82,7 @@ export const SSO = withModuleSettingsFormHelpers(
 						</p>
 						<ModuleToggle
 							slug="sso"
-							disabled={ unavailableInDevMode }
+							disabled={ unavailableInOfflineMode }
 							activated={ isSSOActive }
 							toggling={ this.props.isSavingAnyOption( 'sso' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -96,7 +96,7 @@ export const SSO = withModuleSettingsFormHelpers(
 								checked={ this.state.jetpack_sso_match_by_email }
 								disabled={
 									! isSSOActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_match_by_email' ] )
 								}
 								onChange={ this.handleMatchByEmailToggleChange }
@@ -109,7 +109,7 @@ export const SSO = withModuleSettingsFormHelpers(
 								checked={ this.state.jetpack_sso_require_two_step }
 								disabled={
 									! isSSOActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'sso', 'jetpack_sso_require_two_step' ] )
 								}
 								onChange={ this.handleTwoStepToggleChange }

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -12,8 +12,8 @@ import Card from 'components/card';
 import { getModule } from 'state/modules';
 import { getSettings } from 'state/settings';
 import {
-	isDevMode,
-	isUnavailableInDevMode,
+	isOfflineMode,
+	isUnavailableInOfflineMode,
 	isCurrentUserLinked,
 	getConnectUrl,
 } from 'state/connection';
@@ -29,8 +29,8 @@ class Sharing extends Component {
 		const commonProps = {
 			settings: this.props.settings,
 			getModule: this.props.module,
-			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isOfflineMode: this.props.isOfflineMode,
+			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			isLinked: this.props.isLinked,
 			connectUrl: this.props.connectUrl,
 			siteRawUrl: this.props.siteRawUrl,
@@ -76,8 +76,8 @@ export default connect( state => {
 	return {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
-		isDevMode: isDevMode( state ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isOfflineMode: isOfflineMode( state ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => _isModuleFound( state, module_name ),
 		isLinked: isCurrentUserLinked( state ),
 		connectUrl: getConnectUrl( state ),

--- a/_inc/client/sharing/likes.jsx
+++ b/_inc/client/sharing/likes.jsx
@@ -16,7 +16,7 @@ import { ModuleToggle } from 'components/module-toggle';
 export const Likes = withModuleSettingsFormHelpers(
 	class extends Component {
 		render() {
-			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'likes' );
+			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'likes' );
 			const isActive = this.props.getOptionValue( 'likes' );
 
 			return (
@@ -27,7 +27,7 @@ export const Likes = withModuleSettingsFormHelpers(
 					hideButton
 				>
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						module={ { module: 'likes' } }
 						support={ {
 							text: __(
@@ -42,7 +42,7 @@ export const Likes = withModuleSettingsFormHelpers(
 						</p>
 						<ModuleToggle
 							slug="likes"
-							disabled={ unavailableInDevMode }
+							disabled={ unavailableInOfflineMode }
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'likes' ) }
 							toggleModule={ this.props.toggleModuleNow }

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -25,7 +25,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 		}
 
 		render() {
-			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'publicize' ),
+			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'publicize' ),
 				isLinked = this.props.isLinked,
 				connectUrl = this.props.connectUrl,
 				siteRawUrl = this.props.siteRawUrl,
@@ -33,7 +33,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 				userCanManageModules = this.props.userCanManageModules;
 
 			const configCard = () => {
-				if ( unavailableInDevMode ) {
+				if ( unavailableInOfflineMode ) {
 					return;
 				}
 
@@ -74,7 +74,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 				>
 					{ userCanManageModules && (
 						<SettingsGroup
-							disableInDevMode
+							disableInOfflineMode
 							module={ { module: 'publicize' } }
 							support={ {
 								text: __(
@@ -92,7 +92,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 							</p>
 							<ModuleToggle
 								slug="publicize"
-								disabled={ unavailableInDevMode }
+								disabled={ unavailableInOfflineMode }
 								activated={ isActive }
 								toggling={ this.props.isSavingAnyOption( 'publicize' ) }
 								toggleModule={ this.props.toggleModuleNow }

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -29,11 +29,11 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 				connectUrl = this.props.connectUrl,
 				siteRawUrl = this.props.siteRawUrl,
 				siteAdminUrl = this.props.siteAdminUrl,
-				isDevMode = this.props.isDevMode,
+				isOfflineMode = this.props.isOfflineMode,
 				isActive = this.props.getOptionValue( 'sharedaddy' );
 
 			const configCard = () => {
-				if ( isDevMode ) {
+				if ( isOfflineMode ) {
 					return (
 						<Card
 							compact
@@ -81,7 +81,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 					hideButton
 				>
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						module={ { module: 'sharing' } }
 						support={ {
 							text: __(

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -126,14 +126,14 @@ export const reducer = combineReducers( {
  * Returns true if site is connected to WordPress.com
  *
  * @param  {Object}      state Global state tree
- * @return {bool|string} True if site is connected, False if it is not, 'dev' if site is in offline mode.
+ * @return {bool|string} True if site is connected, False if it is not, 'offline' if site is in offline mode.
  */
 export function getSiteConnectionStatus( state ) {
 	if ( 'object' !== typeof state.jetpack.connection.status.siteConnected ) {
 		return false;
 	}
-	if ( state.jetpack.connection.status.siteConnected.devMode.isActive ) {
-		return 'dev';
+	if ( state.jetpack.connection.status.siteConnected.offlineMode.isActive ) {
+		return 'offline';
 	}
 	return state.jetpack.connection.status.siteConnected.isActive;
 }
@@ -142,12 +142,12 @@ export function getSiteConnectionStatus( state ) {
  * Checks if the site is connected to WordPress.com. Unlike getSiteConnectionStatus, this one returns only a boolean.
  *
  * @param  {Object}  state Global state tree
- * @return {boolean} True if site is connected to WordPress.com. False if site is in Dev Mode or there's no connection data.
+ * @return {boolean} True if site is connected to WordPress.com. False if site is in Offline Mode or there's no connection data.
  */
 export function isSiteConnected( state ) {
 	if (
 		'object' !== typeof state.jetpack.connection.status.siteConnected ||
-		true === state.jetpack.connection.status.siteConnected.devMode.isActive
+		true === state.jetpack.connection.status.siteConnected.offlineMode.isActive
 	) {
 		return false;
 	}
@@ -155,14 +155,14 @@ export function isSiteConnected( state ) {
 }
 
 /**
- * Returns an object with information about the Dev Mode.
+ * Returns an object with information about the Offline Mode.
  *
  * @param  {Object}      state Global state tree
- * @return {bool|object} False if site is not in Dev Mode. If it is, returns an object with information about the Dev Mode.
+ * @return {bool|object} False if site is not in Offline Mode. If it is, returns an object with information about the Offline Mode.
  */
-export function getSiteDevMode( state ) {
-	if ( get( state.jetpack.connection.status, [ 'siteConnected', 'devMode', 'isActive' ] ) ) {
-		return get( state.jetpack.connection.status, [ 'siteConnected', 'devMode' ] );
+export function getSiteOfflineMode( state ) {
+	if ( get( state.jetpack.connection.status, [ 'siteConnected', 'offlineMode', 'isActive' ] ) ) {
+		return get( state.jetpack.connection.status, [ 'siteConnected', 'offlineMode' ] );
 	}
 	return false;
 }
@@ -251,10 +251,10 @@ export function isCurrentUserLinked( state ) {
  * Checks if the site is currently in offline mode.
  *
  * @param  {Object}  state Global state tree
- * @return {boolean} True if site is in dev mode. False otherwise.
+ * @return {boolean} True if site is in offline mode. False otherwise.
  */
-export function isDevMode( state ) {
-	return 'dev' === getSiteConnectionStatus( state );
+export function isOfflineMode( state ) {
+	return 'offline' === getSiteConnectionStatus( state );
 }
 
 /**
@@ -293,10 +293,10 @@ export function requiresConnection( state, slug ) {
  *
  * @param  {Object}  state Global state tree
  * @param  {String}  module Module slug.
- * @return {boolean} True if site is in dev mode and module requires connection. False otherwise.
+ * @return {boolean} True if site is in offline mode and module requires connection. False otherwise.
  */
-export function isUnavailableInDevMode( state, module ) {
-	return isDevMode( state ) && requiresConnection( state, module );
+export function isUnavailableInOfflineMode( state, module ) {
+	return isOfflineMode( state ) && requiresConnection( state, module );
 }
 
 /**

--- a/_inc/client/state/connection/reducer.js
+++ b/_inc/client/state/connection/reducer.js
@@ -126,7 +126,7 @@ export const reducer = combineReducers( {
  * Returns true if site is connected to WordPress.com
  *
  * @param  {Object}      state Global state tree
- * @return {bool|string} True if site is connected, False if it is not, 'dev' if site is in development mode.
+ * @return {bool|string} True if site is connected, False if it is not, 'dev' if site is in offline mode.
  */
 export function getSiteConnectionStatus( state ) {
 	if ( 'object' !== typeof state.jetpack.connection.status.siteConnected ) {
@@ -248,7 +248,7 @@ export function isCurrentUserLinked( state ) {
 }
 
 /**
- * Checks if the site is currently in development mode.
+ * Checks if the site is currently in offline mode.
  *
  * @param  {Object}  state Global state tree
  * @return {boolean} True if site is in dev mode. False otherwise.
@@ -289,7 +289,7 @@ export function requiresConnection( state, slug ) {
 }
 
 /**
- * Checks if the current module is unavailable in development mode.
+ * Checks if the current module is unavailable in offline mode.
  *
  * @param  {Object}  state Global state tree
  * @param  {String}  module Module slug.

--- a/_inc/client/state/connection/test/selectors.js
+++ b/_inc/client/state/connection/test/selectors.js
@@ -24,7 +24,7 @@ let state = {
 			status: {
 				siteConnected: {
 					isActive: true,
-					devMode: {
+					offlineMode: {
 						isActive: false
 					}
 				}

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -47,7 +47,7 @@ export const Ads = withModuleSettingsFormHelpers(
 
 		render() {
 			const isAdsActive = this.props.getOptionValue( 'wordads' );
-			const unavailableInDevMode = this.props.isUnavailableInDevMode( 'wordads' );
+			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'wordads' );
 			const enable_header_ad = this.props.getOptionValue( 'enable_header_ad', 'wordads' );
 			const wordads_second_belowpost = this.props.getOptionValue(
 				'wordads_second_belowpost',
@@ -82,7 +82,7 @@ export const Ads = withModuleSettingsFormHelpers(
 					saveDisabled={ this.props.isSavingAnyOption( [ 'wordads_custom_adstxt' ] ) }
 				>
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						hasChild
 						module={ { module: 'wordads' } }
 						support={ {
@@ -121,7 +121,7 @@ export const Ads = withModuleSettingsFormHelpers(
 
 						<ModuleToggle
 							slug="wordads"
-							disabled={ unavailableInDevMode }
+							disabled={ unavailableInOfflineMode }
 							activated={ isAdsActive }
 							toggling={ this.props.isSavingAnyOption( 'wordads' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -136,7 +136,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ wordads_display_front_page }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_front_page' ] )
 								}
 								onChange={ this.handleChange( 'wordads_display_front_page' ) }
@@ -149,7 +149,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ wordads_display_post }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_post' ] )
 								}
 								onChange={ this.handleChange( 'wordads_display_post' ) }
@@ -160,7 +160,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ wordads_display_page }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_page' ] )
 								}
 								onChange={ this.handleChange( 'wordads_display_page' ) }
@@ -171,7 +171,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ wordads_display_archive }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'wordads_display_archive' ] )
 								}
 								onChange={ this.handleChange( 'wordads_display_archive' ) }
@@ -185,7 +185,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ enable_header_ad }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'enable_header_ad' ] )
 								}
 								onChange={ this.handleChange( 'enable_header_ad' ) }
@@ -198,7 +198,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ wordads_second_belowpost }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'wordads_second_belowpost' ] )
 								}
 								onChange={ this.handleChange( 'wordads_second_belowpost' ) }
@@ -242,7 +242,7 @@ export const Ads = withModuleSettingsFormHelpers(
 							checked={ wordads_ccpa_enabled }
 							disabled={
 								! isAdsActive ||
-								unavailableInDevMode ||
+								unavailableInOfflineMode ||
 								this.props.isSavingAnyOption( [ 'wordads', 'wordads_ccpa_enabled' ] )
 							}
 							onChange={ this.handleChange( 'wordads_ccpa_enabled' ) }
@@ -317,7 +317,7 @@ export const Ads = withModuleSettingsFormHelpers(
 									value={ wordads_ccpa_privacy_policy_url }
 									disabled={
 										! isAdsActive ||
-										unavailableInDevMode ||
+										unavailableInOfflineMode ||
 										! wordads_ccpa_enabled ||
 										this.props.isSavingAnyOption( [ 'wordads', 'wordads_ccpa_privacy_policy_url' ] )
 									}
@@ -347,7 +347,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								checked={ wordads_custom_adstxt_enabled }
 								disabled={
 									! isAdsActive ||
-									unavailableInDevMode ||
+									unavailableInOfflineMode ||
 									this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt_enabled' ] )
 								}
 								onChange={ this.handleChange( 'wordads_custom_adstxt_enabled' ) }
@@ -392,7 +392,7 @@ export const Ads = withModuleSettingsFormHelpers(
 									value={ wordads_custom_adstxt }
 									disabled={
 										! isAdsActive ||
-										unavailableInDevMode ||
+										unavailableInOfflineMode ||
 										this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt' ] )
 									}
 									onChange={ this.props.onOptionChange }
@@ -400,7 +400,7 @@ export const Ads = withModuleSettingsFormHelpers(
 							</FormFieldset>
 						) }
 					</SettingsGroup>
-					{ ! unavailableInDevMode && isAdsActive && (
+					{ ! unavailableInOfflineMode && isAdsActive && (
 						<Card
 							compact
 							className="jp-settings-card__configure-link"

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -31,7 +31,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 					hideButton
 				>
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						module={ { module: 'google-analytics' } }
 						support={ {
 							text: __(
@@ -57,7 +57,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 							}
 						) }
 					</SettingsGroup>
-					{ ! this.props.isUnavailableInDevMode( 'google-analytics' ) && (
+					{ ! this.props.isUnavailableInOfflineMode( 'google-analytics' ) && (
 						<Card
 							compact
 							className="jp-settings-card__configure-link"

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -12,7 +12,7 @@ import Card from 'components/card';
 import { getModule, getModuleOverride } from 'state/modules';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getSettings } from 'state/settings';
-import { isSiteConnected, isDevMode, isUnavailableInDevMode } from 'state/connection';
+import { isSiteConnected, isOfflineMode, isUnavailableInOfflineMode } from 'state/connection';
 import { isModuleFound } from 'state/search';
 import QuerySite from 'components/data/query-site';
 import { SEO } from './seo';
@@ -34,8 +34,8 @@ export class Traffic extends React.Component {
 			siteRawUrl: this.props.siteRawUrl,
 			getModule: this.props.module,
 			isSiteConnected: this.props.isSiteConnected,
-			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isOfflineMode: this.props.isOfflineMode,
+			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			getModuleOverride: this.props.getModuleOverride,
 		};
 
@@ -132,8 +132,8 @@ export default connect( state => {
 	return {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
-		isDevMode: isDevMode( state ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isOfflineMode: isOfflineMode( state ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		isModuleFound: module_name => isModuleFound( state, module_name ),
 		isSiteConnected: isSiteConnected( state ),
 		lastPostUrl: getLastPostUrl( state ),

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -57,12 +57,12 @@ class RelatedPostsComponent extends React.Component {
 
 	render() {
 		const isRelatedPostsActive = this.props.getOptionValue( 'related-posts' ),
-			unavailableInDevMode = this.props.isUnavailableInDevMode( 'related-posts' );
+			unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'related-posts' );
 		return (
 			<SettingsCard { ...this.props } hideButton module="related-posts">
 				<SettingsGroup
 					hasChild
-					disableInDevMode
+					disableInOfflineMode
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
 						text: __(
@@ -91,7 +91,7 @@ class RelatedPostsComponent extends React.Component {
 					</p>
 					<ModuleToggle
 						slug="related-posts"
-						disabled={ unavailableInDevMode }
+						disabled={ unavailableInOfflineMode }
 						activated={ isRelatedPostsActive }
 						toggling={ this.props.isSavingAnyOption( 'related-posts' ) }
 						toggleModule={ this.props.toggleModuleNow }
@@ -105,7 +105,7 @@ class RelatedPostsComponent extends React.Component {
 							checked={ this.state.show_headline }
 							disabled={
 								! isRelatedPostsActive ||
-								unavailableInDevMode ||
+								unavailableInOfflineMode ||
 								this.props.isSavingAnyOption( [ 'related-posts', 'show_headline' ] )
 							}
 							onChange={ this.handleShowHeadlineToggleChange }
@@ -118,7 +118,7 @@ class RelatedPostsComponent extends React.Component {
 							checked={ this.state.show_thumbnails }
 							disabled={
 								! isRelatedPostsActive ||
-								unavailableInDevMode ||
+								unavailableInOfflineMode ||
 								this.props.isSavingAnyOption( [ 'related-posts', 'show_thumbnails' ] )
 							}
 							onChange={ this.handleShowThumbnailsToggleChange }
@@ -189,7 +189,7 @@ class RelatedPostsComponent extends React.Component {
 						) }
 					</FormFieldset>
 				</SettingsGroup>
-				{ ! this.props.isUnavailableInDevMode( 'related-posts' ) && isRelatedPostsActive && (
+				{ ! this.props.isUnavailableInOfflineMode( 'related-posts' ) && isRelatedPostsActive && (
 					<Card
 						compact
 						className="jp-settings-card__configure-link"

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -32,7 +32,7 @@ class SeoComponent extends React.Component {
 				hideButton
 			>
 				<SettingsGroup
-					disableInDevMode
+					disableInOfflineMode
 					module={ { module: 'seo-tools' } }
 					support={ {
 						text: __(
@@ -49,7 +49,7 @@ class SeoComponent extends React.Component {
 						) }
 					</span>
 				</SettingsGroup>
-				{ ! this.props.isUnavailableInDevMode( 'seo-tools' ) &&
+				{ ! this.props.isUnavailableInOfflineMode( 'seo-tools' ) &&
 					( 'is-business-plan' === planClass || 'is-premium-plan' === planClass ) && (
 						<Card
 							compact

--- a/_inc/client/traffic/shortlinks.jsx
+++ b/_inc/client/traffic/shortlinks.jsx
@@ -32,7 +32,7 @@ class Shortlinks extends Component {
 						text: this.props.shortlinksModule.description,
 						link: getRedirectUrl( 'jetpack-support-shortlinks' ),
 					} }
-					disableInDevMode
+					disableInOfflineMode
 				>
 					<ModuleToggle
 						slug="shortlinks"

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -113,7 +113,7 @@ class SiteStatsComponent extends React.Component {
 	render() {
 		const stats = this.props.getModule( 'stats' ),
 			isStatsActive = this.props.getOptionValue( 'stats' ),
-			unavailableInDevMode = this.props.isUnavailableInDevMode( 'stats' ),
+			unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'stats' ),
 			siteRoles = this.props.getSiteRoles();
 
 		if ( 'inactive' === this.props.getModuleOverride( 'stats' ) ) {
@@ -124,7 +124,7 @@ class SiteStatsComponent extends React.Component {
 			return (
 				<Card
 					className={
-						'jp-at-a-glance__stats-card ' + ( this.props.isDevMode ? 'is-inactive' : '' )
+						'jp-at-a-glance__stats-card ' + ( this.props.isOfflineMode ? 'is-inactive' : '' )
 					}
 				>
 					<div className="jp-at-a-glance__stats-inactive">
@@ -138,8 +138,8 @@ class SiteStatsComponent extends React.Component {
 							/>
 						</div>
 						<div className="jp-at-a-glance__stats-inactive-text">
-							{ this.props.isDevMode
-								? __( 'Unavailable in Dev Mode', 'jetpack' )
+							{ this.props.isOfflineMode
+								? __( 'Unavailable in Offline Mode', 'jetpack' )
 								: jetpackCreateInterpolateElement(
 										__(
 											'<a>Activate Site Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
@@ -157,7 +157,7 @@ class SiteStatsComponent extends React.Component {
 										}
 								  ) }
 						</div>
-						{ ! this.props.isDevMode && (
+						{ ! this.props.isOfflineMode && (
 							<div className="jp-at-a-glance__stats-inactive-button">
 								<Button onClick={ this.activateStats } primary={ true }>
 									{ __( 'Activate Site Stats', 'jetpack' ) }
@@ -184,11 +184,11 @@ class SiteStatsComponent extends React.Component {
 					) }
 					clickableHeader={ true }
 					className={ classNames( 'jp-foldable-settings-standalone', {
-						'jp-foldable-settings-disable': unavailableInDevMode,
+						'jp-foldable-settings-disable': unavailableInOfflineMode,
 					} ) }
 				>
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						module={ stats }
 						support={ {
 							text: __(
@@ -201,7 +201,7 @@ class SiteStatsComponent extends React.Component {
 						<FormFieldset>
 							<CompactFormToggle
 								checked={ !! this.props.getOptionValue( 'admin_bar' ) }
-								disabled={ ! isStatsActive || unavailableInDevMode }
+								disabled={ ! isStatsActive || unavailableInOfflineMode }
 								toggling={ this.props.isSavingAnyOption( [ 'stats', 'admin_bar' ] ) }
 								onChange={ this.handleStatsOptionToggle( 'admin_bar' ) }
 							>
@@ -213,7 +213,7 @@ class SiteStatsComponent extends React.Component {
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ !! this.props.getOptionValue( 'hide_smile' ) }
-								disabled={ ! isStatsActive || unavailableInDevMode }
+								disabled={ ! isStatsActive || unavailableInOfflineMode }
 								toggling={ this.props.isSavingAnyOption( [ 'stats', 'hide_smile' ] ) }
 								onChange={ this.handleStatsOptionToggle( 'hide_smile' ) }
 							>
@@ -232,7 +232,7 @@ class SiteStatsComponent extends React.Component {
 									checked={ this.state[ `count_roles_${ key }` ] }
 									disabled={
 										! isStatsActive ||
-										unavailableInDevMode ||
+										unavailableInOfflineMode ||
 										this.props.isSavingAnyOption( [ 'stats', 'count_roles' ] )
 									}
 									onChange={ this.handleRoleToggleChange( key, 'count_roles' ) }
@@ -254,7 +254,7 @@ class SiteStatsComponent extends React.Component {
 											checked={ this.state[ `roles_${ key }` ] }
 											disabled={
 												! isStatsActive ||
-												unavailableInDevMode ||
+												unavailableInOfflineMode ||
 												this.props.isSavingAnyOption( [ 'stats', 'roles' ] )
 											}
 											onChange={ this.handleRoleToggleChange( key, 'roles' ) }

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -12,8 +12,8 @@ import Card from 'components/card';
 import { getSettings } from 'state/settings';
 import { userCanManageModules, userCanEditPosts, isAtomicSite } from 'state/initial-state';
 import {
-	isDevMode,
-	isUnavailableInDevMode,
+	isOfflineMode,
+	isUnavailableInOfflineMode,
 	isCurrentUserLinked,
 	getConnectUrl,
 } from 'state/connection';
@@ -35,8 +35,8 @@ export class Writing extends React.Component {
 		const commonProps = {
 			settings: this.props.settings,
 			getModule: this.props.module,
-			isDevMode: this.props.isDevMode,
-			isUnavailableInDevMode: this.props.isUnavailableInDevMode,
+			isOfflineMode: this.props.isOfflineMode,
+			isUnavailableInOfflineMode: this.props.isUnavailableInOfflineMode,
 			isLinked: this.props.isLinked,
 			getModuleOverride: this.props.getModuleOverride,
 		};
@@ -121,8 +121,8 @@ export default connect( state => {
 		module: module_name => getModule( state, module_name ),
 		settings: getSettings( state ),
 		masterbarIsAlwaysActive: isAtomicSite( state ),
-		isDevMode: isDevMode( state ),
-		isUnavailableInDevMode: module_name => isUnavailableInDevMode( state, module_name ),
+		isOfflineMode: isOfflineMode( state ),
+		isUnavailableInOfflineMode: module_name => isUnavailableInOfflineMode( state, module_name ),
 		userCanEditPosts: userCanEditPosts( state ),
 		isModuleActivated: module_name => isModuleActivated( state, module_name ),
 		isLinked: isCurrentUserLinked( state ),

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -18,7 +18,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 	class extends Component {
 		render() {
 			const isActive = this.props.getOptionValue( 'masterbar' ),
-				unavailableInDevMode = this.props.isUnavailableInDevMode( 'masterbar' ),
+				unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'masterbar' ),
 				isLinked = this.props.isLinked;
 
 			return (
@@ -29,7 +29,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 					hideButton
 				>
 					<SettingsGroup
-						disableInDevMode
+						disableInOfflineMode
 						module={ { module: 'masterbar' } }
 						support={ {
 							text: __(
@@ -47,7 +47,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						</p>
 						<ModuleToggle
 							slug="masterbar"
-							disabled={ unavailableInDevMode || ! isLinked }
+							disabled={ unavailableInOfflineMode || ! isLinked }
 							activated={ isActive }
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }
@@ -55,7 +55,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 							{ __( 'Enable the WordPress.com toolbar', 'jetpack' ) }
 						</ModuleToggle>
 					</SettingsGroup>
-					{ ! this.props.isUnavailableInDevMode( 'masterbar' ) && ! this.props.isLinked && (
+					{ ! this.props.isUnavailableInOfflineMode( 'masterbar' ) && ! this.props.isLinked && (
 						<Card
 							compact
 							className="jp-settings-card__configure-link"

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -47,14 +47,14 @@ class PostByEmail extends React.Component {
 		const postByEmail = this.props.getModule( 'post-by-email' ),
 			isPbeActive = this.props.getOptionValue( 'post-by-email' ),
 			disabledControls =
-				this.props.isUnavailableInDevMode( 'post-by-email' ) || ! this.props.isLinked,
+				this.props.isUnavailableInOfflineMode( 'post-by-email' ) || ! this.props.isLinked,
 			emailAddress = this.address();
 
 		return (
 			<SettingsCard { ...this.props } module="post-by-email" hideButton>
 				<SettingsGroup
 					hasChild
-					disableInDevMode
+					disableInOfflineMode
 					module={ postByEmail }
 					support={ {
 						text: __(
@@ -114,7 +114,7 @@ class PostByEmail extends React.Component {
 						</Button>
 					</FormFieldset>
 				</SettingsGroup>
-				{ ! this.props.isUnavailableInDevMode( 'post-by-email' ) && ! this.props.isLinked && (
+				{ ! this.props.isUnavailableInOfflineMode( 'post-by-email' ) && ! this.props.isLinked && (
 					<Card
 						compact
 						className="jp-settings-card__configure-link"

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -54,14 +54,14 @@ abstract class Jetpack_Admin_Page {
 	function add_actions() {
 		global $pagenow;
 
-		$is_development_mode = ( new Status() )->is_development_mode();
+		$is_offline_mode = ( new Status() )->is_offline_mode();
 		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything.
-		if ( ! current_user_can( 'manage_options' ) && ( $is_development_mode || ! Jetpack::is_active() ) ) {
+		if ( ! current_user_can( 'manage_options' ) && ( $is_offline_mode || ! Jetpack::is_active() ) ) {
 			return;
 		}
 
 		// Don't add in the modules page unless modules are available!
-		if ( $this->dont_show_if_not_active && ! Jetpack::is_active() && ! $is_development_mode ) {
+		if ( $this->dont_show_if_not_active && ! Jetpack::is_active() && ! $is_offline_mode ) {
 			return;
 		}
 
@@ -83,7 +83,7 @@ abstract class Jetpack_Admin_Page {
 			( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] )
 			&& ! Jetpack::is_active()
 			&& current_user_can( 'jetpack_connect' )
-			&& ! $is_development_mode
+			&& ! $is_offline_mode
 		) {
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_banner_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
@@ -97,7 +97,7 @@ abstract class Jetpack_Admin_Page {
 			( 'index.php' === $pagenow || 'plugins.php' === $pagenow )
 			&& ! Jetpack::is_active()
 			&& current_user_can( 'jetpack_connect' )
-			&& ! $is_development_mode
+			&& ! $is_offline_mode
 		) {
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
 		}
@@ -175,7 +175,7 @@ abstract class Jetpack_Admin_Page {
 	 */
 	function check_plan_deactivate_modules( $page ) {
 		if (
-			( new Status() )->is_development_mode()
+			( new Status() )->is_offline_mode()
 			|| ! in_array(
 				$page->base,
 				array(
@@ -276,11 +276,11 @@ abstract class Jetpack_Admin_Page {
 		);
 		$args              = wp_parse_args( $args, $defaults );
 		$jetpack_admin_url = admin_url( 'admin.php?page=jetpack' );
-		$jetpack_about_url = ( Jetpack::is_active() || Jetpack::is_development_mode() )
+		$jetpack_about_url = ( Jetpack::is_active() || Jetpack::is_offline_mode() )
 			? admin_url( 'admin.php?page=jetpack_about' )
 			: Redirect::get_url( 'jetpack' );
 
-		$jetpack_privacy_url = ( Jetpack::is_active() || Jetpack::is_development_mode() )
+		$jetpack_privacy_url = ( Jetpack::is_active() || Jetpack::is_offline_mode() )
 			? $jetpack_admin_url . '#/privacy'
 			: Redirect::get_url( 'a8c-privacy' );
 

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -52,24 +52,27 @@ abstract class Jetpack_Admin_Page {
 	}
 
 	function add_actions() {
-		global $pagenow;
-
 		$is_offline_mode = ( new Status() )->is_offline_mode();
-		// If user is not an admin and site is in Dev Mode or not connected yet then don't do anything.
+
+		// If user is not an admin and site is in Offline Mode or not connected yet then don't do anything.
 		if ( ! current_user_can( 'manage_options' ) && ( $is_offline_mode || ! Jetpack::is_active() ) ) {
 			return;
 		}
 
+		// Is Jetpack not active and not offline?
+		// True means that Jetpack is NOT active and NOT in offline mode.
+		// If Jetpack is active OR in offline mode, this will be false.
+		$connectable = ! Jetpack::is_active() && ! $is_offline_mode;
+
 		// Don't add in the modules page unless modules are available!
-		if ( $this->dont_show_if_not_active && ! Jetpack::is_active() && ! $is_offline_mode ) {
+		if ( $this->dont_show_if_not_active && $connectable ) {
 			return;
 		}
 
 		// Initialize menu item for the page in the admin
 		$hook = $this->get_page_hook();
 
-		// Attach hooks common to all Jetpack admin pages based on the created
-		// hook
+		// Attach hooks common to all Jetpack admin pages based on the created hook.
 		add_action( "load-$hook", array( $this, 'admin_help' ) );
 		add_action( "load-$hook", array( $this, 'admin_page_load' ) );
 		add_action( "admin_print_styles-$hook", array( $this, 'admin_styles' ) );
@@ -78,13 +81,26 @@ abstract class Jetpack_Admin_Page {
 		if ( ! self::$block_page_rendering_for_idc ) {
 			add_action( "admin_print_styles-$hook", array( $this, 'additional_styles' ) );
 		}
+
+		// Check if the site plan changed and deactivate modules accordingly.
+		add_action( 'current_screen', array( $this, 'check_plan_deactivate_modules' ) );
+
+		// Attach page specific actions in addition to the above.
+		$this->add_page_actions( $hook );
+
+		// If the current user can connect Jetpack, Jetpack isn't active, and is not in offline mode, let's prompt!
+		if ( current_user_can( 'jetpack_connect' ) && $connectable ) {
+			$this->add_connection_banner_actions();
+		}
+	}
+
+	/**
+	 * Hooks to add when Jetpack is not active or in offline mode for an user capable of connecting.
+	 */
+	private function add_connection_banner_actions() {
+		global $pagenow;
 		// If someone just activated Jetpack, let's show them a fullscreen connection banner.
-		if (
-			( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] )
-			&& ! Jetpack::is_active()
-			&& current_user_can( 'jetpack_connect' )
-			&& ! $is_offline_mode
-		) {
+		if ( ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'jetpack' === $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_banner_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
 			add_action( 'admin_print_styles', array( Jetpack::init(), 'admin_banner_styles' ) );
@@ -93,20 +109,10 @@ abstract class Jetpack_Admin_Page {
 		}
 
 		// If Jetpack not yet connected, but user is viewing one of the pages with a Jetpack connection banner.
-		if (
-			( 'index.php' === $pagenow || 'plugins.php' === $pagenow )
-			&& ! Jetpack::is_active()
-			&& current_user_can( 'jetpack_connect' )
-			&& ! $is_offline_mode
-		) {
+		if ( ( 'index.php' === $pagenow || 'plugins.php' === $pagenow ) ) {
 			add_action( 'admin_enqueue_scripts', array( 'Jetpack_Connection_Banner', 'enqueue_connect_button_scripts' ) );
 		}
 
-		// Check if the site plan changed and deactivate modules accordingly.
-		add_action( 'current_screen', array( $this, 'check_plan_deactivate_modules' ) );
-
-		// Attach page specific actions in addition to the above
-		$this->add_page_actions( $hook );
 	}
 
 	// Render the page with a common top and bottom part, and page specific content
@@ -382,7 +388,7 @@ abstract class Jetpack_Admin_Page {
 					<?php } ?>
 					<?php if ( current_user_can( 'manage_options' ) ) { ?>
 						<li class="jp-footer__link-item">
-							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack_modules' ) ); ?>" title="<?php esc_html_e( "Access the full list of Jetpack modules available on your site.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Modules', 'Navigation item', 'jetpack' ); ?></a>
+							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack_modules' ) ); ?>" title="<?php esc_html_e( 'Access the full list of Jetpack modules available on your site.', 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Modules', 'Navigation item', 'jetpack' ); ?></a>
 						</li>
 						<li class="jp-footer__link-item">
 							<a href="<?php echo esc_url( admin_url( 'admin.php?page=jetpack-debugger' ) ); ?>" title="<?php esc_html_e( "Test your site's compatibility with Jetpack.", 'jetpack' ); ?>" class="jp-footer__link"><?php echo esc_html_x( 'Debug', 'Navigation item', 'jetpack' ); ?></a>

--- a/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -276,11 +276,12 @@ abstract class Jetpack_Admin_Page {
 		);
 		$args              = wp_parse_args( $args, $defaults );
 		$jetpack_admin_url = admin_url( 'admin.php?page=jetpack' );
-		$jetpack_about_url = ( Jetpack::is_active() || Jetpack::is_offline_mode() )
+		$jetpack_offline   = ( new Status() )->is_offline_mode();
+		$jetpack_about_url = ( Jetpack::is_active() || $jetpack_offline )
 			? admin_url( 'admin.php?page=jetpack_about' )
 			: Redirect::get_url( 'jetpack' );
 
-		$jetpack_privacy_url = ( Jetpack::is_active() || Jetpack::is_offline_mode() )
+		$jetpack_privacy_url = ( Jetpack::is_active() || $jetpack_offline )
 			? $jetpack_admin_url . '#/privacy'
 			: Redirect::get_url( 'a8c-privacy' );
 

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -65,7 +65,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_dashboard_sub_nav_item() {
-		if ( ( new Status() )->is_development_mode() || Jetpack::is_active() ) {
+		if ( ( new Status() )->is_offline_mode() || Jetpack::is_active() ) {
 			global $submenu;
 			if ( current_user_can( 'jetpack_admin_page' ) ) {
 				$submenu['jetpack'][] = array( __( 'Dashboard', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/dashboard' );
@@ -79,7 +79,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 	 * @since 4.3.0
 	 */
 	function jetpack_add_settings_sub_nav_item() {
-		if ( ( ( new Status() )->is_development_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
+		if ( ( ( new Status() )->is_offline_mode() || Jetpack::is_active() ) && current_user_can( 'jetpack_admin_page' ) && current_user_can( 'edit_posts' ) ) {
 			global $submenu;
 			$submenu['jetpack'][] = array( __( 'Settings', 'jetpack' ), 'jetpack_admin_page', 'admin.php?page=jetpack#/settings' );
 		}
@@ -159,7 +159,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 		}
 
 
-		$is_development_mode = ( new Status() )->is_development_mode();
+		$is_offline_mode     = ( new Status() )->is_offline_mode();
 		$script_deps_path    = JETPACK__PLUGIN_DIR . '_inc/build/admin.asset.php';
 		$script_dependencies = array( 'wp-polyfill' );
 		if ( file_exists( $script_deps_path ) ) {
@@ -175,7 +175,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			true
 		);
 
-		if ( ! $is_development_mode && Jetpack::is_active() ) {
+		if ( ! $is_offline_mode && Jetpack::is_active() ) {
 			// Required for Analytics.
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
@@ -247,7 +247,7 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 				'isActive'           => Jetpack::is_active(),
 				'isStaging'          => $status->is_staging_site(),
 				'devMode'            => array(
-					'isActive' => $status->is_development_mode(),
+					'isActive' => $status->is_offline_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
 					'filter'   => apply_filters( 'jetpack_development_mode', false ),

--- a/_inc/lib/admin-pages/class.jetpack-react-page.php
+++ b/_inc/lib/admin-pages/class.jetpack-react-page.php
@@ -246,11 +246,12 @@ class Jetpack_React_Page extends Jetpack_Admin_Page {
 			'connectionStatus'            => array(
 				'isActive'           => Jetpack::is_active(),
 				'isStaging'          => $status->is_staging_site(),
-				'devMode'            => array(
+				'offlineMode'        => array(
 					'isActive' => $status->is_offline_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
-					'filter'   => apply_filters( 'jetpack_development_mode', false ),
+					/** This filter is documented in packages/status/src/class-status.php */
+					'filter'   => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				),
 				'isPublic'           => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 				'isInIdentityCrisis' => Jetpack::validate_sync_error_idc_option(),

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -21,7 +21,7 @@ class Jetpack_Tweetstorm_Helper {
 	 * @return mixed
 	 */
 	public static function gather( $url ) {
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			return new WP_Error(
 				'dev_mode',
 				__( 'Tweet unrolling is not available in development mode.', 'jetpack' )

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -24,7 +24,7 @@ class Jetpack_Tweetstorm_Helper {
 		if ( ( new Status() )->is_offline_mode() ) {
 			return new WP_Error(
 				'dev_mode',
-				__( 'Tweet unrolling is not available in development mode.', 'jetpack' )
+				__( 'Tweet unrolling is not available in offline mode.', 'jetpack' )
 			);
 		}
 

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -5,7 +5,6 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Tracking;
-use Automattic\Jetpack\Status;
 
 /**
  * Register WP REST API endpoints for Jetpack.
@@ -1079,8 +1078,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return WP_REST_Response Connection information.
 	 */
 	public static function jetpack_connection_status() {
-		_deprecated_function( __METHOD__, 'jetpack-8.8.0', '\Automattic\Jetpack\Connection\REST_Connector::rest_authorization_required_code' );
-
+		_deprecated_function( __METHOD__, 'jetpack-8.8.0', '\Automattic\Jetpack\Connection\REST_Connector::connection_status' );
 		return REST_Connector::connection_status();
 	}
 

--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -199,7 +199,7 @@ class Jetpack_Core_API_Module_List_Endpoint {
 			if (
 				isset( $modules[ $slug ]['requires_connection'] )
 				&& $modules[ $slug ]['requires_connection']
-				&& ( new Status() )->is_development_mode()
+				&& ( new Status() )->is_offline_mode()
 			) {
 				$modules[ $slug ]['activated'] = false;
 			}
@@ -366,7 +366,7 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 			if (
 				isset( $module['requires_connection'] )
 				&& $module['requires_connection']
-				&& ( new Status() )->is_development_mode()
+				&& ( new Status() )->is_offline_mode()
 			) {
 				$module['activated'] = false;
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -385,7 +385,7 @@ class Jetpack_Cxn_Test_Base {
 	public function output_results_for_cli( $type = 'all', $group = 'all' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			if ( ( new Status() )->is_development_mode() ) {
-				WP_CLI::line( __( 'Jetpack is in Development Mode:', 'jetpack' ) );
+				WP_CLI::line( __( 'Jetpack is in Offline Mode:', 'jetpack' ) );
 				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}
 			WP_CLI::line( __( 'TEST RESULTS:', 'jetpack' ) );

--- a/_inc/lib/debugger/class-jetpack-cxn-test-base.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-test-base.php
@@ -384,7 +384,7 @@ class Jetpack_Cxn_Test_Base {
 	 */
 	public function output_results_for_cli( $type = 'all', $group = 'all' ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			if ( ( new Status() )->is_development_mode() ) {
+			if ( ( new Status() )->is_offline_mode() ) {
 				WP_CLI::line( __( 'Jetpack is in Offline Mode:', 'jetpack' ) );
 				WP_CLI::line( Jetpack::development_mode_trigger_text() );
 			}

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -76,7 +76,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	 * Is Jetpack even connected and supposed to be talking to WP.com?
 	 */
 	protected function helper_is_jetpack_connected() {
-		return Jetpack::is_active() && ! ( new Status() )->is_development_mode();
+		return Jetpack::is_active() && ! ( new Status() )->is_offline_mode();
 	}
 
 	/**
@@ -189,7 +189,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 					),
 				)
 			);
-		} elseif ( ( new Status() )->is_development_mode() ) {
+		} elseif ( ( new Status() )->is_offline_mode() ) {
 			$result = self::skipped_test(
 				array(
 					'name'              => $name,
@@ -409,7 +409,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = __FUNCTION__;
 
 		$status = new Status();
-		if ( ! Jetpack::is_active() || $status->is_development_mode() || $status->is_staging_site() || ! $this->pass ) {
+		if ( ! Jetpack::is_active() || $status->is_offline_mode() || $status->is_staging_site() || ! $this->pass ) {
 			return self::skipped_test( array( 'name' => $name ) );
 		}
 
@@ -776,7 +776,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		$name = 'test__wpcom_self_test';
 
 		$status = new Status();
-		if ( ! Jetpack::is_active() || $status->is_development_mode() || $status->is_staging_site() || ! $this->pass ) {
+		if ( ! Jetpack::is_active() || $status->is_offline_mode() || $status->is_staging_site() || ! $this->pass ) {
 			return self::skipped_test( array( 'name' => $name ) );
 		}
 

--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -89,7 +89,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 	}
 
 	/**
-	 * Returns a support url based on development mode.
+	 * Returns a support url based on using a development version.
 	 */
 	protected function helper_get_support_url() {
 		return Jetpack::is_development_version()
@@ -193,7 +193,7 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 			$result = self::skipped_test(
 				array(
 					'name'              => $name,
-					'short_description' => __( 'Jetpack is in Development Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(),
+					'short_description' => __( 'Jetpack is in Offline Mode:', 'jetpack' ) . ' ' . Jetpack::development_mode_trigger_text(),
 				)
 			);
 		} else {

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -237,7 +237,7 @@ class Jetpack_Debugger {
 				<?php
 				if (
 					current_user_can( 'jetpack_manage_modules' )
-					&& ( ( new Status() )->is_development_mode() || Jetpack::is_active() )
+					&& ( ( new Status() )->is_offline_mode() || Jetpack::is_active() )
 				) {
 					printf(
 						wp_kses(

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -225,7 +225,7 @@ class Jetpack_Debugger {
 						printf(
 							wp_kses(
 								/* translators: Link to a Jetpack support page. */
-								__( 'Would you like to use Jetpack on your local development site? You can do so thanks to <a href="%s">Jetpack\'s development mode</a>.', 'jetpack' ),
+								__( 'Would you like to use Jetpack on your local development site? You can do so thanks to <a href="%s">Jetpack\'s offline mode</a>.', 'jetpack' ),
 								array( 'a' => array( 'href' => array() ) )
 							),
 							esc_url( Redirect::get_url( 'jetpack-support-development-mode' ) )

--- a/class.jetpack-admin.php
+++ b/class.jetpack-admin.php
@@ -72,7 +72,7 @@ class Jetpack_Admin {
 		$available_modules = Jetpack::get_available_modules();
 		$active_modules    = Jetpack::get_active_modules();
 		$modules           = array();
-		$jetpack_active    = Jetpack::is_active() || ( new Status() )->is_development_mode();
+		$jetpack_active    = Jetpack::is_active() || ( new Status() )->is_offline_mode();
 		$overrides         = Jetpack_Modules_Overrides::instance();
 		foreach ( $available_modules as $module ) {
 			if ( $module_array = Jetpack::get_module( $module ) ) {
@@ -207,7 +207,7 @@ class Jetpack_Admin {
 			return false;
 		}
 
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			return ! ( $module['requires_connection'] );
 		} else {
 			if ( ! Jetpack::is_active() ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -907,8 +907,8 @@ class Jetpack_CLI extends WP_CLI_Command {
 
 					$status = new Status();
 
-					if ( $status->is_development_mode() ) {
-						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. The site is in development mode.', 'jetpack' ) );
+					if ( $status->is_offline_mode() ) {
+						WP_CLI::error( __( 'Jetpack sync is not currently allowed for this site. The site is in offline mode.', 'jetpack' ) );
 						return;
 					}
 					if ( $status->is_staging_site() ) {
@@ -1614,16 +1614,16 @@ class Jetpack_CLI extends WP_CLI_Command {
 			WP_CLI::error( __( 'The publicize module is not active.', 'jetpack' ) );
 		}
 
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			if (
 				! defined( 'JETPACK_DEV_DEBUG' ) &&
 				! has_filter( 'jetpack_development_mode' ) &&
 				false === strpos( site_url(), '.' )
 			) {
-				WP_CLI::error( __( "Jetpack is current in development mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in development mode, the publicize module will not load.", 'jetpack' ) );
+				WP_CLI::error( __( "Jetpack is current in offline mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in development mode, the publicize module will not load.", 'jetpack' ) );
 			}
 
-			WP_CLI::error( __( 'Jetpack is currently in development mode, so the publicize module will not load.', 'jetpack' ) );
+			WP_CLI::error( __( 'Jetpack is currently in offline mode, so the publicize module will not load.', 'jetpack' ) );
 		}
 
 		if ( ! class_exists( 'Publicize' ) ) {

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1618,6 +1618,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 			if (
 				! defined( 'JETPACK_DEV_DEBUG' ) &&
 				! has_filter( 'jetpack_development_mode' ) &&
+				! has_filter( 'jetpack_offline_mode' ) &&
 				false === strpos( site_url(), '.' )
 			) {
 				WP_CLI::error( __( "Jetpack is current in offline mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in offline mode, the publicize module will not load.", 'jetpack' ) );

--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -1620,7 +1620,7 @@ class Jetpack_CLI extends WP_CLI_Command {
 				! has_filter( 'jetpack_development_mode' ) &&
 				false === strpos( site_url(), '.' )
 			) {
-				WP_CLI::error( __( "Jetpack is current in offline mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in development mode, the publicize module will not load.", 'jetpack' ) );
+				WP_CLI::error( __( "Jetpack is current in offline mode because the site url does not contain a '.', which often occurs when dynamically setting the WP_SITEURL constant. While in offline mode, the publicize module will not load.", 'jetpack' ) );
 			}
 
 			WP_CLI::error( __( 'Jetpack is currently in offline mode, so the publicize module will not load.', 'jetpack' ) );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -71,7 +71,7 @@ class Jetpack_Connection_Banner {
 	 * Will initialize hooks to display the new (as of 4.4) connection banner if the current user can
 	 * connect Jetpack, if Jetpack has not been deactivated, and if the current page is the plugins page.
 	 *
-	 * This method should not be called if the site is connected to WordPress.com or if the site is in development mode.
+	 * This method should not be called if the site is connected to WordPress.com or if the site is in offline mode.
 	 *
 	 * @since 4.4.0
 	 * @since 4.5.0 Made the new (as of 4.4) connection banner display to everyone by default.

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -562,7 +562,7 @@ class Jetpack_Gutenberg {
 	 * @return bool
 	 */
 	public static function should_load() {
-		if ( ! Jetpack::is_active() && ! ( new Status() )->is_development_mode() ) {
+		if ( ! Jetpack::is_active() && ! ( new Status() )->is_offline_mode() ) {
 			return false;
 		}
 
@@ -697,7 +697,7 @@ class Jetpack_Gutenberg {
 		}
 
 		// Required for Analytics. See _inc/lib/admin-pages/class.jetpack-admin-page.php.
-		if ( ! ( new Status() )->is_development_mode() && Jetpack::is_active() ) {
+		if ( ! ( new Status() )->is_offline_mode() && Jetpack::is_active() ) {
 			wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 		}
 

--- a/class.jetpack-network.php
+++ b/class.jetpack-network.php
@@ -455,7 +455,7 @@ class Jetpack_Network {
 			return;
 		}
 
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			return;
 		}
 
@@ -566,7 +566,7 @@ class Jetpack_Network {
 		restore_current_blog();
 
 		// If we are in dev mode, just show the notice and bail.
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			Jetpack::show_development_mode_notice();
 			return;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1665,6 +1665,8 @@ class Jetpack {
 
 		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
 			$notice = __( 'The JETPACK_DEV_DEBUG constant is defined in wp-config.php or elsewhere.', 'jetpack' );
+		} elseif ( defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV ) {
+			$notice = __( 'The WP_LOCAL_DEV constant is defined in wp-config.php or elsewhere.', 'jetpack' );
 		} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
 			$notice = __( 'The site URL lacking a dot (e.g. http://localhost).', 'jetpack' );
 		} else {

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1659,7 +1659,9 @@ class Jetpack {
 	 * Determines reason for Jetpack offline mode.
 	 */
 	public static function development_mode_trigger_text() {
-		if ( ! ( new Status() )->is_offline_mode() ) {
+		$status = new Status();
+
+		if ( ! $status->is_offline_mode() ) {
 			return __( 'Jetpack is not in Offline Mode.', 'jetpack' );
 		}
 
@@ -1667,8 +1669,8 @@ class Jetpack {
 			$notice = __( 'The JETPACK_DEV_DEBUG constant is defined in wp-config.php or elsewhere.', 'jetpack' );
 		} elseif ( defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV ) {
 			$notice = __( 'The WP_LOCAL_DEV constant is defined in wp-config.php or elsewhere.', 'jetpack' );
-		} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
-			$notice = __( 'The site URL lacking a dot (e.g. http://localhost).', 'jetpack' );
+		} elseif ( $status->is_local_site() ) {
+			$notice = __( 'The site URL is a known local development environment URL (e.g. http://localhost).', 'jetpack' );
 			/** This filter is documented in packages/status/src/class-status.php */
 		} elseif ( has_filter( 'jetpack_development_mode' ) && apply_filters( 'jetpack_development_mode', false ) ) { // This is a deprecated filter name.
 			$notice = __( 'The jetpack_development_mode filter is set to true.', 'jetpack' );

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1685,7 +1685,7 @@ class Jetpack {
 		if ( ( new Status() )->is_offline_mode() ) {
 			$notice = sprintf(
 				/* translators: %s is a URL */
-				__( 'In <a href="%s" target="_blank">Development Mode</a>:', 'jetpack' ),
+				__( 'In <a href="%s" target="_blank">Offline Mode</a>:', 'jetpack' ),
 				Redirect::get_url( 'jetpack-support-development-mode' )
 			);
 
@@ -2966,7 +2966,7 @@ class Jetpack {
 				return false;
 			}
 
-			// If we're not connected but in development mode, make sure the module doesn't require a connection
+			// If we're not connected but in offline mode, make sure the module doesn't require a connection.
 			if ( $is_offline_mode && $module_data['requires_connection'] ) {
 				return false;
 			}
@@ -6896,7 +6896,7 @@ endif;
 			wp_enqueue_style( 'jetpack-dashboard-widget', plugins_url( 'css/dashboard-widget.css', JETPACK__PLUGIN_FILE ), array(), JETPACK__VERSION );
 			wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
 
-			// If we're inactive and not in development mode, sort our box to the top.
+			// If we're inactive and not in offline mode, sort our box to the top.
 			if ( ! self::is_active() && ! ( new Status() )->is_offline_mode() ) {
 				global $wp_meta_boxes;
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1669,8 +1669,11 @@ class Jetpack {
 			$notice = __( 'The WP_LOCAL_DEV constant is defined in wp-config.php or elsewhere.', 'jetpack' );
 		} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
 			$notice = __( 'The site URL lacking a dot (e.g. http://localhost).', 'jetpack' );
-		} else {
+			/** This filter is documented in packages/status/src/class-status.php */
+		} elseif ( has_filter( 'jetpack_development_mode' ) && apply_filters( 'jetpack_development_mode', false ) ) { // This is a deprecated filter name.
 			$notice = __( 'The jetpack_development_mode filter is set to true.', 'jetpack' );
+		} else {
+			$notice = __( 'The jetpack_offline_mode filter is set to true.', 'jetpack' );
 		}
 
 		return $notice;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7328,9 +7328,28 @@ endif;
 	 *
 	 * This is a DRY function to avoid repeating `Jetpack::is_active && ! Automattic\Jetpack\Status->is_offline_mode`.
 	 *
-	 * @return bool True if Jetpack is active and not in development.
+	 * @deprecated 8.8.0
+	 *
+	 * @return bool True if Jetpack is active and not in offline mode.
 	 */
 	public static function is_active_and_not_development_mode() {
+		_deprecated_function( __FUNCTION__, 'jetpack-8.8.0', 'Jetpack::is_active_and_not_offline_mode' );
+		if ( ! self::is_active() || ( new Status() )->is_offline_mode() ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Checks if a Jetpack site is both active and not in offline mode.
+	 *
+	 * This is a DRY function to avoid repeating `Jetpack::is_active && ! Automattic\Jetpack\Status->is_offline_mode`.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return bool True if Jetpack is active and not in offline mode.
+	 */
+	public static function is_active_and_not_offline_mode() {
 		if ( ! self::is_active() || ( new Status() )->is_offline_mode() ) {
 			return false;
 		}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1073,7 +1073,7 @@ class Jetpack {
 	 * @param array    $args    Adds the context to the cap. Typically the object ID.
 	 */
 	public function jetpack_custom_caps( $caps, $cap, $user_id, $args ) {
-		$is_development_mode = ( new Status() )->is_development_mode();
+		$is_offline_mode = ( new Status() )->is_offline_mode();
 		switch ( $cap ) {
 			case 'jetpack_manage_modules':
 			case 'jetpack_activate_modules':
@@ -1097,7 +1097,7 @@ class Jetpack {
 				$caps = array( 'manage_sites' );
 				break;
 			case 'jetpack_admin_page':
-				if ( $is_development_mode ) {
+				if ( $is_offline_mode ) {
 					$caps = array( 'manage_options' );
 					break;
 				} else {
@@ -1632,12 +1632,12 @@ class Jetpack {
 	 * This static method is being left here intentionally without the use of _deprecated_function(), as other plugins
 	 * and themes still use it, and we do not want to flood them with notices.
 	 *
-	 * Please use Automattic\Jetpack\Status()->is_development_mode() instead.
+	 * Please use Automattic\Jetpack\Status()->is_offline_mode() instead.
 	 *
 	 * @deprecated since 8.0.
 	 */
 	public static function is_development_mode() {
-		return ( new Status() )->is_development_mode();
+		return ( new Status() )->is_offline_mode();
 	}
 
 	/**
@@ -1656,11 +1656,11 @@ class Jetpack {
 	}
 
 	/**
-	 * Determines reason for Jetpack development mode.
+	 * Determines reason for Jetpack offline mode.
 	 */
 	public static function development_mode_trigger_text() {
-		if ( ! ( new Status() )->is_development_mode() ) {
-			return __( 'Jetpack is not in Development Mode.', 'jetpack' );
+		if ( ! ( new Status() )->is_offline_mode() ) {
+			return __( 'Jetpack is not in Offline Mode.', 'jetpack' );
 		}
 
 		if ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) {
@@ -1677,12 +1677,12 @@ class Jetpack {
 
 	}
 	/**
-	 * Get Jetpack development mode notice text and notice class.
+	 * Get Jetpack offline mode notice text and notice class.
 	 *
-	 * Mirrors the checks made in Automattic\Jetpack\Status->is_development_mode
+	 * Mirrors the checks made in Automattic\Jetpack\Status->is_offline_mode
 	 */
 	public static function show_development_mode_notice() {
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			$notice = sprintf(
 				/* translators: %s is a URL */
 				__( 'In <a href="%s" target="_blank">Development Mode</a>:', 'jetpack' ),
@@ -1849,10 +1849,10 @@ class Jetpack {
 	 * Loads the currently active modules.
 	 */
 	public static function load_modules() {
-		$is_development_mode = ( new Status() )->is_development_mode();
+		$is_offline_mode = ( new Status() )->is_offline_mode();
 		if (
 			! self::is_active()
-			&& ! $is_development_mode
+			&& ! $is_offline_mode
 			&& ! self::is_onboarding()
 			&& (
 				! is_multisite()
@@ -1895,8 +1895,8 @@ class Jetpack {
 		}
 
 		foreach ( $modules as $index => $module ) {
-			// If we're in dev mode, disable modules requiring a connection
-			if ( $is_development_mode ) {
+			// If we're in offline mode, disable modules requiring a connection.
+			if ( $is_offline_mode ) {
 				// Prime the pump if we need to
 				if ( empty( $modules_data[ $module ] ) ) {
 					$modules_data[ $module ] = self::get_module( $module );
@@ -2234,7 +2234,7 @@ class Jetpack {
 	}
 
 	public static function activate_new_modules( $redirect = false ) {
-		if ( ! self::is_active() && ! ( new Status() )->is_development_mode() ) {
+		if ( ! self::is_active() && ! ( new Status() )->is_offline_mode() ) {
 			return;
 		}
 
@@ -2960,14 +2960,14 @@ class Jetpack {
 
 		$module_data = self::get_module( $module );
 
-		$is_development_mode = ( new Status() )->is_development_mode();
+		$is_offline_mode = ( new Status() )->is_offline_mode();
 		if ( ! self::is_active() ) {
-			if ( ! $is_development_mode && ! self::is_onboarding() ) {
+			if ( ! $is_offline_mode && ! self::is_onboarding() ) {
 				return false;
 			}
 
 			// If we're not connected but in development mode, make sure the module doesn't require a connection
-			if ( $is_development_mode && $module_data['requires_connection'] ) {
+			if ( $is_offline_mode && $module_data['requires_connection'] ) {
 				return false;
 			}
 		}
@@ -3520,8 +3520,8 @@ p {
 			self::plugin_initialize();
 		}
 
-		$is_development_mode = ( new Status() )->is_development_mode();
-		if ( ! self::is_active() && ! $is_development_mode ) {
+		$is_offline_mode = ( new Status() )->is_offline_mode();
+		if ( ! self::is_active() && ! $is_offline_mode ) {
 			Jetpack_Connection_Banner::init();
 		} elseif ( false === Jetpack_Options::get_option( 'fallback_no_verify_ssl_certs' ) ) {
 			// Upgrade: 1.1 -> 1.1.1
@@ -3546,7 +3546,7 @@ p {
 		add_action( 'admin_enqueue_scripts', array( $this, 'deactivate_dialog' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( JETPACK__PLUGIN_DIR . 'jetpack.php' ), array( $this, 'plugin_action_links' ) );
 
-		if ( self::is_active() || $is_development_mode ) {
+		if ( self::is_active() || $is_offline_mode ) {
 			// Artificially throw errors in certain specific cases during plugin activation.
 			add_action( 'activate_plugin', array( $this, 'throw_error_on_activate_plugin' ) );
 		}
@@ -3939,7 +3939,7 @@ p {
 
 		$jetpack_home = array( 'jetpack-home' => sprintf( '<a href="%s">%s</a>', self::admin_url( 'page=jetpack' ), 'Jetpack' ) );
 
-		if ( current_user_can( 'jetpack_manage_modules' ) && ( self::is_active() || ( new Status() )->is_development_mode() ) ) {
+		if ( current_user_can( 'jetpack_manage_modules' ) && ( self::is_active() || ( new Status() )->is_offline_mode() ) ) {
 			return array_merge(
 				$jetpack_home,
 				array( 'settings' => sprintf( '<a href="%s">%s</a>', self::admin_url( 'page=jetpack#/settings' ), __( 'Settings', 'jetpack' ) ) ),
@@ -6163,7 +6163,7 @@ endif;
 	 * @return array|bool Array of options that are in a crisis, or false if everything is OK.
 	 */
 	public static function check_identity_crisis() {
-		if ( ! self::is_active() || ( new Status() )->is_development_mode() || ! self::validate_sync_error_idc_option() ) {
+		if ( ! self::is_active() || ( new Status() )->is_offline_mode() || ! self::validate_sync_error_idc_option() ) {
 			return false;
 		}
 
@@ -6711,7 +6711,7 @@ endif;
 		}
 
 		// We do not want to use the imploded file in dev mode, or if not connected
-		if ( ( new Status() )->is_development_mode() || ! self::is_active() ) {
+		if ( ( new Status() )->is_offline_mode() || ! self::is_active() ) {
 			if ( ! $travis_test ) {
 				return;
 			}
@@ -6897,7 +6897,7 @@ endif;
 			wp_style_add_data( 'jetpack-dashboard-widget', 'rtl', 'replace' );
 
 			// If we're inactive and not in development mode, sort our box to the top.
-			if ( ! self::is_active() && ! ( new Status() )->is_development_mode() ) {
+			if ( ! self::is_active() && ! ( new Status() )->is_offline_mode() ) {
 				global $wp_meta_boxes;
 
 				$dashboard = $wp_meta_boxes['dashboard']['normal']['core'];
@@ -6958,7 +6958,7 @@ endif;
 					<?php echo number_format_i18n( get_site_option( 'jetpack_protect_blocked_attempts', 0 ) ); ?>
 				</p>
 				<p><?php echo esc_html_x( 'Blocked malicious login attempts', '{#} Blocked malicious login attempts -- number is on a prior line, text is a caption.', 'jetpack' ); ?></p>
-			<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! ( new Status() )->is_development_mode() ) : ?>
+			<?php elseif ( current_user_can( 'jetpack_activate_modules' ) && ! ( new Status() )->is_offline_mode() ) : ?>
 				<a href="
 				<?php
 				echo esc_url(
@@ -7321,14 +7321,14 @@ endif;
 	}
 
 	/**
-	 * Checks if a Jetpack site is both active and not in development.
+	 * Checks if a Jetpack site is both active and not in offline mode.
 	 *
-	 * This is a DRY function to avoid repeating `Jetpack::is_active && ! Automattic\Jetpack\Status->is_development_mode`.
+	 * This is a DRY function to avoid repeating `Jetpack::is_active && ! Automattic\Jetpack\Status->is_offline_mode`.
 	 *
 	 * @return bool True if Jetpack is active and not in development.
 	 */
 	public static function is_active_and_not_development_mode() {
-		if ( ! self::is_active() || ( new Status() )->is_development_mode() ) {
+		if ( ! self::is_active() || ( new Status() )->is_offline_mode() ) {
 			return false;
 		}
 		return true;

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -385,15 +385,15 @@ We strongly recommend that you install tools to review your code in your IDE. It
 
 * ### JETPACK_DEV_DEBUG
 
-	`JETPACK_DEV_DEBUG` constant can be used to enable development mode in Jetpack. Add `define( 'JETPACK_DEV_DEBUG', true );` in your `wp-config.php` to enable it. With Development Mode, features that do not require a connection to WordPress.com servers can be activated on a local WordPress installation for testing.
+	`JETPACK_DEV_DEBUG` constant can be used to enable offline mode in Jetpack. Add `define( 'JETPACK_DEV_DEBUG', true );` in your `wp-config.php` to enable it. With Offline Mode, features that do not require a connection to WordPress.com servers can be activated on a local WordPress installation for testing.
 	
-	Development mode automatically gets enabled if you don’t have a period in your site’s hostname, i.e. localhost. If you use a different URL, such as mycooltestsite.local, then you will need to define the `JETPACK_DEV_DEBUG` constant.
+	Offline mode automatically gets enabled if you don’t have a period in your site’s hostname, i.e. localhost. If you use a different URL, such as mycooltestsite.local, then you will need to define the `JETPACK_DEV_DEBUG` constant.
 	
-	You can also enable Jetpack’s development mode through a plugin, thanks to the jetpack_development_mode filter:
+	You can also enable Jetpack’s offline mode through a plugin, thanks to the jetpack_offline_mode filter:
 	
-	`add_filter( 'jetpack_development_mode', '__return_true' );`
+	`add_filter( 'jetpack_offline_mode', '__return_true' );`
 	
-	While in Development Mode, some features will not be available at all as they require WordPress.com for all functionality—Related Posts and Publicize, for example. Other features will have reduced functionality to give developers a good-faith representation of the feature. For example, Tiled Galleries requires the WordPress.com Photon CDN; however, in Development Mode, Jetpack provides a fallback so developers can have a similar experience during development and testing. Find out more in [our support documentation](https://jetpack.com/support/jetpack-for-developers/).
+	While in Offline Mode, some features will not be available at all as they require WordPress.com for all functionality—Related Posts and Publicize, for example. Other features will have reduced functionality to give developers a good-faith representation of the feature. For example, Tiled Galleries requires the WordPress.com Photon CDN; however, in Offline Mode, Jetpack provides a fallback so developers can have a similar experience during development and testing. Find out more in [our support documentation](https://jetpack.com/support/jetpack-for-developers/).
 
 * ### JETPACK__SANDBOX_DOMAIN
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -192,7 +192,7 @@ Fetch Jetpack's current connection status.
 {
 	"isActive": true,
 	"isStaging": false,
-	"devMode": {
+	"offlineMode": {
 		"isActive":false,
 		"constant":false,
 		"url":false,

--- a/functions.photon.php
+++ b/functions.photon.php
@@ -31,9 +31,9 @@ function jetpack_photon_url( $image_url, $args = array(), $scheme = null ) {
 		 *
 		 * @since 4.1.0
 		 *
-		 * @param bool false Result of Automattic\Jetpack\Status->is_development_mode().
+		 * @param bool false Result of Automattic\Jetpack\Status->is_offline_mode().
 		 */
-		if ( true === apply_filters( 'jetpack_photon_development_mode', ( new Status() )->is_development_mode() ) ) {
+		if ( true === apply_filters( 'jetpack_photon_development_mode', ( new Status() )->is_offline_mode() ) ) {
 			return $image_url;
 		}
 	}

--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -316,7 +316,7 @@ class Jetpack_Carousel {
 			 *
 			 * @param bool Enable Jetpack Carousel stat collection. Default false.
 			 */
-			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules() ) && ! ( new Status() )->is_development_mode() ) {
+			if ( apply_filters( 'jetpack_enable_carousel_stats', false ) && in_array( 'stats', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_offline_mode() ) {
 				$localize_strings['stats'] = 'blog=' . Jetpack_Options::get_option( 'id' ) . '&host=' . wp_parse_url( get_option( 'home' ), PHP_URL_HOST ) . '&v=ext&j=' . JETPACK__API_VERSION . ':' . JETPACK__VERSION;
 
 				// Set the stats as empty if user is logged in but logged-in users shouldn't be tracked.

--- a/modules/module-extras.php
+++ b/modules/module-extras.php
@@ -9,7 +9,7 @@
 
 /**
  * Features available all the time:
- *    - When in development mode.
+ *    - When in offline mode.
  *    - When connected to WordPress.com.
  */
 $tools = array(
@@ -60,7 +60,7 @@ if ( Jetpack::is_active() ) {
  * Filter extra tools (not modules) to include.
  *
  * @since 2.4.0
- * @since 5.4.0 can be used in multisite when Jetpack is not connected to WordPress.com and not in development mode.
+ * @since 5.4.0 can be used in multisite when Jetpack is not connected to WordPress.com and not in offline mode.
  *
  * @param array $tools Array of extra tools to include.
  */

--- a/modules/sharedaddy.php
+++ b/modules/sharedaddy.php
@@ -39,7 +39,7 @@ function sharedaddy_loaded() {
  */
 function jetpack_sharedaddy_configuration_url() {
 	$status = new Status();
-	if ( $status->is_development_mode() || $status->is_staging_site() || ! Jetpack::is_user_connected() ) {
+	if ( $status->is_offline_mode() || $status->is_staging_site() || ! Jetpack::is_user_connected() ) {
 		return admin_url( 'options-general.php?page=sharing' );
 	}
 

--- a/modules/tiled-gallery/tiled-gallery.php
+++ b/modules/tiled-gallery/tiled-gallery.php
@@ -184,7 +184,7 @@ class Jetpack_Tiled_Gallery {
 			if ( $gallery_html && class_exists( 'Jetpack' ) && class_exists( 'Jetpack_Photon' ) ) {
 				// Tiled Galleries in Jetpack require that Photon be active.
 				// If it's not active, run it just on the gallery output.
-				if ( ! in_array( 'photon', Jetpack::get_active_modules() ) && ! ( new Status() )->is_development_mode() ) {
+				if ( ! in_array( 'photon', Jetpack::get_active_modules(), true ) && ! ( new Status() )->is_offline_mode() ) {
 					$gallery_html = Jetpack_Photon::filter_the_content( $gallery_html );
 				}
 			}

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -294,7 +294,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$instance = $this->jetpack_search_populate_defaults( $instance );
 
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			echo $args['before_widget']; //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
 				<div class="jetpack-search-sort-wrapper">

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -299,7 +299,7 @@ class Jetpack_Search_Widget extends WP_Widget {
 			?><div id="<?php echo esc_attr( $this->id ); ?>-wrapper">
 				<div class="jetpack-search-sort-wrapper">
 					<label>
-						<?php esc_html_e( 'Jetpack Search not supported in Development Mode', 'jetpack' ); ?>
+						<?php esc_html_e( 'Jetpack Search not supported in Offline Mode', 'jetpack' ); ?>
 					</label>
 				</div>
 			</div><?php

--- a/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget.php
+++ b/modules/widgets/wordpress-post-widget/class.jetpack-display-posts-widget.php
@@ -145,9 +145,9 @@ class Jetpack_Display_Posts_Widget extends Jetpack_Display_Posts_Widget__Base {
 
 		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
 			/**
-			 * If Jetpack is not active or in development mode, we don't want to update widget data.
+			 * If Jetpack is not active or in offline mode, we don't want to update widget data.
 			 */
-			if ( ! Jetpack::is_active() && ! ( new Status() )->is_development_mode() ) {
+			if ( ! Jetpack::is_active() && ! ( new Status() )->is_offline_mode() ) {
 				return false;
 			}
 

--- a/modules/wordads/php/class-wordads-api.php
+++ b/modules/wordads/php/class-wordads-api.php
@@ -31,7 +31,7 @@ class WordAds_API {
 	 */
 	public static function get_wordads_status() {
 		global $wordads_status_response;
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			self::$wordads_status = array(
 				'approved' => true,
 				'active'   => true,

--- a/modules/wordads/php/class-wordads-params.php
+++ b/modules/wordads/php/class-wordads-params.php
@@ -72,7 +72,7 @@ class WordAds_Params {
 		$this->mobile_device  = jetpack_is_mobile( 'any', true );
 		$this->targeting_tags = array(
 			'WordAds' => 1,
-			'BlogId'  => ( new Status() )->is_development_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
+			'BlogId'  => ( new Status() )->is_offline_mode() ? 0 : Jetpack_Options::get_option( 'id' ),
 			'Domain'  => esc_js( wp_parse_url( home_url(), PHP_URL_HOST ) ),
 			'PageURL' => esc_js( $this->url ),
 			'LangId'  => false !== strpos( get_bloginfo( 'language' ), 'en' ) ? 1 : 0, // TODO something else?

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1118,8 +1118,8 @@ class Manager {
 					$caps = array( 'do_not_allow' );
 					break;
 				}
-				// Pass through. If it's not development mode, these should match disconnect.
-				// Let users disconnect if it's development mode, just in case things glitch.
+				// Pass through. If it's not offline mode, these should match disconnect.
+				// Let users disconnect if it's offline mode, just in case things glitch.
 			case 'jetpack_disconnect':
 				/**
 				 * Filters the jetpack_disconnect capability.

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1110,11 +1110,11 @@ class Manager {
 	 * @param array    $args    Adds the context to the cap. Typically the object ID.
 	 */
 	public function jetpack_connection_custom_caps( $caps, $cap, $user_id, $args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$is_development_mode = ( new Status() )->is_development_mode();
+		$is_offline_mode = ( new Status() )->is_offline_mode();
 		switch ( $cap ) {
 			case 'jetpack_connect':
 			case 'jetpack_reconnect':
-				if ( $is_development_mode ) {
+				if ( $is_offline_mode ) {
 					$caps = array( 'do_not_allow' );
 					break;
 				}
@@ -1131,7 +1131,7 @@ class Manager {
 				$caps = apply_filters( 'jetpack_disconnect_cap', array( 'manage_options' ) );
 				break;
 			case 'jetpack_connect_user':
-				if ( $is_development_mode ) {
+				if ( $is_offline_mode ) {
 					$caps = array( 'do_not_allow' );
 					break;
 				}

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -133,26 +133,35 @@ class REST_Connector {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @return WP_REST_Response Connection information.
+	 * @param bool $rest_response Should we return a rest response or a simple array. Default to rest response.
+	 *
+	 * @return WP_REST_Response|array Connection information.
 	 */
-	public static function connection_status() {
+	public static function connection_status( $rest_response = true ) {
 		$status     = new Status();
 		$connection = new Manager();
 
-		return rest_ensure_response(
-			array(
-				'isActive'     => $connection->is_active(),
-				'isStaging'    => $status->is_staging_site(),
-				'isRegistered' => $connection->is_registered(),
-				'offlineMode'      => array(
-					'isActive' => $status->is_offline_mode(),
-					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
-					'url'      => site_url() && false === strpos( site_url(), '.' ),
-					/** This filter is documented in packages/status/src/class-status.php */
-					'filter'   => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
-				),
-			)
+		$connection_status = array(
+			'isActive'     => $connection->is_active(),
+			'isStaging'    => $status->is_staging_site(),
+			'isRegistered' => $connection->is_registered(),
+			'offlineMode'      => array(
+				'isActive' => $status->is_offline_mode(),
+				'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
+				'url'      => site_url() && false === strpos( site_url(), '.' ),
+				/** This filter is documented in packages/status/src/class-status.php */
+				'filter'   => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
+			),
+			'isPublic'     => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		);
+
+		if ( $rest_response ) {
+			return rest_ensure_response(
+				$connection_status
+			);
+		} else {
+			return $connection_status;
+		}
 	}
 
 

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -144,11 +144,12 @@ class REST_Connector {
 				'isActive'     => $connection->is_active(),
 				'isStaging'    => $status->is_staging_site(),
 				'isRegistered' => $connection->is_registered(),
-				'devMode'      => array(
-					'isActive' => $status->is_development_mode(),
+				'offlineMode'      => array(
+					'isActive' => $status->is_offline_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
 					'url'      => site_url() && false === strpos( site_url(), '.' ),
-					'filter'   => apply_filters( 'jetpack_development_mode', false ),
+					/** This filter is documented in packages/status/src/class-status.php */
+					'filter'   => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				),
 			)
 		);

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -148,7 +148,7 @@ class REST_Connector {
 			'offlineMode'  => array(
 				'isActive'        => $status->is_offline_mode(),
 				'constant'        => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
-				'url'             => site_url() && false === strpos( site_url(), '.' ),
+				'url'             => $status->is_local_site(),
 				/** This filter is documented in packages/status/src/class-status.php */
 				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -64,8 +64,8 @@ class REST_Connector {
 			'jetpack/v4',
 			'/remote_authorize',
 			array(
-				'methods'  => WP_REST_Server::EDITABLE,
-				'callback' => __CLASS__ . '::remote_authorize',
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => __CLASS__ . '::remote_authorize',
 				'permission_callback' => '__return_true',
 			)
 		);
@@ -75,8 +75,8 @@ class REST_Connector {
 			'jetpack/v4',
 			'/connection',
 			array(
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => __CLASS__ . '::connection_status',
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => __CLASS__ . '::connection_status',
 				'permission_callback' => '__return_true',
 			)
 		);
@@ -145,12 +145,13 @@ class REST_Connector {
 			'isActive'     => $connection->is_active(),
 			'isStaging'    => $status->is_staging_site(),
 			'isRegistered' => $connection->is_registered(),
-			'offlineMode'      => array(
-				'isActive' => $status->is_offline_mode(),
-				'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
-				'url'      => site_url() && false === strpos( site_url(), '.' ),
+			'offlineMode'  => array(
+				'isActive'        => $status->is_offline_mode(),
+				'constant'        => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
+				'url'             => site_url() && false === strpos( site_url(), '.' ),
 				/** This filter is documented in packages/status/src/class-status.php */
-				'filter'   => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
+				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
+				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,
 			),
 			'isPublic'     => '1' == get_option( 'blog_public' ), // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		);

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -75,7 +75,7 @@ class Test_REST_Endpoints extends TestCase {
 				->setName( 'apply_filters' )
 				->setFunction(
 					function( $hook, $value ) {
-						return 'jetpack_development_mode' === $hook ? true : $value;
+						return 'jetpack_offline_mode' === $hook ? true : $value;
 					}
 				);
 
@@ -89,7 +89,7 @@ class Test_REST_Endpoints extends TestCase {
 
 		$this->assertFalse( $data['isActive'] );
 		$this->assertFalse( $data['isRegistered'] );
-		$this->assertTrue( $data['devMode']['isActive'] );
+		$this->assertTrue( $data['offlineMode']['isActive'] );
 	}
 
 	/**

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -336,7 +336,7 @@ class ManagerTest extends TestCase {
 		// Mock the site_url call in Status::is_offline_mode.
 		$this->mock_function( 'site_url', false, 'Automattic\Jetpack' );
 
-		// Mock the apply_filters( 'jetpack_development_mode', ) call in Status::is_offline_mode.
+		// Mock the apply_filters( 'jetpack_offline_mode', ) call in Status::is_offline_mode.
 		$this->mock_function( 'apply_filters', $in_offline_mode, 'Automattic\Jetpack' );
 
 		// Mock the apply_filters( 'jetpack_disconnect_cap', ) call in jetpack_connection_custom_caps.

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -328,16 +328,16 @@ class ManagerTest extends TestCase {
 	 * @covers Automattic\Jetpack\Connection\Manager::jetpack_connection_custom_caps
 	 * @dataProvider jetpack_connection_custom_caps_data_provider
 	 *
-	 * @param bool   $in_dev_mode Whether development mode is active.
+	 * @param bool   $in_offline_mode Whether offline mode is active.
 	 * @param string $custom_cap The custom capability that is being tested.
 	 * @param array  $expected_caps The expected output.
 	 */
-	public function test_jetpack_connection_custom_caps( $in_dev_mode, $custom_cap, $expected_caps ) {
+	public function test_jetpack_connection_custom_caps( $in_offline_mode, $custom_cap, $expected_caps ) {
 		// Mock the site_url call in Status::is_offline_mode.
 		$this->mock_function( 'site_url', false, 'Automattic\Jetpack' );
 
 		// Mock the apply_filters( 'jetpack_development_mode', ) call in Status::is_offline_mode.
-		$this->mock_function( 'apply_filters', $in_dev_mode, 'Automattic\Jetpack' );
+		$this->mock_function( 'apply_filters', $in_offline_mode, 'Automattic\Jetpack' );
 
 		// Mock the apply_filters( 'jetpack_disconnect_cap', ) call in jetpack_connection_custom_caps.
 		$this->mock_function( 'apply_filters', array( 'manage_options' ) );
@@ -350,9 +350,9 @@ class ManagerTest extends TestCase {
 	 * Data provider test_jetpack_connection_custom_caps.
 	 *
 	 * Structure of the test data arrays:
-	 *     [0] => 'in_dev_mode'   boolean Whether development mode is active.
-	 *     [1] => 'custom_cap'    string The custom capability that is being tested.
-	 *     [2] => 'expected_caps' array The expected output of the call to jetpack_connection_custom_caps.
+	 *     [0] => 'in_offline_mode'   boolean Whether offline mode is active.
+	 *     [1] => 'custom_cap'        string The custom capability that is being tested.
+	 *     [2] => 'expected_caps'     array The expected output of the call to jetpack_connection_custom_caps.
 	 */
 	public function jetpack_connection_custom_caps_data_provider() {
 

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -52,7 +52,8 @@ class ManagerTest extends TestCase {
 					}
 				);
 
-		$this->apply_filters = $builder->build();
+		$this->apply_filters            = $builder->build();
+		$this->apply_filters_deprecated = $builder->build();
 
 		$builder = new MockBuilder();
 		$builder->setNamespace( __NAMESPACE__ )
@@ -333,17 +334,28 @@ class ManagerTest extends TestCase {
 	 * @param array  $expected_caps The expected output.
 	 */
 	public function test_jetpack_connection_custom_caps( $in_offline_mode, $custom_cap, $expected_caps ) {
+		$this->apply_filters_deprecated->enable();
 		// Mock the site_url call in Status::is_offline_mode.
 		$this->mock_function( 'site_url', false, 'Automattic\Jetpack' );
 
+		// Mock the apply_filters_deprecated( 'jetpack_development_mode' ) call in Status->is_offline_mode.
+		$this->mock_function( 'apply_filters_deprecated', false, 'Automattic\Jetpack' );
+
+		$this->apply_filters->disable();
 		// Mock the apply_filters( 'jetpack_offline_mode', ) call in Status::is_offline_mode.
-		$this->mock_function( 'apply_filters', $in_offline_mode, 'Automattic\Jetpack' );
+		add_filter(
+			'jetpack_offline_mode',
+			function() use ( $in_offline_mode ) {
+				return $in_offline_mode;
+			}
+		);
 
 		// Mock the apply_filters( 'jetpack_disconnect_cap', ) call in jetpack_connection_custom_caps.
 		$this->mock_function( 'apply_filters', array( 'manage_options' ) );
 
 		$caps = $this->manager->jetpack_connection_custom_caps( self::DEFAULT_TEST_CAPS, $custom_cap, 1, array() );
 		$this->assertEquals( $expected_caps, $caps );
+		$this->apply_filters_deprecated->disable();
 	}
 
 	/**
@@ -357,16 +369,16 @@ class ManagerTest extends TestCase {
 	public function jetpack_connection_custom_caps_data_provider() {
 
 		return array(
-			'dev mode, jetpack_connect'          => array( true, 'jetpack_connect', array( 'do_not_allow' ) ),
-			'dev mode, jetpack_reconnect'        => array( true, 'jetpack_reconnect', array( 'do_not_allow' ) ),
-			'dev mode, jetpack_disconnect'       => array( true, 'jetpack_disconnect', array( 'manage_options' ) ),
-			'dev mode, jetpack_connect_user'     => array( true, 'jetpack_connect_user', array( 'do_not_allow' ) ),
-			'dev mode, unknown cap'              => array( true, 'unknown_cap', self::DEFAULT_TEST_CAPS ),
-			'not dev mode, jetpack_connect'      => array( false, 'jetpack_connect', array( 'manage_options' ) ),
-			'not dev mode, jetpack_reconnect'    => array( false, 'jetpack_reconnect', array( 'manage_options' ) ),
-			'not dev mode, jetpack_disconnect'   => array( false, 'jetpack_disconnect', array( 'manage_options' ) ),
-			'not dev mode, jetpack_connect_user' => array( false, 'jetpack_connect_user', array( 'read' ) ),
-			'not dev mode, unknown cap'          => array( false, 'unknown_cap', self::DEFAULT_TEST_CAPS ),
+			'offline mode, jetpack_connect'          => array( true, 'jetpack_connect', array( 'do_not_allow' ) ),
+			'offline mode, jetpack_reconnect'        => array( true, 'jetpack_reconnect', array( 'do_not_allow' ) ),
+			'offline mode, jetpack_disconnect'       => array( true, 'jetpack_disconnect', array( 'manage_options' ) ),
+			'offline mode, jetpack_connect_user'     => array( true, 'jetpack_connect_user', array( 'do_not_allow' ) ),
+			'offline mode, unknown cap'              => array( true, 'unknown_cap', self::DEFAULT_TEST_CAPS ),
+			'not offline mode, jetpack_connect'      => array( false, 'jetpack_connect', array( 'manage_options' ) ),
+			'not offline mode, jetpack_reconnect'    => array( false, 'jetpack_reconnect', array( 'manage_options' ) ),
+			'not offline mode, jetpack_disconnect'   => array( false, 'jetpack_disconnect', array( 'manage_options' ) ),
+			'not offline mode, jetpack_connect_user' => array( false, 'jetpack_connect_user', array( 'read' ) ),
+			'not offline mode, unknown cap'          => array( false, 'unknown_cap', self::DEFAULT_TEST_CAPS ),
 		);
 	}
 

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -333,10 +333,10 @@ class ManagerTest extends TestCase {
 	 * @param array  $expected_caps The expected output.
 	 */
 	public function test_jetpack_connection_custom_caps( $in_dev_mode, $custom_cap, $expected_caps ) {
-		// Mock the site_url call in Status::is_development_mode.
+		// Mock the site_url call in Status::is_offline_mode.
 		$this->mock_function( 'site_url', false, 'Automattic\Jetpack' );
 
-		// Mock the apply_filters( 'jetpack_development_mode', ) call in Status::is_development_mode.
+		// Mock the apply_filters( 'jetpack_development_mode', ) call in Status::is_offline_mode.
 		$this->mock_function( 'apply_filters', $in_dev_mode, 'Automattic\Jetpack' );
 
 		// Mock the apply_filters( 'jetpack_disconnect_cap', ) call in jetpack_connection_custom_caps.

--- a/packages/jitm/src/class-jitm.php
+++ b/packages/jitm/src/class-jitm.php
@@ -64,7 +64,7 @@ class JITM {
 		}
 
 		// Folks cannot connect to WordPress.com and won't really be able to act on the pre-connection messages. So bail.
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			return false;
 		}
 

--- a/packages/jitm/tests/php/test_JITM.php
+++ b/packages/jitm/tests/php/test_JITM.php
@@ -39,7 +39,7 @@ class Test_Jetpack_JITM extends TestCase {
 			array( 'jetpack_just_in_time_msgs', false, false ),
 		), "Automattic\Jetpack\JITMS" );
 
-		// Used for Status->is_development_mode().
+		// Used for Status->is_offline_mode().
 		$this->mock_filters( array(
 			array( 'jetpack_just_in_time_msgs', false, false ),
 		), "Automattic\Jetpack" );
@@ -56,7 +56,7 @@ class Test_Jetpack_JITM extends TestCase {
 			array( 'jetpack_just_in_time_msgs', false, true ),
 		), "Automattic\Jetpack\JITMS" );
 
-		// Used for Status->is_development_mode().
+		// Used for Status->is_offline_mode().
 		$this->mock_filters( array(
 			array( 'jetpack_just_in_time_msgs', false, true ),
 		), "Automattic\Jetpack" );

--- a/packages/jitm/tests/php/test_JITM.php
+++ b/packages/jitm/tests/php/test_JITM.php
@@ -15,6 +15,8 @@ class Test_Jetpack_JITM extends TestCase {
 		$this->mock_add_action();
 		$this->mock_do_action();
 		$this->mock_wp_enqueue_script();
+		//$this->mock_wp_enqueue_script();
+		$this->mock_filters_deprecated();
 
 		// input/output of these functions doesn't matter right now, they just need to exist
 		$this->mock_empty_function( 'wp_register_style' );
@@ -146,6 +148,19 @@ class Test_Jetpack_JITM extends TestCase {
 			);
 		$this->apply_filters_mock = $builder->build();
 		$this->apply_filters_mock->enable();
+	}
+
+	protected function mock_filters_deprecated() {
+		$builder = new MockBuilder();
+		$builder->setNamespace( 'Automattic\Jetpack' )
+		        ->setName( 'apply_filters_deprecated' )
+		        ->setFunction(
+			        function( ...$args ) {
+				        return $args[1][0]; // Return the 2nd argument's first array item.
+			        }
+		        );
+		$this->apply_filters_deprecated_mock = $builder->build();
+		$this->apply_filters_deprecated_mock->enable();
 	}
 
 	protected function clear_mock_filters() {

--- a/packages/status/README.md
+++ b/packages/status/README.md
@@ -6,13 +6,13 @@ Used to retrieve information about the current status of Jetpack and the site ov
 
 ### Usage
 
-Find out whether the site is in development mode:
+Find out whether the site is in offline mode:
 
 ```php
 use Automattic\Jetpack\Status;
 
 $status = new Status();
-$is_development_mode = $status->is_development_mode();
+$is_offline_mode = $status->is_offline_mode();
 ```
 
 Find out whether this is a system with multiple networks:

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -89,7 +89,9 @@ class Status {
 	 * @return bool
 	 */
 	public function is_staging_site() {
-		$is_staging = false;
+		// @todo Remove function_exists when WP 5.5 is the minimum version.
+		// Core's wp_get_environment_type allows for a few specific options. We should default to bowing out gracefully for anything other than production.
+		$is_staging = function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type();
 
 		$known_staging = array(
 			'urls'      => array(

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -57,7 +57,7 @@ class Status {
 		 *
 		 * @param bool $offline_mode Is Jetpack's offline mode active.
 		 */
-		$offline_mode = (bool) apply_filters_deprecated( 'jetpack_development_mode', array( $offline_mode ), '8.8.0', 'jetpack_offline_mode' );
+		$offline_mode = (bool) \apply_filters_deprecated( 'jetpack_development_mode', array( $offline_mode ), '8.8.0', 'jetpack_offline_mode' );
 
 		/**
 		 * Filters Jetpack's offline mode.
@@ -69,7 +69,7 @@ class Status {
 		 *
 		 * @param bool $offline_mode Is Jetpack's offline mode active.
 		 */
-		$offline_mode = (bool) apply_filters( 'jetpack_offline_mode', $offline_mode );
+		$offline_mode = (bool) \apply_filters( 'jetpack_offline_mode', $offline_mode );
 
 		return $offline_mode;
 	}

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -52,10 +52,23 @@ class Status {
 		 * @todo Update documentation ^^.
 		 *
 		 * @since 2.2.1
+		 * @deprecated 8.8.0
 		 *
-		 * @param bool $offline_mode Is Jetpack's development mode active.
+		 * @param bool $offline_mode Is Jetpack's offline mode active.
 		 */
-		$offline_mode = (bool) apply_filters( 'jetpack_development_mode', $offline_mode );
+		$offline_mode = (bool) apply_filters_deprecated( 'jetpack_development_mode', array( $offline_mode ), '8.8.0', 'jetpack_offline_mode' );
+
+		/**
+		 * Filters Jetpack's offline mode.
+		 *
+		 * @see https://jetpack.com/support/development-mode/
+		 * @todo Update documentation ^^.
+		 *
+		 * @since 8.8.0
+		 *
+		 * @param bool $offline_mode Is Jetpack's offline mode active.
+		 */
+		$offline_mode = (bool) apply_filters( 'jetpack_offline_mode', $offline_mode );
 
 		return $offline_mode;
 	}

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -24,6 +24,8 @@ class Status {
 
 		if ( defined( '\\JETPACK_DEV_DEBUG' ) ) {
 			$development_mode = constant( '\\JETPACK_DEV_DEBUG' );
+		} elseif ( defined( '\\WP_LOCAL_DEV' ) ) {
+			$development_mode = constant( '\\WP_LOCAL_DEV' );
 		} elseif ( $site_url ) {
 			$development_mode = false === strpos( $site_url, '.' );
 		}
@@ -99,12 +101,14 @@ class Status {
 				'#\.staging\.kinsta\.com$#i',   // Kinsta.com.
 				'#\.stage\.site$#i',            // DreamPress.
 				'#\.newspackstaging\.com$#i',   // Newspack.
+				'#\.flywheelstaging\.com$#i',   // Flywheel.
 			),
 			'constants' => array(
 				'IS_WPE_SNAPSHOT',      // WP Engine.
 				'KINSTA_DEV_ENV',       // Kinsta.com.
 				'WPSTAGECOACH_STAGING', // WP Stagecoach.
 				'JETPACK_STAGING_MODE', // Generic.
+				'WP_LOCAL_DEV',         // Generic.
 			),
 		);
 		/**

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -21,6 +21,7 @@ class Status {
 	 * @return bool Whether Jetpack's offline mode is active.
 	 */
 	public function is_development_mode() {
+		_deprecated_function( __FUNCTION__, 'Jetpack 8.8.0', 'Automattic\Jetpack\Status->is_offline_mode' );
 		return $this->is_offline_mode();
 	}
 

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -69,7 +69,7 @@ class Status {
 		 *
 		 * @param bool $offline_mode Is Jetpack's offline mode active.
 		 */
-		$offline_mode = (bool) \apply_filters( 'jetpack_offline_mode', $offline_mode );
+		$offline_mode = (bool) apply_filters( 'jetpack_offline_mode', $offline_mode );
 
 		return $offline_mode;
 	}

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -57,7 +57,7 @@ class Status {
 		 *
 		 * @param bool $offline_mode Is Jetpack's offline mode active.
 		 */
-		$offline_mode = (bool) \apply_filters_deprecated( 'jetpack_development_mode', array( $offline_mode ), '8.8.0', 'jetpack_offline_mode' );
+		$offline_mode = (bool) apply_filters_deprecated( 'jetpack_development_mode', array( $offline_mode ), '8.8.0', 'jetpack_offline_mode' );
 
 		/**
 		 * Filters Jetpack's offline mode.

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -16,32 +16,48 @@ class Status {
 	/**
 	 * Is Jetpack in development (offline) mode?
 	 *
-	 * @return bool Whether Jetpack's development mode is active.
+	 * @deprecated 8.8.0 Use Status->is_offline_mode().
+	 *
+	 * @return bool Whether Jetpack's offline mode is active.
 	 */
 	public function is_development_mode() {
-		$development_mode = false;
-		$site_url         = site_url();
+		return $this->is_offline_mode();
+	}
+
+	/**
+	 * Is Jetpack in offline mode?
+	 *
+	 * This was formerly called "Development Mode", but sites "in development" aren't always offline/localhost.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return bool Whether Jetpack's offline mode is active.
+	 */
+	public function is_offline_mode() {
+		$offline_mode = false;
+		$site_url     = site_url();
 
 		if ( defined( '\\JETPACK_DEV_DEBUG' ) ) {
-			$development_mode = constant( '\\JETPACK_DEV_DEBUG' );
+			$offline_mode = constant( '\\JETPACK_DEV_DEBUG' );
 		} elseif ( defined( '\\WP_LOCAL_DEV' ) ) {
-			$development_mode = constant( '\\WP_LOCAL_DEV' );
+			$offline_mode = constant( '\\WP_LOCAL_DEV' );
 		} elseif ( $site_url ) {
-			$development_mode = false === strpos( $site_url, '.' );
+			$offline_mode = false === strpos( $site_url, '.' );
 		}
 
 		/**
-		 * Filters Jetpack's development mode.
+		 * Filters Jetpack's offline mode.
 		 *
 		 * @see https://jetpack.com/support/development-mode/
+		 * @todo Update documentation ^^.
 		 *
 		 * @since 2.2.1
 		 *
-		 * @param bool $development_mode Is Jetpack's development mode active.
+		 * @param bool $offline_mode Is Jetpack's development mode active.
 		 */
-		$development_mode = (bool) apply_filters( 'jetpack_development_mode', $development_mode );
+		$offline_mode = (bool) apply_filters( 'jetpack_development_mode', $offline_mode );
 
-		return $development_mode;
+		return $offline_mode;
 	}
 
 	/**

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -52,62 +52,62 @@ class Test_Status extends TestCase {
 	}
 
 	/**
-	 * Test is_development_mode when not using any filter
+	 * Test is_offline_mode when not using any filter
 	 *
-	 * @covers Automattic\Jetpack\Status::is_development_mode
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
-	public function test_is_development_mode_default() {
+	public function test_is_offline_mode_default() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( false );
 
-		$this->assertFalse( $this->status->is_development_mode() );
+		$this->assertFalse( $this->status->is_offline_mode() );
 	}
 
 	/**
-	 * Test is_development_mode when using the jetpack_development_mode filter
+	 * Test is_offline_mode when using the jetpack_development_mode filter
 	 *
-	 * @covers Automattic\Jetpack\Status::is_development_mode
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
-	public function test_is_development_mode_filter_true() {
+	public function test_is_offline_mode_filter_true() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( true );
 
-		$this->assertTrue( $this->status->is_development_mode() );
+		$this->assertTrue( $this->status->is_offline_mode() );
 	}
 
 	/**
 	 * Test when using a bool value for the jetpack_development_mode filter.
 	 *
-	 * @covers Automattic\Jetpack\Status::is_development_mode
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
-	public function test_is_development_mode_filter_bool() {
+	public function test_is_offline_mode_filter_bool() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( 0 );
 
-		$this->assertFalse( $this->status->is_development_mode() );
+		$this->assertFalse( $this->status->is_offline_mode() );
 	}
 
 	/**
 	 * Test when site url is localhost (dev mode on)
 	 *
-	 * @covers Automattic\Jetpack\Status::is_development_mode
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
-	public function test_is_development_mode_localhost() {
+	public function test_is_offline_mode_localhost() {
 		Functions\when( 'site_url' )->justReturn( 'localhost' );
 
 		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( false );
 
-		$this->assertTrue( $this->status->is_development_mode() );
+		$this->assertTrue( $this->status->is_offline_mode() );
 	}
 
 	/**
 	 * Test when using the constant to set dev mode
 	 *
-	 * @covers Automattic\Jetpack\Status::is_development_mode
+	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 *
 	 * @runInSeparateProcess
 	 */
-	public function test_is_development_mode_constant() {
+	public function test_is_offline_mode_constant() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
 		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( false );
 
@@ -117,7 +117,7 @@ class Test_Status extends TestCase {
 			)
 		);
 
-		$this->assertTrue( $this->status->is_development_mode() );
+		$this->assertTrue( $this->status->is_offline_mode() );
 
 		array_map(
 			function( $mock ) {

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -334,4 +334,60 @@ class Test_Status extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests known local development sites.
+	 *
+	 * @dataProvider get_is_local_site_known_tld
+	 *
+	 * @param string $site_url Site URL.
+	 * @param bool   $expected_response Expected response.
+	 */
+	public function test_is_local_site_for_known_tld( $site_url, $expected_response ) {
+		Functions\when( 'site_url' )->justReturn( $site_url );
+		$result = $this->status->is_local_site();
+		$this->assertEquals(
+			$expected_response,
+			$result,
+			sprintf(
+				'Expected %1$s to return %2$s for is_local_site()',
+				$site_url,
+				$expected_response
+			)
+		);
+	}
+
+	/**
+	 * Known hosting providers.
+	 *
+	 * @return array
+	 */
+	public function get_is_local_site_known_tld() {
+		return array(
+			'vvv'            => array(
+				'http://jetpack.test',
+				true,
+			),
+			'docksal'        => array(
+				'http://jetpack.docksal',
+				true,
+			),
+			'serverpress'    => array(
+				'http://jetpack.dev.cc',
+				true,
+			),
+			'lando'          => array(
+				'http://jetpack.lndo.site',
+				true,
+			),
+			'test_subdomain' => array(
+				'https://test.jetpack.com',
+				false,
+			),
+			'test_in_domain' => array(
+				'https://jetpack.test.jetpack.com',
+				false,
+			),
+		);
+	}
 }

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -39,8 +39,8 @@ class Test_Status extends TestCase {
 	 * Test setup.
 	 */
 	public function setUp() {
-		$this->status = new Status();
 		Monkey\setUp();
+		$this->status = new Status();
 	}
 
 	/**

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -58,31 +58,31 @@ class Test_Status extends TestCase {
 	 */
 	public function test_is_offline_mode_default() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
-		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( false );
+		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( false );
 
 		$this->assertFalse( $this->status->is_offline_mode() );
 	}
 
 	/**
-	 * Test is_offline_mode when using the jetpack_development_mode filter
+	 * Test is_offline_mode when using the jetpack_offline_mode filter
 	 *
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter_true() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
-		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( true );
+		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( true );
 
 		$this->assertTrue( $this->status->is_offline_mode() );
 	}
 
 	/**
-	 * Test when using a bool value for the jetpack_development_mode filter.
+	 * Test when using a bool value for the jetpack_offline_mode filter.
 	 *
 	 * @covers Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter_bool() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
-		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( 0 );
+		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( 0 );
 
 		$this->assertFalse( $this->status->is_offline_mode() );
 	}
@@ -95,7 +95,7 @@ class Test_Status extends TestCase {
 	public function test_is_offline_mode_localhost() {
 		Functions\when( 'site_url' )->justReturn( 'localhost' );
 
-		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( false );
+		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( false );
 
 		$this->assertTrue( $this->status->is_offline_mode() );
 	}
@@ -109,7 +109,7 @@ class Test_Status extends TestCase {
 	 */
 	public function test_is_offline_mode_constant() {
 		Functions\when( 'site_url' )->justReturn( $this->site_url );
-		Filters\expectApplied( 'jetpack_development_mode' )->once()->with( false )->andReturn( false );
+		Filters\expectApplied( 'jetpack_offline_mode' )->once()->with( false )->andReturn( false );
 
 		$constants_mocks = $this->mock_constants(
 			array(

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -206,7 +206,7 @@ class Actions {
 			return false;
 		}
 
-		if ( ( new Status() )->is_development_mode() ) {
+		if ( ( new Status() )->is_offline_mode() ) {
 			return false;
 		}
 

--- a/packages/terms-of-service/src/class-terms-of-service.php
+++ b/packages/terms-of-service/src/class-terms-of-service.php
@@ -60,7 +60,7 @@ class Terms_Of_Service {
 	 * @return bool
 	 */
 	public function has_agreed() {
-		if ( $this->is_development_mode() ) {
+		if ( $this->is_offline_mode() ) {
 			return false;
 		}
 
@@ -73,8 +73,8 @@ class Terms_Of_Service {
 	 *
 	 * @return bool
 	 */
-	protected function is_development_mode() {
-		return ( new Status() )->is_development_mode();
+	protected function is_offline_mode() {
+		return ( new Status() )->is_offline_mode();
 	}
 
 	/**

--- a/packages/terms-of-service/tests/php/test-terms-of-service.php
+++ b/packages/terms-of-service/tests/php/test-terms-of-service.php
@@ -24,7 +24,7 @@ class Test_Terms_Of_Service extends TestCase {
 	public function setUp() {
 		$this->terms_of_service = $this->createPartialMock(
 			__NAMESPACE__ . '\\Terms_Of_Service',
-			array( 'get_raw_has_agreed', 'is_development_mode', 'set_agree', 'is_active', 'set_reject' )
+			array( 'get_raw_has_agreed', 'is_offline_mode', 'set_agree', 'is_active', 'set_reject' )
 		);
 	}
 
@@ -74,10 +74,10 @@ class Test_Terms_Of_Service extends TestCase {
 	 *
 	 * @covers Automattic\Jetpack\Terms_Of_Service->has_agreed
 	 */
-	public function test_returns_false_if_has_agreed_but_is_development_mode() {
-		// is_development_mode.
+	public function test_returns_false_if_has_agreed_but_is_offline_mode() {
+		// is_offline_mode.
 		$this->terms_of_service->method( 'get_raw_has_agreed' )->willReturn( true );
-		$this->terms_of_service->expects( $this->once() )->method( 'is_development_mode' )->willReturn( true );
+		$this->terms_of_service->expects( $this->once() )->method( 'is_offline_mode' )->willReturn( true );
 		$this->assertFalse( $this->terms_of_service->has_agreed() );
 	}
 
@@ -88,7 +88,7 @@ class Test_Terms_Of_Service extends TestCase {
 	 */
 	public function test_returns_true_if_active_even_if_not_agreed() {
 		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( false );
-		$this->terms_of_service->expects( $this->once() )->method( 'is_development_mode' )->willReturn( false );
+		$this->terms_of_service->expects( $this->once() )->method( 'is_offline_mode' )->willReturn( false );
 
 		// Jetpack is active.
 		$this->terms_of_service->expects( $this->once() )->method( 'is_active' )->willReturn( true );

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -415,10 +415,11 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			'isActive'    => true,
 			'isStaging'   => false,
 			'offlineMode' => array(
-				'isActive' => false,
-				'constant' => false,
-				'url'      => false,
-				'filter'   => false,
+				'isActive'        => false,
+				'constant'        => false,
+				'url'             => false,
+				'filter'          => false,
+				'wpLocalConstant' => false,
 			),
 		), $response );
 	}
@@ -449,10 +450,11 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			'isActive'    => true,
 			'isStaging'   => true,
 			'offlineMode' => array(
-				'isActive' => false,
-				'constant' => false,
-				'url'      => false,
-				'filter'   => false,
+				'isActive'        => false,
+				'constant'        => false,
+				'url'             => false,
+				'filter'          => false,
+				'wpLocalConstant' => false,
 			),
 		), $response );
 
@@ -481,10 +483,11 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			'isActive'    => false,
 			'isStaging'   => false,
 			'offlineMode' => array(
-				'isActive' => true,
-				'constant' => false,
-				'url'      => false,
-				'filter'   => true,
+				'isActive'        => true,
+				'constant'        => false,
+				'url'             => false,
+				'filter'          => true,
+				'wpLocalConstant' => false,
 			),
 		), $response );
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -195,8 +195,8 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// User has capability so this should work this time
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::view_admin_page_permission_check() );
 
-		// It should not work in Dev Mode
-		add_filter( 'jetpack_development_mode', '__return_true' );
+		// It should not work in Offline Mode.
+		add_filter( 'jetpack_offline_mode', '__return_true' );
 
 		// Subscribers only have access to connect, which is not available in Dev Mode so this should fail
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::view_admin_page_permission_check() );
@@ -211,7 +211,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Admins have acces to everything, to this should work
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::view_admin_page_permission_check() );
 
-		remove_filter( 'jetpack_development_mode', '__return_true' );
+		remove_filter( 'jetpack_offline_mode', '__return_true' );
 	}
 
 	/**
@@ -240,13 +240,13 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
 		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
 
-		// It should not work in Dev Mode
-		add_filter( 'jetpack_development_mode', '__return_true' );
+		// It should not work in Offline Mode.
+		add_filter( 'jetpack_offline_mode', '__return_true' );
 
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::connect_url_permission_callback() );
 		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::get_user_connection_data_permission_callback() );
 
-		remove_filter( 'jetpack_development_mode', '__return_true' );
+		remove_filter( 'jetpack_offline_mode', '__return_true' );
 	}
 
 	/**
@@ -412,9 +412,9 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Success, authenticated user and connected site
 		$this->assertResponseStatus( 200, $response );
 		$this->assertResponseData( array(
-			'isActive'  => true,
-			'isStaging' => false,
-			'devMode'   => array(
+			'isActive'    => true,
+			'isStaging'   => false,
+			'offlineMode' => array(
 				'isActive' => false,
 				'constant' => false,
 				'url'      => false,
@@ -446,9 +446,9 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Success, authenticated user and connected site
 		$this->assertResponseStatus( 200, $response );
 		$this->assertResponseData( array(
-			'isActive'  => true,
-			'isStaging' => true,
-			'devMode'   => array(
+			'isActive'    => true,
+			'isStaging'   => true,
+			'offlineMode' => array(
 				'isActive' => false,
 				'constant' => false,
 				'url'      => false,
@@ -470,7 +470,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$user = $this->create_and_get_user();
 		wp_set_current_user( $user->ID );
 
-		add_filter( 'jetpack_development_mode', '__return_true' );
+		add_filter( 'jetpack_offline_mode', '__return_true' );
 
 		// Create REST request in JSON format and dispatch
 		$response = $this->create_and_get_request( 'connection' );
@@ -478,9 +478,9 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		// Success, authenticated user and connected site
 		$this->assertResponseStatus( 200, $response );
 		$this->assertResponseData( array(
-			'isActive'  => false,
-			'isStaging' => false,
-			'devMode'   => array(
+			'isActive'    => false,
+			'isStaging'   => false,
+			'offlineMode' => array(
 				'isActive' => true,
 				'constant' => false,
 				'url'      => false,
@@ -488,7 +488,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 			),
 		), $response );
 
-		remove_filter( 'jetpack_development_mode', '__return_true' );
+		remove_filter( 'jetpack_offline_mode', '__return_true' );
 	}
 
 	/**

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -486,9 +486,9 @@ EXPECTED;
 	 * @covers \Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_filter() {
-		add_filter( 'jetpack_development_mode', '__return_true' );
+		add_filter( 'jetpack_offline_mode', '__return_true' );
 		$this->assertTrue( ( new Status() )->is_offline_mode() );
-		remove_filter( 'jetpack_development_mode', '__return_true' );
+		remove_filter( 'jetpack_offline_mode', '__return_true' );
 	}
 
 	/**
@@ -497,9 +497,9 @@ EXPECTED;
 	 * @covers \Automattic\Jetpack\Status::is_offline_mode
 	 */
 	public function test_is_offline_mode_bool() {
-		add_filter( 'jetpack_development_mode', '__return_zero' );
+		add_filter( 'jetpack_offline_mode', '__return_zero' );
 		$this->assertFalse( ( new Status() )->is_offline_mode() );
-		remove_filter( 'jetpack_development_mode', '__return_zero' );
+		remove_filter( 'jetpack_offline_mode', '__return_zero' );
 	}
 
 	function test_get_sync_idc_option_sanitizes_out_www_and_protocol() {

--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -480,15 +480,25 @@ EXPECTED;
 		$this->assertFalse( Jetpack::is_development_version() );
 	}
 
-	function test_is_development_mode_filter() {
+	/**
+	 * Tests is_offline_mode filter.
+	 *
+	 * @covers \Automattic\Jetpack\Status::is_offline_mode
+	 */
+	public function test_is_offline_mode_filter() {
 		add_filter( 'jetpack_development_mode', '__return_true' );
-		$this->assertTrue( ( new Status() )->is_development_mode() );
+		$this->assertTrue( ( new Status() )->is_offline_mode() );
 		remove_filter( 'jetpack_development_mode', '__return_true' );
 	}
 
-	function test_is_development_mode_bool() {
+	/**
+	 * Tests is_offline_mode filter's bool type casting.
+	 *
+	 * @covers \Automattic\Jetpack\Status::is_offline_mode
+	 */
+	public function test_is_offline_mode_bool() {
 		add_filter( 'jetpack_development_mode', '__return_zero' );
-		$this->assertFalse( ( new Status() )->is_development_mode() );
+		$this->assertFalse( ( new Status() )->is_offline_mode() );
 		remove_filter( 'jetpack_development_mode', '__return_zero' );
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-listener.php
+++ b/tests/php/sync/test_class.jetpack-sync-listener.php
@@ -9,7 +9,7 @@ class WP_Test_Jetpack_Sync_Listener extends WP_Test_Jetpack_Sync_Base {
 	function test_never_queues_if_development() {
 		$this->markTestIncomplete( "We now check this during 'init', so testing is pretty hard" );
 
-		add_filter( 'jetpack_development_mode', '__return_true' );
+		add_filter( 'jetpack_offline_mode', '__return_true' );
 
 		$queue = $this->listener->get_sync_queue();
 		$queue->reset(); // remove any actions that already got queued

--- a/tests/php/sync/test_class.jetpack-sync-modules.php
+++ b/tests/php/sync/test_class.jetpack-sync-modules.php
@@ -7,8 +7,8 @@ class WP_Test_Jetpack_Sync_Modules extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sync_activate_module_event() {
 		// Calling the activate_module in tests is difficult.
-		// Since the site need to eather be connected or in development mode.
-		// But we don't allow sync to happen in development mode.
+		// Since the site need to eather be connected or in offline mode.
+		// But we don't allow sync to happen in offline mode.
 		do_action( 'jetpack_activate_module', 'stuff' );
 		$this->sender->do_sync();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = [
 						Initial_State: {
 							dismissedNotices: [],
 							connectionStatus: {
-								devMode: {
+								offlineMode: {
 									isActive: false,
 								},
 							},


### PR DESCRIPTION
Fixes #11798

#### Changes proposed in this Pull Request:
* Uses `wp_get_environment_type` as the default value for the Status package `is_staging_site` value (by way of !== production is a staging site in how we handle them).
* Uses the `WP_LOCAL_DEV` that Core site health does check. This activates our "Development Mode".
* Renames "Development Mode" to "Offline Mode" to be clearer our intent of this mode.
* Deprecation and updates relevant for ^.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Todo required
If this lands, we need to update documentation. I'm okay doing this in a folllow-up PR or adding a new commit here if this is otherwise approved.

If we're happy with this, I'll coordinate with Quill.

#### Testing instructions:
* Ensure Offline mode works (try this on localhost without a dot in the domain, e.g. our docker without using ngrok/JT.
* On a JN site running on WP trunk on a connected Jetpack site, set a constant `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` Does this activate staging mode?

#### Proposed changelog entry for your changes:
* WordPress 5.5: Utilize new wp_get_environment_type function to determing Staging sites.
* Rename Development Mode to Offline Mode to be clearer our intent for its use.
