### PR TITLE
new module and UI to activate modules

### DIFF
--- a/docker/mu-plugins/jetpack-debug-helper/class-admin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/class-admin.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Simple admin interface to activate/deactivate modules
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Debug_Helper;
+
+/**
+ * Class Jetpack_Debug_Helper_Admin
+ */
+class Admin {
+
+	/**
+	 * Option name.
+	 */
+	const OPTION_NAME = 'jetpack_debug_helper_active_modules';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
+	}
+
+	/**
+	 * Register's submenu.
+	 */
+	public function register_submenu_page() {
+		add_submenu_page(
+			'jetpack',
+			'Debug tools',
+			'Debug tools',
+			'manage_options',
+			'debug-tools',
+			array( $this, 'render_ui' ),
+			99
+		);
+	}
+
+	/**
+	 * Get the list of active modules
+	 *
+	 * @return array
+	 */
+	public static function get_active_modules() {
+		return get_option( self::OPTION_NAME, array() );
+	}
+
+	/**
+	 * Render UI.
+	 */
+	public function render_ui() {
+
+		$this->update_option();
+
+		$stored_options = get_option( self::OPTION_NAME, array() );
+		global $jetpack_dev_debug_modules;
+		?>
+		<h1>Jetpack Debug tools</h1>
+		<p>This plugin adds debugging tools to your jetpack. Choose which tools you want to activate.</p>
+
+		<form method="post">
+			<input type="hidden" name="action" value="store_debug_active_modules">
+			<?php wp_nonce_field( 'store-debug-modules' ); ?>
+
+			<?php foreach ( $jetpack_dev_debug_modules as $module_slug => $module_details ) : ?>
+
+				<p>
+					<input type="checkbox" name="active_modules[]" value="<?php echo esc_attr( $module_slug ); ?>" <?php checked( in_array( $module_slug, $stored_options, true ) ); ?> />
+					<b><?php echo esc_html( $module_details['name'] ); ?></b>
+					<?php echo esc_html( $module_details['description'] ); ?>
+				</p>
+
+			<?php endforeach; ?>
+
+			<input type="submit" value="Save" class="button button-primary">
+
+		</form>
+		<br>
+
+		<?php
+	}
+
+	/**
+	 * Store options.
+	 */
+	public function update_option() {
+
+		if ( isset( $_POST['action'] ) && 'store_debug_active_modules' === $_POST['action'] ) {
+			check_admin_referer( 'store-debug-modules' );
+			update_option( self::OPTION_NAME, $_POST['active_modules'] );
+		}
+
+	}
+
+}
+
+add_action(
+	'plugins_loaded',
+	function() {
+		new Admin();
+	}
+);
+

--- a/docker/mu-plugins/jetpack-debug-helper/modules/class-jetpack-sync-debug-helper.php
+++ b/docker/mu-plugins/jetpack-debug-helper/modules/class-jetpack-sync-debug-helper.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Jetpack sync debug helper class
+ *
+ * @package jetpack
+ */
+
+defined( 'JETPACK__API_BASE' ) || define( 'JETPACK__API_BASE', get_option( Jetpack_Sync_Debug_Helper::API_BASE, 'https://jetpack.wordpress.com/jetpack.' ) );
+
+Jetpack_Sync_Debug_Helper::init();
+
+register_deactivation_hook( JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE, array( 'Jetpack_Sync_Debug_Helper', 'deactivate' ) );
+
+/**
+ * Helps debug sync errors
+ */
+class Jetpack_Sync_Debug_Helper {
+	const API_BASE        = 'jetpack_debugger_api_base';
+	const LAST_SYNC_ERROR = 'jetpack_debugger_last_sync_error';
+
+	/**
+	 * Saved error
+	 *
+	 * @var boolean
+	 */
+	public static $saved_error = false;
+
+	/**
+	 * Init hooks
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		// allows us to set the value via the api.
+		add_filter( 'jetpack_options_whitelist', array( 'Jetpack_Sync_Debug_Helper', 'whitelist_options' ) );
+		add_filter( 'jetpack_sync_send_data', array( 'Jetpack_Sync_Debug_Helper', 'pre_send' ), 8, 4 );
+		add_filter( 'jetpack_sync_send_data', array( 'Jetpack_Sync_Debug_Helper', 'store_sync_error' ), 11, 4 );
+	}
+
+	/**
+	 * Deactivation hook
+	 */
+	public static function deactivate() {
+		delete_option( self::API_BASE );
+		delete_option( self::LAST_SYNC_ERROR );
+	}
+
+	/**
+	 * Pre send
+	 *
+	 * @param array  $data The action buffer.
+	 * @param string $codec_name The codec name used to encode the data.
+	 * @param double $sent_timestamp The current time.
+	 * @param string $queue_id The queue used to send ('sync' or 'full_sync').
+	 * @return array
+	 */
+	public static function pre_send( $data, $codec_name, $sent_timestamp, $queue_id ) {
+		if ( empty( $data ) ) {
+			update_option(
+				self::LAST_SYNC_ERROR,
+				array(
+					'error_code' => 'pre_empty',
+					'queue'      => $queue_id,
+					'timestamp'  => $sent_timestamp,
+					'codec'      => $codec_name,
+				)
+			);
+
+			self::$saved_error = true;
+		}
+		return $data;
+	}
+
+	/**
+	 * Pre send
+	 *
+	 * @param array  $data The action buffer.
+	 * @param string $codec_name The codec name used to encode the data.
+	 * @param double $sent_timestamp The current time.
+	 * @param string $queue_id The queue used to send ('sync' or 'full_sync').
+	 * @return array
+	 */
+	public static function store_sync_error( $data, $codec_name, $sent_timestamp, $queue_id ) {
+		if ( isset( $data['error_code'] ) && ! self::$saved_error ) {
+			update_option(
+				self::LAST_SYNC_ERROR,
+				array(
+					'error_code' => $data['error_code'],
+					'queue'      => $queue_id,
+					'timestamp'  => $sent_timestamp,
+					'codec'      => $codec_name,
+				)
+			);
+		}
+		if ( empty( $data ) && ! self::$saved_error ) {
+			update_option(
+				self::LAST_SYNC_ERROR,
+				array(
+					'error_code' => 'empty',
+					'queue'      => $queue_id,
+					'timestamp'  => $sent_timestamp,
+					'codec'      => $codec_name,
+				)
+			);
+		}
+		return $data;
+	}
+
+	/**
+	 * Whitelist synced options
+	 *
+	 * @param array $options options.
+	 * @return array
+	 */
+	public static function whitelist_options( $options ) {
+		return array_merge(
+			$options,
+			array(
+				self::API_BASE,
+				self::LAST_SYNC_ERROR,
+			)
+		);
+	}
+
+}
+

