### PR TITLE
Action to update the Jetpack Debug helper plugin mirror repo

### DIFF
--- a/.github/workflows/update-debug-helper-plugin.yml
+++ b/.github/workflows/update-debug-helper-plugin.yml
@@ -2,7 +2,7 @@ name: Update the Debug Helper plugin mirror repo
 on:
   push:
     branches:
-      - add/update-dev-helper-plugin-action # Every time a PR is merged to master.
+      - master # Every time a PR is merged to master.
     paths:
       - 'docker/mu-plugins/jetpack-debug-helper/**' # Only when the plugin is modified.
 

--- a/.github/workflows/update-debug-helper-plugin.yml
+++ b/.github/workflows/update-debug-helper-plugin.yml
@@ -1,0 +1,19 @@
+name: Update the Debug Helper plugin mirror repo
+on:
+  push:
+    branches:
+      - add/update-dev-helper-plugin-action # Every time a PR is merged to master.
+    paths:
+      - 'docker/mu-plugins/jetpack-debug-helper/**' # Only when the plugin is modified.
+
+jobs:
+  update_debug_helper_plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Keep Jetpack Debug Helper plugin mirror repo updated
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        run: |
+          sh ./bin/update-debug-helper-plugin.sh

--- a/bin/update-debug-helper-plugin.sh
+++ b/bin/update-debug-helper-plugin.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+git_setup()
+{
+  cat <<- EOF > "$HOME/.netrc"
+		machine github.com
+			login matticbot
+			password $GITHUB_TOKEN
+		machine api.github.com
+			login matticbot
+			password $GITHUB_TOKEN
+EOF
+  chmod 600 "$HOME/.netrc"
+
+  git config --global user.email "matticbot@users.noreply.github.com"
+  git config --global user.name "matticbot"
+}
+
+# Halt on error
+set -e
+
+git_setup
+
+BASE=$(pwd)
+MONOREPO_COMMIT_MESSAGE=$(git show -s --format=%B $GITHUB_SHA)
+COMMIT_MESSAGE=$( echo "${MONOREPO_COMMIT_MESSAGE}\n\nCommitted via a GitHub action: https://github.com/automattic/jetpack/runs/${GITHUB_RUN_ID}" )
+COMMIT_ORIGINAL_AUTHOR="${GITHUB_ACTOR} <${GITHUB_ACTOR}@users.noreply.github.com>"
+
+echo "Cloning Jetpack Debug Helper"
+
+# sync to read-only clones
+
+git clone --depth 1 https://$API_TOKEN_GITHUB@github.com/automattic/jetpack-debug-helper.git
+
+cd jetpack-debug-helper
+
+find . | grep -v ".git" | grep -v "^\.*$" | xargs rm -rf # delete all files (to handle deletions in monorepo)
+
+echo "  Copying from ${BASE}/docker/mu-plugins/jetpack-debug-helper/."
+
+cp -r $BASE/docker/mu-plugins/jetpack-debug-helper/. .
+
+echo "  Committing to mirror repository"
+git add -A
+git commit --author="${COMMIT_ORIGINAL_AUTHOR}" -m "${COMMIT_MESSAGE}"
+git push origin master
+echo "  Completed"

--- a/docker/mu-plugins/jetpack-debug-helper/plugin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/plugin.php
@@ -31,7 +31,6 @@ $jetpack_dev_debug_modules = array(
 
 require_once 'class-admin.php';
 
-// Testing GH action.
 foreach ( (array) Admin::get_active_modules() as $module ) {
 	if ( isset( $jetpack_dev_debug_modules[ $module ] ) ) {
 		include_once plugin_dir_path( __FILE__ ) . 'modules/' . $jetpack_dev_debug_modules[ $module ]['file'];

--- a/docker/mu-plugins/jetpack-debug-helper/plugin.php
+++ b/docker/mu-plugins/jetpack-debug-helper/plugin.php
@@ -31,6 +31,7 @@ $jetpack_dev_debug_modules = array(
 
 require_once 'class-admin.php';
 
+// Testing GH action.
 foreach ( (array) Admin::get_active_modules() as $module ) {
 	if ( isset( $jetpack_dev_debug_modules[ $module ] ) ) {
 		include_once plugin_dir_path( __FILE__ ) . 'modules/' . $jetpack_dev_debug_modules[ $module ]['file'];


### PR DESCRIPTION
Adds a new GH Action to update the Jetpack Debug helper plugin mirror repo

it will copy the contents from `docker/mu-plugins/jetpack-debug-helper` to https://github.com/Automattic/jetpack-debug-helper/

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Not possible to test since it will only work on master. We can run a test once this PR is merged.

I tested it on this branch:

This commit: f2769ce9303b39f6533482dd6007f8a05d827c53

triggered this action: https://github.com/Automattic/jetpack/actions/runs/155423707

And you can see the commit in the target repo here: https://github.com/Automattic/jetpack-debug-helper/commit/e2d7ffff24ae6788524c3e1d3d50a4e5b9234cdc
