### PR TITLE
Debug Tools: Removing "Missing Jetpack" error from REST API Tester

### DIFF
--- a/packages/debug-helper/modules/class-rest-api-tester.php
+++ b/packages/debug-helper/modules/class-rest-api-tester.php
@@ -117,18 +117,8 @@ class REST_API_Tester {
 	public static function register_rest_api_tester() {
 		if ( class_exists( 'Jetpack' ) ) {
 			new REST_API_Tester();
-		} else {
-			add_action( 'admin_notices', array( __CLASS__, 'jetpack_not_active' ) );
 		}
 	}
-
-	/**
-	 * Jetpack is missing ¯\_(ツ)_/¯.
-	 */
-	public function jetpack_not_active() {
-		echo '<div class="notice info"><p>Jetpack needs to be active and installed for the Broken Token plugin.</p></div>';
-	}
-
 }
 
 add_action( 'plugins_loaded', array( REST_API_Tester::class, 'register_rest_api_tester' ), 1000 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Removes the "Jetpack is required" notice from the REST API tester.
The notice is already displayed by the "Broken Token" module, no need for another one.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
This is a minor change in an internal tool, no testing needed.

#### Proposed changelog entry for your changes:
N/a.