### PR TITLE
PaidBlocks: add Upgrade block control

### DIFF
--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -6,6 +6,7 @@ import './shared/block-category';
 import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
 import './shared/external-media';
+import './shared/paid-blocks';
 import './shared/blocks/cover';
 import analytics from '../_inc/client/lib/analytics';
 

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -8,8 +8,9 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { isUpgradable, isVideoFile } from './utils';
+import { isVideoFile } from './utils';
 import { CoverMediaProvider, JetpackCoverUpgradeNudge } from './components';
+import { isUpgradable } from "../../paid-blocks/utils";
 
 export default createHigherOrderComponent(
 	BlockEdit => props => {

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -13,8 +13,8 @@ import { addFilter } from '@wordpress/hooks';
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import coverMediaReplaceFlow from './cover-replace-control-button';
 import jetpackCoverBlockEdit from './edit';
-import { isUpgradable } from './utils';
 import './editor.scss';
+import { isUpgradable } from "../../paid-blocks/utils";
 
 const addVideoUploadPlanCheck = ( settings, name ) => {
 	if ( ! settings.isDeprecation && isUpgradable( name ) ) {

--- a/extensions/shared/blocks/cover/utils.js
+++ b/extensions/shared/blocks/cover/utils.js
@@ -6,8 +6,6 @@ import { values } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isSimpleSite } from '../../site-type-utils';
-import getJetpackExtensionAvailability from '../../get-jetpack-extension-availability';
 import getAllowedMimeTypesBySite, {
 	getAllowedVideoTypesByType,
 	pickFileExtensionsFromMimeTypes,
@@ -42,21 +40,4 @@ export function isVideoFile( file ) {
 	}
 
 	return false;
-}
-
-/**
- * Check if the cover block should show the upgrade nudge.
- *
- * @param {string} name - Block name.
- * @returns {boolean} True if it should show the nudge. Otherwise, False.
- */
-export function isUpgradable( name ) {
-	const { unavailableReason } = getJetpackExtensionAvailability( 'videopress' );
-
-	return (
-		name &&
-		name === 'core/cover' && // upgrade only for cover block
-		isSimpleSite() && // only for Simple sites
-		[ 'missing_plan', 'unknown' ].includes( unavailableReason )
-	);
 }

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -15,7 +15,6 @@ import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
 import { getPlanPathSlug, getUpgradeUrl } from "../../paid-blocks/utils";
 
-import './store';
 import './style.scss';
 
 const getTitle = ( customTitle, planName ) => {

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -3,8 +3,7 @@
  */
 import GridiconStar from 'gridicons/dist/star';
 import { __, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import { compact, get, startsWith } from 'lodash';
+import { get, startsWith } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -14,10 +13,9 @@ import { useEffect } from '@wordpress/element';
  */
 import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
-import getSiteFragment from '../../get-site-fragment';
-import { isSimpleSite } from '../../site-type-utils';
-import './store';
+import { getUpgradeUrl } from "../../paid-blocks/utils";
 
+import './store';
 import './style.scss';
 
 const getTitle = ( customTitle, planName ) => {
@@ -94,45 +92,16 @@ export const UpgradeNudge = ( {
 export default compose( [
 	withSelect( ( select, { plan: planSlug, blockName } ) => {
 		const plan = select( 'wordpress-com/plans' ).getPlan( planSlug );
+		const postId = select( 'core/editor' ).getCurrentPostId();
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		const upgradeUrl = getUpgradeUrl( { plan, planSlug, postId, postType } );
 
 		// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
 		// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
 		const planPathSlug = startsWith( planSlug, 'jetpack_' )
 			? planSlug.substr( 'jetpack_'.length )
 			: get( plan, [ 'path_slug' ] );
-
-		const postId = select( 'core/editor' ).getCurrentPostId();
-		const postType = select( 'core/editor' ).getCurrentPostType();
-
-		// The editor for CPTs has an `edit/` route fragment prefixed
-		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
-
-		// Post-checkout: redirect back here
-		const redirect_to = isSimpleSite()
-			? addQueryArgs(
-					'/' +
-						compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
-							'/'
-						),
-					{
-						plan_upgraded: 1,
-					}
-			  )
-			: addQueryArgs(
-					window.location.protocol +
-						`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
-					{
-						action: 'edit',
-						post: postId,
-						plan_upgraded: 1,
-					}
-			  );
-
-		const upgradeUrl =
-			planPathSlug &&
-			addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
-				redirect_to,
-			} );
 
 		const planName = get( plan, [ 'product_name' ] );
 		return {

--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -13,7 +13,7 @@ import { useEffect } from '@wordpress/element';
  */
 import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
-import { getUpgradeUrl } from "../../paid-blocks/utils";
+import { getPlanPathSlug, getUpgradeUrl } from "../../paid-blocks/utils";
 
 import './store';
 import './style.scss';
@@ -95,13 +95,8 @@ export default compose( [
 		const postId = select( 'core/editor' ).getCurrentPostId();
 		const postType = select( 'core/editor' ).getCurrentPostType();
 
-		const upgradeUrl = getUpgradeUrl( { plan, planSlug, postId, postType } );
-
-		// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
-		// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
-		const planPathSlug = startsWith( planSlug, 'jetpack_' )
-			? planSlug.substr( 'jetpack_'.length )
-			: get( plan, [ 'path_slug' ] );
+		const upgradeUrl = getUpgradeUrl( { planSlug, plan, postId, postType } );
+		const planPathSlug = getPlanPathSlug( { planSlug, plan } );
 
 		const planName = get( plan, [ 'product_name' ] );
 		return {

--- a/extensions/shared/paid-blocks/index.js
+++ b/extensions/shared/paid-blocks/index.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { Fragment } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarGroup, Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getUpgradeUrl, isUpgradable } from "./utils";
+
+const jetpackPaidBlockEdit = createHigherOrderComponent(
+	OriginalBlockEdit => props => {
+		const planSlug = 'value_bundle';
+		const { plan, postId, postType } = useSelect( select => {
+			return {
+				plan: select( 'wordpress-com/plans' ).getPlan( planSlug ),
+				postId: select( 'core/editor' ).getCurrentPostId(),
+				postType: select( 'core/editor' ).getCurrentPostType(),
+			};
+		} );
+
+		if ( ! isUpgradable( props?.name ) ) {
+			return <OriginalBlockEdit { ...props } />;
+		}
+
+		const goToCheckoutPage = () => {
+			window.location = getUpgradeUrl( { plan, planSlug, postId, postType } );
+		};
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<ToolbarGroup>
+						<Button
+							aria-label={ __( 'Upgrade to Premium to use this block', 'jetpack' ) }
+							onClick={ goToCheckoutPage }
+							label={ __(
+								'Upgrade to Premium to use this block.',
+								'jetpack'
+							) }
+							showTooltip={ true }
+						>
+							{ __( 'Upgrade', 'jetpack' ) }
+						</Button>
+					</ToolbarGroup>
+				</BlockControls>
+
+				<OriginalBlockEdit { ...props } />
+			</Fragment>
+		);
+	},
+	'JetpackPaidBlockEdit'
+);
+
+addFilter( 'editor.BlockEdit', 'jetpack/paid-block-edit', jetpackPaidBlockEdit );

--- a/extensions/shared/paid-blocks/index.js
+++ b/extensions/shared/paid-blocks/index.js
@@ -6,60 +6,11 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { Fragment } from '@wordpress/element';
-import { createHigherOrderComponent } from '@wordpress/compose';
-import { BlockControls } from '@wordpress/block-editor';
-import { ToolbarGroup, Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { getUpgradeUrl, isUpgradable } from "./utils";
+import jetpackPaidBlockEdit from './paid-block-edit';
 
-const jetpackPaidBlockEdit = createHigherOrderComponent(
-	OriginalBlockEdit => props => {
-		const planSlug = 'value_bundle';
-		const { plan, postId, postType } = useSelect( select => {
-			return {
-				plan: select( 'wordpress-com/plans' ).getPlan( planSlug ),
-				postId: select( 'core/editor' ).getCurrentPostId(),
-				postType: select( 'core/editor' ).getCurrentPostType(),
-			};
-		} );
-
-		if ( ! isUpgradable( props?.name ) ) {
-			return <OriginalBlockEdit { ...props } />;
-		}
-
-		const goToCheckoutPage = () => {
-			window.location = getUpgradeUrl( { plan, planSlug, postId, postType } );
-		};
-
-		return (
-			<Fragment>
-				<BlockControls>
-					<ToolbarGroup>
-						<Button
-							aria-label={ __( 'Upgrade to Premium to use this block', 'jetpack' ) }
-							onClick={ goToCheckoutPage }
-							label={ __(
-								'Upgrade to Premium to use this block.',
-								'jetpack'
-							) }
-							showTooltip={ true }
-						>
-							{ __( 'Upgrade', 'jetpack' ) }
-						</Button>
-					</ToolbarGroup>
-				</BlockControls>
-
-				<OriginalBlockEdit { ...props } />
-			</Fragment>
-		);
-	},
-	'JetpackPaidBlockEdit'
-);
-
+// Extend all blocks that required a paid plan.
 addFilter( 'editor.BlockEdit', 'jetpack/paid-block-edit', jetpackPaidBlockEdit );

--- a/extensions/shared/paid-blocks/index.js
+++ b/extensions/shared/paid-blocks/index.js
@@ -11,6 +11,18 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import jetpackPaidBlockEdit from './paid-block-edit';
+import { isUpgradable } from './utils';
+
+const jetpackPaidBlock = ( settings, name ) => {
+	if ( ! isUpgradable( name ) ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		edit: jetpackPaidBlockEdit( settings.edit ),
+	};
+};
 
 // Extend all blocks that required a paid plan.
-addFilter( 'editor.BlockEdit', 'jetpack/paid-block-edit', jetpackPaidBlockEdit );
+addFilter( 'blocks.registerBlockType', 'jetpack/paid-block', jetpackPaidBlock );

--- a/extensions/shared/paid-blocks/paid-block-edit.js
+++ b/extensions/shared/paid-blocks/paid-block-edit.js
@@ -3,61 +3,68 @@
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
-import { createHigherOrderComponent } from '@wordpress/compose';
+import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { BlockControls } from '@wordpress/block-editor';
 import { ToolbarGroup, Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { getUpgradeUrl, isUpgradable } from './utils';
+import { getUpgradeUrl } from './utils';
 
-export default createHigherOrderComponent(
-	OriginalBlockEdit => props => {
-		const planSlug = 'value_bundle';
-		const { plan, postId, postType } = useSelect( select => {
-			return {
-				plan: select( 'wordpress-com/plans' ).getPlan( planSlug ),
-				postId: select( 'core/editor' ).getCurrentPostId(),
-				postType: select( 'core/editor' ).getCurrentPostType(),
-			};
-		} );
+const JetpackPaidBlockEdit = OriginalBlockEdit => props => {
+	const { plan, postId, postType, planSlug } = props;
 
-		if ( ! isUpgradable( props?.name ) ) {
-			return <OriginalBlockEdit { ...props } />;
+	const goToCheckoutPage = () => {
+		if ( ! window?.location?.href ) {
+			return;
 		}
 
-		const goToCheckoutPage = () => {
-			if ( ! window?.location?.href ) {
-				return;
-			}
-			// Redirect to checkout page.
-			window.location.href = getUpgradeUrl( { plan, planSlug, postId, postType } );
-		};
+		// Redirect to checkout page.
+		window.location.href = getUpgradeUrl( { plan, planSlug, postId, postType } );
+	};
 
-		return (
-			<Fragment>
-				<BlockControls>
-					<ToolbarGroup>
-						<Button
-							aria-label={ __( 'Upgrade to Premium to use this block', 'jetpack' ) }
-							onClick={ goToCheckoutPage }
-							label={ __(
-								'Upgrade to Premium to use this block.',
-								'jetpack'
-							) }
-							showTooltip={ true }
-						>
-							{ __( 'Upgrade', 'jetpack' ) }
-						</Button>
-					</ToolbarGroup>
-				</BlockControls>
+	return (
+		<Fragment>
+			<BlockControls>
+				<ToolbarGroup>
+					<Button
+						aria-label={ __( 'Upgrade to Premium to use this block', 'jetpack' ) }
+						onClick={ goToCheckoutPage }
+						label={ __(
+							'Upgrade to Premium to use this block.',
+							'jetpack'
+						) }
+						showTooltip={ true }
+					>
+						{ __( 'Upgrade', 'jetpack' ) }
+					</Button>
+				</ToolbarGroup>
+			</BlockControls>
 
-				<OriginalBlockEdit { ...props } />
-			</Fragment>
-		);
-	},
+			<OriginalBlockEdit { ...props } />
+		</Fragment>
+	);
+};
+
+export default createHigherOrderComponent(
+	compose( [
+		withSelect( select => {
+			const editorSelector = select( 'core/editor' );
+			const post = editorSelector.getCurrentPost();
+			const planSlug = 'value_bundle';
+
+			return {
+				plan: select( 'wordpress-com/plans' ).getPlan( planSlug ),
+				planSlug,
+				postId: post.id,
+				postType: post.type,
+				postStatus: post.status,
+			};
+		} ),
+		JetpackPaidBlockEdit,
+	] ),
 	'JetpackPaidBlockEdit'
 );

--- a/extensions/shared/paid-blocks/paid-block-edit.js
+++ b/extensions/shared/paid-blocks/paid-block-edit.js
@@ -30,7 +30,11 @@ export default createHigherOrderComponent(
 		}
 
 		const goToCheckoutPage = () => {
-			window.location = getUpgradeUrl( { plan, planSlug, postId, postType } );
+			if ( ! window?.location?.href ) {
+				return;
+			}
+			// Redirect to checkout page.
+			window.location.href = getUpgradeUrl( { plan, planSlug, postId, postType } );
 		};
 
 		return (

--- a/extensions/shared/paid-blocks/paid-block-edit.js
+++ b/extensions/shared/paid-blocks/paid-block-edit.js
@@ -86,11 +86,11 @@ export default createHigherOrderComponent(
 		withSelect( select => {
 			const editorSelector = select( 'core/editor' );
 			const post = editorSelector.getCurrentPost();
-			const planSlug = 'value_bundle';
+			const PLAN_SLUG = 'value_bundle';
 
 			return {
-				plan: select( 'wordpress-com/plans' ).getPlan( planSlug ),
-				planSlug,
+				plan: select( 'wordpress-com/plans' ).getPlan( PLAN_SLUG ),
+				PLAN_SLUG,
 				postId: post.id,
 				postType: post.type,
 				postStatus: post.status,

--- a/extensions/shared/paid-blocks/paid-block-edit.js
+++ b/extensions/shared/paid-blocks/paid-block-edit.js
@@ -1,0 +1,59 @@
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarGroup, Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getUpgradeUrl, isUpgradable } from './utils';
+
+export default createHigherOrderComponent(
+	OriginalBlockEdit => props => {
+		const planSlug = 'value_bundle';
+		const { plan, postId, postType } = useSelect( select => {
+			return {
+				plan: select( 'wordpress-com/plans' ).getPlan( planSlug ),
+				postId: select( 'core/editor' ).getCurrentPostId(),
+				postType: select( 'core/editor' ).getCurrentPostType(),
+			};
+		} );
+
+		if ( ! isUpgradable( props?.name ) ) {
+			return <OriginalBlockEdit { ...props } />;
+		}
+
+		const goToCheckoutPage = () => {
+			window.location = getUpgradeUrl( { plan, planSlug, postId, postType } );
+		};
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<ToolbarGroup>
+						<Button
+							aria-label={ __( 'Upgrade to Premium to use this block', 'jetpack' ) }
+							onClick={ goToCheckoutPage }
+							label={ __(
+								'Upgrade to Premium to use this block.',
+								'jetpack'
+							) }
+							showTooltip={ true }
+						>
+							{ __( 'Upgrade', 'jetpack' ) }
+						</Button>
+					</ToolbarGroup>
+				</BlockControls>
+
+				<OriginalBlockEdit { ...props } />
+			</Fragment>
+		);
+	},
+	'JetpackPaidBlockEdit'
+);

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -13,7 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import { isSimpleSite } from '../site-type-utils';
 import getJetpackExtensionAvailability from '../get-jetpack-extension-availability';
-import getSiteFragment from "../get-site-fragment";
+import getSiteFragment from '../get-site-fragment';
 
 /*
  * Blocks list that require a paid plan.

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -12,6 +12,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { isSimpleSite } from '../site-type-utils';
+import getJetpackExtensionAvailability from '../get-jetpack-extension-availability';
 import getSiteFragment from "../get-site-fragment";
 
 /**
@@ -61,3 +62,22 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 			redirect_to,
 		} );
 }
+
+/**
+ * Check if the cover block should show the upgrade nudge.
+ *
+ * @param {string} name - Block name.
+ * @returns {boolean} True if it should show the nudge. Otherwise, False.
+ */
+export function isUpgradable( name ) {
+	// Remove the namespace form the block name.
+	const blockName = name.replace( /[a-zA-Z_-]+\//, '' );
+	const { unavailableReason } = getJetpackExtensionAvailability( blockName );
+
+	return (
+		name &&
+		isSimpleSite() &&
+		[ 'missing_plan', 'unknown' ].includes( unavailableReason )
+	);
+}
+

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -73,7 +73,8 @@ export function isUpgradable( name ) {
 	// Split up the block name to get blockNamespace/blockName.
 	const [ blockNamespace, blockName ] = /\//.test( name ) ? name.split( '/' ) : [ null, name ];
 
-	if ( blockNamespace && blockNamespace !== 'jetpack' ) {
+	// Check only fow known namespaces.
+	if ( blockNamespace && ! [ 'jetpack', 'premium-content' ].includes( blockNamespace ) ) {
 		return false;
 	}
 
@@ -81,7 +82,6 @@ export function isUpgradable( name ) {
 
 	return (
 		name &&
-		blockNamespace === 'jetpack' &&
 		isSimpleSite() &&
 		[ 'missing_plan', 'unknown' ].includes( unavailableReason )
 	);

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -57,7 +57,7 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 	const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
 
 	// Post-checkout: redirect back here
-	const redirect_to = isSimpleSite()
+	const redirectTo = isSimpleSite()
 		? addQueryArgs(
 			'/' +
 			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
@@ -79,7 +79,7 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 
 	return planPathSlug &&
 		addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
-			redirect_to,
+			redirect_to: redirectTo,
 		} );
 }
 

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { compact, get, startsWith } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { isSimpleSite } from '../site-type-utils';
+import getSiteFragment from "../get-site-fragment";
+
+/**
+ * Return the checkout URL to upgrade the site plan,
+ * depending on the plan, postId, and postType site values.
+ *
+ * @param {object} siteParams -          Site params used to build the URL.
+ * @param {string} siteParams.planSlug - Plan slug.
+ * @param {string} siteParams.plan -     An object with details about the plan.
+ * @param {number} siteParams.postId -   Post id.
+ * @param {string} siteParams.postType - Post type.
+ * @returns {string}                     Upgrade URL.
+ */
+export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
+	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
+	// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
+	const planPathSlug = startsWith( planSlug, 'jetpack_' )
+		? planSlug.substr( 'jetpack_'.length )
+		: get( plan, [ 'path_slug' ] );
+
+	// The editor for CPTs has an `edit/` route fragment prefixed
+	const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
+
+	// Post-checkout: redirect back here
+	const redirect_to = isSimpleSite()
+		? addQueryArgs(
+			'/' +
+			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
+				'/'
+			),
+			{
+				plan_upgraded: 1,
+			}
+		)
+		: addQueryArgs(
+			window.location.protocol +
+			`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
+			{
+				action: 'edit',
+				post: postId,
+				plan_upgraded: 1,
+			}
+		);
+
+	return planPathSlug &&
+		addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
+			redirect_to,
+		} );
+}

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -15,6 +15,14 @@ import { isSimpleSite } from '../site-type-utils';
 import getJetpackExtensionAvailability from '../get-jetpack-extension-availability';
 import getSiteFragment from "../get-site-fragment";
 
+/*
+ * Blocks list that require a paid plan.
+ */
+export const PAID_BLOCKS_LIST = [
+	'core/cover',
+	'core/video',
+];
+
 /**
  * Return the checkout URL to upgrade the site plan,
  * depending on the plan, postId, and postType site values.
@@ -73,8 +81,10 @@ export function isUpgradable( name ) {
 	// Split up the block name to get blockNamespace/blockName.
 	const [ blockNamespace, blockName ] = /\//.test( name ) ? name.split( '/' ) : [ null, name ];
 
-	// Check only fow known namespaces.
-	if ( blockNamespace && ! [ 'jetpack', 'premium-content' ].includes( blockNamespace ) ) {
+	if (
+		blockNamespace && ! [ 'jetpack', 'premium-content' ].includes( blockNamespace ) && // known namespaces.
+		! ( PAID_BLOCKS_LIST.includes( name ) )
+	) {
 		return false;
 	}
 

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -24,6 +24,22 @@ export const PAID_BLOCKS_LIST = [
 ];
 
 /**
+ * WP.com plan objects have a dedicated `path_slug` field,
+ * Jetpack plan objects don't.
+ * For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
+ *
+ * @param {object} PlanData -          Plan data object.
+ * @param {string} PlanData.planSlug - Plan slug.
+ * @param {object} PlanData.plan -     Object with details about the plan.
+ * @returns {string}                   Plan path slug.
+ */
+export function getPlanPathSlug( { planSlug, plan } ) {
+	return startsWith( planSlug, 'jetpack_' )
+		? planSlug.substr( 'jetpack_'.length )
+		: get( plan, [ 'path_slug' ] );
+}
+
+/**
  * Return the checkout URL to upgrade the site plan,
  * depending on the plan, postId, and postType site values.
  *
@@ -35,11 +51,7 @@ export const PAID_BLOCKS_LIST = [
  * @returns {string}                     Upgrade URL.
  */
 export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
-	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
-	// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
-	const planPathSlug = startsWith( planSlug, 'jetpack_' )
-		? planSlug.substr( 'jetpack_'.length )
-		: get( plan, [ 'path_slug' ] );
+	const planPathSlug = getPlanPathSlug( { planSlug, plan } );
 
 	// The editor for CPTs has an `edit/` route fragment prefixed
 	const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';

--- a/extensions/shared/paid-blocks/utils.js
+++ b/extensions/shared/paid-blocks/utils.js
@@ -64,18 +64,24 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 }
 
 /**
- * Check if the cover block should show the upgrade nudge.
+ * Check if the block should is upgradable.
  *
  * @param {string} name - Block name.
  * @returns {boolean} True if it should show the nudge. Otherwise, False.
  */
 export function isUpgradable( name ) {
-	// Remove the namespace form the block name.
-	const blockName = name.replace( /[a-zA-Z_-]+\//, '' );
+	// Split up the block name to get blockNamespace/blockName.
+	const [ blockNamespace, blockName ] = /\//.test( name ) ? name.split( '/' ) : [ null, name ];
+
+	if ( blockNamespace && blockNamespace !== 'jetpack' ) {
+		return false;
+	}
+
 	const { unavailableReason } = getJetpackExtensionAvailability( blockName );
 
 	return (
 		name &&
+		blockNamespace === 'jetpack' &&
 		isSimpleSite() &&
 		[ 'missing_plan', 'unknown' ].includes( unavailableReason )
 	);


### PR DESCRIPTION
This PR adds an `Upgrade` control button to the block menu. For now, it delegates the task to identify whether the block is upgradable to the Jetpack system for the `jetpack` and `premium-content` namespaces, and also to the `core/cover` and `core/video` blocks. We can continue polishing this approach in the following up PR.

In order to avoid code duplication, this PR also refacts the code moving the `isUpgradable()` helper function to the `./extesions/share/paid-blocks/` folder, and creates a new `getUpgradeUrl()` helper.

Fixes https://github.com/Automattic/wp-calypso/issues/44056

#### Changes proposed in this Pull Request:
* This PR implements two refactorings in order to avoid duplicated code.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
https://github.com/Automattic/wp-calypso/issues/44056

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
1) Apply these changes to your sandbox (D46380-code)
2) Get sandboxed
3) Select a Simple site
4) Start to edit a blog post
5) Add a (paid) block.

Type a `paid` term in the blocks list to get the paid ones.
<img src="https://user-images.githubusercontent.com/77539/87448384-2606b800-c5d2-11ea-9a6d-22a6c0332950.png" width="300px" />

6) Confirm that the block has a new `Upgrade` button in its nav menu.

<img src="https://user-images.githubusercontent.com/77539/87448697-8ac21280-c5d2-11ea-8f9b-1731bb423e09.png" width="400px" />

7) Confirm you see the tooltip

<img src="https://user-images.githubusercontent.com/77539/87448715-91508a00-c5d2-11ea-9710-2ecc87a93980.png" width="400px" />

8) Confirm that the button redirects to the checkout page.

9) Switch to a paid site.
10) Confirm that the `Upgrade` button doesn't appear in the block nav menu.

11) Since this PR creates a new `getUpgradeUrl()` helper and changes the code in the Upgrade nudge, it's a good idea to check its functionality. Just insert a `video` block and confirm that the Nudge shows as expected.

<img src="https://user-images.githubusercontent.com/77539/87470155-c371e400-c5f2-11ea-9fac-1b84bf6d637e.png" width="500px" />



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
