### PR TITLE
Instant Search: Add support for excluding certain post types from search results

### DIFF
--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -55,6 +55,7 @@ module.exports = [
 	'modules/search/class-jetpack-search-customize.php',
 	'modules/search/class-jetpack-search-options.php',
 	'modules/search/class.jetpack-search.php',
+	'modules/search/customize-controls/class-excluded-post-types-control.php',
 	'modules/search/customize-controls/class-label-control.php',
 	'modules/sharedaddy.php',
 	'modules/shortcodes/',

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -122,6 +122,14 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$posts_per_page = 20;
 		}
 
+		$disabled_post_types = array();
+		foreach ( Jetpack_Search_Helpers::generate_post_type_customizer_ids() as $post_type => $customizer_key ) {
+			l( $customizer_key, get_option( $customizer_key, '' ), get_option( $customizer_key, '' ) === '1' || get_option( $customizer_key, '' ) === true );
+			if ( get_option( $customizer_key, '' ) === '1' || get_option( $customizer_key, '' ) === true ) {
+				$disabled_post_types[] = $post_type;
+			}
+		}
+
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -143,6 +151,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
+			'disabledPostTypes'     => $disabled_post_types,
 
 			// widget info.
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -122,14 +122,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			$posts_per_page = 20;
 		}
 
-		$disabled_post_types = array();
-		foreach ( Jetpack_Search_Helpers::generate_post_type_customizer_ids() as $post_type => $customizer_key ) {
-			l( $customizer_key, get_option( $customizer_key, '' ), get_option( $customizer_key, '' ) === '1' || get_option( $customizer_key, '' ) === true );
-			if ( get_option( $customizer_key, '' ) === '1' || get_option( $customizer_key, '' ) === true ) {
-				$disabled_post_types[] = $post_type;
-			}
-		}
-
 		$options = array(
 			'overlayOptions'        => array(
 				'colorTheme'      => get_option( $prefix . 'color_theme', 'light' ),
@@ -151,7 +143,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),
-			'disabledPostTypes'     => $disabled_post_types,
+			'excludedPostTypes'     => explode( ',', get_option( $prefix . 'excluded_post_types', '' ) ),
 
 			// widget info.
 			'hasOverlayWidgets'     => count( $overlay_widget_ids ) > 0,

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -383,7 +383,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	}
 
 	/**
-	 * Autoconfig search by adding filter widgets
+	 * Automatically configure necessary settings for instant search
 	 *
 	 * @since  8.3.0
 	 */
@@ -395,6 +395,16 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		// Set default result format to "expanded".
 		update_option( Jetpack_Search_Options::OPTION_PREFIX . 'result_format', 'expanded' );
 
+		$this->auto_config_excluded_post_types();
+		$this->auto_config_overlay_sidebar_widgets();
+	}
+
+	/**
+	 * Automatically copy configured search widgets into the overlay sidebar
+	 *
+	 * @since  8.8.0
+	 */
+	public function auto_config_overlay_sidebar_widgets() {
 		global $wp_registered_sidebars;
 		$sidebars = get_option( 'sidebars_widgets', array() );
 		$slug     = Jetpack_Search_Helpers::FILTER_WIDGET_BASE;
@@ -482,10 +492,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 */
 	protected function get_preconfig_widget_options() {
 		$settings = array(
-			'title'              => '',
-			'search_box_enabled' => 1,
-			'user_sort_enabled'  => 0,
-			'filters'            => array(),
+			'title'   => '',
+			'filters' => array(),
 		);
 
 		$post_types = get_post_types(
@@ -540,8 +548,34 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'field'    => 'post_date',
 			'interval' => 'year',
 		);
-
 		return $settings;
 	}
+	/**
+	 * Automatically configure post types to exclude from one of the search widgets
+	 *
+	 * @since  8.8.0
+	 */
+	public function auto_config_excluded_post_types() {
+		$post_types         = get_post_types(
+			array(
+				'exclude_from_search' => false,
+				'public'              => true,
+			)
+		);
+		$enabled_post_types = array();
+		$widget_options     = get_option( Jetpack_Search_Helpers::get_widget_option_name(), array() );
 
+		// Iterate through each Jetpack Search widget configuration and append each enabled post type
+		// to $enabled_post_types.
+		foreach ( $widget_options as $widget_option ) {
+			if ( isset( $widget_option['post_types'] ) && is_array( $widget_option['post_types'] ) ) {
+				foreach ( $widget_option['post_types'] as $enabled_post_type ) {
+					$enabled_post_types[ $enabled_post_type ] = $enabled_post_type;
+				}
+			}
+		}
+
+		$post_types_to_disable = array_diff( $post_types, $enabled_post_types );
+		update_option( Jetpack_Search_Options::OPTION_PREFIX . 'excluded_post_types', join( ',', $post_types_to_disable ) );
+	}
 }

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -118,6 +118,43 @@ class Jetpack_Search_Customize {
 			)
 		);
 
