### PR TITLE
Rework Sender to properly return state during do_full_sync

### DIFF
--- a/class.jetpack-cli.php
+++ b/class.jetpack-cli.php
@@ -8,6 +8,7 @@ use Automattic\Jetpack\Connection\Utils as Connection_Utils;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Sync\Actions;
 use Automattic\Jetpack\Sync\Listener;
+use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Queue;
 use Automattic\Jetpack\Sync\Settings;
 
@@ -996,6 +997,11 @@ class Jetpack_CLI extends WP_CLI_Command {
 							WP_CLI::log( __( 'Sent data to WordPress.com', 'jetpack' ) );
 						} else {
 							WP_CLI::log( __( 'Sent more data to WordPress.com', 'jetpack' ) );
+						}
+
+						// Immediate Full Sync does not wait for WP.com to process data so we need to enforce a wait.
+						if ( false !== strpos( get_class( Modules::get_module( 'full-sync' ) ), 'Full_Sync_Immediately' ) ) {
+							sleep( 15 );
 						}
 					}
 					$i++;

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -504,15 +504,18 @@ class Actions {
 					sleep( $delay );
 				}
 			}
-			$executions ++;
 
 			// Explicitly only allow 1 do_full_sync call until issue with Immediate Full Sync is resolved.
 			// For more context see p1HpG7-9pe-p2.
-			if ( 'full_sync' === $type && $executions > 1 ) {
+			if ( 'full_sync' === $type && $executions >= 1 ) {
 				break;
 			}
 
 			$result = 'full_sync' === $type ? self::$sender->do_full_sync() : self::$sender->do_sync();
+
+			// # of send actions performed.
+			$executions ++;
+
 		} while ( $result && ! is_wp_error( $result ) && ( $start_time + $time_limit ) > time() );
 
 		return $executions;

