### PR TITLE
Search: Increase instant search bundle limit to 150 KiB

### DIFF
--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -45,8 +45,8 @@ module.exports = [
 					hints: 'error',
 			  }
 			: {
-					maxAssetSize: 122880,
-					maxEntrypointSize: 122880,
+					maxAssetSize: 153600,
+					maxEntrypointSize: 153600,
 					hints: 'error',
 			  },
 		plugins: [


### PR DESCRIPTION
We are increasing the bundle size limit for Jetpack Instant Search due to WPCOM's bundle exceeding the 130 KiB limit (currently, the bundle is 115 KiB in Jetpack and 134 KiB in WPCOM).

#### Changes proposed in this Pull Request:
* Increases Jetpack Instant Search bundle limit to 150 [KiB](https://en.wikipedia.org/wiki/Kibibyte).

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Run `yarn build-production`. Ensure that it completes without an error code.

#### Proposed changelog entry for your changes:
* None.
