### PR TITLE
Tests: improve the test_classic_xmlrpc_* tests

### DIFF
--- a/tests/php/general/test_class.jetpack.php
+++ b/tests/php/general/test_class.jetpack.php
@@ -878,6 +878,10 @@ EXPECTED;
 	}
 
 	/**
+	 * Asserts that:
+	 *   - all of the required xmlrpc methods are in the actual method list.
+	 *   - all of the actual xmlrpc methods are in the required or allowed lists.
+	 *
 	 * @param string[] $required List of XML-RPC methods that must be contained in $actual.
 	 * @param string[] $allowed  Additional list of XML-RPC methods that may be contained in $actual.
 	 *                           Useful for listing methods that are added by modules that may or may
@@ -885,41 +889,45 @@ EXPECTED;
 	 * @param string[] $actual   The list of XML-RPC methods.
 	 */
 	private function assertXMLRPCMethodsComply( $required, $allowed, $actual ) {
-		$this->assertArraySubset( $required, $actual );
-		$this->assertEquals( [], array_diff( $actual, $required, $allowed ) );
+		$this->assertEquals( array(), array_diff( $required, $actual ) );
+		$this->assertEquals( array(), array_diff( $actual, $required, $allowed ) );
 	}
 
 	/**
+	 * Tests the setup of the xmlrpc methods when the site is active, the request is signed, and without a user.
+	 *
 	 * @group xmlrpc
 	 */
 	public function test_classic_xmlrpc_when_active_and_signed_with_no_user() {
-		$this->mocked_setup_xmlrpc_handlers( [ 'for' => 'jetpack' ], true, true );
+		$this->mocked_setup_xmlrpc_handlers( array( 'for' => 'jetpack' ), true, true );
 
-		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
+		$methods = apply_filters( 'xmlrpc_methods', array( 'test.test' => '__return_true' ) );
 
-		$required = [
+		$required = array(
 			'jetpack.verifyAction',
 			'jetpack.getUser',
 			'jetpack.remoteRegister',
 			'jetpack.remoteProvision',
 			'jetpack.jsonAPI',
-		];
+		);
 
 		// Nothing else is allowed.
-		$allowed = [];
+		$allowed = array();
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}
 
 	/**
+	 * Tests the setup of the xmlrpc methods when the site is active, the request is signed, and with a user.
+	 *
 	 * @group xmlrpc
 	 */
 	public function test_classic_xmlrpc_when_active_and_signed_with_user() {
-		$this->mocked_setup_xmlrpc_handlers( [ 'for' => 'jetpack' ], true, true, get_user_by( 'ID', self::$admin_id ) );
+		$this->mocked_setup_xmlrpc_handlers( array( 'for' => 'jetpack' ), true, true, get_user_by( 'ID', self::$admin_id ) );
 
-		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
+		$methods = apply_filters( 'xmlrpc_methods', array( 'test.test' => '__return_true' ) );
 
-		$required = [
+		$required = array(
 			'jetpack.verifyAction',
 			'jetpack.getUser',
 			'jetpack.remoteRegister',
@@ -935,31 +943,42 @@ EXPECTED;
 			'jetpack.featuresEnabled',
 
 			'jetpack.syncObject',
-		];
+		);
 
-		// It's OK if these module-added methods are present. (Module active in tests.)
-		// It's OK if they are not. (Module inactive in tests.)
-		$allowed = [
+		// It's OK if these module-added methods are present (module active in tests).
+		// It's OK if they are not (module inactive in tests).
+		$allowed = array(
 			'jetpack.subscriptions.subscribe',
 			'jetpack.updatePublicizeConnections',
-		];
+		);
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}
 
 	/**
+	 * Tests the setup of the xmlrpc methods when the site is active, the request is signed, with a user,
+	 * and with edit methods enabled.
+	 *
 	 * @group xmlrpc
 	 */
 	public function test_classic_xmlrpc_when_active_and_signed_with_user_with_edit() {
-		$this->mocked_setup_xmlrpc_handlers( [ 'for' => 'jetpack' ], true, true, get_user_by( 'ID', self::$admin_id ) );
+		$this->mocked_setup_xmlrpc_handlers(
+			array( 'for' => 'jetpack' ),
+			true,
+			true,
+			get_user_by( 'ID', self::$admin_id )
+		);
 
-		$methods = apply_filters( 'xmlrpc_methods', [
-			'test.test'                 => '__return_true',
-			'metaWeblog.editPost'       => '__return_true',
-			'metaWeblog.newMediaObject' => '__return_true',
-		] );
+		$methods = apply_filters(
+			'xmlrpc_methods',
+			array(
+				'test.test'                 => '__return_true',
+				'metaWeblog.editPost'       => '__return_true',
+				'metaWeblog.newMediaObject' => '__return_true',
+			)
+		);
 
-		$required = [
+		$required = array(
 			'jetpack.verifyAction',
 			'jetpack.getUser',
 			'jetpack.remoteRegister',
@@ -978,74 +997,80 @@ EXPECTED;
 			'jetpack.updateAttachmentParent',
 
 			'jetpack.syncObject',
-		];
+		);
 
-		// It's OK if these module-added methods are present. (Module active in tests.)
-		// It's OK if they are not. (Module inactive in tests.)
-		$allowed = [
+		// It's OK if these module-added methods are present (module active in tests).
+		// It's OK if they are not (module inactive in tests).
+		$allowed = array(
 			'jetpack.subscriptions.subscribe',
 			'jetpack.updatePublicizeConnections',
-		];
+		);
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}
 
 	/**
+	 * Tests the setup of the xmlrpc methods when the site is active and the request is not signed.
+	 *
 	 * @group xmlrpc
 	 */
 	public function test_classic_xmlrpc_when_active_and_not_signed() {
-		$this->mocked_setup_xmlrpc_handlers( [ 'for' => 'jetpack' ], true, false );
+		$this->mocked_setup_xmlrpc_handlers( array( 'for' => 'jetpack' ), true, false );
 
-		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
+		$methods = apply_filters( 'xmlrpc_methods', array( 'test.test' => '__return_true' ) );
 
-		$required = [
+		$required = array(
 			'jetpack.remoteAuthorize',
-		];
+		);
 
 		// Nothing else is allowed.
-		$allowed = [];
+		$allowed = array();
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}
 
 	/**
+	 * Tests the setup of the xmlrpc methods when the site is not active and the request is not signed.
+	 *
 	 * @group xmlrpc
 	 */
 	public function test_classic_xmlrpc_when_not_active_and_not_signed() {
-		$this->mocked_setup_xmlrpc_handlers( [ 'for' => 'jetpack' ], false, false );
+		$this->mocked_setup_xmlrpc_handlers( array( 'for' => 'jetpack' ), false, false );
 
-		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
+		$methods = apply_filters( 'xmlrpc_methods', array( 'test.test' => '__return_true' ) );
 
-		$required = [
+		$required = array(
 			'jetpack.remoteAuthorize',
 			'jetpack.remoteRegister',
 
 			'jetpack.verifyRegistration',
-		];
+		);
 
 		// Nothing else is allowed.
-		$allowed = [];
+		$allowed = array();
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}
 
 	/**
+	 * Tests the setup of the xmlrpc methods when the site is not active and the request is signed.
+	 *
 	 * @group xmlrpc
 	 */
 	public function test_classic_xmlrpc_when_not_active_and_signed() {
-		$this->mocked_setup_xmlrpc_handlers( [ 'for' => 'jetpack' ], false, true );
+		$this->mocked_setup_xmlrpc_handlers( array( 'for' => 'jetpack' ), false, true );
 
-		$methods = apply_filters( 'xmlrpc_methods', [ 'test.test' => '__return_true' ] );
+		$methods = apply_filters( 'xmlrpc_methods', array( 'test.test' => '__return_true' ) );
 
-		$required = [
+		$required = array(
 			'jetpack.remoteRegister',
 			'jetpack.remoteProvision',
 			'jetpack.remoteConnect',
 			'jetpack.getUser',
-		];
+		);
 
 		// Nothing else is allowed.
-		$allowed = [];
+		$allowed = array();
 
 		$this->assertXMLRPCMethodsComply( $required, $allowed, array_keys( $methods ) );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The `test_classic_xmlrpc_*` unit tests are brittle because `assertArraySubset` returns true only when the subset array being evaluated is in the same order as the input array. The order of the xmlrpc methods arrays doesn't matter, so Improve the tests by using `array_diff()` instead.

* Also clean up the phpcs errors in the `test_classic_xmlrpc_*` tests.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* These changes affect only the unit tests, so verify that the unit tests passed.

#### Proposed changelog entry for your changes:
* n/a
