### PR TITLE
Debug tools: Fix warnings and notices on save of empty checkboxes. 

### DIFF
--- a/docker/mu-plugins/jetpack-debug-helper/class-admin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/class-admin.php
@@ -22,6 +22,7 @@ class Admin {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
+		add_action( 'admin_post_store_debug_active_modules', array( $this, 'update_option' ) );
 	}
 
 	/**
@@ -52,16 +53,13 @@ class Admin {
 	 * Render UI.
 	 */
 	public function render_ui() {
-
-		$this->update_option();
-
 		$stored_options = get_option( self::OPTION_NAME, array() );
 		global $jetpack_dev_debug_modules;
 		?>
 		<h1>Jetpack Debug tools</h1>
 		<p>This plugin adds debugging tools to your jetpack. Choose which tools you want to activate.</p>
 
-		<form method="post">
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
 			<input type="hidden" name="action" value="store_debug_active_modules">
 			<?php wp_nonce_field( 'store-debug-modules' ); ?>
 
@@ -88,11 +86,13 @@ class Admin {
 	 */
 	public function update_option() {
 		check_admin_referer( 'store-debug-modules' );
-		if ( isset( $_POST['action'] ) && 'store_debug_active_modules' === $_POST['action'] ) {
-			$active_modules = ! empty( $_POST['active_modules'] ) ? (array) $_POST['active_modules'] : array();
-			update_option( self::OPTION_NAME, $active_modules );
+		$active_modules = ! empty( $_POST['active_modules'] ) ? (array) $_POST['active_modules'] : array();
+		update_option( self::OPTION_NAME, $active_modules );
+		if ( wp_get_referer() ) {
+			wp_safe_redirect( wp_get_referer() );
+		} else {
+			wp_safe_redirect( get_home_url() );
 		}
-
 	}
 
 }

--- a/docker/mu-plugins/jetpack-debug-helper/class-admin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/class-admin.php
@@ -68,7 +68,7 @@ class Admin {
 			<?php foreach ( $jetpack_dev_debug_modules as $module_slug => $module_details ) : ?>
 
 				<p>
-					<input type="checkbox" name="active_modules[]" value="<?php echo esc_attr( $module_slug ); ?>" <?php checked( in_array( $module_slug, $stored_options, true ) ); ?> />
+					<input type="checkbox" name="active_modules[]" value="<?php echo esc_attr( $module_slug ); ?>" <?php checked( in_array( $module_slug, (array) $stored_options, true ) ); ?> />
 					<b><?php echo esc_html( $module_details['name'] ); ?></b>
 					<?php echo esc_html( $module_details['description'] ); ?>
 				</p>
@@ -87,10 +87,10 @@ class Admin {
 	 * Store options.
 	 */
 	public function update_option() {
-
+		check_admin_referer( 'store-debug-modules' );
 		if ( isset( $_POST['action'] ) && 'store_debug_active_modules' === $_POST['action'] ) {
-			check_admin_referer( 'store-debug-modules' );
-			update_option( self::OPTION_NAME, $_POST['active_modules'] );
+			$active_modules = ! empty( $_POST['active_modules'] ) ? (array) $_POST['active_modules'] : array();
+			update_option( self::OPTION_NAME, $active_modules );
 		}
 
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes this issue: 

This is what I was seeing when trying to `save` after unchecking the boxes.

![Screen Shot 2020-07-01 at 4 46 21 PM](https://user-images.githubusercontent.com/7129409/86290103-dd570400-bbba-11ea-97c1-4322cc0ced4f.png)

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
- Ensuring we are only trying to update the option if the value is set
- Defaulting to array everywhere we rely on it
- Moves the nonce up in the method to pass phpcs checks. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Go to `/wp-admin/admin.php?page=debug-tools`
- Check one of the boxes. Click save. 
- Uncheck the box, click save. 
- Try saving with no values at all. 
- You should see no notices. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
N/A