--- a/docker/mu-plugins/jetpack-debug-helper/plugin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/plugin.php
@@ -11,51 +11,28 @@
 
 namespace Automattic\Jetpack\Debug_Helper;
 
-// phpcs:disable WordPress.WhiteSpace.PrecisionAlignment.Found
-
-/*
- .--..--..--..--..--..--..--..--..--..--..--..--..--..--..--..--.
-/ .. \.. \.. \.. \.. \.. \.. \.. \.. \.. \.. \.. \.. \.. \.. \.. \
-\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/ /
- \/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /
- / /\/ /`' /`' /`' /`' /`' /`' /`' /`' /`' /`' /`' /`' /`' /\/ /\
-/ /\ \/`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'\ \/\ \
-\ \/\ \                                                    /\ \/ /
- \/ /\ \                                                  / /\/ /
- / /\/ /    MUST COMMENT OUT THE LINE BELOW               \ \/ /\
-/ /\ \/                                                    \ \/\ \
-\ \/\ \             TO ACTIVATE THE BROKEN TOKEN TOOL.     /\ \/ /
- \/ /\ \                                                  / /\/ /
- / /\/ /                                                  \ \/ /\
-/ /\ \/                                                    \ \/\ \
-\ \/\ \.--..--..--..--..--..--..--..--..--..--..--..--..--./\ \/ /
- \/ /\/ ../ ../ ../ ../ ../ ../ ../ ../ ../ ../ ../ ../ ../ /\/ /
- / /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\/ /\
-/ /\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \/\ \
-\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `'\ `' /
- `--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'`--'
- */
-add_filter( 'jetpack_debug_helper_modules', '__return_empty_array' );
-
-// phpcs:enable
+define( 'JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE', __FILE__ );
 
 /**
  * Include file names from the modules directory here.
- *
- * @todo Add UI to make this easier to use in a testing situation.
  */
-$modules = array(
-	'class-broken-token.php',
+$jetpack_dev_debug_modules = array(
+	'broken-token' => array(
+		'file'        => 'class-broken-token.php',
+		'name'        => 'Broken token Utilities',
+		'description' => '',
+	),
+	'sync-debug'   => array(
+		'file'        => 'class-jetpack-sync-debug-helper.php',
+		'name'        => 'Sync Debug Utilities',
+		'description' => '',
+	),
 );
 
-/**
- * Filter the features of the Jetpack Debug Helper.
- *
- * This is part of the mu-plugins folder within Jetpack's built-in local Docker environment.
- * This filter does not exist and is non-functional in production code.
- *
- * @param array $modules Array of file names. File names are based on the docker/mu-plugins/jetpack-debug-helper/inc folder.
- */
-foreach ( (array) apply_filters( 'jetpack_debug_helper_modules', $modules ) as $module ) {
-	include_once plugin_dir_path( __FILE__ ) . 'modules/' . $module;
+require_once 'class-admin.php';
+
+foreach ( (array) Admin::get_active_modules() as $module ) {
+	if ( isset( $jetpack_dev_debug_modules[ $module ] ) ) {
+		include_once plugin_dir_path( __FILE__ ) . 'modules/' . $jetpack_dev_debug_modules[ $module ]['file'];
+	}
 }


### PR DESCRIPTION
Adds the sync helper module that used to live in the jetpack-debug-helper repository

adds a simple UI to activate modules