### PR TITLE
Unit Tests: valid JSON schema type / file deprecation changes

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -40,7 +40,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 					'args'                => array(
 						'service_api_key' => array(
 							'required' => true,
-							'type'     => 'text',
+							'type'     => 'string',
 						),
 					),
 				),

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -150,25 +150,27 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 	/**
 	 * Provides deprecated files and expected relacements.
 	 *
-	 * @todo Remove version check when WordPress 5.4 is the minimum.
+	 * @todo Remove error version check when WordPress 5.4 is the minimum.
+	 * @todo Remove replacement version check when WordPress 5.5 is the minimum.
 	 *
 	 * @return array
 	 */
 	function provider_deprecated_file_paths() {
 		global $wp_version;
 
-		$error = ( version_compare( $wp_version, '5.4-alpha', '>=' ) ) ? E_USER_DEPRECATED : E_USER_NOTICE;
+		$error       = ( version_compare( $wp_version, '5.4-alpha', '>=' ) ) ? E_USER_DEPRECATED : E_USER_NOTICE;
+		$replacement = ( version_compare( $wp_version, '5.5-alpha', '>=' ) ) ? '' : null;
 
 		return array(
 
 			array(
 				'class.jetpack-ixr-client.php',
-				null,
+				$replacement,
 				$error,
 			),
 			array(
 				'class.jetpack-xmlrpc-server.php',
-				null,
+				$replacement,
 				$error,
 			),
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This came up because of 2 changes made in Core this weekend:

- https://core.trac.wordpress.org/ticket/50300
- https://core.trac.wordpress.org/changeset/48327/

They caused our tests to start failing, because:

1. we were not using a valid schema type.
2. We were not expecting the right replacement for deprecated files anymore.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Do the tests pass?
* Can you still add a Mapbox API key to a brand new Map block?

#### Proposed changelog entry for your changes:

* N/A
