### PR TITLE
Repo Gardening: add new action to mark issues being worked on

### DIFF
--- a/.github/actions/assign-issues/action.yml
+++ b/.github/actions/assign-issues/action.yml
@@ -1,0 +1,10 @@
+name: "Assign Issues"
+description: "Assigns an issue to a PR author and add a label"
+inputs:
+  token:
+    description: "GitHub access token"
+    required: true
+    default: ""
+runs:
+  using: node12
+  main: "src/index.js"

--- a/.github/actions/assign-issues/package.json
+++ b/.github/actions/assign-issues/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "assign-issues",
+	"version": "1.0.0",
+	"description": "Assigns an issue to a PR author and add a label",
+	"author": "Automattic",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress",
+		"jetpack",
+		"github",
+		"action"
+	],
+	"main": "index.js",
+	"dependencies": {
+		"@actions/core": "^1.2.3",
+		"@actions/github": "^2.1.1"
+	},
+	"private": true
+}

--- a/.github/actions/assign-issues/src/index.js
+++ b/.github/actions/assign-issues/src/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+const { setFailed, getInput } = require( '@actions/core' );
+const { context, GitHub } = require( '@actions/github' );
+
+async function run() {
+	const token = getInput( 'token' );
+	if ( ! token ) {
+		setFailed( 'main: Input `token` is required' );
+		return;
+	}
+
+	const octokit = new GitHub( token );
+
+	// Get info about the event.
+	const eventPayload = context.payload;
+
+	// Look for words indicating that a PR fixes an issue.
+	const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? +(?:\#?|https?:\/\/github\.com\/automattic\/jetpack\/issues\/)(\d+)/gi;
+
+	let match;
+	while ( ( match = regex.exec( eventPayload.pull_request.body ) ) ) {
+		const [ , issue ] = match;
+		console.log( `We have a match. The issue ID is ${ issue }` );
+
+		// Assign the issue to the PR author.
+		await octokit.issues.addAssignees( {
+			owner: eventPayload.repository.owner.login,
+			repo: eventPayload.repository.name,
+			issue_number: +issue,
+			assignees: [ eventPayload.pull_request.user.login ],
+		} );
+
+		// Add the In Progress label to the issue.
+		await octokit.issues.addLabels( {
+			owner: eventPayload.repository.owner.login,
+			repo: eventPayload.repository.name,
+			issue_number: +issue,
+			labels: [ '[Status] In Progress' ],
+		} );
+	}
+}
+
+run();

--- a/.github/workflows/assign-issues.yml
+++ b/.github/workflows/assign-issues.yml
@@ -1,0 +1,24 @@
+name: "Assign Issue to PR author"
+on:
+- pull_request
+
+jobs:
+  assign-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Building Action
+        run: npm install
+        working-directory: ./.github/actions/assign-issues
+
+      - name: Check if a PR fixes an issue
+        uses: ./.github/actions/assign-issues
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #16358

#### Changes proposed in this Pull Request:

When a PR is created to fix a specific issue, let's:
1. Assign the issue to the PR author
2. Mark the issue as In progress.

This commit adds the new action as well as a new dir (.github/actions) where we can add more similar actions in the future. I'd like to work on assigning milestones to PRs once this makes it in.

This work is based off something similar being done in the Gutenberg repo:
https://github.com/WordPress/gutenberg/tree/master/packages/project-management-automation

#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

* Go check #16358
* Has an action updated the assignee to me and added the "in progress" label to the issue?
* See the action's output here: https://github.com/Automattic/jetpack/pull/16359/checks?check_run_id=827587282

#### Proposed changelog entry for your changes:

* N/A
