### PR TITLE
Debugger: Update vars after #14901

### DIFF
--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -72,11 +72,14 @@ class Jetpack_Debugger {
 					} else {
 						$failures = $cxntests->list_fails();
 						foreach ( $failures as $fail ) {
+							$action_link  = $fail['action'];
+							$action_label = $fail['action_label'];
+							$action       = ( $action_link ) ? '<a href="' . $action_link . '">' . $action_link : $action_label;
 							echo '<div class="jetpack-test-error">';
-							echo '<p><a class="jetpack-test-heading" href="#">' . esc_html( $fail['message'] );
+							echo '<p><a class="jetpack-test-heading" href="#">' . esc_html( $fail['short_description'] );
 							echo '<span class="noticon noticon-collapse"></span></a></p>';
 							echo '<p class="jetpack-test-details">' . wp_kses(
-								$fail['resolution'],
+								$action,
 								array(
 									'a' => array(
 										'href'   => array(),

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -74,7 +74,7 @@ class Jetpack_Debugger {
 						foreach ( $failures as $fail ) {
 							$action_link  = $fail['action'];
 							$action_label = $fail['action_label'];
-							$action       = ( $action_link ) ? '<a href="' . $action_link . '">' . $action_link : $action_label;
+							$action       = ( $action_link ) ? '<a href="' . $action_link . '">' . $action_link . '</a>' : $action_label;
 							echo '<div class="jetpack-test-error">';
 							echo '<p><a class="jetpack-test-heading" href="#">' . esc_html( $fail['short_description'] );
 							echo '<span class="noticon noticon-collapse"></span></a></p>';

--- a/_inc/lib/debugger/class-jetpack-debugger.php
+++ b/_inc/lib/debugger/class-jetpack-debugger.php
@@ -74,7 +74,7 @@ class Jetpack_Debugger {
 						foreach ( $failures as $fail ) {
 							$action_link  = $fail['action'];
 							$action_label = $fail['action_label'];
-							$action       = ( $action_link ) ? '<a href="' . $action_link . '">' . $action_link . '</a>' : $action_label;
+							$action       = ( $action_link ) ? '<a href="' . $action_link . '">' . $action_label . '</a>' : $action_label;
 							echo '<div class="jetpack-test-error">';
 							echo '<p><a class="jetpack-test-heading" href="#">' . esc_html( $fail['short_description'] );
 							echo '<span class="noticon noticon-collapse"></span></a></p>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See #14901

The in-plugin debugger did not get the new variable names introduced for failed tests.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Debugger: Display error message on the in-plugin debug page.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a failed testing state (add another admin, demote the initial admin without disconnecting Jetpack)
* Review the in-plugin debugger. Look for PHP notices.
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Bug Fix: Display error on the Jetpack Debuging Page.
