### PR TITLE
Tiled Gallery Block: only available when Jetpack is connected

### DIFF
--- a/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -10,6 +10,7 @@
 
 namespace Automattic\Jetpack\Extensions;
 
+use Jetpack;
 use Jetpack_Gutenberg;
 use Jetpack_Plan;
 
@@ -31,12 +32,17 @@ class Tiled_Gallery {
 	 * Register the block
 	 */
 	public static function register() {
-		jetpack_register_block(
-			self::BLOCK_NAME,
-			array(
-				'render_callback' => array( __CLASS__, 'render' ),
-			)
-		);
+		if (
+			( defined( 'IS_WPCOM' ) && IS_WPCOM )
+			|| Jetpack::is_active()
+		) {
+			jetpack_register_block(
+				self::BLOCK_NAME,
+				array(
+					'render_callback' => array( __CLASS__, 'render' ),
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #16426

#### Changes proposed in this Pull Request:

The Tiled Gallery block relies on Jetpack's Image CDN to resize the images on the fly, and consequently cannot be used on a site that's not publicly accessible, where the CDN cannot fetch the images.

With this change, the block will not appear when your site is not connected to WordPress.com.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Launch a new JN site with this branch.
* Under Settings > Jetpack Constants, enable Dev mode
* Go to Posts > Add New: the Tiled Gallery block should not be available.
* Disable Dev mode
* Connect your site to WordPress.com.
* The block should become available


#### Proposed changelog entry for your changes:

* Blocks: do not load the Tiled Gallery block when your site is not connected to WordPress.com.
