### PR TITLE
Admin Page: Move to Core translation functions -- PART 3

### DIFF
--- a/_inc/client/discussion/comments.jsx
+++ b/_inc/client/discussion/comments.jsx
@@ -2,20 +2,20 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FormFieldset, FormLabel, FormSelect } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import CompactFormToggle from 'components/form/form-toggle/compact';
 import SupportInfo from 'components/support-info';
+import TextInput from 'components/text-input';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 import './style.scss';
 
@@ -68,7 +68,7 @@ class CommentsComponent extends React.Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Comments' ) }
+				header={ __( 'Comments', 'jetpack' ) }
 				module="comments"
 				saveDisabled={ this.props.isSavingAnyOption( [
 					'highlander_comment_form_prompt',
@@ -82,8 +82,8 @@ class CommentsComponent extends React.Component {
 						module={ comments }
 						support={ {
 							text: __(
-								'Replaces the standard WordPress comment form with a new comment system ' +
-									'that includes social media login options.'
+								'Replaces the standard WordPress comment form with a new comment system that includes social media login options.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-comments' ),
 						} }
@@ -100,7 +100,9 @@ class CommentsComponent extends React.Component {
 						</ModuleToggle>
 						<FormFieldset>
 							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Comment form introduction' ) }</span>
+								<span className="jp-form-label-wide">
+									{ __( 'Comment form introduction', 'jetpack' ) }
+								</span>
 								<TextInput
 									name={ 'highlander_comment_form_prompt' }
 									value={ this.props.getOptionValue( 'highlander_comment_form_prompt' ) }
@@ -113,10 +115,10 @@ class CommentsComponent extends React.Component {
 								/>
 							</FormLabel>
 							<span className="jp-form-setting-explanation">
-								{ __( 'A few catchy words to motivate your visitors to comment.' ) }
+								{ __( 'A few catchy words to motivate your visitors to comment.', 'jetpack' ) }
 							</span>
 							<FormLabel>
-								<span className="jp-form-label-wide">{ __( 'Color scheme' ) }</span>
+								<span className="jp-form-label-wide">{ __( 'Color scheme', 'jetpack' ) }</span>
 								<FormSelect
 									name={ 'jetpack_comment_form_color_scheme' }
 									value={ this.props.getOptionValue( 'jetpack_comment_form_color_scheme' ) }
@@ -152,7 +154,7 @@ class CommentsComponent extends React.Component {
 									</ModuleToggle>
 								</FormFieldset>
 								<SupportInfo
-									text={ __( 'Show Gravatar hovercards alongside comments.' ) }
+									text={ __( 'Show Gravatar hovercards alongside comments.', 'jetpack' ) }
 									link={ gravatar.learn_more_button }
 									privacyLink={ gravatar.learn_more_button + '#privacy' }
 								/>
@@ -181,12 +183,12 @@ class CommentsComponent extends React.Component {
 										onChange={ this.handleMarkdownCommentsToggle }
 									>
 										<span className="jp-form-toggle-explanation">
-											{ __( 'Enable Markdown use for comments.' ) }
+											{ __( 'Enable Markdown use for comments.', 'jetpack' ) }
 										</span>
 									</CompactFormToggle>
 								</FormFieldset>
 								<SupportInfo
-									text={ __( 'Allow readers to use markdown in comments.' ) }
+									text={ __( 'Allow readers to use markdown in comments.', 'jetpack' ) }
 									link={ markdown.learn_more_button }
 									privacyLink={ markdown.learn_more_button + '#privacy' }
 								/>
@@ -204,12 +206,12 @@ class CommentsComponent extends React.Component {
 										toggleModule={ this.props.toggleModuleNow }
 									>
 										<span className="jp-form-toggle-explanation">
-											{ __( 'Enable comment likes.' ) }
+											{ __( 'Enable comment likes.', 'jetpack' ) }
 										</span>
 									</ModuleToggle>
 								</FormFieldset>
 								<SupportInfo
-									text={ __( 'Allow readers to like individual comments.' ) }
+									text={ __( 'Allow readers to like individual comments.', 'jetpack' ) }
 									link={ getRedirectUrl( 'jetpack-support-comment-likes' ) }
 									privacyLink={ getRedirectUrl( 'jetpack-support-comment-likes', {
 										anchor: 'privacy',

--- a/_inc/client/discussion/index.jsx
+++ b/_inc/client/discussion/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -59,9 +59,10 @@ export class Discussion extends React.Component {
 				<Card
 					title={
 						this.props.searchTerm
-							? __( 'Discussion' )
+							? __( 'Discussion', 'jetpack' )
 							: __(
-									'Manage advanced comment settings and grow your audience with email subscriptions.'
+									'Manage advanced comment settings and grow your audience with email subscriptions.',
+									'jetpack'
 							  )
 					}
 					className="jp-settings-description"

--- a/_inc/client/discussion/subscriptions.jsx
+++ b/_inc/client/discussion/subscriptions.jsx
@@ -2,20 +2,20 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import CompactFormToggle from 'components/form/form-toggle/compact';
+import Card from 'components/card';
 import { FormFieldset } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 class SubscriptionsComponent extends React.Component {
 	/**
@@ -73,7 +73,7 @@ class SubscriptionsComponent extends React.Component {
 						site: this.props.siteRawUrl,
 					} ) }
 				>
-					{ __( 'View your Email Followers' ) }
+					{ __( 'View your Email Followers', 'jetpack' ) }
 				</Card>
 			) : (
 				<Card
@@ -81,7 +81,7 @@ class SubscriptionsComponent extends React.Component {
 					className="jp-settings-card__configure-link"
 					href={ `${ this.props.connectUrl }&from=unlinked-user-connect-masterbar` }
 				>
-					{ __( 'Create a Jetpack account to view your email followers' ) }{ ' ' }
+					{ __( 'Create a Jetpack account to view your email followers', 'jetpack' ) }{ ' ' }
 				</Card>
 			);
 		};
@@ -94,8 +94,8 @@ class SubscriptionsComponent extends React.Component {
 					module={ subscriptions }
 					support={ {
 						text: __(
-							'Allows readers to subscribe to your posts or comments, ' +
-								'and receive notifications of new content by email.'
+							'Allows readers to subscribe to your posts or comments, and receive notifications of new content by email.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-subscriptions' ),
 					} }
@@ -121,7 +121,7 @@ class SubscriptionsComponent extends React.Component {
 								onChange={ this.handleSubscribeToBlogToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Enable the “subscribe to site” option on your comment form' ) }
+									{ __( 'Enable the “subscribe to site” option on your comment form', 'jetpack' ) }
 								</span>
 							</CompactFormToggle>
 							<CompactFormToggle
@@ -134,7 +134,10 @@ class SubscriptionsComponent extends React.Component {
 								onChange={ this.handleSubscribeToCommentToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Enable the “subscribe to comments” option on your comment form' ) }
+									{ __(
+										'Enable the “subscribe to comments” option on your comment form',
+										'jetpack'
+									) }
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>

--- a/_inc/client/my-plan/my-plan-body.jsx
+++ b/_inc/client/my-plan/my-plan-body.jsx
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import Button from 'components/button';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import { getPlanClass, FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
-import { get, includes } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import { getPlanClass, FEATURE_UNLIMITED_PREMIUM_THEMES } from 'lib/plans/constants';
+import { get, includes } from 'lodash';
+import getRedirectUrl from 'lib/jp-redirect';
 import { imagePath } from 'constants/urls';
 import {
 	fetchPluginsData,
@@ -99,7 +99,7 @@ class MyPlanBody extends React.Component {
 						<img
 							src={ imagePath + '/jetpack-backup.svg' }
 							className="jp-landing__plan-features-icon"
-							alt={ __( 'A Jetpack Site securely backed up with Jetpack Backup' ) }
+							alt={ __( 'A Jetpack Site securely backed up with Jetpack Backup', 'jetpack' ) }
 						/>
 					</div>
 					<div className="jp-landing__plan-features-text">
@@ -109,7 +109,7 @@ class MyPlanBody extends React.Component {
 							onClick={ this.handleButtonClickForTracking( 'view_backup_dash' ) }
 							href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 						>
-							{ __( 'View Your Backups' ) }
+							{ __( 'View Your Backups', 'jetpack' ) }
 						</Button>
 					</div>
 				</div>
@@ -128,21 +128,24 @@ class MyPlanBody extends React.Component {
 							<img
 								src={ imagePath + '/jetpack-security.svg' }
 								className="jp-landing__plan-features-icon"
-								alt={ __( 'A secure site, locked and protected by Jetpack' ) }
+								alt={ __( 'A secure site, locked and protected by Jetpack', 'jetpack' ) }
 							/>
 						</div>
 						<div className="jp-landing__plan-features-text">
-							<h3 className="jp-landing__plan-features-title">{ __( 'Site Backups' ) }</h3>
+							<h3 className="jp-landing__plan-features-title">
+								{ __( 'Site Backups', 'jetpack' ) }
+							</h3>
 							<p>
 								{ __(
-									'Real-time backup of all your site data with unlimited space, one-click restores, and automated security scanning.'
+									'Real-time backup of all your site data with unlimited space, one-click restores, and automated security scanning.',
+									'jetpack'
 								) }
 							</p>
 							<Button
 								onClick={ this.handleButtonClickForTracking( 'view_security_dash_rewind' ) }
 								href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 							>
-								{ __( 'View your security activity' ) }
+								{ __( 'View your security activity', 'jetpack' ) }
 							</Button>
 						</div>
 					</div>
@@ -153,17 +156,20 @@ class MyPlanBody extends React.Component {
 			switch ( planClass ) {
 				case 'is-personal-plan':
 					description = __(
-						'Daily backup of all your site data with unlimited space and one-click restores'
+						'Daily backup of all your site data with unlimited space and one-click restores',
+						'jetpack'
 					);
 					break;
 				case 'is-premium-plan':
 					description = __(
-						'Daily backup of all your site data with unlimited space, one-click restores, automated security scanning, and priority support'
+						'Daily backup of all your site data with unlimited space, one-click restores, automated security scanning, and priority support',
+						'jetpack'
 					);
 					break;
 				case 'is-business-plan':
 					description = __(
-						'Real-time backup of all your site data with unlimited space, one-click restores, automated security scanning, and priority support'
+						'Real-time backup of all your site data with unlimited space, one-click restores, automated security scanning, and priority support',
+						'jetpack'
 					);
 					break;
 				default:
@@ -177,19 +183,21 @@ class MyPlanBody extends React.Component {
 						<img
 							src={ imagePath + '/jetpack-security.svg' }
 							className="jp-landing__plan-features-icon"
-							alt={ __( 'A secure site, locked and protected by Jetpack' ) }
+							alt={ __( 'A secure site, locked and protected by Jetpack', 'jetpack' ) }
 						/>
 					</div>
 					<div className="jp-landing__plan-features-text">
-						<h3 className="jp-landing__plan-features-title">{ __( 'Site Security' ) }</h3>
-						<p>{ description + __( ' (powered by VaultPress).' ) }</p>
+						<h3 className="jp-landing__plan-features-title">
+							{ __( 'Site Security', 'jetpack' ) }
+						</h3>
+						<p>{ description + __( ' (powered by VaultPress).', 'jetpack' ) }</p>
 						{ this.props.isPluginInstalled( 'vaultpress/vaultpress.php' ) &&
 						this.props.isPluginActive( 'vaultpress/vaultpress.php' ) ? (
 							<Button
 								onClick={ this.handleButtonClickForTracking( 'view_security_dash' ) }
 								href={ getRedirectUrl( 'vaultpress-dashboard' ) }
 							>
-								{ __( 'View your security dashboard' ) }
+								{ __( 'View your security dashboard', 'jetpack' ) }
 							</Button>
 						) : (
 							<Button
@@ -199,7 +207,7 @@ class MyPlanBody extends React.Component {
 									query: 'only=vaultpress',
 								} ) }
 							>
-								{ __( 'View settings' ) }
+								{ __( 'View settings', 'jetpack' ) }
 							</Button>
 						) }
 					</div>
@@ -210,18 +218,20 @@ class MyPlanBody extends React.Component {
 		let jetpackBackupCard;
 		if ( 'is-daily-backup-plan' === planClass ) {
 			jetpackBackupCard = getJetpackBackupCard( {
-				title: __( 'Automated Daily Backups' ),
+				title: __( 'Automated Daily Backups', 'jetpack' ),
 				description: __(
-					'We back up your website every day, so you never have to worry about your data again.'
+					'We back up your website every day, so you never have to worry about your data again.',
+					'jetpack'
 				),
 			} );
 		}
 
 		if ( 'is-realtime-backup-plan' === planClass ) {
 			jetpackBackupCard = getJetpackBackupCard( {
-				title: __( 'Automated Real-time Backups' ),
+				title: __( 'Automated Real-time Backups', 'jetpack' ),
 				description: __(
-					'We back up your website with every change you make, making it easy to fix your mistakes.'
+					'We back up your website with every change you make, making it easy to fix your mistakes.',
+					'jetpack'
 				),
 			} );
 		}
@@ -233,21 +243,24 @@ class MyPlanBody extends React.Component {
 						<img
 							src={ imagePath + '/jetpack-search-icon.svg' }
 							className="jp-landing__plan-features-icon"
-							alt={ __( 'A Jetpack Site with the power of Jetpack Search' ) }
+							alt={ __( 'A Jetpack Site with the power of Jetpack Search', 'jetpack' ) }
 						/>
 					</div>
 					<div className="jp-landing__plan-features-text">
 						<h3 className="jp-landing__plan-features-title">
-							{ __( 'Instant Search and Filtering' ) }
+							{ __( 'Instant Search and Filtering', 'jetpack' ) }
 						</h3>
 						<p>
-							{ __( 'Relevant search results and filtering tightly integrated with your theme.' ) }
+							{ __(
+								'Relevant search results and filtering tightly integrated with your theme.',
+								'jetpack'
+							) }
 						</p>
 						<Button
 							onClick={ this.handleButtonClickForTracking( 'view_search_customizer' ) }
 							href={ this.props.siteAdminUrl + 'customize.php?autofocus[section]=jetpack_search' }
 						>
-							{ __( 'Customize Search' ) }
+							{ __( 'Customize Search', 'jetpack' ) }
 						</Button>
 					</div>
 				</div>
@@ -269,23 +282,24 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-speed-icon.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'A fast and performant website' ) }
+									alt={ __( 'A fast and performant website', 'jetpack' ) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Optimized performance' ) }
+									{ __( 'Optimized performance', 'jetpack' ) }
 								</h3>
 								<p>
 									{ __(
-										'Load pages faster by serving your images from our global network of servers.'
+										'Load pages faster by serving your images from our global network of servers.',
+										'jetpack'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'paid_performance' ) }
 									href={ this.props.siteAdminUrl + 'admin.php?page=jetpack#/performance' }
 								>
-									{ __( 'Make your site faster' ) }
+									{ __( 'Make your site faster', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -295,19 +309,21 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-spam.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'A folder holding real comments' ) }
+									alt={ __( 'A folder holding real comments', 'jetpack' ) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Anti-spam' ) }</h3>
-								<p>{ __( 'Spam is automatically blocked from your comments.' ) }</p>
+								<h3 className="jp-landing__plan-features-title">
+									{ __( 'Anti-spam', 'jetpack' ) }
+								</h3>
+								<p>{ __( 'Spam is automatically blocked from your comments.', 'jetpack' ) }</p>
 								{ this.props.isPluginInstalled( 'akismet/akismet.php' ) &&
 								this.props.isPluginActive( 'akismet/akismet.php' ) ? (
 									<Button
 										onClick={ this.handleButtonClickForTracking( 'view_spam_stats' ) }
 										href={ this.props.siteAdminUrl + 'admin.php?page=akismet-key-config' }
 									>
-										{ __( 'View your spam stats' ) }
+										{ __( 'View your spam stats', 'jetpack' ) }
 									</Button>
 								) : (
 									<Button
@@ -317,7 +333,7 @@ class MyPlanBody extends React.Component {
 											query: 'only=akismet',
 										} ) }
 									>
-										{ __( 'View settings' ) }
+										{ __( 'View settings', 'jetpack' ) }
 									</Button>
 								) }
 							</div>
@@ -330,27 +346,35 @@ class MyPlanBody extends React.Component {
 										<img
 											src={ imagePath + '/jetpack-video-hosting.svg' }
 											className="jp-landing__plan-features-icon"
-											alt={ __( 'A cloud with multiple types of content floating around it' ) }
+											alt={ __(
+												'A cloud with multiple types of content floating around it',
+												'jetpack'
+											) }
 										/>
 									</div>
 									<div className="jp-landing__plan-features-text">
-										<h3 className="jp-landing__plan-features-title">{ __( 'Video Hosting' ) }</h3>
+										<h3 className="jp-landing__plan-features-title">
+											{ __( 'Video Hosting', 'jetpack' ) }
+										</h3>
 										<p>
-											{ __( 'High-speed, high-definition video hosting with no third-party ads.' ) }
+											{ __(
+												'High-speed, high-definition video hosting with no third-party ads.',
+												'jetpack'
+											) }
 										</p>
 										{ this.props.getFeatureState( 'videopress' ) ? (
 											<Button
 												onClick={ this.handleButtonClickForTracking( 'upload_videos' ) }
 												href={ this.props.siteAdminUrl + 'upload.php' }
 											>
-												{ __( 'Upload videos' ) }
+												{ __( 'Upload videos', 'jetpack' ) }
 											</Button>
 										) : (
 											<Button
 												onClick={ this.activateVideoPress }
 												disabled={ this.props.isActivatingFeature( 'videopress' ) }
 											>
-												{ __( 'Activate video hosting' ) }
+												{ __( 'Activate video hosting', 'jetpack' ) }
 											</Button>
 										) }
 									</div>
@@ -363,22 +387,24 @@ class MyPlanBody extends React.Component {
 									src={ imagePath + '/jetpack-site-activity.svg' }
 									className="jp-landing__plan-features-icon"
 									alt={ __(
-										'Interface showing a chronological list of changes and updates in a site'
+										'Interface showing a chronological list of changes and updates in a site',
+										'jetpack'
 									) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Activity' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">{ __( 'Activity', 'jetpack' ) }</h3>
 								<p>
 									{ __(
-										'View a chronological list of all the changes and updates to your site in an organized, readable way.'
+										'View a chronological list of all the changes and updates to your site in an organized, readable way.',
+										'jetpack'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) }
 									href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 								>
-									{ __( 'View your site activity' ) }
+									{ __( 'View your site activity', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -390,16 +416,17 @@ class MyPlanBody extends React.Component {
 										<img
 											src={ imagePath + '/jetpack-wordads.svg' }
 											className="jp-landing__plan-features-icon"
-											alt={ __( 'A chart showing an healthy increase in earnings' ) }
+											alt={ __( 'A chart showing an healthy increase in earnings', 'jetpack' ) }
 										/>
 									</div>
 									<div className="jp-landing__plan-features-text">
 										<h3 className="jp-landing__plan-features-title">
-											{ __( 'Monetize your site with ads' ) }
+											{ __( 'Monetize your site with ads', 'jetpack' ) }
 										</h3>
 										<p>
 											{ __(
-												'WordAds lets you earn money by displaying promotional content. Start earning today.'
+												'WordAds lets you earn money by displaying promotional content. Start earning today.',
+												'jetpack'
 											) }
 										</p>
 										{ this.props.isModuleActivated( 'wordads' ) ? (
@@ -409,14 +436,14 @@ class MyPlanBody extends React.Component {
 													site: this.props.siteRawUrl,
 												} ) }
 											>
-												{ __( 'View your earnings' ) }
+												{ __( 'View your earnings', 'jetpack' ) }
 											</Button>
 										) : (
 											<Button
 												onClick={ this.activateAds }
 												disabled={ this.props.isActivatingModule( 'wordads' ) }
 											>
-												{ __( 'Start earning' ) }
+												{ __( 'Start earning', 'jetpack' ) }
 											</Button>
 										) }
 									</div>
@@ -430,14 +457,20 @@ class MyPlanBody extends React.Component {
 										<img
 											src={ imagePath + '/jetpack-performance-icon.svg' }
 											className="jp-landing__plan-features-icon"
-											alt={ __( 'Site stats showing an evolution in traffic and engagement' ) }
+											alt={ __(
+												'Site stats showing an evolution in traffic and engagement',
+												'jetpack'
+											) }
 										/>
 									</div>
 									<div className="jp-landing__plan-features-text">
-										<h3 className="jp-landing__plan-features-title">{ __( 'SEO Tools' ) }</h3>
+										<h3 className="jp-landing__plan-features-title">
+											{ __( 'SEO Tools', 'jetpack' ) }
+										</h3>
 										<p>
 											{ __(
-												'Advanced SEO tools to help your site get found when people search for relevant content.'
+												'Advanced SEO tools to help your site get found when people search for relevant content.',
+												'jetpack'
 											) }
 										</p>
 										{ this.props.isModuleActivated( 'seo-tools' ) ? (
@@ -447,14 +480,14 @@ class MyPlanBody extends React.Component {
 													site: this.props.siteRawUrl,
 												} ) }
 											>
-												{ __( 'Configure site SEO' ) }
+												{ __( 'Configure site SEO', 'jetpack' ) }
 											</Button>
 										) : (
 											<Button
 												onClick={ this.activateSeo }
 												disabled={ this.props.isActivatingModule( 'seo-tools' ) }
 											>
-												{ __( 'Activate SEO tools' ) }
+												{ __( 'Activate SEO tools', 'jetpack' ) }
 											</Button>
 										) }
 									</div>
@@ -468,16 +501,20 @@ class MyPlanBody extends React.Component {
 										<img
 											src={ imagePath + '/jetpack-google-analytics.svg' }
 											className="jp-landing__plan-features-icon"
-											alt={ __( 'Site stats showing an evolution in traffic and engagement' ) }
+											alt={ __(
+												'Site stats showing an evolution in traffic and engagement',
+												'jetpack'
+											) }
 										/>
 									</div>
 									<div className="jp-landing__plan-features-text">
 										<h3 className="jp-landing__plan-features-title">
-											{ __( 'Google Analytics' ) }
+											{ __( 'Google Analytics', 'jetpack' ) }
 										</h3>
 										<p>
 											{ __(
-												'Complement WordPress.com’s stats with Google’s in-depth look at your visitors and traffic patterns.'
+												'Complement WordPress.com’s stats with Google’s in-depth look at your visitors and traffic patterns.',
+												'jetpack'
 											) }
 										</p>
 										{ this.props.isModuleActivated( 'google-analytics' ) ? (
@@ -487,14 +524,14 @@ class MyPlanBody extends React.Component {
 													site: this.props.siteRawUrl,
 												} ) }
 											>
-												{ __( 'Configure Google Analytics' ) }
+												{ __( 'Configure Google Analytics', 'jetpack' ) }
 											</Button>
 										) : (
 											<Button
 												onClick={ this.activateGoogleAnalytics }
 												disabled={ this.props.isActivatingModule( 'google-analytics' ) }
 											>
-												{ __( 'Activate Google Analytics' ) }
+												{ __( 'Activate Google Analytics', 'jetpack' ) }
 											</Button>
 										) }
 									</div>
@@ -507,21 +544,26 @@ class MyPlanBody extends React.Component {
 									<img
 										src={ imagePath + '/jetpack-themes.svg' }
 										className="jp-landing__plan-features-icon"
-										alt={ __( 'A secure site, locked and protected by Jetpack' ) }
+										alt={ __( 'A secure site, locked and protected by Jetpack', 'jetpack' ) }
 									/>
 								</div>
 								<div className="jp-landing__plan-features-text">
 									<h3 className="jp-landing__plan-features-title">
-										{ __( 'Try a premium theme' ) }
+										{ __( 'Try a premium theme', 'jetpack' ) }
 									</h3>
-									<p>{ __( 'Access beautifully designed premium themes at no extra cost.' ) }</p>
+									<p>
+										{ __(
+											'Access beautifully designed premium themes at no extra cost.',
+											'jetpack'
+										) }
+									</p>
 									<Button
 										onClick={ this.handleButtonClickForTracking( 'premium_themes' ) }
 										href={ getRedirectUrl( 'calypso-themes-premium', {
 											site: this.props.siteRawUrl,
 										} ) }
 									>
-										{ __( 'Browse premium themes' ) }
+										{ __( 'Browse premium themes', 'jetpack' ) }
 									</Button>
 								</div>
 							</div>
@@ -534,16 +576,17 @@ class MyPlanBody extends React.Component {
 										<img
 											src={ imagePath + '/jetpack-marketing.svg' }
 											className="jp-landing__plan-features-icon"
-											alt={ __( 'A secure site, locked and protected by Jetpack' ) }
+											alt={ __( 'A secure site, locked and protected by Jetpack', 'jetpack' ) }
 										/>
 									</div>
 									<div className="jp-landing__plan-features-text">
 										<h3 className="jp-landing__plan-features-title">
-											{ __( 'Marketing Automation' ) }
+											{ __( 'Marketing Automation', 'jetpack' ) }
 										</h3>
 										<p>
 											{ __(
-												'Schedule unlimited tweets, Facebook posts, and other social posts in advance.'
+												'Schedule unlimited tweets, Facebook posts, and other social posts in advance.',
+												'jetpack'
 											) }
 										</p>
 										{ this.props.isModuleActivated( 'publicize' ) ? (
@@ -553,14 +596,14 @@ class MyPlanBody extends React.Component {
 													site: this.props.siteRawUrl,
 												} ) }
 											>
-												{ __( 'Schedule posts' ) }
+												{ __( 'Schedule posts', 'jetpack' ) }
 											</Button>
 										) : (
 											<Button
 												onClick={ this.activatePublicize }
 												disabled={ this.props.isActivatingModule( 'publicize' ) }
 											>
-												{ __( 'Activate Publicize' ) }
+												{ __( 'Activate Publicize', 'jetpack' ) }
 											</Button>
 										) }
 									</div>
@@ -584,14 +627,17 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-security.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'A secure site, locked and protected by Jetpack' ) }
+									alt={ __( 'A secure site, locked and protected by Jetpack', 'jetpack' ) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Always-on security' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">
+									{ __( 'Always-on security', 'jetpack' ) }
+								</h3>
 								<p>
 									{ __(
-										'Prevent login attacks, and get instant notifications when there’s an issue with your site.'
+										'Prevent login attacks, and get instant notifications when there’s an issue with your site.',
+										'jetpack'
 									) }
 								</p>
 								<Button
@@ -600,7 +646,7 @@ class MyPlanBody extends React.Component {
 										site: this.props.siteRawUrl,
 									} ) }
 								>
-									{ __( 'Set up your site security' ) }
+									{ __( 'Set up your site security', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -610,23 +656,24 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-speed-icon.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'A fast and performant website' ) }
+									alt={ __( 'A fast and performant website', 'jetpack' ) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Optimized performance' ) }
+									{ __( 'Optimized performance', 'jetpack' ) }
 								</h3>
 								<p>
 									{ __(
-										'Load pages faster by serving your images from our global network of servers.'
+										'Load pages faster by serving your images from our global network of servers.',
+										'jetpack'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_performance' ) }
 									href={ this.props.siteAdminUrl + 'admin.php?page=jetpack#/performance' }
 								>
-									{ __( 'Make your site faster' ) }
+									{ __( 'Make your site faster', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -636,23 +683,24 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-themes.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'A wide variety of themes and tools to customize a site' ) }
+									alt={ __( 'A wide variety of themes and tools to customize a site', 'jetpack' ) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Design the perfect website' ) }
+									{ __( 'Design the perfect website', 'jetpack' ) }
 								</h3>
 								<p>
 									{ __(
-										'Get unlimited access to hundreds of professional themes, and customize your site exactly how you like it.'
+										'Get unlimited access to hundreds of professional themes, and customize your site exactly how you like it.',
+										'jetpack'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_themes' ) }
 									href={ getRedirectUrl( 'calypso-themes', { site: this.props.siteRawUrl } ) }
 								>
-									{ __( 'Explore free themes' ) }
+									{ __( 'Explore free themes', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -662,16 +710,20 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-performance-icon.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'Site stats showing an evolution in traffic and engagement' ) }
+									alt={ __(
+										'Site stats showing an evolution in traffic and engagement',
+										'jetpack'
+									) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Increase traffic to your site' ) }
+									{ __( 'Increase traffic to your site', 'jetpack' ) }
 								</h3>
 								<p>
 									{ __(
-										'Reach a wider audience by automatically sharing your posts on social media.'
+										'Reach a wider audience by automatically sharing your posts on social media.',
+										'jetpack'
 									) }
 								</p>
 								<Button
@@ -680,7 +732,7 @@ class MyPlanBody extends React.Component {
 										site: this.props.siteRawUrl,
 									} ) }
 								>
-									{ __( 'Start sharing' ) }
+									{ __( 'Start sharing', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -691,22 +743,26 @@ class MyPlanBody extends React.Component {
 									src={ imagePath + '/jetpack-site-activity.svg' }
 									className="jp-landing__plan-features-icon"
 									alt={ __(
-										'Interface showing a chronological list of changes and updates in a site'
+										'Interface showing a chronological list of changes and updates in a site',
+										'jetpack'
 									) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
-								<h3 className="jp-landing__plan-features-title">{ __( 'Site activity' ) }</h3>
+								<h3 className="jp-landing__plan-features-title">
+									{ __( 'Site activity', 'jetpack' ) }
+								</h3>
 								<p>
 									{ __(
-										'View a chronological list of all the changes and updates to your site in an organized, readable way.'
+										'View a chronological list of all the changes and updates to your site in an organized, readable way.',
+										'jetpack'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'view_site_activity' ) }
 									href={ getRedirectUrl( 'calypso-activity-log', { site: this.props.siteRawUrl } ) }
 								>
-									{ __( 'View your site activity' ) }
+									{ __( 'View your site activity', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -716,23 +772,24 @@ class MyPlanBody extends React.Component {
 								<img
 									src={ imagePath + '/jetpack-support.svg' }
 									className="jp-landing__plan-features-icon"
-									alt={ __( 'Chat bubbles representing getting in touch with support' ) }
+									alt={ __( 'Chat bubbles representing getting in touch with support', 'jetpack' ) }
 								/>
 							</div>
 							<div className="jp-landing__plan-features-text">
 								<h3 className="jp-landing__plan-features-title">
-									{ __( 'Support documentation' ) }
+									{ __( 'Support documentation', 'jetpack' ) }
 								</h3>
 								<p>
 									{ __(
-										'Need help? Learn about getting started, customizing your site, using advanced code snippets, and more.'
+										'Need help? Learn about getting started, customizing your site, using advanced code snippets, and more.',
+										'jetpack'
 									) }
 								</p>
 								<Button
 									onClick={ this.handleButtonClickForTracking( 'free_support_documentation' ) }
 									href={ getRedirectUrl( 'jetpack-support' ) }
 								>
-									{ __( 'Search support docs' ) }
+									{ __( 'Search support docs', 'jetpack' ) }
 								</Button>
 							</div>
 						</div>
@@ -741,19 +798,19 @@ class MyPlanBody extends React.Component {
 							<div className="jp-landing__plan-features-card">
 								<div className="jp-landing__plan-features-text">
 									<h3 className="jp-landing__plan-features-title">
-										{ __( 'Take your site to the next level!' ) }
+										{ __( 'Take your site to the next level!', 'jetpack' ) }
 									</h3>
 									<ul className="jp-landing__plan-features-list">
-										<li>{ __( 'Expand your audience with pro SEO tools.' ) }</li>
-										<li>{ __( 'Customize your social posting schedule.' ) }</li>
-										<li>{ __( 'Monetize your site by running high quality ads.' ) }</li>
+										<li>{ __( 'Expand your audience with pro SEO tools.', 'jetpack' ) }</li>
+										<li>{ __( 'Customize your social posting schedule.', 'jetpack' ) }</li>
+										<li>{ __( 'Monetize your site by running high quality ads.', 'jetpack' ) }</li>
 									</ul>
 									<Button
 										className="is-primary"
 										onClick={ this.handleButtonClickForTracking( 'free_explore_jetpack_plans' ) }
 										href={ '#/plans' }
 									>
-										{ __( 'Upgrade Jetpack now' ) }
+										{ __( 'Upgrade Jetpack now', 'jetpack' ) }
 									</Button>
 								</div>
 							</div>

--- a/_inc/client/my-plan/my-plan-header/checklist-cta.js
+++ b/_inc/client/my-plan/my-plan-header/checklist-cta.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import getRedirectUrl from 'lib/jp-redirect';
 
 export default function ChecklistCta( { onClick, siteSlug } ) {
 	return (
@@ -18,7 +18,7 @@ export default function ChecklistCta( { onClick, siteSlug } ) {
 				onClick={ onClick }
 				primary
 			>
-				{ __( 'View your setup checklist' ) }
+				{ __( 'View your setup checklist', 'jetpack' ) }
 			</Button>
 		</div>
 	);

--- a/_inc/client/my-plan/my-plan-header/checklist-progress-card/index.js
+++ b/_inc/client/my-plan/my-plan-header/checklist-progress-card/index.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { translate as __ } from 'i18n-calypso';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import getRedirectUrl from 'lib/jp-redirect';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,6 +11,7 @@ import getRedirectUrl from 'lib/jp-redirect';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import ProgressBar from './progress-bar';
 import QueryChecklistProgress from 'components/data/query-checklist-progress';
 import { getSiteRawUrl } from 'state/initial-state';
@@ -38,9 +38,11 @@ class ChecklistProgressCard extends Component {
 						<div className="checklist__header-main">
 							<div className="checklist__header-progress">
 								<span className="checklist__header-progress-text">
-									{ __( 'Your Jetpack setup progress', {
-										comment: 'Onboarding task list progress',
-									} ) }
+									{ _x(
+										'Your Jetpack setup progress',
+										'Onboarding task list progress',
+										'jetpack'
+									) }
 								</span>
 								<span className="checklist__header-progress-number">{ `${ completed }/${ total }` }</span>
 							</div>
@@ -53,9 +55,11 @@ class ChecklistProgressCard extends Component {
 								onClick={ this.trackCtaClick }
 								primary
 							>
-								{ __( 'Complete Jetpack Setup', {
-									comment: 'Text on link to list of onboarding tasks',
-								} ) }
+								{ _x(
+									'Complete Jetpack Setup',
+									'Text on link to list of onboarding tasks',
+									'jetpack'
+								) }
 							</Button>
 						</div>
 					</Card>

--- a/_inc/client/my-plan/my-plan-header/index.js
+++ b/_inc/client/my-plan/my-plan-header/index.js
@@ -3,9 +3,10 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { translate as __ } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { find, isEmpty } from 'lodash';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -46,21 +47,22 @@ class MyPlanHeader extends React.Component {
 			case 'is-free-plan':
 				return {
 					icon: imagePath + '/plans/plan-free.svg',
-					tagLine: __(
-						'Worried about security? Get backups, automated security fixes and more: {{a}}Upgrade now{{/a}}',
+					tagLine: jetpackCreateInterpolateElement(
+						__(
+							'Worried about security? Get backups, automated security fixes and more: <a>Upgrade now</a>',
+							'jetpack'
+						),
 						{
-							components: {
-								a: (
-									<UpgradeLink
-										source="my-plan-header-free-plan-text-link"
-										target="upgrade-now"
-										feature="my-plan-header-free-upgrade"
-									/>
-								),
-							},
+							a: (
+								<UpgradeLink
+									source="my-plan-header-free-plan-text-link"
+									target="upgrade-now"
+									feature="my-plan-header-free-upgrade"
+								/>
+							),
 						}
 					),
-					title: __( 'Jetpack Free' ),
+					title: __( 'Jetpack Free', 'jetpack' ),
 				};
 
 			case 'is-personal-plan':
@@ -68,9 +70,9 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: imagePath + '/plans/plan-personal.svg',
 					tagLine: displayBackups
-						? __( 'Daily backups, spam filtering, and priority support.' )
-						: __( 'Spam filtering and priority support.' ),
-					title: __( 'Jetpack Personal' ),
+						? __( 'Daily backups, spam filtering, and priority support.', 'jetpack' )
+						: __( 'Spam filtering and priority support.', 'jetpack' ),
+					title: __( 'Jetpack Personal', 'jetpack' ),
 				};
 
 			case 'is-premium-plan':
@@ -78,9 +80,10 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: imagePath + '/plans/plan-premium.svg',
 					tagLine: __(
-						'Full security suite, marketing and revenue automation tools, unlimited video hosting, and priority support.'
+						'Full security suite, marketing and revenue automation tools, unlimited video hosting, and priority support.',
+						'jetpack'
 					),
-					title: __( 'Jetpack Premium' ),
+					title: __( 'Jetpack Premium', 'jetpack' ),
 				};
 
 			case 'is-business-plan':
@@ -88,41 +91,47 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: imagePath + '/plans/plan-business.svg',
 					tagLine: __(
-						'Full security suite, marketing and revenue automation tools, unlimited video hosting, unlimited themes, and priority support.'
+						'Full security suite, marketing and revenue automation tools, unlimited video hosting, unlimited themes, and priority support.',
+						'jetpack'
 					),
-					title: __( 'Jetpack Professional' ),
+					title: __( 'Jetpack Professional', 'jetpack' ),
 				};
 
 			case 'is-daily-backup-plan':
 				return {
 					details: expiration,
 					icon: imagePath + '/products/product-jetpack-backup.svg',
-					tagLine: __( 'Your data is being securely backed up every day with a 30-day archive.' ),
-					title: __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-						components: {
+					tagLine: __(
+						'Your data is being securely backed up every day with a 30-day archive.',
+						'jetpack'
+					),
+					title: jetpackCreateInterpolateElement(
+						__( 'Jetpack Backup <em>Daily</em>', 'jetpack' ),
+						{
 							em: <em />,
-						},
-					} ),
+						}
+					),
 				};
 
 			case 'is-realtime-backup-plan':
 				return {
 					details: expiration,
 					icon: imagePath + '/products/product-jetpack-backup.svg',
-					tagLine: __( 'Your data is being securely backed up as you edit.' ),
-					title: __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-						components: {
+					tagLine: __( 'Your data is being securely backed up as you edit.', 'jetpack' ),
+					title: jetpackCreateInterpolateElement(
+						__( 'Jetpack Backup <em>Real-Time</em>', 'jetpack' ),
+						{
 							em: <em />,
-						},
-					} ),
+						}
+					),
 				};
 
 			case 'is-search-plan':
 				return {
 					details: expiration,
 					icon: imagePath + '/products/product-jetpack-search.svg',
-					tagLine: __( 'Fast, highly relevant search results and powerful filtering.' ),
-					title: __( 'Jetpack Search' ),
+					tagLine: __( 'Fast, highly relevant search results and powerful filtering.', 'jetpack' ),
+					title: __( 'Jetpack Search', 'jetpack' ),
 				};
 
 			case 'is-scan-plan':
@@ -130,9 +139,12 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: `${ imagePath }/products/product-jetpack-scan.svg`,
 					tagLine: __(
-						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.'
+						'Automatic scanning and one-click fixes keep your site one step ahead of security threats.',
+						'jetpack'
 					),
-					title: __( 'Jetpack Scan {{em}}Daily{{/em}}', { components: { em: <em /> } } ),
+					title: jetpackCreateInterpolateElement( __( 'Jetpack Scan <em>Daily</em>', 'jetpack' ), {
+						em: <em />,
+					} ),
 				};
 
 			case 'is-anti-spam-plan':
@@ -140,9 +152,10 @@ class MyPlanHeader extends React.Component {
 					details: expiration,
 					icon: `${ imagePath }/products/product-jetpack-anti-spam.svg`,
 					tagLine: __(
-						'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.'
+						'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.',
+						'jetpack'
 					),
-					title: __( 'Jetpack Anti-Spam' ),
+					title: __( 'Jetpack Anti-Spam', 'jetpack' ),
 				};
 
 			default:
@@ -155,7 +168,7 @@ class MyPlanHeader extends React.Component {
 	renderPlan() {
 		return (
 			<Card compact>
-				{ this.renderHeader( __( 'My Plan' ) ) }
+				{ this.renderHeader( __( 'My Plan', 'jetpack' ) ) }
 				<MyPlanCard { ...this.getProductProps( this.props.plan ) } />
 			</Card>
 		);
@@ -168,7 +181,7 @@ class MyPlanHeader extends React.Component {
 
 		return (
 			<Card compact>
-				{ this.renderHeader( __( 'My Products' ) ) }
+				{ this.renderHeader( __( 'My Products', 'jetpack' ) ) }
 				{ this.props.activeProducts.map( ( { ID, product_slug } ) => (
 					<MyPlanCard key={ 'product-card-' + ID } { ...this.getProductProps( product_slug ) } />
 				) ) }

--- a/_inc/client/notices/validation-error-list.jsx
+++ b/_inc/client/notices/validation-error-list.jsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-
 import React from 'react';
+import PropTypes from 'prop-types';
 import { map } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { _n } from '@wordpress/i18n';
 
 export default class ValidationErrorList extends React.Component {
 	static displayName = 'ValidationErrorList';
@@ -18,12 +17,11 @@ export default class ValidationErrorList extends React.Component {
 		return (
 			<div>
 				<p>
-					{ __(
+					{ _n(
 						'Please correct the issue below and try again.',
 						'Please correct the issues listed below and try again.',
-						{
-							count: this.props.messages.length,
-						}
+						this.props.messages.length,
+						'jetpack'
 					) }
 				</p>
 				<ul>

--- a/_inc/client/performance/index.jsx
+++ b/_inc/client/performance/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -47,8 +47,11 @@ class Performance extends Component {
 				<Card
 					title={
 						this.props.searchTerm
-							? __( 'Performance' )
-							: __( 'Load pages faster, optimize images, and speed up your visitors’ experience.' )
+							? __( 'Performance', 'jetpack' )
+							: __(
+									'Load pages faster, optimize images, and speed up your visitors’ experience.',
+									'jetpack'
+							  )
 					}
 					className="jp-settings-description"
 				/>

--- a/_inc/client/performance/media.jsx
+++ b/_inc/client/performance/media.jsx
@@ -3,15 +3,15 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
 import { includes } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { FEATURE_VIDEO_HOSTING_JETPACK, getPlanClass } from 'lib/plans/constants';
 import { FormLegend } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -40,13 +40,12 @@ class Media extends React.Component {
 					link: getRedirectUrl( 'jetpack-support-videopress' ),
 				} }
 			>
-				<FormLegend className="jp-form-label-wide">{ __( 'Video' ) }</FormLegend>
+				<FormLegend className="jp-form-label-wide">{ __( 'Video', 'jetpack' ) }</FormLegend>
 				<p>
 					{ ' ' }
 					{ __(
-						'Make the content you publish more engaging with high-resolution video. ' +
-							'With Jetpack Video you can customize your media player and deliver ' +
-							'high-speed, ad-free, and unbranded videos to your visitors. Videos are hosted on our WordPress.com servers and do not subtract space from your hosting plan!'
+						'Make the content you publish more engaging with high-resolution video. With Jetpack Video you can customize your media player and deliver high-speed, ad-free, and unbranded videos to your visitors. Videos are hosted on our WordPress.com servers and do not subtract space from your hosting plan!',
+						'jetpack'
 					) }{ ' ' }
 				</p>
 				<ModuleToggle
@@ -57,7 +56,7 @@ class Media extends React.Component {
 					toggleModule={ this.props.toggleModuleNow }
 				>
 					<span className="jp-form-toggle-explanation">
-						{ __( 'Enable high-speed, ad-free video player' ) }
+						{ __( 'Enable high-speed, ad-free video player', 'jetpack' ) }
 					</span>
 				</ModuleToggle>
 			</SettingsGroup>
@@ -68,7 +67,7 @@ class Media extends React.Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Media' ) }
+				header={ __( 'Media', 'jetpack' ) }
 				feature={ ! videoPressForcedInactive && FEATURE_VIDEO_HOSTING_JETPACK }
 				hideButton
 			>

--- a/_inc/client/performance/search.jsx
+++ b/_inc/client/performance/search.jsx
@@ -4,26 +4,26 @@
 import React, { Fragment, useMemo, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import getRedirectUrl from 'lib/jp-redirect';
 
 /**
  * Internal dependencies
  */
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
-import { ModuleToggle } from 'components/module-toggle';
-import SettingsCard from 'components/settings-card';
-import SettingsGroup from 'components/settings-group';
-import { FormFieldset } from 'components/forms';
+import Card from 'components/card';
 import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FEATURE_SEARCH_JETPACK, getPlanClass } from 'lib/plans/constants';
-import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
-import { hasUpdatedSetting, isSettingActivated, isUpdatingSetting } from 'state/settings';
+import { FormFieldset } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import {
 	getSitePlan,
 	hasActiveSearchPurchase as selectHasActiveSearchPurchase,
 	isFetchingSitePurchases,
 } from 'state/site';
+import { hasUpdatedSetting, isSettingActivated, isUpdatingSetting } from 'state/settings';
+import { ModuleToggle } from 'components/module-toggle';
+import { SEARCH_DESCRIPTION, SEARCH_CUSTOMIZE_CTA, SEARCH_SUPPORT } from 'plans/constants';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 function toggleModuleFactory( {
 	getOptionValue,
@@ -78,7 +78,7 @@ function Search( props ) {
 				} }
 			>
 				<p>{ SEARCH_DESCRIPTION } </p>
-				{ props.isLoading && __( 'Loading…' ) }
+				{ props.isLoading && __( 'Loading…', 'jetpack' ) }
 				{ ! props.isLoading && ( props.isBusinessPlan || props.hasActiveSearchPurchase ) && (
 					<Fragment>
 						<ModuleToggle
@@ -88,7 +88,7 @@ function Search( props ) {
 							toggleModule={ toggleModule }
 							toggling={ props.isSavingAnyOption( 'search' ) }
 						>
-							{ __( 'Enable Search' ) }
+							{ __( 'Enable Search', 'jetpack' ) }
 						</ModuleToggle>
 
 						<FormFieldset>
@@ -99,13 +99,13 @@ function Search( props ) {
 								toggling={ props.isSavingAnyOption( 'instant_search_enabled' ) }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Enable instant search experience (recommended)' ) }
+									{ __( 'Enable instant search experience (recommended)', 'jetpack' ) }
 								</span>
 							</CompactFormToggle>
 							<p className="jp-form-setting-explanation jp-form-search-setting-explanation">
 								{ __(
-									'Instant search will allow your visitors to get search results as soon as they start typing. ' +
-										'If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.'
+									'Instant search will allow your visitors to get search results as soon as they start typing. If deactivated, Jetpack Search will still optimize your search results but visitors will have to submit a search query before seeing any results.',
+									'jetpack'
 								) }
 							</p>
 						</FormFieldset>
@@ -121,7 +121,7 @@ function Search( props ) {
 						className="jp-settings-card__configure-link"
 						href="customize.php?autofocus[panel]=widgets"
 					>
-						{ __( 'Add Jetpack Search Widget' ) }
+						{ __( 'Add Jetpack Search Widget', 'jetpack' ) }
 					</Card>
 				) }
 			{ props.hasActiveSearchPurchase && isModuleEnabled && isInstantSearchEnabled && (

--- a/_inc/client/performance/speed-up-site.jsx
+++ b/_inc/client/performance/speed-up-site.jsx
@@ -3,21 +3,21 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { FormFieldset } from 'components/forms';
+import analytics from 'lib/analytics';
 import CompactFormToggle from 'components/form/form-toggle/compact';
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import { FormFieldset } from 'components/forms';
 import { getModule, getModuleOverride } from 'state/modules';
+import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleFound as _isModuleFound } from 'state/search';
+import { ModuleToggle } from 'components/module-toggle';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
-import { ModuleToggle } from 'components/module-toggle';
-import analytics from 'lib/analytics';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 const SpeedUpSite = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -57,10 +57,14 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 			// If one of them is on, we turn everything off, including Tiled Galleries that depend on Photon.
 			if ( true === siteAcceleratorStatus ) {
 				const messages = {
-					progress: __( 'Disabling site accelerator…' ),
-					success: __( 'Site accelerator is no longer speeding up your site!' ),
+					progress: __( 'Disabling site accelerator…', 'jetpack' ),
+					success: __( 'Site accelerator is no longer speeding up your site!', 'jetpack' ),
 					error: error =>
-						__( 'Error disabling site accelerator. %(error)s', { args: { error: error } } ),
+						sprintf(
+							/* translators: placeholder is an error code. */
+							__( 'Error disabling site accelerator. %s', 'jetpack' ),
+							error
+						),
 				};
 				let settings = {};
 
@@ -82,10 +86,14 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 				this.props.updateOptions( settings, messages );
 			} else {
 				const messages = {
-					progress: __( 'Enabling Site accelerator…' ),
-					success: __( 'Site accelerator is now speeding up your site!' ),
+					progress: __( 'Enabling Site accelerator…', 'jetpack' ),
+					success: __( 'Site accelerator is now speeding up your site!', 'jetpack' ),
 					error: error =>
-						__( 'Error enabling Site accelerator. %(error)s', { args: { error: error } } ),
+						sprintf(
+							/* translators: placeholder is an error code. */
+							__( 'Error enabling Site accelerator. %s', 'jetpack' ),
+							error
+						),
 				};
 				let settings = {};
 
@@ -221,7 +229,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Performance & speed' ) }
+					header={ __( 'Performance & speed', 'jetpack' ) }
 					hideButton
 					module="performance-speed"
 				>
@@ -234,8 +242,8 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 						>
 							<p>
 								{ __(
-									'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
-										'and static files (like CSS and JavaScript) from our global network of servers.'
+									'Load pages faster by allowing Jetpack to optimize your images and serve your images and static files (like CSS and JavaScript) from our global network of servers.',
+									'jetpack'
 								) }
 							</p>
 							{ canAppearInSearch && (
@@ -246,7 +254,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 									disabled={ ! canDisplaySiteAcceleratorSettings }
 								>
 									<span className="jp-form-toggle-explanation">
-										{ __( 'Enable site accelerator' ) }
+										{ __( 'Enable site accelerator', 'jetpack' ) }
 									</span>
 								</CompactFormToggle>
 							) }
@@ -260,7 +268,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 										toggleModule={ this.toggleModule }
 									>
 										<span className="jp-form-toggle-explanation">
-											{ __( 'Speed up image load times' ) }
+											{ __( 'Speed up image load times', 'jetpack' ) }
 										</span>
 									</ModuleToggle>
 								) }
@@ -272,7 +280,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 										toggleModule={ this.toggleModule }
 									>
 										<span className="jp-form-toggle-explanation">
-											{ __( 'Speed up static file load times' ) }
+											{ __( 'Speed up static file load times', 'jetpack' ) }
 										</span>
 									</ModuleToggle>
 								) }
@@ -290,9 +298,8 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 						>
 							<p>
 								{ __(
-									'Lazy-loading images will improve your site’s speed and create a ' +
-										'smoother viewing experience. Images will load as visitors ' +
-										'scroll down the screen, instead of all at once.'
+									'Lazy-loading images will improve your site’s speed and create a smoother viewing experience. Images will load as visitors scroll down the screen, instead of all at once.',
+									'jetpack'
 								) }
 							</p>
 							<ModuleToggle
@@ -303,7 +310,7 @@ const SpeedUpSite = withModuleSettingsFormHelpers(
 								toggleModule={ this.toggleModule }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Enable Lazy Loading for images' ) }
+									{ __( 'Enable Lazy Loading for images', 'jetpack' ) }
 								</span>
 							</ModuleToggle>
 						</SettingsGroup>

--- a/_inc/client/plans-prompt/index.jsx
+++ b/_inc/client/plans-prompt/index.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -10,7 +11,6 @@ import { connect } from 'react-redux';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import Plans from '../plans';
-import { translate as __ } from 'i18n-calypso';
 import Gridicon from '../components/gridicon';
 import JetpackLogo from '../components/jetpack-logo';
 import { getAvailablePlans } from 'state/site/reducer';
@@ -27,9 +27,9 @@ export class PlansPrompt extends React.Component {
 		return (
 			<div className="plans-prompt__banner">
 				<JetpackLogo className="plans-prompt__logo" />
-				<h2 className="plans-prompt__heading">{ __( 'Explore our Jetpack plans' ) }</h2>
+				<h2 className="plans-prompt__heading">{ __( 'Explore our Jetpack plans', 'jetpack' ) }</h2>
 				<p className="plans-prompt__intro">
-					{ __( "Now that you're set up, pick a plan that fits your needs." ) }
+					{ __( "Now that you're set up, pick a plan that fits your needs.", 'jetpack' ) }
 				</p>
 			</div>
 		);
@@ -45,7 +45,7 @@ export class PlansPrompt extends React.Component {
 					href={ this.props.siteAdminUrl + 'admin.php?page=jetpack' }
 					onClick={ this.trackStartWithFreeClick }
 				>
-					{ __( 'Start with free' ) }
+					{ __( 'Start with free', 'jetpack' ) }
 					<Gridicon icon={ 'arrow-right' } size={ 18 } />
 				</Button>
 			</div>

--- a/_inc/client/plans/constants.js
+++ b/_inc/client/plans/constants.js
@@ -2,24 +2,36 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
-export const BACKUP_TITLE = __( 'Jetpack Backup' );
-export const BACKUP_DESCRIPTION = __( 'Always-on backups ensure you never lose your site.' );
+export const BACKUP_TITLE = __( 'Jetpack Backup', 'jetpack' );
+export const BACKUP_DESCRIPTION = __(
+	'Always-on backups ensure you never lose your site.',
+	'jetpack'
+);
 export const BACKUP_DESCRIPTION_REALTIME = __(
-	'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.'
+	'Always-on backups ensure you never lose your site. Your changes are saved as you edit and you have unlimited backup archives.',
+	'jetpack'
 );
-export const DAILY_BACKUP_TITLE = __( 'Jetpack Backup {{em}}Daily{{/em}}', {
-	components: { em: <em /> },
-} );
+export const DAILY_BACKUP_TITLE = jetpackCreateInterpolateElement(
+	__( 'Jetpack Backup <em>Daily</em>', 'jetpack' ),
+	{
+		em: <em />,
+	}
+);
 
-export const REALTIME_BACKUP_TITLE = __( 'Jetpack Backup {{em}}Real-Time{{/em}}', {
-	components: { em: <em /> },
-} );
+export const REALTIME_BACKUP_TITLE = jetpackCreateInterpolateElement(
+	__( 'Jetpack Backup <em>Real-Time</em>', 'jetpack' ),
+	{
+		em: <em />,
+	}
+);
 
-export const SEARCH_TITLE = __( 'Jetpack Search' );
+export const SEARCH_TITLE = __( 'Jetpack Search', 'jetpack' );
 export const SEARCH_DESCRIPTION = __(
-	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.'
+	'Incredibly powerful and customizable, Jetpack Search helps your visitors instantly find the right content – right when they need it.',
+	'jetpack'
 );
-export const SEARCH_CUSTOMIZE_CTA = __( 'Customize your Search experience.' );
-export const SEARCH_SUPPORT = __( 'Search supports many customizations. ' );
+export const SEARCH_CUSTOMIZE_CTA = __( 'Customize your Search experience.', 'jetpack' );
+export const SEARCH_SUPPORT = __( 'Search supports many customizations. ', 'jetpack' );

--- a/_inc/client/plans/duration-switcher.js
+++ b/_inc/client/plans/duration-switcher.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { map } from 'lodash';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import analytics from 'lib/analytics';
 import Button from 'components/button';
 import ButtonGroup from 'components/button-group';
 import { setPlanDuration, getPlanDuration } from 'state/plans';
-import { translate as __ } from 'i18n-calypso';
 
 class DurationSwitcher extends React.Component {
 	handlePeriodChange( newPeriod ) {
@@ -33,8 +33,8 @@ class DurationSwitcher extends React.Component {
 	render() {
 		const { planDuration } = this.props;
 		const periods = {
-			monthly: __( 'Monthly' ),
-			yearly: __( 'Yearly' ),
+			monthly: __( 'Monthly', 'jetpack' ),
+			yearly: __( 'Yearly', 'jetpack' ),
 		};
 
 		return (

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -5,18 +5,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { includes, map, reduce } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
 import Button from 'components/button';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getSiteRawUrl, getUpgradeUrl, getUserId, showBackups } from 'state/initial-state';
 import { getSitePlan, getAvailablePlans, isFetchingSiteData } from 'state/site/reducer';
 import { getPlanDuration } from 'state/plans';
 import { getPlanClass } from 'lib/plans/constants';
-import { translate as __ } from 'i18n-calypso';
 import TopButton from './top-button';
 import FeatureItem from './feture-item';
 import DurationSwitcher from './duration-switcher';
@@ -75,19 +75,21 @@ class PlanGrid extends React.Component {
 	}
 
 	renderMobileCard() {
-		const currently = __( 'You’re currently on Jetpack %(plan)s.', {
-			args: { plan: this.props.sitePlan.product_name_short },
-		} );
+		const currently = sprintf(
+			/* translators: placeholder is a plan name, like "Premium". */
+			__( 'You’re currently on Jetpack %s.', 'jetpack' ),
+			this.props.sitePlan.product_name_short
+		);
 		const myPlanUrl = getRedirectUrl( 'calypso-plans-my-plan', { site: this.props.siteRawUrl } );
 		const plansUrl = getRedirectUrl( 'calypso-plans', { site: this.props.siteRawUrl } );
 
 		return (
 			<div className="plans-mobile-notice dops-card">
-				<h2>{ __( 'Your Plan' ) }</h2>
+				<h2>{ __( 'Your Plan', 'jetpack' ) }</h2>
 				<p>{ currently }</p>
-				<Button href={ myPlanUrl }>{ __( 'Manage your plan' ) }</Button>
+				<Button href={ myPlanUrl }>{ __( 'Manage your plan', 'jetpack' ) }</Button>
 				<Button href={ plansUrl } primary>
-					{ __( 'View all Jetpack plans' ) }
+					{ __( 'View all Jetpack plans', 'jetpack' ) }
 				</Button>
 			</div>
 		);

--- a/_inc/client/plans/product-selector.jsx
+++ b/_inc/client/plans/product-selector.jsx
@@ -3,8 +3,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import { get } from 'lodash';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -39,9 +38,9 @@ class ProductSelector extends Component {
 	renderTitleSection() {
 		return (
 			<Fragment>
-				<h1 className="plans-section__header">{ __( 'Solutions' ) }</h1>
+				<h1 className="plans-section__header">{ __( 'Solutions', 'jetpack' ) }</h1>
 				<h2 className="plans-section__subheader">
-					{ __( "Looking for specific features? We've got you covered." ) }
+					{ __( "Looking for specific features? We've got you covered.", 'jetpack' ) }
 				</h2>
 			</Fragment>
 		);

--- a/_inc/client/plans/single-product-components/plan-radio-button.jsx
+++ b/_inc/client/plans/single-product-components/plan-radio-button.jsx
@@ -3,13 +3,15 @@
  */
 import React from 'react';
 import classNames from 'classnames';
+import { __, sprintf } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import PriceGroup from './price-group';
 import './plan-radio-button.scss';
 
-import { numberFormat, translate as __ } from 'i18n-calypso';
+import { numberFormat } from 'i18n-calypso';
 
 import {
 	JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS,
@@ -23,20 +25,22 @@ import {
 function getSearchTierLabel( priceTierSlug, recordCount ) {
 	switch ( priceTierSlug ) {
 		case JETPACK_SEARCH_TIER_UP_TO_100_RECORDS:
-			return __( 'Up to 100 records' );
+			return __( 'Up to 100 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_1K_RECORDS:
-			return __( 'Up to 1,000 records' );
+			return __( 'Up to 1,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_10K_RECORDS:
-			return __( 'Up to 10,000 records' );
+			return __( 'Up to 10,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_100K_RECORDS:
-			return __( 'Up to 100,000 records' );
+			return __( 'Up to 100,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_1M_RECORDS:
-			return __( 'Up to 1,000,000 records' );
+			return __( 'Up to 1,000,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS: {
 			const tierMaximumRecords = 1000000 * Math.ceil( recordCount / 1000000 );
-			return __( 'Up to %(tierMaximumRecords)s records', {
-				args: { tierMaximumRecords: numberFormat( tierMaximumRecords ) },
-			} );
+			return sprintf(
+				/* translators: placeholder is a number. */
+				__( 'Up to %s records', 'jetpack' ),
+				numberFormat( tierMaximumRecords )
+			);
 		}
 		default:
 			return null;

--- a/_inc/client/plans/single-product-components/product-options-label.js
+++ b/_inc/client/plans/single-product-components/product-options-label.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { numberFormat, translate as __ } from 'i18n-calypso';
+import { numberFormat } from 'i18n-calypso';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -10,10 +11,15 @@ import { numberFormat, translate as __ } from 'i18n-calypso';
 import InfoPopover from 'components/info-popover';
 
 function getSearchLabel( recordCount ) {
-	return __(
-		'Your current site record size: %s record',
-		'Your current site record size: %s records',
-		{ args: numberFormat( recordCount ), count: recordCount }
+	return sprintf(
+		/* translators: placeholder is a number of records (posts, pages, ...) on your site. */
+		_n(
+			'Your current site record size: %s record',
+			'Your current site record size: %s records',
+			recordCount,
+			'jetpack'
+		),
+		numberFormat( recordCount )
 	);
 }
 

--- a/_inc/client/plans/single-product-components/product-savings.jsx
+++ b/_inc/client/plans/single-product-components/product-savings.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -30,8 +31,20 @@ export default function ProductSavings( {
 	return (
 		<p className="single-product__savings">
 			{ billingTimeframe === 'monthly'
-				? __( 'You would save {{savings /}} by paying yearly', { components: { savings } } )
-				: __( 'You are saving {{savings /}} by paying yearly', { components: { savings } } ) }
+				? jetpackCreateInterpolateElement(
+						/* translators: placeholder is an amount of money. */
+						__( 'You would save <savings /> by paying yearly', 'jetpack' ),
+						{
+							savings,
+						}
+				  )
+				: jetpackCreateInterpolateElement(
+						/* translators: placeholder is an amount of money. */
+						__( 'You are saving <savings /> by paying yearly', 'jetpack' ),
+						{
+							savings,
+						}
+				  ) }
 		</p>
 	);
 }

--- a/_inc/client/plans/single-product-components/promo-nudge.jsx
+++ b/_inc/client/plans/single-product-components/promo-nudge.jsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -14,14 +15,15 @@ export default function PromoNudge( { percent } ) {
 	return (
 		<div className="single-product-backup__promo">
 			<div className="single-product-backup__promo-star">
-				{ __( 'Up to %(percent)d%% off!', { args: { percent: discountPercent } } ) }
+				{ sprintf( __( 'Up to %d%% off!', 'jetpack' ), discountPercent ) }
 			</div>
 			<h4 className="single-product-backup__promo-header">
-				{ __( 'Hurry, these are {{s}}Limited time introductory prices!{{/s}}', {
-					components: {
+				{ jetpackCreateInterpolateElement(
+					__( 'Hurry, these are <s>Limited time introductory prices!</s>', 'jetpack' ),
+					{
 						s: <strong />,
-					},
-				} ) }
+					}
+				) }
 			</h4>
 		</div>
 	);

--- a/_inc/client/plans/single-product-components/purchased-product-card.jsx
+++ b/_inc/client/plans/single-product-components/purchased-product-card.jsx
@@ -2,15 +2,12 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import ProductCard from 'components/product-card';
-import ProductExpiration from 'components/product-expiration';
-import { getPlanClass } from 'lib/plans/constants';
 import {
 	BACKUP_DESCRIPTION_REALTIME,
 	BACKUP_DESCRIPTION,
@@ -19,6 +16,10 @@ import {
 	SEARCH_DESCRIPTION,
 	SEARCH_TITLE,
 } from '../constants';
+import { getPlanClass } from 'lib/plans/constants';
+import getRedirectUrl from 'lib/jp-redirect';
+import ProductCard from 'components/product-card';
+import ProductExpiration from 'components/product-expiration';
 
 export default function PurchasedProductCard( { purchase, siteRawlUrl } ) {
 	if ( ! purchase || ! siteRawlUrl ) {
@@ -69,27 +70,36 @@ export default function PurchasedProductCard( { purchase, siteRawlUrl } ) {
 		case 'is-personal-plan':
 			productCardProps = {
 				title: DAILY_BACKUP_TITLE,
-				subtitle: __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
-					components: { planLink },
-				} ),
+				subtitle: jetpackCreateInterpolateElement(
+					__( 'Included in your <planLink>Personal Plan</planLink>', 'jetpack' ),
+					{
+						planLink,
+					}
+				),
 				description: BACKUP_DESCRIPTION,
 				...productCardProps,
 			};
 		case 'is-premium-plan':
 			productCardProps = {
 				title: DAILY_BACKUP_TITLE,
-				subtitle: __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
-					components: { planLink },
-				} ),
+				subtitle: jetpackCreateInterpolateElement(
+					__( 'Included in your <planLink>Premium Plan</planLink>', 'jetpack' ),
+					{
+						planLink,
+					}
+				),
 				description: BACKUP_DESCRIPTION,
 				...productCardProps,
 			};
 		case 'is-business-plan':
 			productCardProps = {
 				title: REALTIME_BACKUP_TITLE,
-				subtitle: __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
-					components: { planLink },
-				} ),
+				subtitle: jetpackCreateInterpolateElement(
+					__( 'Included in your <planLink>Professional Plan</planLink>', 'jetpack' ),
+					{
+						planLink,
+					}
+				),
 				description: BACKUP_DESCRIPTION_REALTIME,
 				...productCardProps,
 			};

--- a/_inc/client/plans/single-product-components/upgrade-button.jsx
+++ b/_inc/client/plans/single-product-components/upgrade-button.jsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -17,10 +17,11 @@ export default function UpgradeButton( { selectedUpgrade, onClickHandler } ) {
 	return (
 		<div className="single-product__upgrade-button-container">
 			<Button href={ link } onClick={ onClickHandler( type ) } primary>
-				{ __( 'Upgrade to %(name)s', {
-					args: { name },
-					comment: 'Button to purchase product upgrade. %(name)s is the product name.',
-				} ) }
+				{ sprintf(
+					/* translators: Button to purchase product upgrade. Placeholder is the product name. */
+					__( 'Upgrade to %s', 'jetpack' ),
+					name
+				) }
 			</Button>
 		</div>
 	);

--- a/_inc/client/plans/single-product-search/index.jsx
+++ b/_inc/client/plans/single-product-search/index.jsx
@@ -3,8 +3,9 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __, numberFormat } from 'i18n-calypso';
 import { get } from 'lodash';
+import { numberFormat } from 'i18n-calypso';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -30,20 +31,22 @@ import ProductSavings from '../single-product-components/product-savings';
 function getTierLabel( priceTierSlug, recordCount ) {
 	switch ( priceTierSlug ) {
 		case JETPACK_SEARCH_TIER_UP_TO_100_RECORDS:
-			return __( 'Up to 100 records' );
+			return __( 'Up to 100 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_1K_RECORDS:
-			return __( 'Up to 1,000 records' );
+			return __( 'Up to 1,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_10K_RECORDS:
-			return __( 'Up to 10,000 records' );
+			return __( 'Up to 10,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_100K_RECORDS:
-			return __( 'Up to 100,000 records' );
+			return __( 'Up to 100,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_UP_TO_1M_RECORDS:
-			return __( 'Up to 1,000,000 records' );
+			return __( 'Up to 1,000,000 records', 'jetpack' );
 		case JETPACK_SEARCH_TIER_MORE_THAN_1M_RECORDS: {
 			const tierMaximumRecords = 1000000 * Math.ceil( recordCount / 1000000 );
-			return __( 'Up to %(tierMaximumRecords)s records', {
-				args: { tierMaximumRecords: numberFormat( tierMaximumRecords ) },
-			} );
+			return sprintf(
+				/* translators: placehodler is a number of records (posts, pages, ...). */
+				__( 'Up to %s records', 'jetpack' ),
+				numberFormat( tierMaximumRecords )
+			);
 		}
 		default:
 			return null;
@@ -85,18 +88,23 @@ export function SingleProductSearchCard( props ) {
 						iconSize={ 12 }
 						onClick={ handleLandingPageLinkClick }
 					>
-						{ __( 'Learn more' ) }
+						{ __( 'Learn more', 'jetpack' ) }
 					</ExternalLink>
 				</div>
 				<h4 className="single-product-backup__options-header">
-					{ __(
-						'Your current site record size: %s record',
-						'Your current site record size: %s records',
-						{ args: numberFormat( recordCount ), count: recordCount }
+					{ sprintf(
+						_n(
+							'Your current site record size: %s record',
+							'Your current site record size: %s records',
+							recordCount,
+							'jetpack'
+						),
+						numberFormat( recordCount )
 					) }
 					<InfoPopover position="right">
 						{ __(
-							'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.'
+							'Records are all posts, pages, custom post types, and other types of content indexed by Jetpack Search.',
+							'jetpack'
 						) }
 					</InfoPopover>
 				</h4>
@@ -126,7 +134,7 @@ export function SingleProductSearchCard( props ) {
 						}
 						primary
 					>
-						{ __( 'Upgrade to Jetpack Search' ) }
+						{ __( 'Upgrade to Jetpack Search', 'jetpack' ) }
 					</Button>
 				</div>
 			</div>

--- a/_inc/client/plans/single-product/index.js
+++ b/_inc/client/plans/single-product/index.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import React from 'react';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { withRouter } from 'react-router-dom';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,7 +22,6 @@ import analytics from 'lib/analytics';
 import getRedirectUrl from 'lib/jp-redirect';
 import { getPlanClass } from 'lib/plans/constants';
 import { DAILY_BACKUP_TITLE, REALTIME_BACKUP_TITLE } from 'plans/constants';
-import { translate as __ } from 'i18n-calypso';
 import ProductExpiration from 'components/product-expiration';
 
 import './style.scss';
@@ -102,7 +103,7 @@ function renderPurchase( product, purchase ) {
 	} );
 	return (
 		<div className="single-product__purchase">
-			<Button href={ purchaseUrl }>{ __( 'Manage Subscription' ) }</Button>
+			<Button href={ purchaseUrl }>{ __( 'Manage Subscription', 'jetpack' ) }</Button>
 			<div className="single-product__purchase-description">{ product.description }</div>
 		</div>
 	);
@@ -143,23 +144,32 @@ function getProduct( product, purchase, siteRawlUrl ) {
 
 		case 'is-personal-plan':
 			product.title = product.key === 'backup' ? DAILY_BACKUP_TITLE : product.title;
-			product.description = __( 'Included in your {{planLink}}Personal Plan{{/planLink}}', {
-				components: { planLink },
-			} );
+			product.description = jetpackCreateInterpolateElement(
+				__( 'Included in your <planLink>Personal Plan</planLink>', 'jetpack' ),
+				{
+					planLink,
+				}
+			);
 			break;
 
 		case 'is-premium-plan':
 			product.title = product.key === 'backup' ? DAILY_BACKUP_TITLE : product.title;
-			product.description = __( 'Included in your {{planLink}}Premium Plan{{/planLink}}', {
-				components: { planLink },
-			} );
+			product.description = jetpackCreateInterpolateElement(
+				__( 'Included in your <planLink>Premium Plan</planLink>', 'jetpack' ),
+				{
+					planLink,
+				}
+			);
 			break;
 
 		case 'is-business-plan':
 			product.title = product.key === 'backup' ? REALTIME_BACKUP_TITLE : product.title;
-			product.description = __( 'Included in your {{planLink}}Professional Plan{{/planLink}}', {
-				components: { planLink },
-			} );
+			product.description = jetpackCreateInterpolateElement(
+				__( 'Included in your <planLink>Professional Plan</planLink>', 'jetpack' ),
+				{
+					planLink,
+				}
+			);
 			break;
 		default:
 			product.description = description;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is part 3, follow-up of #13527. We're moving away from `translate` and using the `@wordpress/i18n` package instead.

This PR focusses on updating 3 parts of the dashboard:
- The My Plan and Plans pages
- The Discussion settings
- The Performance settings

**Note: this PR is open against the branch used for part 1 in #13527 for now, hence the "Do not merge" label. Once the other PR is merged I'll update the base branch for this PR.**

#### Jetpack product discussion

* p1HpG7-99c-p2
* Primary issue: #16481 

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Nothing should change at first sight.

* Check the modified pages (My Plan, Plans, Discussion, Performance) for any changes; you shouldn't see anything odd.

#### Proposed changelog entry for your changes:

* TBD