### PR TITLE
Connection Errors: Properly handle invalid JSON response.

### DIFF
--- a/_inc/client/state/site/reducer.js
+++ b/_inc/client/state/site/reducer.js
@@ -3,6 +3,7 @@
  */
 import { combineReducers } from 'redux';
 import { assign, find, get, merge } from 'lodash';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -124,9 +125,16 @@ export const errors = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case JETPACK_SITE_DATA_FETCH_FAIL:
 			return assign( {}, state, {
-				message: action.error.response.message,
+				message: action.error.hasOwnProperty( 'response' )
+					? action.error.response.message
+					: __(
+							'There seems to be a problem with your connection to WordPress.com. If the problem persists, try reconnecting.',
+							'jetpack'
+					  ),
 				action: 'reconnect',
-				code: action.error.response.code,
+				code: action.error.hasOwnProperty( 'response' )
+					? action.error.response.code
+					: 'fetch_site_data_fail',
 			} );
 		default:
 			return state;


### PR DESCRIPTION
If the endpoint `jetpack/v4/site` returns invalid JSON, the exception is thrown, but properties `message` and `code` of the error object don't exist.
It leads to an error displayed in the browser console, and the "Reconnect" error notice doesn't show up.
This commit fixes the issue, providing default error message and code, therefore the error notice will still show up in the dashboard, and suggestion reconnecting.

#### Changes proposed in this Pull Request:
* The "Reconnect" error notice shows up in the Jetpack Dashboard if API request to the REST endpoint `jetpack/v4/site` fails due to invalid JSON.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Open file `_inc/lib/class.core-rest-api-endpoints.php` and find method `Jetpack_Core_Json_Api_Endpoints::get_site_data()`.
2. Add some random output (non-JSON) info the top of the method:
```
public static function get_site_data() {
    echo 'non-json';
    // Leave the rest of the method untouched.       
}
```
3. Go to the Jetpack Dashboard, the error notice should appear soon after the page loads:
<img width="1059" alt="Screen Shot 2020-07-16 at 4 50 31 PM" src="https://user-images.githubusercontent.com/1341249/87726389-89d0e280-c784-11ea-8735-3717ebebb466.png">
4. Remove the invalid output from the method `Jetpack_Core_Json_Api_Endpoints::get_site_data()`.
5. Reload the Jetpack Dashboard, confirm that all AJAX requests have completed and the page it fully loaded. The "Reconnect" error notice should not appear.

#### Proposed changelog entry for your changes:
n/a
