### PR TITLE
External Media: handle errors from the copy endpoint

### DIFF
--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -197,6 +197,17 @@ export default function withMedia() {
 						const { value, addToGallery, multiple } = this.props;
 						const media = multiple ? result : result[ 0 ];
 
+						const itemWithErrors = result.find( item => item.errors );
+						if ( itemWithErrors ) {
+							const { errors } = itemWithErrors;
+							const firstErrorKey = Object.keys( errors )[ 0 ];
+							this.handleApiError( {
+								code: firstErrorKey,
+								message: errors[ firstErrorKey ],
+							} );
+							return;
+						}
+
 						this.props.onClose();
 
 						// Select the image(s). This will close the modal


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
handles upload errors from the copy endpoint

#### Jetpack product discussion
…

#### Does this pull request change what data or activity we track or use?
nope

#### Testing instructions:

- apply D46021-code to enable the feature
- build extensions and sync `editor.js` and `editor-beta.js` to your sandbox
- now test on a sandboxed simple site and **unsandboxed** API
- external media feature should fail consistently in this setup when confirming an insertion of selected picture
- this PR adds a visible error message instead of just closing the modal:

<img width="681" alt="Screenshot 2020-07-07 at 13 52 37" src="https://user-images.githubusercontent.com/156676/86778191-5bebef80-c05a-11ea-9399-843723aed4e5.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* none, bugfix of unreleased feature
