### PR TITLE
Contact Form: Ensure hash is expected type.

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1987,10 +1987,11 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		}
 
 		if ( isset( $_GET['contact-form-id'] )
-		     && $_GET['contact-form-id'] == self::$last->get_attribute( 'id' )
-		     && isset( $_GET['contact-form-sent'], $_GET['contact-form-hash'] )
-		     && hash_equals( $form->hash, $_GET['contact-form-hash'] ) ) {
-			// The contact form was submitted.  Show the success message/results
+			&& (int) $_GET['contact-form-id'] === (int) self::$last->get_attribute( 'id' )
+			&& isset( $_GET['contact-form-sent'], $_GET['contact-form-hash'] )
+			&& is_string( $_GET['contact-form-hash'] )
+			&& hash_equals( $form->hash, $_GET['contact-form-hash'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// The contact form was submitted.  Show the success message/results.
 			$feedback_id = (int) $_GET['contact-form-sent'];
 
 			$back_url = remove_query_arg( array( 'contact-form-id', 'contact-form-sent', '_wpnonce' ) );


### PR DESCRIPTION
Fixes:
```
E_WARNING
stripslashes() expects parameter 1 to be string, array given

Page
/news/page/2/?_wpnonce0=exp&_wpnonce1=1&contact-form-hash=91a34bc4135cf099b48a4c5b916250db4fe47f3a&contact-form-id=4&contact-form-sent=2599&subscribe=many_pending_subs

File
/home/public_html/wp-content/plugins/jetpack/modules/contact-form/grunion-contact-form.php:2004
```

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensures the hash is a string.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* On an archive page with a contact form and a subscription form, submit the contact form and then submit the subscription form.

#### Proposed changelog entry for your changes:
* Covered in an earlier warning bug fix changelog item.
