### PR TITLE
Gathering Tweetstorms: Show the loading spinner in WP 5.3.

### DIFF
--- a/extensions/blocks/gathering-tweetstorms/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/editor.js
@@ -61,6 +61,7 @@ const addTweetstormToTweets = blockSettings => {
 							</ToolbarGroup>
 						) : (
 							<Toolbar
+								className="gathering-tweetstorms__embed-toolbar"
 								controls={ [
 									{
 										title: __(
@@ -71,10 +72,13 @@ const addTweetstormToTweets = blockSettings => {
 										extraProps: {
 											className: 'gathering-tweetstorms__embed-toolbar-button',
 											children: __( 'Unroll', 'jetpack' ),
+											disabled: isGatheringStorm,
 										},
 									},
 								] }
-							/>
+							>
+								{ isGatheringStorm && <Spinner /> }
+							</Toolbar>
 						) }
 					</BlockControls>
 					<CoreTweetEdit { ...props } />


### PR DESCRIPTION
The Twitter thread importer uses a fallback UI for WordPress 5.3. #16369 implemented a loading spinner on newer versions of WordPress, but didn't include it for WordPress 5.3.

#### Changes proposed in this Pull Request:
* Add the functionality implemented in #16369 to WordPress 5.3.

#### Jetpack product discussion
58i-98G-p2#comment-46754

#### Does this pull request change what data or activity we track or use?
No change.

#### Testing instructions:

* Ensure you're testing on WordPress 5.3.x.
* Embed a tweet in a post.
* Click the Unroll button.

#### Proposed changelog entry for your changes:
* Gathering Tweetstorms: Show a loading spinner when unrolling Twitter threads on WordPress 5.3.
