### PR TITLE
Broken token plugin: fixes invalid user token method

### DIFF
--- a/packages/debug-helper/modules/class-broken-token.php
+++ b/packages/debug-helper/modules/class-broken-token.php
@@ -70,7 +70,7 @@ class Broken_Token {
 	 *
 	 * @var string
 	 */
-	public $invalid_user_token = 'broken.token.1';
+	public $invalid_user_token = 'broken.token.%d';
 
 	/**
 	 * Broken_Token constructor.
@@ -290,7 +290,7 @@ class Broken_Token {
 		check_admin_referer( 'set-invalid-user-tokens' );
 		$this->notice_type = 'jetpack-broken';
 		foreach ( Jetpack_Options::get_option( 'user_tokens', array() ) as $id => $token ) {
-			Jetpack_Options::update_option( 'user_tokens', array( $id => $this->invalid_user_token ) );
+			Jetpack_Options::update_option( 'user_tokens', array( $id => sprintf( $this->invalid_user_token, $id ) ) );
 		}
 
 		$this->admin_post_redirect_referrer();


### PR DESCRIPTION
Consider the user ID when creating an invalid user token, this better simulates a token where the "hash" part is broken while still assigned to the user.

In order to test, you have to have a primary user whose ID is not 1.

. Without this patch: an invalid user token would look like a completely disconnected site. No access to dashboard
. With this patch: user still has access to the Dashboard