### PR TITLE
Various: Fix PHP warnings

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -134,12 +134,15 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 		$body = json_decode( wp_remote_retrieve_body( $response ) );
 
 		$connections = array();
-		foreach ( $body->connections as $connection ) {
-			if ( 'instagram-basic-display' === $connection->service && 'ok' === $connection->status ) {
-				$connections[] = array(
-					'token'    => (string) $connection->ID,
-					'username' => $connection->external_name,
-				);
+
+		if ( isset( $body->connections ) && is_array( $body->connections ) ) {
+			foreach ( $body->connections as $connection ) {
+				if ( 'instagram-basic-display' === $connection->service && 'ok' === $connection->status ) {
+					$connections[] = array(
+						'token'    => (string) $connection->ID,
+						'username' => $connection->external_name,
+					);
+				}
 			}
 		}
 		return $connections;

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -244,7 +244,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			$query['tax_query'] = array();
 			foreach ( $args['term'] as $taxonomy => $slug ) {
 				$taxonomy_object = get_taxonomy( $taxonomy );
-				if ( false === $taxonomy_object || ( ! $taxonomy_object->public && 
+				if ( false === $taxonomy_object || ( ! $taxonomy_object->public &&
 						! current_user_can( $taxonomy_object->cap->assign_terms ) ) ) {
 					continue;
 				}
@@ -253,7 +253,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 					'taxonomy' => $taxonomy,
 					'field' => 'slug',
 					'terms' => explode( ',', $slug )
-				);				
+				);
 			}
 		}
 
@@ -382,7 +382,9 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 						if ( ! isset( $return[$key] ) ) {
 							$return[$key] = (object) array();
 						}
-						$return[$key]->next_page = $this->build_page_handle( $last_post, $query );
+							if ( isset( $last_post['ID'] ) ) {
+								$return[ $key ]->next_page = $this->build_page_handle( $last_post, $query );
+							}
 					}
 				}
 

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-1-endpoint.php
@@ -1,71 +1,73 @@
 <?php
 
