### PR TITLE
Gathering Tweetstorms: Allow private sites to unroll threads.

### DIFF
--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -41,7 +41,7 @@ class Jetpack_Tweetstorm_Helper {
 			return WPCOM_Gather_Tweetstorm::gather( $url );
 		}
 
-		$response = Client::wpcom_json_api_request_as_user(
+		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/tweetstorm/gather?url=%s', $site_id, rawurlencode( $url ) ),
 			2,
 			array( 'headers' => array( 'content-type' => 'application/json' ) ),

--- a/_inc/lib/class-jetpack-tweetstorm-helper.php
+++ b/_inc/lib/class-jetpack-tweetstorm-helper.php
@@ -41,7 +41,7 @@ class Jetpack_Tweetstorm_Helper {
 			return WPCOM_Gather_Tweetstorm::gather( $url );
 		}
 
-		$response = Client::wpcom_json_api_request_as_blog(
+		$response = Client::wpcom_json_api_request_as_user(
 			sprintf( '/sites/%d/tweetstorm/gather?url=%s', $site_id, rawurlencode( $url ) ),
 			2,
 			array( 'headers' => array( 'content-type' => 'application/json' ) ),

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -46,15 +46,16 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base,
 			array(
-				'args'     => array(
+				'args'                                  => array(
 					'url' => array(
 						'description' => __( 'The tweet URL to gather from.', 'jetpack' ),
 						'type'        => 'string',
 						'required'    => true,
 					),
 				),
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'gather_tweetstorm' ),
+				'methods'                               => WP_REST_Server::READABLE,
+				'callback'                              => array( $this, 'gather_tweetstorm' ),
+				'allow_blog_token_when_site_is_private' => true,
 			)
 		);
 	}


### PR DESCRIPTION
Private sites are currently unable to unroll twitter threads, getting the fairly obscure “User cannot access this private blog.” error. This is due to use connecting to the WPCOM API as the blog, rather than the current user.

#### Changes proposed in this Pull Request:
* Allow private sites to unroll twitter threads.

#### Jetpack product discussion
p58i-98G-p2#comment-46743

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

Note that this fix _only_ applies to Atomic sites, since these are the only sites that can be officially set to private.

##### Setup
* Create a private Atomic site.
* Apply D45966-code to your sandbox, and set `JETPACK__SANDBOX_DOMAIN` to your sandbox domain on your Atomic site.

##### Testing
* Paste a Tweet URL.
* Click the Unroll button.

Before this change, it would fail. After, it works.

#### Proposed changelog entry for your changes:
* None needed.
