### PR TITLE
Subscriptions Block: Stop saving localized attributes defaults in the block content

### DIFF
--- a/extensions/blocks/subscriptions/deprecated/index.js
+++ b/extensions/blocks/subscriptions/deprecated/index.js
@@ -5,5 +5,6 @@
 import deprecatedV1 from './v1';
 import deprecatedV2 from './v2';
 import deprecatedV3 from './v3';
+import deprecatedV4 from './v4';
 
-export default [ deprecatedV1, deprecatedV2, deprecatedV3 ];
+export default [ deprecatedV1, deprecatedV2, deprecatedV3, deprecatedV4 ];

--- a/extensions/blocks/subscriptions/deprecated/index.js
+++ b/extensions/blocks/subscriptions/deprecated/index.js
@@ -4,5 +4,6 @@
 
 import deprecatedV1 from './v1';
 import deprecatedV2 from './v2';
+import deprecatedV3 from './v3';
 
-export default [ deprecatedV1, deprecatedV2 ];
+export default [ deprecatedV1, deprecatedV2, deprecatedV3 ];

--- a/extensions/blocks/subscriptions/deprecated/v3/attributes.js
+++ b/extensions/blocks/subscriptions/deprecated/v3/attributes.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	subscribePlaceholder: {
+		type: 'string',
+		default: __( 'Enter your email address', 'jetpack' ),
+	},
+	showSubscribersTotal: {
+		type: 'boolean',
+		default: false,
+	},
+	buttonOnNewLine: {
+		type: 'boolean',
+		default: false,
+	},
+	submitButtonText: {
+		type: 'string',
+		default: __( 'Sign Up', 'jetpack' ),
+	},
+	emailFieldBackgroundColor: {
+		type: 'string',
+	},
+	customEmailFieldBackgroundColor: {
+		type: 'string',
+	},
+	emailFieldGradient: {
+		type: 'string',
+	},
+	customEmailFieldGradient: {
+		type: 'string',
+	},
+	buttonBackgroundColor: {
+		type: 'string',
+	},
+	customButtonBackgroundColor: {
+		type: 'string',
+	},
+	buttonGradient: {
+		type: 'string',
+	},
+	customButtonGradient: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+	fontSize: {
+		type: 'number',
+	},
+	customFontSize: {
+		type: 'number',
+	},
+	borderRadius: {
+		type: 'number',
+	},
+	borderWeight: {
+		type: 'number',
+	},
+	borderColor: {
+		type: 'string',
+	},
+	customBorderColor: {
+		type: 'string',
+	},
+	padding: {
+		type: 'number',
+	},
+	spacing: {
+		type: 'number',
+	},
+};

