### PR TITLE
Update blocks categories

### DIFF
--- a/extensions/blocks/button/index.js
+++ b/extensions/blocks/button/index.js
@@ -10,13 +10,14 @@ import attributes from './attributes';
 import edit from './edit';
 import icon from './icon';
 import save from './save';
+import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 
 export const name = 'button';
 
 export const settings = {
 	title: __( 'Button', 'jetpack' ),
 	icon,
-	category: 'layout',
+	category: getCategoryWithFallbacks( 'design', 'layout' ),
 	keywords: [],
 	supports: {
 		html: false,

--- a/extensions/blocks/image-compare/index.js
+++ b/extensions/blocks/image-compare/index.js
@@ -11,6 +11,7 @@ import icon from './icon';
 import save from './save';
 import imgExampleAfter from './img-example-after.png';
 import imgExampleBefore from './img-example-before.png';
+import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 
 export const name = 'image-compare';
 
@@ -22,8 +23,7 @@ export const settings = {
 	),
 
 	icon,
-
-	category: 'layout',
+	category: getCategoryWithFallbacks( 'media', 'layout' ),
 	keywords: [
 		_x( 'juxtapose', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),

--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -12,6 +12,7 @@ import './editor.scss';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import edit from './edit';
 import save from './save';
+import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 
 export const name = 'markdown';
 
@@ -57,8 +58,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: 'formatting',
-
+	category: getCategoryWithFallbacks( 'text', 'formatting' ),
 	keywords: [
 		_x( 'formatting', 'block search term', 'jetpack' ),
 		_x( 'syntax', 'block search term', 'jetpack' ),

--- a/extensions/blocks/rating-star/index.js
+++ b/extensions/blocks/rating-star/index.js
@@ -26,7 +26,7 @@ export const settings = {
 		_x( 'rating', 'block search term', 'jetpack' ),
 		_x( 'review', 'block search term', 'jetpack' ),
 	],
-	category: 'formatting',
+	category: 'widgets',
 	example: {},
 	styles: [
 		{

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -10,6 +10,7 @@ import { Path, SVG } from '@wordpress/components';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
+import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 
 /**
  * Example Images
@@ -111,7 +112,7 @@ export const name = 'slideshow';
 
 export const settings = {
 	title: __( 'Slideshow', 'jetpack' ),
-	category: 'layout',
+	category: getCategoryWithFallbacks( 'media', 'layout' ),
 	keywords: [
 		_x( 'image', 'block search term', 'jetpack' ),
 		_x( 'gallery', 'block search term', 'jetpack' ),

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -19,6 +19,7 @@ import {
 	LAYOUT_STYLES,
 } from './constants';
 import { isSimpleSite } from '../../shared/site-type-utils';
+import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 
 /**
  * Style dependencies
@@ -55,8 +56,8 @@ const layoutStylesWithLabels = LAYOUT_STYLES.map( style => ( {
 /**
  * Filter valid images
  *
- * @param {array} images Array of image objects
- * @return {array} Array of image objects which have id and url
+ * @param {Array} images - Array of image objects
+ * @returns {Array} Array of image objects which have id and url
  */
 function getValidImages( images ) {
 	return filter( images, ( { id, url } ) => id && url );
@@ -201,7 +202,7 @@ export const icon = (
 
 export const settings = {
 	attributes: blockAttributes,
-	category: 'layout',
+	category: getCategoryWithFallbacks( 'media', 'layout' ),
 	description:
 		__( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ) +
 		( ! isSimpleSite()

--- a/extensions/shared/get-category-with-fallbacks.js
+++ b/extensions/shared/get-category-with-fallbacks.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { getCategories } from '@wordpress/blocks';
+
+/**
+ * Accepts an array of category names and returns the first one that
+ * exists in the categories returned by `getCategories`. This allows
+ * for a "graceful degradation" strategy to category names, where
+ * we just add the new category name as the first item in the array
+ * argument, and leave the old ones for environments where they still
+ * exist and are used.
+ *
+ * @example
+ * // Prefer passing the new category first in the array, followed by
+ * // older fallback categories. Considering the 'new' category is
+ * // registered:
+ * getCategoryWithFallbacks( 'new', 'old', 'older' );
+ * // => 'new'
+ *
+ * @param {string[]} requestedCategories - an array of categories.
+ * @returns {string} the first category name found.
+ * @throws {Error} if the no categories could be found.
+ */
+export default function getCategoryWithFallbacks( ...requestedCategories ) {
+	const knownCategories = getCategories();
+	for ( const requestedCategory of requestedCategories ) {
+		if ( knownCategories.some( ( { slug } ) => slug === requestedCategory ) ) {
+			return requestedCategory;
+		}
+	}
+	throw new Error(
+		`Could not find a category from the provided list: ${ requestedCategories.join( ',' ) }`
+	);
+}

--- a/extensions/shared/test/get-category-with-fallbacks.js
+++ b/extensions/shared/test/get-category-with-fallbacks.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import getCategoryWithFallbacks from '../get-category-with-fallbacks';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	getCategories: () => [ { slug: 'foobar' }, { slug: 'barfoo' } ],
+} ) );
+
+describe( 'getCategoryWithFallbacks', () => {
+	describe( 'single category passed', () => {
+		it( 'returns the category if it exists', () => {
+			expect( getCategoryWithFallbacks( 'foobar' ) ).toBe( 'foobar' );
+		} );
+		it( 'throws an error if it does not exist', () => {
+			expect( () => getCategoryWithFallbacks( 'nah' ) ).toThrow( /nah/ );
+		} );
+	} );
+
+	describe( 'multiple categories are passed', () => {
+		it( 'throws an error if none of the categories exist', () => {
+			expect( () => getCategoryWithFallbacks( 'nah', 'meh', 'wut', 'foo' ) ).toThrow(
+				/nah,meh,wut,foo/
+			);
+		} );
+
+		it( 'ignores all unexisting categories until it finds the *first one* that exists, then returns it', () => {
+			expect( getCategoryWithFallbacks( 'foobar', 'meh', 'barfoo' ) ).toBe( 'foobar' );
+			expect( getCategoryWithFallbacks( 'nah', 'foobar', 'barfoo', 'foo' ) ).toBe( 'foobar' );
+			expect( getCategoryWithFallbacks( 'nah', 'meh', 'foobar' ) ).toBe( 'foobar' );
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Update the category names for relevant Jetpack blocks. More details [here](https://github.com/Automattic/wp-calypso/issues/43198) (**first** task listed in the issue). There's an equivalent [PR](https://github.com/Automattic/wp-calypso/pull/43670) for `wp-calypso`. 
-  Adds a helper function that is used to safely update category names while still supporting old environments

#### Related PRs
* FSE blocks (wp-calypso): https://github.com/Automattic/wp-calypso/pull/43670
* wpcom-blocks: https://github.com/Automattic/wpcom-blocks/pull/178
* block-experiments: https://github.com/Automattic/block-experiments/pull/110

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

##### Atomated tests

* `yarn test-extensions`

##### To manually test the changes

1. Follow the instructions here to set up your local Jurassic Ninja instance
2. Activate Jetpack
3. To test that old category still work in old environments where the new categories are not available, leave the built-in block editor
4. To test that new categories have been set, install the last version of Gutenberg
5. Add or edit a post, click the + button on the page to add a new block and bring up the picker
6. Search for the block you're testing and make sure it's in the right category.

#### Categories

- [X] keep `amazon` in the  `earn`
- [X] keep `business-hours` in the `grow`
- [X] [Change](https://github.com/Automattic/jetpack/pull/16363/files#diff-335f8f715a7cae946581374994c6a3ebR20) `button` from `layout` -> `design`*[1] _(could not test, didn't find it in the picker)_
- [X] Keep `calendly` in `grow`
- [X] Keep `contact-form` in `grow`
- [X] Keep `contact-info` in `grow`
- [X] Keep `eventbrite` in `embed`
- [X] Keep `gathering-tweetstorms` as is  _(category doesn't seem to be explicitely set)_
- [X] Keep `gif` in `embed`
- [X] Keep `google-calendar` in `embed`
- [X] [Change](https://github.com/Automattic/jetpack/pull/16363/files#diff-85816fca7684d982023ac539f51e91efR28) `image-compare` from `layout` -> `media` 
- [X] Keep `instagram-gallery` in `embed`
- [X] Keep ` likes` as is  _(category doesn't seem to be explicitely set)_
- [X] Keep ` mailchimp` in `grow`
- [X] Keep `map` in `embed` _(has many internal sub-blocks that I think are safe to ignore?)_
- [X] [Change](https://github.com/Automattic/jetpack/pull/16363/files#diff-03efbbd23ff60b8a7eabc125ab99a852R62)  markdown from `formatting` -> `text`
- [X] Keep `opentable` in `earn`
- [X] Keep `pinterest` in `embed`
- [X] Keep `podcast-player` in  `embed`
- [X] Keep `publicize` as is  _(category doesn't seem to be explicitely set)_
- [X] [Change](https://github.com/Automattic/jetpack/pull/16363/files#diff-51270babf53ebf40ff5e4730d0742dc8R31) ` rating-star` from `formatting` -> `widgets`
- [X] Keep `payments` in `earn`
- [X] Keep `related-posts` in `embed`
- [X] Keep `repeat-visitor` in `widgets`
- [X] Keep `revue` in `grow`
- [X] Keep `send-a-message` in `grow`
- [X] Keep `seo` as is _(category doesn't seem to be explicitely set)_
- [X] Keep `sharing` as is  _(category doesn't seem to be explicitely set)_
- [X] Keep `shortlinks` as is _(category doesn't seem to be explicitely set)_
- [X] Keep `simple-payments` in `earn`
- [X] [Change](https://github.com/Automattic/jetpack/pull/16363/files#diff-61b229393358043e77464e993a7feccaR116) `slideshow` from `layout` -> `media`
- [X] Keep `subscriptions` in `grow`
- [X] [Change](https://github.com/Automattic/jetpack/pull/16363/files#diff-96851578b44163e189db4155319961a6R206) `tiled-gallery` from `layout` -> `media`
- [X] Keep `videopress` as is _(category doesn't seem to be explicitely set)_
- [X] Keep `wordads` in `earn`

#### Proposed changelog entry for your changes:

- Blocks: Update categories to improve discoverability

~Note: If [this PR](https://github.com/WordPress/gutenberg/pull/23695) gets approved and merged, then I'll remove the helper function and tests from here (including the installation/configuration of jest).~