### PR TITLE
Debug Tools: Added missing Plugin Version constant.

### DIFF
--- a/packages/debug-helper/plugin.php
+++ b/packages/debug-helper/plugin.php
@@ -14,6 +14,12 @@ namespace Automattic\Jetpack\Debug_Helper;
 define( 'JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE', __FILE__ );
 
 /**
+ * The plugin version.
+ * Increase that if you do any edits to ensure refreshing the cached assets.
+ */
+define( 'JETPACK_DEBUG_HELPER_VERSION', '1.0' );
+
+/**
  * Include file names from the modules directory here.
  */
 $jetpack_dev_debug_modules = array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Added missing "Plugin Version" constant.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Go to the Debug Tools plugin.
* Make sure the error notice no longer shows up.
* Confirm that the plugin is still working.

#### Proposed changelog entry for your changes:
n/a
