### PR TITLE
Fix the links for the build instructions for extensions and the search module

### DIFF
--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -200,8 +200,8 @@ yarn distclean
 
 Jetpack contains several extensions that have a separate build process. You can find information how to build them below: 
 
-* Jetpack Instant Search - [build instructions](../extensions/README.md)
-* Jetpack Block Editor Extensions - [build instructions](../modules/search/instant-search/README.md)
+* Jetpack Instant Search - [build instructions](../modules/search/instant-search/README.md)
+* Jetpack Block Editor Extensions - [build instructions](../extensions/README.md)
 
 ---
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Fix the links to the build instruction docs for extensions and the search modules. They were inverted: the one for the search was being linked in the extensions line and vice-versa.

#### Proposed changelog entry

* Fix the links to the build instruction docs for extensions and the search modules