+		$id = $setting_prefix . 'post_types_title_placeholder';
+		$wp_customize->add_setting(
+			$id,
+			array( 'type' => 'option' )
+		);
+		$wp_customize->add_control(
+			new Label_Control(
+				$wp_customize,
+				$id,
+				array(
+					'description' => __( 'Choose post types to exclude from search results.', 'jetpack' ),
+					'label'       => __( 'Excluded Post Types', 'jetpack' ),
+					'section'     => $section_id,
+				)
+			)
+		);
+
+		foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) {
+			$id = Jetpack_Search_Helpers::generate_post_type_customizer_id( $post_type );
+			$wp_customize->add_setting(
+				$id,
+				array(
+					'default'           => false,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'type'              => 'option',
+				)
+			);
+			$wp_customize->add_control(
+				$id,
+				array(
+					'label'   => $post_type->label,
+					'section' => $section_id,
+					'type'    => 'checkbox',
+				)
+			);
+		}
+
 		$id = $setting_prefix . 'result_format';
 		$wp_customize->add_setting(
 			$id,

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
 require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
+require_once dirname( __FILE__ ) . '/customize-controls/class-excluded-post-types-control.php';
 
 /**
  * Class to customize search on the site.
@@ -118,13 +119,16 @@ class Jetpack_Search_Customize {
 			)
 		);
 
-		$id = $setting_prefix . 'post_types_title_placeholder';
+		$id = $setting_prefix . 'excluded_post_types';
 		$wp_customize->add_setting(
 			$id,
-			array( 'type' => 'option' )
+			array(
+				'default' => '',
+				'type'    => 'option',
+			)
 		);
 		$wp_customize->add_control(
-			new Label_Control(
+			new Excluded_Post_Types_Control(
 				$wp_customize,
 				$id,
 				array(
@@ -134,26 +138,6 @@ class Jetpack_Search_Customize {
 				)
 			)
 		);
-
-		foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) {
-			$id = Jetpack_Search_Helpers::generate_post_type_customizer_id( $post_type );
-			$wp_customize->add_setting(
-				$id,
-				array(
-					'default'           => false,
-					'sanitize_callback' => 'rest_sanitize_boolean',
-					'type'              => 'option',
-				)
-			);
-			$wp_customize->add_control(
-				$id,
-				array(
-					'label'   => $post_type->label,
-					'section' => $section_id,
-					'type'    => 'checkbox',
-				)
-			);
-		}
 
 		$id = $setting_prefix . 'result_format';
 		$wp_customize->add_setting(

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -713,4 +713,29 @@ class Jetpack_Search_Helpers {
 			? filemtime( JETPACK__PLUGIN_DIR . $file )
 			: JETPACK__VERSION;
 	}
+
+
+	/**
+	 * Generates a customizer settings ID for a given post type.
+	 *
+	 * @since 8.7.0
+	 * @param object $post_type Post type object returned from get_post_types.
+	 * @return string $customizer_id Customizer setting ID.
+	 */
+	public static function generate_post_type_customizer_id( $post_type ) {
+		return Jetpack_Search_Options::OPTION_PREFIX . 'disable_post_type_' . $post_type->name;
+	}
+
+	/**
+	 * Generates an array of post types associated with their customizer IDs.
+	 *
+	 * @since 8.7.0
+	 * @return array $ids Post type => post type customizer ID object.
+	 */
+	public static function generate_post_type_customizer_ids() {
+		return array_map(
+			array( 'self', 'generate_post_type_customizer_id' ),
+			get_post_types( array( 'exclude_from_search' => false ), 'objects' )
+		);
+	}
 }

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -718,7 +718,7 @@ class Jetpack_Search_Helpers {
 	/**
 	 * Generates a customizer settings ID for a given post type.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 * @param object $post_type Post type object returned from get_post_types.
 	 * @return string $customizer_id Customizer setting ID.
 	 */
@@ -729,7 +729,7 @@ class Jetpack_Search_Helpers {
 	/**
 	 * Generates an array of post types associated with their customizer IDs.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 * @return array $ids Post type => post type customizer ID object.
 	 */
 	public static function generate_post_type_customizer_ids() {

--- a/modules/search/customize-controls/class-excluded-post-types-control.css
+++ b/modules/search/customize-controls/class-excluded-post-types-control.css
@@ -1,0 +1,5 @@
+.customize-control-excluded-post-type-checkbox-container {
+	line-height: 1.6;
+	padding-top: 6px;
+	padding-bottom: 6px;
+}

--- a/modules/search/customize-controls/class-excluded-post-types-control.js
+++ b/modules/search/customize-controls/class-excluded-post-types-control.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-var */
+
+jQuery( document ).ready( function( $ ) {
+	// Refresh our hidden field value if any checkboxes change
+	$( '.customize-control-excluded-post-type-checkbox' ).on( 'change', function() {
+		var $parent = $( this )
+			.parent()
+			.parent();
+		var newValue = $parent
+			.find( '.customize-control-excluded-post-type-checkbox:checked' )
+			.map( function() {
+				return $( this ).val();
+			} )
+			.toArray();
+		$parent
+			.find( '.customize-control-excluded-post-types' )
+			.val( newValue )
+			.trigger( 'change' );
+	} );
+} );

--- a/modules/search/customize-controls/class-excluded-post-types-control.php
+++ b/modules/search/customize-controls/class-excluded-post-types-control.php
@@ -3,7 +3,7 @@
  * A multi-checkbox Customizer control for use with Jetpack Search configuration
  *
  * @package jetpack
- * @since 8.7.0
+ * @since 8.8.0
  */
 
 /**
@@ -13,7 +13,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 	/**
 	 * Control type.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 * @var string
 	 */
 	public $type = 'excluded-post-types';
@@ -37,7 +37,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 	/**
 	 * Checks if the post type has been selected.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 * @return array $post_types An array of strings representing post type names.
 	 */
 	public function get_arrayed_value() {
@@ -48,7 +48,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 	/**
 	 * Generates a customizer settings ID for a given post type.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 * @param object $post_type Post type object returned from get_post_types.
 	 * @return string $customizer_id Customizer setting ID.
 	 */
@@ -59,7 +59,7 @@ class Excluded_Post_Types_Control extends WP_Customize_Control {
 	/**
 	 * Checks if the post type has been selected.
 	 *
-	 * @since 8.7.0
+	 * @since 8.8.0
 	 * @param object $post_type Post type object returned from get_post_types.
 	 * @return array $ids Post type => post type customizer ID object.
 	 */

--- a/modules/search/customize-controls/class-excluded-post-types-control.php
+++ b/modules/search/customize-controls/class-excluded-post-types-control.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * A multi-checkbox Customizer control for use with Jetpack Search configuration
+ *
+ * @package jetpack
+ * @since 8.7.0
+ */
+
+/**
+ * Label Control class.
+ */
+class Excluded_Post_Types_Control extends WP_Customize_Control {
+	/**
+	 * Control type.
+	 *
+	 * @since 8.7.0
+	 * @var string
+	 */
+	public $type = 'excluded-post-types';
+
+	/**
+	 * Enqueue styles related to this control.
+	 */
+	public function enqueue() {
+		require_once dirname( dirname( __FILE__ ) ) . '/class.jetpack-search-helpers.php';
+		$style_relative_path = 'modules/search/customize-controls/class-excluded-post-types-control.css';
+		$style_version       = Jetpack_Search_Helpers::get_asset_version( $style_relative_path );
+		$style_path          = plugins_url( $style_relative_path, JETPACK__PLUGIN_FILE );
+		wp_enqueue_style( 'jetpack-instant-search', $style_path, array(), $style_version );
+
+		$script_relative_path = 'modules/search/customize-controls/class-excluded-post-types-control.js';
+		$script_version       = Jetpack_Search_Helpers::get_asset_version( $script_relative_path );
+		$script_path          = plugins_url( $script_relative_path, JETPACK__PLUGIN_FILE );
+		wp_enqueue_script( 'jetpack-instant-search', $script_path, array(), $script_version, true );
+	}
+
+	/**
+	 * Checks if the post type has been selected.
+	 *
+	 * @since 8.7.0
+	 * @return array $post_types An array of strings representing post type names.
+	 */
+	public function get_arrayed_value() {
+		return explode( ',', $this->value() );
+	}
+
+
+	/**
+	 * Generates a customizer settings ID for a given post type.
+	 *
+	 * @since 8.7.0
+	 * @param object $post_type Post type object returned from get_post_types.
+	 * @return string $customizer_id Customizer setting ID.
+	 */
+	public function generate_post_type_customizer_id( $post_type ) {
+		return '_customize-post-type-input-' . $post_type->name;
+	}
+
+	/**
+	 * Checks if the post type has been selected.
+	 *
+	 * @since 8.7.0
+	 * @param object $post_type Post type object returned from get_post_types.
+	 * @return array $ids Post type => post type customizer ID object.
+	 */
+	public function is_checked( $post_type ) {
+		return in_array( $post_type->name, $this->get_arrayed_value(), true );
+	}
+
+	/**
+	 * Override rendering for custom class name; omit element ID.
+	 */
+	protected function render() {
+		$id    = 'customize-control-' . str_replace( array( '[', ']' ), array( '-', '' ), $this->id );
+		$class = 'customize-control customize-control-excluded-post-types';
+
+		printf( '<li id="%s" class="%s">', esc_attr( $id ), esc_attr( $class ) );
+		$this->render_content();
+		echo '</li>';
+	}
+
+	/**
+	 * Override content rendering.
+	 */
+	protected function render_content() {
+		$post_types = get_post_types( array( 'exclude_from_search' => false ), 'objects' );
+		if ( count( $post_types ) === 0 ) {
+			return;
+		}
+		?>
+			<label class="customize-control-title">
+				<?php echo esc_html( $this->label ); ?>
+			</label>
+			<?php if ( ! empty( $this->description ) ) : ?>
+			<span class="description customize-control-description">
+				<?php echo esc_html( $this->description ); ?>
+			</span>
+			<?php endif ?>
+			<input 
+				class="customize-control-excluded-post-types"
+				id="<?php echo esc_attr( $this->id ); ?>" 
+				name="<?php echo esc_attr( $this->id ); ?>" 
+				type="hidden" 
+				value="<?php echo esc_attr( $this->value() ); ?>"
+				<?php $this->link(); ?> 
+			/>
+		<?php
+
+		foreach ( $post_types as $post_type ) {
+			$input_id = Jetpack_Search_Helpers::generate_post_type_customizer_id( $post_type );
+			?>
+			<div class="customize-control-excluded-post-type-checkbox-container">
+				<input
+					class="customize-control-excluded-post-type-checkbox"
+					id="<?php echo esc_attr( $input_id ); ?>"
+					type="checkbox"
+					value="<?php echo esc_attr( $post_type->name ); ?>"
+					<?php checked( $this->is_checked( $post_type ) ); ?>
+				/>
+				<label for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $post_type->label ); ?></label>
+			</div>
+			<?php
+		}
+	}
+}

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -216,7 +216,7 @@ class SearchApp extends Component {
 		return search( {
 			// Skip aggregations when requesting for paged results
 			aggregations: !! pageHandle ? {} : this.props.aggregations,
-			disabledPostTypes: this.props.options.disabledPostTypes,
+			excludedPostTypes: this.props.options.excludedPostTypes,
 			filter,
 			pageHandle,
 			query,

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -216,6 +216,7 @@ class SearchApp extends Component {
 		return search( {
 			// Skip aggregations when requesting for paged results
 			aggregations: !! pageHandle ? {} : this.props.aggregations,
+			disabledPostTypes: this.props.options.disabledPostTypes,
 			filter,
 			pageHandle,
 			query,

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -103,7 +103,7 @@ const filterKeyToEsFilter = new Map( [
 	],
 ] );
 
-function buildFilterObject( filterQuery, adminQueryFilter, disabledPostTypes ) {
+function buildFilterObject( filterQuery, adminQueryFilter, excludedPostTypes ) {
 	const filter = { bool: { must: [] } };
 	getFilterKeys()
 		.filter( key => isLengthyArray( filterQuery[ key ] ) )
@@ -121,10 +121,11 @@ function buildFilterObject( filterQuery, adminQueryFilter, disabledPostTypes ) {
 	if ( adminQueryFilter ) {
 		filter.bool.must.push( adminQueryFilter );
 	}
-	if ( isLengthyArray( disabledPostTypes ) ) {
+
+	if ( excludedPostTypes?.length > 0 ) {
 		filter.bool.must.push( {
 			bool: {
-				must_not: disabledPostTypes.map( postType =>
+				must_not: excludedPostTypes.map( postType =>
 					filterKeyToEsFilter.get( 'post_types' )( postType )
 				),
 			},
@@ -145,7 +146,7 @@ function mapSortToApiValue( sort ) {
 
 export function search( {
 	aggregations,
-	disabledPostTypes,
+	excludedPostTypes,
 	filter,
 	pageHandle,
 	query,
@@ -192,7 +193,7 @@ export function search( {
 			aggregations,
 			fields,
 			highlight_fields: highlightFields,
-			filter: buildFilterObject( filter, adminQueryFilter, disabledPostTypes ),
+			filter: buildFilterObject( filter, adminQueryFilter, excludedPostTypes ),
 			query: encodeURIComponent( query ),
 			sort: mapSortToApiValue( sort ),
 			page_handle: pageHandle,

--- a/modules/widgets/search.php
+++ b/modules/widgets/search.php
@@ -276,9 +276,8 @@ class Jetpack_Search_Widget extends WP_Widget {
 		return wp_parse_args(
 			(array) $instance,
 			array(
-				'title'      => '',
-				'filters'    => array(),
-				'post_types' => array(),
+				'title'   => '',
+				'filters' => array(),
 			)
 		);
 	}
@@ -840,22 +839,6 @@ class Jetpack_Search_Widget extends WP_Widget {
 					type="text"
 					value="<?php echo esc_attr( wp_strip_all_tags( $instance['title'] ) ); ?>"
 				/>
-			</p>
-
-			<!-- Post types control -->
-			<p class="jetpack-search-filters-widget__post-types-select">
-				<label><?php esc_html_e( 'Post types to search (minimum of 1):', 'jetpack' ); ?></label>
-				<?php foreach ( get_post_types( array( 'exclude_from_search' => false ), 'objects' ) as $post_type ) : ?>
-					<label>
-						<input
-							type="checkbox"
-							value="<?php echo esc_attr( $post_type->name ); ?>"
-							name="<?php echo esc_attr( $this->get_field_name( 'post_types' ) ); ?>[]"
-							<?php checked( empty( $instance['post_types'] ) || in_array( $post_type->name, $instance['post_types'], true ) ); ?>
-						/>&nbsp;
-						<?php echo esc_html( $post_type->label ); ?>
-					</label>
-				<?php endforeach; ?>
 			</p>
 
 			<!-- Filters control -->


### PR DESCRIPTION
Replaces #16072.

#### Changes proposed in this Pull Request:
* Adds a site-wide setting for excluding certain post types from search results in the Instant Search overlay.
* Removes per-widget setting for including only certain post types from the Jetpack Search widget when Instant Search is enabled.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this change to your site with a Jetpack Search subscription. Ensure that Instant Search is enabled for your site.

2. Navigate to the Jetpack Search section of the customizer.

3. Ensure that you see a new Excluded Post Types input section with a checkbox for each post type your site supports:

<img width="298" alt="Screen Shot 2020-07-01 at 1 49 51 PM" src="https://user-images.githubusercontent.com/4044428/86285397-c2c46100-bba1-11ea-89a4-8b2430e94ac2.png">

4. Try excluding one of your post types by checking one of the checkboxes. This should refresh the iframe preview on the right.

5. Try a query. Ensure that no search results match an excluded post type. 

6. Navigate to the widget section of the Customizer. Ensure that the `Post types to search` input section has been removed.

<img width="298" alt="Screen Shot 2020-07-01 at 1 56 25 PM" src="https://user-images.githubusercontent.com/4044428/86285876-ad036b80-bba2-11ea-96c2-293dc6ca0b71.png">

7. Disable instant search and repeat step 6. Ensure that the `Post types to search` input section has been restored.

<img width="299" alt="Screen Shot 2020-06-04 at 3 46 01 PM" src="https://user-images.githubusercontent.com/4044428/83813405-82dd8d00-a67a-11ea-9911-22db439e7cf3.png">

#### Proposed changelog entry for your changes:
* Adds support for excluding certain post types from search results.