--- a/packages/sync/src/class-sender.php
+++ b/packages/sync/src/class-sender.php
@@ -256,14 +256,26 @@ class Sender {
 	 * @return boolean|\WP_Error True if this sync sending was successful, error object otherwise.
 	 */
 	public function do_full_sync() {
-		if ( ! Modules::get_module( 'full-sync' ) ) {
+		$sync_module = Modules::get_module( 'full-sync' );
+		if ( ! $sync_module ) {
 			return;
 		}
 		if ( ! Settings::get_setting( 'full_sync_sender_enabled' ) ) {
 			return;
 		}
 		$this->continue_full_sync_enqueue();
-		return $this->do_sync_and_set_delays( $this->full_sync_queue );
+		// immediate full sync sends data in continue_full_sync_enqueue.
+		if ( false === strpos( get_class( $sync_module ), 'Full_Sync_Immediately' ) ) {
+			return $this->do_sync_and_set_delays( $this->full_sync_queue );
+		} else {
+			$status = $sync_module->get_status();
+			// Sync not started or Sync finished.
+			if ( false === $status['started'] || ( ! empty( $status['started'] ) && ! empty( $status['finished'] ) ) ) {
+				return false;
+			} else {
+				return true;
+			}
+		}
 	}
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-actions.php
+++ b/tests/php/sync/test_class.jetpack-sync-actions.php
@@ -119,14 +119,9 @@ class WP_Test_Jetpack_Sync_Actions extends WP_UnitTestCase {
 	 */
 	public function test_do_cron_sync_by_type_full_sync_in_progress() {
 
-		// udpate settings to In Progress.
-		$settings = array(
-			'started'  => true,
-			'finished' => false,
-			'progress' => array(),
-			'config'   => array(),
-		);
-		\Jetpack_Options::update_raw_option( 'jetpack_sync_full_status', $settings );
+		// Initialize a Full Sync (all modules).
+		$full_sync = Modules::get_module( 'full-sync' );
+		$full_sync->start();
 
 		$executions = Actions::do_cron_sync_by_type( 'full_sync' );
 		$this->assertEquals( $executions, 1 );

--- a/tests/php/sync/test_class.jetpack-sync-sender.php
+++ b/tests/php/sync/test_class.jetpack-sync-sender.php
@@ -4,6 +4,7 @@ use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Lock;
 use Automattic\Jetpack\Sync\Modules\Callables;
+use Automattic\Jetpack\Sync\Settings;
 
 
 class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
@@ -249,22 +250,16 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 	function test_sends_queue_id_to_server() {
 		add_action( 'my_incremental_action', array( $this->listener, 'action_handler' ) );
-		add_action( 'my_full_sync_action', array( $this->listener, 'full_sync_action_handler' ) );
 
 		do_action( 'my_incremental_action' );
-		do_action( 'my_full_sync_action' );
 
 		$this->sender->do_sync();
-		$this->sender->do_full_sync();
 
 		$incremental_event = $this->server_event_storage->get_most_recent_event( 'my_incremental_action' );
-		$full_sync_event = $this->server_event_storage->get_most_recent_event( 'my_full_sync_action' );
 
 		$this->assertEquals( $incremental_event->queue, $this->listener->get_sync_queue()->id );
-		$this->assertEquals( $this->listener->get_full_sync_queue()->id, $full_sync_event->queue );
 
 		remove_action( 'my_incremental_action', array( $this->listener, 'action_handler' ) );
-		remove_action( 'my_full_sync_action', array( $this->listener, 'full_sync_action_handler' ) );
 	}
 
 	function test_reset_module_also_resets_full_sync_lock() {
@@ -484,41 +479,35 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	/**
-	 * Verify that do_full_sync returns WP_Error when Full Sync is in progress.
+	 * Verify that do_full_sync returns TRUE when Full Sync is in progress.
 	 *
-	 * Note Highlights existing behavior which is broken, correct value should be True.
 	 * For more context see p1HpG7-9pe-p2.
 	 */
 	public function test_do_full_sync_return_in_progress() {
 
-		// udpate settings to In Progress.
-		$settings = array(
-			'started'  => true,
-			'finished' => false,
-			'progress' => array(),
-			'config'   => array(),
-		);
-		\Jetpack_Options::update_raw_option( 'jetpack_sync_full_status', $settings );
+		// Initialize a Full Sync (all modules).
+		$full_sync = Modules::get_module( 'full-sync' );
+		$full_sync->start();
+
+		// Modify send_duration so we don't send all data at once.
+		Settings::update_settings( array( 'full_sync_send_duration' => 0 ) );
 
 		$result = $this->sender->do_full_sync();
-
-		// WP_Error is expected.
-		$this->assertInstanceOf( 'WP_Error', $result );
-		// Correct state would be "True".
+		// True is expected.
+		$this->assertTrue( $result );
 	}
 
 	/**
-	 * Verify that do_full_sync returns WP_Error when Full Sync is complete.
+	 * Verify that do_full_sync returns FALSE when Full Sync is complete.
 	 *
-	 * Note Highlights existing behavior which is broken, correct value should be False.
 	 * For more context see p1HpG7-9pe-p2.
 	 */
 	public function test_do_full_sync_return_complete() {
 
 		// udpate settings to In Progress.
 		$settings = array(
-			'started'  => true,
-			'finished' => true,
+			'started'  => '1594051403',
+			'finished' => '1594051404',
 			'progress' => array(),
 			'config'   => array(),
 		);
@@ -526,15 +515,13 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$result = $this->sender->do_full_sync();
 
-		// WP_Error is expected.
-		$this->assertInstanceOf( 'WP_Error', $result );
-		// Correct state would be "False".
+		// FALSE is expected.
+		$this->assertFalse( $result );
 	}
 
 	/**
-	 * Verify that do_full_sync returns WP_Error when Full Sync has a send lock.
+	 * Verify that do_full_sync returns TRUE when Full Sync has a send lock.
 	 *
-	 * Note Highlights existing behavior which is broken, correct value should be False.
 	 * For more context see p1HpG7-9pe-p2.
 	 */
 	public function test_do_full_sync_return_send_lock() {
@@ -553,9 +540,9 @@ class WP_Test_Jetpack_Sync_Sender extends WP_Test_Jetpack_Sync_Base {
 
 		$result = $this->sender->do_full_sync();
 
-		// WP_Error is expected.
-		$this->assertInstanceOf( 'WP_Error', $result );
-		// Correct state would be "False".
+		// TRUE is expected.
+		$this->assertTrue( $result );
+
 		( new Lock() )->remove( 'full_sync' );
 	}
 


### PR DESCRIPTION
As of Jetpack 8.3 the jetpack sync start cli command would initiate a Full Sync but would not continually send data. This update adds appropriate logic so that the command will run until the full sync has completed. This is re-applying the logic in https://github.com/Automattic/jetpack/pull/16010 that got reverted in 8.6.1 due to not having proper checks for cron behavior. (p1HpG7-9pe-p2)

#### Changes proposed in this Pull Request:
Adds a check for the Full Sync Module in use to properly send data until the Full Sync is complete when using `jetpack sync start` cli

#### Is this a new feature or does it add/remove features to an existing part of Jetpack?
Resolves an issue introduced in 8.3

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

TEST CLI Command
1) execute `wp jetpack sync start` from the remote site's cli
2) Verify that the command runs until complete "Success: Finished syncing to WordPress.com"

Test Standard Full Sync Flow
3) Trigger a Full Sync from the jetpack Debugger
4) Perform admin actions on the jetpack site (viewing pages is sufficient)
5)Verify in the Debugger that the Full Sync processes until complete.

TEST Cron behavior
6) Trigger a Full Sync from the Jetpack Debugger
7) run `wp cron event run jetpack_sync_full_cron` command from remote site's cli
8) verify you see the cron event was executed "Executed the cron event 'jetpack_sync_full_cron' in 0.04s."
9) View the Full Sync Status in the debugger, you should see that more items are still pending sync.

#### Proposed changelog entry for your changes:
Jetpack CLI :: fix issue where jetpack sync start was triggering the error message "Sync error'd with code: empty_queue_full_sync"