### PR TITLE
Tiled Gallery Block: Add a style extension to core gallery block to allow tiling

### DIFF
--- a/extensions/blocks/new-tiled-gallery/index.js
+++ b/extensions/blocks/new-tiled-gallery/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockStyle } from '@wordpress/blocks';
+import './view.js';
+
+registerBlockStyle( 'core/gallery', [
+	{
+		name: 'tiled',
+		label: 'Tiled',
+	},
+	{
+		name: 'standard',
+		label: 'Standard',
+	},
+] );

--- a/extensions/blocks/new-tiled-gallery/view.js
+++ b/extensions/blocks/new-tiled-gallery/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './view.scss';

--- a/extensions/blocks/new-tiled-gallery/view.scss
+++ b/extensions/blocks/new-tiled-gallery/view.scss
@@ -1,0 +1,48 @@
+.is-style-tiled {
+	.blocks-gallery-grid {
+		display: grid;
+		grid-gap: 4px;
+		grid-template-columns: repeat( 6, 1fr );
+		grid-auto-rows: 200px;
+
+		.blocks-gallery-item {
+			width: 100%;
+			margin: 0;
+		}
+
+		.blocks-gallery-item figure {
+			display: block;
+			width: 100%;
+			height: 100%;
+		}
+		.blocks-gallery-item {
+			grid-column: auto / span 2;
+		}
+		.blocks-gallery-item img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+		.blocks-gallery-item:nth-child( 30n + 1 ),
+		.blocks-gallery-item:nth-child( 30n + 5 ),
+		.blocks-gallery-item:nth-child( 30n + 7 ),
+		.blocks-gallery-item:nth-child( 30n + 14 ),
+		.blocks-gallery-item:nth-child( 30n + 17 ),
+		.blocks-gallery-item:nth-child( 30n + 23 ),
+		.blocks-gallery-item:nth-child( 30n + 25 ) {
+			grid-column: auto / span 4;
+			grid-row: auto / span 2;
+		}
+		.blocks-gallery-item:nth-child( 30n + 8 ),
+		.blocks-gallery-item:nth-child( 30n + 9 ),
+		.blocks-gallery-item:nth-child( 30n + 10 ),
+		.blocks-gallery-item:nth-child( 30n + 11 ),
+		.blocks-gallery-item:nth-child( 30n + 18 ) {
+			grid-row: auto / span 2;
+		}
+		.blocks-gallery-item:nth-child( 30n + 12 ),
+		.blocks-gallery-item:nth-child( 30n + 13 ) {
+			grid-column: auto / span 3;
+		}
+	}
+}

--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -7,6 +7,7 @@ import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
 import './shared/external-media';
 import './shared/blocks/cover';
+import './blocks/new-tiled-gallery';
 import analytics from '../_inc/client/lib/analytics';
 
 // @TODO Please make a shared analytics solution and remove this!


### PR DESCRIPTION
This is currently just a PoC to look at options for enhancing the core block and deprecating the tiled gallery block as a way to get the captions outlined in #11794 and reduce duplication.

#### Changes proposed in this Pull Request:

* Add a style option to core gallery block


#### Testing instructions:

- Check out PR, add a core gallery block and select the 'Tiled' style option
- The tiled layout has a repeating pattern after 30 images, so if you add more than 30 images you will see the full extent of the layout

![tile](https://user-images.githubusercontent.com/3629020/87385698-d389c380-c5f2-11ea-8de3-121c57b9617d.gif)
