### PR TITLE
REST API: Move some endpoints to `jetpack-connection` package.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -1029,17 +1029,16 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * Verify that user can view Jetpack admin page and can activate plugins.
 	 *
-	 * @return bool Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
-	 * @deprecated 8.8.0 The method is moved to the `REST_Connector` class.
-	 *
-	 * @see REST_Connector::activate_plugins_permission_check()
-	 *
 	 * @since 4.3.0
+	 *
+	 * @return bool Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
 	 */
 	public static function activate_plugins_permission_check() {
-		_deprecated_function( __METHOD__, 'jetpack-8.8.0', 'REST_Connector::activate_plugins_permission_check' );
+		if ( current_user_can( 'jetpack_admin_page' ) && current_user_can( 'activate_plugins' ) ) {
+			return true;
+		}
 
-		return REST_Connector::activate_plugins_permission_check();
+		return new WP_Error( 'invalid_user_permission_activate_plugins', REST_Connector::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -63,11 +63,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-site-endpoints.php';
 		require_once JETPACK__PLUGIN_DIR . '_inc/lib/core-api/class.jetpack-core-api-widgets-endpoints.php';
 
-		self::$user_permissions_error_msg = esc_html__(
-			'You do not have the correct user permissions to perform this action.
-			Please contact your site admin if you think this is a mistake.',
-			'jetpack'
-		);
+		self::$user_permissions_error_msg = REST_Connector::get_user_permissions_error_msg();
 
 		self::$stats_roles = array( 'administrator', 'editor', 'author', 'contributor', 'subscriber' );
 
@@ -1041,11 +1037,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @since 4.3.0
 	 */
 	public static function activate_plugins_permission_check() {
-		if ( current_user_can( 'jetpack_admin_page' ) && current_user_can( 'activate_plugins' ) ) {
-			return true;
-		}
+		_deprecated_function( __METHOD__, 'jetpack-8.8.0', 'REST_Connector::activate_plugins_permission_check' );
 
-		return new WP_Error( 'invalid_user_permission_activate_plugins', self::$user_permissions_error_msg, array( 'status' => rest_authorization_required_code() ) );
+		return REST_Connector::activate_plugins_permission_check();
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2,6 +2,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Status;
@@ -38,7 +39,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * @var string Generic error message when user is not allowed to perform an action.
 	 *
-	 * @deprecated 8.8.0 Use `\Automattic\Jetpack\Connection\REST_Connector::get_user_permissions_error_msg()` instead.
+	 * @deprecated 8.8.0 Use `REST_Connector::get_user_permissions_error_msg()` instead.
 	 */
 	public static $user_permissions_error_msg;
 
@@ -824,6 +825,21 @@ class Jetpack_Core_Json_Api_Endpoints {
 	}
 
 	/**
+	 * Handles verification that a site is registered
+	 *
+	 * @since 5.4.0
+	 * @deprecated 8.8.0 The method is moved to the `REST_Connector` class.
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return array|wp-error
+	 */
+	public static function remote_authorize( $request ) {
+		_deprecated_function( __METHOD__, 'jetpack-8.8.0', '\Automattic\Jetpack\Connection\REST_Connector::remote_authorize' );
+		return REST_Connector::remote_authorize( $request );
+	}
+
+	/**
 	 * Handles dismissing of Jetpack Notices
 	 *
 	 * @since 4.3.0
@@ -1018,9 +1034,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Verify that user can view Jetpack admin page and can activate plugins.
 	 *
 	 * @return bool Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
-	 * @deprecated 8.8.0 The method is moved to the `\Automattic\Jetpack\Connection\REST_Connector` class.
+	 * @deprecated 8.8.0 The method is moved to the `REST_Connector` class.
 	 *
-	 * @see \Automattic\Jetpack\Connection\REST_Connector::activate_plugins_permission_check()
+	 * @see REST_Connector::activate_plugins_permission_check()
 	 *
 	 * @since 4.3.0
 	 */
@@ -1060,6 +1076,19 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function rest_authorization_required_code() {
 		_deprecated_function( __METHOD__, 'jetpack-8.8.0', 'rest_authorization_required_code' );
 		return rest_authorization_required_code();
+	}
+
+	/**
+	 * Get connection status for this Jetpack site.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return WP_REST_Response Connection information.
+	 */
+	public static function jetpack_connection_status() {
+		_deprecated_function( __METHOD__, 'jetpack-8.8.0', '\Automattic\Jetpack\Connection\REST_Connector::rest_authorization_required_code' );
+
+		return REST_Connector::connection_status();
 	}
 
 	/**

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -2,7 +2,6 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
-use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\JITMS\JITM;
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Status;
@@ -39,7 +38,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 	/**
 	 * @var string Generic error message when user is not allowed to perform an action.
 	 *
-	 * @deprecated 8.8.0 Use `REST_Connector::get_user_permissions_error_msg()` instead.
+	 * @deprecated 8.8.0 Use `\Automattic\Jetpack\Connection\REST_Connector::get_user_permissions_error_msg()` instead.
 	 */
 	public static $user_permissions_error_msg;
 
@@ -1019,9 +1018,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * Verify that user can view Jetpack admin page and can activate plugins.
 	 *
 	 * @return bool Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
-	 * @deprecated 8.8.0 The method is moved to the `REST_Connector` class.
+	 * @deprecated 8.8.0 The method is moved to the `\Automattic\Jetpack\Connection\REST_Connector` class.
 	 *
-	 * @see REST_Connector::activate_plugins_permission_check()
+	 * @see \Automattic\Jetpack\Connection\REST_Connector::activate_plugins_permission_check()
 	 *
 	 * @since 4.3.0
 	 */

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -93,9 +93,9 @@ class Manager {
 
 		if ( $manager->is_active() ) {
 			add_filter( 'xmlrpc_methods', array( $manager, 'public_xmlrpc_methods' ) );
-		} else {
-			add_action( 'rest_api_init', array( $manager, 'initialize_rest_api_registration_connector' ) );
 		}
+
+		add_action( 'rest_api_init', array( $manager, 'initialize_rest_api_registration_connector' ) );
 
 		add_action( 'jetpack_clean_nonces', array( $manager, 'clean_nonces' ) );
 		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
@@ -284,7 +284,7 @@ class Manager {
 	 * @param String        $password password string.
 	 * @return WP_User|Mixed authenticated user or error.
 	 */
-	public function authenticate_jetpack( $user, $username, $password ) {
+	public function authenticate_jetpack( $user, $username, $password ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		if ( is_a( $user, '\\WP_User' ) ) {
 			return $user;
 		}
@@ -1109,7 +1109,7 @@ class Manager {
 	 * @param int      $user_id The user ID.
 	 * @param array    $args    Adds the context to the cap. Typically the object ID.
 	 */
-	public function jetpack_connection_custom_caps( $caps, $cap, $user_id, $args ) {
+	public function jetpack_connection_custom_caps( $caps, $cap, $user_id, $args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$is_development_mode = ( new Status() )->is_development_mode();
 		switch ( $cap ) {
 			case 'jetpack_connect':

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -7,6 +7,13 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Status;
+use Jetpack_XMLRPC_Server;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
 /**
  * Registers the REST routes for Connections.
  */
@@ -19,6 +26,13 @@ class REST_Connector {
 	private $connection;
 
 	/**
+	 * This property stores the localized "Insufficient Permissions" error message.
+	 *
+	 * @var string Generic error message when user is not allowed to perform an action.
+	 */
+	private static $user_permissions_error_msg;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param Manager $connection The Connection Manager.
@@ -26,14 +40,55 @@ class REST_Connector {
 	public function __construct( Manager $connection ) {
 		$this->connection = $connection;
 
-		// Register a site.
+		self::$user_permissions_error_msg = esc_html__(
+			'You do not have the correct user permissions to perform this action.
+			Please contact your site admin if you think this is a mistake.',
+			'jetpack'
+		);
+
+		if ( ! $this->connection->is_active() ) {
+			// Register a site.
+			register_rest_route(
+				'jetpack/v4',
+				'/verify_registration',
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'verify_registration' ),
+					'permission_callback' => '__return_true',
+				)
+			);
+		}
+
+		// Authorize a remote user.
 		register_rest_route(
 			'jetpack/v4',
-			'/verify_registration',
+			'/remote_authorize',
 			array(
-				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => array( $this, 'verify_registration' ),
+				'methods'  => WP_REST_Server::EDITABLE,
+				'callback' => __CLASS__ . '::remote_authorize',
 				'permission_callback' => '__return_true',
+			)
+		);
+
+		// Get current connection status of Jetpack.
+		register_rest_route(
+			'jetpack/v4',
+			'/connection',
+			array(
+				'methods'  => WP_REST_Server::READABLE,
+				'callback' => array( $this, 'connection_status' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		// Get list of plugins that use the Jetpack connection.
+		register_rest_route(
+			'jetpack/v4',
+			'/connection/plugins',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_connection_plugins' ),
+				'permission_callback' => __CLASS__ . '::activate_plugins_permission_check',
 			)
 		);
 	}
@@ -52,4 +107,99 @@ class REST_Connector {
 
 		return $this->connection->handle_registration( $registration_data );
 	}
+
+	/**
+	 * Handles verification that a site is registered
+	 *
+	 * @since 5.4.0
+	 *
+	 * @param WP_REST_Request $request The request sent to the WP REST API.
+	 *
+	 * @return array|wp-error
+	 */
+	public static function remote_authorize( $request ) {
+		$xmlrpc_server = new Jetpack_XMLRPC_Server();
+		$result        = $xmlrpc_server->remote_authorize( $request );
+
+		if ( is_a( $result, 'IXR_Error' ) ) {
+			$result = new WP_Error( $result->code, $result->message );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get connection status for this Jetpack site.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @return WP_REST_Response Connection information.
+	 */
+	public function connection_status() {
+		$status = new Status();
+
+		return rest_ensure_response(
+			array(
+				'isActive'     => $this->connection->is_active(),
+				'isStaging'    => $status->is_staging_site(),
+				'isRegistered' => $this->connection->is_registered(),
+				'devMode'      => array(
+					'isActive' => $status->is_development_mode(),
+					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
+					'url'      => site_url() && false === strpos( site_url(), '.' ),
+					'filter'   => apply_filters( 'jetpack_development_mode', false ),
+				),
+			)
+		);
+	}
+
+
+	/**
+	 * Get plugins connected to the Jetpack.
+	 *
+	 * @since 8.6.0
+	 *
+	 * @return WP_REST_Response|WP_Error Response or error object, depending on the request result.
+	 */
+	public function get_connection_plugins() {
+		$plugins = $this->connection->get_connected_plugins();
+
+		if ( is_wp_error( $plugins ) ) {
+			return $plugins;
+		}
+
+		array_walk(
+			$plugins,
+			function( &$data, $slug ) {
+				$data['slug'] = $slug;
+			}
+		);
+
+		return rest_ensure_response( array_values( $plugins ) );
+	}
+
+	/**
+	 * Verify that user can view Jetpack admin page and can activate plugins.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return bool|WP_Error Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
+	 */
+	public static function activate_plugins_permission_check() {
+		if ( current_user_can( 'jetpack_admin_page' ) && current_user_can( 'activate_plugins' ) ) {
+			return true;
+		}
+
+		return new WP_Error( 'invalid_user_permission_activate_plugins', self::get_user_permissions_error_msg(), array( 'status' => rest_authorization_required_code() ) );
+	}
+
+	/**
+	 * Returns generic error message when user is not allowed to perform an action.
+	 *
+	 * @return string The error message.
+	 */
+	public static function get_user_permissions_error_msg() {
+		return self::$user_permissions_error_msg;
+	}
+
 }

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -187,7 +187,7 @@ class REST_Connector {
 	 * @return bool|WP_Error Whether user has the capability 'jetpack_admin_page' and 'activate_plugins'.
 	 */
 	public static function activate_plugins_permission_check() {
-		if ( current_user_can( 'jetpack_admin_page' ) && current_user_can( 'activate_plugins' ) ) {
+		if ( current_user_can( 'activate_plugins' ) ) {
 			return true;
 		}
 

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -76,7 +76,7 @@ class REST_Connector {
 			'/connection',
 			array(
 				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'connection_status' ),
+				'callback' => __CLASS__ . '::connection_status',
 				'permission_callback' => '__return_true',
 			)
 		);
@@ -135,14 +135,15 @@ class REST_Connector {
 	 *
 	 * @return WP_REST_Response Connection information.
 	 */
-	public function connection_status() {
-		$status = new Status();
+	public static function connection_status() {
+		$status     = new Status();
+		$connection = new Manager();
 
 		return rest_ensure_response(
 			array(
-				'isActive'     => $this->connection->is_active(),
+				'isActive'     => $connection->is_active(),
 				'isStaging'    => $status->is_staging_site(),
-				'isRegistered' => $this->connection->is_registered(),
+				'isRegistered' => $connection->is_registered(),
 				'devMode'      => array(
 					'isActive' => $status->is_development_mode(),
 					'constant' => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -1,0 +1,132 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+require_once ABSPATH . WPINC . '/class-IXR.php';
+
+use Automattic\Jetpack\Config;
+use Automattic\Jetpack\Connection\Plugin as Connection_Plugin;
+use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
+use PHPUnit\Framework\TestCase;
+use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Connection\Manager;
+
+/**
+ * Unit tests for the REST API endpoints.
+ *
+ * @package automattic/jetpack-connection
+ * @see \Automattic\Jetpack\Connection\REST_Connector
+ */
+class Test_REST_Endpoints extends TestCase {
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+		new REST_Connector( new Manager() );
+
+		add_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/remote_authorize` endpoint.
+	 */
+	public function test_remote_authorize() {
+		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/remote_authorize' );
+		$this->request->set_header( 'Content-Type', 'application/json' );
+		$this->request->set_body( '{ "state": 111, "secret": "12345", "redirect_uri": "https://example.org", "code": "54321" }' );
+
+		$response = $this->server->dispatch( $this->request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $data['code'] );
+		$this->assertContains( '[verify_secrets_missing]', $data['message'] );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/connection` endpoint.
+	 */
+	public function test_connection() {
+		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/connection' );
+
+		$response = $this->server->dispatch( $this->request );
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['isActive'] );
+		$this->assertFalse( $data['isRegistered'] );
+	}
+
+	/**
+	 * Testing the `/jetpack/v4/connection/plugins` endpoint.
+	 */
+	public function test_connection_plugins() {
+		$user = wp_get_current_user();
+		$user->add_cap( 'jetpack_admin_page' );
+		$user->add_cap( 'activate_plugins' );
+
+		$plugins = array(
+			array(
+				'name' => 'Plugin Name 1',
+				'slug' => 'plugin-slug-1',
+			),
+			array(
+				'name' => 'Plugin Name 2',
+				'slug' => 'plugin-slug-2',
+			),
+		);
+
+		array_walk(
+			$plugins,
+			function( $plugin ) {
+				( new Connection_Plugin( $plugin['slug'] ) )->add( $plugin['name'] );
+			}
+		);
+
+		Connection_Plugin_Storage::configure();
+
+		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/connection/plugins' );
+
+		$response = $this->server->dispatch( $this->request );
+
+		$this->assertEquals( $plugins, $response->get_data() );
+
+		$user->remove_cap( 'activate_plugins' );
+		$user->remove_cap( 'jetpack_admin_page' );
+	}
+
+	/**
+	 * This filter callback allow us to skip the database query by `Jetpack_Options` to retrieve the option.
+	 *
+	 * @param array $options List of options already skipping the database request.
+	 *
+	 * @return array
+	 */
+	public function bypass_raw_options( array $options ) {
+		$options[ Manager::SECRETS_OPTION_NAME ] = true;
+
+		return $options;
+	}
+
+}

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -5,6 +5,7 @@ require_once ABSPATH . WPINC . '/class-IXR.php';
 use Automattic\Jetpack\Config;
 use Automattic\Jetpack\Connection\Plugin as Connection_Plugin;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
+use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Connection\Manager;
@@ -69,6 +70,18 @@ class Test_REST_Endpoints extends TestCase {
 	 * Testing the `/jetpack/v4/connection` endpoint.
 	 */
 	public function test_connection() {
+		$builder = new MockBuilder();
+		$builder->setNamespace( 'Automattic\Jetpack' )
+				->setName( 'apply_filters' )
+				->setFunction(
+					function( $hook, $value ) {
+						return 'jetpack_development_mode' === $hook ? true : $value;
+					}
+				);
+
+		$mock = $builder->build();
+		$mock->enable();
+
 		$this->request = new WP_REST_Request( 'GET', '/jetpack/v4/connection' );
 
 		$response = $this->server->dispatch( $this->request );
@@ -76,6 +89,7 @@ class Test_REST_Endpoints extends TestCase {
 
 		$this->assertFalse( $data['isActive'] );
 		$this->assertFalse( $data['isRegistered'] );
+		$this->assertTrue( $data['devMode']['isActive'] );
 	}
 
 	/**

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -128,10 +128,8 @@ class ManagerTest extends TestCase {
 	 */
 	public function test_api_url_defaults() {
 		$this->apply_filters->enable();
-		$this->constants_apply_filters->enable();
 
-		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
-		Constants::set_constant( 'JETPACK__API_VERSION', '1' );
+		add_filter( 'jetpack_constant_default_value', array( $this, 'filter_api_constant' ), 10, 2 );
 
 		$this->assertEquals(
 			'https://jetpack.wordpress.com/jetpack.something/1/',
@@ -141,6 +139,8 @@ class ManagerTest extends TestCase {
 			'https://jetpack.wordpress.com/jetpack.another_thing/1/',
 			$this->manager->api_url( 'another_thing/' )
 		);
+
+		remove_filter( 'jetpack_constant_default_value', array( $this, 'filter_api_constant' ), 10, 2 );
 	}
 
 	/**
@@ -440,6 +440,21 @@ class ManagerTest extends TestCase {
 		$mock->enable();
 
 		return $mock;
+	}
+
+	/**
+	 * Filter to set the default constant values.
+	 *
+	 * @param string $value Existing value (empty and ignored).
+	 * @param string $name Constant name.
+	 *
+	 * @see Utils::DEFAULT_JETPACK__API_BASE
+	 * @see Utils::DEFAULT_JETPACK__API_VERSION
+	 *
+	 * @return string
+	 */
+	public function filter_api_constant( $value, $name ) {
+		return constant( __NAMESPACE__ . "\Utils::DEFAULT_$name" );
 	}
 
 }

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -130,6 +130,9 @@ class ManagerTest extends TestCase {
 		$this->apply_filters->enable();
 		$this->constants_apply_filters->enable();
 
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+		Constants::set_constant( 'JETPACK__API_VERSION', '1' );
+
 		$this->assertEquals(
 			'https://jetpack.wordpress.com/jetpack.something/1/',
 			$this->manager->api_url( 'something' )
@@ -150,6 +153,7 @@ class ManagerTest extends TestCase {
 		$this->constants_apply_filters->enable();
 
 		Constants::set_constant( 'JETPACK__API_BASE', 'https://example.com/api/base.' );
+		Constants::set_constant( 'JETPACK__API_VERSION', '1' );
 		$this->assertEquals(
 			'https://example.com/api/base.something/1/',
 			$this->manager->api_url( 'something' )

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -3,7 +3,11 @@
  * Class for REST API endpoints testing.
  *
  * @since 4.4.0
+ * @package Jetpack
  */
+
+use Automattic\Jetpack\Connection\REST_Connector;
+
 require_once( dirname( __FILE__ ) . '/../../../../modules/widgets/milestone.php' );
 
 class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
@@ -60,7 +64,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 	 * @return array
 	 */
 	protected function get_jetpack_connection_status() {
-		$status = Jetpack_Core_Json_Api_Endpoints::jetpack_connection_status();
+		$status = REST_Connector::connection_status();
 		return isset( $status->data ) ? $status->data : array();
 	}
 

--- a/tests/php/_inc/lib/test_class.rest-api-endpoints.php
+++ b/tests/php/_inc/lib/test_class.rest-api-endpoints.php
@@ -294,7 +294,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		$this->load_rest_endpoints_direct();
 
 		// Current user doesn't have credentials, so checking permissions should fail
-		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::activate_plugins_permission_check() );
+		$this->assertInstanceOf( 'WP_Error', REST_Connector::activate_plugins_permission_check() );
 
 		$user = $this->create_and_get_user();
 
@@ -305,7 +305,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		wp_set_current_user( $user->ID );
 
 		// Should fail because requires more capabilities
-		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::activate_plugins_permission_check() );
+		$this->assertInstanceOf( 'WP_Error', REST_Connector::activate_plugins_permission_check() );
 
 		// Add Jetpack capability
 		$user->add_cap( 'activate_plugins' );
@@ -319,7 +319,7 @@ class WP_Test_Jetpack_REST_API_endpoints extends WP_UnitTestCase {
 		wp_set_current_user( $user->ID );
 
 		// User has capability so this should work this time
-		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::activate_plugins_permission_check() );
+		$this->assertTrue( REST_Connector::activate_plugins_permission_check() );
 
 	}
 


### PR DESCRIPTION
Some of the endpoints can function without Jetpack, especially the ones that return status of the connection, and manage it.
This is the first effort to split the REST endpoints between Jetpack and `jetpack-connection`.

#### Changes proposed in this Pull Request:
* Moved following REST endpoints into `jetpack-connection` package:
    - `jetpack/v4/remote_authorize`
    - `jetpack/v4/connection`
    - `jetpack/v4/connection/plugins`.
* Unit tests for these endpoints.

#### Jetpack product discussion
`p9dueE-1qA-p2`

#### Does this pull request change what data or activity we track or use?
No, it doesn't.

#### Testing instructions:
1. Go to "Jetpack -> Debug Tools" and enable "REST API Tester".
2. Go to "Jetpack -> REST API Tester" and send the POST request:
    * Endpoint: `remote_authorize`
    * Body (replace `[user_id]` with the primary user ID: `{ "state": [user_id], "secret": "12345", "redirect_uri": "http://jetpack.com", "code": "54321" }`
    * If the site is already connected, you should see `Error 500`, `Jetpack: [already_connected] User already connected.`. That's the success, it means the endpoint is working.
3. Send a GET request to the endpoint `connection`. You should see the `200 OK`, and the connection information in the response body (`isActive`, `isStaging`, etc.)
4. Send a GET request to the endpoint `connection/plugins`. You should see the `200 OK`, and the list of connected plugins in the response body (at least `Jetpack` itself should be there).

#### Proposed changelog entry for your changes:
I'm not sure it's needed, but anyway:
* Moving some REST API endpoints form Jetpack to the `jetpack-connection` package.
