### PR TITLE
Sharing - add link to customize share button settings

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -869,9 +869,9 @@ function sharing_display( $text = '', $echo = false ) {
 
 			// Link to customization options if user can manage them.
 			if ( current_user_can( 'manage_options' ) ) {
-				$link_text        = esc_html__( 'Customize buttons', 'jetpack' );
+				$link_text        = __( 'Customize buttons', 'jetpack' );
 				$link_url         = 'https://jetpack.com/redirect/?source=calypso-marketing-sharing-buttons&site=' . Jetpack::build_raw_urls( get_home_url() );
-				$sharing_content .= '<p class="share-customize-link"><a href="' . $link_url . '" target="_blank" rel="noopener noreferrer">' . $link_text . '</a></p>';
+				$sharing_content .= '<p class="share-customize-link"><a href="' . esc_url( $link_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $link_text ) . '</a></p>';
 			}
 
 			if ( count( $enabled['hidden'] ) > 0 ) {

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -867,6 +867,13 @@ function sharing_display( $text = '', $echo = false ) {
 			$sharing_content .= implode( '', $parts );
 			$sharing_content .= '<li class="share-end"></li></ul>';
 
+			// Link to customization options if user can manage them.
+			if ( current_user_can( 'manage_options' ) ) {
+				$link_text        = esc_html__( 'Customize buttons', 'jetpack' );
+				$link_url         = 'https://jetpack.com/redirect/?source=calypso-marketing-sharing-buttons&site=' . Jetpack::build_raw_urls( get_home_url() );
+				$sharing_content .= '<p class="share-customize-link"><a href="' . $link_url . '" target="_blank" rel="noopener noreferrer">' . $link_text . '</a></p>';
+			}
+
 			if ( count( $enabled['hidden'] ) > 0 ) {
 				$sharing_content .= '<div class="sharing-hidden"><div class="inner" style="display: none;';
 

--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -679,6 +679,24 @@ function sharing_process_requests() {
 add_action( 'template_redirect', 'sharing_process_requests', 9 );
 
 /**
+ * Gets the url to customise the sharing buttons in Calypso.
+ *
+ * @return string the customisation URL or null if it couldn't be determinde.
+ */
+function get_sharing_buttons_customisation_url() {
+	if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'build_raw_urls' ) ) {
+		$site_suffix = Jetpack::build_raw_urls( home_url() );
+	} elseif ( class_exists( 'WPCOM_Masterbar' ) && method_exists( 'WPCOM_Masterbar', 'get_calypso_site_slug' ) ) {
+		$site_suffix = WPCOM_Masterbar::get_calypso_site_slug( get_current_blog_id() );
+	}
+
+	if ( $site_suffix ) {
+		return Automattic\Jetpack\Redirect::get_url( 'calypso-marketing-sharing-buttons', array( 'site' => $site_suffix ) );
+	}
+	return null;
+}
+
+/**
  * Append sharing links to text.
  *
  * @param string $text The original text to append sharing links onto.
@@ -869,9 +887,11 @@ function sharing_display( $text = '', $echo = false ) {
 
 			// Link to customization options if user can manage them.
 			if ( current_user_can( 'manage_options' ) ) {
-				$link_text        = __( 'Customize buttons', 'jetpack' );
-				$link_url         = 'https://jetpack.com/redirect/?source=calypso-marketing-sharing-buttons&site=' . Jetpack::build_raw_urls( get_home_url() );
-				$sharing_content .= '<p class="share-customize-link"><a href="' . esc_url( $link_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $link_text ) . '</a></p>';
+				$link_url = get_sharing_buttons_customisation_url();
+				if ( ! empty( $link_url ) ) {
+					$link_text        = __( 'Customize buttons', 'jetpack' );
+					$sharing_content .= '<p class="share-customize-link"><a href="' . esc_url( $link_url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html( $link_text ) . '</a></p>';
+				}
 			}
 
 			if ( count( $enabled['hidden'] ) > 0 ) {

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -759,7 +759,7 @@ div.sharedaddy.sharedaddy-dark #sharing_email {
 	line-height: 11px;
 }
 
-.sd-content .share-customize-link a{
+.sd-content .share-customize-link a {
 	font-size: 11px;
 	font-family: "Open Sans", sans-serif;
 }

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -755,7 +755,7 @@ div.sharedaddy.sharedaddy-dark #sharing_email {
 }
 
 .sd-content .share-customize-link {
-	margin-top: -.7em;
+	margin-top: 0em;
 	line-height: 11px;
 }
 

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -753,3 +753,14 @@ div.sharedaddy.sharedaddy-dark #sharing_email {
 	height: 123px;
 	margin: 0 0 1em 0;
 }
+
+.sd-content .share-customize-link {
+	margin-top: -.7em; 
+	line-height: 11px;
+}
+
+.sd-content .share-customize-link a{
+	font-size: 11px !important;
+	font-family: "Open Sans", sans-serif !important;
+	color: #000;
+}

--- a/modules/sharedaddy/sharing.css
+++ b/modules/sharedaddy/sharing.css
@@ -755,12 +755,11 @@ div.sharedaddy.sharedaddy-dark #sharing_email {
 }
 
 .sd-content .share-customize-link {
-	margin-top: -.7em; 
+	margin-top: -.7em;
 	line-height: 11px;
 }
 
 .sd-content .share-customize-link a{
-	font-size: 11px !important;
-	font-family: "Open Sans", sans-serif !important;
-	color: #000;
+	font-size: 11px;
+	font-family: "Open Sans", sans-serif;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 116-gh-dotcom-manage

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This PR adds a link under the "Share This" buttons on post pages (for users with sufficient permissions) to the customization screen for those buttons, to make it easier for users to realize that they are indeed customizable.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Enable share buttons on Jetpack-enabled site by navigating to WP Admin -> Jetpack -> Settings -> Sharing and enabling the "Add sharing buttons to your posts and pages" toggle.
* Navigate to a post on the site, both while logged in as a user with admin permissions (`manage_options`, specifically) and while not.
* Verify that while logged in with permissions, a "Customize buttons" link is displayed under the sharing buttons which links the user to the customization options in Calypso.
* Verify that this option does not exist if the user does not have admin permissions.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added direct link to share button customization for logged-in admins.
