### PR TITLE
Autoloader: Avoid a PHP warning when an empty string is passed to `is_directory_plugin()`.

### DIFF
--- a/packages/autoloader/src/class-plugins-handler.php
+++ b/packages/autoloader/src/class-plugins-handler.php
@@ -68,7 +68,7 @@ class Plugins_Handler {
 	 * @return bool
 	 */
 	public function is_directory_plugin( $plugin ) {
-		return false !== strpos( $plugin, '/', 1 );
+		return strlen( $plugin ) > 1 && false !== strpos( $plugin, '/', 1 );
 	}
 
 	/**

--- a/packages/autoloader/tests/php/test_plugins_handler.php
+++ b/packages/autoloader/tests/php/test_plugins_handler.php
@@ -74,6 +74,15 @@ class PluginsHandlerTest extends TestCase {
 	}
 
 	/**
+	 * Tests is_directory_plugin() with an empty string.
+	 *
+	 * @covers Plugins_Handler::is_directory_plugin
+	 */
+	public function test_is_directory_plugin_single_file_with_slash() {
+		$this->assertFalse( $this->plugins_handler->is_directory_plugin( '' ) );
+	}
+
+	/**
 	 * Tests is_directory_plugin() with a single-file plugin that begins with '/'.
 	 *
 	 * @covers Plugins_Handler::is_directory_plugin

--- a/packages/autoloader/tests/php/test_plugins_handler.php
+++ b/packages/autoloader/tests/php/test_plugins_handler.php
@@ -78,7 +78,7 @@ class PluginsHandlerTest extends TestCase {
 	 *
 	 * @covers Plugins_Handler::is_directory_plugin
 	 */
-	public function test_is_directory_plugin_single_file_with_slash() {
+	public function test_is_directory_plugin_single_file_with_empty_string() {
 		$this->assertFalse( $this->plugins_handler->is_directory_plugin( '' ) );
 	}
 


### PR DESCRIPTION
Autoloader: Avoid a PHP warning when an empty string is passed to `is_directory_plugin()`.

Example Warning: `strpos(): Offset not contained in string`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoids a PHP warning when an empty string is passed to `is_directory_plugin()`.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I'm not really sure how this has happened, but on WordPress.org `get_option( 'active_plugins' )` returns `''` (an empty string) on some sites. I don't know if that's expected or not, but I suspect it only happens on sites that have never had a plugin activated on it directly, only through Network-activated plugins.

It causes `get_active_plugin_paths()` https://github.com/Automattic/jetpack/blob/master/packages/autoloader/src/class-plugins-handler.php#L48-L52 to have `array( '' )` as it's `$plugin_slugs` value, which seems like it might be expected due to it casting the option result to an array..
I've included a unit test which covers at least the result of this.

An alternative patch could have been to perform an `array_filter()` over `$plugin_slugs` first in `get_active_plugin_paths()` but this seemed more defensive.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
