### PR TITLE
Copy Post: update support link

### DIFF
--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -58,7 +58,7 @@ export class Composing extends React.Component {
 							'Duplicate existing posts, pages, Testimonials, and Portfolios. ' +
 								'All the content will be copied including text, featured images, sharing settings, and more.'
 						),
-						link: getRedirectUrl( 'jetpack-support-copy-post-2' ),
+						link: getRedirectUrl( 'jetpack-support-copy-post' ),
 					} }
 				>
 					<FormFieldset>

--- a/modules/module-info.php
+++ b/modules/module-info.php
@@ -863,7 +863,7 @@ add_action( 'jetpack_module_more_info_photon-cdn', 'jetpack_assetcdn_more_info' 
  * Copy Post support link.
  */
 function jetpack_copy_post_more_link() {
-	echo esc_url( Redirect::get_url( 'jetpack-support-copy-post-2' ) );
+	echo esc_url( Redirect::get_url( 'jetpack-support-copy-post' ) );
 }
 add_action( 'jetpack_learn_more_button_copy-post', 'jetpack_copy_post_more_link' );
 


### PR DESCRIPTION


#### Changes proposed in this Pull Request:

The support doc used to be https://jetpack.com/support/copy-post-2/

It now uses `support/copy-post` like it should have from the start. :)

See p1594628241203200-slack-jpop-quill

#### Jetpack product discussion

N/A 

#### Does this pull request change what data or activity we track or use?
N/A 
#### Testing instructions:

* Go to Jetpack > Settings
* Search for "Copy"
* Make sure the link to the support doc is correct.

#### Proposed changelog entry for your changes:

* N/A 
