### PR TITLE
Extensions: update documentation: React in strings is now possible

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -260,19 +260,23 @@ See [Publicize](blocks/publicize/index.js) and [Shortlinks](blocks/shortlinks/in
 
 ### i18n
 
-As of 04/2019, `wp.i18n` [doesn't support React elements in strings](https://github.com/WordPress/gutenberg/issues/9846). You will have to structure your copy so that links and other HTML can be translated separately.
-
-Not possible:
-
-```js
-__( 'Still confused? Check out <a>documentation</a> for more!' )
-```
-
-Possible:
+`@wordpress/i18n` doesn't support React elements in strings, but you can use `__experimentalCreateInterpolateElement` from `@wordpress/element`:
 
 ```jsx
-{ __( 'Still confused?' ) } <a>{ __( 'Check out documentation for more!' ) }</a>
+import { BlockIcon } from '@wordpress/block-editor';
+import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
+const getDocumentationLink = () => {
+	return createInterpolateElement(
+		__( '<FlagIcon /> Still confused? <a>Check out documentation for more!</a>', 'jetpack' ),
+		{
+			FlagIcon: <BlockIcon icon={ 'flag' } />,
+			a: <a href={ 'https://jetpack.com' } />,
+		}
+	);
+};
 ```
+
+Once Jetpack will require WordPress 5.5+, you will be able to use `createInterpolateElement`.
 
 ### Colors
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -269,8 +269,8 @@ const getDocumentationLink = () => {
 	return createInterpolateElement(
 		__( '<FlagIcon /> Still confused? <a>Check out documentation for more!</a>', 'jetpack' ),
 		{
-			FlagIcon: <BlockIcon icon={ 'flag' } />,
-			a: <a href={ 'https://jetpack.com' } />,
+			FlagIcon: <BlockIcon icon="flag" />,
+			a: <a href="https://jetpack.com" />,
 		}
 	);
 };

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -260,13 +260,13 @@ See [Publicize](blocks/publicize/index.js) and [Shortlinks](blocks/shortlinks/in
 
 ### i18n
 
-`@wordpress/i18n` doesn't support React elements in strings, but you can use `createInterpolateElement` from `@wordpress/element`:
+`@wordpress/i18n` doesn't support React elements in strings, but you can use `createInterpolateElement` from `@wordpress/element`. However, since `createInterpolateElement` is only available in WordPress 5.5+, you will need to use `jetpackCreateInterpolateElement` instead to avoid issues on older versions of WordPress.
 
 ```jsx
 import { BlockIcon } from '@wordpress/block-editor';
-import { createInterpolateElement } from '@wordpress/element';
+import { jetpackCreateInterpolateElement } from '../../shared/create-interpolate-element';
 const getDocumentationLink = () => {
-	return createInterpolateElement(
+	return jetpackCreateInterpolateElement(
 		__( '<FlagIcon /> Still confused? <a>Check out documentation for more!</a>', 'jetpack' ),
 		{
 			FlagIcon: <BlockIcon icon="flag" />,
@@ -275,8 +275,6 @@ const getDocumentationLink = () => {
 	);
 };
 ```
-
-**Since `createInterpolateElement` is only available in WordPress 5.5+, you will need to check for it before you use it, and support a fallback until Jetpack stops supporting WordPress 5.4.**
 
 ### Colors
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -260,11 +260,11 @@ See [Publicize](blocks/publicize/index.js) and [Shortlinks](blocks/shortlinks/in
 
 ### i18n
 
-`@wordpress/i18n` doesn't support React elements in strings, but you can use `__experimentalCreateInterpolateElement` from `@wordpress/element`:
+`@wordpress/i18n` doesn't support React elements in strings, but you can use `createInterpolateElement` from `@wordpress/element`:
 
 ```jsx
 import { BlockIcon } from '@wordpress/block-editor';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 const getDocumentationLink = () => {
 	return createInterpolateElement(
 		__( '<FlagIcon /> Still confused? <a>Check out documentation for more!</a>', 'jetpack' ),
@@ -276,7 +276,7 @@ const getDocumentationLink = () => {
 };
 ```
 
-Once Jetpack will require WordPress 5.5+, you will be able to use `createInterpolateElement`.
+**Since `createInterpolateElement` is only available in WordPress 5.5+, you will need to check for it before you use it, and support a fallback until Jetpack stops supporting WordPress 5.4.**
 
 ### Colors
 

--- a/extensions/shared/create-interpolate-element.js
+++ b/extensions/shared/create-interpolate-element.js
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import {
+	createInterpolateElement,
+	__experimentalCreateInterpolateElement,
+} from '@wordpress/element';
+
+/**
+ * createInterpolateElement is available in WordPress 5.5
+ * and in latest versions of the Gutenberg plugin,
+ * but it is not available in WordPress 5.4, which we still support.
+ *
+ * @todo remove when Jetpack requires WordPress 5.5.
+ */
+export const jetpackCreateInterpolateElement =
+	createInterpolateElement || __experimentalCreateInterpolateElement;


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* While we are not yet clear to use `createInterpolateElement` (it will only be available in WordPress 5.5), we can now rely on `__experimentalCreateInterpolateElement` as Jetpack now requires WordPress 5.4+.

References:
- WordPress 5.5 Compatibility: #15388 
- Jetpack now requires WordPress 5.4+ as of #16445
- `__experimentalCreateInterpolateElement` was introduced in https://github.com/WordPress/gutenberg/pull/17376

#### Jetpack product discussion

* N/A 

#### Does this pull request change what data or activity we track or use?

* N/A 

#### Testing instructions:

* Check for typos
* Is my example the best and clearer way to show what can be done?

#### Proposed changelog entry for your changes:

* N/A 

