### PR TITLE
Asset CDN: don't fix local script translation path when $file is false

### DIFF
--- a/modules/photon-cdn.php
+++ b/modules/photon-cdn.php
@@ -129,17 +129,20 @@ class Jetpack_Photon_Static_Assets_CDN {
 	/**
 	 * Ensure use of the correct local path when loading the JavaScript translation file for a CDN'ed asset.
 	 *
-	 * @param string $file   The path that's going to be loaded.
-	 * @param string $handle The script handle.
-	 * @param string $domain The text domain.
+	 * @param string|false $file   Path to the translation file to load. False if there isn't one.
+	 * @param string       $handle The script handle.
+	 * @param string       $domain The text domain.
+	 *
 	 * @return string The transformed local languages path.
 	 */
 	public static function fix_local_script_translation_path( $file, $handle, $domain ) {
 		global $wp_scripts;
+
 		// This is a rewritten plugin URL, so load the language file from the plugins path.
-		if ( isset( $wp_scripts->registered[ $handle ] ) && wp_startswith( $wp_scripts->registered[ $handle ]->src, self::CDN . 'p' ) ) {
+		if ( $file && isset( $wp_scripts->registered[ $handle ] ) && wp_startswith( $wp_scripts->registered[ $handle ]->src, self::CDN . 'p' ) ) {
 			return WP_LANG_DIR . '/plugins/' . basename( $file );
 		}
+
 		return $file;
 	}
 

--- a/tests/php/modules/photon/test_class.jetpack-photon-static-asset-cdn.php
+++ b/tests/php/modules/photon/test_class.jetpack-photon-static-asset-cdn.php
@@ -1,0 +1,64 @@
+<?php //phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * The WP_Test_Jetpack_Photon_Static_Assets_CDN class file.
+ *
+ * @package Jetpack
+ */
+
+require_jetpack_file( 'modules/photon-cdn.php' );
+
+/**
+ * Unit tests for the Jetpack_Photon_Static_Assets_CDN class.
+ */
+class WP_Test_Jetpack_Photon_Static_Assets_CDN extends WP_UnitTestCase {
+
+	/**
+	 * Test Jetpack_Photon_Static_Assets_CDN::fix_local_script_translation_path.
+	 *
+	 * @covers Jetpack_Photon_Static_Assets_CDN::fix_local_script_translation_path
+	 *
+	 * @param string|false $file The path to the translation file to load. False if there isn't one.
+	 * @param string       $script_src The script source.
+	 * @param string|false $expected_output The expected output of fix_local_script_translation_path().
+	 *
+	 * @dataProvider fix_local_script_translation_path_data_provider
+	 */
+	public function test_fix_local_script_translation_path( $file, $script_src, $expected_output ) {
+		global $wp_scripts;
+		$handle = 'test_handle';
+
+		$test_script                       = (object) array( 'src' => $script_src );
+		$wp_scripts->registered[ $handle ] = $test_script;
+
+		$actual_output = Jetpack_Photon_Static_assets_CDN::fix_local_script_translation_path( $file, $handle, 'test_domain' );
+		$this->assertEquals( $expected_output, $actual_output );
+	}
+
+	/**
+	 * Data provider for test_fix_local_script_translation_path.
+	 *
+	 * @return array An array of test data. The structure of the test data is:
+	 *    [0] string|false $file The path to the translation file to load. False if there isn't one.
+	 *    [1] string       $script_src The script source.
+	 *    [2] string|false $expected_output The expected output of fix_local_script_translation_path().
+	 */
+	public function fix_local_script_translation_path_data_provider() {
+		return array(
+			'File is false'              => array(
+				false,
+				'https://c0.wp.com/p/jetpack/8.7/_inc/blocks/editor.js',
+				false,
+			),
+			'Has a file, src is CDN'     => array(
+				'path/to/test_translation_file.json',
+				'https://c0.wp.com/p/jetpack/8.7/_inc/blocks/editor.js',
+				WP_LANG_DIR . '/plugins/test_translation_file.json',
+			),
+			'Has a file, src is not CDN' => array(
+				'path/to/test_translation_file.json',
+				'https://example.com/p/jetpack/8.7/_inc/blocks/editor.js',
+				'path/to/test_translation_file.json',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Fixes #15995

#### Changes proposed in this Pull Request:
* Check the value of `$file` before setting the local path for translation files. `$file` [can be false](https://core.trac.wordpress.org/browser/tags/5.4/src/wp-includes/l10n.php#L1086), and in that case, we should not return the local path.
* Add unit tests for `Jetpack_Photon_Static_Assets_CDN::fix_local_script_translation_path`. The "File is false" test data should fail with the current implementation of `Jetpack_Photon_Static_Assets_CDN::fix_local_script_translation_path`. The test should pass with the changes in this PR.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

##### Reproduce the Error
1. Install the latest stable version of Jetpack. Activate and connect Jetpack.
2. Enable debug logging.
3. Navigate to Jetpack -> Settings -> Performance and turn on the toggle for Enable Site Accelerator. Both the image and static file load times toggles should be enabled.
4. Navigate to Settings -> General and change the site language to a language that doesn't have translations for the Jetpack block descriptions. I used Polski. 
5. Navigate to Dashboard -> Updates and update the language files.
6. Add a new post.
7. Check the `debug.log` file. You should see this error:

   `PHP Notice:  file_get_contents(): read of 8192 bytes failed with errno=21 Is a directory in …/wp-includes/l10n.php on line 1096`

9. That error is generated each time you add or edit a post.

##### Test the Fix

1. Apply this branch.
2. Add a new post or edit an existing post and confirm that the error isn’t generated.
3. Navigate to Settings -> General and change the site language to a language that has translations for the Jetpack block descriptions. I used Français. 
5. Navigate to Dashboard -> Updates and update the language files.
6. Add a new post.
7. Click the button to add a block, navigate to the Jetpack blocks, and verify that the Jetpack block descriptions are translated.

#### Proposed changelog entry for your changes:
* Asset CDN: avoid returning a directory when setting the local path for translation files.
