### PR TITLE
Button Block: Set missing text color in AMP mode 

### DIFF
--- a/extensions/blocks/button/button.php
+++ b/extensions/blocks/button/button.php
@@ -38,6 +38,10 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
 function render_block( $attributes, $content ) {
 	$save_in_post_content = get_attribute( $attributes, 'saveInPostContent' );
 
+	if ( class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request() ) {
+		Jetpack_Gutenberg::load_styles_as_required( FEATURE_NAME );
+	}
+
 	if ( $save_in_post_content || ! class_exists( 'DOMDocument' ) ) {
 		return $content;
 	}

--- a/extensions/blocks/button/view.js
+++ b/extensions/blocks/button/view.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './view.scss';

--- a/extensions/blocks/button/view.scss
+++ b/extensions/blocks/button/view.scss
@@ -1,0 +1,3 @@
+.amp-wp-article .wp-block-jetpack-button {
+	color: #ffffff;
+}


### PR DESCRIPTION
Fixes #15697

#### Changes proposed in this Pull Request:
* Set a default text color for Jetpack button block in AMP mode (without Gutenberg plugin)

This change only addresses the lack of a default text color for Jetpack buttons that is visible against the default button background color when in an AMP view. Given updating the AMP styles from theme color schemes will be much more involved, this simple fix could be shipped in the meantime.

*Note:*
* Custom colors for the background and text get applied as inline styles which in turn get imported to the AMP custom CSS
* Default options from color schemes apply CSS classes which come from themes and so aren't imported to the AMP CSS
  e.g. `.has-accent-background-color`
* Gradient colors are imported into the resulting AMP CSS

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Install and activate the AMP plugin, deactivate Gutenberg plugin, switch to Twenty Twenty theme
2. Create a new post adding a Revue block to it
3. View that post in an AMP view and confirm missing text color
4. Checkout this branch and build files
5. Refresh the post in AMP mode and confirm white text

#### Before
<img width="348" alt="Screen Shot 2020-07-15 at 7 24 00 pm" src="https://user-images.githubusercontent.com/60436221/87528409-d5c24f80-c6d0-11ea-95bf-4f68c625acef.png">

#### After
<img width="353" alt="Screen Shot 2020-07-15 at 7 24 14 pm" src="https://user-images.githubusercontent.com/60436221/87528431-da870380-c6d0-11ea-91e3-6888188362a3.png">



#### Proposed changelog entry for your changes:
* Add default button text color in AMP mode
