### PR TITLE
General: update minimum required WP version

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Jetpack">
-	<config name="minimum_supported_wp_version" value="5.3" />
+	<config name="minimum_supported_wp_version" value="5.4" />
 	<config name="testVersion" value="5.6-"/>
 
 	<rule ref="PHPCompatibilityWP"/>

--- a/extensions/blocks/amazon/index.js
+++ b/extensions/blocks/amazon/index.js
@@ -14,7 +14,6 @@ import edit from './edit';
  * Style dependencies
  */
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'amazon';
 export const title = __( 'Amazon', 'jetpack' );
@@ -23,7 +22,7 @@ export const settings = {
 	title,
 	description: __( 'Promote Amazon products and earn a commission from sales.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'earn' : 'jetpack',
+	category: 'earn',
 	keywords: [ __( 'amazon', 'jetpack' ), __( 'affiliate', 'jetpack' ) ],
 	supports: {
 		align: true,

--- a/extensions/blocks/business-hours/index.js
+++ b/extensions/blocks/business-hours/index.js
@@ -11,7 +11,6 @@ import './editor.scss';
 import './style.scss';
 import BusinessHours from './edit';
 import renderMaterialIcon from '../../shared/render-material-icon';
-import { supportsCollections } from '../../shared/block-category';
 
 /**
  * Block Registrations:
@@ -83,7 +82,7 @@ export const settings = {
 	title: __( 'Business Hours', 'jetpack' ),
 	description: __( 'Display opening hours for your business.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	supports: {
 		html: true,
 	},

--- a/extensions/blocks/calendly/index.js
+++ b/extensions/blocks/calendly/index.js
@@ -18,7 +18,6 @@ import { getAttributesFromEmbedCode, REGEX } from './utils';
  * Style dependencies
  */
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const CALENDLY_EXAMPLE_URL = 'https://calendly.com/wordpresscom/jetpack-block-example';
 
@@ -38,7 +37,7 @@ export const settings = {
 	title,
 	description: __( 'Embed a calendar for customers to schedule appointments', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	keywords: [
 		_x( 'calendar', 'block search term', 'jetpack' ),
 		_x( 'schedule', 'block search term', 'jetpack' ),

--- a/extensions/blocks/contact-form/index.js
+++ b/extensions/blocks/contact-form/index.js
@@ -20,7 +20,6 @@ import JetpackFieldTextarea from './components/jetpack-field-textarea';
 import JetpackFieldCheckbox from './components/jetpack-field-checkbox';
 import JetpackFieldMultiple from './components/jetpack-field-multiple';
 import renderMaterialIcon from '../../shared/render-material-icon';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'contact-form';
 export const settings = {
@@ -41,12 +40,12 @@ export const settings = {
 	edit,
 	save: InnerBlocks.Content,
 	variations,
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	deprecated,
 };
 
 const FieldDefaults = {
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	parent: [ 'jetpack/contact-form' ],
 	supports: {
 		reusable: false,

--- a/extensions/blocks/contact-info/address/index.js
+++ b/extensions/blocks/contact-info/address/index.js
@@ -11,7 +11,6 @@ import { Path, Circle } from '@wordpress/components';
 import edit from './edit';
 import save from './save';
 import renderMaterialIcon from '../../../shared/render-material-icon';
-import { supportsCollections } from '../../../shared/block-category';
 
 const attributes = {
 	address: {
@@ -64,7 +63,7 @@ export const settings = {
 			<Circle cx="12" cy="9" r="2.5" />
 		</Fragment>
 	),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	attributes,
 	parent: [ 'jetpack/contact-info' ],
 	edit,

--- a/extensions/blocks/contact-info/email/index.js
+++ b/extensions/blocks/contact-info/email/index.js
@@ -10,7 +10,6 @@ import { Path } from '@wordpress/components';
 import edit from './edit';
 import renderMaterialIcon from '../../../shared/render-material-icon';
 import save from './save';
-import { supportsCollections } from '../../../shared/block-category';
 
 const attributes = {
 	email: {
@@ -35,7 +34,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6zm-2 0l-8 5-8-5h16zm0 12H4V8l8 5 8-5v10z" />
 	),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	attributes,
 	edit,
 	save,

--- a/extensions/blocks/contact-info/index.js
+++ b/extensions/blocks/contact-info/index.js
@@ -15,7 +15,6 @@ import './style.scss';
 import { name as addressName, settings as addressSettings } from './address/';
 import { name as emailName, settings as emailSettings } from './email/';
 import { name as phoneName, settings as phoneSettings } from './phone/';
-import { supportsCollections } from '../../shared/block-category';
 
 const attributes = {};
 
@@ -41,7 +40,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M19 5v14H5V5h14m0-2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 9c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3zm0-4c-.55 0-1 .45-1 1s.45 1 1 1 1-.45 1-1-.45-1-1-1zm6 10H6v-1.53c0-2.5 3.97-3.58 6-3.58s6 1.08 6 3.58V18zm-9.69-2h7.38c-.69-.56-2.38-1.12-3.69-1.12s-3.01.56-3.69 1.12z" />
 	),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,

--- a/extensions/blocks/contact-info/phone/index.js
+++ b/extensions/blocks/contact-info/phone/index.js
@@ -10,7 +10,6 @@ import { Path } from '@wordpress/components';
 import edit from './edit';
 import renderMaterialIcon from '../../../shared/render-material-icon';
 import save from './save';
-import { supportsCollections } from '../../../shared/block-category';
 
 const attributes = {
 	phone: {
@@ -35,7 +34,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M6.54 5c.06.89.21 1.76.45 2.59l-1.2 1.2c-.41-1.2-.67-2.47-.76-3.79h1.51m9.86 12.02c.85.24 1.72.39 2.6.45v1.49c-1.32-.09-2.59-.35-3.8-.75l1.2-1.19M7.5 3H4c-.55 0-1 .45-1 1 0 9.39 7.61 17 17 17 .55 0 1-.45 1-1v-3.49c0-.55-.45-1-1-1-1.24 0-2.45-.2-3.57-.57-.1-.04-.21-.05-.31-.05-.26 0-.51.1-.71.29l-2.2 2.2c-2.83-1.45-5.15-3.76-6.59-6.59l2.2-2.2c.28-.28.36-.67.25-1.02C8.7 6.45 8.5 5.25 8.5 4c0-.55-.45-1-1-1z" />
 	),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	attributes,
 	parent: [ 'jetpack/contact-info' ],
 	edit,

--- a/extensions/blocks/eventbrite/index.js
+++ b/extensions/blocks/eventbrite/index.js
@@ -12,7 +12,6 @@ import attributes from './attributes';
 import deprecated from './deprecated';
 import edit from './edit';
 import save from './save';
-import { supportsCollections } from '../../shared/block-category';
 
 export const innerButtonBlock = {
 	name: 'jetpack/button',
@@ -53,7 +52,7 @@ export const settings = {
 	title,
 	description: __( 'Embed Eventbrite event details and ticket checkout.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 	keywords: [
 		_x( 'events', 'block search term', 'jetpack' ),
 		_x( 'tickets', 'block search term', 'jetpack' ),

--- a/extensions/blocks/gathering-tweetstorms/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/editor.js
@@ -7,7 +7,7 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import useGatherTweetstorm from './use-gather-tweetstorm';
-import { withNotices, Button, ToolbarGroup, Toolbar, Spinner } from '@wordpress/components';
+import { withNotices, Button, ToolbarGroup, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import './editor.scss';
 import { BlockControls } from '@wordpress/editor';
@@ -42,44 +42,21 @@ const addTweetstormToTweets = blockSettings => {
 				<>
 					{ noticeUI }
 					<BlockControls>
-						{ /* @todo Fallback can be removed when WP 5.4 is the minimum supported version. */ }
-						{ ToolbarGroup ? (
-							<ToolbarGroup className="gathering-tweetstorms__embed-toolbar">
-								<Button
-									className="gathering-tweetstorms__embed-toolbar-button"
-									onClick={ () => unleashStorm( url, noticeOperations ) }
-									label={ __(
-										'Import the entire Twitter thread directly into this post.',
-										'jetpack'
-									) }
-									showTooltip={ true }
-									disabled={ isGatheringStorm }
-								>
-									{ __( 'Unroll', 'jetpack' ) }
-								</Button>
-								{ isGatheringStorm && <Spinner /> }
-							</ToolbarGroup>
-						) : (
-							<Toolbar
-								className="gathering-tweetstorms__embed-toolbar"
-								controls={ [
-									{
-										title: __(
-											'Import the entire Twitter thread directly into this post.',
-											'jetpack'
-										),
-										onClick: () => unleashStorm( url, noticeOperations ),
-										extraProps: {
-											className: 'gathering-tweetstorms__embed-toolbar-button',
-											children: __( 'Unroll', 'jetpack' ),
-											disabled: isGatheringStorm,
-										},
-									},
-								] }
+						<ToolbarGroup className="gathering-tweetstorms__embed-toolbar">
+							<Button
+								className="gathering-tweetstorms__embed-toolbar-button"
+								onClick={ () => unleashStorm( url, noticeOperations ) }
+								label={ __(
+									'Import the entire Twitter thread directly into this post.',
+									'jetpack'
+								) }
+								showTooltip={ true }
+								disabled={ isGatheringStorm }
 							>
-								{ isGatheringStorm && <Spinner /> }
-							</Toolbar>
-						) }
+								{ __( 'Unroll', 'jetpack' ) }
+							</Button>
+							{ isGatheringStorm && <Spinner /> }
+						</ToolbarGroup>
 					</BlockControls>
 					<CoreTweetEdit { ...props } />
 				</>

--- a/extensions/blocks/gif/index.js
+++ b/extensions/blocks/gif/index.js
@@ -12,7 +12,6 @@ import edit from './edit';
 // Ordering is important! Editor overrides style!
 import './style.scss';
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'gif';
 export const title = __( 'GIF', 'jetpack' );
@@ -27,7 +26,7 @@ export const icon = (
 export const settings = {
 	title,
 	icon,
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 	keywords: [
 		_x( 'animated', 'block search term', 'jetpack' ),
 		_x( 'giphy', 'block search term', 'jetpack' ),

--- a/extensions/blocks/google-calendar/index.js
+++ b/extensions/blocks/google-calendar/index.js
@@ -11,7 +11,6 @@ import edit from './edit';
 import { extractAttributesFromIframe, URL_REGEX, IFRAME_REGEX } from './utils';
 import './editor.scss';
 import icon from './icon';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'google-calendar';
 export const title = __( 'Google Calendar', 'jetpack' );
@@ -26,7 +25,7 @@ export const settings = {
 		_x( 'appointments', 'block search term', 'jetpack' ),
 	],
 	icon,
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 	supports: {
 		align: true,
 		alignWide: true,

--- a/extensions/blocks/image-compare/index.js
+++ b/extensions/blocks/image-compare/index.js
@@ -11,7 +11,6 @@ import icon from './icon';
 import save from './save';
 import imgExampleAfter from './img-example-after.png';
 import imgExampleBefore from './img-example-before.png';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'image-compare';
 
@@ -24,7 +23,7 @@ export const settings = {
 
 	icon,
 
-	category: supportsCollections() ? 'layout' : 'jetpack',
+	category: 'layout',
 	keywords: [
 		_x( 'juxtapose', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),

--- a/extensions/blocks/instagram-gallery/index.js
+++ b/extensions/blocks/instagram-gallery/index.js
@@ -8,7 +8,6 @@ import { __, _x } from '@wordpress/i18n';
  */
 import attributes from './attributes';
 import edit from './edit';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'instagram-gallery';
 
@@ -19,7 +18,7 @@ export const settings = {
 		'jetpack'
 	),
 	icon: 'instagram',
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 	keywords: [
 		_x( 'images', 'block search term', 'jetpack' ),
 		_x( 'photos', 'block search term', 'jetpack' ),

--- a/extensions/blocks/mailchimp/index.js
+++ b/extensions/blocks/mailchimp/index.js
@@ -11,7 +11,6 @@ import { Path, SVG, G } from '@wordpress/components';
 import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'mailchimp';
 
@@ -44,7 +43,7 @@ export const settings = {
 	title: __( 'Mailchimp', 'jetpack' ),
 	icon,
 	description: __( 'A form enabling readers to join a Mailchimp list.', 'jetpack' ),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/map/edit.js
+++ b/extensions/blocks/map/edit.js
@@ -422,11 +422,6 @@ class MapEdit extends Component {
 				{ inspectorControls }
 				<div className={ className }>
 					<ResizableBox
-						className={
-							// @TODO: This can be removed when WP 5.4 is the minimum version, it's a fallback
-							// for prior to when the `showHandle` property was added.
-							classnames( { 'is-selected': isSelected } )
-						}
 						size={ {
 							height: mapHeight || 'auto',
 							width: '100%',

--- a/extensions/blocks/map/settings.js
+++ b/extensions/blocks/map/settings.js
@@ -13,7 +13,6 @@ import defaultTheme from './map-theme_default.jpg';
 import blackAndWhiteTheme from './map-theme_black_and_white.jpg';
 import satelliteTheme from './map-theme_satellite.jpg';
 import terrainTheme from './map-theme_terrain.jpg';
-import { supportsCollections } from '../../shared/block-category';
 
 export const settings = {
 	name: 'map',
@@ -34,7 +33,7 @@ export const settings = {
 			<path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM10 5.47l4 1.4v11.66l-4-1.4V5.47zm-5 .99l3-1.01v11.7l-3 1.16V6.46zm14 11.08l-3 1.01V6.86l3-1.16v11.84z" />
 		</svg>
 	),
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 	keywords: [
 		_x( 'maps', 'block search term', 'jetpack' ),
 		_x( 'location', 'block search term', 'jetpack' ),

--- a/extensions/blocks/markdown/index.js
+++ b/extensions/blocks/markdown/index.js
@@ -12,7 +12,6 @@ import './editor.scss';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import edit from './edit';
 import save from './save';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'markdown';
 
@@ -58,7 +57,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: supportsCollections() ? 'formatting' : 'jetpack',
+	category: 'formatting',
 
 	keywords: [
 		_x( 'formatting', 'block search term', 'jetpack' ),

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -20,13 +20,12 @@ import './view.scss';
 export const name = 'opentable';
 export const title = __( 'OpenTable', 'jetpack' );
 import { getAttributesFromEmbedCode, restRefRegex, ridRegex } from './utils';
-import { supportsCollections } from '../../shared/block-category';
 
 export const settings = {
 	title,
 	description: __( 'Allow visitors to book a reservation with OpenTable', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'earn' : 'jetpack',
+	category: 'earn',
 	keywords: [
 		_x( 'booking', 'block search term', 'jetpack' ),
 		_x( 'reservation', 'block search term', 'jetpack' ),

--- a/extensions/blocks/pinterest/index.js
+++ b/extensions/blocks/pinterest/index.js
@@ -10,7 +10,6 @@ import { createBlock } from '@wordpress/blocks';
  */
 import edit from './edit';
 import { pinType } from './utils';
-import { supportsCollections } from '../../shared/block-category';
 
 export const URL_REGEX = /^\s*https?:\/\/(?:www\.)?(?:[a-z]{2}\.)?(?:pinterest\.[a-z.]+|pin\.it)\/([^/]+)(\/[^/]+)?/i;
 
@@ -35,7 +34,7 @@ export const settings = {
 
 	icon,
 
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 
 	keywords: [
 		_x( 'social', 'block search term', 'jetpack' ),

--- a/extensions/blocks/podcast-player/edit.js
+++ b/extensions/blocks/podcast-player/edit.js
@@ -14,7 +14,6 @@ import {
 	Placeholder,
 	RangeControl,
 	TextControl,
-	Toolbar,
 	ToolbarGroup,
 	withNotices,
 	ToggleControl,
@@ -264,29 +263,14 @@ const PodcastPlayerEdit = ( {
 	return (
 		<>
 			<BlockControls>
-				{ /* @todo Fallback can be removed when WP 5.4 is the minimum supported version. */ }
-				{ ToolbarGroup ? (
-					<ToolbarGroup>
-						<Button
-							aria-label={ __( 'Edit Podcast Feed URL', 'jetpack' ) }
-							onClick={ () => setIsEditing( true ) }
-						>
-							{ __( 'Replace', 'jetpack' ) }
-						</Button>
-					</ToolbarGroup>
-				) : (
-					<Toolbar
-						controls={ [
-							{
-								title: __( 'Edit Podcast Feed URL', 'jetpack' ),
-								onClick: () => setIsEditing( true ),
-								extraProps: {
-									children: __( 'Replace', 'jetpack' ),
-								},
-							},
-						] }
-					/>
-				) }
+				<ToolbarGroup>
+					<Button
+						aria-label={ __( 'Edit Podcast Feed URL', 'jetpack' ) }
+						onClick={ () => setIsEditing( true ) }
+					>
+						{ __( 'Replace', 'jetpack' ) }
+					</Button>
+				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Podcast settings', 'jetpack' ) }>

--- a/extensions/blocks/podcast-player/index.js
+++ b/extensions/blocks/podcast-player/index.js
@@ -19,7 +19,6 @@ import { queueMusic } from './icons/';
  */
 import './style.scss';
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'podcast-player';
 export const namespaceName = `jetpack/${ name }`;
@@ -28,7 +27,7 @@ export const settings = {
 	title,
 	description: __( 'Select and play episodes from a single podcast.', 'jetpack' ),
 	icon: queueMusic,
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 	keywords: [
 		_x( 'audio', 'block search term', 'jetpack' ),
 		_x( 'embed', 'block search term', 'jetpack' ),

--- a/extensions/blocks/rating-star/index.js
+++ b/extensions/blocks/rating-star/index.js
@@ -11,7 +11,6 @@ import save from './save';
 import { StarIcon, StarBlockIcon } from './icon';
 import './editor.scss';
 import './style.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'rating-star';
 
@@ -27,7 +26,7 @@ export const settings = {
 		_x( 'rating', 'block search term', 'jetpack' ),
 		_x( 'review', 'block search term', 'jetpack' ),
 	],
-	category: supportsCollections() ? 'formatting' : 'jetpack',
+	category: 'formatting',
 	example: {},
 	styles: [
 		{

--- a/extensions/blocks/recurring-payments/index.js
+++ b/extensions/blocks/recurring-payments/index.js
@@ -11,7 +11,6 @@ import { trimEnd } from 'lodash';
 import { __, _x } from '@wordpress/i18n';
 import edit from './edit';
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'recurring-payments';
 
@@ -28,7 +27,7 @@ export const settings = {
 	title: __( 'Payments', 'jetpack' ),
 	icon,
 	description: __( 'Button allowing you to sell products and subscriptions.', 'jetpack' ),
-	category: supportsCollections() ? 'earn' : 'jetpack',
+	category: 'earn',
 	keywords: [
 		_x( 'sell', 'block search term', 'jetpack' ),
 		_x( 'subscriptions', 'block search term', 'jetpack' ),

--- a/extensions/blocks/related-posts/index.js
+++ b/extensions/blocks/related-posts/index.js
@@ -9,7 +9,6 @@ import { G, Path, SVG } from '@wordpress/components';
  */
 import edit from './edit';
 import './style.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'related-posts';
 
@@ -24,7 +23,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: supportsCollections() ? 'embed' : 'jetpack',
+	category: 'embed',
 
 	keywords: [
 		_x( 'similar content', 'block search term', 'jetpack' ),

--- a/extensions/blocks/repeat-visitor/index.js
+++ b/extensions/blocks/repeat-visitor/index.js
@@ -12,7 +12,6 @@ import edit from './components/edit';
 import save from './components/save';
 import { CRITERIA_AFTER, DEFAULT_THRESHOLD } from './constants';
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'repeat-visitor';
 export const icon = renderMaterialIcon(
@@ -29,7 +28,7 @@ export const settings = {
 			default: DEFAULT_THRESHOLD,
 		},
 	},
-	category: supportsCollections() ? 'widgets' : 'jetpack',
+	category: 'widgets',
 	description: __(
 		'Control block visibility based on how often a visitor has viewed the page.',
 		'jetpack'

--- a/extensions/blocks/revue/index.js
+++ b/extensions/blocks/revue/index.js
@@ -11,7 +11,6 @@ import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import icon from './icon';
 import save from './save';
-import { supportsCollections } from '../../shared/block-category';
 
 export const innerButtonBlock = {
 	name: 'jetpack/button',
@@ -27,7 +26,7 @@ export const settings = {
 	title: __( 'Revue', 'jetpack' ),
 	description: __( 'Add a subscription form for your Revue newsletter.', 'jetpack' ),
 	icon,
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	keywords: [
 		_x( 'email', 'block search term', 'jetpack' ),
 		_x( 'subscription', 'block search term', 'jetpack' ),

--- a/extensions/blocks/send-a-message/index.js
+++ b/extensions/blocks/send-a-message/index.js
@@ -11,7 +11,6 @@ import { Path } from '@wordpress/components';
 import edit from './edit';
 import variations from './variations';
 import renderMaterialIcon from '../../shared/render-material-icon';
-import { supportsCollections } from '../../shared/block-category';
 
 /**
  * Style dependencies
@@ -27,7 +26,7 @@ export const settings = {
 	icon: renderMaterialIcon(
 		<Path d="M21 6h-2v9H6v2c0 .55.45 1 1 1h11l4 4V7c0-.55-.45-1-1-1zm-4 6V3c0-.55-.45-1-1-1H3c-.55 0-1 .45-1 1v14l4-4h10c.55 0 1-.45 1-1z" />
 	),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	keywords: [
 		_x( 'whatsapp', 'keyword', 'jetpack' ),
 		_x( 'messenger', 'keyword', 'jetpack' ),

--- a/extensions/blocks/send-a-message/whatsapp-button/index.js
+++ b/extensions/blocks/send-a-message/whatsapp-button/index.js
@@ -10,7 +10,6 @@ import attributes from './attributes';
 import edit from './edit';
 import save from './save';
 import icon from './icon';
-import { supportsCollections } from '../../../shared/block-category';
 import './editor.scss';
 
 export const name = 'whatsapp-button';
@@ -29,7 +28,7 @@ export const settings = {
 		'jetpack'
 	),
 	icon,
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	parent: [ 'jetpack/send-a-message' ],
 	keywords: [
 		_x( 'whatsapp', 'keyword', 'jetpack' ),

--- a/extensions/blocks/simple-payments/index.js
+++ b/extensions/blocks/simple-payments/index.js
@@ -22,7 +22,6 @@ import simplePaymentsExample1 from './simple-payments_example-1.jpg';
  * Styles
  */
 import './editor.scss';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'simple-payments';
 
@@ -56,7 +55,7 @@ export const settings = {
 		</SVG>
 	),
 
-	category: supportsCollections() ? 'earn' : 'jetpack',
+	category: 'earn',
 
 	keywords: [
 		_x( 'buy', 'block search term', 'jetpack' ),

--- a/extensions/blocks/slideshow/index.js
+++ b/extensions/blocks/slideshow/index.js
@@ -10,7 +10,6 @@ import { Path, SVG } from '@wordpress/components';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
-import { supportsCollections } from '../../shared/block-category';
 
 /**
  * Example Images
@@ -112,7 +111,7 @@ export const name = 'slideshow';
 
 export const settings = {
 	title: __( 'Slideshow', 'jetpack' ),
-	category: supportsCollections() ? 'layout' : 'jetpack',
+	category: 'layout',
 	keywords: [
 		_x( 'image', 'block search term', 'jetpack' ),
 		_x( 'gallery', 'block search term', 'jetpack' ),

--- a/extensions/blocks/subscriptions/index.js
+++ b/extensions/blocks/subscriptions/index.js
@@ -11,7 +11,6 @@ import attributes from './attributes';
 import deprecated from './deprecated';
 import edit from './edit';
 import save from './save';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'subscriptions';
 export const settings = {
@@ -45,7 +44,7 @@ export const settings = {
 			/>
 		</SVG>
 	),
-	category: supportsCollections() ? 'grow' : 'jetpack',
+	category: 'grow',
 	keywords: [
 		_x( 'subscribe', 'block search term', 'jetpack' ),
 		_x( 'join', 'block search term', 'jetpack' ),

--- a/extensions/blocks/tiled-gallery/index.js
+++ b/extensions/blocks/tiled-gallery/index.js
@@ -36,7 +36,6 @@ import tiledGalleryExample3 from './tiled-gallery_example-3.jpg';
 import tiledGalleryExample4 from './tiled-gallery_example-4.jpg';
 import tiledGalleryExample5 from './tiled-gallery_example-5.jpg';
 import tiledGalleryExample6 from './tiled-gallery_example-6.jpg';
-import { supportsCollections } from '../../shared/block-category';
 
 // Style names are translated. Avoid introducing an i18n dependency elsewhere (view)
 // by only including the labels here, the only place they're needed.
@@ -202,7 +201,7 @@ export const icon = (
 
 export const settings = {
 	attributes: blockAttributes,
-	category: supportsCollections() ? 'layout' : 'jetpack',
+	category: 'layout',
 	description:
 		__( 'Display multiple images in an elegantly organized tiled layout.', 'jetpack' ) +
 		( ! isSimpleSite()

--- a/extensions/blocks/wordads/index.js
+++ b/extensions/blocks/wordads/index.js
@@ -10,7 +10,6 @@ import { Fragment } from '@wordpress/element';
  */
 import edit from './edit';
 import { DEFAULT_FORMAT } from './constants';
-import { supportsCollections } from '../../shared/block-category';
 
 export const name = 'wordads';
 export const title = __( 'Ad', 'jetpack' );
@@ -57,7 +56,7 @@ export const settings = {
 		attributes: {},
 	},
 
-	category: supportsCollections() ? 'earn' : 'jetpack',
+	category: 'earn',
 
 	keywords: [
 		_x( 'ads', 'block search term', 'jetpack' ),

--- a/extensions/shared/block-category.js
+++ b/extensions/shared/block-category.js
@@ -10,38 +10,14 @@ import { __ } from '@wordpress/i18n';
 import { JetpackLogo } from './icons';
 import { isAtomicSite, isSimpleSite } from '../shared/site-type-utils';
 
-/**
- * Return bool depending on registerBlockCollection compatibility.
- *
- * @todo When Jetpack's minimum is WP 5.4. Remove this function and update all block categories.
- *
- * @returns {boolean} Value to indicate function support.
- */
-export const supportsCollections = () => {
-	return typeof registerBlockCollection === 'function';
-};
-
 const isWpcom = isSimpleSite() || isAtomicSite();
 
-if ( supportsCollections() ) {
-	// We do not want the Jetpack collection on WordPress.com (Simple or Atomic).
-	if ( ! isWpcom ) {
-		registerBlockCollection( 'jetpack', {
-			title: 'Jetpack',
-			icon: <JetpackLogo />,
-		} );
-	}
-} else {
-	// This can be removed once Jetpack's minimum is Core 5.4.
-	setCategories( [
-		...getCategories().filter( ( { slug } ) => slug !== 'jetpack' ),
-		// Add a Jetpack block category
-		{
-			slug: 'jetpack',
-			title: 'Jetpack',
-			icon: <JetpackLogo />,
-		},
-	] );
+// We do not want the Jetpack collection on WordPress.com (Simple or Atomic).
+if ( ! isWpcom ) {
+	registerBlockCollection( 'jetpack', {
+		title: 'Jetpack',
+		icon: <JetpackLogo />,
+	} );
 }
 
 setCategories( [

--- a/extensions/shared/styles/gutenberg-base-styles.scss
+++ b/extensions/shared/styles/gutenberg-base-styles.scss
@@ -4,23 +4,3 @@
 @import '~@wordpress/base-styles/breakpoints';
 @import '~@wordpress/base-styles/mixins';
 @import '~@wordpress/base-styles/animations';
-
-/**
- * Following is a fix for column contents overflowing the parent container
- * when vertically aligned. This has been taken from newer versions of
- * Gutenberg and WP core to provide the fix for WP 5.3.
- *
- * TO-DO: remove once the minimum WP version required by Jetpack is WP 5.4.
- *
- * Issue: https://github.com/Automattic/jetpack/issues/14524
- *
- * See: https://github.com/WordPress/gutenberg/commit/bef41793a12b76a5220d177a768f8fe56deb5eba
- * See: https://github.com/WordPress/WordPress/commit/f616ffb9c1a0abcdbe3306fd9e695ef3173a18c6
- */
-.wp-block-column {
-	&.is-vertically-aligned-top,
-	&.is-vertically-aligned-center,
-	&.is-vertically-aligned-bottom {
-		width: 100%;
-	}
-}

--- a/jetpack.php
+++ b/jetpack.php
@@ -9,13 +9,13 @@
  * License: GPL2+
  * Text Domain: jetpack
  * Domain Path: /languages/
- * Requires at least: 5.3
+ * Requires at least: 5.4
  * Requires PHP: 5.6
  *
  * @package Jetpack
  */
 
-define( 'JETPACK__MINIMUM_WP_VERSION', '5.3' );
+define( 'JETPACK__MINIMUM_WP_VERSION', '5.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '8.8-alpha' );
 define( 'JETPACK_MASTER_USER', true );

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: automattic, adamkheckler, aduth, akirk, allendav, alternatekev, andy, annezazu, apeatling, azaozz, batmoo, barry, beaulebens, blobaugh, brbrr, cainm, cena, cfinke, chaselivingston, chellycat, clickysteve, csonnek, danielbachhuber, davoraltman, daniloercoli, delawski, designsimply, dllh, drawmyface, dsmart, dzver, ebinnion, egregor, eliorivero, enej, eoigal, erania-pinnera, ethitter, gcorne, georgestephanis, gibrown, goldsounds, hew, hugobaeta, hypertextranch, iammattthomas, iandunn, jblz, jasmussen, jeffgolenski, jeherve, jenhooks, jenia, jessefriedman, jgs, jkudish, jmdodd, joanrho, johnjamesjacoby, jshreve, kbrownkd, keoshi, koke, kraftbj, lancewillett, lschuyler, macmanx, martinremy, matt, matveb, mattwiebe, maverick3x6, mcsf, mdawaffe, MichaelArestad, migueluy, mikeyarce, mkaz, nancythanki, nickmomrik, obenland, oskosk, pento, professor44, rachelsquirrel, rdcoll, ryancowles, richardmuscat, richardmtl, roccotripaldi, samhotchkiss, scarstocea, scottsweb, sdquirk, simison, stephdau, tmoorewp, tyxla, Viper007Bond, westi, yoavf, zinigor
 Tags: Jetpack, WordPress.com, backup, security, related posts, CDN, speed, anti-spam, social sharing, SEO, video, stats
 Stable tag: 8.7
-Requires at least: 5.3
+Requires at least: 5.4
 Requires PHP: 5.6
-Tested up to: 5.4
+Tested up to: 5.5
 
 The ideal plugin for stats, related posts, search engine optimization, social sharing, protection, backups, security, and more.
 

--- a/tests/php/test_deprecation.php
+++ b/tests/php/test_deprecation.php
@@ -150,7 +150,6 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 	/**
 	 * Provides deprecated files and expected relacements.
 	 *
-	 * @todo Remove error version check when WordPress 5.4 is the minimum.
 	 * @todo Remove replacement version check when WordPress 5.5 is the minimum.
 	 *
 	 * @return array
@@ -158,7 +157,6 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 	function provider_deprecated_file_paths() {
 		global $wp_version;
 
-		$error       = ( version_compare( $wp_version, '5.4-alpha', '>=' ) ) ? E_USER_DEPRECATED : E_USER_NOTICE;
 		$replacement = ( version_compare( $wp_version, '5.5-alpha', '>=' ) ) ? '' : null;
 
 		return array(
@@ -166,12 +164,12 @@ class WP_Test_Jetpack_Deprecation extends WP_UnitTestCase {
 			array(
 				'class.jetpack-ixr-client.php',
 				$replacement,
-				$error,
+				E_USER_DEPRECATED,
 			),
 			array(
 				'class.jetpack-xmlrpc-server.php',
 				$replacement,
-				$error,
+				E_USER_DEPRECATED,
 			),
 		);
 	}

--- a/tests/setup-travis.sh
+++ b/tests/setup-travis.sh
@@ -38,7 +38,7 @@ latest)
 	git clone --depth=1 --branch $(php ./tests/get-wp-version.php) git://develop.git.wordpress.org/ /tmp/wordpress-latest
 	;;
 previous)
-	git clone --depth=1 --branch 5.3 git://develop.git.wordpress.org/ /tmp/wordpress-previous
+	git clone --depth=1 --branch 5.4 git://develop.git.wordpress.org/ /tmp/wordpress-previous
 	;;
 esac
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

WordPress 5.5 will be released on August 11, a week after Jetpack 8.8. Let's adjust Jetpack's requirements accordingly (WP -1).

This PR updates the minimum requirement to run Jetpack 8.8, and removes WP 5.3 backward compatibility code.

Primary issue: #15388 

#### Jetpack product discussion

* N/A 
#### Does this pull request change what data or activity we track or use?

* N/A 

#### Testing instructions:

* Do the tests pass?
* Do the blocks still work?

#### Proposed changelog entry for your changes:

* General: update Jetpack's minimum required WordPress version to 5.4, in anticipation of the upcoming WordPress 5.5 release.
