### PR TITLE
Add FTP support to partner provision script

### DIFF
--- a/bin/partner-provision.sh
+++ b/bin/partner-provision.sh
@@ -22,7 +22,11 @@ usage () {
 	[--ssh-user=user_name] \
 	[--ssh-pass=user_pass] \
 	[--ssh-private-key=/path/to/private_key] \
-	[--ssh-port=22] '
+	[--ssh-port=22] \
+	[--ftp-host=example.com] \
+	[--ftp-user=user_name] \
+	[--ftp-pass=user_pass] \
+	[--ftp-port=21] '
 }
 
 # Note: this script should always be designed to keep wp-cli OPTIONAL
@@ -106,6 +110,22 @@ for i in "$@"; do
 			;;
 		--ssh-port=* )
 			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ssh_port=${i#*=}"
+			shift
+			;;
+		--ftp-host=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_host=${i#*=}"
+			shift
+			;;
+		--ftp-user=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_user=${i#*=}"
+			shift
+			;;
+		--ftp-pass=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_pass=${i#*=}"
+			shift
+			;;
+		--ftp-port=* )
+			PROVISION_REQUEST_ARGS="$PROVISION_REQUEST_ARGS --form ftp_port=${i#*=}"
 			shift
 			;;
 		--allow-root )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update the partner provision script to accept FTP credentials (previously only SSH credentials were allowed).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
See pbuNQi-gM-p2.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

In order to test this you will need a hosting partner partner ID and partner secret. Feel free to ping the folks at `#jetpack-infinity` in Slack for some testing credentials. You will also need a test site with Jetpack installed, activated, and with working FTP credentials for your server.

SSH to the site and go to the jetpack plugin's bin dir. In there execute the following, replacing whatever is between `<>` with the appropriate values:

```bash
bash partner-provision.sh \
 --partner_id=<PARTNER ID> \
 --partner_secret=<PARTNER SECRET> \
 --user=<SITE USER> \
 --plan=professional \
 --wpcom_user_id=<YOUR WPCOM USER ID> \
 --url=<SITEURL> \
 --ftp-host=<FT HOST> \
 --ftp-user=<FTP USER> \
 --ftp-pass=<FTP PASS>
```

The output should contain a JSON string. The only important bit is that you see `ftp_set` and `ftp_error` keys. If `ftp_set` is true you will get an empty error, otherwise an error should be present in `ftp_error`.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Partner provision shell script now accepts FTP credentials.
