### PR TITLE
Deprecation notices: add details about file/function removals

### DIFF
--- a/functions.global.php
+++ b/functions.global.php
@@ -22,6 +22,98 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Hook into Core's _deprecated_function
+ * Add more details about when a deprecated function will be removed.
+ *
+ * @since 8.8.0
+ *
+ * @param string $function    The function that was called.
+ * @param string $replacement Optional. The function that should have been called. Default null.
+ * @param string $version     The version of Jetpack that deprecated the function.
+ */
+function jetpack_deprecated_function( $function, $replacement, $version ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	// Look for when a function will be removed based on when it was deprecated.
+	$removed_version = jetpack_get_future_removed_version( $version );
+
+	// If we could find a version, let's log a message about when removal will happen.
+	if (
+		! empty( $removed_version )
+		&& ( defined( 'WP_DEBUG' ) && WP_DEBUG )
+	) {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			sprintf(
+				/* Translators: 1. Function name. 2. Jetpack version number. */
+				__( 'The %1$s function will be removed from the Jetpack plugin in version %2$s.', 'jetpack' ),
+				$function,
+				$removed_version
+			)
+		);
+
+	}
+}
+add_action( 'deprecated_function_run', 'jetpack_deprecated_function', 10, 3 );
+
+/**
+ * Hook into Core's _deprecated_file
+ * Add more details about when a deprecated file will be removed.
+ *
+ * @since 8.8.0
+ *
+ * @param string $file        The file that was called.
+ * @param string $replacement The file that should have been included based on ABSPATH.
+ * @param string $version     The version of WordPress that deprecated the file.
+ * @param string $message     A message regarding the change.
+ */
+function jetpack_deprecated_file( $file, $replacement, $version, $message ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	// Look for when a file will be removed based on when it was deprecated.
+	$removed_version = jetpack_get_future_removed_version( $version );
+
+	// If we could find a version, let's log a message about when removal will happen.
+	if (
+		! empty( $removed_version )
+		&& ( defined( 'WP_DEBUG' ) && WP_DEBUG )
+	) {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			sprintf(
+				/* Translators: 1. File name. 2. Jetpack version number. */
+				__( 'The %1$s file will be removed from the Jetpack plugin in version %2$s.', 'jetpack' ),
+				$file,
+				$removed_version
+			)
+		);
+
+	}
+}
+add_action( 'deprecated_file_included', 'jetpack_deprecated_file', 10, 4 );
+
+/**
+ * Get the major version number of Jetpack 6 months after provided version.
+ * Useful to indicate when a deprecated function will be removed from Jetpack.
+ *
+ * @since 8.8.0
+ *
+ * @param string $version The version of WordPress that deprecated the function.
+ *
+ * @return string|float Return a Jetpack Major version number, or an empty string.
+ */
+function jetpack_get_future_removed_version( $version ) {
+	/*
+	 * Extract the version number from a deprecation notice.
+	 * (let's only keep the first decimal, e.g. 8.8 and not 8.8.0)
+	 */
+	preg_match( '#(([0-9]+\.[0-9]+)(?:\.[0-9]+)*)#', $version, $matches );
+
+	if ( ! empty( $matches[2] ) ) {
+		// We'll remove the function from the code 6 months later, thus 6 major versions later.
+		$removed_version = $matches[2] + 0.6;
+
+		return (float) $removed_version;
+	}
+
+	return '';
+}
+
+/**
  * Set the admin language, based on user language.
  *
  * @since 4.5.0

--- a/functions.global.php
+++ b/functions.global.php
@@ -32,6 +32,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $version     The version of Jetpack that deprecated the function.
  */
 function jetpack_deprecated_function( $function, $replacement, $version ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	// Bail early for non-Jetpack deprecations.
+	if ( 0 !== strpos( $version, 'jetpack-' ) ) {
+		return;
+	}
+
 	// Look for when a function will be removed based on when it was deprecated.
 	$removed_version = jetpack_get_future_removed_version( $version );
 
@@ -65,6 +70,11 @@ add_action( 'deprecated_function_run', 'jetpack_deprecated_function', 10, 3 );
  * @param string $message     A message regarding the change.
  */
 function jetpack_deprecated_file( $file, $replacement, $version, $message ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	// Bail early for non-Jetpack deprecations.
+	if ( 0 !== strpos( $version, 'jetpack-' ) ) {
+		return;
+	}
+
 	// Look for when a file will be removed based on when it was deprecated.
 	$removed_version = jetpack_get_future_removed_version( $version );
 

--- a/functions.global.php
+++ b/functions.global.php
@@ -44,6 +44,8 @@ function jetpack_deprecated_function( $function, $replacement, $version ) { // p
 	if (
 		! empty( $removed_version )
 		&& ( defined( 'WP_DEBUG' ) && WP_DEBUG )
+		/** This filter is documented in core/src/wp-includes/functions.php */
+		&& apply_filters( 'deprecated_function_trigger_error', true )
 	) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
@@ -82,6 +84,8 @@ function jetpack_deprecated_file( $file, $replacement, $version, $message ) { //
 	if (
 		! empty( $removed_version )
 		&& ( defined( 'WP_DEBUG' ) && WP_DEBUG )
+		/** This filter is documented in core/src/wp-includes/functions.php */
+		&& apply_filters( 'deprecated_file_trigger_error', true )
 	) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(

--- a/tests/php/general/test_class.functions.global.php
+++ b/tests/php/general/test_class.functions.global.php
@@ -1,0 +1,48 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+
+/**
+ * Tests for functions in functions.global.php
+ */
+class WP_Test_Functions_Global extends WP_UnitTestCase {
+	/**
+	 * Test string returned by jetpack_deprecated_function
+	 *
+	 * @covers ::jetpack_get_future_removed_version
+	 * @since 8.8.0
+	 * @dataProvider jetpack_deprecated_function_versions
+	 *
+	 * @param string $version  Version number passed to the function.
+	 * @param string $expected Expected removed version number.
+	 */
+	public function test_jetpack_get_future_removed_version( $version, $expected ) {
+		$removed_version = jetpack_get_future_removed_version( $version );
+
+		$this->assertEquals( $expected, $removed_version );
+	}
+
+	/**
+	 * Data provider for the test_jetpack_get_future_removed_version() test.
+	 *
+	 * @return Array test version numbers potentially passed to the function.
+	 */
+	public function jetpack_deprecated_function_versions() {
+		return array(
+			'no_version_number'                          => array(
+				'jetpack',
+				'',
+			),
+			'only_major_number'                          => array(
+				'8.8',
+				'9.4',
+			),
+			'full_version_number_without_text'           => array(
+				'8.8.0',
+				'9.4',
+			),
+			'full_version_number_with_jetpack_prepended' => array(
+				'jetpack-8.8.0',
+				'9.4',
+			),
+		);
+	}
+}

--- a/tests/php/general/test_class.functions.global.php
+++ b/tests/php/general/test_class.functions.global.php
@@ -29,7 +29,7 @@ class WP_Test_Functions_Global extends WP_UnitTestCase {
 		return array(
 			'no_version_number'                          => array(
 				'jetpack',
-				'',
+				false,
 			),
 			'only_major_number'                          => array(
 				'8.8',
@@ -42,6 +42,18 @@ class WP_Test_Functions_Global extends WP_UnitTestCase {
 			'full_version_number_with_jetpack_prepended' => array(
 				'jetpack-8.8.0',
 				'9.4',
+			),
+			'full_zero_version_number_with_jetpack'      => array(
+				'jetpack-8.0.0',
+				'8.6',
+			),
+			'semver_number_above_10'                     => array(
+				'9.15.0',
+				false,
+			),
+			'full_version_number_above_10'               => array(
+				'10.5',
+				'11.1',
 			),
 		);
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

In #16433, we determined that we would remove deprecated files and functions 6 months after they've been deprecated.

Let's communicate this to site owners as well, by outputting additional details in the error logs when a deprecation notice is issued. 

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Add the following into a plugin on your site:
```php
function jeherve_test_deprecated_things() {
	require_once JETPACK__PLUGIN_DIR . 'modules/minileven.php';
	$deprecated_function = jetpack_check_mobile();
}
add_action( 'init', 'jeherve_test_deprecated_things' );
```
* Load your site
* Check your error log: you should see the following:
```
[09-Jul-2020 08:19:37 UTC] The minileven.php file will be removed from the Jetpack plugin in version 8.9.
[09-Jul-2020 08:19:37 UTC] PHP Deprecated:  minileven.php is <strong>deprecated</strong> since version jetpack-8.3.0 with no alternative available. in /var/www/html/wp-includes/functions.php on line 4913
[09-Jul-2020 08:19:37 UTC] The jetpack_check_mobile function will be removed from the Jetpack plugin in version 8.9.
[09-Jul-2020 08:19:37 UTC] PHP Deprecated:  jetpack_check_mobile is <strong>deprecated</strong> since version jetpack-8.3.0! Use jetpack_is_mobile instead. in /var/www/html/wp-includes/functions.php on line 4713
```

#### Proposed changelog entry for your changes:

* Deprecation Notices: provide more information about deprecated files and functions.
