### PR TITLE
External Media: avoid styles bleeding out to Gut welcome modal

### DIFF
--- a/extensions/shared/external-media/editor.scss
+++ b/extensions/shared/external-media/editor.scss
@@ -57,20 +57,17 @@ $grid-size: 8px;
 	.components-modal__content {
 		overflow: auto;
 		padding-bottom: 0;
+		width: 100%;
+
+		@media ( min-width: 600px ) {
+			width: 90vw;
+			height: 90vh;
+		}
 	}
 }
 
 .jetpack-external-media-browser--is-copying {
 	pointer-events: none;
-}
-
-.components-modal__content {
-	width: 100%;
-
-	@media ( min-width: 600px ) {
-		width: 90vw;
-		height: 90vh;
-	}
 }
 
 .jetpack-external-media-browser {


### PR DESCRIPTION
Previously: #16144


#### Changes proposed in this Pull Request:

* Let's ensure that the External Media styles do not impact other elements in the block editor.

**Before**

![image](https://user-images.githubusercontent.com/426388/86569569-e1927100-bf6e-11ea-8a01-d187dd481b63.png)


**After**

![image](https://user-images.githubusercontent.com/426388/86569580-e48d6180-bf6e-11ea-9d89-b4e9395dde09.png)


#### Jetpack product discussion

* N/A 

#### Does this pull request change what data or activity we track or use?
* N/A 
#### Testing instructions:

* Go to Posts > Add New
* In the block editor sidebar, select Tools > Welcome Guide
* Also check that the External Media modal (appearing when adding an image block and selecting an external media source) still looks good.

#### Proposed changelog entry for your changes:
* N/A 
