### PR TITLE
React Dash docs: encourage moving to function components

### DIFF
--- a/_inc/client/README.md
+++ b/_inc/client/README.md
@@ -5,6 +5,10 @@ The **Jetpack Admin Page** is a Javascript app built on **React**, [redux](https
 
 It's rendered on page load when visiting Jetpack's Admin Pages and fetches data from Jetpack via a REST API.
 
+### Components
+
+It is preferred to implement all new components as [function components](https://reactjs.org/docs/components-and-props.html), using [hooks](https://reactjs.org/docs/hooks-reference.html) to manage component state and lifecycle. With the exception of [error boundaries](https://reactjs.org/docs/error-boundaries.html), you should never encounter a situation where you must use a class component. Note that the [WordPress guidance on Code Refactoring](https://make.wordpress.org/core/handbook/contribute/code-refactoring/) applies here: There needn't be a concentrated effort to update class components in bulk. Instead, consider it as a good refactoring opportunity in combination with some other change.
+
 ### Data approach on the Admin Page
 
 The **Admin Page** uses **redux**, [redux-thunk](https://github.com/gaearon/redux-thunk), and [react-redux](https://github.com/reactjs/react-redux)  for state handling trying to ressemble [Calypso's data approach, third Era](https://github.com/Automattic/wp-calypso/blob/master/docs/our-approach-to-data.md#third-era-redux-global-state-tree-december-2015---present).


### PR DESCRIPTION
Fixes #15694

#### Changes proposed in this Pull Request:

We currently rely on React in 2 different areas of Jetpack: extensions (aka blocks) and the admin interface). Let's try to follow the same coding guidelines in both environments.

The React dashboard was built a few years back, when React Hooks weren’t a thing yet. As a result, 95% of it relies on classes.
Blocks are still being built, and you’ll find 2 different styles, depending on when the blocks were first built: some use classes, some rely on React Hooks.
As we iterate on the dashboard, let's now encourage the use of function components instead of classes.

The paragraph added in this PR is shamefully stolen from the Gutenberg docs. Kudos @aduth
https://github.com/WordPress/gutenberg/blob/cee8193ca015857d9f9f5e70205588c1a4e6b0a4/docs/contributors/coding-guidelines.md#wordpresselement-react-components

#### Jetpack product discussion

* Internal reference: p9dueE-1nG-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Not much to test here, check for typos.


#### Proposed changelog entry for your changes:

* N/A
