### PR TITLE
Contact Form: fix radio and checkbox alignment on frontend

### DIFF
--- a/modules/contact-form/css/grunion.css
+++ b/modules/contact-form/css/grunion.css
@@ -36,8 +36,12 @@
 .contact-form input[type='radio'],
 .contact-form input[type='checkbox'] {
 	float: none;
-	margin-bottom: 1em;
-	vertical-align: middle;
+	margin: 0 0.75rem 0 5px;
+}
+
+.contact-form input[type='checkbox'] {
+	top: 0;
+	margin-left: 0;
 }
 
 .contact-form label {
@@ -53,7 +57,8 @@
 	margin-bottom: 0.25em;
 	float: none;
 	font-weight: normal;
-	display: inline-block;
+	display: inline-flex;
+	align-items: center;
 }
 
 .contact-form .grunion-field-checkbox-wrap,


### PR DESCRIPTION
Fixes #16128

#### Changes proposed in this Pull Request:
* Improve alignment of radio and checkbox items within contact forms

**Notes:** 
* These CSS tweaks use `inline-flex`. Despite IE11 not supporting all flex has to offer it works well in IE11 for me.
* Tested across Firefox, Safari, Chrome, Edge, and IE11, using the 2020, 2019 and 2017 themes; 

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
1. Create post adding Jetpack form and some radio buttons and checkboxes
2. Save post and view on the frontend to confirm misalignment of radios and checkboxes
3. Checkout this branch and build client files
4. Refresh the post page on the frontend and confirm field alignments

#### Proposed changelog entry for your changes:
* Fix alignment of radio and checkbox items within contact forms
