### PR TITLE
Admin Page: Move to Core translation functions -- PART 4

### DIFF
--- a/_inc/client/privacy/index.jsx
+++ b/_inc/client/privacy/index.jsx
@@ -3,26 +3,27 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { translate as __ } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import analytics from 'lib/analytics';
 import CompactFormToggle from 'components/form/form-toggle/compact';
-import SettingsCard from 'components/settings-card';
-import SettingsGroup from 'components/settings-group';
 import ExternalLink from 'components/external-link';
+import { fetchTrackingSettings, updateTrackingSettings } from 'state/tracking/actions';
+import getRedirectUrl from 'lib/jp-redirect';
 import {
 	getTrackingSettings,
 	isUpdatingTrackingSettings,
 	isFetchingTrackingSettingsList,
 } from 'state/tracking/reducer';
-import { fetchTrackingSettings, updateTrackingSettings } from 'state/tracking/actions';
 import { getSettings } from 'state/settings';
-import analytics from 'lib/analytics';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 const trackPrivacyPolicyView = () =>
 	analytics.tracks.recordJetpackClick( {
@@ -66,12 +67,12 @@ class Privacy extends React.Component {
 		if ( this.props.searchTerm ) {
 			return (
 				[
-					__( 'privacy', { context: 'Search term.' } ),
-					__( 'tracks', { context: 'Search term.' } ),
-					__( 'data', { context: 'Search term.' } ),
-					__( 'gdpr', { context: 'Search term.' } ),
-					__( 'tos', { context: 'Search term.' } ),
-					__( 'terms of service', { context: 'Search term.' } ),
+					_x( 'privacy', 'Search term.', 'jetpack' ),
+					_x( 'tracks', 'Search term.', 'jetpack' ),
+					_x( 'data', 'Search term.', 'jetpack' ),
+					_x( 'gdpr', 'Search term.', 'jetpack' ),
+					_x( 'tos', 'Search term.', 'jetpack' ),
+					_x( 'terms of service', 'Search term.', 'jetpack' ),
 				]
 					.join( ' ' )
 					.toLowerCase()
@@ -103,11 +104,11 @@ class Privacy extends React.Component {
 				<div>
 					<SettingsCard
 						{ ...this.props }
-						header={ __( 'Privacy Settings', { context: 'Settings header' } ) }
+						header={ _x( 'Privacy Settings', 'Settings header', 'jetpack' ) }
 						hideButton
 					>
 						<SettingsGroup hasChild>
-							<p>{ __( 'We are committed to your privacy and security. ' ) }</p>
+							<p>{ __( 'We are committed to your privacy and security.', 'jetpack' ) }</p>
 							<p>
 								<CompactFormToggle
 									compact
@@ -118,47 +119,12 @@ class Privacy extends React.Component {
 									onChange={ this.togglePrivacy }
 									id="privacy-settings"
 								>
-									{ __(
-										'Share information with our analytics tool about your use of services while logged in to your WordPress.com account. ' +
-											'{{cookiePolicyLink}}Learn more{{/cookiePolicyLink}}.',
+									{ jetpackCreateInterpolateElement(
+										__(
+											'Share information with our analytics tool about your use of services while logged in to your WordPress.com account. <cookiePolicyLink>Learn more</cookiePolicyLink>.',
+											'jetpack'
+										),
 										{
-											components: {
-												cookiePolicyLink: (
-													<ExternalLink
-														href={ getRedirectUrl( 'a8c-cookies' ) }
-														onClick={ trackCookiePolicyView }
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											},
-										}
-									) }
-								</CompactFormToggle>
-							</p>
-							<p>
-								{ __(
-									'This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our {{pp}}privacy policy{{/pp}}.',
-									{
-										components: {
-											pp: (
-												<ExternalLink
-													href={ getRedirectUrl( 'a8c-privacy' ) }
-													onClick={ trackPrivacyPolicyView }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								) }
-							</p>
-							<p>
-								{ __(
-									'We use other tracking tools, including some from third parties. ' +
-										'{{cookiePolicyLink}}Read about these{{/cookiePolicyLink}} and how to control them.',
-									{
-										components: {
 											cookiePolicyLink: (
 												<ExternalLink
 													href={ getRedirectUrl( 'a8c-cookies' ) }
@@ -167,24 +133,61 @@ class Privacy extends React.Component {
 													rel="noopener noreferrer"
 												/>
 											),
-										},
+										}
+									) }
+								</CompactFormToggle>
+							</p>
+							<p>
+								{ jetpackCreateInterpolateElement(
+									__(
+										'This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our <pp>privacy policy</pp>.',
+										'jetpack'
+									),
+									{
+										pp: (
+											<ExternalLink
+												href={ getRedirectUrl( 'a8c-privacy' ) }
+												onClick={ trackPrivacyPolicyView }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
 									}
 								) }
 							</p>
 							<p>
-								{ __(
-									'For more information on how specific Jetpack features use data and track activity, please refer to our {{privacyCenterLink}}Privacy Center{{/privacyCenterLink}}.',
+								{ jetpackCreateInterpolateElement(
+									__(
+										'We use other tracking tools, including some from third parties. <cookiePolicyLink>Read about these</cookiePolicyLink> and how to control them.',
+										'jetpack'
+									),
 									{
-										components: {
-											privacyCenterLink: (
-												<ExternalLink
-													href={ getRedirectUrl( 'jetpack-support-privacy' ) }
-													onClick={ trackPrivacyCenterView }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
+										cookiePolicyLink: (
+											<ExternalLink
+												href={ getRedirectUrl( 'a8c-cookies' ) }
+												onClick={ trackCookiePolicyView }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
+									}
+								) }
+							</p>
+							<p>
+								{ jetpackCreateInterpolateElement(
+									__(
+										'For more information on how specific Jetpack features use data and track activity, please refer to our <privacyCenterLink>Privacy Center</privacyCenterLink>.',
+										'jetpack'
+									),
+									{
+										privacyCenterLink: (
+											<ExternalLink
+												href={ getRedirectUrl( 'jetpack-support-privacy' ) }
+												onClick={ trackPrivacyCenterView }
+												target="_blank"
+												rel="noopener noreferrer"
+											/>
+										),
 									}
 								) }
 							</p>

--- a/_inc/client/pro-status/index.jsx
+++ b/_inc/client/pro-status/index.jsx
@@ -4,23 +4,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
-import SimpleNotice from 'components/notice';
-import analytics from 'lib/analytics';
 import { get } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _n, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getPlanClass } from 'lib/plans/constants';
 import { getSiteRawUrl, getSiteAdminUrl, getUpgradeUrl } from 'state/initial-state';
-import QuerySitePlugins from 'components/data/query-site-plugins';
-import QueryVaultPressData from 'components/data/query-vaultpress-data';
-import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
-import { isDevMode } from 'state/connection';
-import { isFetchingPluginsData, isPluginActive, isPluginInstalled } from 'state/site/plugins';
 import {
 	getVaultPressScanThreatCount,
 	getVaultPressData,
@@ -32,6 +26,12 @@ import {
 import { getSitePlan, isFetchingSiteData } from 'state/site';
 import { getRewindStatus } from 'state/rewind';
 import { getScanStatus } from 'state/scan';
+import { isDevMode } from 'state/connection';
+import { isFetchingPluginsData, isPluginActive, isPluginInstalled } from 'state/site/plugins';
+import QuerySitePlugins from 'components/data/query-site-plugins';
+import QueryVaultPressData from 'components/data/query-vaultpress-data';
+import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
+import SimpleNotice from 'components/notice';
 
 /**
  * Track click on Pro status badge.
@@ -77,17 +77,17 @@ class ProStatus extends React.Component {
 			case 'provisioning':
 				return {
 					status: 'is-info',
-					text: __( 'Setting up' ),
+					text: __( 'Setting up', 'jetpack' ),
 				};
 			case 'awaiting_credentials':
 				return {
 					status: 'is-warning',
-					text: __( 'Action needed' ),
+					text: __( 'Action needed', 'jetpack' ),
 				};
 			case 'active':
 				return {
 					status: 'is-success',
-					text: __( 'Connected' ),
+					text: __( 'Connected', 'jetpack' ),
 				};
 			default:
 				return { status: '', text: '' };
@@ -103,13 +103,17 @@ class ProStatus extends React.Component {
 			case 'threats':
 				status = 'is-error';
 				if ( this.props.isCompact ) {
-					action = __( 'Threats', {
-						context: 'A caption for a small button to fix security issues.',
-					} );
+					action = _x(
+						'Threats',
+						'A caption for a small button to fix security issues.',
+						'jetpack'
+					);
 				} else {
-					action = __( 'See threats', {
-						context: 'A caption for a small button to fix security issues.',
-					} );
+					action = _x(
+						'See threats',
+						'A caption for a small button to fix security issues.',
+						'jetpack'
+					);
 				}
 				actionUrl = getRedirectUrl( 'vaultpress-dashboard' );
 				break;
@@ -119,9 +123,11 @@ class ProStatus extends React.Component {
 				return;
 			case 'secure':
 				status = 'is-success';
-				message = __( 'Secure', {
-					context: 'Short message informing user that the site is secure.',
-				} );
+				message = _x(
+					'Secure',
+					'Short message informing user that the site is secure.',
+					'jetpack'
+				);
 				break;
 			case 'invalid_key':
 				return;
@@ -133,7 +139,7 @@ class ProStatus extends React.Component {
 					</SimpleNotice>
 				);
 			case 'active':
-				return <span className="jp-dash-item__active-label">{ __( 'ACTIVE' ) }</span>;
+				return <span className="jp-dash-item__active-label">{ __( 'ACTIVE', 'jetpack' ) }</span>;
 		}
 		return (
 			<SimpleNotice showDismiss={ false } status={ status } isCompact={ true }>
@@ -169,7 +175,7 @@ class ProStatus extends React.Component {
 					query: `only=${ feature }`,
 				} ) }
 			>
-				{ __( 'Set up', { context: 'Caption for a button to set up a feature.' } ) }
+				{ _x( 'Set up', 'Caption for a button to set up a feature.', 'jetpack' ) }
 			</Button>
 		);
 	};
@@ -234,9 +240,7 @@ class ProStatus extends React.Component {
 						if ( Array.isArray( scanStatus.threats ) && scanStatus.threats.length > 0 ) {
 							return (
 								<SimpleNotice showDismiss={ false } status="is-error" isCompact>
-									{ __( 'Threat', 'Threats', {
-										count: scanStatus.threats.length,
-									} ) }
+									{ _n( 'Threat', 'Threats', scanStatus.threats.length, 'jetpack' ) }
 								</SimpleNotice>
 							);
 						}
@@ -246,7 +250,7 @@ class ProStatus extends React.Component {
 						if ( scanStatus.credentials.length === 0 ) {
 							return (
 								<SimpleNotice showDismiss={ false } status="is-warning" isCompact>
-									{ __( 'Action needed' ) }
+									{ __( 'Action needed', 'jetpack' ) }
 								</SimpleNotice>
 							);
 						}

--- a/_inc/client/searchable-modules/index.jsx
+++ b/_inc/client/searchable-modules/index.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { includes, forEach } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
-import Banner from 'components/banner';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Banner from 'components/banner';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { getModules } from 'state/modules';
 import { isModuleFound } from 'state/search';
@@ -58,7 +58,7 @@ export const SearchableModules = withModuleSettingsFormHelpers(
 							<Banner
 								className="jp-searchable-banner"
 								key={ slug }
-								callToAction={ __( 'Activate' ) }
+								callToAction={ __( 'Activate', 'jetpack' ) }
 								description={ moduleData.description }
 								href="javascript:void( 0 )"
 								icon="cog"

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -3,23 +3,24 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
-import FoldableCard from 'components/foldable-card';
-import FormInputValidation from 'components/form-input-validation';
-import Gridicon from 'components/gridicon';
 import { assign, debounce, isEmpty, trim } from 'lodash';
-import { isAkismetKeyValid, checkAkismetKey, isCheckingAkismetKey } from 'state/at-a-glance';
-import { FEATURE_SPAM_AKISMET_PLUS } from 'lib/plans/constants';
-import analytics from 'lib/analytics';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import { FEATURE_SPAM_AKISMET_PLUS } from 'lib/plans/constants';
+import FoldableCard from 'components/foldable-card';
+import FormInputValidation from 'components/form-input-validation';
 import { FormFieldset, FormLabel } from 'components/forms';
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
+import Gridicon from 'components/gridicon';
+import { isAkismetKeyValid, checkAkismetKey, isCheckingAkismetKey } from 'state/at-a-glance';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
+import TextInput from 'components/text-input';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 export const Antispam = withModuleSettingsFormHelpers(
 	class extends Component {
@@ -85,34 +86,37 @@ export const Antispam = withModuleSettingsFormHelpers(
 				onChange: this.updateText,
 			};
 			let akismetStatus = '',
-				foldableHeader = __( 'Checking your spam protection…' ),
+				foldableHeader = __( 'Checking your spam protection…', 'jetpack' ),
 				explanation = true;
 
 			if ( null === this.props.isAkismetKeyValid ) {
-				textProps.value = __( 'Fetching key…' );
+				textProps.value = __( 'Fetching key…', 'jetpack' );
 				textProps.disabled = true;
 				explanation = false;
 			} else if ( '' === this.state.apiKey ) {
 				textProps.value = '';
-				foldableHeader = __( 'Your site needs an Antispam key.' );
+				foldableHeader = __( 'Your site needs an Antispam key.', 'jetpack' );
 			} else if ( ! this.state.delayKeyCheck && ! this.props.isCheckingAkismetKey ) {
 				if ( false === this.props.isAkismetKeyValid ) {
 					akismetStatus = (
 						<FormInputValidation
 							isError
-							text={ __( "There's a problem with your Antispam API key. {{a}}Learn more{{/a}}.", {
-								components: {
+							text={ jetpackCreateInterpolateElement(
+								__( "There's a problem with your Antispam API key. <a>Learn more</a>.", 'jetpack' ),
+								{
 									a: <a href={ 'https://docs.akismet.com/getting-started/api-key/' } />,
-								},
-							} ) }
+								}
+							) }
 						/>
 					);
 					textProps.isError = true;
-					foldableHeader = __( 'Your site is not protected from spam.' );
+					foldableHeader = __( 'Your site is not protected from spam.', 'jetpack' );
 				} else {
-					akismetStatus = <FormInputValidation text={ __( 'Your Antispam key is valid.' ) } />;
+					akismetStatus = (
+						<FormInputValidation text={ __( 'Your Antispam key is valid.', 'jetpack' ) } />
+					);
 					textProps.isValid = true;
-					foldableHeader = __( 'Your site is protected from spam.' );
+					foldableHeader = __( 'Your site is protected from spam.', 'jetpack' );
 					explanation = false;
 				}
 			} else if ( this.props.isCheckingAkismetKey ) {
@@ -120,7 +124,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 					<div className="form-input-validation is-warning">
 						<span>
 							<Gridicon size={ 24 } icon="sync" />
-							{ __( 'Checking key…' ) }
+							{ __( 'Checking key…', 'jetpack' ) }
 						</span>
 					</div>
 				);
@@ -130,31 +134,32 @@ export const Antispam = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Anti-spam', { context: 'Settings header' } ) }
+					header={ _x( 'Anti-spam', 'Settings header', 'jetpack' ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'wordpress_api_key' ) }
 					feature={ FEATURE_SPAM_AKISMET_PLUS }
 				>
 					<FoldableCard onOpen={ this.trackOpenCard } header={ foldableHeader }>
 						<SettingsGroup
 							support={ {
-								text: __( 'Removes spam from comments and contact forms.' ),
+								text: __( 'Removes spam from comments and contact forms.', 'jetpack' ),
 								link: 'https://akismet.com/jetpack/',
 							} }
 						>
 							<FormFieldset>
 								<FormLabel>
-									<span className="jp-form-label-wide">{ __( 'Your API key' ) }</span>
+									<span className="jp-form-label-wide">{ __( 'Your API key', 'jetpack' ) }</span>
 									<TextInput { ...textProps } />
 									{ akismetStatus }
 								</FormLabel>
 								{ explanation && (
 									<p className="jp-form-setting-explanation">
-										{ __(
-											"If you don't already have an API key, then {{a}}get your API key here{{/a}}, and you'll be guided through the process of getting one.",
+										{ jetpackCreateInterpolateElement(
+											__(
+												"If you don't already have an API key, then <a>get your API key here</a>, and you'll be guided through the process of getting one.",
+												'jetpack'
+											),
 											{
-												components: {
-													a: <a href={ 'https://akismet.com/wordpress/' } />,
-												},
+												a: <a href={ 'https://akismet.com/wordpress/' } />,
 											}
 										) }
 									</p>

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -4,31 +4,33 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { numberFormat, translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
 import { get, includes } from 'lodash';
-import Banner from 'components/banner';
-import getRedirectUrl from 'lib/jp-redirect';
+import { numberFormat } from 'i18n-calypso';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Banner from 'components/banner';
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getPlanClass, FEATURE_SECURITY_SCANNING_JETPACK } from 'lib/plans/constants';
-import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
-import QueryRewindStatus from 'components/data/query-rewind-status';
-import SettingsCard from 'components/settings-card';
-import SettingsGroup from 'components/settings-group';
 import { getVaultPressData, getVaultPressScanThreatCount } from 'state/at-a-glance';
 import { getSitePlan } from 'state/site';
 import { isModuleActivated } from 'state/modules';
+import QueryRewindStatus from 'components/data/query-rewind-status';
+import SettingsCard from 'components/settings-card';
+import SettingsGroup from 'components/settings-group';
 import { showBackups } from 'state/initial-state';
+import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 
 class LoadingCard extends Component {
 	render() {
 		return (
 			<SettingsCard
-				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+				header={ _x( 'Backups and security scanning', 'Settings header', 'jetpack' ) }
 				hideButton
 				action="scan"
 			>
@@ -37,13 +39,13 @@ class LoadingCard extends Component {
 					module={ { module: 'backups' } }
 					support={ {
 						text: __(
-							'Backs up your site to the global WordPress.com servers, ' +
-								'allowing you to restore your content in the event of an emergency or error.'
+							'Backs up your site to the global WordPress.com servers, allowing you to restore your content in the event of an emergency or error.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'vaultpress-help-get-to-know' ),
 					} }
 				>
-					{ __( 'Checking site status…' ) }
+					{ __( 'Checking site status…', 'jetpack' ) }
 				</SettingsGroup>
 			</SettingsCard>
 		);
@@ -69,35 +71,38 @@ class BackupsScanRewind extends Component {
 		switch ( rewindState ) {
 			case 'provisioning':
 				return {
-					title: __( 'Provisioning' ),
+					title: __( 'Provisioning', 'jetpack' ),
 					icon: 'info',
-					description: __( 'Backups and Scan are being configured for your site.' ),
+					description: __( 'Backups and Scan are being configured for your site.', 'jetpack' ),
 					url: '',
 				};
 			case 'awaiting_credentials':
 				return {
-					title: __( 'Awaiting credentials' ),
+					title: __( 'Awaiting credentials', 'jetpack' ),
 					icon: 'notice',
 					description: __(
-						'You need to enter your server credentials to finish configuring Backups and Scan.'
+						'You need to enter your server credentials to finish configuring Backups and Scan.',
+						'jetpack'
 					),
 					url: getRedirectUrl( 'calypso-settings-security', { site: siteRawUrl } ),
 				};
 			case 'active':
 				return {
-					title: __( 'Active' ),
+					title: __( 'Active', 'jetpack' ),
 					icon: 'checkmark-circle',
 					description: __(
-						'Your site is being backed up in real time and regularly scanned for security threats.'
+						'Your site is being backed up in real time and regularly scanned for security threats.',
+						'jetpack'
 					),
 					url: getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ),
 				};
 			default:
 				return {
-					title: __( 'Oops!' ),
+					title: __( 'Oops!', 'jetpack' ),
 					icon: 'info',
 					description: __(
-						'The Jetpack Backup and Scan status could not be retrieved at this time.'
+						'The Jetpack Backup and Scan status could not be retrieved at this time.',
+						'jetpack'
 					),
 					url: '',
 				};
@@ -106,7 +111,7 @@ class BackupsScanRewind extends Component {
 
 	getCardText = () => {
 		if ( this.props.isDevMode ) {
-			return __( 'Unavailable in Dev Mode.' );
+			return __( 'Unavailable in Dev Mode.', 'jetpack' );
 		}
 
 		const { title, icon, description, url } = this.getRewindMessage();
@@ -128,7 +133,7 @@ class BackupsScanRewind extends Component {
 			<SettingsCard
 				feature={ 'rewind' }
 				{ ...this.props }
-				header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+				header={ _x( 'Backups and security scanning', 'Settings header', 'jetpack' ) }
 				action={ 'rewind' }
 				hideButton
 			>
@@ -159,7 +164,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 			let cardText = '';
 
 			if ( this.props.isDevMode ) {
-				return __( 'Unavailable in Dev Mode.' );
+				return __( 'Unavailable in Dev Mode.', 'jetpack' );
 			}
 
 			// We check if the features are active first, rather than the plan because it's possible the site is on a
@@ -170,26 +175,24 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					return (
 						<div>
 							<strong>
-								{ __( 'Uh oh, %(number)s threat found.', 'Uh oh, %(number)s threats found.', {
-									count: threats,
-									args: {
-										number: numberFormat( threats ),
-									},
-								} ) }
+								{ sprintf(
+									_n( 'Uh oh, %s threat found.', 'Uh oh, %s threats found.', threats, 'jetpack' ),
+									numberFormat( threats )
+								) }
 							</strong>
 							<br />
 							<br />
-							{ __( '{{a}}View details{{/a}}', {
-								components: { a: <a href={ getRedirectUrl( 'vaultpress-dashboard' ) } /> },
+							{ jetpackCreateInterpolateElement( __( '<a>View details</a>', 'jetpack' ), {
+								a: <a href={ getRedirectUrl( 'vaultpress-dashboard' ) } />,
 							} ) }
 							<br />
-							{ __( '{{a}}Contact Support{{/a}}', {
-								components: { a: <a href={ getRedirectUrl( 'jetpack-support' ) } /> },
+							{ jetpackCreateInterpolateElement( __( '<a>Contact Support</a>', 'jetpack' ), {
+								a: <a href={ getRedirectUrl( 'jetpack-support' ) } />,
 							} ) }
 						</div>
 					);
 				}
-				return __( 'Your site is backed up and threat-free.' );
+				return __( 'Your site is backed up and threat-free.', 'jetpack' );
 			}
 
 			// Only return here if backups enabled and site on on free/personal plan, or if Jetpack Backup is in use.
@@ -201,21 +204,22 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					planClass
 				)
 			) {
-				return __( 'Your site is backed up.' );
+				return __( 'Your site is backed up.', 'jetpack' );
 			}
 
 			// Nothing is enabled. We can show upgrade/setup text now.
 			switch ( planClass ) {
 				case 'is-personal-plan':
-					cardText = __( "You have paid for backups but they're not yet active." );
-					cardText += ' ' + __( 'Click "Set Up" to finish installation.' );
+					cardText = __( "You have paid for backups but they're not yet active.", 'jetpack' );
+					cardText += ' ' + __( 'Click "Set Up" to finish installation.', 'jetpack' );
 					break;
 				case 'is-premium-plan':
 				case 'is-business-plan':
 					cardText = __(
-						'You have paid for backups and security scanning but they’re not yet active.'
+						'You have paid for backups and security scanning but they’re not yet active.',
+						'jetpack'
 					);
-					cardText += ' ' + __( 'Click "Set Up" to finish installation.' );
+					cardText += ' ' + __( 'Click "Set Up" to finish installation.', 'jetpack' );
 					break;
 			}
 
@@ -251,7 +255,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 				<SettingsCard
 					feature={ FEATURE_SECURITY_SCANNING_JETPACK }
 					{ ...this.props }
-					header={ __( 'Backups and security scanning', { context: 'Settings header' } ) }
+					header={ _x( 'Backups and security scanning', 'Settings header', 'jetpack' ) }
 					action="scan"
 					hideButton
 				>
@@ -261,8 +265,8 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 						module={ { module: 'backups' } }
 						support={ {
 							text: __(
-								'Backs up your site to the global WordPress.com servers, ' +
-									'allowing you to restore your content in the event of an emergency or error.'
+								'Backs up your site to the global WordPress.com servers, allowing you to restore your content in the event of an emergency or error.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'vaultpress-help-get-to-know' ),
 						} }
@@ -277,7 +281,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 							target="_blank"
 							href={ getRedirectUrl( 'vaultpress-dashboard' ) }
 						>
-							{ __( 'Configure your Security Scans' ) }
+							{ __( 'Configure your Security Scans', 'jetpack' ) }
 						</Card>
 					) }
 				</SettingsCard>

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -4,7 +4,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -112,9 +112,10 @@ export class Security extends Component {
 				<Card
 					title={
 						isSearchTerm
-							? __( 'Security' )
+							? __( 'Security', 'jetpack' )
 							: __(
-									'Your site is protected by Jetpack. You’ll be notified if anything needs attention.'
+									'Your site is protected by Jetpack. You’ll be notified if anything needs attention.',
+									'jetpack'
 							  )
 					}
 					className="jp-settings-description"

--- a/_inc/client/security/jetpack-backup.jsx
+++ b/_inc/client/security/jetpack-backup.jsx
@@ -3,14 +3,14 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { translate as __ } from 'i18n-calypso';
 import { get } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Banner from 'components/banner';
+import getRedirectUrl from 'lib/jp-redirect';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
 import { FEATURE_SITE_BACKUPS_JETPACK } from 'lib/plans/constants';
@@ -32,13 +32,13 @@ export class JetpackBackup extends Component {
 				module={ { module: 'backups' } }
 				support={ {
 					text: __(
-						'Backs up your site to the global WordPress.com servers, ' +
-							'allowing you to restore your content in the event of an emergency or error.'
+						'Backs up your site to the global WordPress.com servers, allowing you to restore your content in the event of an emergency or error.',
+						'jetpack'
 					),
 					link: getRedirectUrl( 'jetpack-support-backup' ),
 				} }
 			>
-				{ __( 'Your site is backed up.' ) }
+				{ __( 'Your site is backed up.', 'jetpack' ) }
 			</SettingsGroup>
 		);
 	};
@@ -50,32 +50,36 @@ export class JetpackBackup extends Component {
 		switch ( rewindState ) {
 			case 'provisioning':
 				return {
-					title: __( 'Provisioning' ),
+					title: __( 'Provisioning', 'jetpack' ),
 					icon: 'info',
-					description: __( 'Jetpack Backup is being configured for your site.' ),
+					description: __( 'Jetpack Backup is being configured for your site.', 'jetpack' ),
 					url: '',
 				};
 			case 'awaiting_credentials':
 				return {
-					title: __( 'Awaiting credentials' ),
+					title: __( 'Awaiting credentials', 'jetpack' ),
 					icon: 'notice',
 					description: __(
-						'You need to enter your server credentials to finish configuring Jetpack Backup.'
+						'You need to enter your server credentials to finish configuring Jetpack Backup.',
+						'jetpack'
 					),
 					url: getRedirectUrl( 'calypso-settings-security', { site: siteRawUrl } ),
 				};
 			case 'active':
 				return {
-					title: __( 'Active' ),
+					title: __( 'Active', 'jetpack' ),
 					icon: 'checkmark-circle',
-					description: __( 'Your site is being backed up.' ),
+					description: __( 'Your site is being backed up.', 'jetpack' ),
 					url: getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ),
 				};
 			default:
 				return {
-					title: __( 'Oops!' ),
+					title: __( 'Oops!', 'jetpack' ),
 					icon: 'info',
-					description: __( 'The Jetpack Backup status could not be retrieved at this time.' ),
+					description: __(
+						'The Jetpack Backup status could not be retrieved at this time.',
+						'jetpack'
+					),
 					url: '',
 				};
 		}
@@ -106,7 +110,7 @@ export class JetpackBackup extends Component {
 		if ( ! hasRewindData && ! vaultPressEnabled ) {
 			return (
 				<SettingsCard
-					header={ __( 'Jetpack Backup', { context: 'Settings header' } ) }
+					header={ _x( 'Jetpack Backup', 'Settings header', 'jetpack' ) }
 					hideButton
 					action={ FEATURE_SITE_BACKUPS_JETPACK }
 				>
@@ -114,13 +118,13 @@ export class JetpackBackup extends Component {
 						module={ { module: 'backups' } }
 						support={ {
 							text: __(
-								'Backs up your site to the global WordPress.com servers, ' +
-									'allowing you to restore your content in the event of an emergency or error.'
+								'Backs up your site to the global WordPress.com servers, allowing you to restore your content in the event of an emergency or error.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-backup' ),
 						} }
 					>
-						{ __( 'Checking site status…' ) }
+						{ __( 'Checking site status…', 'jetpack' ) }
 					</SettingsGroup>
 				</SettingsCard>
 			);
@@ -130,7 +134,7 @@ export class JetpackBackup extends Component {
 			<SettingsCard
 				feature={ FEATURE_SITE_BACKUPS_JETPACK }
 				{ ...this.props }
-				header={ __( 'Jetpack Backup', { context: 'Settings header' } ) }
+				header={ _x( 'Jetpack Backup', 'Settings header', 'jetpack' ) }
 				hideButton
 			>
 				{ 'unavailable' === rewindState ? this.getVaultPressContent() : this.getRewindBanner() }

--- a/_inc/client/security/manage-plugins.jsx
+++ b/_inc/client/security/manage-plugins.jsx
@@ -5,14 +5,14 @@
  */
 
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
 import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -43,7 +43,7 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 					rel="noopener noreferrer"
 					href={ getRedirectUrl( 'calypso-plugins-manage', { site: this.props.siteRawUrl } ) }
 				>
-					{ __( 'Choose which plugins to auto-update' ) }
+					{ __( 'Choose which plugins to auto-update', 'jetpack' ) }
 				</Card>
 			);
 		};
@@ -53,14 +53,14 @@ export const ManagePlugins = withModuleSettingsFormHelpers(
 				<SettingsCard
 					{ ...this.props }
 					module="manage"
-					header={ __( 'Auto-update plugins', { context: 'Settings header' } ) }
+					header={ _x( 'Auto-update plugins', 'Settings header', 'jetpack' ) }
 					hideButton
 				>
 					<SettingsGroup disableInDevMode module={ this.props.getModule( 'manage' ) }>
 						<div>
 							{ __(
-								'With Jetpack you can choose to have your plugins auto-updated with each new plugin release. ' +
-									'You’ll get the latest security and bug fixes right away, ensuring your site stays secure.'
+								'With Jetpack you can choose to have your plugins auto-updated with each new plugin release. You’ll get the latest security and bug fixes right away, ensuring your site stays secure.',
+								'jetpack'
 							) }
 						</div>
 					</SettingsGroup>

--- a/_inc/client/security/monitor.jsx
+++ b/_inc/client/security/monitor.jsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
 import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -29,7 +29,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 					{ ...this.props }
 					hideButton
 					module="monitor"
-					header={ __( 'Downtime monitoring', { context: 'Settings header' } ) }
+					header={ _x( 'Downtime monitoring', 'Settings header', 'jetpack' ) }
 				>
 					<SettingsGroup
 						hasChild
@@ -37,7 +37,8 @@ export const Monitor = withModuleSettingsFormHelpers(
 						module={ this.props.getModule( 'monitor' ) }
 						support={ {
 							text: __(
-								'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.'
+								'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-monitor' ),
 						} }
@@ -51,7 +52,8 @@ export const Monitor = withModuleSettingsFormHelpers(
 						>
 							<span className="jp-form-toggle-explanation">
 								{ __(
-									'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.'
+									'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.',
+									'jetpack'
 								) }
 							</span>
 						</ModuleToggle>
@@ -66,7 +68,7 @@ export const Monitor = withModuleSettingsFormHelpers(
 								site: this.props.siteRawUrl,
 							} ) }
 						>
-							{ __( 'Configure your notification settings' ) }
+							{ __( 'Configure your notification settings', 'jetpack' ) }
 						</Card>
 					}
 				</SettingsCard>

--- a/_inc/client/security/protect.jsx
+++ b/_inc/client/security/protect.jsx
@@ -2,19 +2,19 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
-import Textarea from 'components/textarea';
 import { includes } from 'lodash';
-import FoldableCard from 'components/foldable-card';
 import classNames from 'classnames';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Textarea from 'components/textarea';
+import FoldableCard from 'components/foldable-card';
 import { FormFieldset, FormLegend, FormLabel } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -94,7 +94,7 @@ export const Protect = withModuleSettingsFormHelpers(
 				<SettingsCard
 					{ ...this.props }
 					module="protect"
-					header={ __( 'Brute force attack protection', { context: 'Settings header' } ) }
+					header={ _x( 'Brute force attack protection', 'Settings header', 'jetpack' ) }
 					saveDisabled={ this.props.isSavingAnyOption( 'jetpack_protect_global_whitelist' ) }
 				>
 					<FoldableCard
@@ -108,7 +108,8 @@ export const Protect = withModuleSettingsFormHelpers(
 							module={ this.props.getModule( 'protect' ) }
 							support={ {
 								text: __(
-									'Protects your site from traditional and distributed brute force login attacks.'
+									'Protects your site from traditional and distributed brute force login attacks.',
+									'jetpack'
 								),
 								link: getRedirectUrl( 'jetpack-support-protect' ),
 							} }
@@ -117,7 +118,11 @@ export const Protect = withModuleSettingsFormHelpers(
 								{ this.props.currentIp && (
 									<div>
 										<div className="jp-form-label-wide">
-											{ __( 'Your current IP: %(ip)s', { args: { ip: this.props.currentIp } } ) }
+											{ sprintf(
+												/* translators: placeholder is an IP address. */
+												__( 'Your current IP: %s', 'jetpack' ),
+												this.props.currentIp
+											) }
 										</div>
 										{
 											<Button
@@ -132,13 +137,13 @@ export const Protect = withModuleSettingsFormHelpers(
 												}
 												onClick={ this.addToSafelist }
 											>
-												{ __( 'Add to Always Allowed list' ) }
+												{ __( 'Add to Always Allowed list', 'jetpack' ) }
 											</Button>
 										}
 									</div>
 								) }
 								<FormLabel>
-									<FormLegend>{ __( 'Always allowed IP addresses' ) }</FormLegend>
+									<FormLegend>{ __( 'Always allowed IP addresses', 'jetpack' ) }</FormLegend>
 									<Textarea
 										disabled={
 											! isProtectActive ||
@@ -157,11 +162,7 @@ export const Protect = withModuleSettingsFormHelpers(
 								<span className="jp-form-setting-explanation">
 									{ __(
 										'You may always allow an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100',
-										{
-											components: {
-												br: <br />,
-											},
-										}
+										'jetpack'
 									) }
 								</span>
 							</FormFieldset>

--- a/_inc/client/security/sso.jsx
+++ b/_inc/client/security/sso.jsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FormFieldset } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -60,7 +60,7 @@ export const SSO = withModuleSettingsFormHelpers(
 					{ ...this.props }
 					hideButton
 					module="sso"
-					header={ __( 'WordPress.com login', { context: 'Settings header, noun.' } ) }
+					header={ _x( 'WordPress.com login', 'Settings header, noun.', 'jetpack' ) }
 				>
 					<SettingsGroup
 						hasChild
@@ -68,16 +68,16 @@ export const SSO = withModuleSettingsFormHelpers(
 						module={ this.props.getModule( 'sso' ) }
 						support={ {
 							text: __(
-								'Allows registered users to log in to your site with their WordPress.com accounts.'
+								'Allows registered users to log in to your site with their WordPress.com accounts.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-sso' ),
 						} }
 					>
 						<p>
 							{ __(
-								'Add an extra layer of security to your website by enabling WordPress.com login and secure ' +
-									'authentication. If you have multiple sites with this option enabled, you will be able to log in to every ' +
-									'one of them with the same credentials.'
+								'Add an extra layer of security to your website by enabling WordPress.com login and secure authentication. If you have multiple sites with this option enabled, you will be able to log in to every one of them with the same credentials.',
+								'jetpack'
 							) }
 						</p>
 						<ModuleToggle
@@ -102,7 +102,7 @@ export const SSO = withModuleSettingsFormHelpers(
 								onChange={ this.handleMatchByEmailToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Match accounts using email addresses' ) }
+									{ __( 'Match accounts using email addresses', 'jetpack' ) }
 								</span>
 							</CompactFormToggle>
 							<CompactFormToggle
@@ -115,7 +115,10 @@ export const SSO = withModuleSettingsFormHelpers(
 								onChange={ this.handleTwoStepToggleChange }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Require accounts to use WordPress.com Two-Step Authentication' ) }
+									{ __(
+										'Require accounts to use WordPress.com Two-Step Authentication',
+										'jetpack'
+									) }
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>

--- a/_inc/client/settings/index.jsx
+++ b/_inc/client/settings/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,12 +34,12 @@ class Settings extends React.Component {
 			<div className="jp-settings-container">
 				<div className="jp-no-results">
 					{ commonProps.searchTerm
-						? __( 'No search results found for %(term)s', {
-								args: {
-									term: commonProps.searchTerm,
-								},
-						  } )
-						: __( 'Enter a search term to find settings or close search.' ) }
+						? sprintf(
+								/* translators: placeholder is a searchterm entered in searchform. */
+								__( 'No search results found for %s', 'jetpack' ),
+								commonProps.searchTerm
+						  )
+						: __( 'Enter a search term to find settings or close search.', 'jetpack' ) }
 				</div>
 				<Security
 					siteAdminUrl={ this.props.siteAdminUrl }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is part 4, follow-up of #13527. We're moving away from `translate` and using the `@wordpress/i18n` package instead.

This PR focusses on updating 3 more parts of the dashboard:
- The Security settings
- The Privacy settings (see link in the footer)
- The search functionality

**Note: this PR is open against the branch used for part 1 in #13527 for now, hence the "Do not merge" label. Once the other PR is merged I'll update the base branch for this PR.**

#### Jetpack product discussion

* p1HpG7-99c-p2
* Primary issue: #16481 

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Nothing should change at first sight.

* Check the modified pages for any changes; you shouldn't see anything odd.

#### Proposed changelog entry for your changes:

* TBD