### PR TITLE
Likes: Resolve warning for a non-post object

### DIFF
--- a/modules/likes/jetpack-likes-settings.php
+++ b/modules/likes/jetpack-likes-settings.php
@@ -305,7 +305,7 @@ class Jetpack_Likes_Settings {
 
 			// Single post including custom post types
 			if ( is_single() ) {
-				if ( ! $this->is_single_post_enabled( $post->post_type ) ) {
+				if ( ! $this->is_single_post_enabled( ( $post instanceof WP_Post ) ? $post->post_type : 'post' ) ) {
 					$enabled = false;
 				}
 


### PR DESCRIPTION
Resolves:
```
E_NOTICE: /home/public_html/wp-content/plugins/jetpack/modules/likes/jetpack-likes-settings.php:308 - Trying to get property 'post_type' of non-object
```

`is_single` will return `true` if the post object is null, so it's possible to get to this point on a null post. This will check for the type of var of `$post` before assuming it is a `WP_Post`.

#### Changes proposed in this Pull Request:
* Checks if the output of `get_post` is a WP_Post object before assuming so.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
* Unsure how to actually duplicate it; fixing based on the logs.
*

#### Proposed changelog entry for your changes:
* Likes: Fixed a potential PHP notice.
