### PR TITLE
add messages for some common connection errors

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2139,7 +2139,7 @@ class Manager {
 
 		if ( $user_id ) {
 			if ( ! $user_tokens ) {
-				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens' );
+				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens', 'No user tokens found' );
 			}
 			if ( self::JETPACK_MASTER_USER === $user_id ) {
 				$user_id = \Jetpack_Options::get_option( 'master_user' );
@@ -2185,7 +2185,8 @@ class Manager {
 		}
 
 		if ( ! $possible_tokens ) {
-			return $suppress_errors ? false : new \WP_Error( 'no_possible_tokens' );
+			// If no user tokens were found, it would have failed earlier, so this is about blog token.
+			return $suppress_errors ? false : new \WP_Error( 'no_possible_tokens', 'No blog token found' );
 		}
 
 		$valid_token = false;
@@ -2210,7 +2211,7 @@ class Manager {
 		}
 
 		if ( ! $valid_token ) {
-			return $suppress_errors ? false : new \WP_Error( 'no_valid_token' );
+			return $suppress_errors ? false : new \WP_Error( 'no_valid_token', $user_id ? 'Invalid token for user ' . $user_id : 'Invalid blog token' );
 		}
 
 		return (object) array(

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2139,23 +2139,26 @@ class Manager {
 
 		if ( $user_id ) {
 			if ( ! $user_tokens ) {
-				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens', 'No user tokens found' );
+				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack' ) );
 			}
 			if ( self::JETPACK_MASTER_USER === $user_id ) {
 				$user_id = \Jetpack_Options::get_option( 'master_user' );
 				if ( ! $user_id ) {
-					return $suppress_errors ? false : new \WP_Error( 'empty_master_user_option' );
+					return $suppress_errors ? false : new \WP_Error( 'empty_master_user_option', __( 'No primary user defined', 'jetpack' ) );
 				}
 			}
 			if ( ! isset( $user_tokens[ $user_id ] ) || ! $user_tokens[ $user_id ] ) {
-				return $suppress_errors ? false : new \WP_Error( 'no_token_for_user', sprintf( 'No token for user %d', $user_id ) );
+				// translators: %s is the user ID.
+				return $suppress_errors ? false : new \WP_Error( 'no_token_for_user', sprintf( __( 'No token for user %d', 'jetpack' ), $user_id ) );
 			}
 			$user_token_chunks = explode( '.', $user_tokens[ $user_id ] );
 			if ( empty( $user_token_chunks[1] ) || empty( $user_token_chunks[2] ) ) {
-				return $suppress_errors ? false : new \WP_Error( 'token_malformed', sprintf( 'Token for user %d is malformed', $user_id ) );
+				// translators: %s is the user ID.
+				return $suppress_errors ? false : new \WP_Error( 'token_malformed', sprintf( __( 'Token for user %d is malformed', 'jetpack' ), $user_id ) );
 			}
 			if ( $user_token_chunks[2] !== (string) $user_id ) {
-				return $suppress_errors ? false : new \WP_Error( 'user_id_mismatch', sprintf( 'Requesting user_id %d does not match token user_id %d', $user_id, $user_token_chunks[2] ) );
+				// translators: %1$d is the ID of the requested user. %2$d is the user ID found in the token.
+				return $suppress_errors ? false : new \WP_Error( 'user_id_mismatch', sprintf( __( 'Requesting user_id %1$d does not match token user_id %2$d', 'jetpack' ), $user_id, $user_token_chunks[2] ) );
 			}
 			$possible_normal_tokens[] = "{$user_token_chunks[0]}.{$user_token_chunks[1]}";
 		} else {
@@ -2186,7 +2189,7 @@ class Manager {
 
 		if ( ! $possible_tokens ) {
 			// If no user tokens were found, it would have failed earlier, so this is about blog token.
-			return $suppress_errors ? false : new \WP_Error( 'no_possible_tokens', 'No blog token found' );
+			return $suppress_errors ? false : new \WP_Error( 'no_possible_tokens', __( 'No blog token found', 'jetpack' ) );
 		}
 
 		$valid_token = false;
@@ -2211,7 +2214,12 @@ class Manager {
 		}
 
 		if ( ! $valid_token ) {
-			return $suppress_errors ? false : new \WP_Error( 'no_valid_token', $user_id ? 'Invalid token for user ' . $user_id : 'Invalid blog token' );
+			if ( $user_id ) {
+				// translators: %d is the user ID.
+				return $suppress_errors ? false : new \WP_Error( 'no_valid_token', sprintf( __( 'Invalid token for user %d', 'jetpack' ), $user_id ) );
+			} else {
+				return $suppress_errors ? false : new \WP_Error( 'no_valid_token', __( 'Invalid blog token', 'jetpack' ) );
+			}
 		}
 
 		return (object) array(


### PR DESCRIPTION
Adds error messages to some common XML-RPC connection errors.

These error messages will be displayed in the Jetpack Debugger.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Ce-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

##### Setting up:

* Start with a fresh Jetpack site, connected and authorized
* Install / activate the Debug Helper plugin (already available on docker env) - https://wp.me/p9dueE-1Ce
* Go to Jetpack >Dev tools and activate the Broken Token module
* set the `JETPACK_DEV_DEBUG` constant to `true`
* Go to Jetpack > Broken token
* Click "Store these options"

##### Test 1:

* Click "Set invalid blog token"
* Visit the Jetpack debugger
* Back to your dashboard, go to Jetpack > XML-RPC Errors
* Confirm there's an error with error code `no_valid_token` and message `Invalid blog token`.
* Clear all errors
* go back to Jetpack > broken token and click "Restore from stored options"

##### Test 2:

* Click "Set invalid user tokens"
* Visit the Jetpack debugger
* Back to your dashboard, go to Jetpack > XML-RPC Errors
* Confirm there's an error with error code `no_valid_token` and message `Invalid token for user XX` (where XX is the user ID).
* Clear all errors
* go back to Jetpack > broken token and click "Restore from stored options"

##### Test 3:

* Click "Clear user tokens"
* Visit the Jetpack debugger
* Back to your dashboard, go to Jetpack > XML-RPC Errors
* Confirm there's an error with error code `no_user_tokens` and message `No user tokens found` 
* Clear all errors
* go back to Jetpack > broken token and click "Restore from stored options"

##### Test 4:

* Click "Clear blog token"
* Visit the Jetpack debugger
* Back to your dashboard, go to Jetpack > XML-RPC Errors
* Confirm there's an error with error code `no_possible_tokens` and message `No blog token found` 
* Clear all errors
* go back to Jetpack > broken token and click "Restore from stored options"


