### PR TITLE
REST Tester: Displaying invalid JSON

### DIFF
--- a/packages/debug-helper/modules/inc/js/rest-api-tester.js
+++ b/packages/debug-helper/modules/inc/js/rest-api-tester.js
@@ -82,7 +82,12 @@ class Jetpack_Debug_REST_API_Tester {
 		let responseText = request.responseText;
 
 		if ( request.getResponseHeader( 'content-type' ).indexOf( 'application/json' ) === 0 ) {
-			responseText = JSON.stringify( JSON.parse( responseText ), null, 4 );
+			try {
+				const parsedResponse = JSON.parse( responseText );
+				responseText = JSON.stringify( parsedResponse, null, 4 );
+			} catch ( e ) {
+				responseText = 'Invalid JSON:\n' + responseText;
+			}
 		}
 
 		this.responseElement.innerHTML = `<h2>Response:</h2>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
If JSON body is expected, but `JSON.parse()` fails, no response is displayed.
This commit fixes the problem. If JSON couldn't be parsed, it's displayed as plain text, and marked as "Invalid JSON"

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
This is an internal tool, and the changes are insignificant. No testing is necessary, code review should be enough.

1. Edit any Jetpack REST endpoint that returns JSON, and make it return invalid JSON (for example, add a dump before JSON output). It should still return `HTTP 200`.
2. Go to the "REST Tester" and run the request to that endpoint.

_Before:_
Response doesn't show up.
A JavaScript error is thrown while attempting to parse the invalid JSON.

_After:_
```
Invalid JSON:
[actual response body]
```

#### Proposed changelog entry for your changes:
N/a.