### PR TITLE
Admin Page: Move to Core translation functions -- PART 2

### DIFF
--- a/_inc/client/components/apps-card/index.jsx
+++ b/_inc/client/components/apps-card/index.jsx
@@ -5,14 +5,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import Button from 'components/button';
-import analytics from 'lib/analytics';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Card from 'components/card';
 import { imagePath } from 'constants/urls';
 import { updateSettings, appsCardDismissed } from 'state/settings';
 import { arePromotionsActive, userCanManageOptions } from 'state/initial-state';
@@ -64,12 +64,13 @@ class AppsCard extends React.Component {
 
 					<div className="jp-apps-card__description">
 						<h3 className="jp-apps-card__header">
-							{ __( 'Get WordPress Apps for every device' ) }
+							{ __( 'Get WordPress Apps for every device', 'jetpack' ) }
 						</h3>
 
 						<p className="jp-apps-card__paragraph">
 							{ __(
-								'Manage all your sites from a single dashboard: publish content, track stats, moderate comments, and so much more from anywhere in the world.'
+								'Manage all your sites from a single dashboard: publish content, track stats, moderate comments, and so much more from anywhere in the world.',
+								'jetpack'
 							) }
 						</p>
 
@@ -78,7 +79,7 @@ class AppsCard extends React.Component {
 							onClick={ this.trackDownloadClick }
 							href="https://apps.wordpress.com/get?utm_source=jpdash&utm_medium=cta&utm_campaign=getappscard"
 						>
-							{ __( 'Download the free apps' ) }
+							{ __( 'Download the free apps', 'jetpack' ) }
 						</Button>
 					</div>
 				</Card>

--- a/_inc/client/components/chart/index.jsx
+++ b/_inc/client/components/chart/index.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { noop, throttle } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -121,9 +121,7 @@ export default class ModuleChart extends React.Component {
 			emptyChart = (
 				<div className="dops-chart__empty">
 					<span className="dops-chart__empty_notice">
-						{ __( 'No activity this period', {
-							context: 'Notice in the empty statistics chart',
-						} ) }
+						{ _x( 'No activity this period', 'Notice in the empty statistics chart', 'jetpack' ) }
 					</span>
 				</div>
 			);

--- a/_inc/client/components/connect-button/index.jsx
+++ b/_inc/client/components/connect-button/index.jsx
@@ -4,14 +4,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import Button from 'components/button';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import getRedirectUrl from 'lib/jp-redirect';
 import {
 	getSiteConnectionStatus as _getSiteConnectionStatus,
 	disconnectSite,
@@ -92,7 +93,7 @@ export class ConnectButton extends React.Component {
 						onClick={ this.props.unlinkUser }
 						disabled={ this.props.isUnlinking }
 					>
-						{ this.props.connectLegend || __( 'Unlink me from WordPress.com' ) }
+						{ this.props.connectLegend || __( 'Unlink me from WordPress.com', 'jetpack' ) }
 					</a>
 				</div>
 			);
@@ -109,7 +110,7 @@ export class ConnectButton extends React.Component {
 				href: connectUrl,
 				disabled: this.props.fetchingConnectUrl || this.props.isAuthorizing,
 			},
-			connectLegend = this.props.connectLegend || __( 'Link to WordPress.com' );
+			connectLegend = this.props.connectLegend || __( 'Link to WordPress.com', 'jetpack' );
 
 		// Secondary users in-place connection flow
 
@@ -149,7 +150,7 @@ export class ConnectButton extends React.Component {
 					onClick={ this.handleOpenModal }
 					disabled={ this.props.isDisconnecting }
 				>
-					{ this.props.connectLegend || __( 'Manage site connection' ) }
+					{ this.props.connectLegend || __( 'Manage site connection', 'jetpack' ) }
 				</a>
 			);
 		}
@@ -164,7 +165,7 @@ export class ConnectButton extends React.Component {
 				href: connectUrl,
 				disabled: this.props.fetchingConnectUrl,
 			},
-			connectLegend = this.props.connectLegend || __( 'Set up Jetpack' );
+			connectLegend = this.props.connectLegend || __( 'Set up Jetpack', 'jetpack' );
 
 		return this.props.asLink ? (
 			<a { ...buttonProps }>{ connectLegend }</a>
@@ -178,25 +179,26 @@ export class ConnectButton extends React.Component {
 			<div>
 				{ ! this.props.isSiteConnected && (
 					<p className="jp-banner__tos-blurb">
-						{ __(
-							'By clicking the button below, you agree to our {{tosLink}}Terms of Service{{/tosLink}} and to {{shareDetailsLink}}share details{{/shareDetailsLink}} with WordPress.com.',
+						{ jetpackCreateInterpolateElement(
+							__(
+								'By clicking the button below, you agree to our <tosLink>Terms of Service</tosLink> and to <shareDetailsLink>share details</shareDetailsLink> with WordPress.com.',
+								'jetpack'
+							),
 							{
-								components: {
-									tosLink: (
-										<a
-											href={ getRedirectUrl( 'wpcom-tos' ) }
-											rel="noopener noreferrer"
-											target="_blank"
-										/>
-									),
-									shareDetailsLink: (
-										<a
-											href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
-											rel="noopener noreferrer"
-											target="_blank"
-										/>
-									),
-								},
+								tosLink: (
+									<a
+										href={ getRedirectUrl( 'wpcom-tos' ) }
+										rel="noopener noreferrer"
+										target="_blank"
+									/>
+								),
+								shareDetailsLink: (
+									<a
+										href={ getRedirectUrl( 'jetpack-support-what-data-does-jetpack-sync' ) }
+										rel="noopener noreferrer"
+										target="_blank"
+									/>
+								),
 							}
 						) }
 					</p>

--- a/_inc/client/components/dash-item/index.jsx
+++ b/_inc/client/components/dash-item/index.jsx
@@ -5,25 +5,25 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import SimpleNotice from 'components/notice';
-import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
 import { includes } from 'lodash';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import analytics from 'lib/analytics';
+import Button from 'components/button';
 import Card from 'components/card';
-import SectionHeader from 'components/section-header';
-import SupportInfo from 'components/support-info';
-import { ModuleToggle } from 'components/module-toggle';
-import { isDevMode } from 'state/connection';
 import { getModule as _getModule } from 'state/modules';
-import ProStatus from 'pro-status';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
+import { isDevMode } from 'state/connection';
+import { ModuleToggle } from 'components/module-toggle';
+import ProStatus from 'pro-status';
+import SectionHeader from 'components/section-header';
+import SimpleNotice from 'components/notice';
+import SupportInfo from 'components/support-info';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 export class DashItem extends Component {
 	static propTypes = {
@@ -108,7 +108,9 @@ export class DashItem extends Component {
 					);
 				}
 				if ( 'is-working' === this.props.status ) {
-					toggle = <span className="jp-dash-item__active-label">{ __( 'Active' ) }</span>;
+					toggle = (
+						<span className="jp-dash-item__active-label">{ __( 'Active', 'jetpack' ) }</span>
+					);
 				}
 			}
 
@@ -120,9 +122,11 @@ export class DashItem extends Component {
 		if ( this.props.pro && ! this.props.isDevMode ) {
 			proButton = (
 				<Button onClick={ this.trackPaidBtnClick } compact={ true } href="#/plans">
-					{ __( 'Paid', {
-						context: 'Short label appearing near a paid feature configuration block.',
-					} ) }
+					{ _x(
+						'Paid',
+						'Short label appearing near a paid feature configuration block.',
+						'jetpack'
+					) }
 				</Button>
 			);
 

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -4,13 +4,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
+import DevCard from 'components/dev-card';
+import getRedirectUrl from 'lib/jp-redirect';
 import {
 	isDevVersion as _isDevVersion,
 	getCurrentVersion,
@@ -18,8 +20,6 @@ import {
 	getSiteAdminUrl,
 } from 'state/initial-state';
 import { isInIdentityCrisis, getSiteConnectionStatus } from 'state/connection';
-import { canDisplayDevCard, enableDevCard, resetOptions } from 'state/dev-version';
-import DevCard from 'components/dev-card';
 import onKeyDownCallback from 'utils/onkeydown-callback';
 
 const smoothScroll = () => {
@@ -34,7 +34,7 @@ export class Footer extends React.Component {
 	static displayName = 'Footer';
 
 	resetOnClick = () => {
-		if ( window.confirm( __( 'This will reset all Jetpack options, are you sure?' ) ) ) {
+		if ( window.confirm( __( 'This will reset all Jetpack options, are you sure?', 'jetpack' ) ) ) {
 			this.props.resetOptions();
 		}
 	};
@@ -98,7 +98,7 @@ export class Footer extends React.Component {
 							onClick={ this.resetOnClick }
 							className="jp-footer__link"
 						>
-							{ __( 'Reset Options (dev only)', { context: 'Navigation item.' } ) }
+							{ _x( 'Reset Options (dev only)', 'Navigation item.', 'jetpack' ) }
 						</a>
 					</li>
 				);
@@ -113,12 +113,17 @@ export class Footer extends React.Component {
 						<a
 							onClick={ this.trackModulesClick }
 							href={ this.props.siteAdminUrl + 'admin.php?page=jetpack_modules' }
-							title={ __( 'Access the full list of Jetpack modules available on your site.' ) }
+							title={ __(
+								'Access the full list of Jetpack modules available on your site.',
+								'jetpack'
+							) }
 							className="jp-footer__link"
 						>
-							{ __( 'Modules', {
-								context: 'Navigation item. Noun. Links to a list of modules for Jetpack.',
-							} ) }
+							{ _x(
+								'Modules',
+								'Navigation item. Noun. Links to a list of modules for Jetpack.',
+								'jetpack'
+							) }
 						</a>
 					</li>
 				);
@@ -132,12 +137,14 @@ export class Footer extends React.Component {
 						<a
 							onClick={ this.trackDebugClick }
 							href={ this.props.siteAdminUrl + 'admin.php?page=jetpack-debugger' }
-							title={ __( 'Test your site’s compatibility with Jetpack.' ) }
+							title={ __( 'Test your site’s compatibility with Jetpack.', 'jetpack' ) }
 							className="jp-footer__link"
 						>
-							{ __( 'Debug', {
-								context: 'Navigation item. Noun. Links to a debugger tool for Jetpack.',
-							} ) }
+							{ _x(
+								'Debug',
+								'Navigation item. Noun. Links to a debugger tool for Jetpack.',
+								'jetpack'
+							) }
 						</a>
 					</li>
 				);
@@ -155,7 +162,7 @@ export class Footer extends React.Component {
 							onClick={ this.props.enableDevCard }
 							className="jp-footer__link"
 						>
-							{ __( 'Dev Tools', { context: 'Navigation item.' } ) }
+							{ _x( 'Dev Tools', 'Navigation item.', 'jetpack' ) }
 						</a>
 					</li>
 				);
@@ -190,7 +197,7 @@ export class Footer extends React.Component {
 							enableBackground="new 0 0 935 38.2"
 							aria-labelledby="a8c-svg-title"
 						>
-							<title id="a8c-svg-title">{ __( 'An Automattic Airline' ) }</title>
+							<title id="a8c-svg-title">{ __( 'An Automattic Airline', 'jetpack' ) }</title>
 							<path d="M317.1 38.2c-12.6 0-20.7-9.1-20.7-18.5v-1.2c0-9.6 8.2-18.5 20.7-18.5 12.6 0 20.8 8.9 20.8 18.5v1.2C337.9 29.1 329.7 38.2 317.1 38.2zM331.2 18.6c0-6.9-5-13-14.1-13s-14 6.1-14 13v0.9c0 6.9 5 13.1 14 13.1s14.1-6.2 14.1-13.1V18.6zM175 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7L157 1.3h5.5L182 36.8H175zM159.7 8.2L152 23.1h15.7L159.7 8.2zM212.4 38.2c-12.7 0-18.7-6.9-18.7-16.2V1.3h6.6v20.9c0 6.6 4.3 10.5 12.5 10.5 8.4 0 11.9-3.9 11.9-10.5V1.3h6.7V22C231.4 30.8 225.8 38.2 212.4 38.2zM268.6 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H268.6zM397.3 36.8V8.7l-1.8 3.1 -14.9 25h-3.3l-14.7-25 -1.8-3.1v28.1h-6.5V1.3h9.2l14 24.4 1.7 3 1.7-3 13.9-24.4h9.1v35.5H397.3zM454.4 36.8l-4.7-8.8h-20.9l-4.5 8.8h-7l19.2-35.5h5.5l19.5 35.5H454.4zM439.1 8.2l-7.7 14.9h15.7L439.1 8.2zM488.4 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H488.4zM537.3 6.8v30h-6.7v-30h-15.5V1.3h37.7v5.5H537.3zM569.3 36.8V4.6c2.7 0 3.7-1.4 3.7-3.4h2.8v35.5L569.3 36.8 569.3 36.8zM628 11.3c-3.2-2.9-7.9-5.7-14.2-5.7 -9.5 0-14.8 6.5-14.8 13.3v0.7c0 6.7 5.4 13 15.3 13 5.9 0 10.8-2.8 13.9-5.7l4 4.2c-3.9 3.8-10.5 7.1-18.3 7.1 -13.4 0-21.6-8.7-21.6-18.3v-1.2c0-9.6 8.9-18.7 21.9-18.7 7.5 0 14.3 3.1 18 7.1L628 11.3zM321.5 12.4c1.2 0.8 1.5 2.4 0.8 3.6l-6.1 9.4c-0.8 1.2-2.4 1.6-3.6 0.8l0 0c-1.2-0.8-1.5-2.4-0.8-3.6l6.1-9.4C318.7 11.9 320.3 11.6 321.5 12.4L321.5 12.4z" />
 							<path d="M37.5 36.7l-4.7-8.9H11.7l-4.6 8.9H0L19.4 0.8H25l19.7 35.9H37.5zM22 7.8l-7.8 15.1h15.9L22 7.8zM82.8 36.7l-23.3-24 -2.3-2.5v26.6h-6.7v-36H57l22.6 24 2.3 2.6V0.8h6.7v35.9H82.8z" />
 							<path d="M719.9 37l-4.8-8.9H694l-4.6 8.9h-7.1l19.5-36h5.6l19.8 36H719.9zM704.4 8l-7.8 15.1h15.9L704.4 8zM733 37V1h6.8v36H733zM781 37c-1.8 0-2.6-2.5-2.9-5.8l-0.2-3.7c-0.2-3.6-1.7-5.1-8.4-5.1h-12.8V37H750V1h19.6c10.8 0 15.7 4.3 15.7 9.9 0 3.9-2 7.7-9 9 7 0.5 8.5 3.7 8.6 7.9l0.1 3c0.1 2.5 0.5 4.3 2.2 6.1V37H781zM778.5 11.8c0-2.6-2.1-5.1-7.9-5.1h-13.8v10.8h14.4c5 0 7.3-2.4 7.3-5.2V11.8zM794.8 37V1h6.8v30.4h28.2V37H794.8zM836.7 37V1h6.8v36H836.7zM886.2 37l-23.4-24.1 -2.3-2.5V37h-6.8V1h6.5l22.7 24.1 2.3 2.6V1h6.8v36H886.2zM902.3 37V1H935v5.6h-26v9.2h20v5.5h-20v10.1h26V37H902.3z" />
@@ -205,9 +212,9 @@ export class Footer extends React.Component {
 							target="_blank"
 							rel="noopener noreferrer"
 							className="jp-footer__link"
-							title={ __( 'Jetpack version' ) }
+							title={ __( 'Jetpack version', 'jetpack' ) }
 						>
-							{ version ? __( 'Jetpack version %(version)s', { args: { version } } ) : 'Jetpack' }
+							{ version ? sprintf( __( 'Jetpack version %s', 'jetpack' ), version ) : 'Jetpack' }
 						</a>
 					</li>
 					<li className="jp-footer__link-item">
@@ -215,9 +222,9 @@ export class Footer extends React.Component {
 							onClick={ this.trackAboutClick }
 							href={ aboutPageUrl }
 							className="jp-footer__link"
-							title={ __( 'About Jetpack' ) }
+							title={ __( 'About Jetpack', 'jetpack' ) }
 						>
-							{ __( 'About', { context: 'Link to learn more about Jetpack.' } ) }
+							{ _x( 'About', 'Link to learn more about Jetpack.', 'jetpack' ) }
 						</a>
 					</li>
 					<li className="jp-footer__link-item">
@@ -226,10 +233,10 @@ export class Footer extends React.Component {
 							href={ getRedirectUrl( 'wpcom-tos' ) }
 							target="_blank"
 							rel="noopener noreferrer"
-							title={ __( 'WordPress.com Terms of Service' ) }
+							title={ __( 'WordPress.com Terms of Service', 'jetpack' ) }
 							className="jp-footer__link"
 						>
-							{ __( 'Terms', { context: 'Shorthand for Terms of Service.' } ) }
+							{ _x( 'Terms', 'Shorthand for Terms of Service.', 'jetpack' ) }
 						</a>
 					</li>
 					<li className="jp-footer__link-item">
@@ -237,10 +244,10 @@ export class Footer extends React.Component {
 							onClick={ this.trackPrivacyClick }
 							href={ privacyUrl }
 							rel="noopener noreferrer"
-							title={ __( "Automattic's Privacy Policy" ) }
+							title={ __( "Automattic's Privacy Policy", 'jetpack' ) }
 							className="jp-footer__link"
 						>
-							{ __( 'Privacy', { context: 'Shorthand for Privacy Policy.' } ) }
+							{ _x( 'Privacy', 'Shorthand for Privacy Policy.', 'jetpack' ) }
 						</a>
 					</li>
 					{ maybeShowModules() }

--- a/_inc/client/components/forms/index.jsx
+++ b/_inc/client/components/forms/index.jsx
@@ -4,7 +4,11 @@
 import React from 'react';
 import classNames from 'classnames';
 import { isEmpty, forOwn, omit } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
 
@@ -153,7 +157,7 @@ export class FormButton extends React.Component {
 	};
 
 	getDefaultButtonAction = () => {
-		return this.props.isSubmitting ? __( 'Saving…' ) : __( 'Save Settings' );
+		return this.props.isSubmitting ? __( 'Saving…', 'jetpack' ) : __( 'Save Settings', 'jetpack' );
 	};
 
 	render() {

--- a/_inc/client/components/jetpack-dialogue-modern/index.jsx
+++ b/_inc/client/components/jetpack-dialogue-modern/index.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
 import { noop } from 'lodash';
 import classNames from 'classnames';
 

--- a/_inc/client/components/jetpack-dialogue/index.jsx
+++ b/_inc/client/components/jetpack-dialogue/index.jsx
@@ -3,14 +3,14 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import { noop } from 'lodash';
 import classNames from 'classnames';
+import { noop } from 'lodash';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import Gridicon from 'components/gridicon';
 import onKeyDownCallback from 'utils/onkeydown-callback';
 import { imagePath } from 'constants/urls';
@@ -49,14 +49,14 @@ class JetpackDialogue extends Component {
 					src={ imagePath + 'stars-full.svg' }
 					width="60"
 					height="60"
-					alt={ __( 'Stars' ) }
+					alt={ __( 'Stars', 'jetpack' ) }
 					className="jp-dialogue-full__svg-stars"
 				/>
 				<img
 					src={ imagePath + 'jupiter.svg' }
 					width="50"
 					height="100"
-					alt={ __( 'Jupiter' ) }
+					alt={ __( 'Jupiter', 'jetpack' ) }
 					className="jp-dialogue-full__svg-jupiter"
 				/>
 

--- a/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
+++ b/_inc/client/components/jetpack-notices/feedback-dash-request.jsx
@@ -3,9 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action.jsx';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -16,6 +14,8 @@ import {
 	dismissJetpackNotice,
 } from 'state/jetpack-notices';
 import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
+import NoticeAction from 'components/notice/notice-action.jsx';
+import SimpleNotice from 'components/notice';
 
 class FeedbackDashRequest extends React.Component {
 	static displayName = 'FeedbackDashRequest';
@@ -35,9 +35,9 @@ class FeedbackDashRequest extends React.Component {
 					className="jp-dash-item__feedback-request"
 					status="is-basic"
 					onDismissClick={ this.props.dismissNotice }
-					text={ __( 'What would you like to see on your Jetpack Dashboard?' ) }
+					text={ __( 'What would you like to see on your Jetpack Dashboard?', 'jetpack' ) }
 				>
-					<NoticeAction href={ supportURl }>{ __( 'Let us know!' ) }</NoticeAction>
+					<NoticeAction href={ supportURl }>{ __( 'Let us know!', 'jetpack' ) }</NoticeAction>
 				</SimpleNotice>
 			</div>
 		);

--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -4,16 +4,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import SimpleNotice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action.jsx';
-import { translate as __ } from 'i18n-calypso';
-import NoticesList from 'components/global-notices';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import JetpackStateNotices from './state-notices';
+import ConnectionBanner from 'components/connection-banner';
+import DismissableNotices from './dismissable';
+import getRedirectUrl from 'lib/jp-redirect';
 import {
 	getSiteConnectionStatus,
 	getSiteDevMode,
@@ -29,11 +28,13 @@ import {
 	getConnectionErrors,
 } from 'state/initial-state';
 import { getSiteDataErrors } from 'state/site';
-import DismissableNotices from './dismissable';
-import ConnectionBanner from 'components/connection-banner';
 import { JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
-import PlanConflictWarning from './plan-conflict-warning';
+import JetpackStateNotices from './state-notices';
 import JetpackConnectionErrors from './jetpack-connection-errors';
+import NoticeAction from 'components/notice/notice-action.jsx';
+import NoticesList from 'components/global-notices';
+import PlanConflictWarning from './plan-conflict-warning';
+import SimpleNotice from 'components/notice';
 
 export class DevVersionNotice extends React.Component {
 	static displayName = 'DevVersionNotice';
@@ -43,10 +44,10 @@ export class DevVersionNotice extends React.Component {
 			return (
 				<SimpleNotice
 					showDismiss={ false }
-					text={ __( 'You are currently running a development version of Jetpack.' ) }
+					text={ __( 'You are currently running a development version of Jetpack.', 'jetpack' ) }
 				>
 					<NoticeAction href={ JETPACK_CONTACT_BETA_SUPPORT }>
-						{ __( 'Submit Beta feedback' ) }
+						{ __( 'Submit Beta feedback', 'jetpack' ) }
 					</NoticeAction>
 				</SimpleNotice>
 			);
@@ -68,14 +69,16 @@ export class StagingSiteNotice extends React.Component {
 		if ( this.props.isStaging && ! this.props.isInIdentityCrisis ) {
 			const stagingSiteSupportLink = getRedirectUrl( 'jetpack-support-staging-sites' ),
 				props = {
-					text: __( 'You are running Jetpack on a staging server.' ),
+					text: __( 'You are running Jetpack on a staging server.', 'jetpack' ),
 					status: 'is-basic',
 					showDismiss: false,
 				};
 
 			return (
 				<SimpleNotice { ...props }>
-					<NoticeAction href={ stagingSiteSupportLink }>{ __( 'More Info' ) }</NoticeAction>
+					<NoticeAction href={ stagingSiteSupportLink }>
+						{ __( 'More Info', 'jetpack' ) }
+					</NoticeAction>
 				</SimpleNotice>
 			);
 		}
@@ -98,53 +101,43 @@ export class DevModeNotice extends React.Component {
 				reasons = [];
 
 			if ( devMode.filter ) {
-				reasons.push(
-					__( '{{li}}The jetpack_development_mode filter is active{{/li}}', {
-						components: {
-							li: <li />,
-						},
-					} )
-				);
+				reasons.push( __( 'The jetpack_development_mode filter is active', 'jetpack' ) );
 			}
 			if ( devMode.constant ) {
-				reasons.push(
-					__( '{{li}}The JETPACK_DEV_DEBUG constant is defined{{/li}}', {
-						components: {
-							li: <li />,
-						},
-					} )
-				);
+				reasons.push( __( 'The JETPACK_DEV_DEBUG constant is defined', 'jetpack' ) );
 			}
 			if ( devMode.url ) {
-				reasons.push(
-					__( '{{li}}Your site URL lacks a dot (e.g. http://localhost){{/li}}', {
-						components: {
-							li: <li />,
-						},
-					} )
-				);
+				reasons.push( __( 'Your site URL lacks a dot (e.g. http://localhost)', 'jetpack' ) );
 			}
 
-			const text = __(
-				'Currently in {{a}}Development Mode{{/a}} (some features are disabled) because: {{reasons/}}',
+			const text = jetpackCreateInterpolateElement(
+				/* translators: reasons is an unordered list of reasons why a site may be in Development mode. */
+				__(
+					'Currently in <a>Development Mode</a> (some features are disabled) because: <reasons/>',
+					'jetpack'
+				),
 				{
-					components: {
-						a: (
-							<a
-								href={ getRedirectUrl( 'jetpack-support-development-mode' ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						reasons: <ul>{ reasons }</ul>,
-					},
+					a: (
+						<a
+							href={ getRedirectUrl( 'jetpack-support-development-mode' ) }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
+					reasons: (
+						<ul>
+							{ reasons.map( ( reason, i ) => {
+								return <li key={ i }>{ reason }</li>;
+							} ) }
+						</ul>
+					),
 				}
 			);
 
 			return (
 				<SimpleNotice showDismiss={ false } status="is-info" text={ text }>
 					<NoticeAction href={ getRedirectUrl( 'jetpack-support-development-mode' ) }>
-						{ __( 'Learn More' ) }
+						{ __( 'Learn More', 'jetpack' ) }
 					</NoticeAction>
 				</SimpleNotice>
 			);
@@ -168,8 +161,11 @@ export class UserUnlinked extends React.Component {
 				<div className="jp-unlinked-notice">
 					<ConnectionBanner
 						title={ __(
-							'Jetpack is powering your site, but to access all of its features you’ll need to connect your account to WordPress.com.'
+							'Jetpack is powering your site, but to access all of its features you’ll need to connect your account to WordPress.com.',
+							'jetpack'
 						) }
+						callToAction={ __( 'Create account', 'jetpack' ) }
+						href={ `${ this.props.connectUrl }&from=unlinked-user-connect` }
 						icon="my-sites"
 						className="is-jetpack-info"
 						from="unlinked-user-connect"
@@ -231,7 +227,8 @@ class JetpackNotices extends React.Component {
 						showDismiss={ false }
 						status="is-warning"
 						text={ __(
-							'This site is not connected to WordPress.com. Please ask the site administrator to connect.'
+							'This site is not connected to WordPress.com. Please ask the site administrator to connect.',
+							'jetpack'
 						) }
 					/>
 				) }

--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -2,20 +2,18 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-
-import SimpleNotice from 'components/notice';
 import NoticeActionDisconnect from './notice-action-disconnect';
+import SimpleNotice from 'components/notice';
 
 export class ErrorNoticeCycleConnection extends React.Component {
 	static defaultProps = {
-		text: __( 'Connection Error, please reconnect.' ),
+		text: __( 'Connection Error, please reconnect.', 'jetpack' ),
 	};
 
 	static propTypes = {
@@ -32,7 +30,7 @@ export class ErrorNoticeCycleConnection extends React.Component {
 				icon={ 'link-break' }
 			>
 				<NoticeActionDisconnect errorCode={ this.props.errorCode }>
-					{ __( 'Reconnect' ) }
+					{ __( 'Reconnect', 'jetpack' ) }
 				</NoticeActionDisconnect>
 			</SimpleNotice>
 		);

--- a/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
+++ b/_inc/client/components/jetpack-notices/plan-conflict-warning.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 import { withRouter } from 'react-router-dom';
 
 /**
@@ -61,26 +61,24 @@ export function PlanConflictWarning( { activeSitePurchases, location: { pathname
 		return null;
 	}
 
-	let featureName = __( 'daily backups' );
+	let featureName = __( 'daily backups', 'jetpack' );
 	if ( 'jetpack_business' === sitePlanPurchase.product_slug ) {
-		featureName = __( 'real-time backups' );
+		featureName = __( 'real-time backups', 'jetpack' );
 	}
 
 	return (
 		<SimpleNotice
 			status="is-warning"
 			showDismiss={ false }
-			text={ __(
-				'Your %(planName)s Plan includes %(featureName)s. ' +
-					'Looks like you also purchased the %(productName)s product. ' +
-					'Consider removing %(productName)s.',
-				{
-					args: {
-						featureName,
-						planName: sitePlanPurchase.product_name,
-						productName: backupPurchase.product_name,
-					},
-				}
+			text={ sprintf(
+				/* translators: %1$s: feature, such as "daily backups". %2$s: Plan name, such as "Jetpack Premium". %3$s: Product name, such as "Jetpack Backups". */
+				__(
+					'Your %2$s Plan includes %1$s. Looks like you also purchased the %3$s product. Consider removing %3$s.',
+					'jetpack'
+				),
+				featureName,
+				sitePlanPurchase.product_name,
+				backupPurchase.product_name
 			) }
 		/>
 	);

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -3,9 +3,8 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import SimpleNotice from 'components/notice';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,7 +16,9 @@ import {
 	getJetpackStateNoticesErrorDescription,
 	getJetpackStateNoticesMessageContent,
 } from 'state/jetpack-notices';
+import getRedirectUrl from 'lib/jp-redirect';
 import NoticeAction from 'components/notice/notice-action.jsx';
+import SimpleNotice from 'components/notice';
 import UpgradeNoticeContent from 'components/upgrade-notice-content';
 
 class JetpackStateNotices extends React.Component {
@@ -37,76 +38,73 @@ class JetpackStateNotices extends React.Component {
 
 		switch ( key ) {
 			case 'cheatin':
-				message = __( "Cheatin' uh?" );
+				message = __( "Cheatin' uh?", 'jetpack' );
 				break;
 			case 'access_denied':
-				message = __(
-					'{{p}}Would you mind telling us why you did not complete the Jetpack connection in this {{a}}2 question survey{{/a}}?{{/p}}' +
-						'{{p}}A Jetpack connection is required for our free security and traffic features to work.{{/p}}',
+				message = jetpackCreateInterpolateElement(
+					__(
+						'<p>Would you mind telling us why you did not complete the Jetpack connection in this <a>2 question survey</a>?</p><p>A Jetpack connection is required for our free security and traffic features to work.</p>',
+						'jetpack'
+					),
 					{
-						components: {
-							a: (
-								<a
-									href={ getRedirectUrl( 'jetpack-cancelled-connection' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							p: <p />,
-						},
+						a: (
+							<a
+								href={ getRedirectUrl( 'jetpack-cancelled-connection' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						p: <p />,
 					}
 				);
 				break;
 			case 'wrong_state':
 				message = __(
-					'You need to stay logged in to your WordPress blog while you authorize Jetpack.'
+					'You need to stay logged in to your WordPress blog while you authorize Jetpack.',
+					'jetpack'
 				);
 				break;
 			case 'invalid_client':
 				message = __(
-					'We had an issue connecting Jetpack; deactivate then reactivate the Jetpack plugin, then connect again.'
+					'We had an issue connecting Jetpack; deactivate then reactivate the Jetpack plugin, then connect again.',
+					'jetpack'
 				);
 				break;
 			case 'invalid_grant':
 				message = __(
-					'There was an issue connecting your Jetpack. Please click "Connect to WordPress.com" again.'
+					'There was an issue connecting your Jetpack. Please click "Connect to WordPress.com" again.',
+					'jetpack'
 				);
 				break;
 			case 'site_inaccessible':
 			case 'site_requires_authorization':
-				message = __(
-					'Your website needs to be publicly accessible to use Jetpack: %(error_key)s',
-					{
-						args: {
-							error_key: key,
-						},
-					}
+				message = sprintf(
+					/* translators: placeholder is an error code and message. */
+					__( 'Your website needs to be publicly accessible to use Jetpack: %s', 'jetpack' ),
+					key
 				);
 				break;
 			case 'site_blacklisted':
-				message = __(
-					"This site can't be connected to WordPress.com because it violates our {{a}}Terms of Service{{/a}}.",
+				message = jetpackCreateInterpolateElement(
+					__(
+						"This site can't be connected to WordPress.com because it violates our <a>Terms of Service</a>.",
+						'jetpack'
+					),
 					{
-						components: {
-							a: (
-								<a
-									href={ getRedirectUrl( 'wpcom-tos' ) }
-									rel="noopener noreferrer"
-									target="_blank"
-								/>
-							),
-						},
+						a: (
+							<a href={ getRedirectUrl( 'wpcom-tos' ) } rel="noopener noreferrer" target="_blank" />
+						),
 					}
 				);
 				break;
 			case 'not_public':
-				message = __(
-					'{{s}}Your Jetpack has a glitch.{{/s}} Connecting this site with WordPress.com is not possible. ' +
-						'This usually means your site is not publicly accessible (localhost).',
+				message = jetpackCreateInterpolateElement(
+					__(
+						'<s>Your Jetpack has a glitch.</s> Connecting this site with WordPress.com is not possible. This usually means your site is not publicly accessible (localhost).',
+						'jetpack'
+					),
 					{
-						components: {
-							s: <strong />,
-						},
+						s: <strong />,
 					}
 				);
 				break;
@@ -115,18 +113,19 @@ class JetpackStateNotices extends React.Component {
 			case 'wpcom_bad_response':
 			case 'wpcom_outage':
 				message = __(
-					'WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.'
+					'WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.',
+					'jetpack'
 				);
 				break;
 			case 'register_http_request_failed':
 			case 'token_http_request_failed':
-				message = __(
-					'Jetpack could not contact WordPress.com: %(error_key)s.  This usually means something is incorrectly configured on your web host.',
-					{
-						args: {
-							error_key: key,
-						},
-					}
+				message = sprintf(
+					/* translators: placeholder is an error code and message. */
+					__(
+						'Jetpack could not contact WordPress.com: %s.  This usually means something is incorrectly configured on your web host.',
+						'jetpack'
+					),
+					key
 				);
 				break;
 			case 'no_role':
@@ -160,16 +159,17 @@ class JetpackStateNotices extends React.Component {
 			case 'verify_secret_1_malformed':
 			case 'verify_secrets_missing':
 			case 'verify_secrets_mismatch':
-				message = __(
-					"{{s}}Your Jetpack has a glitch.{{/s}}  We're sorry for the inconvenience. " +
-						'Please try again later, if the issue continues please contact support with this message: %(error_key)s',
+				message = jetpackCreateInterpolateElement(
+					sprintf(
+						/* translators: placeholder is an error code and message. */
+						__(
+							'<s>Your Jetpack has a glitch.</s>  We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
+							'jetpack'
+						),
+						key
+					),
 					{
-						components: {
-							s: <strong />,
-						},
-						args: {
-							error_key: key,
-						},
+						s: <strong />,
 					}
 				);
 				break;
@@ -198,37 +198,40 @@ class JetpackStateNotices extends React.Component {
 		switch ( key ) {
 			// This is the message that is shown on first page load after a Jetpack plugin update.
 			case 'modules_activated':
-				message = __( 'Welcome to {{s}}Jetpack %(jetpack_version)s{{/s}}!', {
-					args: {
-						jetpack_version: this.props.currentVersion,
-					},
-					components: {
+				message = jetpackCreateInterpolateElement(
+					sprintf(
+						/* translators: placeholder is a version number, like 8.8. */
+						__( 'Welcome to <s>Jetpack %s</s>!', 'jetpack' ),
+						this.props.currentVersion
+					),
+					{
 						s: <strong />,
-					},
-				} );
+					}
+				);
 				break;
 			case 'already_authorized':
-				message = __( 'Your Jetpack is already connected.' );
+				message = __( 'Your Jetpack is already connected.', 'jetpack' );
 				status = 'is-success';
 				break;
 			case 'authorized':
-				message = __( "You're fueled up and ready to go, Jetpack is now active." );
+				message = __( "You're fueled up and ready to go, Jetpack is now active.", 'jetpack' );
 				status = 'is-success';
 				break;
 			case 'linked':
-				message = __( "You're fueled up and ready to go." );
+				message = __( "You're fueled up and ready to go.", 'jetpack' );
 				status = 'is-success';
 				break;
 			case 'protect_misconfigured_ip':
 				message = __(
-					'Your server is misconfigured, which means that Jetpack Protect is unable to effectively protect your site.'
+					'Your server is misconfigured, which means that Jetpack Protect is unable to effectively protect your site.',
+					'jetpack'
 				);
 				status = 'is-info';
 				action = (
 					<NoticeAction
 						href={ getRedirectUrl( 'jetpack-support-security-troubleshooting-protect' ) }
 					>
-						{ __( 'Learn More' ) }
+						{ __( 'Learn More', 'jetpack' ) }
 					</NoticeAction>
 				);
 				break;

--- a/_inc/client/components/jetpack-termination-dialog/dialog.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/dialog.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -161,11 +161,11 @@ class JetpackTerminationDialog extends Component {
 		const { step } = this.state;
 		return showSurvey && step === JetpackTerminationDialog.FEATURE_STEP ? (
 			<Button primary onClick={ this.handleContinueClick }>
-				{ __( 'Continue' ) }
+				{ __( 'Continue', 'jetpack' ) }
 			</Button>
 		) : (
 			<Button scary primary onClick={ this.handleTerminationClick }>
-				{ purpose === 'disconnect' ? __( 'Disconnect' ) : __( 'Disable' ) }
+				{ purpose === 'disconnect' ? __( 'Disconnect', 'jetpack' ) : __( 'Disable', 'jetpack' ) }
 			</Button>
 		);
 	}
@@ -182,7 +182,9 @@ class JetpackTerminationDialog extends Component {
 				<Card>
 					<div className="jetpack-termination-dialog__header">
 						<h2>
-							{ purpose === 'disconnect' ? __( 'Disconnect Jetpack' ) : __( 'Disable Jetpack' ) }
+							{ purpose === 'disconnect'
+								? __( 'Disconnect Jetpack', 'jetpack' )
+								: __( 'Disable Jetpack', 'jetpack' ) }
 						</h2>
 						{ location === 'dashboard' && (
 							<Gridicon
@@ -200,11 +202,11 @@ class JetpackTerminationDialog extends Component {
 					<div className="jetpack-termination-dialog__button-row">
 						<p>
 							{ purpose === 'disconnect'
-								? __( 'Are you sure you want to disconnect?' )
-								: __( 'Are you sure you want to disconnect and deactivate?' ) }
+								? __( 'Are you sure you want to disconnect?', 'jetpack' )
+								: __( 'Are you sure you want to disconnect and deactivate?', 'jetpack' ) }
 						</p>
 						<div className="jetpack-termination-dialog__button-row-buttons">
-							<Button onClick={ this.handleDialogCloseClick }>{ __( 'Cancel' ) }</Button>
+							<Button onClick={ this.handleDialogCloseClick }>{ __( 'Cancel', 'jetpack' ) }</Button>
 							{ this.renderPrimaryButton() }
 						</div>
 					</div>

--- a/_inc/client/components/jetpack-termination-dialog/features.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/features.jsx
@@ -1,18 +1,19 @@
 /**
  * External dependencies
  */
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import getRedirectUrl from 'lib/jp-redirect';
+import PropTypes from 'prop-types';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
+import Gridicon from 'components/gridicon';
 import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
 import SingleFeature from './single-feature';
-import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies
@@ -30,8 +31,9 @@ class JetpackTerminationDialogFeatures extends Component {
 	renderCDNReason() {
 		return (
 			<li key="reason-cdn">
-				{ __( 'Speed up your site and provide mobile-ready images with {{a}}our CDN{{/a}}', {
-					components: {
+				{ jetpackCreateInterpolateElement(
+					__( 'Speed up your site and provide mobile-ready images with <a>our CDN</a>', 'jetpack' ),
+					{
 						a: (
 							<a
 								className="jetpack-termination-dialog__link"
@@ -40,8 +42,8 @@ class JetpackTerminationDialogFeatures extends Component {
 								target="_blank"
 							/>
 						),
-					},
-				} ) }
+					}
+				) }
 			</li>
 		);
 	}
@@ -49,19 +51,20 @@ class JetpackTerminationDialogFeatures extends Component {
 	renderProtectReason() {
 		return (
 			<li key="reason-brute-force">
-				{ __(
-					'Block {{a}}brute force attacks{{/a}} and get immediate notifications if your site is down',
+				{ jetpackCreateInterpolateElement(
+					__(
+						'Block <a>brute force attacks</a> and get immediate notifications if your site is down',
+						'jetpack'
+					),
 					{
-						components: {
-							a: (
-								<a
-									className="jetpack-termination-dialog__link"
-									href={ getRedirectUrl( 'jetpack-features-security' ) }
-									rel="noopener noreferrer"
-									target="_blank"
-								/>
-							),
-						},
+						a: (
+							<a
+								className="jetpack-termination-dialog__link"
+								href={ getRedirectUrl( 'jetpack-features-security' ) }
+								rel="noopener noreferrer"
+								target="_blank"
+							/>
+						),
 					}
 				) }
 			</li>
@@ -71,8 +74,9 @@ class JetpackTerminationDialogFeatures extends Component {
 	renderSocialReason() {
 		return (
 			<li key="reason-social">
-				{ __( 'Grow your traffic with automated social {{a}}publishing and sharing{{/a}}', {
-					components: {
+				{ jetpackCreateInterpolateElement(
+					__( 'Grow your traffic with automated social <a>publishing and sharing</a>', 'jetpack' ),
+					{
 						a: (
 							<a
 								className="jetpack-termination-dialog__link"
@@ -81,8 +85,8 @@ class JetpackTerminationDialogFeatures extends Component {
 								target="_blank"
 							/>
 						),
-					},
-				} ) }
+					}
+				) }
 			</li>
 		);
 	}
@@ -112,13 +116,15 @@ class JetpackTerminationDialogFeatures extends Component {
 				<p className="jetpack-termination-dialog__info">
 					{ purpose === 'disconnect'
 						? __(
-								'Jetpack is currently powering features on your site. Once you disconnect Jetpack, these features will no longer be available and your site may no longer function the same way.'
+								'Jetpack is currently powering features on your site. Once you disconnect Jetpack, these features will no longer be available and your site may no longer function the same way.',
+								'jetpack'
 						  )
 						: __(
-								'Jetpack is currently powering features on your site. Once you disable Jetpack, these features will no longer be available and your site may no longer function the same way.'
+								'Jetpack is currently powering features on your site. Once you disable Jetpack, these features will no longer be available and your site may no longer function the same way.',
+								'jetpack'
 						  ) }
 					{ siteBenefitCount > 0 &&
-						__( ' We’ve highlighted some of the features you rely on below.' ) }
+						__( ' We’ve highlighted some of the features you rely on below.', 'jetpack' ) }
 				</p>
 				<div
 					className={
@@ -140,7 +146,10 @@ class JetpackTerminationDialogFeatures extends Component {
 				{ siteBenefitCount <= 2 && (
 					<div className="jetpack-termination-dialog__generic-info">
 						<h2>
-							{ __( 'Jetpack has many powerful tools that can help you achieve your goals' ) }
+							{ __(
+								'Jetpack has many powerful tools that can help you achieve your goals',
+								'jetpack'
+							) }
 						</h2>
 						<ul>
 							{ this.renderCDNReason() }
@@ -152,12 +161,11 @@ class JetpackTerminationDialogFeatures extends Component {
 				{ connectedPlugins.length > 0 && (
 					<div className="jetpack-termination-dialog__generic-info">
 						<h2>
-							{ __(
+							{ _n(
 								'The Jetpack Connection is also used by another plugin, and it will lose connection.',
 								'The Jetpack Connection is also used by other plugins, and they will lose connection.',
-								{
-									count: connectedPlugins.length,
-								}
+								connectedPlugins.length,
+								'jetpack'
 							) }
 						</h2>
 						{ this.renderConnectedPlugins( connectedPlugins ) }
@@ -165,19 +173,20 @@ class JetpackTerminationDialogFeatures extends Component {
 				) }
 				<div className="jetpack-termination-dialog__get-help">
 					<p>
-						{ __(
-							'Have a question? We’d love to help! {{a}}Send a question to the Jetpack support team.{{/a}}',
+						{ jetpackCreateInterpolateElement(
+							__(
+								'Have a question? We’d love to help! <a>Send a question to the Jetpack support team.</a>',
+								'jetpack'
+							),
 							{
-								components: {
-									a: (
-										<a
-											className="jetpack-termination-dialog__link"
-											href={ jetpackSupportURl }
-											rel="noopener noreferrer"
-											target="_blank"
-										/>
-									),
-								},
+								a: (
+									<a
+										className="jetpack-termination-dialog__link"
+										href={ jetpackSupportURl }
+										rel="noopener noreferrer"
+										target="_blank"
+									/>
+								),
 							}
 						) }
 					</p>

--- a/_inc/client/components/jetpack-termination-dialog/survey.jsx
+++ b/_inc/client/components/jetpack-termination-dialog/survey.jsx
@@ -1,31 +1,34 @@
 /**
  * External dependencies
  */
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import MultiChoiceQuestion from 'components/multiple-choice-question';
 
 // these answers should line up exactly with the options in Calypso
 // see any changes at
 // https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/site-settings/disconnect-site/confirm.jsx
 const answers = [
-	{ id: 'cannot-work', answerText: __( "I can't get it to work." ) },
-	{ id: 'slow', answerText: __( 'It slowed down my site.' ) },
-	{ id: 'buggy', answerText: __( "It's buggy." ) },
-	{ id: 'no-clarity', answerText: __( "I don't know what it does." ) },
-	{ id: 'delete', answerText: __( "I'm deleting/migrating my site." ) },
-	{ id: 'troubleshooting', answerText: __( "Troubleshooting - I'll be reconnecting afterwards." ) },
+	{ id: 'cannot-work', answerText: __( "I can't get it to work.", 'jetpack' ) },
+	{ id: 'slow', answerText: __( 'It slowed down my site.', 'jetpack' ) },
+	{ id: 'buggy', answerText: __( "It's buggy.", 'jetpack' ) },
+	{ id: 'no-clarity', answerText: __( "I don't know what it does.", 'jetpack' ) },
+	{ id: 'delete', answerText: __( "I'm deleting/migrating my site.", 'jetpack' ) },
+	{
+		id: 'troubleshooting',
+		answerText: __( "Troubleshooting - I'll be reconnecting afterwards.", 'jetpack' ),
+	},
 	{
 		id: 'other',
-		answerText: __( 'Other:' ),
+		answerText: __( 'Other:', 'jetpack' ),
 		textInput: true,
-		textInputPrompt: __( 'share your experience' ),
+		textInputPrompt: __( 'share your experience', 'jetpack' ),
 		doNotShuffle: true,
 	},
 ];
@@ -41,8 +44,8 @@ class JetpackTerminationDialogSurvey extends Component {
 	getQuestion() {
 		const { purpose } = this.props;
 		return 'disconnect' === purpose
-			? __( "Please let us know why you're disconnecting Jetpack" )
-			: __( "Please let us know why you're disabling Jetpack" );
+			? __( "Please let us know why you're disconnecting Jetpack", 'jetpack' )
+			: __( "Please let us know why you're disabling Jetpack", 'jetpack' );
 	}
 
 	render() {
@@ -53,7 +56,7 @@ class JetpackTerminationDialogSurvey extends Component {
 				<MultiChoiceQuestion
 					answers={ answers }
 					question={ this.getQuestion() }
-					subHeader={ __( 'Your feedback will help us improve the product.' ) }
+					subHeader={ __( 'Your feedback will help us improve the product.', 'jetpack' ) }
 					onAnswerChange={ onSurveyAnswerChange }
 					selectedAnswerId={ surveyAnswerId }
 					selectedAnswerText={ surveyAnswerText }

--- a/_inc/client/components/masthead/index.jsx
+++ b/_inc/client/components/masthead/index.jsx
@@ -3,15 +3,15 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
 import { includes } from 'lodash';
-import ButtonGroup from 'components/button-group';
-import analytics from 'lib/analytics';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import ButtonGroup from 'components/button-group';
 import {
 	getSiteConnectionStatus,
 	getSandboxDomain,
@@ -94,7 +94,7 @@ export class Masthead extends React.Component {
 										primary={ isDashboardView && ! isStatic }
 										onClick={ this.trackDashClick }
 									>
-										{ __( 'Dashboard' ) }
+										{ __( 'Dashboard', 'jetpack' ) }
 									</Button>
 									<Button
 										compact={ true }
@@ -102,7 +102,7 @@ export class Masthead extends React.Component {
 										primary={ ! isDashboardView && ! isStatic }
 										onClick={ this.trackSettingsClick }
 									>
-										{ __( 'Settings' ) }
+										{ __( 'Settings', 'jetpack' ) }
 									</Button>
 								</ButtonGroup>
 							) }

--- a/_inc/client/components/mobile-magic-link/index.jsx
+++ b/_inc/client/components/mobile-magic-link/index.jsx
@@ -3,14 +3,14 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import Card from 'components/card';
-import Button from 'components/button';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Card from 'components/card';
 import {
 	getSiteConnectionStatus as _getSiteConnectionStatus,
 	isCurrentUserLinked as _isCurrentUserLinked,
@@ -49,10 +49,11 @@ export class MobileMagicLink extends React.Component {
 		return (
 			<Modal className="mobile-magic-link__modal" onRequestClose={ this.toggleModalVisibility }>
 				<Card className="mobile-magic-link__modal__body">
-					<h2>{ __( 'Email me a link to log in to the app' ) }</h2>
+					<h2>{ __( 'Email me a link to log in to the app', 'jetpack' ) }</h2>
 					<h4>
 						{ __(
-							"Easily log in to the WordPress app by clicking the link we'll send to the email address on your account."
+							"Easily log in to the WordPress app by clicking the link we'll send to the email address on your account.",
+							'jetpack'
 						) }
 					</h4>
 					<div className="mobile-magic-link__modal-actions">
@@ -60,14 +61,14 @@ export class MobileMagicLink extends React.Component {
 							className="mobile-magic-link__modal-cancel"
 							onClick={ this.toggleModalVisibility }
 						>
-							{ __( 'Cancel', {
-								context: 'A caption for a button to cancel an action.',
-							} ) }
+							{ _x( 'Cancel', 'A caption for a button to cancel an action.', 'jetpack' ) }
 						</Button>
 						<Button onClick={ this.clickSendLoginEmail } primary>
-							{ __( 'Send link', {
-								context: 'A caption for a button to log in to the WordPress mobile app.',
-							} ) }
+							{ _x(
+								'Send link',
+								'A caption for a button to log in to the WordPress mobile app.',
+								'jetpack'
+							) }
 						</Button>
 					</div>
 				</Card>
@@ -86,7 +87,7 @@ export class MobileMagicLink extends React.Component {
 					role="button"
 					tabIndex="0"
 				>
-					{ __( 'Log in to the WordPress mobile app' ) }
+					{ __( 'Log in to the WordPress mobile app', 'jetpack' ) }
 				</a>
 				{ showModal && this.renderModal() }
 			</div>

--- a/_inc/client/components/module-overridden-banner/index.jsx
+++ b/_inc/client/components/module-overridden-banner/index.jsx
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import getRedirectUrl from 'lib/jp-redirect';
 import JetpackBanner from 'components/jetpack-banner';
 
 import './style.scss';
@@ -26,21 +27,6 @@ class ModuleOverridenBanner extends JetpackBanner {
 			return null;
 		}
 
-		const translationArgs = {
-			args: {
-				moduleName: this.props.moduleName,
-			},
-			components: {
-				link: (
-					<a
-						href={ getRedirectUrl( 'jetpack-support-module-overrides' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			},
-		};
-
 		const classes = classNames( 'module-overridden-banner', {
 			'is-compact': this.props.compact,
 		} );
@@ -50,9 +36,24 @@ class ModuleOverridenBanner extends JetpackBanner {
 				className={ classes }
 				title={ this.props.moduleName }
 				icon="cog"
-				description={ __(
-					'%(moduleName)s has been disabled by a site administrator. {{link}}Learn more{{/link}}.',
-					translationArgs
+				description={ jetpackCreateInterpolateElement(
+					sprintf(
+						/* translators: placeholder is a feature name. */
+						__(
+							'%s has been disabled by a site administrator. <link>Learn more</link>.',
+							'jetpack'
+						),
+						this.props.moduleName
+					),
+					{
+						link: (
+							<a
+								href={ getRedirectUrl( 'jetpack-support-module-overrides' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					}
 				) }
 			/>
 		);

--- a/_inc/client/components/module-settings/connect-module-options.jsx
+++ b/_inc/client/components/module-settings/connect-module-options.jsx
@@ -3,7 +3,7 @@
  */
 import { connect } from 'react-redux';
 import { get } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -60,10 +60,14 @@ export function connectModuleOptions( Component ) {
 			},
 			regeneratePostByEmailAddress: () => {
 				const messages = {
-					progress: __( 'Updating Post by Email address…' ),
-					success: __( 'Regenerated Post by Email address.' ),
+					progress: __( 'Updating Post by Email address…', 'jetpack' ),
+					success: __( 'Regenerated Post by Email address.', 'jetpack' ),
 					error: error =>
-						__( 'Error regenerating Post by Email address. %(error)s', { args: { error: error } } ),
+						sprintf(
+							/* translators: placeholder is an error message. */
+							__( 'Error regenerating Post by Email address. %s', 'jetpack' ),
+							error
+						),
 				};
 
 				return dispatch( updateSettings( { post_by_email_address: 'regenerate' }, messages ) );

--- a/_inc/client/components/module-settings/index.jsx
+++ b/_inc/client/components/module-settings/index.jsx
@@ -2,15 +2,15 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
 import { FormFieldset, FormLegend, FormButton } from 'components/forms';
-
+import getRedirectUrl from 'lib/jp-redirect';
 import {
 	ModuleSettingRadios,
 	ModuleSettingCheckbox,
@@ -26,12 +26,14 @@ export class VideoPressSettings extends React.Component {
 			<div>
 				<p className="jp-form-setting-explanation">
 					{ __(
-						'The easiest way to upload ad-free and unbranded videos to your site. You get stats on video playback and shares and the player is lightweight and responsive.'
+						'The easiest way to upload ad-free and unbranded videos to your site. You get stats on video playback and shares and the player is lightweight and responsive.',
+						'jetpack'
 					) }
 				</p>
 				<p className="jp-form-setting-explanation">
 					{ __(
-						'To get started, click on Add Media in your post editor and upload a video; we’ll take care of the rest!'
+						'To get started, click on Add Media in your post editor and upload a video; we’ll take care of the rest!',
+						'jetpack'
 					) }
 				</p>
 			</div>
@@ -49,7 +51,7 @@ export class SharedaddySettings extends React.Component {
 					<ModuleSettingCheckbox
 						name={ 'option_name' }
 						{ ...this.props }
-						label={ __( 'Subscriber' ) }
+						label={ __( 'Subscriber', 'jetpack' ) }
 					/>
 					<FormButton
 						className="is-primary"
@@ -71,15 +73,15 @@ export class RelatedPostsSettings extends React.Component {
 		const previews = [
 			{
 				url: 'https://jetpackme.files.wordpress.com/2019/03/cat-blog.png',
-				text: __( 'Big iPhone/iPad Update Now Available' ),
+				text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
 			},
 			{
 				url: 'https://jetpackme.files.wordpress.com/2019/03/devices.jpg',
-				text: __( 'The WordPress for Android App Gets a Big Facelift' ),
+				text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
 			},
 			{
 				url: 'https://jetpackme.files.wordpress.com/2019/03/mobile-wedding.jpg',
-				text: __( 'Upgrade Focus: VideoPress For Weddings' ),
+				text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
 			},
 		];
 
@@ -87,7 +89,7 @@ export class RelatedPostsSettings extends React.Component {
 			<div className="jp-related-posts-preview">
 				{ show_headline ? (
 					<div className="jp-related-posts-preview__title">
-						{ __( 'Related', { context: 'A heading for a block of related posts.' } ) }
+						{ _x( 'Related', 'A heading for a block of related posts.', 'jetpack' ) }
 					</div>
 				) : (
 					''
@@ -108,43 +110,46 @@ export class RelatedPostsSettings extends React.Component {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<FormFieldset>
-					{ __(
-						'{{span}}You can now also configure related posts in the Customizer. {{ExternalLink}}Try it out!{{/ExternalLink}}{{/span}}',
+					{ jetpackCreateInterpolateElement(
+						__(
+							'<span>You can now also configure related posts in the Customizer. <ExternalLink>Try it out!</ExternalLink></span>',
+							'jetpack'
+						),
 						{
-							components: {
-								span: <span className="jp-form-setting-explanation" />,
-								ExternalLink: (
-									<ExternalLink
-										className="jp-module-settings__external-link"
-										href={
-											this.props.siteAdminUrl +
-											'customize.php?autofocus[section]=jetpack_relatedposts' +
-											'&return=' +
-											encodeURIComponent(
-												this.props.siteAdminUrl + 'admin.php?page=jetpack#/engagement'
-											) +
-											'&url=' +
-											encodeURIComponent( this.props.lastPostUrl )
-										}
-									/>
-								),
-							},
+							span: <span className="jp-form-setting-explanation" />,
+							ExternalLink: (
+								<ExternalLink
+									className="jp-module-settings__external-link"
+									href={
+										this.props.siteAdminUrl +
+										'customize.php?autofocus[section]=jetpack_relatedposts' +
+										'&return=' +
+										encodeURIComponent(
+											this.props.siteAdminUrl + 'admin.php?page=jetpack#/engagement'
+										) +
+										'&url=' +
+										encodeURIComponent( this.props.lastPostUrl )
+									}
+								/>
+							),
 						}
 					) }
 					<ModuleSettingCheckbox
 						name={ 'show_headline' }
-						label={ __( 'Highlight related content with a heading' ) }
+						label={ __( 'Highlight related content with a heading', 'jetpack' ) }
 						{ ...this.props }
 					/>
 					<ModuleSettingCheckbox
 						name={ 'show_thumbnails' }
-						label={ __( 'Show a thumbnail image where available' ) }
+						label={ __( 'Show a thumbnail image where available', 'jetpack' ) }
 						{ ...this.props }
 					/>
 					<div className="jp-related-posts-settings__preview-label">
-						{ __( 'Preview', {
-							context: 'Noun, a header for a preview block in a configuration screen.',
-						} ) }
+						{ _x(
+							'Preview',
+							'Noun, a header for a preview block in a configuration screen.',
+							'jetpack'
+						) }
 					</div>
 					<Card>{ this.renderPreviews() }</Card>
 					<FormButton
@@ -166,7 +171,7 @@ export class LikesSettings extends React.Component {
 		return (
 			<form onSubmit={ this.props.onSubmit }>
 				<FormFieldset>
-					<FormLegend> { __( 'WordPress.com Likes are:' ) }</FormLegend>
+					<FormLegend> { __( 'WordPress.com Likes are:', 'jetpack' ) }</FormLegend>
 					<ModuleSettingRadios
 						name={ 'wpl_default' }
 						{ ...this.props }
@@ -179,11 +184,12 @@ export class LikesSettings extends React.Component {
 					/>
 				</FormFieldset>
 				<p>
-					{ __( '{{a}}Manage Likes visibility from the Sharing Module Settings{{/a}}', {
-						components: {
+					{ jetpackCreateInterpolateElement(
+						__( '<a>Manage Likes visibility from the Sharing Module Settings</a>', 'jetpack' ),
+						{
 							a: <a href={ old_sharing_settings_url } />,
-						},
-					} ) }
+						}
+					) }
 				</p>
 			</form>
 		);
@@ -197,8 +203,12 @@ export class MonitorSettings extends React.Component {
 		return (
 			<span className="jp-form-setting-explanation">
 				<span>
-					{ __( '{{link}}Configure your Monitor notification settings on WordPress.com{{/link}}', {
-						components: {
+					{ jetpackCreateInterpolateElement(
+						__(
+							'<link>Configure your Monitor notification settings on WordPress.com</link>',
+							'jetpack'
+						),
+						{
 							link: (
 								<ExternalLink
 									className="jp-module-settings__external-link"
@@ -209,8 +219,8 @@ export class MonitorSettings extends React.Component {
 									} ) }
 								/>
 							),
-						},
-					} ) }
+						}
+					) }
 				</span>
 			</span>
 		);
@@ -225,7 +235,8 @@ export class WordAdsSettings extends React.Component {
 			<div>
 				<p>
 					{ __(
-						'By default ads are shown at the end of every page, post, or the first article on your front page. You can also add them to the top of your site and to any widget area to increase your earnings!'
+						'By default ads are shown at the end of every page, post, or the first article on your front page. You can also add them to the top of your site and to any widget area to increase your earnings!',
+						'jetpack'
 					) }
 				</p>
 				<form onSubmit={ this.props.onSubmit }>
@@ -233,7 +244,7 @@ export class WordAdsSettings extends React.Component {
 						<ModuleSettingCheckbox
 							name={ 'enable_header_ad' }
 							{ ...this.props }
-							label={ __( 'Display an ad unit at the top of your site.' ) }
+							label={ __( 'Display an ad unit at the top of your site.', 'jetpack' ) }
 						/>
 						<FormButton
 							className="is-primary"

--- a/_inc/client/components/module-toggle/index.jsx
+++ b/_inc/client/components/module-toggle/index.jsx
@@ -2,17 +2,18 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import analytics from 'lib/analytics';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { connect } from 'react-redux';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import { getModuleOverride } from 'state/modules';
+import getRedirectUrl from 'lib/jp-redirect';
 
 class ModuleToggleComponent extends Component {
 	static displayName = 'ModuleToggle';
@@ -62,32 +63,39 @@ class ModuleToggleComponent extends Component {
 		}
 		const override = this.props.getModuleOverride( this.props.slug );
 		const args = {
-			components: {
-				link: (
-					<a
-						href={ getRedirectUrl( 'jetpack-support-module-overrides' ) }
-						target="_blank"
-						rel="noopener noreferrer"
-						style={ { textDecoration: 'underline' } }
-					/>
-				),
-			},
+			link: (
+				<a
+					href={ getRedirectUrl( 'jetpack-support-module-overrides' ) }
+					target="_blank"
+					rel="noopener noreferrer"
+					style={ { textDecoration: 'underline' } }
+				/>
+			),
 		};
 
 		switch ( override ) {
 			case 'active':
-				return __(
-					'This feature has been enabled by a site administrator. {{link}}Learn more{{/link}}.',
+				return jetpackCreateInterpolateElement(
+					__(
+						'This feature has been enabled by a site administrator. <link>Learn more</link>.',
+						'jetpack'
+					),
 					args
 				);
 			case 'inactive':
-				return __(
-					'This feature has been disabled by a site administrator. {{link}}Learn more{{/link}}.',
+				return jetpackCreateInterpolateElement(
+					__(
+						'This feature has been disabled by a site administrator. <link>Learn more</link>.',
+						'jetpack'
+					),
 					args
 				);
 			default:
-				return __(
-					'This feature is being managed by a site administrator. {{link}}Learn more{{/link}}.',
+				return jetpackCreateInterpolateElement(
+					__(
+						'This feature is being managed by a site administrator. <link>Learn more</link>.',
+						'jetpack'
+					),
 					args
 				);
 		}

--- a/_inc/client/components/navigation-settings/index.jsx
+++ b/_inc/client/components/navigation-settings/index.jsx
@@ -1,29 +1,19 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { connect } from 'react-redux';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import Search from 'components/search';
-import { translate as __ } from 'i18n-calypso';
 import { noop } from 'lodash';
-import UrlSearch from 'mixins/url-search';
-import analytics from 'lib/analytics';
 import { withRouter } from 'react-router-dom';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import { filterSearch, getSearchTerm } from 'state/search';
-import {
-	userCanManageModules as _userCanManageModules,
-	userIsSubscriber as _userIsSubscriber,
-	userCanPublish,
-} from 'state/initial-state';
 import { isSiteConnected, isCurrentUserLinked } from 'state/connection';
 import {
 	getModules,
@@ -33,7 +23,17 @@ import {
 	isModuleActivated,
 } from 'state/modules';
 import { isPluginActive } from 'state/site/plugins';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
 import QuerySitePlugins from 'components/data/query-site-plugins';
+import Search from 'components/search';
+import SectionNav from 'components/section-nav';
+import UrlSearch from 'mixins/url-search';
+import {
+	userCanManageModules as _userCanManageModules,
+	userIsSubscriber as _userIsSubscriber,
+	userCanPublish,
+} from 'state/initial-state';
 
 export const NavigationSettings = createReactClass( {
 	displayName: 'NavigationSettings',
@@ -68,7 +68,7 @@ export const NavigationSettings = createReactClass( {
 					onClick={ this.handleClickForTracking( 'search' ) }
 					pinned={ true }
 					fitsContainer={ true }
-					placeholder={ __( 'Search for a Jetpack feature.' ) }
+					placeholder={ __( 'Search for a Jetpack feature.', 'jetpack' ) }
 					delaySearch={ true }
 					delayTimeout={ 500 }
 					onSearch={ this.doSearch }
@@ -119,7 +119,7 @@ export const NavigationSettings = createReactClass( {
 								this.props.location.pathname === '/settings'
 							}
 						>
-							{ __( 'Security', { context: 'Navigation item.' } ) }
+							{ _x( 'Security', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{ this.props.hasAnyPerformanceFeature && (
@@ -128,7 +128,7 @@ export const NavigationSettings = createReactClass( {
 							onClick={ this.handleClickForTracking( 'performance' ) }
 							selected={ this.props.location.pathname === '/performance' }
 						>
-							{ __( 'Performance', { context: 'Navigation item.' } ) }
+							{ _x( 'Performance', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{ this.props.hasAnyOfTheseModules( [
@@ -144,7 +144,7 @@ export const NavigationSettings = createReactClass( {
 							onClick={ this.handleClickForTracking( 'writing' ) }
 							selected={ this.props.location.pathname === '/writing' }
 						>
-							{ __( 'Writing', { context: 'Navigation item.' } ) }
+							{ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{ this.props.hasAnyOfTheseModules( [ 'publicize', 'sharedaddy', 'likes' ] ) && (
@@ -153,7 +153,7 @@ export const NavigationSettings = createReactClass( {
 							onClick={ this.handleClickForTracking( 'sharing' ) }
 							selected={ this.props.location.pathname === '/sharing' }
 						>
-							{ __( 'Sharing', { context: 'Navigation item.' } ) }
+							{ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{ this.props.hasAnyOfTheseModules( [
@@ -167,7 +167,7 @@ export const NavigationSettings = createReactClass( {
 							onClick={ this.handleClickForTracking( 'discussion' ) }
 							selected={ this.props.location.pathname === '/discussion' }
 						>
-							{ __( 'Discussion', { context: 'Navigation item.' } ) }
+							{ _x( 'Discussion', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{ this.props.hasAnyOfTheseModules( [
@@ -184,7 +184,7 @@ export const NavigationSettings = createReactClass( {
 							onClick={ this.handleClickForTracking( 'traffic' ) }
 							selected={ this.props.location.pathname === '/traffic' }
 						>
-							{ __( 'Traffic', { context: 'Navigation item.' } ) }
+							{ _x( 'Traffic', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 				</NavTabs>
@@ -201,7 +201,7 @@ export const NavigationSettings = createReactClass( {
 						onClick={ this.handleClickForTracking( 'sharing' ) }
 						selected={ this.props.location.pathname === '/sharing' }
 					>
-						{ __( 'Sharing', { context: 'Navigation item.' } ) }
+						{ _x( 'Sharing', 'Navigation item.', 'jetpack' ) }
 					</NavItem>
 				);
 			}
@@ -216,7 +216,7 @@ export const NavigationSettings = createReactClass( {
 								this.props.location.pathname === '/settings'
 							}
 						>
-							{ __( 'Writing', { context: 'Navigation item.' } ) }
+							{ _x( 'Writing', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{

--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -1,25 +1,25 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import SectionNav from 'components/section-nav';
-import NavTabs from 'components/section-nav/tabs';
-import NavItem from 'components/section-nav/item';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
 import { withRouter } from 'react-router-dom';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import { isCurrentUserLinked, isDevMode } from 'state/connection';
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
+import NavTabs from 'components/section-nav/tabs';
+import NavItem from 'components/section-nav/item';
+import SectionNav from 'components/section-nav';
 import {
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 } from 'state/initial-state';
-import { isCurrentUserLinked, isDevMode } from 'state/connection';
 
 export class Navigation extends React.Component {
 	trackNavClick = target => {
@@ -53,7 +53,7 @@ export class Navigation extends React.Component {
 							this.props.location.pathname === '/dashboard' || this.props.location.pathname === '/'
 						}
 					>
-						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
+						{ _x( 'At a Glance', 'Navigation item.', 'jetpack' ) }
 					</NavItem>
 					{ ! this.props.isDevMode && this.props.isLinked && (
 						<NavItem
@@ -61,7 +61,7 @@ export class Navigation extends React.Component {
 							onClick={ this.trackMyPlanClick }
 							selected={ this.props.location.pathname === '/my-plan' }
 						>
-							{ __( 'My Plan', { context: 'Navigation item.' } ) }
+							{ _x( 'My Plan', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 					{ ! this.props.isDevMode && this.props.isLinked && (
@@ -70,7 +70,7 @@ export class Navigation extends React.Component {
 							onClick={ this.trackPlansClick }
 							selected={ this.props.location.pathname === '/plans' }
 						>
-							{ __( 'Plans', { context: 'Navigation item.' } ) }
+							{ _x( 'Plans', 'Navigation item.', 'jetpack' ) }
 						</NavItem>
 					) }
 				</NavTabs>
@@ -84,7 +84,7 @@ export class Navigation extends React.Component {
 							this.props.location.pathname === '/dashboard' || this.props.location.pathname === '/'
 						}
 					>
-						{ __( 'At a Glance', { context: 'Navigation item.' } ) }
+						{ _x( 'At a Glance', 'Navigation item.', 'jetpack' ) }
 					</NavItem>
 				</NavTabs>
 			);

--- a/_inc/client/components/plans/plan-price/index.jsx
+++ b/_inc/client/components/plans/plan-price/index.jsx
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { translate as __ } from 'i18n-calypso';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { getCurrencyObject } from '@automattic/format-currency';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Style dependencies
@@ -51,18 +51,36 @@ export class PlanPrice extends Component {
 		const smallerPrice = this.renderPrice( priceRange[ 0 ] );
 		const higherPrice = priceRange[ 1 ] && this.renderPrice( priceRange[ 1 ] );
 
+		if ( ! higherPrice ) {
+			return (
+				<>
+					{ jetpackCreateInterpolateElement(
+						/* translators: This shows a price, like $22. */
+						__( '<Currency /><Price />', 'jetpack' ),
+						{
+							Currency: (
+								<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+							),
+							Price: smallerPrice,
+						}
+					) }
+				</>
+			);
+		}
+
 		return (
 			<>
-				<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
-				{ higherPrice
-					? __( '{{smallerPrice/}}-{{higherPrice/}}', {
-							components: {
-								smallerPrice,
-								higherPrice,
-							},
-							comment: 'The price range for a particular product',
-					  } )
-					: smallerPrice }
+				{ jetpackCreateInterpolateElement(
+					/* translators: This shows a price range, like $ 22-55. */
+					__( '<Currency /><smallerPrice />-<higherPrice />', 'jetpack' ),
+					{
+						Currency: (
+							<sup className="plan-price__currency-symbol">{ priceRange[ 0 ].price.symbol }</sup>
+						),
+						smallerPrice: smallerPrice,
+						higherPrice: higherPrice,
+					}
+				) }
 			</>
 		);
 	}

--- a/_inc/client/components/product-expiration/index.jsx
+++ b/_inc/client/components/product-expiration/index.jsx
@@ -3,7 +3,8 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { moment, translate as __ } from 'i18n-calypso';
+import { moment } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 class ProductExpiration extends React.PureComponent {
 	static propTypes = {
@@ -32,7 +33,11 @@ class ProductExpiration extends React.PureComponent {
 		if ( ! expiryDate || isRefundable ) {
 			const purchaseMoment = moment( purchaseDate );
 			if ( purchaseMoment.isValid() ) {
-				return __( 'Purchased on %s.', { args: purchaseMoment.format( dateFormat ) } );
+				return sprintf(
+					/* translators: placeholder is a date. */
+					__( 'Purchased on %s.', 'jetpack' ),
+					purchaseMoment.format( dateFormat )
+				);
 			}
 			return null;
 		}
@@ -46,11 +51,19 @@ class ProductExpiration extends React.PureComponent {
 
 		// If the expiry date is in the past, show the expiration date.
 		if ( expiryMoment.diff( new Date() ) < 0 ) {
-			return __( 'Expired on %s.', { args: expiryMoment.format( dateFormat ) } );
+			return sprintf(
+				/* translators: placeholder is a date. */
+				__( 'Expired on %s.', 'jetpack' ),
+				expiryMoment.format( dateFormat )
+			);
 		}
 
 		// Lastly, return the renewal date.
-		return __( 'Renews on %s.', { args: expiryMoment.format( dateFormat ) } );
+		return sprintf(
+			/* translators: placeholder is a date. */
+			__( 'Renews on %s.', 'jetpack' ),
+			expiryMoment.format( dateFormat )
+		);
 	}
 }
 

--- a/_inc/client/components/settings-card/index.jsx
+++ b/_inc/client/components/settings-card/index.jsx
@@ -1,17 +1,17 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
-import analytics from 'lib/analytics';
 import { get, includes, isEmpty } from 'lodash';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
 import {
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_BUSINESS,
@@ -82,9 +82,11 @@ export const SettingsCard = props => {
 
 	const getBanner = () => {
 		const planClass = getPlanClass( props.sitePlan.product_slug ),
-			upgradeLabel = __( 'Upgrade', {
-				context: 'A caption for a button to upgrade an existing paid feature to a higher tier.',
-			} );
+			upgradeLabel = _x(
+				'Upgrade',
+				'A caption for a button to upgrade an existing paid feature to a higher tier.',
+				'jetpack'
+			);
 
 		switch ( feature ) {
 			case FEATURE_VIDEO_HOSTING_JETPACK:
@@ -94,7 +96,7 @@ export const SettingsCard = props => {
 
 				return (
 					<JetpackBanner
-						title={ __( 'Host fast, high-quality, ad-free video.' ) }
+						title={ __( 'Host fast, high-quality, ad-free video.', 'jetpack' ) }
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
@@ -114,7 +116,7 @@ export const SettingsCard = props => {
 
 				return (
 					<JetpackBanner
-						title={ __( 'Generate income with high-quality ads.' ) }
+						title={ __( 'Generate income with high-quality ads.', 'jetpack' ) }
 						callToAction={ upgradeLabel }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
@@ -131,7 +133,7 @@ export const SettingsCard = props => {
 				if ( 'is-premium-plan' === planClass ) {
 					return (
 						<JetpackBanner
-							title={ __( 'Real-time site backups and automatic threat resolution.' ) }
+							title={ __( 'Real-time site backups and automatic threat resolution.', 'jetpack' ) }
 							plan={ PLAN_JETPACK_BUSINESS }
 							callToAction={ upgradeLabel }
 							feature={ feature }
@@ -144,7 +146,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Protect against data loss, malware, and malicious attacks.' ) }
+						title={ __( 'Protect against data loss, malware, and malicious attacks.', 'jetpack' ) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
 						onClick={ handleClickForTracking( feature ) }
@@ -161,7 +163,8 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.'
+							'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional.',
+							'jetpack'
 						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
@@ -178,7 +181,8 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium or Professional.'
+							'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium or Professional.',
+							'jetpack'
 						) }
 						plan={ PLAN_JETPACK_PREMIUM }
 						feature={ feature }
@@ -196,7 +200,8 @@ export const SettingsCard = props => {
 					<JetpackBanner
 						callToAction={ upgradeLabel }
 						title={ __(
-							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.'
+							'Help visitors quickly find answers with highly relevant instant search results and powerful filtering.',
+							'jetpack'
 						) }
 						plan={ PLAN_JETPACK_SEARCH }
 						feature={ feature }
@@ -217,7 +222,7 @@ export const SettingsCard = props => {
 				return (
 					<JetpackBanner
 						callToAction={ upgradeLabel }
-						title={ __( 'Protect your site from spam.' ) }
+						title={ __( 'Protect your site from spam.', 'jetpack' ) }
 						plan={ PLAN_JETPACK_PERSONAL }
 						feature={ feature }
 						href={ props.spamUpgradeUrl }
@@ -337,8 +342,8 @@ export const SettingsCard = props => {
 					{ ! props.hideButton && (
 						<Button primary compact type="submit" disabled={ isSaving || ! props.isDirty() }>
 							{ isSaving
-								? __( 'Saving…', { context: 'Button caption' } )
-								: __( 'Save settings', { context: 'Button caption' } ) }
+								? _x( 'Saving…', 'Button caption', 'jetpack' )
+								: _x( 'Save settings', 'Button caption', 'jetpack' ) }
 						</Button>
 					) }
 					{ props.action && (

--- a/_inc/client/components/support-card/index.jsx
+++ b/_inc/client/components/support-card/index.jsx
@@ -5,21 +5,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import Button from 'components/button';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
-import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import Button from 'components/button';
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getSiteConnectionStatus } from 'state/connection';
+import getRedirectUrl from 'lib/jp-redirect';
+import { isAtomicSite, isDevVersion as _isDevVersion, getUpgradeUrl } from 'state/initial-state';
 import JetpackBanner from 'components/jetpack-banner';
 import { JETPACK_CONTACT_SUPPORT, JETPACK_CONTACT_BETA_SUPPORT } from 'constants/urls';
+import { PLAN_JETPACK_PERSONAL } from 'lib/plans/constants';
 
 class SupportCard extends React.Component {
 	static displayName = 'SupportCard';
@@ -78,11 +78,14 @@ class SupportCard extends React.Component {
 			<div className={ classes }>
 				<Card className="jp-support-card__happiness">
 					<div className="jp-support-card__happiness-contact">
-						<h3 className="jp-support-card__header">{ __( "We're here to help" ) }</h3>
+						<h3 className="jp-support-card__header">{ __( "We're here to help", 'jetpack' ) }</h3>
 						<p className="jp-support-card__description">
 							{ noPrioritySupport
-								? __( 'Jetpack comes with free, basic support for all users.' )
-								: __( 'Your paid plan gives you access to prioritized Jetpack support.' ) }
+								? __( 'Jetpack comes with free, basic support for all users.', 'jetpack' )
+								: __(
+										'Your paid plan gives you access to prioritized Jetpack support.',
+										'jetpack'
+								  ) }
 						</p>
 						<p className="jp-support-card__description">
 							<Button
@@ -93,7 +96,7 @@ class SupportCard extends React.Component {
 										: jetpackSupportURl
 								}
 							>
-								{ __( 'Ask a question' ) }
+								{ __( 'Ask a question', 'jetpack' ) }
 							</Button>
 							<Button
 								onClick={ this.trackSearchClick }
@@ -103,16 +106,16 @@ class SupportCard extends React.Component {
 										: getRedirectUrl( 'jetpack-support' )
 								}
 							>
-								{ __( 'Search our support site' ) }
+								{ __( 'Search our support site', 'jetpack' ) }
 							</Button>
 						</p>
 					</div>
 				</Card>
 				{ this.props.siteConnectionStatus && noPrioritySupport && (
 					<JetpackBanner
-						title={ __( 'Get a faster resolution to your support questions.' ) }
+						title={ __( 'Get a faster resolution to your support questions.', 'jetpack' ) }
 						plan={ PLAN_JETPACK_PERSONAL }
-						callToAction={ __( 'Upgrade' ) }
+						callToAction={ __( 'Upgrade', 'jetpack' ) }
 						onClick={ this.trackBannerClick }
 						href={ this.props.supportUpgradeUrl }
 					/>

--- a/_inc/client/components/support-info/index.jsx
+++ b/_inc/client/components/support-info/index.jsx
@@ -3,12 +3,12 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
 import InfoPopover from 'components/info-popover';
 import ExternalLink from 'components/external-link';
 
@@ -76,7 +76,7 @@ export default class SupportInfo extends Component {
 				<InfoPopover
 					position="left"
 					onClick={ this.trackInfoClick }
-					screenReaderText={ __( 'Learn more' ) }
+					screenReaderText={ __( 'Learn more', 'jetpack' ) }
 				>
 					{ text + ' ' }
 					<span className="jp-support-info__learn-more">
@@ -86,7 +86,7 @@ export default class SupportInfo extends Component {
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{ __( 'Learn more' ) }
+							{ __( 'Learn more', 'jetpack' ) }
 						</ExternalLink>
 					</span>
 					<span className="jp-support-info__privacy">
@@ -96,7 +96,7 @@ export default class SupportInfo extends Component {
 							target="_blank"
 							rel="noopener noreferrer"
 						>
-							{ __( 'Privacy information' ) }
+							{ __( 'Privacy information', 'jetpack' ) }
 						</ExternalLink>
 					</span>
 				</InfoPopover>

--- a/_inc/client/components/upgrade-notice-content/index.jsx
+++ b/_inc/client/components/upgrade-notice-content/index.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -71,12 +71,11 @@ const UpgradeNoticeContent = withModuleSettingsFormHelpers(
 			}
 
 			if ( ! title || 0 === title.length ) {
-				title = __( 'New in Jetpack %(version)s', {
-					args: {
-						version: this.props.version,
-					},
-					comment: '%(version) is a version number.',
-				} );
+				title = sprintf(
+					/* translators: Placeholder is a version number. */
+					__( 'New in Jetpack %s', 'jetpack' ),
+					this.props.version
+				);
 			}
 
 			return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is part 2, follow-up of #13527. We're moving away from `translate` and using the `@wordpress/i18n` package instead.

This PR focusses on updating all components used throughout the dashboard.

**Note: this PR is open against the branch used for part 1 in #13527 for now, hence the "Do not merge" label. Once the other PR is merged I'll update the base branch for this PR.**

#### Jetpack product discussion

* p1HpG7-99c-p2
* Primary issue: #16481 

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Nothing should change at first sight.

* Everything should look good in the admin dashboard.
* Try activating and deactivating modules, changing settings, connecting / disconnecting
* Try using filters to trigger alternate views; something like #8934 for example.
* Try enabling development mode in different ways: `add_filter( 'jetpack_development_mode', '__return_true' );`, `define( 'JETPACK_DEV_DEBUG', true );`, both.

#### Proposed changelog entry for your changes:

* TBD
