### PR TITLE
External Media: Use existing copy endpoint on WP.com

### DIFF
--- a/extensions/shared/external-media/sources/api.js
+++ b/extensions/shared/external-media/sources/api.js
@@ -3,9 +3,16 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 
+/**
+ * Internal dependencies
+ */
+import { isSimpleSite } from '../../../shared/site-type-utils';
+
 const ENDPOINTS = {
 	list: '/wpcom/v2/external-media/list/',
-	copy: '/wpcom/v2/external-media/copy/',
+	copy: isSimpleSite()
+		? '/rest/v1.1/external-media-upload?service='
+		: '/wpcom/v2/external-media/copy/',
 	connection: '/wpcom/v2/external-media/connection/',
 };
 

--- a/extensions/shared/external-media/sources/google-photos/google-photos-media.js
+++ b/extensions/shared/external-media/sources/google-photos/google-photos-media.js
@@ -77,7 +77,7 @@ function GooglePhotosMedia( props ) {
 
 	const onCopy = useCallback(
 		items => {
-			copyMedia( items, getApiUrl( 'copy', SOURCE_GOOGLE_PHOTOS ) );
+			copyMedia( items, getApiUrl( 'copy', SOURCE_GOOGLE_PHOTOS ), SOURCE_GOOGLE_PHOTOS );
 		},
 		[ copyMedia ]
 	);

--- a/extensions/shared/external-media/sources/pexels.js
+++ b/extensions/shared/external-media/sources/pexels.js
@@ -22,7 +22,7 @@ function PexelsMedia( props ) {
 
 	const onCopy = useCallback(
 		items => {
-			copyMedia( items, getApiUrl( 'copy', SOURCE_PEXELS ) );
+			copyMedia( items, getApiUrl( 'copy', SOURCE_PEXELS ), SOURCE_PEXELS );
 		},
 		[ copyMedia ]
 	);

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -160,7 +160,7 @@ export default function withMedia() {
 					.catch( this.handleApiError );
 			};
 
-			copyMedia = ( items, apiUrl ) => {
+			copyMedia = ( items, apiUrl, source ) => {
 				this.setState( { isCopying: items } );
 				this.props.noticeOperations.removeAllNotices();
 
@@ -186,14 +186,27 @@ export default function withMedia() {
 					path: apiUrl,
 					method: 'POST',
 					data: {
+						external_ids: items.map( item => item.guid ), // WPCOM.
 						media: items.map( item => ( {
 							guid: item.guid,
 							caption: item.caption,
 							title: item.title,
 						} ) ),
+						service: source, // WPCOM.
 					},
 				} )
 					.then( result => {
+						// Convert response on Simple Sites.
+						if ( result.media ) {
+							result = result.media.map( image => ( {
+								alt: image.alt,
+								caption: image.caption,
+								id: image.ID,
+								type: image.mime_type,
+								url: image.URL,
+							} ) );
+						}
+
 						const { value, addToGallery, multiple } = this.props;
 						const media = multiple ? result : result[ 0 ];
 

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -202,7 +202,7 @@ export default function withMedia() {
 								alt: image.alt,
 								caption: image.caption,
 								id: image.ID,
-								type: image.mime_type,
+								type: 'image',
 								url: image.URL,
 							} ) );
 						}


### PR DESCRIPTION
This PR adds SImple Site compatibility for the copy endpoint, re-using the existing endpoint that was written for Calypso, rather than requiring Systems to allow a new upload endpoint.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Swaps copy endpoint when called from a simple site.
* Passes additional data as needed by the old endpoint
* Adds a compat layer, mapping the old endpoints response format to the format expected by media blocks.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Verify External Media still works as expected in Jetpack.
* Don't sandbox your API. This PR fixes a bug that only exist in the production API.
* Apply D46139-code (you might have to refresh the build) and test External Media on your sandboxed site.

Steps to refresh the phab patch from your sandbox:
```
arc patch D46139
svn revert -R wp-content/mu-plugins/jetpack/_inc
svn cleanup --remove-unversioned
arc diff --update D46139 
svn revert -R .
# Wait until build is finished
arc patch D46139
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
None needed, it doesn't affect Jetpack users.

See 133-gh-dotcom-manage
 