### PR TITLE
Send a Message Block: Add option for the button to open in a new tab

### DIFF
--- a/extensions/blocks/send-a-message/whatsapp-button/attributes.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/attributes.js
@@ -28,4 +28,8 @@ export default {
 		type: 'string',
 		default: 'dark',
 	},
+	openInNewTab: {
+		type: 'boolean',
+		default: false,
+	},
 };

--- a/extensions/blocks/send-a-message/whatsapp-button/edit.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/edit.js
@@ -14,6 +14,7 @@ import {
 	ToolbarGroup,
 	Dropdown,
 	Path,
+	ToggleControl,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -43,6 +44,7 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 		firstMessage,
 		colorClass,
 		backgroundColor,
+		openInNewTab,
 	} = attributes;
 
 	const [ isValidPhoneNumber, setIsValidPhoneNumber ] = useState( true );
@@ -174,6 +176,16 @@ export default function WhatsAppButtonEdit( { attributes, setAttributes, classNa
 					) }
 					value={ firstMessage }
 					onChange={ text => setAttributes( { firstMessage: text } ) }
+				/>
+
+				<ToggleControl
+					label={ __( 'Open in new tab', 'jetpack' ) }
+					checked={ openInNewTab }
+					onChange={ newValue => setAttributes( { openInNewTab: newValue } ) }
+					help={ __(
+						'When the button is tapped, should a new tab be opened if the visitor does not have WhatsApp installed?',
+						'jetpack'
+					) }
 				/>
 			</>
 		);

--- a/extensions/blocks/send-a-message/whatsapp-button/save.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/save.js
@@ -17,6 +17,7 @@ export default function SendAMessageSave( { attributes, className } ) {
 		buttonText,
 		backgroundColor,
 		colorClass,
+		openInNewTab,
 	} = attributes;
 
 	const fullPhoneNumber =
@@ -40,12 +41,16 @@ export default function SendAMessageSave( { attributes, className } ) {
 		! buttonText.length ? 'has-no-text' : undefined
 	);
 
+	const target = openInNewTab ? '_blank' : '_self';
+
 	return (
 		<div className={ cssClassNames }>
 			<a
 				className="whatsapp-block__button"
 				href={ getWhatsAppUrl() }
 				style={ { backgroundColor: backgroundColor } }
+				target={ target }
+				rel="noopener noreferrer"
 			>
 				<RichText.Content value={ buttonText } />
 			</a>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16340 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add an option for the button to open a new tab when tapped.

<img width="1019" alt="Screen Shot 2020-07-01 at 10 46 59 AM" src="https://user-images.githubusercontent.com/1464705/86275514-43766380-bb88-11ea-8810-757657fea9d6.png">

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Insert a WhatsApp block
* Check the "Open in new tab" option.
* Confirm that the button opens a new tab on the front end, and the setting is saved when refreshing the editor.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None