-new WPCOM_JSON_API_List_Posts_v1_1_Endpoint( array(
-	'description' => 'Get a list of matching posts.',
-	'min_version' => '1.1',
-	'max_version' => '1.1',
+new WPCOM_JSON_API_List_Posts_v1_1_Endpoint(
+	array(
+		'description'      => 'Get a list of matching posts.',
+		'min_version'      => '1.1',
+		'max_version'      => '1.1',
 
-	'group'       => 'posts',
-	'stat'        => 'posts',
+		'group'            => 'posts',
+		'stat'             => 'posts',
 
-	'method'      => 'GET',
-	'path'        => '/sites/%s/posts/',
-	'path_labels' => array(
-		'$site' => '(int|string) Site ID or domain',
-	),
-
-	'query_parameters' => array(
-		'number'   => '(int=20) The number of posts to return. Limit: 100.',
-		'offset'   => '(int=0) 0-indexed offset.',
-		'page'     => '(int) Return the Nth 1-indexed page of posts. Takes precedence over the <code>offset</code> parameter.',
-		'page_handle' => '(string) A page handle, returned from a previous API call as a <code>meta.next_page</code> property. This is the most efficient way to fetch the next page of results.',
-		'order'    => array(
-			'DESC' => 'Return posts in descending order. For dates, that means newest to oldest.',
-			'ASC'  => 'Return posts in ascending order. For dates, that means oldest to newest.',
+		'method'           => 'GET',
+		'path'             => '/sites/%s/posts/',
+		'path_labels'      => array(
+			'$site' => '(int|string) Site ID or domain',
 		),
-		'order_by' => array(
-			'date'          => 'Order by the created time of each post.',
-			'modified'      => 'Order by the modified time of each post.',
-			'title'         => "Order lexicographically by the posts' titles.",
-			'comment_count' => 'Order by the number of comments for each post.',
-			'ID'            => 'Order by post ID.',
-		),
-		'after'    => '(ISO 8601 datetime) Return posts dated after the specified datetime.',
-		'before'   => '(ISO 8601 datetime) Return posts dated before the specified datetime.',
-		'modified_after'    => '(ISO 8601 datetime) Return posts modified after the specified datetime.',
-		'modified_before'   => '(ISO 8601 datetime) Return posts modified before the specified datetime.',
-		'tag'      => '(string) Specify the tag name or slug.',
-		'category' => '(string) Specify the category name or slug.',
-		'term'     => '(object:string) Specify comma-separated term slugs to search within, indexed by taxonomy slug.',
-		'type'     => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
-		'parent_id' => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
-		'exclude'  => '(array:int|int) Excludes the specified post ID(s) from the response',
-		'exclude_tree' => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
-		'status'   => '(string) Comma-separated list of statuses for which to query, including any of: "publish", "private", "draft", "pending", "future", and "trash", or simply "any". Defaults to "publish"',
-		'sticky'    => array(
-			'include'   => 'Sticky posts are not excluded from the list.',
-			'exclude'   => 'Sticky posts are excluded from the list.',
-			'require'   => 'Only include sticky posts',
-		),
-		'author'   => "(int) Author's user ID",
-		'search'   => '(string) Search query',
-		'meta_key'   => '(string) Metadata key that the post should contain',
-		'meta_value'   => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
-	),
 
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/?number=2'
-) );
+		'query_parameters' => array(
+			'number'          => '(int=20) The number of posts to return. Limit: 100.',
+			'offset'          => '(int=0) 0-indexed offset.',
+			'page'            => '(int) Return the Nth 1-indexed page of posts. Takes precedence over the <code>offset</code> parameter.',
+			'page_handle'     => '(string) A page handle, returned from a previous API call as a <code>meta.next_page</code> property. This is the most efficient way to fetch the next page of results.',
+			'order'           => array(
+				'DESC' => 'Return posts in descending order. For dates, that means newest to oldest.',
+				'ASC'  => 'Return posts in ascending order. For dates, that means oldest to newest.',
+			),
+			'order_by'        => array(
+				'date'          => 'Order by the created time of each post.',
+				'modified'      => 'Order by the modified time of each post.',
+				'title'         => "Order lexicographically by the posts' titles.",
+				'comment_count' => 'Order by the number of comments for each post.',
+				'ID'            => 'Order by post ID.',
+			),
+			'after'           => '(ISO 8601 datetime) Return posts dated after the specified datetime.',
+			'before'          => '(ISO 8601 datetime) Return posts dated before the specified datetime.',
+			'modified_after'  => '(ISO 8601 datetime) Return posts modified after the specified datetime.',
+			'modified_before' => '(ISO 8601 datetime) Return posts modified before the specified datetime.',
+			'tag'             => '(string) Specify the tag name or slug.',
+			'category'        => '(string) Specify the category name or slug.',
+			'term'            => '(object:string) Specify comma-separated term slugs to search within, indexed by taxonomy slug.',
+			'type'            => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+			'parent_id'       => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
+			'exclude'         => '(array:int|int) Excludes the specified post ID(s) from the response',
+			'exclude_tree'    => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
+			'status'          => '(string) Comma-separated list of statuses for which to query, including any of: "publish", "private", "draft", "pending", "future", and "trash", or simply "any". Defaults to "publish"',
+			'sticky'          => array(
+				'include' => 'Sticky posts are not excluded from the list.',
+				'exclude' => 'Sticky posts are excluded from the list.',
+				'require' => 'Only include sticky posts',
+			),
+			'author'          => "(int) Author's user ID",
+			'search'          => '(string) Search query',
+			'meta_key'        => '(string) Metadata key that the post should contain',
+			'meta_value'      => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
+		),
+
+		'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/?number=2',
+	)
+);
 
 class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_Endpoint {
-	public $date_range = array();
-	public $modified_range = array();
-	public $page_handle = array();
+	public $date_range      = array();
+	public $modified_range  = array();
+	public $page_handle     = array();
 	public $performed_query = null;
 
 	public $response_format = array(
-		'found'    => '(int) The total number of posts found that match the request (ignoring limits, offsets, and pagination).',
-		'posts'    => '(array:post) An array of post objects.',
-		'meta'     => '(object) Meta data',
+		'found' => '(int) The total number of posts found that match the request (ignoring limits, offsets, and pagination).',
+		'posts' => '(array:post) An array of post objects.',
+		'meta'  => '(object) Meta data',
 	);
 
 	// /sites/%s/posts/ -> $blog_id
@@ -75,14 +77,14 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			return $blog_id;
 		}
 
-		$args = $this->query_args();
+		$args                        = $this->query_args();
 		$is_eligible_for_page_handle = true;
-		$site = $this->get_platform()->get_site( $blog_id );
+		$site                        = $this->get_platform()->get_site( $blog_id );
 
 		if ( $args['number'] < 1 ) {
 			$args['number'] = 20;
 		} elseif ( 100 < $args['number'] ) {
-			return new WP_Error( 'invalid_number',  'The NUMBER parameter must be less than or equal to 100.', 400 );
+			return new WP_Error( 'invalid_number', 'The NUMBER parameter must be less than or equal to 100.', 400 );
 		}
 
 		if ( isset( $args['type'] ) &&
@@ -116,15 +118,18 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 				'trash',
 				'any',
 			);
-			$status = array_intersect( $status, $statuses_whitelist );
+			$status             = array_intersect( $status, $statuses_whitelist );
 		} else {
 			// logged-out users can see only published posts
 			$statuses_whitelist = array( 'publish', 'any' );
-			$status = array_intersect( $status, $statuses_whitelist );
+			$status             = array_intersect( $status, $statuses_whitelist );
 
 			if ( empty( $status ) ) {
 				// requested only protected statuses? nothing for you here
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 			// clear it (AKA published only) because "any" includes protected
 			$status = array();
@@ -138,21 +143,25 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			$allowed_types = array();
 			foreach ( $args['type'] as $post_type ) {
 				if ( $site->current_user_can_access_post_type( $post_type, $args['context'] ) ) {
-				   	$allowed_types[] = $post_type;
+					$allowed_types[] = $post_type;
 				}
 			}
 
 			if ( empty( $allowed_types ) ) {
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 			$args['type'] = $allowed_types;
-		}
-		else {
+		} else {
 			if ( ! $site->current_user_can_access_post_type( $args['type'], $args['context'] ) ) {
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 		}
-
 
 		$query = array(
 			'posts_per_page' => $args['number'],
@@ -166,57 +175,64 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 			'fields'         => 'ids',
 		);
 
-		if ( ! is_user_logged_in () ) {
+		if ( ! is_user_logged_in() ) {
 			$query['has_password'] = false;
 		}
 
 		if ( isset( $args['meta_key'] ) ) {
 			$show = false;
-			if ( WPCOM_JSON_API_Metadata::is_public( $args['meta_key'] ) )
+			if ( WPCOM_JSON_API_Metadata::is_public( $args['meta_key'] ) ) {
 				$show = true;
-			if ( current_user_can( 'edit_post_meta', $query['post_type'], $args['meta_key'] ) )
+			}
+			if ( current_user_can( 'edit_post_meta', $query['post_type'], $args['meta_key'] ) ) {
 				$show = true;
+			}
 
-			if ( is_protected_meta( $args['meta_key'], 'post' ) && ! $show )
+			if ( is_protected_meta( $args['meta_key'], 'post' ) && ! $show ) {
 				return new WP_Error( 'invalid_meta_key', 'Invalid meta key', 404 );
+			}
 
 			$meta = array( 'key' => $args['meta_key'] );
-			if ( isset( $args['meta_value'] ) )
+			if ( isset( $args['meta_value'] ) ) {
 				$meta['value'] = $args['meta_value'];
+			}
 
 			$query['meta_query'] = array( $meta );
 		}
 
 		if ( $args['sticky'] === 'include' ) {
 			$query['ignore_sticky_posts'] = 1;
-		} else if ( $args['sticky'] === 'exclude' ) {
+		} elseif ( $args['sticky'] === 'exclude' ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( is_array( $sticky ) ) {
 				$query['post__not_in'] = $sticky;
 			}
-		} else if ( $args['sticky'] === 'require' ) {
+		} elseif ( $args['sticky'] === 'require' ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( is_array( $sticky ) && ! empty( $sticky ) ) {
 				$query['post__in'] = $sticky;
 			} else {
 				// no sticky posts exist
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 		}
 
 		if ( isset( $args['exclude'] ) ) {
-			$excluded_ids = (array) $args['exclude'];
+			$excluded_ids          = (array) $args['exclude'];
 			$query['post__not_in'] = isset( $query['post__not_in'] ) ? array_merge( $query['post__not_in'], $excluded_ids ) : $excluded_ids;
 		}
 
 		if ( isset( $args['exclude_tree'] ) && is_post_type_hierarchical( $args['type'] ) ) {
 			// get_page_children is a misnomer; it supports all hierarchical post types
-			$page_args = array(
-					'child_of' => $args['exclude_tree'],
-					'post_type' => $args['type'],
-					// since we're looking for things to exclude, be aggressive
-					'post_status' => 'publish,draft,pending,private,future,trash',
-				);
+			$page_args        = array(
+				'child_of'    => $args['exclude_tree'],
+				'post_type'   => $args['type'],
+				// since we're looking for things to exclude, be aggressive
+				'post_status' => 'publish,draft,pending,private,future,trash',
+			);
 			$post_descendants = get_pages( $page_args );
 
 			$exclude_tree = array( $args['exclude_tree'] );
@@ -229,7 +245,7 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 
 		if ( isset( $args['category'] ) ) {
 			$category = get_term_by( 'slug', $args['category'], 'category' );
-			if ( $category === false) {
+			if ( $category === false ) {
 				$query['category_name'] = $args['category'];
 			} else {
 				$query['cat'] = $category->term_id;
@@ -251,8 +267,8 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 
 				$query['tax_query'][] = array(
 					'taxonomy' => $taxonomy,
-					'field' => 'slug',
-					'terms' => explode( ',', $slug )
+					'field'    => 'slug',
+					'terms'    => explode( ',', $slug ),
 				);
 			}
 		}
@@ -340,61 +356,62 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 
 		}
 
-		$return = array();
+		$return         = array();
 		$excluded_count = 0;
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
-			case 'found' :
-				$return[$key] = (int) $wp_query->found_posts;
-				break;
-			case 'posts' :
-				$posts = array();
-				foreach ( $wp_query->posts as $post_ID ) {
-					$the_post = $this->get_post_by( 'ID', $post_ID, $args['context'] );
-					if ( $the_post && ! is_wp_error( $the_post ) ) {
-						$posts[] = $the_post;
-					} else {
-						$excluded_count++;
-					}
-				}
-
-				if ( $posts ) {
-					/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
-					do_action( 'wpcom_json_api_objects', 'posts', count( $posts ) );
-				}
-
-				$return[$key] = $posts;
-				break;
-
-			case 'meta' :
-				if ( ! is_array( $args['type'] ) ) {
-					$return[$key] = (object) array(
-						'links' => (object) array(
-							'counts' => (string) $this->links->get_site_link( $blog_id, 'post-counts/' . $args['type'] ),
-						)
-					);
-				}
-
-				if ( $is_eligible_for_page_handle && $return['posts'] ) {
-					$last_post = end( $return['posts'] );
-					reset( $return['posts'] );
-					if ( ( $return['found'] > count( $return['posts'] ) ) && $last_post ) {
-						if ( ! isset( $return[$key] ) ) {
-							$return[$key] = (object) array();
+				case 'found':
+					$return[ $key ] = (int) $wp_query->found_posts;
+					break;
+				case 'posts':
+					$posts = array();
+					foreach ( $wp_query->posts as $post_ID ) {
+						$the_post = $this->get_post_by( 'ID', $post_ID, $args['context'] );
+						if ( $the_post && ! is_wp_error( $the_post ) ) {
+							$posts[] = $the_post;
+						} else {
+							$excluded_count++;
 						}
+					}
+
+					if ( $posts ) {
+						/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+						do_action( 'wpcom_json_api_objects', 'posts', count( $posts ) );
+					}
+
+					$return[ $key ] = $posts;
+					break;
+
+				case 'meta':
+					if ( ! is_array( $args['type'] ) ) {
+						$return[ $key ] = (object) array(
+							'links' => (object) array(
+								'counts' => (string) $this->links->get_site_link( $blog_id, 'post-counts/' . $args['type'] ),
+							),
+						);
+					}
+
+					if ( $is_eligible_for_page_handle && $return['posts'] ) {
+						$last_post = end( $return['posts'] );
+						reset( $return['posts'] );
+						if ( ( $return['found'] > count( $return['posts'] ) ) && $last_post ) {
+							if ( ! isset( $return[ $key ] ) ) {
+								$return[ $key ] = (object) array();
+							}
 							if ( isset( $last_post['ID'] ) ) {
 								$return[ $key ]->next_page = $this->build_page_handle( $last_post, $query );
 							}
+						}
 					}
-				}
 
-				if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-					if ( !isset( $return[$key] ) )
-						$return[$key] = new stdClass;
-					$return[$key]->wpcom = true;
-				}
+					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+						if ( ! isset( $return[ $key ] ) ) {
+							$return[ $key ] = new stdClass();
+						}
+						$return[ $key ]->wpcom = true;
+					}
 
-				break;
+					break;
 			}
 		}
 
@@ -408,21 +425,26 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		if ( ! $column ) {
 			$column = 'date';
 		}
-		return build_query( array( 'value' => urlencode($post[$column]), 'id' => $post['ID'] ) );
+		return build_query(
+			array(
+				'value' => urlencode( $post[ $column ] ),
+				'id'    => $post['ID'],
+			)
+		);
 	}
 
 	function _build_date_range_query( $column, $range, $where ) {
 		global $wpdb;
 
 		switch ( count( $range ) ) {
-			case 2 :
+			case 2:
 				$where .= $wpdb->prepare(
 					" AND `$wpdb->posts`.$column >= CAST( %s AS DATETIME ) AND `$wpdb->posts`.$column < CAST( %s AS DATETIME ) ",
 					$range['after'],
 					$range['before']
 				);
 				break;
-			case 1 :
+			case 1:
 				if ( isset( $range['before'] ) ) {
 					$where .= $wpdb->prepare(
 						" AND `$wpdb->posts`.$column < CAST( %s AS DATETIME ) ",
@@ -469,31 +491,31 @@ class WPCOM_JSON_API_List_Posts_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_E
 		}
 
 		$db_column = '';
-		$db_value = '';
-		switch( $column ) {
+		$db_value  = '';
+		switch ( $column ) {
 			case 'ID':
 				$db_column = 'ID';
-				$db_value = '%d';
+				$db_value  = '%d';
 				break;
 			case 'title':
 				$db_column = 'post_title';
-				$db_value = '%s';
+				$db_value  = '%s';
 				break;
 			case 'date':
 				$db_column = 'post_date';
-				$db_value = 'CAST( %s as DATETIME )';
+				$db_value  = 'CAST( %s as DATETIME )';
 				break;
 			case 'modified':
 				$db_column = 'post_modified';
-				$db_value = 'CAST( %s as DATETIME )';
+				$db_value  = 'CAST( %s as DATETIME )';
 				break;
 			case 'comment_count':
 				$db_column = 'comment_count';
-				$db_value = '%d';
+				$db_value  = '%d';
 				break;
 		}
 
-		if ( 'DESC'=== $order ) {
+		if ( 'DESC' === $order ) {
 			$db_order = '<';
 		} else {
 			$db_order = '>';

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -375,7 +375,10 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 						if ( ! isset( $return[$key] ) ) {
 							$return[$key] = (object) array();
 						}
-						$return[$key]->next_page = $this->build_page_handle( $last_post, $query );
+
+							if ( isset( $last_post['ID'] ) ) {
+								$return[ $key ]->next_page = $this->build_page_handle( $last_post, $query );
+							}
 					}
 				}
 

--- a/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-list-posts-v1-2-endpoint.php
@@ -1,61 +1,63 @@
 <?php
 
-new WPCOM_JSON_API_List_Posts_v1_2_Endpoint( array(
-	'description' => 'Get a list of matching posts.',
-	'min_version' => '1.2',
-	'max_version' => '1.2',
+new WPCOM_JSON_API_List_Posts_v1_2_Endpoint(
+	array(
+		'description'      => 'Get a list of matching posts.',
+		'min_version'      => '1.2',
+		'max_version'      => '1.2',
 
-	'group'       => 'posts',
-	'stat'        => 'posts',
+		'group'            => 'posts',
+		'stat'             => 'posts',
 
-	'method'      => 'GET',
-	'path'        => '/sites/%s/posts/',
-	'path_labels' => array(
-		'$site' => '(int|string) Site ID or domain',
-	),
-
-	'query_parameters' => array(
-		'number'   => '(int=20) The number of posts to return. Limit: 100.',
-		'offset'   => '(int=0) 0-indexed offset.',
-		'page'     => '(int) Return the Nth 1-indexed page of posts. Takes precedence over the <code>offset</code> parameter.',
-		'page_handle' => '(string) A page handle, returned from a previous API call as a <code>meta.next_page</code> property. This is the most efficient way to fetch the next page of results.',
-		'order'    => array(
-			'DESC' => 'Return posts in descending order. For dates, that means newest to oldest.',
-			'ASC'  => 'Return posts in ascending order. For dates, that means oldest to newest.',
+		'method'           => 'GET',
+		'path'             => '/sites/%s/posts/',
+		'path_labels'      => array(
+			'$site' => '(int|string) Site ID or domain',
 		),
-		'order_by' => array(
-			'date'          => 'Order by the created time of each post.',
-			'modified'      => 'Order by the modified time of each post.',
-			'title'         => "Order lexicographically by the posts' titles.",
-			'comment_count' => 'Order by the number of comments for each post.',
-			'ID'            => 'Order by post ID.',
-		),
-		'after'    => '(ISO 8601 datetime) Return posts dated after the specified datetime.',
-		'before'   => '(ISO 8601 datetime) Return posts dated before the specified datetime.',
-		'modified_after'    => '(ISO 8601 datetime) Return posts modified after the specified datetime.',
-		'modified_before'   => '(ISO 8601 datetime) Return posts modified before the specified datetime.',
-		'tag'      => '(string) Specify the tag name or slug.',
-		'category' => '(string) Specify the category name or slug.',
-		'term'     => '(object:string) Specify comma-separated term slugs to search within, indexed by taxonomy slug.',
-		'type'     => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
-		'exclude_private_types' => '(bool=false) Use this flag together with `type=any` to get only publicly accessible posts.',
-		'parent_id' => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
-		'exclude'  => '(array:int|int) Excludes the specified post ID(s) from the response',
-		'exclude_tree' => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
-		'status'   => '(string) Comma-separated list of statuses for which to query, including any of: "publish", "private", "draft", "pending", "future", and "trash", or simply "any". Defaults to "publish"',
-		'sticky'    => array(
-			'include'   => 'Sticky posts are not excluded from the list.',
-			'exclude'   => 'Sticky posts are excluded from the list.',
-			'require'   => 'Only include sticky posts',
-		),
-		'author'   => "(int) Author's user ID",
-		'search'   => '(string) Search query',
-		'meta_key'   => '(string) Metadata key that the post should contain',
-		'meta_value'   => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
-	),
 
-	'example_request' => 'https://public-api.wordpress.com/rest/v1.2/sites/en.blog.wordpress.com/posts/?number=2'
-) );
+		'query_parameters' => array(
+			'number'                => '(int=20) The number of posts to return. Limit: 100.',
+			'offset'                => '(int=0) 0-indexed offset.',
+			'page'                  => '(int) Return the Nth 1-indexed page of posts. Takes precedence over the <code>offset</code> parameter.',
+			'page_handle'           => '(string) A page handle, returned from a previous API call as a <code>meta.next_page</code> property. This is the most efficient way to fetch the next page of results.',
+			'order'                 => array(
+				'DESC' => 'Return posts in descending order. For dates, that means newest to oldest.',
+				'ASC'  => 'Return posts in ascending order. For dates, that means oldest to newest.',
+			),
+			'order_by'              => array(
+				'date'          => 'Order by the created time of each post.',
+				'modified'      => 'Order by the modified time of each post.',
+				'title'         => "Order lexicographically by the posts' titles.",
+				'comment_count' => 'Order by the number of comments for each post.',
+				'ID'            => 'Order by post ID.',
+			),
+			'after'                 => '(ISO 8601 datetime) Return posts dated after the specified datetime.',
+			'before'                => '(ISO 8601 datetime) Return posts dated before the specified datetime.',
+			'modified_after'        => '(ISO 8601 datetime) Return posts modified after the specified datetime.',
+			'modified_before'       => '(ISO 8601 datetime) Return posts modified before the specified datetime.',
+			'tag'                   => '(string) Specify the tag name or slug.',
+			'category'              => '(string) Specify the category name or slug.',
+			'term'                  => '(object:string) Specify comma-separated term slugs to search within, indexed by taxonomy slug.',
+			'type'                  => "(string) Specify the post type. Defaults to 'post', use 'any' to query for both posts and pages. Post types besides post and page need to be whitelisted using the <code>rest_api_allowed_post_types</code> filter.",
+			'exclude_private_types' => '(bool=false) Use this flag together with `type=any` to get only publicly accessible posts.',
+			'parent_id'             => '(int) Returns only posts which are children of the specified post. Applies only to hierarchical post types.',
+			'exclude'               => '(array:int|int) Excludes the specified post ID(s) from the response',
+			'exclude_tree'          => '(int) Excludes the specified post and all of its descendants from the response. Applies only to hierarchical post types.',
+			'status'                => '(string) Comma-separated list of statuses for which to query, including any of: "publish", "private", "draft", "pending", "future", and "trash", or simply "any". Defaults to "publish"',
+			'sticky'                => array(
+				'include' => 'Sticky posts are not excluded from the list.',
+				'exclude' => 'Sticky posts are excluded from the list.',
+				'require' => 'Only include sticky posts',
+			),
+			'author'                => "(int) Author's user ID",
+			'search'                => '(string) Search query',
+			'meta_key'              => '(string) Metadata key that the post should contain',
+			'meta_value'            => '(string) Metadata value that the post should contain. Will only be applied if a `meta_key` is also given',
+		),
+
+		'example_request'  => 'https://public-api.wordpress.com/rest/v1.2/sites/en.blog.wordpress.com/posts/?number=2',
+	)
+);
 
 class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_v1_1_Endpoint {
 	// /sites/%s/posts/ -> $blog_id
@@ -65,14 +67,14 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 			return $blog_id;
 		}
 
-		$args = $this->query_args();
+		$args                        = $this->query_args();
 		$is_eligible_for_page_handle = true;
-		$site = $this->get_platform()->get_site( $blog_id );
+		$site                        = $this->get_platform()->get_site( $blog_id );
 
 		if ( $args['number'] < 1 ) {
 			$args['number'] = 20;
 		} elseif ( 100 < $args['number'] ) {
-			return new WP_Error( 'invalid_number',  'The NUMBER parameter must be less than or equal to 100.', 400 );
+			return new WP_Error( 'invalid_number', 'The NUMBER parameter must be less than or equal to 100.', 400 );
 		}
 
 		if ( isset( $args['type'] ) ) {
@@ -91,7 +93,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 
 				if ( isset( $args['exclude_private_types'] ) && $args['exclude_private_types'] == true ) {
 					$public_post_types = get_post_types( array( 'public' => true ) );
-					$args['type'] = array_intersect( $public_post_types, $whitelisted_post_types );
+					$args['type']      = array_intersect( $public_post_types, $whitelisted_post_types );
 				} else {
 					$args['type'] = $whitelisted_post_types;
 				}
@@ -111,13 +113,18 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 			}
 
 			if ( empty( $allowed_types ) ) {
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 			$args['type'] = $allowed_types;
-		}
-		else {
+		} else {
 			if ( ! $site->current_user_can_access_post_type( $args['type'], $args['context'] ) ) {
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 		}
 
@@ -133,15 +140,18 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 				'trash',
 				'any',
 			);
-			$status = array_intersect( $status, $statuses_whitelist );
+			$status             = array_intersect( $status, $statuses_whitelist );
 		} else {
 			// logged-out users can see only published posts
 			$statuses_whitelist = array( 'publish', 'any' );
-			$status = array_intersect( $status, $statuses_whitelist );
+			$status             = array_intersect( $status, $statuses_whitelist );
 
 			if ( empty( $status ) ) {
 				// requested only protected statuses? nothing for you here
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 			// clear it (AKA published only) because "any" includes protected
 			$status = array();
@@ -159,57 +169,64 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 			'fields'         => 'ids',
 		);
 
-		if ( ! is_user_logged_in () ) {
+		if ( ! is_user_logged_in() ) {
 			$query['has_password'] = false;
 		}
 
 		if ( isset( $args['meta_key'] ) ) {
 			$show = false;
-			if ( WPCOM_JSON_API_Metadata::is_public( $args['meta_key'] ) )
+			if ( WPCOM_JSON_API_Metadata::is_public( $args['meta_key'] ) ) {
 				$show = true;
-			if ( current_user_can( 'edit_post_meta', $query['post_type'], $args['meta_key'] ) )
+			}
+			if ( current_user_can( 'edit_post_meta', $query['post_type'], $args['meta_key'] ) ) {
 				$show = true;
+			}
 
-			if ( is_protected_meta( $args['meta_key'], 'post' ) && ! $show )
+			if ( is_protected_meta( $args['meta_key'], 'post' ) && ! $show ) {
 				return new WP_Error( 'invalid_meta_key', 'Invalid meta key', 404 );
+			}
 
 			$meta = array( 'key' => $args['meta_key'] );
-			if ( isset( $args['meta_value'] ) )
+			if ( isset( $args['meta_value'] ) ) {
 				$meta['value'] = $args['meta_value'];
+			}
 
 			$query['meta_query'] = array( $meta );
 		}
 
 		if ( $args['sticky'] === 'include' ) {
 			$query['ignore_sticky_posts'] = 1;
-		} else if ( $args['sticky'] === 'exclude' ) {
+		} elseif ( $args['sticky'] === 'exclude' ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( is_array( $sticky ) ) {
 				$query['post__not_in'] = $sticky;
 			}
-		} else if ( $args['sticky'] === 'require' ) {
+		} elseif ( $args['sticky'] === 'require' ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( is_array( $sticky ) && ! empty( $sticky ) ) {
 				$query['post__in'] = $sticky;
 			} else {
 				// no sticky posts exist
-				return array( 'found' => 0, 'posts' => array() );
+				return array(
+					'found' => 0,
+					'posts' => array(),
+				);
 			}
 		}
 
 		if ( isset( $args['exclude'] ) ) {
-			$excluded_ids = (array) $args['exclude'];
+			$excluded_ids          = (array) $args['exclude'];
 			$query['post__not_in'] = isset( $query['post__not_in'] ) ? array_merge( $query['post__not_in'], $excluded_ids ) : $excluded_ids;
 		}
 
 		if ( isset( $args['exclude_tree'] ) && is_post_type_hierarchical( $args['type'] ) ) {
 			// get_page_children is a misnomer; it supports all hierarchical post types
-			$page_args = array(
-					'child_of' => $args['exclude_tree'],
-					'post_type' => $args['type'],
-					// since we're looking for things to exclude, be aggressive
-					'post_status' => 'publish,draft,pending,private,future,trash',
-				);
+			$page_args        = array(
+				'child_of'    => $args['exclude_tree'],
+				'post_type'   => $args['type'],
+				// since we're looking for things to exclude, be aggressive
+				'post_status' => 'publish,draft,pending,private,future,trash',
+			);
 			$post_descendants = get_pages( $page_args );
 
 			$exclude_tree = array( $args['exclude_tree'] );
@@ -222,7 +239,7 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 
 		if ( isset( $args['category'] ) ) {
 			$category = get_term_by( 'slug', $args['category'], 'category' );
-			if ( $category === false) {
+			if ( $category === false ) {
 				$query['category_name'] = $args['category'];
 			} else {
 				$query['cat'] = $category->term_id;
@@ -244,8 +261,8 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 
 				$query['tax_query'][] = array(
 					'taxonomy' => $taxonomy,
-					'field' => 'slug',
-					'terms' => explode( ',', $slug )
+					'field'    => 'slug',
+					'terms'    => explode( ',', $slug ),
 				);
 			}
 		}
@@ -333,62 +350,63 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 
 		}
 
-		$return = array();
+		$return         = array();
 		$excluded_count = 0;
 		foreach ( array_keys( $this->response_format ) as $key ) {
 			switch ( $key ) {
-			case 'found' :
-				$return[$key] = (int) $wp_query->found_posts;
-				break;
-			case 'posts' :
-				$posts = array();
-				foreach ( $wp_query->posts as $post_ID ) {
-					$the_post = $this->get_post_by( 'ID', $post_ID, $args['context'] );
-					if ( $the_post && ! is_wp_error( $the_post ) ) {
-						$posts[] = $the_post;
-					} else {
-						$excluded_count++;
-					}
-				}
-
-				if ( $posts ) {
-					/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
-					do_action( 'wpcom_json_api_objects', 'posts', count( $posts ) );
-				}
-
-				$return[$key] = $posts;
-				break;
-
-			case 'meta' :
-				if ( ! is_array( $args['type'] ) ) {
-					$return[$key] = (object) array(
-						'links' => (object) array(
-							'counts' => (string) $this->links->get_site_link( $blog_id, 'post-counts/' . $args['type'] ),
-						)
-					);
-				}
-
-				if ( $is_eligible_for_page_handle && $return['posts'] ) {
-					$last_post = end( $return['posts'] );
-					reset( $return['posts'] );
-					if ( ( $return['found'] > count( $return['posts'] ) ) && $last_post ) {
-						if ( ! isset( $return[$key] ) ) {
-							$return[$key] = (object) array();
+				case 'found':
+					$return[ $key ] = (int) $wp_query->found_posts;
+					break;
+				case 'posts':
+					$posts = array();
+					foreach ( $wp_query->posts as $post_ID ) {
+						$the_post = $this->get_post_by( 'ID', $post_ID, $args['context'] );
+						if ( $the_post && ! is_wp_error( $the_post ) ) {
+							$posts[] = $the_post;
+						} else {
+							$excluded_count++;
 						}
+					}
+
+					if ( $posts ) {
+						/** This action is documented in json-endpoints/class.wpcom-json-api-site-settings-endpoint.php */
+						do_action( 'wpcom_json_api_objects', 'posts', count( $posts ) );
+					}
+
+					$return[ $key ] = $posts;
+					break;
+
+				case 'meta':
+					if ( ! is_array( $args['type'] ) ) {
+						$return[ $key ] = (object) array(
+							'links' => (object) array(
+								'counts' => (string) $this->links->get_site_link( $blog_id, 'post-counts/' . $args['type'] ),
+							),
+						);
+					}
+
+					if ( $is_eligible_for_page_handle && $return['posts'] ) {
+						$last_post = end( $return['posts'] );
+						reset( $return['posts'] );
+						if ( ( $return['found'] > count( $return['posts'] ) ) && $last_post ) {
+							if ( ! isset( $return[ $key ] ) ) {
+								$return[ $key ] = (object) array();
+							}
 
 							if ( isset( $last_post['ID'] ) ) {
 								$return[ $key ]->next_page = $this->build_page_handle( $last_post, $query );
 							}
+						}
 					}
-				}
 
-				if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-					if ( !isset( $return[$key] ) )
-						$return[$key] = new stdClass;
-					$return[$key]->wpcom = true;
-				}
+					if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+						if ( ! isset( $return[ $key ] ) ) {
+							$return[ $key ] = new stdClass();
+						}
+						$return[ $key ]->wpcom = true;
+					}
 
-				break;
+					break;
 			}
 		}
 
@@ -402,21 +420,26 @@ class WPCOM_JSON_API_List_Posts_v1_2_Endpoint extends WPCOM_JSON_API_List_Posts_
 		if ( ! $column ) {
 			$column = 'date';
 		}
-		return build_query( array( 'value' => urlencode($post[$column]), 'id' => $post['ID'] ) );
+		return build_query(
+			array(
+				'value' => urlencode( $post[ $column ] ),
+				'id'    => $post['ID'],
+			)
+		);
 	}
 
 	function _build_date_range_query( $column, $range, $where ) {
 		global $wpdb;
 
 		switch ( count( $range ) ) {
-			case 2 :
+			case 2:
 				$where .= $wpdb->prepare(
 					" AND `$wpdb->posts`.$column >= CAST( %s AS DATETIME ) AND `$wpdb->posts`.$column < CAST( %s AS DATETIME ) ",
 					$range['after'],
 					$range['before']
 				);
 				break;
-			case 1 :
+			case 1:
 				if ( isset( $range['before'] ) ) {
 					$where .= $wpdb->prepare(
 						" AND `$wpdb->posts`.$column < CAST( %s AS DATETIME ) ",

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -667,7 +667,7 @@ function sharing_process_requests() {
 	global $post;
 
 	// Only process if: single post and share=X defined
-	if ( ( is_page() || is_single() ) && isset( $_GET['share'] ) ) {
+	if ( ( is_page() || is_single() ) && isset( $_GET['share'] ) && is_string( $_GET['share'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$sharer = new Sharing_Service();
 
 		$service = $sharer->get_service( $_GET['share'] );


### PR DESCRIPTION
Fixes two warnings:

Warning: Illegal offset type in isset or empty in /srv/public/wp-content/plugins/jetpack/modules/sharedaddy/sharing-service.php on line 307

E_WARNING: /home/public_html/wp-content/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php:137 - Invalid argument supplied for foreach()


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Validation of variable type before use.

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:

* For the Sharing one, connected JP, activate Sharing and hit an URL like https://continuing-sacred.jurassic.ninja/2020/07/09/hello-world/?share[0]=twitter&share[1]=facebook&nb=1
(notice the `share[0]` and `share[1]` values.

#### Proposed changelog entry for your changes:
* Bug Fix: Prevent PHP warnings in two instances.
