### PR TITLE
Gathering Tweetstorms: Show a spinner while the thread is loading.

### DIFF
--- a/extensions/blocks/gathering-tweetstorms/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/editor.js
@@ -7,7 +7,7 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import useGatherTweetstorm from './use-gather-tweetstorm';
-import { withNotices, Button, ToolbarGroup, Toolbar } from '@wordpress/components';
+import { withNotices, Button, ToolbarGroup, Toolbar, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { BlockControls } from '@wordpress/editor';
@@ -34,7 +34,7 @@ const addTweetstormToTweets = blockSettings => {
 		edit: withNotices( props => {
 			const { noticeOperations, noticeUI, onReplace } = props;
 			const { url } = props.attributes;
-			const { unleashStorm } = useGatherTweetstorm( {
+			const { isGatheringStorm, unleashStorm } = useGatherTweetstorm( {
 				onReplace,
 			} );
 
@@ -44,7 +44,7 @@ const addTweetstormToTweets = blockSettings => {
 					<BlockControls>
 						{ /* @todo Fallback can be removed when WP 5.4 is the minimum supported version. */ }
 						{ ToolbarGroup ? (
-							<ToolbarGroup>
+							<ToolbarGroup className="gathering-tweetstorms__embed-toolbar">
 								<Button
 									className="gathering-tweetstorms__embed-toolbar-button"
 									onClick={ () => unleashStorm( url, noticeOperations ) }
@@ -53,9 +53,11 @@ const addTweetstormToTweets = blockSettings => {
 										'jetpack'
 									) }
 									showTooltip={ true }
+									disabled={ isGatheringStorm }
 								>
 									{ __( 'Unroll', 'jetpack' ) }
 								</Button>
+								{ isGatheringStorm && <Spinner /> }
 							</ToolbarGroup>
 						) : (
 							<Toolbar

--- a/extensions/blocks/gathering-tweetstorms/editor.scss
+++ b/extensions/blocks/gathering-tweetstorms/editor.scss
@@ -1,5 +1,9 @@
-.gathering-tweetstorms__embed-toolbar-button {
+.gathering-tweetstorms__embed-toolbar {
+	justify-content: center;
+	align-items: center;
+
 	.components-spinner {
+		position: absolute;
 		margin: 0;
 	}
 }


### PR DESCRIPTION
This PR shows a spinner over the "Unroll" button after it's clicked, while the twitter thread is loading.

#### Changes proposed in this Pull Request:
* Add a loading spinner to the twitter thread loader.

#### Jetpack product discussion
p58i-98G-p2#comment-46742

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:

* Embed a tweet in a post.
* Click the "Unroll" button.

![](https://user-images.githubusercontent.com/352291/86304711-15118a80-bc53-11ea-8811-5dc104546b5a.gif)

#### Proposed changelog entry for your changes:
* None needed.
