### PR TITLE
Autoloader: Tests: Use a string with define

### DIFF
--- a/packages/autoloader/tests/php/test_plugins_handler.php
+++ b/packages/autoloader/tests/php/test_plugins_handler.php
@@ -7,7 +7,7 @@
 
 use PHPUnit\Framework\TestCase;
 
-define( WP_PLUGIN_DIR, '/var/www/wp-content/plugins' );
+define( 'WP_PLUGIN_DIR', '/var/www/wp-content/plugins' );
 
 /**
  * Provides unit tests for the methods in the Plugins_Handler class.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes `Notice: Use of undefined constant WP_PLUGIN_DIR - assumed 'WP_PLUGIN_DIR' in /home/travis/build/Automattic/jetpack/packages/autoloader/tests/php/test_plugins_handler.php on line 10`

#### Changes proposed in this Pull Request:
* use string in the `define`

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Confirm the notice above does not appear on Travis runs that tests the package tests.
*

#### Proposed changelog entry for your changes:
* n/a
