### PR TITLE
Open Graph: description for posts that start with an image

### DIFF
--- a/functions.opengraph.php
+++ b/functions.opengraph.php
@@ -456,26 +456,8 @@ function jetpack_og_get_image_gravatar( $email, $width ) {
  * @return string $description Cleaned up description string.
  */
 function jetpack_og_get_description( $description = '', $data = null ) {
-	// Remove links.
-	$description = preg_replace(
-		'@https?://[\S]+@',
-		'',
-		$description
-	);
-
-	// Remove shortcodes.
-	$description = strip_shortcodes( $description );
-
 	// Remove tags such as <style or <script.
 	$description = wp_strip_all_tags( $description );
-
-	/*
-	 * Limit things to a small text blurb.
-	 * There isn't a hard limit set by Facebook, so let's rely on WP's own limit.
-	 * (55 words or the localized equivalent).
-	 * This limit can be customized with the wp_trim_words filter.
-	 */
-	$description = wp_trim_words( $description );
 
 	/*
 	 * Clean up any plain text entities left into formatted entities.
@@ -490,6 +472,24 @@ function jetpack_og_get_description( $description = '', $data = null ) {
 		),
 		array()
 	);
+
+	// Remove shortcodes.
+	$description = strip_shortcodes( $description );
+
+	// Remove links.
+	$description = preg_replace(
+		'@https?://[\S]+@',
+		'',
+		$description
+	);
+
+	/*
+	 * Limit things to a small text blurb.
+	 * There isn't a hard limit set by Facebook, so let's rely on WP's own limit.
+	 * (55 words or the localized equivalent).
+	 * This limit can be customized with the wp_trim_words filter.
+	 */
+	$description = wp_trim_words( $description );
 
 	// Let's set a default if we have no text by now.
 	if ( empty( $description ) ) {

--- a/tests/php/test_class.functions.opengraph.php
+++ b/tests/php/test_class.functions.opengraph.php
@@ -101,32 +101,40 @@ class WP_Test_Functions_OpenGraph extends Jetpack_Attachment_Test_Case {
 	 */
 	public function jetpack_og_get_description_data_provider() {
 		return array(
-			'empty'          => array(
+			'empty'                  => array(
 				'',
 				'Visit the post for more.',
 			),
-			'no_entities'    => array(
+			'no_entities'            => array(
 				"OpenGraph's test",
 				'OpenGraph&#8217;s test',
 			),
-			'too_many_words' => array(
+			'too_many_words'         => array(
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam consectetur quam eget finibus consectetur. Donec sollicitudin finibus massa, ut cursus elit. Mauris dictum quam eu ullamcorper feugiat. Proin id ante purus. Aliquam lorem libero, tempus id dictum non, feugiat vel eros. Sed sed viverra libero. Praesent eu lacinia felis, et tempus turpis. Proin bibendum, ligula. These last sentence should be removed.',
 				'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam consectetur quam eget finibus consectetur. Donec sollicitudin finibus massa, ut cursus elit. Mauris dictum quam eu ullamcorper feugiat. Proin id ante purus. Aliquam lorem libero, tempus id dictum non, feugiat vel eros. Sed sed viverra libero. Praesent eu lacinia felis, et tempus turpis. Proin bibendum, ligula.&hellip;',
 			),
-			'no_tags'        => array(
+			'no_tags'                => array(
 				'A post description<script>alert("hello");</script>',
 				'A post description',
 			),
-			'no_shortcodes'  => array(
+			'no_shortcodes'          => array(
 				'[foo test="true"]A post description',
 				'A post description',
 			),
-			'no_links'       => array(
+			'no_links'               => array(
 				'A post description https://jetpack.com',
 				'A post description',
 			),
-			'no_html'        => array(
+			'no_html'                => array(
 				'<strong>A post description</strong>',
+				'A post description',
+			),
+			'image_then_text'        => array(
+				'<img src="https://example.org/jetpack-icon.jpg" />A post description',
+				'A post description',
+			),
+			'linked_image_then_text' => array(
+				'<a href="https://jetpack.com"><img src="https://example.org/jetpack-icon.jpg" /></a>A post description',
 				'A post description',
 			),
 		);


### PR DESCRIPTION
Fixes #16459

#### Changes proposed in this Pull Request:

As described on the issue:

> The refactoring changed the order of some calls, namely removing URLs and stripping HTML tags. It now removes URLs first, which invalidates the img tag by removing the last " of the src attribute. Stripping HTML tags next removes the img tag and everything after instead of just the img tag itself. If the description is empty it uses the fallback text.

This fixes that by going back to a proper order for cleaning up the description.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Do the tests pass?
* On a site with the sharing module active, create a new post.
* That post should start with an image, and then include some text.
* View source after publishing the post; the `og:description` tag should include the beginning of the text you wrote.

#### Proposed changelog entry for your changes:

* Sharing: create proper Open Graph Description tag when a post starts with an image.
