### PR TITLE
Media & Twitter Cards: Verify WP_Post object before attempted use.

### DIFF
--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -31,18 +31,23 @@ class Jetpack_Media_Meta_Extractor {
 	 * Gets the specified media and meta info from the given post.
 	 * NOTE: If you have the post's HTML content already and don't need image data, use extract_from_content() instead.
 	 *
-	 * @param $blog_id The ID of the blog
-	 * @param $post_id The ID of the post
-	 * @param $what_to_extract (int) A mask of things to extract, e.g. Jetpack_Media_Meta_Extractor::IMAGES | Jetpack_Media_Meta_Extractor::MENTIONS
-	 * @returns a structure containing metadata about the embedded things, or empty array if nothing found, or WP_Error on error
+	 * @param int $blog_id The ID of the blog.
+	 * @param int $post_id The ID of the post.
+	 * @param int $what_to_extract A mask of things to extract, e.g. Jetpack_Media_Meta_Extractor::IMAGES | Jetpack_Media_Meta_Extractor::MENTIONS.
+	 *
+	 * @return array|WP_Error a structure containing metadata about the embedded things, or empty array if nothing found, or WP_Error on error.
 	 */
 	static public function extract( $blog_id, $post_id, $what_to_extract = self::ALL ) {
 
 		// multisite?
-		if ( function_exists( 'switch_to_blog') )
+		if ( function_exists( 'switch_to_blog' ) ) {
 			switch_to_blog( $blog_id );
+		}
 
 		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return array();
+		}
 		$content = $post->post_title . "\n\n" . $post->post_content;
 		$char_cnt = strlen( $content );
 
@@ -60,8 +65,9 @@ class Jetpack_Media_Meta_Extractor {
 			$what_to_extract = $what_to_extract - self::IMAGES;
 		}
 
-		if ( function_exists( 'switch_to_blog') )
+		if ( function_exists( 'switch_to_blog' ) ) {
 			restore_current_blog();
+		}
 
 		// All of the other things besides images can be extracted from just the content
 		$extracted = self::extract_from_content( $content, $what_to_extract, $extracted );
@@ -325,13 +331,20 @@ class Jetpack_Media_Meta_Extractor {
 	}
 
 	/**
-	 * @param $post A post object
-	 * @param $args (array) Optional args, see defaults list for details
-	 * @returns array Returns an array of all images meeting the specified criteria in $args
+	 * Get image fields for matching images.
 	 *
-	 * Uses Jetpack Post Images
+	 * @uses Jetpack_PostImages
+	 *
+	 * @param WP_Post $post A post object.
+	 * @param array   $args Optional args, see defaults list for details.
+	 *
+	 * @return array Returns an array of all images meeting the specified criteria in $args.
 	 */
 	private static function get_image_fields( $post, $args = array() ) {
+
+		if ( ! $post instanceof WP_Post ) {
+			return array();
+		}
 
 		$defaults = array(
 			'width'               => 200, // Required minimum width (if possible to determine)

--- a/_inc/lib/class.media-extractor.php
+++ b/_inc/lib/class.media-extractor.php
@@ -1,4 +1,11 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class with methods to extract metadata from a post/page about videos, images, links, mentions embedded
+ * in or attached to the post/page.
+ *
+ * @package Jetpack
+ */
+
 /**
  * Class with methods to extract metadata from a post/page about videos, images, links, mentions embedded
  * in or attached to the post/page.
@@ -7,18 +14,24 @@
  */
 class Jetpack_Media_Meta_Extractor {
 
-	// Some consts for what to extract
-	const ALL = 255;
-	const LINKS = 1;
-	const MENTIONS = 2;
-	const IMAGES = 4;
-	const SHORTCODES = 8; // Only the keeper shortcodes below
-	const EMBEDS = 16;
-	const HASHTAGS = 32;
+	// Some consts for what to extract.
+	const ALL        = 255;
+	const LINKS      = 1;
+	const MENTIONS   = 2;
+	const IMAGES     = 4;
+	const SHORTCODES = 8; // Only the keeper shortcodes below.
+	const EMBEDS     = 16;
+	const HASHTAGS   = 32;
 
-	// For these, we try to extract some data from the shortcode, rather than just recording its presence (which we do for all)
-	// There should be a function get_{shortcode}_id( $atts ) or static method SomethingShortcode::get_{shortcode}_id( $atts ) for these.
-	private static $KEEPER_SHORTCODES = array(
+	/**
+	 * Shortcodes to keep.
+	 *
+	 * For these, we try to extract some data from the shortcode, rather than just recording its presence (which we do for all)
+	 * There should be a function get_{shortcode}_id( $atts ) or static method SomethingShortcode::get_{shortcode}_id( $atts ) for these.
+	 *
+	 * @var string[]
+	 */
+	private static $keeper_shortcodes = array(
 		'youtube',
 		'vimeo',
 		'hulu',
@@ -37,7 +50,7 @@ class Jetpack_Media_Meta_Extractor {
 	 *
 	 * @return array|WP_Error a structure containing metadata about the embedded things, or empty array if nothing found, or WP_Error on error.
 	 */
-	static public function extract( $blog_id, $post_id, $what_to_extract = self::ALL ) {
+	public static function extract( $blog_id, $post_id, $what_to_extract = self::ALL ) {
 
 		// multisite?
 		if ( function_exists( 'switch_to_blog' ) ) {
@@ -48,20 +61,21 @@ class Jetpack_Media_Meta_Extractor {
 		if ( ! $post instanceof WP_Post ) {
 			return array();
 		}
-		$content = $post->post_title . "\n\n" . $post->post_content;
+		$content  = $post->post_title . "\n\n" . $post->post_content;
 		$char_cnt = strlen( $content );
 
-		//prevent running extraction on really huge amounts of content
-		if ( $char_cnt > 100000 ) //about 20k English words
+		// prevent running extraction on really huge amounts of content.
+		if ( $char_cnt > 100000 ) { // about 20k English words.
 			$content = substr( $content, 0, 100000 );
+		}
 
 		$extracted = array();
 
-		// Get images first, we need the full post for that
+		// Get images first, we need the full post for that.
 		if ( self::IMAGES & $what_to_extract ) {
 			$extracted = self::get_image_fields( $post );
 
-			// Turn off images so we can safely call extract_from_content() below
+			// Turn off images so we can safely call extract_from_content() below.
 			$what_to_extract = $what_to_extract - self::IMAGES;
 		}
 
@@ -69,7 +83,7 @@ class Jetpack_Media_Meta_Extractor {
 			restore_current_blog();
 		}
 
-		// All of the other things besides images can be extracted from just the content
+		// All of the other things besides images can be extracted from just the content.
 		$extracted = self::extract_from_content( $content, $what_to_extract, $extracted );
 
 		return $extracted;
@@ -80,21 +94,22 @@ class Jetpack_Media_Meta_Extractor {
 	 * NOTE: If you want IMAGES, call extract( $blog_id, $post_id, ...) which will give you more/better image extraction
 	 * This method will give you an error if you ask for IMAGES.
 	 *
-	 * @param $content The HTML post_content of a post
-	 * @param $what_to_extract (int) A mask of things to extract, e.g. Jetpack_Media_Meta_Extractor::IMAGES | Jetpack_Media_Meta_Extractor::MENTIONS
-	 * @param $already_extracted (array) Previously extracted things, e.g. images from extract(), which can be used for x-referencing here
-	 * @returns a structure containing metadata about the embedded things, or empty array if nothing found, or WP_Error on error
+	 * @param string $content The HTML post_content of a post.
+	 * @param int    $what_to_extract A mask of things to extract, e.g. Jetpack_Media_Meta_Extractor::IMAGES | Jetpack_Media_Meta_Extractor::MENTIONS.
+	 * @param array  $already_extracted Previously extracted things, e.g. images from extract(), which can be used for x-referencing here.
+	 *
+	 * @return array a structure containing metadata about the embedded things, or empty array if nothing found, or WP_Error on error.
 	 */
-	static public function extract_from_content( $content, $what_to_extract = self::ALL, $already_extracted = array() ) {
+	public static function extract_from_content( $content, $what_to_extract = self::ALL, $already_extracted = array() ) {
 		$stripped_content = self::get_stripped_content( $content );
 
-		// Maybe start with some previously extracted things (e.g. images from extract()
+		// Maybe start with some previously extracted things (e.g. images from extract().
 		$extracted = $already_extracted;
 
 		// Embedded media objects will have already been converted to shortcodes by pre_kses hooks on save.
 
- 		if ( self::IMAGES & $what_to_extract ) {
-			$images = Jetpack_Media_Meta_Extractor::extract_images_from_content( $stripped_content, array() );
+		if ( self::IMAGES & $what_to_extract ) {
+			$images    = self::extract_images_from_content( $stripped_content, array() );
 			$extracted = array_merge( $extracted, $images );
 		}
 
@@ -102,30 +117,33 @@ class Jetpack_Media_Meta_Extractor {
 
 		if ( self::MENTIONS & $what_to_extract ) {
 			if ( preg_match_all( '/(^|\s)@(\w+)/u', $stripped_content, $matches ) ) {
-				$mentions = array_values( array_unique( $matches[2] ) ); //array_unique() retains the keys!
-				$mentions = array_map( 'strtolower', $mentions );
+				$mentions             = array_values( array_unique( $matches[2] ) ); // array_unique() retains the keys!
+				$mentions             = array_map( 'strtolower', $mentions );
 				$extracted['mention'] = array( 'name' => $mentions );
-				if ( !isset( $extracted['has'] ) )
+				if ( ! isset( $extracted['has'] ) ) {
 					$extracted['has'] = array();
+				}
 				$extracted['has']['mention'] = count( $mentions );
 			}
 		}
 
 		// ----------------------------------- HASHTAGS ------------------------------
-		/** Some hosts may not compile with --enable-unicode-properties and kick a warning:
-		  *   Warning: preg_match_all() [function.preg-match-all]: Compilation failed: support for \P, \p, and \X has not been compiled
-		  * Therefore, we only run this code block on wpcom, not in Jetpack.
+		/**
+		 * Some hosts may not compile with --enable-unicode-properties and kick a warning:
+		 * Warning: preg_match_all() [function.preg-match-all]: Compilation failed: support for \P, \p, and \X has not been compiled
+		 * Therefore, we only run this code block on wpcom, not in Jetpack.
 		 */
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) && ( self::HASHTAGS & $what_to_extract ) ) {
-			//This regex does not exactly match Twitter's
+			// This regex does not exactly match Twitter's
 			// if there are problems/complaints we should implement this:
-			//   https://github.com/twitter/twitter-text/blob/master/java/src/com/twitter/Regex.java
+			// https://github.com/twitter/twitter-text/blob/master/java/src/com/twitter/Regex.java .
 			if ( preg_match_all( '/(?:^|\s)#(\w*\p{L}+\w*)/u', $stripped_content, $matches ) ) {
-				$hashtags = array_values( array_unique( $matches[1] ) ); //array_unique() retains the keys!
-				$hashtags = array_map( 'strtolower', $hashtags );
+				$hashtags             = array_values( array_unique( $matches[1] ) ); // array_unique() retains the keys!
+				$hashtags             = array_map( 'strtolower', $hashtags );
 				$extracted['hashtag'] = array( 'name' => $hashtags );
-				if ( !isset( $extracted['has'] ) )
+				if ( ! isset( $extracted['has'] ) ) {
 					$extracted['has'] = array();
+				}
 				$extracted['has']['hashtag'] = count( $hashtags );
 			}
 		}
@@ -133,64 +151,72 @@ class Jetpack_Media_Meta_Extractor {
 		// ----------------------------------- SHORTCODES ------------------------------
 
 		// Always look for shortcodes.
-		// If we don't want them, we'll just remove them, so we don't grab them as links below
+		// If we don't want them, we'll just remove them, so we don't grab them as links below.
 		$shortcode_pattern = '/' . get_shortcode_regex() . '/s';
- 		if ( preg_match_all( $shortcode_pattern, $content, $matches ) ) {
+		if ( preg_match_all( $shortcode_pattern, $content, $matches ) ) {
 
 			$shortcode_total_count = 0;
 			$shortcode_type_counts = array();
-			$shortcode_types = array();
-			$shortcode_details = array();
+			$shortcode_types       = array();
+			$shortcode_details     = array();
 
 			if ( self::SHORTCODES & $what_to_extract ) {
 
-				foreach( $matches[2] as $key => $shortcode ) {
-					//Elasticsearch (and probably other things) doesn't deal well with some chars as key names
+				foreach ( $matches[2] as $key => $shortcode ) {
+					// Elasticsearch (and probably other things) doesn't deal well with some chars as key names.
 					$shortcode_name = preg_replace( '/[.,*"\'\/\\\\#+ ]/', '_', $shortcode );
 
 					$attr = shortcode_parse_atts( $matches[3][ $key ] );
 
 					$shortcode_total_count++;
-					if ( ! isset( $shortcode_type_counts[$shortcode_name] ) )
-						$shortcode_type_counts[$shortcode_name] = 0;
-					$shortcode_type_counts[$shortcode_name]++;
+					if ( ! isset( $shortcode_type_counts[ $shortcode_name ] ) ) {
+						$shortcode_type_counts[ $shortcode_name ] = 0;
+					}
+					$shortcode_type_counts[ $shortcode_name ]++;
 
 					// Store (uniquely) presence of all shortcode regardless of whether it's a keeper (for those, get ID below)
 					// @todo Store number of occurrences?
-					if ( ! in_array( $shortcode_name, $shortcode_types ) )
+					if ( ! in_array( $shortcode_name, $shortcode_types, true ) ) {
 						$shortcode_types[] = $shortcode_name;
+					}
 
-					// For keeper shortcodes, also store the id/url of the object (e.g. youtube video, TED talk, etc.)
-					if ( in_array( $shortcode, self::$KEEPER_SHORTCODES ) ) {
-						unset( $id ); // Clear shortcode ID data left from the last shortcode
-						// We'll try to get the salient ID from the function jetpack_shortcode_get_xyz_id()
-						// If the shortcode is a class, we'll call XyzShortcode::get_xyz_id()
-						$shortcode_get_id_func = "jetpack_shortcode_get_{$shortcode}_id";
-						$shortcode_class_name = ucfirst( $shortcode ) . 'Shortcode';
+					// For keeper shortcodes, also store the id/url of the object (e.g. youtube video, TED talk, etc.).
+					if ( in_array( $shortcode, self::$keeper_shortcodes, true ) ) {
+						// Clear shortcode ID data left from the last shortcode.
+						$id = null;
+						// We'll try to get the salient ID from the function jetpack_shortcode_get_xyz_id().
+						// If the shortcode is a class, we'll call XyzShortcode::get_xyz_id().
+						$shortcode_get_id_func   = "jetpack_shortcode_get_{$shortcode}_id";
+						$shortcode_class_name    = ucfirst( $shortcode ) . 'Shortcode';
 						$shortcode_get_id_method = "get_{$shortcode}_id";
 						if ( function_exists( $shortcode_get_id_func ) ) {
 							$id = call_user_func( $shortcode_get_id_func, $attr );
-						} else if ( method_exists( $shortcode_class_name, $shortcode_get_id_method ) ) {
+						} elseif ( method_exists( $shortcode_class_name, $shortcode_get_id_method ) ) {
 							$id = call_user_func( array( $shortcode_class_name, $shortcode_get_id_method ), $attr );
 						}
 						if ( ! empty( $id )
-							&& ( ! isset( $shortcode_details[$shortcode_name] ) || ! in_array( $id, $shortcode_details[$shortcode_name] ) ) )
-							$shortcode_details[$shortcode_name][] = $id;
+							&& ( ! isset( $shortcode_details[ $shortcode_name ] ) || ! in_array( $id, $shortcode_details[ $shortcode_name ], true ) ) ) {
+							$shortcode_details[ $shortcode_name ][] = $id;
+						}
 					}
 				}
 
 				if ( $shortcode_total_count > 0 ) {
-					// Add the shortcode info to the $extracted array
-					if ( !isset( $extracted['has'] ) )
+					// Add the shortcode info to the $extracted array.
+					if ( ! isset( $extracted['has'] ) ) {
 						$extracted['has'] = array();
+					}
 					$extracted['has']['shortcode'] = $shortcode_total_count;
-					$extracted['shortcode'] = array();
-					foreach ( $shortcode_type_counts as $type => $count )
-						$extracted['shortcode'][$type] = array( 'count' => $count );
-					if ( ! empty( $shortcode_types ) )
+					$extracted['shortcode']        = array();
+					foreach ( $shortcode_type_counts as $type => $count ) {
+						$extracted['shortcode'][ $type ] = array( 'count' => $count );
+					}
+					if ( ! empty( $shortcode_types ) ) {
 						$extracted['shortcode_types'] = $shortcode_types;
-					foreach ( $shortcode_details as $type => $id )
-						$extracted['shortcode'][$type]['id'] = $id;
+					}
+					foreach ( $shortcode_details as $type => $id ) {
+						$extracted['shortcode'][ $type ]['id'] = $id;
+					}
 				}
 			}
 
@@ -202,112 +228,116 @@ class Jetpack_Media_Meta_Extractor {
 
 		if ( self::LINKS & $what_to_extract ) {
 
-			// To hold the extracted stuff we find
+			// To hold the extracted stuff we find.
 			$links = array();
 
 			// @todo Get the text inside the links?
 
-			// Grab any links, whether in <a href="..." or not, but subtract those from shortcodes and images
-			// (we treat embed links as just another link)
+			// Grab any links, whether in <a href="..." or not, but subtract those from shortcodes and images.
+			// (we treat embed links as just another link).
 			if ( preg_match_all( '#(?:^|\s|"|\')(https?://([^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|/))))#', $content, $matches ) ) {
 
 				foreach ( $matches[1] as $link_raw ) {
 					$url = wp_parse_url( $link_raw );
 
-					// Data URI links
-					if ( isset( $url['scheme'] ) && 'data' === $url['scheme'] )
+					// Data URI links.
+					if ( isset( $url['scheme'] ) && 'data' === $url['scheme'] ) {
 						continue;
-
-					// Remove large (and likely invalid) links
-					if ( 4096 < strlen( $link_raw ) )
-						continue;
-
-					// Build a simple form of the URL so we can compare it to ones we found in IMAGES or SHORTCODES and exclude those
-					$simple_url = $url['scheme'] . '://' . $url['host'] . ( ! empty( $url['path'] ) ? $url['path'] : '' );
-					if ( isset( $extracted['image']['url'] ) ) {
-						if ( in_array( $simple_url, (array) $extracted['image']['url'] ) )
-							continue;
 					}
 
-					list( $proto, $link_all_but_proto ) = explode( '://', $link_raw );
+					// Remove large (and likely invalid) links.
+					if ( 4096 < strlen( $link_raw ) ) {
+						continue;
+					}
 
-					// Build a reversed hostname
-					$host_parts = array_reverse( explode( '.', $url['host'] ) );
+					// Build a simple form of the URL so we can compare it to ones we found in IMAGES or SHORTCODES and exclude those.
+					$simple_url = $url['scheme'] . '://' . $url['host'] . ( ! empty( $url['path'] ) ? $url['path'] : '' );
+					if ( isset( $extracted['image']['url'] ) ) {
+						if ( in_array( $simple_url, (array) $extracted['image']['url'], true ) ) {
+							continue;
+						}
+					}
+
+					list( $proto, $link_all_but_proto ) = explode( '://', $link_raw ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+
+					// Build a reversed hostname.
+					$host_parts    = array_reverse( explode( '.', $url['host'] ) );
 					$host_reversed = '';
 					foreach ( $host_parts as $part ) {
 						$host_reversed .= ( ! empty( $host_reversed ) ? '.' : '' ) . $part;
 					}
 
 					$link_analyzed = '';
-					if ( !empty( $url['path'] ) ) {
-						// The whole path (no query args or fragments)
-						$path = substr( $url['path'], 1 ); // strip the leading '/'
+					if ( ! empty( $url['path'] ) ) {
+						// The whole path (no query args or fragments).
+						$path           = substr( $url['path'], 1 ); // strip the leading '/'.
 						$link_analyzed .= ( ! empty( $link_analyzed ) ? ' ' : '' ) . $path;
 
-						// The path split by /
+						// The path split by /.
 						$path_split = explode( '/', $path );
 						if ( count( $path_split ) > 1 ) {
 							$link_analyzed .= ' ' . implode( ' ', $path_split );
 						}
 
-						// The fragment
-						if ( ! empty( $url['fragment'] ) )
+						// The fragment.
+						if ( ! empty( $url['fragment'] ) ) {
 							$link_analyzed .= ( ! empty( $link_analyzed ) ? ' ' : '' ) . $url['fragment'];
+						}
 					}
 
 					// @todo Check unique before adding
 					$links[] = array(
-						'url' => $link_all_but_proto,
+						'url'           => $link_all_but_proto,
 						'host_reversed' => $host_reversed,
-						'host' => $url['host'],
+						'host'          => $url['host'],
 					);
 				}
-
 			}
 
 			$link_count = count( $links );
 			if ( $link_count ) {
-				$extracted[ 'link' ] = $links;
-				if ( !isset( $extracted['has'] ) )
+				$extracted['link'] = $links;
+				if ( ! isset( $extracted['has'] ) ) {
 					$extracted['has'] = array();
+				}
 				$extracted['has']['link'] = $link_count;
 			}
 		}
 
 		// ----------------------------------- EMBEDS ------------------------------
 
-		//Embeds are just individual links on their own line
+		// Embeds are just individual links on their own line.
 		if ( self::EMBEDS & $what_to_extract ) {
 
-			if ( !function_exists( '_wp_oembed_get_object' ) )
-				include( ABSPATH . WPINC . '/class-oembed.php' );
+			if ( ! function_exists( '_wp_oembed_get_object' ) ) {
+				include ABSPATH . WPINC . '/class-oembed.php';
+			}
 
-			// get an oembed object
+			// get an oembed object.
 			$oembed = _wp_oembed_get_object();
 
-			// Grab any links on their own lines that may be embeds
+			// Grab any links on their own lines that may be embeds.
 			if ( preg_match_all( '|^\s*(https?://[^\s"]+)\s*$|im', $content, $matches ) ) {
 
-				// To hold the extracted stuff we find
+				// To hold the extracted stuff we find.
 				$embeds = array();
 
 				foreach ( $matches[1] as $link_raw ) {
 					$url = wp_parse_url( $link_raw );
 
-					list( $proto, $link_all_but_proto ) = explode( '://', $link_raw );
+					list( $proto, $link_all_but_proto ) = explode( '://', $link_raw ); // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
 					// Check whether this "link" is really an embed.
 					foreach ( $oembed->providers as $matchmask => $data ) {
-						list( $providerurl, $regex ) = $data;
+						list( $providerurl, $regex ) = $data; // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 
-						// Turn the asterisk-type provider URLs into regex
-						if ( !$regex ) {
+						// Turn the asterisk-type provider URLs into regex.
+						if ( ! $regex ) {
 							$matchmask = '#' . str_replace( '___wildcard___', '(.+)', preg_quote( str_replace( '*', '___wildcard___', $matchmask ), '#' ) ) . '#i';
 							$matchmask = preg_replace( '|^#http\\\://|', '#https?\://', $matchmask );
 						}
 
 						if ( preg_match( $matchmask, $link_raw ) ) {
-							$provider = str_replace( '{format}', 'json', $providerurl ); // JSON is easier to deal with than XML
 							$embeds[] = $link_all_but_proto; // @todo Check unique before adding
 
 							// @todo Try to get ID's for the ones we care about (shortcode_keepers)
@@ -317,12 +347,14 @@ class Jetpack_Media_Meta_Extractor {
 				}
 
 				if ( ! empty( $embeds ) ) {
-					if ( !isset( $extracted['has'] ) )
+					if ( ! isset( $extracted['has'] ) ) {
 						$extracted['has'] = array();
+					}
 					$extracted['has']['embed'] = count( $embeds );
-					$extracted['embed'] = array( 'url' => array() );
-					foreach ( $embeds as $e )
+					$extracted['embed']        = array( 'url' => array() );
+					foreach ( $embeds as $e ) {
 						$extracted['embed']['url'][] = $e;
+					}
 				}
 			}
 		}
@@ -347,56 +379,73 @@ class Jetpack_Media_Meta_Extractor {
 		}
 
 		$defaults = array(
-			'width'               => 200, // Required minimum width (if possible to determine)
-			'height'              => 200, // Required minimum height (if possible to determine)
+			'width'  => 200, // Required minimum width (if possible to determine).
+			'height' => 200, // Required minimum height (if possible to determine).
 		);
 
 		$args = wp_parse_args( $args, $defaults );
 
-		$image_list = array();
-		$image_booleans = array();
+		$image_list                = array();
+		$image_booleans            = array();
 		$image_booleans['gallery'] = 0;
 
 		$from_featured_image = Jetpack_PostImages::from_thumbnail( $post->ID, $args['width'], $args['height'] );
-		if ( !empty( $from_featured_image ) ) {
-			$srcs = wp_list_pluck( $from_featured_image, 'src' );
+		if ( ! empty( $from_featured_image ) ) {
+			$srcs       = wp_list_pluck( $from_featured_image, 'src' );
 			$image_list = array_merge( $image_list, $srcs );
 		}
 
 		$from_slideshow = Jetpack_PostImages::from_slideshow( $post->ID, $args['width'], $args['height'] );
-		if ( !empty( $from_slideshow ) ) {
-			$srcs = wp_list_pluck( $from_slideshow, 'src' );
+		if ( ! empty( $from_slideshow ) ) {
+			$srcs       = wp_list_pluck( $from_slideshow, 'src' );
 			$image_list = array_merge( $image_list, $srcs );
 		}
 
 		$from_gallery = Jetpack_PostImages::from_gallery( $post->ID );
-		if ( !empty( $from_gallery ) ) {
-			$srcs = wp_list_pluck( $from_gallery, 'src' );
+		if ( ! empty( $from_gallery ) ) {
+			$srcs       = wp_list_pluck( $from_gallery, 'src' );
 			$image_list = array_merge( $image_list, $srcs );
 			$image_booleans['gallery']++; // @todo This count isn't correct, will only every count 1
 		}
 
 		// @todo Can we check width/height of these efficiently?  Could maybe use query args at least, before we strip them out
-		$image_list = Jetpack_Media_Meta_Extractor::get_images_from_html( $post->post_content, $image_list );
+		$image_list = self::get_images_from_html( $post->post_content, $image_list );
 
-		return Jetpack_Media_Meta_Extractor::build_image_struct( $image_list, $image_booleans );
+		return self::build_image_struct( $image_list, $image_booleans );
 	}
 
+	/**
+	 * Helper function to get images from HTML and return it with the set sturcture.
+	 *
+	 * @param string $content HTML content.
+	 * @param array  $image_list Array of already found images.
+	 *
+	 * @return array|array[] Array of images.
+	 */
 	public static function extract_images_from_content( $content, $image_list ) {
-		$image_list = Jetpack_Media_Meta_Extractor::get_images_from_html( $content, $image_list );
-		return Jetpack_Media_Meta_Extractor::build_image_struct( $image_list, array() );
+		$image_list = self::get_images_from_html( $content, $image_list );
+		return self::build_image_struct( $image_list, array() );
 	}
 
+	/**
+	 * Produces a set structure for extracted media items.
+	 *
+	 * @param array $image_list Array of images.
+	 * @param array $image_booleans Image booleans.
+	 *
+	 * @return array|array[]
+	 */
 	public static function build_image_struct( $image_list, $image_booleans ) {
 		if ( ! empty( $image_list ) ) {
-			$retval = array( 'image' => array() );
+			$retval     = array( 'image' => array() );
 			$image_list = array_unique( $image_list );
 			foreach ( $image_list as $img ) {
 				$retval['image'][] = array( 'url' => $img );
 			}
 			$image_booleans['image'] = count( $retval['image'] );
-			if ( ! empty( $image_booleans ) )
+			if ( ! empty( $image_booleans ) ) {
 				$retval['has'] = $image_booleans;
+			}
 			return $retval;
 		} else {
 			return array();
@@ -404,22 +453,27 @@ class Jetpack_Media_Meta_Extractor {
 	}
 
 	/**
+	 * Extracts images from html.
 	 *
-	 * @param string $html Some markup, possibly containing image tags
-	 * @param array $images_already_extracted (just an array of image URLs without query strings, no special structure), used for de-duplication
+	 * @param string $html Some markup, possibly containing image tags.
+	 * @param array  $images_already_extracted (just an array of image URLs without query strings, no special structure), used for de-duplication.
+	 *
 	 * @return array Image URLs extracted from the HTML, stripped of query params and de-duped
 	 */
 	public static function get_images_from_html( $html, $images_already_extracted ) {
 		$image_list = $images_already_extracted;
-		$from_html = Jetpack_PostImages::from_html( $html );
-		if ( !empty( $from_html ) ) {
+		$from_html  = Jetpack_PostImages::from_html( $html );
+		if ( ! empty( $from_html ) ) {
 			$srcs = wp_list_pluck( $from_html, 'src' );
-			foreach( $srcs as $image_url ) {
-				if ( ( $src = wp_parse_url( $image_url ) ) && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
-					// Rebuild the URL without the query string
+			foreach ( $srcs as $image_url ) {
+				$length = strpos( $image_url, '?' );
+				$src    = wp_parse_url( $image_url );
+
+				if ( $src && isset( $src['scheme'], $src['host'], $src['path'] ) ) {
+					// Rebuild the URL without the query string.
 					$queryless = $src['scheme'] . '://' . $src['host'] . $src['path'];
-				} elseif ( $length = strpos( $image_url, '?' ) ) {
-					// If wp_parse_url() didn't work, strip off the query string the old fashioned way
+				} elseif ( $length ) {
+					// If wp_parse_url() didn't work, strip off the query string the old fashioned way.
 					$queryless = substr( $image_url, 0, $length );
 				} else {
 					// Failing that, there was no spoon! Err ... query string!
@@ -431,7 +485,7 @@ class Jetpack_Media_Meta_Extractor {
 					continue;
 				}
 
-				if ( ! in_array( $queryless, $image_list ) ) {
+				if ( ! in_array( $queryless, $image_list, true ) ) {
 					$image_list[] = $queryless;
 				}
 			}
@@ -439,10 +493,17 @@ class Jetpack_Media_Meta_Extractor {
 		return $image_list;
 	}
 
+	/**
+	 * Strips concents of all tags, shortcodes, and decodes HTML entities.
+	 *
+	 * @param string $content Original content.
+	 *
+	 * @return string Cleaned content.
+	 */
 	private static function get_stripped_content( $content ) {
-		$clean_content = strip_tags( $content );
+		$clean_content = wp_strip_all_tags( $content );
 		$clean_content = html_entity_decode( $clean_content );
-		//completely strip shortcodes and any content they enclose
+		// completely strip shortcodes and any content they enclose.
 		$clean_content = strip_shortcodes( $clean_content );
 		return $clean_content;
 	}

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -57,7 +57,7 @@ class Jetpack_Media_Summary {
 			),
 		);
 
-		if ( empty( $post->post_password ) ) {
+		if ( $post instanceof WP_Post && empty( $post->post_password ) ) {
 			$return['excerpt']       = self::get_excerpt( $post->post_content, $post->post_excerpt, $args['max_words'], $args['max_chars'] , $post);
 			$return['count']['word'] = self::get_word_count( $post->post_content );
 			$return['count']['word_remaining'] = self::get_word_remaining_count( $post->post_content, $return['excerpt'] );

--- a/_inc/lib/class.media-summary.php
+++ b/_inc/lib/class.media-summary.php
@@ -1,23 +1,50 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Provides media summary of a post.
+ *
+ * @package Jetpack.
+ */
+
 /**
  * Class Jetpack_Media_Summary
  *
- * embed [video] > gallery > image > text
+ * Priority: embed [video] > gallery > image > text
  */
 class Jetpack_Media_Summary {
 
+	/**
+	 * Media cache.
+	 *
+	 * @var array
+	 */
 	private static $cache = array();
 
-	static function get( $post_id, $blog_id = 0, $args = array() ) {
+	/**
+	 * Get media summary for a post.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param int   $blog_id Blog ID, if applicable.
+	 * @param array $args {
+	 *      Optional. An array of arguments.
+	 *      @type int $max_words Maximum number of words.
+	 *      @type int $max_chars Maximum number of characters.
+	 * }
+	 *
+	 * @return array|mixed|void
+	 */
+	public static function get( $post_id, $blog_id = 0, $args = array() ) {
+		// @todo: Use type hinting in the line above when at PHP 7.0+.
+		$post_id = (int) $post_id;
+		$blog_id = (int) $blog_id;
 
 		$defaults = array(
 			'max_words' => 16,
 			'max_chars' => 256,
 		);
-		$args = wp_parse_args( $args, $defaults );
+		$args     = wp_parse_args( $args, $defaults );
 
 		$switched = false;
-		if ( !empty( $blog_id ) && $blog_id != get_current_blog_id() && function_exists( 'switch_to_blog' ) ) {
+		if ( ! empty( $blog_id ) && get_current_blog_id() !== $blog_id && function_exists( 'switch_to_blog' ) ) {
 			switch_to_blog( $blog_id );
 			$switched = true;
 		} else {
@@ -47,9 +74,9 @@ class Jetpack_Media_Summary {
 			'excerpt'    => '',
 			'word_count' => 0,
 			'secure'     => array(
-				'image'  => '',
+				'image' => '',
 			),
-			'count'       => array(
+			'count'      => array(
 				'image' => 0,
 				'video' => 0,
 				'word'  => 0,
@@ -58,30 +85,31 @@ class Jetpack_Media_Summary {
 		);
 
 		if ( $post instanceof WP_Post && empty( $post->post_password ) ) {
-			$return['excerpt']       = self::get_excerpt( $post->post_content, $post->post_excerpt, $args['max_words'], $args['max_chars'] , $post);
-			$return['count']['word'] = self::get_word_count( $post->post_content );
+			$return['excerpt']                 = self::get_excerpt( $post->post_content, $post->post_excerpt, $args['max_words'], $args['max_chars'], $post );
+			$return['count']['word']           = self::get_word_count( $post->post_content );
 			$return['count']['word_remaining'] = self::get_word_remaining_count( $post->post_content, $return['excerpt'] );
-			$return['count']['link'] = self::get_link_count( $post->post_content );
+			$return['count']['link']           = self::get_link_count( $post->post_content );
 		}
 
 		$extract = Jetpack_Media_Meta_Extractor::extract( $blog_id, $post_id, Jetpack_Media_Meta_Extractor::ALL );
 
-		if ( empty( $extract['has'] ) )
+		if ( empty( $extract['has'] ) ) {
 			return $return;
+		}
 
-		// Prioritize [some] video embeds
-		if ( !empty( $extract['has']['shortcode'] ) ) {
+		// Prioritize [some] video embeds.
+		if ( ! empty( $extract['has']['shortcode'] ) ) {
 			foreach ( $extract['shortcode'] as $type => $data ) {
 				switch ( $type ) {
 					case 'videopress':
 					case 'wpvideo':
-						if ( 0 == $return['count']['video'] ) {
-							// If there is no id on the video, then let's just skip this
-							if ( ! isset ( $data['id'][0] ) ) {
+						if ( 0 === $return['count']['video'] ) {
+							// If there is no id on the video, then let's just skip this.
+							if ( ! isset( $data['id'][0] ) ) {
 								break;
 							}
 
-							$guid = $data['id'][0];
+							$guid       = $data['id'][0];
 							$video_info = videopress_get_video_details( $guid );
 
 							// Only add the video tags if the guid returns a valid videopress object.
@@ -99,39 +127,38 @@ class Jetpack_Media_Summary {
 
 								$thumbnail = $video_info->poster;
 								if ( ! empty( $thumbnail ) ) {
-									$return['image'] = $thumbnail;
+									$return['image']           = $thumbnail;
 									$return['secure']['image'] = $thumbnail;
 								}
 
-								$return['type'] = 'video';
-								$return['video'] = esc_url_raw( $url );
-								$return['video_type'] = 'video/mp4';
+								$return['type']            = 'video';
+								$return['video']           = esc_url_raw( $url );
+								$return['video_type']      = 'video/mp4';
 								$return['secure']['video'] = $return['video'];
 							}
-
 						}
 						$return['count']['video']++;
 						break;
 					case 'youtube':
-						if ( 0 == $return['count']['video'] ) {
-							$return['type'] = 'video';
-							$return['video'] = esc_url_raw( 'http://www.youtube.com/watch?feature=player_embedded&v=' . $extract['shortcode']['youtube']['id'][0] );
-							$return['image'] = self::get_video_poster( 'youtube', $extract['shortcode']['youtube']['id'][0] );
+						if ( 0 === $return['count']['video'] ) {
+							$return['type']            = 'video';
+							$return['video']           = esc_url_raw( 'http://www.youtube.com/watch?feature=player_embedded&v=' . $extract['shortcode']['youtube']['id'][0] );
+							$return['image']           = self::get_video_poster( 'youtube', $extract['shortcode']['youtube']['id'][0] );
 							$return['secure']['video'] = self::https( $return['video'] );
 							$return['secure']['image'] = self::https( $return['image'] );
 						}
 						$return['count']['video']++;
 						break;
 					case 'vimeo':
-						if ( 0 == $return['count']['video'] ) {
-							$return['type'] = 'video';
-							$return['video'] = esc_url_raw( 'http://vimeo.com/' . $extract['shortcode']['vimeo']['id'][0] );
+						if ( 0 === $return['count']['video'] ) {
+							$return['type']            = 'video';
+							$return['video']           = esc_url_raw( 'http://vimeo.com/' . $extract['shortcode']['vimeo']['id'][0] );
 							$return['secure']['video'] = self::https( $return['video'] );
 
 							$poster_image = get_post_meta( $post_id, 'vimeo_poster_image', true );
-							if ( !empty( $poster_image ) ) {
-								$return['image'] = $poster_image;
-								$poster_url_parts = wp_parse_url( $poster_image );
+							if ( ! empty( $poster_image ) ) {
+								$return['image']           = $poster_image;
+								$poster_url_parts          = wp_parse_url( $poster_image );
 								$return['secure']['image'] = 'https://secure-a.vimeocdn.com' . $poster_url_parts['path'];
 							}
 						}
@@ -139,38 +166,36 @@ class Jetpack_Media_Summary {
 						break;
 				}
 			}
-
 		}
 
-		if ( !empty( $extract['has']['embed'] ) ) {
-			foreach( $extract['embed']['url'] as $embed ) {
+		if ( ! empty( $extract['has']['embed'] ) ) {
+			foreach ( $extract['embed']['url'] as $embed ) {
 				if ( preg_match( '/((youtube|vimeo|dailymotion)\.com|youtu.be)/', $embed ) ) {
-					if ( 0 == $return['count']['video'] ) {
-						$return['type']   = 'video';
-						$return['video']  = 'http://' .  $embed;
+					if ( 0 === $return['count']['video'] ) {
+						$return['type']            = 'video';
+						$return['video']           = 'http://' . $embed;
 						$return['secure']['video'] = self::https( $return['video'] );
 						if ( false !== strpos( $embed, 'youtube' ) ) {
-							$return['image'] = self::get_video_poster( 'youtube', jetpack_get_youtube_id( $return['video'] ) );
+							$return['image']           = self::get_video_poster( 'youtube', jetpack_get_youtube_id( $return['video'] ) );
 							$return['secure']['image'] = self::https( $return['image'] );
-						} else if ( false !== strpos( $embed, 'youtu.be' ) ) {
-							$youtube_id = jetpack_get_youtube_id( $return['video'] );
-							$return['video'] = 'http://youtube.com/watch?v=' . $youtube_id . '&feature=youtu.be';
+						} elseif ( false !== strpos( $embed, 'youtu.be' ) ) {
+							$youtube_id                = jetpack_get_youtube_id( $return['video'] );
+							$return['video']           = 'http://youtube.com/watch?v=' . $youtube_id . '&feature=youtu.be';
 							$return['secure']['video'] = self::https( $return['video'] );
-							$return['image'] = self::get_video_poster( 'youtube', jetpack_get_youtube_id( $return['video'] ) );
+							$return['image']           = self::get_video_poster( 'youtube', jetpack_get_youtube_id( $return['video'] ) );
 							$return['secure']['image'] = self::https( $return['image'] );
-						} else if ( false !== strpos( $embed, 'vimeo' ) ) {
+						} elseif ( false !== strpos( $embed, 'vimeo' ) ) {
 							$poster_image = get_post_meta( $post_id, 'vimeo_poster_image', true );
-							if ( !empty( $poster_image ) ) {
-								$return['image'] = $poster_image;
-								$poster_url_parts = wp_parse_url( $poster_image );
+							if ( ! empty( $poster_image ) ) {
+								$return['image']           = $poster_image;
+								$poster_url_parts          = wp_parse_url( $poster_image );
 								$return['secure']['image'] = 'https://secure-a.vimeocdn.com' . $poster_url_parts['path'];
 							}
-						} else if ( false !== strpos( $embed, 'dailymotion' ) ) {
-							$return['image'] = str_replace( 'dailymotion.com/video/','dailymotion.com/thumbnail/video/', $embed );
-							$return['image'] = wp_parse_url( $return['image'], PHP_URL_SCHEME ) === null ? 'http://' . $return['image'] : $return['image'];
+						} elseif ( false !== strpos( $embed, 'dailymotion' ) ) {
+							$return['image']           = str_replace( 'dailymotion.com/video/', 'dailymotion.com/thumbnail/video/', $embed );
+							$return['image']           = wp_parse_url( $return['image'], PHP_URL_SCHEME ) === null ? 'http://' . $return['image'] : $return['image'];
 							$return['secure']['image'] = self::https( $return['image'] );
 						}
-
 					}
 					$return['count']['video']++;
 				}
@@ -178,64 +203,65 @@ class Jetpack_Media_Summary {
 		}
 
 		// Do we really want to make the video the primary focus of the post?
-		if ( 'video' == $return['type'] ) {
-			$content = wpautop( strip_tags( $post->post_content ) );
-			$paragraphs = explode( '</p>', $content );
+		if ( 'video' === $return['type'] ) {
+			$content              = wpautop( wp_strip_all_tags( $post->post_content ) );
+			$paragraphs           = explode( '</p>', $content );
 			$number_of_paragraphs = 0;
 
 			foreach ( $paragraphs as $i => $paragraph ) {
-				// Don't include blank lines as a paragraph
-				if ( '' == trim( $paragraph ) ) {
-					unset( $paragraphs[$i] );
+				// Don't include blank lines as a paragraph.
+				if ( '' === trim( $paragraph ) ) {
+					unset( $paragraphs[ $i ] );
 					continue;
 				}
 				$number_of_paragraphs++;
 			}
 
-			$number_of_paragraphs = $number_of_paragraphs - $return['count']['video']; // subtract amount for videos..
+			$number_of_paragraphs = $number_of_paragraphs - $return['count']['video']; // subtract amount for videos.
 
-			// More than 2 paragraph? The video is not the primary focus so we can do some more analysis
-			if ( $number_of_paragraphs > 2 )
+			// More than 2 paragraph? The video is not the primary focus so we can do some more analysis.
+			if ( $number_of_paragraphs > 2 ) {
 				$return['type'] = 'standard';
+			}
 		}
 
 		// If we don't have any prioritized embed...
-		if ( 'standard' == $return['type'] ) {
+		if ( 'standard' === $return['type'] ) {
 			if ( ( ! empty( $extract['has']['gallery'] ) || ! empty( $extract['shortcode']['gallery']['count'] ) ) && ! empty( $extract['image'] ) ) {
-				//... Then we prioritize galleries first (multiple images returned)
+				// ... Then we prioritize galleries first (multiple images returned)
 				$return['type']   = 'gallery';
 				$return['images'] = $extract['image'];
 				foreach ( $return['images'] as $image ) {
 					$return['secure']['images'][] = array( 'url' => self::ssl_img( $image['url'] ) );
 					$return['count']['image']++;
 				}
-			} else if ( ! empty( $extract['has']['image'] ) ) {
-				// ... Or we try and select a single image that would make sense
-				$content = wpautop( strip_tags( $post->post_content ) );
-				$paragraphs = explode( '</p>', $content );
+			} elseif ( ! empty( $extract['has']['image'] ) ) {
+				// ... Or we try and select a single image that would make sense.
+				$content              = wpautop( wp_strip_all_tags( $post->post_content ) );
+				$paragraphs           = explode( '</p>', $content );
 				$number_of_paragraphs = 0;
 
 				foreach ( $paragraphs as $i => $paragraph ) {
-					// Don't include 'actual' captions as a paragraph
+					// Don't include 'actual' captions as a paragraph.
 					if ( false !== strpos( $paragraph, '[caption' ) ) {
-						unset( $paragraphs[$i] );
+						unset( $paragraphs[ $i ] );
 						continue;
 					}
-					// Don't include blank lines as a paragraph
-					if ( '' == trim( $paragraph ) ) {
-						unset( $paragraphs[$i] );
+					// Don't include blank lines as a paragraph.
+					if ( '' === trim( $paragraph ) ) {
+						unset( $paragraphs[ $i ] );
 						continue;
 					}
 					$number_of_paragraphs++;
 				}
 
-				$return['image'] = $extract['image'][0]['url'];
+				$return['image']           = $extract['image'][0]['url'];
 				$return['secure']['image'] = self::ssl_img( $return['image'] );
 				$return['count']['image']++;
 
-				if ( $number_of_paragraphs <= 2 && 1 == count( $extract['image'] ) ) {
-					// If we have lots of text or images, let's not treat it as an image post, but return its first image
-					$return['type']  = 'image';
+				if ( $number_of_paragraphs <= 2 && 1 === count( $extract['image'] ) ) {
+					// If we have lots of text or images, let's not treat it as an image post, but return its first image.
+					$return['type'] = 'image';
 				}
 			}
 		}
@@ -259,11 +285,25 @@ class Jetpack_Media_Summary {
 		return $return;
 	}
 
-	static function https( $str ) {
+	/**
+	 * Converts http to https://
+	 *
+	 * @param string $str URL.
+	 *
+	 * @return string URL.
+	 */
+	public static function https( $str ) {
 		return str_replace( 'http://', 'https://', $str );
 	}
 
-	static function ssl_img( $url ) {
+	/**
+	 * Returns a Photonized version of the URL.
+	 *
+	 * @param string $url URL.
+	 *
+	 * @return string URL.
+	 */
+	public static function ssl_img( $url ) {
 		if ( false !== strpos( $url, 'files.wordpress.com' ) ) {
 			return self::https( $url );
 		} else {
@@ -271,20 +311,35 @@ class Jetpack_Media_Summary {
 		}
 	}
 
-	static function get_video_poster( $type, $id ) {
-		if ( 'videopress' == $type ) {
+	/**
+	 * Get the video poster.
+	 *
+	 * @param string $type Video service.
+	 * @param string $id Video ID for the service.
+	 *
+	 * @return string URL of image thumbnail for the video.
+	 */
+	public static function get_video_poster( $type, $id ) {
+		if ( 'videopress' === $type ) {
 			if ( function_exists( 'video_get_highest_resolution_image_url' ) ) {
 				return video_get_highest_resolution_image_url( $id );
-			} else if ( class_exists( 'VideoPress_Video' ) ) {
+			} elseif ( class_exists( 'VideoPress_Video' ) ) {
 				$video = new VideoPress_Video( $id );
 				return $video->poster_frame_uri;
 			}
-		} else if ( 'youtube' == $type ) {
-			return  'http://img.youtube.com/vi/'.$id.'/0.jpg';
+		} elseif ( 'youtube' === $type ) {
+			return 'http://img.youtube.com/vi/' . $id . '/0.jpg';
 		}
 	}
 
-	static function clean_text( $text ) {
+	/**
+	 * Clean text of shortcodes and tags.
+	 *
+	 * @param string $text Dirty text.
+	 *
+	 * @return string Clean text.
+	 */
+	public static function clean_text( $text ) {
 		return trim(
 			preg_replace(
 				'/[\s]+/',
@@ -293,7 +348,7 @@ class Jetpack_Media_Summary {
 					'@https?://[\S]+@',
 					'',
 					strip_shortcodes(
-						strip_tags(
+						wp_strip_all_tags(
 							$text
 						)
 					)
@@ -306,6 +361,7 @@ class Jetpack_Media_Summary {
 	 * Retrieve an excerpt for the post summary.
 	 *
 	 * This function works around a suspected problem with Core. If resolved, this function should be simplified.
+	 *
 	 * @link https://github.com/Automattic/jetpack/pull/8510
 	 * @link https://core.trac.wordpress.org/ticket/42814
 	 *
@@ -316,24 +372,31 @@ class Jetpack_Media_Summary {
 	 * @param  WP_Post $requested_post The post object.
 	 * @return string Post excerpt.
 	 **/
-	static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256, $requested_post = null ) {
+	public static function get_excerpt( $post_content, $post_excerpt, $max_words = 16, $max_chars = 256, $requested_post = null ) {
 		global $post;
 		$original_post = $post; // Saving the global for later use.
 		if ( function_exists( 'wpcom_enhanced_excerpt_extract_excerpt' ) ) {
-			return self::clean_text( wpcom_enhanced_excerpt_extract_excerpt( array(
-				'text'                => $post_content,
-				'excerpt_only'        => true,
-				'show_read_more'      => false,
-				'max_words'           => $max_words,
-				'max_chars'           => $max_chars,
-				'read_more_threshold' => 25,
-			) ) );
+			return self::clean_text(
+				wpcom_enhanced_excerpt_extract_excerpt(
+					array(
+						'text'                => $post_content,
+						'excerpt_only'        => true,
+						'show_read_more'      => false,
+						'max_words'           => $max_words,
+						'max_chars'           => $max_chars,
+						'read_more_threshold' => 25,
+					)
+				)
+			);
 		} elseif ( $requested_post instanceof WP_Post ) {
+			// @todo Refactor to not need to override the global.
+			// phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
 			$post = $requested_post; // setup_postdata does not set the global.
 			setup_postdata( $post );
 			/** This filter is documented in core/src/wp-includes/post-template.php */
 			$post_excerpt = apply_filters( 'get_the_excerpt', $post_excerpt, $post );
-			$post         = $original_post; // wp_reset_postdata uses the $post global.
+			// phpcs:ignore: WordPress.WP.GlobalVariablesOverride.Prohibited
+			$post = $original_post; // wp_reset_postdata uses the $post global.
 			wp_reset_postdata();
 			return self::clean_text( $post_excerpt );
 		}
@@ -344,26 +407,50 @@ class Jetpack_Media_Summary {
 	 * Split a string into an array of words.
 	 *
 	 * @param string $text Post content or excerpt.
+	 *
+	 * @return array Array of words.
 	 */
-	static function split_content_in_words( $text ) {
+	public static function split_content_in_words( $text ) {
 		$words = preg_split( '/[\s!?;,.]+/', $text, null, PREG_SPLIT_NO_EMPTY );
 
 		// Return an empty array if the split above fails.
 		return $words ? $words : array();
 	}
 
-	static function get_word_count( $post_content ) {
+	/**
+	 * Get the word count.
+	 *
+	 * @param string $post_content Post content.
+	 *
+	 * @return int Word count.
+	 */
+	public static function get_word_count( $post_content ) {
 		return (int) count( self::split_content_in_words( self::clean_text( $post_content ) ) );
 	}
 
-	static function get_word_remaining_count( $post_content, $excerpt_content ) {
+	/**
+	 * Get remainder word count (after the excerpt).
+	 *
+	 * @param string $post_content Post content.
+	 * @param string $excerpt_content Excerpt content.
+	 *
+	 * @return int Number of words after the excerpt.
+	 */
+	public static function get_word_remaining_count( $post_content, $excerpt_content ) {
 		$content_word_count = count( self::split_content_in_words( self::clean_text( $post_content ) ) );
 		$excerpt_word_count = count( self::split_content_in_words( self::clean_text( $excerpt_content ) ) );
 
 		return (int) $content_word_count - $excerpt_word_count;
 	}
 
-	static function get_link_count( $post_content ) {
+	/**
+	 * Counts the number of links in a post.
+	 *
+	 * @param string $post_content Post content.
+	 *
+	 * @return false|int Number of links.
+	 */
+	public static function get_link_count( $post_content ) {
 		return preg_match_all( '/\<a[\> ]/', $post_content, $matches );
 	}
 }

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -17,6 +17,7 @@ module.exports = [
 	'functions.global.php',
 	'functions.opengraph.php',
 	'_inc/lib/admin-pages/class-jetpack-about-page.php',
+	'_inc/lib/class.media-extractor.php',
 	'_inc/lib/class-jetpack-instagram-gallery-helper.php',
 	'_inc/lib/class-jetpack-tweetstorm-helper.php',
 	'_inc/lib/class-jetpack-mapbox-helper.php',

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -18,6 +18,7 @@ module.exports = [
 	'functions.opengraph.php',
 	'_inc/lib/admin-pages/class-jetpack-about-page.php',
 	'_inc/lib/class.media-extractor.php',
+	'_inc/lib/class.media-summary.php',
 	'_inc/lib/class-jetpack-instagram-gallery-helper.php',
 	'_inc/lib/class-jetpack-tweetstorm-helper.php',
 	'_inc/lib/class-jetpack-mapbox-helper.php',

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -10,6 +10,7 @@ module.exports = [
 	'class.jetpack-bbpress-json-api.compat.php',
 	'class.jetpack-gutenberg.php',
 	'class.jetpack-plan.php',
+	'class.jetpack-twitter-cards.php',
 	'class-jetpack-wizard-banner.php',
 	'docker',
 	'extensions/',

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -1,6 +1,12 @@
-<?php
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Jetpack Twitter Card handling.
+ *
+ * @package Jetpack.
+ */
 
-/*
+
+/**
  * Twitter Cards
  *
  * Hooks onto the Open Graph protocol and extends it by adding only the tags
@@ -11,7 +17,14 @@
  */
 class Jetpack_Twitter_Cards {
 
-	static function twitter_cards_tags( $og_tags ) {
+	/**
+	 * Adds Twitter Card tags.
+	 *
+	 * @param array $og_tags Existing OG tags.
+	 *
+	 * @return array OG tags inclusive of Twitter Card output.
+	 */
+	public static function twitter_cards_tags( $og_tags ) {
 		global $post;
 		$post_id = ( $post instanceof WP_Post ) ? $post->ID : null;
 
@@ -32,10 +45,10 @@ class Jetpack_Twitter_Cards {
 		}
 
 		/*
-		 * These tags apply to any page (home, archives, etc)
+		 * These tags apply to any page (home, archives, etc).
 		 */
 
-		// If we have information on the author/creator, then include that as well
+		// If we have information on the author/creator, then include that as well.
 		if ( ! empty( $post ) && ! empty( $post->post_author ) ) {
 			/** This action is documented in modules/sharedaddy/sharing-sources.php */
 			$handle = apply_filters( 'jetpack_sharing_twitter_via', '', $post_id );
@@ -83,7 +96,7 @@ class Jetpack_Twitter_Cards {
 
 		$card_type = 'summary';
 
-		// Try to give priority to featured images
+		// Try to give priority to featured images.
 		if ( class_exists( 'Jetpack_PostImages' ) && ! empty( $post_id ) ) {
 			$post_image = Jetpack_PostImages::get_image(
 				$post_id,
@@ -131,14 +144,14 @@ class Jetpack_Twitter_Cards {
 			}
 
 			// Test again, class should already be auto-loaded in Jetpack.
-			// If not, skip extra media analysis and stick with a summary card
+			// If not, skip extra media analysis and stick with a summary card.
 			if ( class_exists( 'Jetpack_Media_Summary' ) && ! empty( $post_id ) ) {
 				$extract = Jetpack_Media_Summary::get( $post_id );
 
-				if ( 'gallery' == $extract['type'] ) {
+				if ( 'gallery' === $extract['type'] ) {
 					list( $og_tags, $card_type ) = self::twitter_cards_define_type_based_on_image_count( $og_tags, $extract );
-				} elseif ( 'video' == $extract['type'] ) {
-					// Leave as summary, but with large pict of poster frame (we know those comply to Twitter's size requirements)
+				} elseif ( 'video' === $extract['type'] ) {
+					// Leave as summary, but with large pict of poster frame (we know those comply to Twitter's size requirements).
 					$card_type                = 'summary_large_image';
 					$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 640, $extract['image'] ) );
 				} else {
@@ -150,9 +163,9 @@ class Jetpack_Twitter_Cards {
 		$og_tags['twitter:card'] = $card_type;
 
 		// Make sure we have a description for Twitter, their validator isn't happy without some content (single space not valid).
-		if ( ! isset( $og_tags['og:description'] ) || '' == trim( $og_tags['og:description'] ) || __( 'Visit the post for more.', 'jetpack' ) == $og_tags['og:description'] ) { // empty( trim( $og_tags['og:description'] ) ) isn't valid php
-			$has_creator = ( ! empty( $og_tags['twitter:creator'] ) && '@wordpressdotcom' != $og_tags['twitter:creator'] ) ? true : false;
-			if ( ! empty( $extract ) && 'video' == $extract['type'] ) { // use $extract['type'] since $card_type is 'summary' for video posts
+		if ( ! isset( $og_tags['og:description'] ) || '' === trim( $og_tags['og:description'] ) || __( 'Visit the post for more.', 'jetpack' ) === $og_tags['og:description'] ) { // empty( trim( $og_tags['og:description'] ) ) isn't valid php.
+			$has_creator = ( ! empty( $og_tags['twitter:creator'] ) && '@wordpressdotcom' !== $og_tags['twitter:creator'] ) ? true : false;
+			if ( ! empty( $extract ) && 'video' === $extract['type'] ) { // use $extract['type'] since $card_type is 'summary' for video posts.
 				/* translators: %s is the post author */
 				$og_tags['twitter:description'] = ( $has_creator ) ? sprintf( __( 'Video post by %s.', 'jetpack' ), $og_tags['twitter:creator'] ) : __( 'Video post.', 'jetpack' );
 			} else {
@@ -172,22 +185,52 @@ class Jetpack_Twitter_Cards {
 		return $og_tags;
 	}
 
-	static function sanitize_twitter_user( $str ) {
+	/**
+	 * Sanitize the Twitter user by normalizing the @.
+	 *
+	 * @param string $str Twitter user value.
+	 *
+	 * @return string Twitter user value.
+	 */
+	public static function sanitize_twitter_user( $str ) {
 		return '@' . preg_replace( '/^@/', '', $str );
 	}
 
-	static function is_default_site_tag( $site_tag ) {
-		return in_array( $site_tag, array( '@wordpressdotcom', '@jetpack', 'wordpressdotcom', 'jetpack' ) );
+	/**
+	 * Determines if a site tag is one of the default WP.com/Jetpack ones.
+	 *
+	 * @param string $site_tag Site tag.
+	 *
+	 * @return bool True if the default site tag is being used.
+	 */
+	public static function is_default_site_tag( $site_tag ) {
+		return in_array( $site_tag, array( '@wordpressdotcom', '@jetpack', 'wordpressdotcom', 'jetpack' ), true );
 	}
 
-	static function prioritize_creator_over_default_site( $site_tag, $og_tags = array() ) {
+	/**
+	 * Give priority to the creator tag if using the default site tag.
+	 *
+	 * @param string $site_tag Site tag.
+	 * @param array  $og_tags OG tags.
+	 *
+	 * @return string Site tag.
+	 */
+	public static function prioritize_creator_over_default_site( $site_tag, $og_tags = array() ) {
 		if ( ! empty( $og_tags['twitter:creator'] ) && self::is_default_site_tag( $site_tag ) ) {
 			return $og_tags['twitter:creator'];
 		}
 		return $site_tag;
 	}
 
-	static function twitter_cards_define_type_based_on_image_count( $og_tags, $extract ) {
+	/**
+	 * Define the Twitter Card type based on image count.
+	 *
+	 * @param array $og_tags Existing OG tags.
+	 * @param array $extract Result of the Image Extractor class.
+	 *
+	 * @return array
+	 */
+	public static function twitter_cards_define_type_based_on_image_count( $og_tags, $extract ) {
 		$card_type = 'summary';
 		$img_count = $extract['count']['image'];
 
@@ -201,19 +244,19 @@ class Jetpack_Twitter_Cards {
 				}
 			}
 
-			// Second fall back, Site Logo
+			// Second fall back, Site Logo.
 			if ( empty( $og_tags['twitter:image'] ) && ( function_exists( 'jetpack_has_site_logo' ) && jetpack_has_site_logo() ) ) {
 				$og_tags['twitter:image'] = jetpack_get_site_logo( 'url' );
 			}
 
-			// Third fall back, Site Icon
+			// Third fall back, Site Icon.
 			if ( empty( $og_tags['twitter:image'] ) && has_site_icon() ) {
 				$og_tags['twitter:image'] = get_site_icon_url( '240' );
 			}
 
 			// Not falling back on Gravatar, because there's no way to know if we end up with an auto-generated one.
 
-		} elseif ( $img_count && ( 'image' == $extract['type'] || 'gallery' == $extract['type'] ) ) {
+		} elseif ( $img_count && ( 'image' === $extract['type'] || 'gallery' === $extract['type'] ) ) {
 			// Test for $extract['type'] to limit to image and gallery, so we don't send a potential fallback image like a Gravatar as a photo post.
 			$card_type                = 'summary_large_image';
 			$og_tags['twitter:image'] = esc_url( add_query_arg( 'w', 1400, ( empty( $extract['images'] ) ) ? $extract['image'] : $extract['images'][0]['url'] ) );
@@ -222,11 +265,21 @@ class Jetpack_Twitter_Cards {
 		return array( $og_tags, $card_type );
 	}
 
-	static function twitter_cards_output( $og_tag ) {
+	/**
+	 * Updates the Twitter Card output.
+	 *
+	 * @param string $og_tag A single OG tag.
+	 *
+	 * @return string Result of the OG tag.
+	 */
+	public static function twitter_cards_output( $og_tag ) {
 		return ( false !== strpos( $og_tag, 'twitter:' ) ) ? preg_replace( '/property="([^"]+)"/', 'name="\1"', $og_tag ) : $og_tag;
 	}
 
-	static function settings_init() {
+	/**
+	 * Adds settings section and field.
+	 */
+	public static function settings_init() {
 		add_settings_section( 'jetpack-twitter-cards-settings', 'Twitter Cards', '__return_false', 'sharing' );
 		add_settings_field(
 			'jetpack-twitter-cards-site-tag',
@@ -240,11 +293,19 @@ class Jetpack_Twitter_Cards {
 		);
 	}
 
-	static function sharing_global_options() {
+	/**
+	 * Add global sharing options.
+	 */
+	public static function sharing_global_options() {
 		do_settings_fields( 'sharing', 'jetpack-twitter-cards-settings' );
 	}
 
-	static function site_tag() {
+	/**
+	 * Get the Twitter Via tag.
+	 *
+	 * @return string Twitter via tag.
+	 */
+	public static function site_tag() {
 		$site_tag = ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ?
 			trim( get_option( 'twitter_via' ) ) :
 			Jetpack_Options::get_option_and_ensure_autoload( 'jetpack-twitter-cards-site-tag', '' );
@@ -255,7 +316,10 @@ class Jetpack_Twitter_Cards {
 		return $site_tag;
 	}
 
-	static function settings_field() {
+	/**
+	 * Output the settings field.
+	 */
+	public static function settings_field() {
 		wp_nonce_field( 'jetpack-twitter-cards-settings', 'jetpack_twitter_cards_nonce', false );
 		?>
 		<input type="text" id="jetpack-twitter-cards-site-tag" class="regular-text" name="jetpack-twitter-cards-site-tag" value="<?php echo esc_attr( get_option( 'jetpack-twitter-cards-site-tag' ) ); ?>" />
@@ -263,13 +327,19 @@ class Jetpack_Twitter_Cards {
 		<?php
 	}
 
-	static function settings_validate() {
+	/**
+	 * Validate the settings submission.
+	 */
+	public static function settings_validate() {
 		if ( wp_verify_nonce( $_POST['jetpack_twitter_cards_nonce'], 'jetpack-twitter-cards-settings' ) ) {
-			update_option( 'jetpack-twitter-cards-site-tag', trim( ltrim( strip_tags( $_POST['jetpack-twitter-cards-site-tag'] ), '@' ) ) );
+			update_option( 'jetpack-twitter-cards-site-tag', trim( ltrim( wp_strip_all_tags( $_POST['jetpack-twitter-cards-site-tag'] ), '@' ) ) );
 		}
 	}
 
-	static function init() {
+	/**
+	 * Initiates the class.
+	 */
+	public static function init() {
 		add_filter( 'jetpack_open_graph_tags', array( __CLASS__, 'twitter_cards_tags' ) );
 		add_filter( 'jetpack_open_graph_output', array( __CLASS__, 'twitter_cards_output' ) );
 		add_filter( 'jetpack_twitter_cards_site_tag', array( __CLASS__, 'site_tag' ), -99 );

--- a/class.jetpack-twitter-cards.php
+++ b/class.jetpack-twitter-cards.php
@@ -13,6 +13,7 @@ class Jetpack_Twitter_Cards {
 
 	static function twitter_cards_tags( $og_tags ) {
 		global $post;
+		$post_id = ( $post instanceof WP_Post ) ? $post->ID : null;
 
 		/**
 		 * Maximum alt text length.
@@ -37,7 +38,7 @@ class Jetpack_Twitter_Cards {
 		// If we have information on the author/creator, then include that as well
 		if ( ! empty( $post ) && ! empty( $post->post_author ) ) {
 			/** This action is documented in modules/sharedaddy/sharing-sources.php */
-			$handle = apply_filters( 'jetpack_sharing_twitter_via', '', $post->ID );
+			$handle = apply_filters( 'jetpack_sharing_twitter_via', '', $post_id );
 			if ( ! empty( $handle ) && ! self::is_default_site_tag( $handle ) ) {
 				$og_tags['twitter:creator'] = self::sanitize_twitter_user( $handle );
 			}
@@ -45,7 +46,7 @@ class Jetpack_Twitter_Cards {
 
 		$site_tag = self::site_tag();
 		/** This action is documented in modules/sharedaddy/sharing-sources.php */
-		$site_tag = apply_filters( 'jetpack_sharing_twitter_via', $site_tag, ( is_singular() ? $post->ID : null ) );
+		$site_tag = apply_filters( 'jetpack_sharing_twitter_via', $site_tag, ( is_singular() ? $post_id : null ) );
 		/** This action is documented in modules/sharedaddy/sharing-sources.php */
 		$site_tag = apply_filters( 'jetpack_twitter_cards_site_tag', $site_tag, $og_tags );
 		if ( ! empty( $site_tag ) ) {
@@ -83,9 +84,9 @@ class Jetpack_Twitter_Cards {
 		$card_type = 'summary';
 
 		// Try to give priority to featured images
-		if ( class_exists( 'Jetpack_PostImages' ) ) {
+		if ( class_exists( 'Jetpack_PostImages' ) && ! empty( $post_id ) ) {
 			$post_image = Jetpack_PostImages::get_image(
-				$post->ID,
+				$post_id,
 				array(
 					'width'  => 144,
 					'height' => 144,
@@ -131,8 +132,8 @@ class Jetpack_Twitter_Cards {
 
 			// Test again, class should already be auto-loaded in Jetpack.
 			// If not, skip extra media analysis and stick with a summary card
-			if ( class_exists( 'Jetpack_Media_Summary' ) ) {
-				$extract = Jetpack_Media_Summary::get( $post->ID );
+			if ( class_exists( 'Jetpack_Media_Summary' ) && ! empty( $post_id ) ) {
+				$extract = Jetpack_Media_Summary::get( $post_id );
 
 				if ( 'gallery' == $extract['type'] ) {
 					list( $og_tags, $card_type ) = self::twitter_cards_define_type_based_on_image_count( $og_tags, $extract );


### PR DESCRIPTION
Fixes #16499 
Fixes #16500 
Fixes #16501 
PHPCS impacted files.

#### Changes proposed in this Pull Request:
* Defensive coding to ensure that `$post` is a `WP_Post` object before use.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* A simple test would be to intentionally override the global `$post` via a filter on `jetpack_open_graph_tags` at a priority <10 so that the Twitter Card functionality would have a non-object global $post.

#### Proposed changelog entry for your changes:
* Twitter Cards: Resolve potential PHP notice.
* Media Tools: Resolve potential PHP notice.
