### PR TITLE
In-place connection flow: Remove ab tests

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -37,38 +37,14 @@ jQuery( document ).ready( function( $ ) {
 
 			if ( ! jetpackConnectButton.isRegistering ) {
 				if ( 'original' === jpConnect.forceVariation ) {
-					// Forcing original connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = false`
+					// Forcing original connection flow, `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME = true`
 					// or we're dealing with Safari which has issues with handling 3rd party cookies.
 					jetpackConnectButton.handleOriginalFlow();
-				} else if ( 'in_place' === jpConnect.forceVariation ) {
-					// Forcing new connection flow, `JETPACK_SHOULD_USE_CONNECTION_IFRAME = true`.
-					jetpackConnectButton.handleConnectInPlaceFlow();
 				} else {
-					// Forcing A/B test driven connection flow variation, `JETPACK_SHOULD_USE_CONNECTION_IFRAME` not defined.
-					jetpackConnectButton.startConnectionFlow();
+					// Default in-place connection flow.
+					jetpackConnectButton.handleConnectInPlaceFlow();
 				}
 			}
-		},
-		startConnectionFlow: function() {
-			var abTestName = 'jetpack_connect_in_place_v4';
-
-			$.ajax( {
-				url: 'https://public-api.wordpress.com/wpcom/v2/abtest/' + abTestName,
-				type: 'GET',
-				error: jetpackConnectButton.handleConnectionError,
-				data: jpConnect.identity,
-				xhrFields: {
-					withCredentials: true,
-				},
-				crossDomain: true,
-				success: function( data ) {
-					if ( data && 'in_place' === data.variation ) {
-						jetpackConnectButton.handleConnectInPlaceFlow();
-						return;
-					}
-					jetpackConnectButton.handleOriginalFlow();
-				},
-			} );
 		},
 		handleOriginalFlow: function() {
 			window.location = connectButton.attr( 'href' );

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -172,14 +172,10 @@ class Jetpack_Connection_Banner {
 
 		// Due to the limitation in how 3rd party cookies are handled in Safari,
 		// we're falling back to the original flow on Safari desktop and mobile.
-		if ( $is_safari ) {
-			$force_variation = 'original';
-		} elseif ( Constants::is_true( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
-			$force_variation = 'in_place';
-		} elseif ( Constants::is_defined( 'JETPACK_SHOULD_USE_CONNECTION_IFRAME' ) ) {
+		if ( $is_safari || Constants::is_true( 'JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME' ) ) {
 			$force_variation = 'original';
 		} else {
-			$force_variation = null;
+			$force_variation = 'in_place';
 		}
 
 		$tracking = new Automattic\Jetpack\Tracking();

--- a/docs/testing/regression-checklist/regression-checklist.md
+++ b/docs/testing/regression-checklist/regression-checklist.md
@@ -1,6 +1,6 @@
 # Regression checklist
-This is the "global" checklist, that might be used for beta testing. 
-NOTE: it might become outdated, so it could be a good idea to generate this file via test-suites files. 
+This is the "global" checklist, that might be used for beta testing.
+NOTE: it might become outdated, so it could be a good idea to generate this file via test-suites files.
 
 ## Global
 
@@ -39,7 +39,7 @@ NOTE: it might become outdated, so it could be a good idea to generate this file
 - [ ] In-place connection with free plan
 - [ ] In-place connection with paid plan
 - [ ] In-place connection with product purchase
-- [ ] Classic connection. Use Safari, or set a constant “JETPACK_SHOULD_USE_CONNECTION_IFRAME” to false
+- [ ] Classic connection. Use Safari, or set a constant JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME to true
 - [ ] Disconnect/reconnect connection
 - [ ] Secondary user connection
 - [ ] Connection on multisite

--- a/docs/testing/regression-checklist/test-suites/packages/connection.md
+++ b/docs/testing/regression-checklist/test-suites/packages/connection.md
@@ -3,7 +3,7 @@
 - [ ] In-place connection with free plan
 - [ ] In-place connection with paid plan
 - [ ] In-place connection with product purchase
-- [ ] Classic connection. Use Safari, or set a constant `JETPACK_SHOULD_USE_CONNECTION_IFRAME` to false
+- [ ] Classic connection. Use Safari, or set a constant `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` to true
 - [ ] Disconnect/reconnect connection
 - [ ] Secondary user connection
 - [ ] Connection on multisite

--- a/tests/e2e/bin/install-wordpress.sh
+++ b/tests/e2e/bin/install-wordpress.sh
@@ -75,7 +75,7 @@ docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER touch /var/www/h
 
 # NOTE: Force classic connection flow
 # https://github.com/Automattic/jetpack/pull/13288
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI config set JETPACK_SHOULD_USE_CONNECTION_IFRAME false --raw --type=constant --quiet
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI config set JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME true --raw --type=constant --quiet
 
 
 echo -e $(status_message "Activating Jetpack and test plugins..")

--- a/tests/e2e/bin/setup-e2e-travis.sh
+++ b/tests/e2e/bin/setup-e2e-travis.sh
@@ -135,7 +135,7 @@ PHP
 
 	# NOTE: Force classic connection flow
 	# https://github.com/Automattic/jetpack/pull/13288
-	wp --allow-root config set JETPACK_SHOULD_USE_CONNECTION_IFRAME false --raw --type=constant
+	wp --allow-root config set JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME true --raw --type=constant
 
 	wp db create
 

--- a/tests/e2e/specs/connection.test.js
+++ b/tests/e2e/specs/connection.test.js
@@ -9,7 +9,6 @@ import JetpackPage from '../lib/pages/wp-admin/jetpack';
 
 describe( 'Connection', () => {
 	catchBeforeAll( async () => {
-		await execWpCommand( 'wp config set JETPACK_SHOULD_USE_CONNECTION_IFRAME true' );
 		await execWpCommand( 'wp option delete jetpack_private_options' );
 		await page.reload();
 		// For some reason it need 2 reloads to make constant actually work.
@@ -21,7 +20,6 @@ describe( 'Connection', () => {
 			'wp option update jetpack_private_options --format=json',
 			'< jetpack_private_options.txt'
 		);
-		await execWpCommand( 'wp config set JETPACK_SHOULD_USE_CONNECTION_IFRAME false' );
 	} );
 
 	it( 'In-place', async () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR removes the A/B testing flow from the existing connection flow. Given this, the `in-place` connection flow becomes the default flow.
Furthermore, up to now we were using the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant to force the `in-place` connection flow. Given that this is now the default flow and aiming to preserve a corresponding constant for testing purposes we replace the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant with `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` which when set to `true` will force the original (aka authorization via redirection flow).

To summarize, this PR:
* Removes A/B testing logic for our 2 different connection flows
* Replaces the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` with `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME`  constant
* Updates the existing e2e tests that were using the `JETPACK_SHOULD_USE_CONNECTION_IFRAME` constant
* Updates the testing documentation, in particular the connection related regression checklist with updated instruction on how to trigger the original (redirection) flow

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

**Prerequisites**: 
* Jetpack plugin not connected/setup

**Instructions:**

**Default connection flow on any browser except Safari:**
* Go to Admin->Jetpack where you will be presented with the setup screen, as before (use any browser except Safari)
* Click on the `Set up` button and verify the `in-place` connection flow will be triggered.

**Connection flow on Safari:**
* Repeat the above process on Safari and make sure the original (redirection) flow will be triggered

**Connection flow with constant set:**
* Set the `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` and repeat the above process. 
* Verify the original (redirection) flow will be triggered

#### Proposed changelog entry for your changes:
* In-place connection flow: Remove ab tests

#### Important note
When this PR is merged to master, make sure to update the [Companion Plugin](https://github.com/Automattic/companion/blob/master/companion.php#L276) to utliize the `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` constant instead.