### PR TITLE
Tweetstorms: Disable the Unroll button when there's no url.

### DIFF
--- a/extensions/blocks/gathering-tweetstorms/editor.js
+++ b/extensions/blocks/gathering-tweetstorms/editor.js
@@ -51,7 +51,7 @@ const addTweetstormToTweets = blockSettings => {
 									'jetpack'
 								) }
 								showTooltip={ true }
-								disabled={ isGatheringStorm }
+								disabled={ isGatheringStorm || ! url }
 							>
 								{ __( 'Unroll', 'jetpack' ) }
 							</Button>


### PR DESCRIPTION
The Unroll button is clickable (though it does nothing) when a URL hasn't been embedded in the Twitter embed block. This can be slightly confusing if the author pastes a URL into the block, and then clicks Unroll: the URL isn't available as an attribute until after the Embed button has been clicked.

This PR fixes that by setting it to be disabled when there's no URL available.

<img width="619" alt="" src="https://user-images.githubusercontent.com/352291/87486741-4a6c9e00-c67f-11ea-9565-c3dbdce3ff58.png">

#### Changes proposed in this Pull Request:
* Disable the Gathering Tweetstorms Unroll button when there's no URL entered.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Use the block inserter to add a Twitter embed.
* Note that the Unroll button is disabled.
* Enter a Tweet URL, and click Embed.
* Note that the Unroll button is enabled.

#### Proposed changelog entry for your changes:
* Gathering Tweetstorms: Don't enable the Unroll button until after a Twitter URL has been entered and verified.