--- a/extensions/blocks/subscriptions/deprecated/v3/get-subscriptions-shortcode.js
+++ b/extensions/blocks/subscriptions/deprecated/v3/get-subscriptions-shortcode.js
@@ -12,6 +12,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import definedAttributes from './attributes';
 import {
 	DEFAULT_BORDER_RADIUS_VALUE,
 	DEFAULT_BORDER_WEIGHT_VALUE,
@@ -20,7 +21,7 @@ import {
 	DEFAULT_FONTSIZE_VALUE,
 } from '../../constants';
 
-export default function Save( { className, attributes } ) {
+export default function getSubscriptionsShortcode( className, attributes, checkTextDefaults = null ) {
 	const {
 		subscribePlaceholder,
 		showSubscribersTotal,
@@ -102,15 +103,27 @@ export default function Save( { className, attributes } ) {
 		);
 	};
 
+	let placeholderText = subscribePlaceholder;
+	let buttonText = submitButtonText;
+
+	if ( 'check-text-defaults' === checkTextDefaults ) {
+		placeholderText = subscribePlaceholder === definedAttributes.subscribePlaceholder.default
+			? 'Enter your email address'
+			: subscribePlaceholder;
+		buttonText = submitButtonText === definedAttributes.submitButtonText.default
+			? 'Sign Up'
+			: submitButtonText;
+	}
+
 	return (
 		<div className={ getBlockClassName() }>
 			<RawHTML>
 				{ `
 			[jetpack_subscription_form
-				subscribe_placeholder="${ subscribePlaceholder }"
+				subscribe_placeholder="${ placeholderText }"
 				show_subscribers_total="${ showSubscribersTotal }"
 				button_on_newline="${ buttonOnNewLine }"
-				submit_button_text="${ submitButtonText }"
+				submit_button_text="${ buttonText }"
 				custom_background_emailfield_color="${ emailFieldBackgroundStyle }"
 				custom_background_button_color="${ buttonBackgroundStyle }"
 				custom_text_button_color="${ customTextColor }"

--- a/extensions/blocks/subscriptions/deprecated/v3/index.js
+++ b/extensions/blocks/subscriptions/deprecated/v3/index.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import attributes from './attributes';
+import definedAttributes from './attributes';
 import getSubscriptionsShortcode from './get-subscriptions-shortcode';
 
 export default {
-	attributes,
-	save: ( { className, attrs } ) => getSubscriptionsShortcode( className, attrs ),
+	attributes: definedAttributes,
+	save: ( { className, attributes } ) => getSubscriptionsShortcode( className, attributes ),
 };

--- a/extensions/blocks/subscriptions/deprecated/v3/index.js
+++ b/extensions/blocks/subscriptions/deprecated/v3/index.js
@@ -2,9 +2,9 @@
  * Internal dependencies
  */
 import attributes from './attributes';
-import save from './save';
+import getSubscriptionsShortcode from './get-subscriptions-shortcode';
 
 export default {
 	attributes,
-	save,
+	save: ( { className, attrs } ) => getSubscriptionsShortcode( className, attrs ),
 };

--- a/extensions/blocks/subscriptions/deprecated/v3/index.js
+++ b/extensions/blocks/subscriptions/deprecated/v3/index.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import save from './save';
+
+export default {
+	attributes,
+	save,
+};

--- a/extensions/blocks/subscriptions/deprecated/v3/save.js
+++ b/extensions/blocks/subscriptions/deprecated/v3/save.js
@@ -8,19 +8,17 @@ import {
 	getFontSizeClass,
 } from '@wordpress/block-editor';
 import classnames from 'classnames';
-import { reduce } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import defaultAttributes from './attributes';
 import {
 	DEFAULT_BORDER_RADIUS_VALUE,
 	DEFAULT_BORDER_WEIGHT_VALUE,
 	DEFAULT_PADDING_VALUE,
 	DEFAULT_SPACING_VALUE,
 	DEFAULT_FONTSIZE_VALUE,
-} from './constants';
+} from '../../constants';
 
 export default function Save( { className, attributes } ) {
 	const {
@@ -104,45 +102,29 @@ export default function Save( { className, attributes } ) {
 		);
 	};
 
-	const shortcodeAttributes = {
-		subscribe_placeholder:
-			subscribePlaceholder !== defaultAttributes.subscribePlaceholder.default
-				? subscribePlaceholder
-				: undefined,
-		show_subscribers_total: showSubscribersTotal,
-		button_on_newline: buttonOnNewLine,
-		submit_button_text:
-			submitButtonText !== defaultAttributes.submitButtonText.default
-				? submitButtonText
-				: undefined,
-		custom_background_emailfield_color: emailFieldBackgroundStyle,
-		custom_background_button_color: buttonBackgroundStyle,
-		custom_text_button_color: customTextColor,
-		custom_font_size: customFontSize || DEFAULT_FONTSIZE_VALUE,
-		custom_border_radius: borderRadius || DEFAULT_BORDER_RADIUS_VALUE,
-		custom_border_weight: borderWeight || DEFAULT_BORDER_WEIGHT_VALUE,
-		custom_border_color: customBorderColor,
-		custom_padding: padding || DEFAULT_PADDING_VALUE,
-		custom_spacing: spacing || DEFAULT_SPACING_VALUE,
-		submit_button_classes: submitButtonClasses,
-		email_field_classes: emailFieldClasses,
-		show_only_email_and_button: true,
-	};
-
-	const shortcodeAttributesStringified = reduce(
-		shortcodeAttributes,
-		( stringifiedAttributes, value, key ) => {
-			if ( undefined === value ) {
-				return stringifiedAttributes;
-			}
-			return stringifiedAttributes + ` ${ key }="${ value }"`;
-		},
-		''
-	);
-
 	return (
 		<div className={ getBlockClassName() }>
-			<RawHTML>{ `[jetpack_subscription_form${ shortcodeAttributesStringified }]` }</RawHTML>
+			<RawHTML>
+				{ `
+			[jetpack_subscription_form
+				subscribe_placeholder="${ subscribePlaceholder }"
+				show_subscribers_total="${ showSubscribersTotal }"
+				button_on_newline="${ buttonOnNewLine }"
+				submit_button_text="${ submitButtonText }"
+				custom_background_emailfield_color="${ emailFieldBackgroundStyle }"
+				custom_background_button_color="${ buttonBackgroundStyle }"
+				custom_text_button_color="${ customTextColor }"
+				custom_font_size="${ customFontSize || DEFAULT_FONTSIZE_VALUE }"
+				custom_border_radius="${ borderRadius || DEFAULT_BORDER_RADIUS_VALUE }"
+				custom_border_weight="${ borderWeight || DEFAULT_BORDER_WEIGHT_VALUE }"
+				custom_border_color="${ customBorderColor }"
+				custom_padding="${ padding || DEFAULT_PADDING_VALUE }"
+				custom_spacing="${ spacing || DEFAULT_SPACING_VALUE }"
+				submit_button_classes="${ submitButtonClasses }"
+				email_field_classes="${ emailFieldClasses }"
+				show_only_email_and_button="true"
+			]` }
+			</RawHTML>
 		</div>
 	);
 }

--- a/extensions/blocks/subscriptions/deprecated/v4/index.js
+++ b/extensions/blocks/subscriptions/deprecated/v4/index.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import attributes from '../v3/attributes';
+import definedAttributes from '../v3/attributes';
 import getSubscriptionsShortcode from '../v3/get-subscriptions-shortcode';
 
 export default {
-	attributes,
-	save: ( { className, attrs } ) =>
-		getSubscriptionsShortcode( className, attrs, 'check-text-defaults' ),
+	attributes: definedAttributes,
+	save: ( { className, attributes } ) =>
+		getSubscriptionsShortcode( className, attributes, 'check-text-defaults' ),
 };

--- a/extensions/blocks/subscriptions/deprecated/v4/index.js
+++ b/extensions/blocks/subscriptions/deprecated/v4/index.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import attributes from '../v3/attributes';
+import getSubscriptionsShortcode from '../v3/get-subscriptions-shortcode';
+
+export default {
+	attributes,
+	save: ( { className, attrs } ) =>
+		getSubscriptionsShortcode( className, attrs, 'check-text-defaults' ),
+};


### PR DESCRIPTION
Fixes #15776

#### Changes proposed in this Pull Request:

* Stop saving localized attributes defaults in the Subscriptions block content.

The Subscriptions block has two attributes with localized default values which are saved in the block content as shortcode attributes. Changing the site language will break the block validation, because the strings are saved in the previous language, while the validator expects them to be in the new language.

In this PR we stop adding those attributes to the shortcode if they are the same as the default (haven't been changed by the user).

The shortcode will take care of those missing attributes by using [its own defined defaults](https://github.com/Automattic/jetpack/blob/020effc64833fa2f378d1b8a9a18ff0b8a118672/modules/subscriptions/views.php#L625-L653).

#### Note

There have been two deprecated versions added. The first handles the normal migration when the language hasn't changed. The second almost identical one, allows for the placeholder text, if left to default values, to fall back to the known English version of the text. It does not change the attribute values just the generated content from the deprecated save so the block isn't invalidated. 

Unfortunately, this will only be able to solve the case when the block was created in English, the site switched to a new language and then the block loaded in the editor again afterwards. If the block was created in a non-English language then the site switched to English, we don't know what the original default text should be so can't fallback to it.

Migrating the block and saving the post _before_ changing the language would fix it.

Repro steps:
1. Add a Subscriptions block on master, and save the post.
2. Checkout this branch.
3. Change site language.
4. Reload the editor: the block breaks. 👎 

Working steps:
1. Add a Subscriptions block on master, and save the post.
2. Checkout this branch.
3. Reload the editor, let the block migrate, and save the post.
4. Change site language.
5. Reload the editor: the block works. 👍 

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Before checking out this PR:
	* Edit a post and add two Subscriptions block. (You will need to be connected to WordPress.com).
	* Leave one unchanged, and update the button label of the other.
	* Save the post.
* Checkout this PR, build the extensions, and reload the editor.
* Make sure the blocks have migrated without errors.
* Check the code view, and make sure the shortcode attributes are not output in separate lines anymore (this will confirm the blocks are using the new save function).
	E.g.
```diff
- [jetpack_subscription_form
-		attribute="value"
-		another_attribute="value"
- ]
+ [jetpack_subscription_form attribute="value" another_attribute="value"]
```

* Without saving the post, change the site language in `/wp-admin/options-general.php`, and make sure you also install the new language pack in `/wp-admin/update-core.php`.
* Reload the editor and make sure the blocks don't break anymore.
* Make sure that the button label of the block left unchanged is now translated in the new language.

#### Proposed changelog entry for your changes:

* Subscriptions Block: Stop saving localized attributes defaults in the block content
