### PR TITLE
Send a Message Block: Make sure empty text buttons look good

### DIFF
--- a/extensions/blocks/send-a-message/whatsapp-button/save.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/save.js
@@ -34,7 +34,11 @@ export default function SendAMessageSave( { attributes, className } ) {
 		return url;
 	};
 
-	const cssClassNames = classnames( className, colorClass ? 'is-color-' + colorClass : undefined );
+	const cssClassNames = classnames(
+		className,
+		colorClass ? 'is-color-' + colorClass : undefined,
+		! buttonText.length ? 'has-no-text' : undefined
+	);
 
 	return (
 		<div className={ cssClassNames }>

--- a/extensions/blocks/send-a-message/whatsapp-button/view.scss
+++ b/extensions/blocks/send-a-message/whatsapp-button/view.scss
@@ -10,6 +10,7 @@ div.wp-block-jetpack-whatsapp-button {
 		border-radius: 8px;
 		text-decoration: none;
 		white-space: nowrap;
+		min-height: 50px;
 
 		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 		font-weight: 500;
@@ -33,6 +34,12 @@ div.wp-block-jetpack-whatsapp-button {
 
 	&.alignright {
 		text-align: right;
+	}
+
+	&.has-no-text {
+		a.whatsapp-block__button {
+			padding-left: 48px;
+		}
 	}
 
 	&:hover {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/16343

Before:

<img width="112" alt="Screen Shot 2020-06-30 at 2 34 10 PM" src="https://user-images.githubusercontent.com/1464705/86179294-d6f35a00-bade-11ea-9ed0-fa2013fead4c.png">

After:

<img width="128" alt="Screen Shot 2020-06-30 at 2 33 49 PM" src="https://user-images.githubusercontent.com/1464705/86179305-da86e100-bade-11ea-8d65-1e35d267e2c1.png">


#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a WhatsApp button block
* Remove the text label
* Publish and confirm it looks like the after picture on the front end

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
