### PR TITLE
Admin Page: Move to Core translation functions -- PART 6

### DIFF
--- a/_inc/client/admin.js
+++ b/_inc/client/admin.js
@@ -6,13 +6,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import { assign, get } from 'lodash';
+import i18n from 'i18n-calypso';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import accessibleFocus from 'lib/accessible-focus';
 import store from 'state/redux-store';
-import i18n from 'i18n-calypso';
 import Main from 'main';
 import * as actionTypes from 'state/action-types';
 
@@ -126,30 +127,30 @@ function render() {
 export function getRouteName( path ) {
 	switch ( path ) {
 		case '/dashboard':
-			return i18n.translate( 'At A Glance', { context: 'Navigation item.' } );
+			return _x( 'At A Glance', 'Navigation item.', 'jetpack' );
 		case '/setup':
-			return i18n.translate( 'Set up', { context: 'Navigation item.' } );
+			return _x( 'Set up', 'Navigation item.', 'jetpack' );
 		case '/my-plan':
-			return i18n.translate( 'My Plan', { context: 'Navigation item.' } );
+			return _x( 'My Plan', 'Navigation item.', 'jetpack' );
 		case '/plans':
-			return i18n.translate( 'Plans', { context: 'Navigation item.' } );
+			return _x( 'Plans', 'Navigation item.', 'jetpack' );
 		case '/plans-prompt':
-			return i18n.translate( 'Plans', { context: 'Navigation item.' } );
+			return _x( 'Plans', 'Navigation item.', 'jetpack' );
 		case '/settings':
-			return i18n.translate( 'Settings', { context: 'Navigation item.' } );
+			return _x( 'Settings', 'Navigation item.', 'jetpack' );
 		case '/discussion':
-			return i18n.translate( 'Discussion', { context: 'Navigation item.' } );
+			return _x( 'Discussion', 'Navigation item.', 'jetpack' );
 		case '/security':
-			return i18n.translate( 'Security', { context: 'Navigation item.' } );
+			return _x( 'Security', 'Navigation item.', 'jetpack' );
 		case '/performance':
-			return i18n.translate( 'Performance', { context: 'Navigation item.' } );
+			return _x( 'Performance', 'Navigation item.', 'jetpack' );
 		case '/traffic':
-			return i18n.translate( 'Traffic', { context: 'Navigation item.' } );
+			return _x( 'Traffic', 'Navigation item.', 'jetpack' );
 		case '/writing':
-			return i18n.translate( 'Writing', { context: 'Navigation item.' } );
+			return _x( 'Writing', 'Navigation item.', 'jetpack' );
 		case '/sharing':
-			return i18n.translate( 'Sharing', { context: 'Navigation item.' } );
+			return _x( 'Sharing', 'Navigation item.', 'jetpack' );
 		default:
-			return i18n.translate( 'At A Glance', { context: 'Navigation item.' } );
+			return _x( 'At A Glance', 'Navigation item.', 'jetpack' );
 	}
 }

--- a/_inc/client/main.jsx
+++ b/_inc/client/main.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter, Prompt } from 'react-router-dom';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -107,7 +107,8 @@ class Main extends React.Component {
 	 */
 	handleRouterWillLeave = () => {
 		const question = __(
-			'There are unsaved settings in this tab that will be lost if you leave it. Proceed?'
+			'There are unsaved settings in this tab that will be lost if you leave it. Proceed?',
+			'jetpack'
 		);
 
 		if ( confirm( question ) ) {

--- a/_inc/client/sharing/index.jsx
+++ b/_inc/client/sharing/index.jsx
@@ -3,7 +3,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -56,9 +56,10 @@ class Sharing extends Component {
 				<Card
 					title={
 						this.props.searchTerm
-							? __( 'Sharing' )
+							? __( 'Sharing', 'jetpack' )
 							: __(
-									'Share your content to social media, reaching new audiences and increasing engagement.'
+									'Share your content to social media, reaching new audiences and increasing engagement.',
+									'jetpack'
 							  )
 					}
 					className="jp-settings-description"

--- a/_inc/client/sharing/likes.jsx
+++ b/_inc/client/sharing/likes.jsx
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -22,7 +22,7 @@ export const Likes = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Like buttons', { context: 'Settings header' } ) }
+					header={ _x( 'Like buttons', 'Settings header', 'jetpack' ) }
 					module="likes"
 					hideButton
 				>
@@ -31,12 +31,15 @@ export const Likes = withModuleSettingsFormHelpers(
 						module={ { module: 'likes' } }
 						support={ {
 							text: __(
-								'Adds like buttons to your content so that visitors can show their appreciation or enjoyment.'
+								'Adds like buttons to your content so that visitors can show their appreciation or enjoyment.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-likes' ),
 						} }
 					>
-						<p>{ __( 'When visitors enjoy your content, let them show it with a Like.' ) }</p>
+						<p>
+							{ __( 'When visitors enjoy your content, let them show it with a Like.', 'jetpack' ) }
+						</p>
 						<ModuleToggle
 							slug="likes"
 							disabled={ unavailableInDevMode }
@@ -44,7 +47,7 @@ export const Likes = withModuleSettingsFormHelpers(
 							toggling={ this.props.isSavingAnyOption( 'likes' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
-							{ __( 'Add Like buttons to your posts and pages' ) }
+							{ __( 'Add Like buttons to your posts and pages', 'jetpack' ) }
 						</ModuleToggle>
 					</SettingsGroup>
 				</SettingsCard>

--- a/_inc/client/sharing/publicize.jsx
+++ b/_inc/client/sharing/publicize.jsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -46,7 +46,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 						rel="noopener noreferrer"
 						href={ getRedirectUrl( 'calypso-marketing-connections', { site: siteRawUrl } ) }
 					>
-						{ __( 'Connect your social media accounts' ) }
+						{ __( 'Connect your social media accounts', 'jetpack' ) }
 					</Card>
 				) : (
 					<Card
@@ -56,7 +56,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 						rel="noopener noreferrer"
 						href={ `${ connectUrl }&from=unlinked-user-connect-publicize` }
 					>
-						{ __( 'Create a Jetpack account to use this feature' ) }
+						{ __( 'Create a Jetpack account to use this feature', 'jetpack' ) }
 					</Card>
 				);
 			};
@@ -68,7 +68,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Publicize connections', { context: 'Settings header' } ) }
+					header={ _x( 'Publicize connections', 'Settings header', 'jetpack' ) }
 					module="publicize"
 					hideButton
 				>
@@ -78,17 +78,16 @@ export const Publicize = withModuleSettingsFormHelpers(
 							module={ { module: 'publicize' } }
 							support={ {
 								text: __(
-									'Allows you to automatically share your newest content on social media sites, ' +
-										'including Facebook and Twitter.'
+									'Allows you to automatically share your newest content on social media sites, including Facebook and Twitter.',
+									'jetpack'
 								),
 								link: getRedirectUrl( 'jetpack-support-publicize' ),
 							} }
 						>
 							<p>
 								{ __(
-									'Connect your website to the social media networks you use and share your content ' +
-										'across all your social accounts with a single click. ' +
-										'When you publish a post, it will appear on all connected accounts.'
+									'Connect your website to the social media networks you use and share your content across all your social accounts with a single click. When you publish a post, it will appear on all connected accounts.',
+									'jetpack'
 								) }
 							</p>
 							<ModuleToggle
@@ -98,7 +97,7 @@ export const Publicize = withModuleSettingsFormHelpers(
 								toggling={ this.props.isSavingAnyOption( 'publicize' ) }
 								toggleModule={ this.props.toggleModuleNow }
 							>
-								{ __( 'Automatically share your posts to social networks' ) }
+								{ __( 'Automatically share your posts to social networks', 'jetpack' ) }
 							</ModuleToggle>
 						</SettingsGroup>
 					) }

--- a/_inc/client/sharing/share-buttons.jsx
+++ b/_inc/client/sharing/share-buttons.jsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -40,7 +40,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							className="jp-settings-card__configure-link"
 							href={ siteAdminUrl + 'options-general.php?page=sharing' }
 						>
-							{ __( 'Configure your sharing buttons' ) }
+							{ __( 'Configure your sharing buttons', 'jetpack' ) }
 						</Card>
 					);
 				}
@@ -55,7 +55,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							rel="noopener noreferrer"
 							href={ getRedirectUrl( 'calypso-marketing-sharing-buttons', { site: siteRawUrl } ) }
 						>
-							{ __( 'Configure your sharing buttons' ) }
+							{ __( 'Configure your sharing buttons', 'jetpack' ) }
 						</Card>
 					);
 				}
@@ -68,7 +68,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 						rel="noopener noreferrer"
 						href={ `${ connectUrl }&from=unlinked-user-connect-sharing` }
 					>
-						{ __( 'Create a Jetpack account to use this feature' ) }
+						{ __( 'Create a Jetpack account to use this feature', 'jetpack' ) }
 					</Card>
 				);
 			};
@@ -76,7 +76,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Sharing buttons', { context: 'Settings header' } ) }
+					header={ _x( 'Sharing buttons', 'Settings header', 'jetpack' ) }
 					module="sharing"
 					hideButton
 				>
@@ -85,14 +85,16 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 						module={ { module: 'sharing' } }
 						support={ {
 							text: __(
-								'You can customize the sharing buttons and choose which services to display.'
+								'You can customize the sharing buttons and choose which services to display.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-sharing' ),
 						} }
 					>
 						<p>
 							{ __(
-								'Add sharing buttons so visitors can share your posts and pages on social media with a couple of quick clicks.'
+								'Add sharing buttons so visitors can share your posts and pages on social media with a couple of quick clicks.',
+								'jetpack'
 							) }
 						</p>
 						<ModuleToggle
@@ -101,7 +103,7 @@ export const ShareButtons = withModuleSettingsFormHelpers(
 							toggling={ this.props.isSavingAnyOption( 'sharedaddy' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
-							{ __( 'Add sharing buttons to your posts and pages' ) }
+							{ __( 'Add sharing buttons to your posts and pages', 'jetpack' ) }
 						</ModuleToggle>
 					</SettingsGroup>
 					{ isActive && configCard() }

--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	JETPACK_CONNECTION_STATUS_FETCH,
 	JETPACK_CONNECTION_TEST_FETCH,
@@ -41,7 +41,7 @@ export const fetchSiteConnectionStatus = () => {
 export const fetchSiteConnectionTest = () => {
 	return dispatch => {
 		dispatch(
-			createNotice( 'is-info', __( 'Testing Jetpack Connection' ), {
+			createNotice( 'is-info', __( 'Testing Jetpack Connection', 'jetpack' ), {
 				id: 'test-jetpack-connection',
 			} )
 		);
@@ -66,11 +66,11 @@ export const fetchSiteConnectionTest = () => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( 'There was an error testing Jetpack. Error: %(error)s', {
-							args: {
-								error: error.message,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is an error message. */
+							__( 'There was an error testing Jetpack. Error: %s', 'jetpack' ),
+							error.message
+						),
 						{ id: 'test-jetpack-connection' }
 					)
 				);
@@ -128,7 +128,9 @@ export const disconnectSite = ( reloadAfter = false ) => {
 			type: DISCONNECT_SITE,
 		} );
 		dispatch(
-			createNotice( 'is-info', __( 'Disconnecting Jetpack' ), { id: 'disconnect-jetpack' } )
+			createNotice( 'is-info', __( 'Disconnecting Jetpack', 'jetpack' ), {
+				id: 'disconnect-jetpack',
+			} )
 		);
 		return restApi
 			.disconnectSite()
@@ -154,11 +156,11 @@ export const disconnectSite = ( reloadAfter = false ) => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( 'There was an error disconnecting Jetpack. Error: %(error)s', {
-							args: {
-								error: error,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is an error message. */
+							__( 'There was an error disconnecting Jetpack. Error: %s', 'jetpack' ),
+							error
+						),
 						{ id: 'disconnect-jetpack' }
 					)
 				);
@@ -172,7 +174,9 @@ export const unlinkUser = () => {
 			type: UNLINK_USER,
 		} );
 		dispatch(
-			createNotice( 'is-info', __( 'Unlinking from WordPress.com' ), { id: 'unlink-user' } )
+			createNotice( 'is-info', __( 'Unlinking from WordPress.com', 'jetpack' ), {
+				id: 'unlink-user',
+			} )
 		);
 		return restApi
 			.unlinkUser()
@@ -184,7 +188,7 @@ export const unlinkUser = () => {
 				dispatch( fetchConnectUrl() );
 				dispatch( removeNotice( 'unlink-user' ) );
 				dispatch(
-					createNotice( 'is-success', __( 'Unlinked from WordPress.com.' ), {
+					createNotice( 'is-success', __( 'Unlinked from WordPress.com.', 'jetpack' ), {
 						id: 'unlink-user',
 						duration: 2000,
 					} )
@@ -199,11 +203,11 @@ export const unlinkUser = () => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( 'Error unlinking from WordPress.com. %(error)s', {
-							args: {
-								error: error,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is an error message. */
+							__( 'Error unlinking from WordPress.com. %s', 'jetpack' ),
+							error
+						),
 						{ id: 'unlink-user' }
 					)
 				);
@@ -225,7 +229,7 @@ export const authorizeUserInPlaceSuccess = () => {
 			type: AUTH_USER_IN_PLACE_SUCCESS,
 		} );
 		dispatch(
-			createNotice( 'is-success', __( 'Linked to WordPress.com.' ), {
+			createNotice( 'is-success', __( 'Linked to WordPress.com.', 'jetpack' ), {
 				id: 'link-user-in-place',
 				duration: 2000,
 			} )

--- a/_inc/client/state/dev-version/actions.js
+++ b/_inc/client/state/dev-version/actions.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	RESET_OPTIONS,
 	RESET_OPTIONS_FAIL,
@@ -27,7 +27,9 @@ export const resetOptions = options => {
 			type: RESET_OPTIONS,
 		} );
 		dispatch(
-			createNotice( 'is-info', __( 'Resetting Jetpack options…' ), { id: 'reset-options' } )
+			createNotice( 'is-info', __( 'Resetting Jetpack options…', 'jetpack' ), {
+				id: 'reset-options',
+			} )
 		);
 		return restApi
 			.resetOptions( options )
@@ -37,7 +39,7 @@ export const resetOptions = options => {
 				} );
 				dispatch( removeNotice( 'reset-options' ) );
 				dispatch(
-					createNotice( 'is-success', __( 'Options reset.' ), {
+					createNotice( 'is-success', __( 'Options reset.', 'jetpack' ), {
 						id: 'reset-options',
 						duration: 2000,
 					} )
@@ -50,7 +52,9 @@ export const resetOptions = options => {
 				} );
 				dispatch( removeNotice( 'reset-options' ) );
 				dispatch(
-					createNotice( 'is-error', __( 'Options failed to reset.' ), { id: 'reset-options' } )
+					createNotice( 'is-error', __( 'Options failed to reset.', 'jetpack' ), {
+						id: 'reset-options',
+					} )
 				);
 			} );
 	};

--- a/_inc/client/state/mobile/actions.js
+++ b/_inc/client/state/mobile/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import restApi from 'rest-api';
@@ -7,7 +12,6 @@ import {
 	JETPACK_MOBILE_LOGIN_SEND_LOGIN_EMAIL_SUCCESS,
 	JETPACK_MOBILE_LOGIN_SEND_LOGIN_EMAIL_FAIL,
 } from 'state/action-types';
-import { translate as __ } from 'i18n-calypso';
 import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 
 export const sendMobileLoginEmail = () => {
@@ -19,7 +23,7 @@ export const sendMobileLoginEmail = () => {
 		dispatch( removeNotice( 'mobile-login-email-sent' ) );
 		dispatch( removeNotice( 'mobile-login-email-error' ) );
 		dispatch(
-			createNotice( 'is-info', __( 'Sending login email…' ), {
+			createNotice( 'is-info', __( 'Sending login email…', 'jetpack' ), {
 				id: 'mobile-login-email-send',
 			} )
 		);
@@ -31,7 +35,7 @@ export const sendMobileLoginEmail = () => {
 					type: JETPACK_MOBILE_LOGIN_SEND_LOGIN_EMAIL_SUCCESS,
 				} );
 				dispatch(
-					createNotice( 'is-success', __( 'Login email sent' ), {
+					createNotice( 'is-success', __( 'Login email sent', 'jetpack' ), {
 						id: 'mobile-login-email-sent',
 						duration: 2000,
 					} )
@@ -46,7 +50,7 @@ export const sendMobileLoginEmail = () => {
 				} );
 				dispatch( removeNotice( 'mobile-login-email-send' ) );
 				dispatch(
-					createNotice( 'is-error', __( 'Failed to send login email' ), {
+					createNotice( 'is-error', __( 'Failed to send login email', 'jetpack' ), {
 						id: 'mobile-login-email-error',
 					} )
 				);

--- a/_inc/client/state/modules/actions.js
+++ b/_inc/client/state/modules/actions.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
-import { translate as __ } from 'i18n-calypso';
 import { forEach, some } from 'lodash';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	JETPACK_MODULES_LIST_FETCH,
 	JETPACK_MODULES_LIST_FETCH_FAIL,
@@ -84,11 +84,11 @@ export const activateModule = ( slug, reloadAfter = false ) => {
 		dispatch(
 			createNotice(
 				'is-info',
-				__( 'Activating %(slug)s…', {
-					args: {
-						slug: getModule( getState(), slug ).name,
-					},
-				} ),
+				sprintf(
+					/* translators: placeholder is a feature name, such as "Image CDN". */
+					__( 'Activating %s…', 'jetpack' ),
+					getModule( getState(), slug ).name
+				),
 				{ id: 'module-toggle' }
 			)
 		);
@@ -104,11 +104,11 @@ export const activateModule = ( slug, reloadAfter = false ) => {
 				dispatch(
 					createNotice(
 						'is-success',
-						__( '%(slug)s has been activated.', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is a feature name, such as "Image CDN". */
+							__( '%s has been activated.', 'jetpack' ),
+							getModule( getState(), slug ).name
+						),
 						{ id: 'module-toggle', duration: 2000 }
 					)
 				);
@@ -127,12 +127,12 @@ export const activateModule = ( slug, reloadAfter = false ) => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( '%(slug)s failed to activate. %(error)s', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-								error: error,
-							},
-						} ),
+						sprintf(
+							/* translators: %1$s: feature name, such as "Image CDN". - %2$s: error message. */
+							__( '%1$s failed to activate. %2$s', 'jetpack' ),
+							getModule( getState(), slug ).name,
+							error
+						),
 						{ id: 'module-toggle' }
 					)
 				);
@@ -150,11 +150,11 @@ export const deactivateModule = ( slug, reloadAfter = false ) => {
 		dispatch(
 			createNotice(
 				'is-info',
-				__( 'Deactivating %(slug)s…', {
-					args: {
-						slug: getModule( getState(), slug ).name,
-					},
-				} ),
+				sprintf(
+					/* translators: placeholder is a feature name, such as "Image CDN". */
+					__( 'Deactivating %s…', 'jetpack' ),
+					getModule( getState(), slug ).name
+				),
 				{ id: 'module-toggle' }
 			)
 		);
@@ -170,11 +170,11 @@ export const deactivateModule = ( slug, reloadAfter = false ) => {
 				dispatch(
 					createNotice(
 						'is-success',
-						__( '%(slug)s has been deactivated.', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is a feature name, such as "Image CDN". */
+							__( '%s has been deactivated.', 'jetpack' ),
+							getModule( getState(), slug ).name
+						),
 						{ id: 'module-toggle', duration: 2000 }
 					)
 				);
@@ -193,12 +193,12 @@ export const deactivateModule = ( slug, reloadAfter = false ) => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( '%(slug)s failed to deactivate. %(error)s', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-								error: error,
-							},
-						} ),
+						sprintf(
+							/* translators: %1$s: feature name, such as "Image CDN". - %2$s: error message. */
+							__( '%1$s failed to deactivate. %2$s', 'jetpack' ),
+							getModule( getState(), slug ).name,
+							error
+						),
 						{ id: 'module-toggle' }
 					)
 				);
@@ -219,11 +219,11 @@ export const updateModuleOptions = ( module, newOptionValues ) => {
 		dispatch(
 			createNotice(
 				'is-info',
-				__( 'Updating %(slug)s settings…', {
-					args: {
-						slug: getModule( getState(), slug ).name,
-					},
-				} ),
+				sprintf(
+					/* translators: placeholder is a feature name, such as "Image CDN". */
+					__( 'Updating %s settings…', 'jetpack' ),
+					getModule( getState(), slug ).name
+				),
 				{ id: `module-setting-${ slug }` }
 			)
 		);
@@ -241,11 +241,11 @@ export const updateModuleOptions = ( module, newOptionValues ) => {
 				dispatch(
 					createNotice(
 						'is-success',
-						__( 'Updated %(slug)s settings.', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is a feature name, such as "Image CDN". */
+							__( 'Updated %s settings.', 'jetpack' ),
+							getModule( getState(), slug ).name
+						),
 						{ id: `module-setting-${ slug }`, duration: 2000 }
 					)
 				);
@@ -262,12 +262,12 @@ export const updateModuleOptions = ( module, newOptionValues ) => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( 'Error updating %(slug)s settings. %(error)s', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-								error: error,
-							},
-						} ),
+						sprintf(
+							/* translators: %1$s: feature name, such as "Image CDN". - %2$s: error message. */
+							__( 'Error updating %1$ss settings. %2$s', 'jetpack' ),
+							getModule( getState(), slug ).name,
+							error
+						),
 						{ id: `module-setting-${ slug }` }
 					)
 				);
@@ -291,11 +291,11 @@ export const regeneratePostByEmailAddress = () => {
 		dispatch(
 			createNotice(
 				'is-info',
-				__( 'Updating %(slug)s address…', {
-					args: {
-						slug: getModule( getState(), slug ).name,
-					},
-				} ),
+				sprintf(
+					/* translators: placeholder is a feature name, such as "Post By Email". */
+					__( 'Updating %s address…', 'jetpack' ),
+					getModule( getState(), slug ).name
+				),
 				{ id: `module-setting-${ slug }` }
 			)
 		);
@@ -315,11 +315,11 @@ export const regeneratePostByEmailAddress = () => {
 				dispatch(
 					createNotice(
 						'is-success',
-						__( 'Regenerated %(slug)s address .', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-							},
-						} ),
+						sprintf(
+							/* translators: placeholder is a feature name, such as "Post By Email". */
+							__( 'Regenerated %s address.', 'jetpack' ),
+							getModule( getState(), slug ).name
+						),
 						{ id: `module-setting-${ slug }`, duration: 2000 }
 					)
 				);
@@ -336,12 +336,12 @@ export const regeneratePostByEmailAddress = () => {
 				dispatch(
 					createNotice(
 						'is-error',
-						__( 'Error regenerating %(slug)s address. %(error)s', {
-							args: {
-								slug: getModule( getState(), slug ).name,
-								error: error,
-							},
-						} ),
+						sprintf(
+							/* translators: %1$s: feature name, such as "Post By Email". - %2$s: error message. */
+							__( 'Error regenerating %1$s address. %2$s', 'jetpack' ),
+							getModule( getState(), slug ).name,
+							error
+						),
 						{ id: `module-setting-${ slug }` }
 					)
 				);

--- a/_inc/client/state/settings/actions.js
+++ b/_inc/client/state/settings/actions.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import { get, some } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	JETPACK_SETTINGS_FETCH,
 	JETPACK_SETTINGS_FETCH_RECEIVE,
@@ -88,15 +88,17 @@ export const updateSetting = updatedOption => {
 export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 	return dispatch => {
 		const messages = {
-			progress: __( 'Updating settings…' ),
-			success: __( 'Updated settings.' ),
+			progress: __( 'Updating settings…', 'jetpack' ),
+			success: __( 'Updated settings.', 'jetpack' ),
 			// We try to get a message or an error code if this is an unexpected WP_Error coming from the API.
 			// Otherwise we try to show error.name (coming from the custom errors defined in rest-api/index.js and if that's not useful
 			// then we try to let Javascript stringify the error object.
 			error: error =>
-				__( 'Error updating settings. %(error)s', {
-					args: { error: error.message || error.code || error.name || error },
-				} ),
+				sprintf(
+					/* translators: placeholder is an error code or an error message. */
+					__( 'Error updating settings. %s', 'jetpack' ),
+					error.message || error.code || error.name || error
+				),
 			...noticeMessages,
 		};
 
@@ -109,7 +111,7 @@ export const updateSettings = ( newOptionValues, noticeMessages = {} ) => {
 			'object' === typeof newOptionValues &&
 			some( reloadForOptionValues, optionValue => optionValue in newOptionValues )
 		) {
-			messages.success = __( 'Updated settings. Refreshing page…' );
+			messages.success = __( 'Updated settings. Refreshing page…', 'jetpack' );
 		}
 
 		dispatch( removeNotice( 'module-setting-update' ) );

--- a/_inc/client/state/setup-wizard/reducer.js
+++ b/_inc/client/state/setup-wizard/reducer.js
@@ -3,7 +3,7 @@
  */
 import { combineReducers } from 'redux';
 import { assign, get, intersection, reduce, union } from 'lodash';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -102,30 +102,34 @@ function getFeatureGroupContent( featureGroupKey ) {
 	switch ( featureGroupKey ) {
 		case 'security':
 			return {
-				title: __( 'Security' ),
+				title: __( 'Security', 'jetpack' ),
 				details: __(
-					'Keep your site backed up, prevent unwanted intrusions, find issues with malware scanning, and stop spammers in their tracks.'
+					'Keep your site backed up, prevent unwanted intrusions, find issues with malware scanning, and stop spammers in their tracks.',
+					'jetpack'
 				),
 			};
 		case 'performance':
 			return {
-				title: __( 'Performance' ),
+				title: __( 'Performance', 'jetpack' ),
 				details: __(
-					'Load pages faster! Shorter load times can lead to happier readers, more page views, and — if you’re running a store — improved sales.'
+					'Load pages faster! Shorter load times can lead to happier readers, more page views, and — if you’re running a store — improved sales.',
+					'jetpack'
 				),
 			};
 		case 'marketing':
 			return {
-				title: __( 'Marketing' ),
+				title: __( 'Marketing', 'jetpack' ),
 				details: __(
-					'Increase visitors with social integrations, keep them engaged with related content, and so much more.'
+					'Increase visitors with social integrations, keep them engaged with related content, and so much more.',
+					'jetpack'
 				),
 			};
 		case 'publishing':
 			return {
-				title: __( 'Design & Publishing' ),
+				title: __( 'Design & Publishing', 'jetpack' ),
 				details: __(
-					'Customize your homepage, blog posts, sidebars, and widgets — all without touching any code.'
+					'Customize your homepage, blog posts, sidebars, and widgets — all without touching any code.',
+					'jetpack'
 				),
 			};
 	}

--- a/_inc/client/state/site-verify/actions.js
+++ b/_inc/client/state/site-verify/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import {
@@ -11,7 +16,6 @@ import {
 } from 'state/action-types';
 
 import restApi from 'rest-api';
-import { translate as __ } from 'i18n-calypso';
 import { createNotice } from 'components/global-notices/state/notices/actions';
 
 export const checkVerifyStatusGoogle = ( keyringId = null ) => {
@@ -86,7 +90,7 @@ export const verifySiteGoogle = keyringId => {
 
 				if ( data.verified ) {
 					dispatch(
-						createNotice( 'is-success', __( 'Site is verified' ), {
+						createNotice( 'is-success', __( 'Site is verified', 'jetpack' ), {
 							id: 'verify-site-google-verified',
 							duration: 2000,
 						} )

--- a/_inc/client/state/tracking/actions.js
+++ b/_inc/client/state/tracking/actions.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
-import { translate as __ } from 'i18n-calypso';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import { createNotice, removeNotice } from 'components/global-notices/state/notices/actions';
 import {
 	USER_TRACKING_SETTINGS_FETCH,
 	USER_TRACKING_SETTINGS_FETCH_FAIL,
@@ -43,15 +43,17 @@ export const fetchTrackingSettings = () => {
 export const updateTrackingSettings = newSettings => {
 	return dispatch => {
 		const messages = {
-				progress: __( 'Updating privacy settings…' ),
-				success: __( 'Updated privacy settings.' ),
+				progress: __( 'Updating privacy settings…', 'jetpack' ),
+				success: __( 'Updated privacy settings.', 'jetpack' ),
 				// We try to get a message or an error code if this is an unexpected WP_Error coming from the API.
 				// Otherwise we try to show error.name (coming from the custom errors defined in rest-api/index.js and if that's not useful
 				// then we try to let Javascript stringify the error object.
 				error: error =>
-					__( 'Error updating privacy settings. %(error)s', {
-						args: { error: error.message || error.code || error.name || error },
-					} ),
+					sprintf(
+						/* translators: placeholder is an error message. */
+						__( 'Error updating privacy settings. %s', 'jetpack' ),
+						error.message || error.code || error.name || error
+					),
 			},
 			updatedSettingsSuccess = () => newSettings;
 

--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -2,16 +2,17 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
-import ExternalLink from 'components/external-link';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import CompactFormToggle from 'components/form/form-toggle/compact';
+import ExternalLink from 'components/external-link';
+import getRedirectUrl from 'lib/jp-redirect';
 import { FEATURE_WORDADS_JETPACK } from 'lib/plans/constants';
 import { FormFieldset, FormLegend } from 'components/forms';
 import Textarea from 'components/textarea';
@@ -76,7 +77,7 @@ export const Ads = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Ads', { context: 'Ads header' } ) }
+					header={ _x( 'Ads', 'Ads header', 'jetpack' ) }
 					feature={ FEATURE_WORDADS_JETPACK }
 					saveDisabled={ this.props.isSavingAnyOption( [ 'wordads_custom_adstxt' ] ) }
 				>
@@ -85,29 +86,34 @@ export const Ads = withModuleSettingsFormHelpers(
 						hasChild
 						module={ { module: 'wordads' } }
 						support={ {
-							text: __( 'Displays high-quality ads on your site that allow you to earn income.' ),
+							text: __(
+								'Displays high-quality ads on your site that allow you to earn income.',
+								'jetpack'
+							),
 							link: getRedirectUrl( 'jetpack-support-ads' ),
 						} }
 					>
 						<p>
 							{ __(
-								'Show ads on the first article on your home page or at the end of every page and post. Place additional ads at the top of your site and to any widget area to increase your earnings.'
+								'Show ads on the first article on your home page or at the end of every page and post. Place additional ads at the top of your site and to any widget area to increase your earnings.',
+								'jetpack'
 							) }
 							<br />
 							<small className="jp-form-setting-explanation">
-								{ __(
-									'By activating ads, you agree to the Automattic Ads {{link}}Terms of Service{{/link}}.',
+								{ jetpackCreateInterpolateElement(
+									__(
+										'By activating ads, you agree to the Automattic Ads <link>Terms of Service</link>.',
+										'jetpack'
+									),
 									{
-										components: {
-											link: (
-												<a
-													href={ getRedirectUrl( 'wpcom-automattic-ads-tos' ) }
-													target="_blank"
-													rel="noopener noreferrer"
-													onClick={ this.trackConfigureWidgetClick }
-												/>
-											),
-										},
+										link: (
+											<a
+												href={ getRedirectUrl( 'wpcom-automattic-ads-tos' ) }
+												target="_blank"
+												rel="noopener noreferrer"
+												onClick={ this.trackConfigureWidgetClick }
+											/>
+										),
 									}
 								) }
 							</small>
@@ -121,11 +127,11 @@ export const Ads = withModuleSettingsFormHelpers(
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Enable ads and display an ad below each post' ) }
+								{ __( 'Enable ads and display an ad below each post', 'jetpack' ) }
 							</span>
 						</ModuleToggle>
 						<FormFieldset>
-							<FormLegend>{ __( 'Display ads below posts on' ) }</FormLegend>
+							<FormLegend>{ __( 'Display ads below posts on', 'jetpack' ) }</FormLegend>
 							<CompactFormToggle
 								checked={ wordads_display_front_page }
 								disabled={
@@ -135,7 +141,9 @@ export const Ads = withModuleSettingsFormHelpers(
 								}
 								onChange={ this.handleChange( 'wordads_display_front_page' ) }
 							>
-								<span className="jp-form-toggle-explanation">{ __( 'Front page' ) }</span>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Front page', 'jetpack' ) }
+								</span>
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ wordads_display_post }
@@ -146,7 +154,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								}
 								onChange={ this.handleChange( 'wordads_display_post' ) }
 							>
-								<span className="jp-form-toggle-explanation">{ __( 'Posts' ) }</span>
+								<span className="jp-form-toggle-explanation">{ __( 'Posts', 'jetpack' ) }</span>
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ wordads_display_page }
@@ -157,7 +165,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								}
 								onChange={ this.handleChange( 'wordads_display_page' ) }
 							>
-								<span className="jp-form-toggle-explanation">{ __( 'Pages' ) }</span>
+								<span className="jp-form-toggle-explanation">{ __( 'Pages', 'jetpack' ) }</span>
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ wordads_display_archive }
@@ -168,11 +176,11 @@ export const Ads = withModuleSettingsFormHelpers(
 								}
 								onChange={ this.handleChange( 'wordads_display_archive' ) }
 							>
-								<span className="jp-form-toggle-explanation">{ __( 'Archives' ) }</span>
+								<span className="jp-form-toggle-explanation">{ __( 'Archives', 'jetpack' ) }</span>
 							</CompactFormToggle>
 						</FormFieldset>
 						<FormFieldset>
-							<FormLegend>{ __( 'Additional ad placements' ) }</FormLegend>
+							<FormLegend>{ __( 'Additional ad placements', 'jetpack' ) }</FormLegend>
 							<CompactFormToggle
 								checked={ enable_header_ad }
 								disabled={
@@ -182,7 +190,9 @@ export const Ads = withModuleSettingsFormHelpers(
 								}
 								onChange={ this.handleChange( 'enable_header_ad' ) }
 							>
-								<span className="jp-form-toggle-explanation">{ __( 'Top of each page' ) }</span>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Top of each page', 'jetpack' ) }
+								</span>
 							</CompactFormToggle>
 							<CompactFormToggle
 								checked={ wordads_second_belowpost }
@@ -193,21 +203,24 @@ export const Ads = withModuleSettingsFormHelpers(
 								}
 								onChange={ this.handleChange( 'wordads_second_belowpost' ) }
 							>
-								<span className="jp-form-toggle-explanation">{ __( 'Second ad below post' ) }</span>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Second ad below post', 'jetpack' ) }
+								</span>
 							</CompactFormToggle>
 							<small className="jp-form-setting-explanation">
 								{ isAdsActive &&
-									__(
-										'You can place additional ads using the Ad widget. {{link}}Try it out!{{/link}}',
+									jetpackCreateInterpolateElement(
+										__(
+											'You can place additional ads using the Ad widget. <link>Try it out!</link>',
+											'jetpack'
+										),
 										{
-											components: {
-												link: (
-													<a
-														className="jp-module-settings__external-link"
-														href="customize.php?autofocus[panel]=widgets"
-													/>
-												),
-											},
+											link: (
+												<a
+													className="jp-module-settings__external-link"
+													href="customize.php?autofocus[panel]=widgets"
+												/>
+											),
 										}
 									) }
 							</small>
@@ -217,7 +230,8 @@ export const Ads = withModuleSettingsFormHelpers(
 						hasChild
 						support={ {
 							text: __(
-								'Enables a targeted advertising opt-out link for California consumers, as required by the California Consumer Privacy Act (CCPA).'
+								'Enables a targeted advertising opt-out link for California consumers, as required by the California Consumer Privacy Act (CCPA).',
+								'jetpack'
 							),
 							link: this.props.isAtomicSite
 								? getRedirectUrl( 'wpcom-support-ccpa' )
@@ -234,61 +248,69 @@ export const Ads = withModuleSettingsFormHelpers(
 							onChange={ this.handleChange( 'wordads_ccpa_enabled' ) }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Enable targeted advertising to California site visitors (CCPA)' ) }
+								{ __(
+									'Enable targeted advertising to California site visitors (CCPA)',
+									'jetpack'
+								) }
 							</span>
 						</CompactFormToggle>
 						{ wordads_ccpa_enabled && (
 							<FormFieldset>
 								<p>
 									<small className="jp-form-setting-explanation">
-										{ __(
-											'For more information about the California Consumer Privacy Act (CCPA) {{br/}}and how it pertains to your site, please consult our {{link}}CCPA guide for site owners{{/link}}.',
+										{ jetpackCreateInterpolateElement(
+											__(
+												'For more information about the California Consumer Privacy Act (CCPA) <br/>and how it pertains to your site, please consult our <link>CCPA guide for site owners</link>.',
+												'jetpack'
+											),
 											{
-												components: {
-													br: <br />,
-													link: (
-														<ExternalLink
-															icon={ true }
-															href={
-																this.props.isAtomicSite
-																	? getRedirectUrl( 'wpcom-support-ccpa' )
-																	: getRedirectUrl( 'jetpack-support-ads' )
-															}
-															target="_blank"
-															rel="noopener noreferrer"
-														/>
-													),
-												},
+												br: <br />,
+												link: (
+													<ExternalLink
+														icon={ true }
+														href={
+															this.props.isAtomicSite
+																? getRedirectUrl( 'wpcom-support-ccpa' )
+																: getRedirectUrl( 'jetpack-support-ads' )
+														}
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
 											}
 										) }
 									</small>
 								</p>
 								<p>
-									<FormLegend>{ __( 'Do Not Sell Link' ) }</FormLegend>
-									{ __(
-										'CCPA requires that you place a "Do Not Sell My Personal Information" link on every page of your site where targeted advertising will appear. {{br/}}You can use the {{widgetLink}}Do Not Sell Link (CCPA) Widget{{/widgetLink}}, or the {{code}}[ccpa-do-not-sell-link]{{/code}} shortcode to automatically place this link on your site. Note: the link will always display to logged in administrators regardless of geolocation.',
+									<FormLegend>{ __( 'Do Not Sell Link', 'jetpack' ) }</FormLegend>
+									{ jetpackCreateInterpolateElement(
+										__(
+											'CCPA requires that you place a "Do Not Sell My Personal Information" link on every page of your site where targeted advertising will appear. <br/>You can use the <widgetLink>Do Not Sell Link (CCPA) Widget</widgetLink>, or the <code>[ccpa-do-not-sell-link]</code> shortcode to automatically place this link on your site. Note: the link will always display to logged in administrators regardless of geolocation.',
+											'jetpack'
+										),
 										{
-											components: {
-												br: <br />,
-												code: <code />,
-												widgetLink: (
-													<a
-														className="jp-module-settings__external-link"
-														href="customize.php?autofocus[panel]=widgets"
-													/>
-												),
-											},
+											br: <br />,
+											code: <code />,
+											widgetLink: (
+												<a
+													className="jp-module-settings__external-link"
+													href="customize.php?autofocus[panel]=widgets"
+												/>
+											),
 										}
 									) }
 									<span className="jp-form-setting-explanation">
-										{ __( 'Failure to add this link will result in non-compliance with CCPA.' ) }
+										{ __(
+											'Failure to add this link will result in non-compliance with CCPA.',
+											'jetpack'
+										) }
 									</span>
 								</p>
 							</FormFieldset>
 						) }
 						{ wordads_ccpa_enabled && (
 							<FormFieldset>
-								<FormLegend>{ __( 'Privacy Policy URL' ) }</FormLegend>
+								<FormLegend>{ __( 'Privacy Policy URL', 'jetpack' ) }</FormLegend>
 								<TextInput
 									name={ 'wordads_ccpa_privacy_policy_url' }
 									placeholder={ 'https://' }
@@ -303,7 +325,8 @@ export const Ads = withModuleSettingsFormHelpers(
 								/>
 								<span className="jp-form-setting-explanation">
 									{ __(
-										'Adds a link to your privacy policy to the bottom of the CCPA notice popup (optional).'
+										'Adds a link to your privacy policy to the bottom of the CCPA notice popup (optional).',
+										'jetpack'
 									) }
 								</span>
 							</FormFieldset>
@@ -313,7 +336,8 @@ export const Ads = withModuleSettingsFormHelpers(
 						hasChild
 						support={ {
 							text: __(
-								'Ads.txt (Authorized Digital Sellers) is a mechanism that enables content owners to declare who is authorized to sell their ad inventory. It’s the formal list of advertising partners you support as a publisher.'
+								'Ads.txt (Authorized Digital Sellers) is a mechanism that enables content owners to declare who is authorized to sell their ad inventory. It’s the formal list of advertising partners you support as a publisher.',
+								'jetpack'
 							),
 							link: 'https://jetpack.com/support/ads/',
 						} }
@@ -329,7 +353,7 @@ export const Ads = withModuleSettingsFormHelpers(
 								onChange={ this.handleChange( 'wordads_custom_adstxt_enabled' ) }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Customize your ads.txt file' ) }
+									{ __( 'Customize your ads.txt file', 'jetpack' ) }
 								</span>
 							</CompactFormToggle>
 						) }
@@ -338,29 +362,29 @@ export const Ads = withModuleSettingsFormHelpers(
 								<br />
 								<p>
 									{ isAdsActive &&
-										__(
-											'Jetpack Ads automatically generates a custom {{link1}}ads.txt{{/link1}} tailored for your site. ' +
-												'If you need to add additional entries for other networks please add them in the space below, one per line. ' +
-												'{{link2}}Check here for more details{{/link2}}.',
+										jetpackCreateInterpolateElement(
+											__(
+												'Jetpack Ads automatically generates a custom <link1>ads.txt</link1> tailored for your site. If you need to add additional entries for other networks please add them in the space below, one per line. <link2>Check here for more details</link2>.',
+												'jetpack'
+											),
 											{
-												components: {
-													link1: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />,
-													link2: (
-														<a
-															href={ getRedirectUrl(
-																'jetpack-how-jetpack-ads-members-can-increase-their-earnings-with-ads-txt'
-															) }
-															target="_blank"
-															rel="noopener noreferrer"
-														/>
-													),
-												},
+												link1: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />,
+												link2: (
+													<a
+														href={ getRedirectUrl(
+															'jetpack-how-jetpack-ads-members-can-increase-their-earnings-with-ads-txt'
+														) }
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
 											}
 										) }
 
 									{ ! isAdsActive &&
 										__(
-											'When ads are enabled, Jetpack automatically generates a custom ads.txt tailored for your site.'
+											'When ads are enabled, Jetpack automatically generates a custom ads.txt tailored for your site.',
+											'jetpack'
 										) }
 								</p>
 								<Textarea
@@ -383,7 +407,7 @@ export const Ads = withModuleSettingsFormHelpers(
 							onClick={ this.trackConfigureClick }
 							href={ this.props.configureUrl }
 						>
-							{ __( 'View your earnings' ) }
+							{ __( 'View your earnings', 'jetpack' ) }
 						</Card>
 					) }
 				</SettingsCard>

--- a/_inc/client/traffic/google-analytics.jsx
+++ b/_inc/client/traffic/google-analytics.jsx
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { FEATURE_GOOGLE_ANALYTICS_JETPACK } from 'lib/plans/constants';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -25,7 +26,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'Google Analytics', { context: 'Settings header' } ) }
+					header={ _x( 'Google Analytics', 'Settings header', 'jetpack' ) }
 					feature={ FEATURE_GOOGLE_ANALYTICS_JETPACK }
 					hideButton
 				>
@@ -34,26 +35,25 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 						module={ { module: 'google-analytics' } }
 						support={ {
 							text: __(
-								'Integrates your WordPress site with Google Analytics, ' +
-									'a platform that offers insights into your traffic, visitors, and conversions.'
+								'Integrates your WordPress site with Google Analytics, a platform that offers insights into your traffic, visitors, and conversions.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-google-analytics' ),
 						} }
 					>
-						{ __(
-							'Google Analytics is a free service that complements our {{a}}built-in stats{{/a}} with different insights into your traffic.' +
-								' WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will ' +
-								'normally show slightly different totals for your visits, views, etc.',
+						{ jetpackCreateInterpolateElement(
+							__(
+								'Google Analytics is a free service that complements our <a>built-in stats</a> with different insights into your traffic. WordPress.com stats and Google Analytics use different methods to identify and track activity on your site, so they will normally show slightly different totals for your visits, views, etc.',
+								'jetpack'
+							),
 							{
-								components: {
-									a: (
-										<a
-											href={ getRedirectUrl( 'calypso-stats-day', {
-												site: this.props.siteRawUrl,
-											} ) }
-										/>
-									),
-								},
+								a: (
+									<a
+										href={ getRedirectUrl( 'calypso-stats-day', {
+											site: this.props.siteRawUrl,
+										} ) }
+									/>
+								),
 							}
 						) }
 					</SettingsGroup>
@@ -64,7 +64,7 @@ export const GoogleAnalytics = withModuleSettingsFormHelpers(
 							onClick={ this.trackConfigureClick }
 							href={ this.props.configureUrl }
 						>
-							{ __( 'Configure your Google Analytics settings' ) }
+							{ __( 'Configure your Google Analytics settings', 'jetpack' ) }
 						</Card>
 					) }
 				</SettingsCard>

--- a/_inc/client/traffic/index.jsx
+++ b/_inc/client/traffic/index.jsx
@@ -3,14 +3,14 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
 import { getModule, getModuleOverride } from 'state/modules';
+import getRedirectUrl from 'lib/jp-redirect';
 import { getSettings } from 'state/settings';
 import { isSiteConnected, isDevMode, isUnavailableInDevMode } from 'state/connection';
 import { isModuleFound } from 'state/search';
@@ -71,9 +71,10 @@ export class Traffic extends React.Component {
 				<Card
 					title={
 						this.props.searchTerm
-							? __( 'Traffic' )
+							? __( 'Traffic', 'jetpack' )
 							: __(
-									'Maximize your site’s visibility in search engines and view traffic stats in real time.'
+									'Maximize your site’s visibility in search engines and view traffic stats in real time.',
+									'jetpack'
 							  )
 					}
 					className="jp-settings-description"

--- a/_inc/client/traffic/related-posts.jsx
+++ b/_inc/client/traffic/related-posts.jsx
@@ -1,16 +1,17 @@
 /**
  * External dependencies
  */
-import analytics from 'lib/analytics';
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import CompactFormToggle from 'components/form/form-toggle/compact';
+import getRedirectUrl from 'lib/jp-redirect';
 import { FormFieldset, FormLabel } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -65,28 +66,26 @@ class RelatedPostsComponent extends React.Component {
 					module={ this.props.getModule( 'related-posts' ) }
 					support={ {
 						text: __(
-							'The feature helps visitors find more of your content by ' +
-								'displaying related posts at the bottom of each post.'
+							'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-related-posts' ),
 					} }
 				>
 					<p>
-						{ __(
-							'Keep your visitors engaged with related content at the bottom of each post. ' +
-								"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
+						{ jetpackCreateInterpolateElement(
+							__(
+								'Keep your visitors engaged with related content at the bottom of each post. These settings won’t apply to <a>related posts added using the block editor</a>.',
+								'jetpack'
+							),
 							{
-								components: {
-									a: (
-										<a
-											href={ getRedirectUrl(
-												'jetpack-support-jetpack-blocks-related-posts-block'
-											) }
-											target="_blank"
-											rel="noopener noreferrer"
-										/>
-									),
-								},
+								a: (
+									<a
+										href={ getRedirectUrl( 'jetpack-support-jetpack-blocks-related-posts-block' ) }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
 							}
 						) }
 					</p>
@@ -98,7 +97,7 @@ class RelatedPostsComponent extends React.Component {
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">
-							{ __( 'Show related content after posts' ) }
+							{ __( 'Show related content after posts', 'jetpack' ) }
 						</span>
 					</ModuleToggle>
 					<FormFieldset>
@@ -112,7 +111,7 @@ class RelatedPostsComponent extends React.Component {
 							onChange={ this.handleShowHeadlineToggleChange }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Highlight related content with a heading' ) }
+								{ __( 'Highlight related content with a heading', 'jetpack' ) }
 							</span>
 						</CompactFormToggle>
 						<CompactFormToggle
@@ -125,44 +124,51 @@ class RelatedPostsComponent extends React.Component {
 							onChange={ this.handleShowThumbnailsToggleChange }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Show a thumbnail image where available' ) }
+								{ __( 'Show a thumbnail image where available', 'jetpack' ) }
 							</span>
 						</CompactFormToggle>
 						{ isRelatedPostsActive && (
 							<div>
 								<FormLabel className="jp-form-label-wide">
-									{ __( 'Preview', {
-										context: 'A header for a preview area in the configuration screen.',
-									} ) }
+									{ _x(
+										'Preview',
+										'A header for a preview area in the configuration screen.',
+										'jetpack'
+									) }
 								</FormLabel>
 								<Card className="jp-related-posts-preview">
 									{ this.state.show_headline && (
-										<div className="jp-related-posts-preview__title">{ __( 'Related' ) }</div>
+										<div className="jp-related-posts-preview__title">
+											{ __( 'Related', 'jetpack' ) }
+										</div>
 									) }
 									{ [
 										{
 											url: 'cat-blog.png',
-											text: __( 'Big iPhone/iPad Update Now Available' ),
-											context: __( 'In "Mobile"', {
-												comment:
-													'It refers to the category where a post was found. Used in an example preview.',
-											} ),
+											text: __( 'Big iPhone/iPad Update Now Available', 'jetpack' ),
+											context: _x(
+												'In "Mobile"',
+												'It refers to the category where a post was found. Used in an example preview.',
+												'jetpack'
+											),
 										},
 										{
 											url: 'devices.jpg',
-											text: __( 'The WordPress for Android App Gets a Big Facelift' ),
-											context: __( 'In "Mobile"', {
-												comment:
-													'It refers to the category where a post was found. Used in an example preview.',
-											} ),
+											text: __( 'The WordPress for Android App Gets a Big Facelift', 'jetpack' ),
+											context: _x(
+												'In "Mobile"',
+												'It refers to the category where a post was found. Used in an example preview.',
+												'jetpack'
+											),
 										},
 										{
 											url: 'mobile-wedding.jpg',
-											text: __( 'Upgrade Focus: VideoPress For Weddings' ),
-											context: __( 'In "Upgrade"', {
-												comment:
-													'It refers to the category where a post was found. Used in an example preview.',
-											} ),
+											text: __( 'Upgrade Focus: VideoPress For Weddings', 'jetpack' ),
+											context: _x(
+												'In "Upgrade"',
+												'It refers to the category where a post was found. Used in an example preview.',
+												'jetpack'
+											),
 										},
 									].map( ( item, index ) => (
 										<div key={ `preview_${ index }` } className="jp-related-posts-preview__item">
@@ -190,7 +196,7 @@ class RelatedPostsComponent extends React.Component {
 						onClick={ this.trackConfigureClick }
 						href={ this.props.configureUrl }
 					>
-						{ __( 'Configure related posts in the Customizer' ) }
+						{ __( 'Configure related posts in the Customizer', 'jetpack' ) }
 					</Card>
 				) }
 			</SettingsCard>

--- a/_inc/client/traffic/seo.jsx
+++ b/_inc/client/traffic/seo.jsx
@@ -2,17 +2,16 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
 import { connect } from 'react-redux';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { FEATURE_SEO_TOOLS_JETPACK, getPlanClass } from 'lib/plans/constants';
-
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -28,7 +27,7 @@ class SeoComponent extends React.Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Search engine optimization', { context: 'Settings header' } ) }
+				header={ _x( 'Search engine optimization', 'Settings header', 'jetpack' ) }
 				feature={ FEATURE_SEO_TOOLS_JETPACK }
 				hideButton
 			>
@@ -37,14 +36,16 @@ class SeoComponent extends React.Component {
 					module={ { module: 'seo-tools' } }
 					support={ {
 						text: __(
-							'Allows you to optimize your site and its content for better results in search engines.'
+							'Allows you to optimize your site and its content for better results in search engines.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-seo-tools' ),
 					} }
 				>
 					<span>
 						{ __(
-							'Take control of the way search engines represent your site. With Jetpack’s SEO tools you can preview how your content will look on popular search engines and change items like your site name and tagline in seconds.'
+							'Take control of the way search engines represent your site. With Jetpack’s SEO tools you can preview how your content will look on popular search engines and change items like your site name and tagline in seconds.',
+							'jetpack'
 						) }
 					</span>
 				</SettingsGroup>
@@ -56,7 +57,7 @@ class SeoComponent extends React.Component {
 							onClick={ this.trackConfigureClick }
 							href={ this.props.configureUrl }
 						>
-							{ __( 'Customize your SEO settings' ) }
+							{ __( 'Customize your SEO settings', 'jetpack' ) }
 						</Card>
 					) }
 			</SettingsCard>

--- a/_inc/client/traffic/shortlinks.jsx
+++ b/_inc/client/traffic/shortlinks.jsx
@@ -3,11 +3,12 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { getModule } from 'state/modules';
 import SettingsCard from 'components/settings-card';
@@ -21,7 +22,7 @@ class Shortlinks extends Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'WP.me Shortlinks', { context: 'Settings header' } ) }
+				header={ _x( 'WP.me Shortlinks', 'Settings header', 'jetpack' ) }
 				module="shortlinks"
 				hideButton
 			>
@@ -40,7 +41,7 @@ class Shortlinks extends Component {
 						toggling={ this.props.isSavingAnyOption( 'shortlinks' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
-						{ __( 'Generate shortened URLs for simpler sharing.' ) }
+						{ __( 'Generate shortened URLs for simpler sharing.', 'jetpack' ) }
 					</ModuleToggle>
 				</SettingsGroup>
 			</SettingsCard>

--- a/_inc/client/traffic/site-stats.jsx
+++ b/_inc/client/traffic/site-stats.jsx
@@ -2,20 +2,21 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import FoldableCard from 'components/foldable-card';
-import Button from 'components/button';
-import Card from 'components/card';
 import { filter, includes } from 'lodash';
 import classNames from 'classnames';
-import { imagePath } from 'constants/urls';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import Card from 'components/card';
+import CompactFormToggle from 'components/form/form-toggle/compact';
+import FoldableCard from 'components/foldable-card';
+import getRedirectUrl from 'lib/jp-redirect';
+import { imagePath } from 'constants/urls';
 import { FormFieldset, FormLegend } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsGroup from 'components/settings-group';
@@ -132,33 +133,34 @@ class SiteStatsComponent extends React.Component {
 								src={ imagePath + 'stats.svg' }
 								width="60"
 								height="60"
-								alt={ __( 'Jetpack Stats Icon' ) }
+								alt={ __( 'Jetpack Stats Icon', 'jetpack' ) }
 								className="jp-at-a-glance__stats-icon"
 							/>
 						</div>
 						<div className="jp-at-a-glance__stats-inactive-text">
 							{ this.props.isDevMode
-								? __( 'Unavailable in Dev Mode' )
-								: __(
-										'{{a}}Activate Site Stats{{/a}} to see detailed stats, likes, followers, subscribers, and more! {{a1}}Learn More{{/a1}}',
+								? __( 'Unavailable in Dev Mode', 'jetpack' )
+								: jetpackCreateInterpolateElement(
+										__(
+											'<a>Activate Site Stats</a> to see detailed stats, likes, followers, subscribers, and more! <a1>Learn More</a1>',
+											'jetpack'
+										),
 										{
-											components: {
-												a: <a href="javascript:void(0)" onClick={ this.activateStats } />,
-												a1: (
-													<a
-														href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											},
+											a: <a href="javascript:void(0)" onClick={ this.activateStats } />,
+											a1: (
+												<a
+													href={ getRedirectUrl( 'jetpack-support-wordpress-com-stats' ) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
 										}
 								  ) }
 						</div>
 						{ ! this.props.isDevMode && (
 							<div className="jp-at-a-glance__stats-inactive-button">
 								<Button onClick={ this.activateStats } primary={ true }>
-									{ __( 'Activate Site Stats' ) }
+									{ __( 'Activate Site Stats', 'jetpack' ) }
 								</Button>
 							</div>
 						) }
@@ -170,14 +172,15 @@ class SiteStatsComponent extends React.Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Site stats', { context: 'Settings header' } ) }
+				header={ _x( 'Site stats', 'Settings header', 'jetpack' ) }
 				hideButton
 				module="site-stats"
 			>
 				<FoldableCard
 					onOpen={ this.trackOpenCard }
 					header={ __(
-						'Expand to update settings for how visits are counted and manage who can view this information.'
+						'Expand to update settings for how visits are counted and manage who can view this information.',
+						'jetpack'
 					) }
 					clickableHeader={ true }
 					className={ classNames( 'jp-foldable-settings-standalone', {
@@ -189,7 +192,8 @@ class SiteStatsComponent extends React.Component {
 						module={ stats }
 						support={ {
 							text: __(
-								'Displays information on your site activity, including visitors and popular posts or pages.'
+								'Displays information on your site activity, including visitors and popular posts or pages.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-wordpress-com-stats' ),
 						} }
@@ -214,15 +218,15 @@ class SiteStatsComponent extends React.Component {
 								onChange={ this.handleStatsOptionToggle( 'hide_smile' ) }
 							>
 								<span className="jp-form-toggle-explanation">
-									{ __( 'Hide the stats smiley face image' ) }
+									{ __( 'Hide the stats smiley face image', 'jetpack' ) }
 								</span>
 								<span className="jp-form-setting-explanation">
-									{ __( 'The image helps collect stats, but should work when hidden.' ) }
+									{ __( 'The image helps collect stats, but should work when hidden.', 'jetpack' ) }
 								</span>
 							</CompactFormToggle>
 						</FormFieldset>
 						<FormFieldset>
-							<FormLegend>{ __( 'Count logged in page views from' ) }</FormLegend>
+							<FormLegend>{ __( 'Count logged in page views from', 'jetpack' ) }</FormLegend>
 							{ Object.keys( siteRoles ).map( key => (
 								<CompactFormToggle
 									checked={ this.state[ `count_roles_${ key }` ] }
@@ -239,7 +243,7 @@ class SiteStatsComponent extends React.Component {
 							) ) }
 						</FormFieldset>
 						<FormFieldset>
-							<FormLegend>{ __( 'Allow stats reports to be viewed by' ) }</FormLegend>
+							<FormLegend>{ __( 'Allow stats reports to be viewed by', 'jetpack' ) }</FormLegend>
 							<CompactFormToggle checked={ true } disabled={ true }>
 								<span className="jp-form-toggle-explanation">{ siteRoles.administrator.name }</span>
 							</CompactFormToggle>

--- a/_inc/client/traffic/sitemaps.jsx
+++ b/_inc/client/traffic/sitemaps.jsx
@@ -4,15 +4,16 @@
 import React from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
 import { get } from 'lodash';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import ExternalLink from 'components/external-link';
+import getRedirectUrl from 'lib/jp-redirect';
 import { FormFieldset } from 'components/forms';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
@@ -28,9 +29,9 @@ export class Sitemaps extends React.Component {
 			<span className="jp-sitemap-row">
 				<ClipboardButtonInput
 					value={ sitemap }
-					copy={ __( 'Copy', { context: 'verb' } ) }
-					copied={ __( 'Copied!' ) }
-					prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+					copy={ _x( 'Copy', 'verb', 'jetpack' ) }
+					copied={ __( 'Copied!', 'jetpack' ) }
+					prompt={ __( 'Highlight and copy the following text to your clipboard:', 'jetpack' ) }
 				/>
 				<ExternalLink
 					// eslint-disable-next-line react/jsx-no-bind
@@ -66,11 +67,8 @@ export class Sitemaps extends React.Component {
 				>
 					<p>
 						{ __(
-							'Sitemaps are files that search engines like Google or Bing use ' +
-								'to index your website. They can help improve your ranking in ' +
-								'search results. When you enable this feature, Jetpack will ' +
-								'create sitemaps for you and update them automatically when ' +
-								'the content on your site changes.'
+							'Sitemaps are files that search engines like Google or Bing use to index your website. They can help improve your ranking in search results. When you enable this feature, Jetpack will create sitemaps for you and update them automatically when the content on your site changes.',
+							'jetpack'
 						) }
 					</p>
 					<ModuleToggle
@@ -80,15 +78,15 @@ export class Sitemaps extends React.Component {
 						toggling={ this.props.isSavingAnyOption( 'sitemaps' ) }
 						toggleModule={ this.props.toggleModuleNow }
 					>
-						{ __( 'Generate XML sitemaps' ) }
+						{ __( 'Generate XML sitemaps', 'jetpack' ) }
 					</ModuleToggle>
 					{ this.props.isSiteVisibleToSearchEngines ? (
 						this.props.getOptionValue( 'sitemaps' ) && (
 							<FormFieldset>
 								<p className="jp-form-setting-explanation">
 									{ __(
-										'Good news: Jetpack is sending your sitemap automatically ' +
-											'to all major search engines for indexing.'
+										'Good news: Jetpack is sending your sitemap automatically to all major search engines for indexing.',
+										'jetpack'
 									) }
 									{ this.renderSitemapRow( sitemap_url, 'sitemap-url-link' ) }
 									{ this.renderSitemapRow( news_sitemap_url, 'sitemap-news-url-link' ) }
@@ -98,15 +96,13 @@ export class Sitemaps extends React.Component {
 					) : (
 						<FormFieldset>
 							<p className={ searchEngineVisibilityClasses }>
-								{ __(
-									"Search engines can't access your site at the moment. " +
-										"If you'd like to make your site accessible, check " +
-										'your {{a}}Reading settings{{/a}} and switch ' +
-										'"Search Engine Visibility" on.',
+								{ jetpackCreateInterpolateElement(
+									__(
+										'Search engines can’t access your site at the moment. If you’d like to make your site accessible, check your <a>Reading settings</a> and switch "Search Engine Visibility" on.',
+										'jetpack'
+									),
 									{
-										components: {
-											a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />,
-										},
+										a: <a href={ this.props.siteAdminUrl + 'options-reading.php' } />,
 									}
 								) }
 							</p>

--- a/_inc/client/traffic/verification-services.jsx
+++ b/_inc/client/traffic/verification-services.jsx
@@ -2,15 +2,16 @@
  * External dependencies
  */
 import React from 'react';
-import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
-import ExternalLink from 'components/external-link';
 import { get, includes } from 'lodash';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
+import getRedirectUrl from 'lib/jp-redirect';
+import TextInput from 'components/text-input';
 import { FormFieldset, FormLabel } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -67,11 +68,11 @@ class VerificationServicesComponent extends React.Component {
 				<JetpackBanner
 					title={ verification.name }
 					icon="cog"
-					description={ __( '%(moduleName)s has been disabled by a site administrator.', {
-						args: {
-							moduleName: verification.name,
-						},
-					} ) }
+					description={ sprintf(
+						/* translators: placeholder is a feature name. */
+						__( '%s has been disabled by a site administrator.', 'jetpack' ),
+						verification.name
+					) }
 				/>
 			);
 		}
@@ -88,7 +89,8 @@ class VerificationServicesComponent extends React.Component {
 					module={ verification }
 					support={ {
 						text: __(
-							'Provides the necessary hidden tags needed to verify your WordPress site with various services.'
+							'Provides the necessary hidden tags needed to verify your WordPress site with various services.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-site-verification-tools' ),
 					} }
@@ -101,51 +103,51 @@ class VerificationServicesComponent extends React.Component {
 						toggleModule={ this.props.toggleModuleNow }
 					>
 						<span className="jp-form-toggle-explanation">
-							{ __( 'Verify site ownership with third party services' ) }
+							{ __( 'Verify site ownership with third party services', 'jetpack' ) }
 						</span>
 					</ModuleToggle>
 					<p>
-						{ __(
-							'Note that {{b}}verifying your site with these services is not necessary{{/b}} in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the {{support}}full instructions{{/support}} if you are having trouble. Supported verification services: {{google}}Google Search Console{{/google}}, {{bing}}Bing Webmaster Center{{/bing}}, {{pinterest}}Pinterest Site Verification{{/pinterest}}, and {{yandex}}Yandex.Webmaster{{/yandex}}.',
+						{ jetpackCreateInterpolateElement(
+							/* translators: placeholders are links to external sites. */
+							__(
+								'Note that <b>verifying your site with these services is not necessary</b> in order for your site to be indexed by search engines. To use these advanced search engine tools and verify your site with a service, paste the HTML Tag code below. Read the <support>full instructions</support> if you are having trouble. Supported verification services: <google>Google Search Console</google>, <bing>Bing Webmaster Center</bing>, <pinterest>Pinterest Site Verification</pinterest>, and <yandex>Yandex.Webmaster</yandex>.',
+								'jetpack'
+							),
 							{
-								components: {
-									b: <strong />,
-									support: (
-										<a href={ getRedirectUrl( 'jetpack-support-site-verification-tools' ) } />
-									),
-									google: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											rel="noopener noreferrer"
-											href="https://www.google.com/webmasters/tools/"
-										/>
-									),
-									bing: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											rel="noopener noreferrer"
-											href="https://www.bing.com/webmaster/"
-										/>
-									),
-									pinterest: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											rel="noopener noreferrer"
-											href="https://pinterest.com/website/verify/"
-										/>
-									),
-									yandex: (
-										<ExternalLink
-											icon={ true }
-											target="_blank"
-											rel="noopener noreferrer"
-											href="https://webmaster.yandex.com/sites/"
-										/>
-									),
-								},
+								b: <strong />,
+								support: <a href={ getRedirectUrl( 'jetpack-support-site-verification-tools' ) } />,
+								google: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://www.google.com/webmasters/tools/"
+									/>
+								),
+								bing: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://www.bing.com/webmaster/"
+									/>
+								),
+								pinterest: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://pinterest.com/website/verify/"
+									/>
+								),
+								yandex: (
+									<ExternalLink
+										icon={ true }
+										target="_blank"
+										rel="noopener noreferrer"
+										href="https://webmaster.yandex.com/sites/"
+									/>
+								),
 							}
 						) }
 					</p>
@@ -157,7 +159,7 @@ class VerificationServicesComponent extends React.Component {
 							disabled={ this.props.isUpdating( 'google' ) || ! isVerificationActive }
 						/>
 						<FormLabel className="jp-form-input-with-prefix" key="verification_service_bing">
-							<span>{ __( 'Bing' ) }</span>
+							<span>{ __( 'Bing', 'jetpack' ) }</span>
 							<TextInput
 								name="bing"
 								value={ this.getSiteVerificationValue( 'bing' ) }
@@ -168,7 +170,7 @@ class VerificationServicesComponent extends React.Component {
 							/>
 						</FormLabel>
 						<FormLabel className="jp-form-input-with-prefix" key="verification_service_pinterest">
-							<span>{ __( 'Pinterest' ) }</span>
+							<span>{ __( 'Pinterest', 'jetpack' ) }</span>
 							<TextInput
 								name="pinterest"
 								value={ this.getSiteVerificationValue( 'pinterest' ) }
@@ -179,7 +181,7 @@ class VerificationServicesComponent extends React.Component {
 							/>
 						</FormLabel>
 						<FormLabel className="jp-form-input-with-prefix" key="verification_service_yandex">
-							<span>{ __( 'Yandex' ) }</span>
+							<span>{ __( 'Yandex', 'jetpack' ) }</span>
 							<TextInput
 								name="yandex"
 								value={ this.getSiteVerificationValue( 'yandex' ) }

--- a/_inc/client/traffic/verification-services/google.jsx
+++ b/_inc/client/traffic/verification-services/google.jsx
@@ -3,15 +3,16 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { translate as __ } from 'i18n-calypso';
-import TextInput from 'components/text-input';
-import ExternalLink from 'components/external-link';
 import { connect } from 'react-redux';
-import analytics from 'lib/analytics';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import ExternalLink from 'components/external-link';
+import TextInput from 'components/text-input';
 import { isFetchingSiteData } from 'state/site';
 import { FormLabel } from 'components/forms';
 import Gridicon from 'components/gridicon';
@@ -76,7 +77,9 @@ class GoogleVerificationServiceComponent extends React.Component {
 	}
 
 	checkAndVerifySite( keyringId ) {
-		this.props.createNotice( 'is-info', __( 'Verifying…' ), { id: 'verifying-site-google' } );
+		this.props.createNotice( 'is-info', __( 'Verifying…', 'jetpack' ), {
+			id: 'verifying-site-google',
+		} );
 		this.props
 			.checkVerifyStatusGoogle( keyringId )
 			.then( response => {
@@ -98,11 +101,11 @@ class GoogleVerificationServiceComponent extends React.Component {
 							} );
 							this.props.createNotice(
 								'is-error',
-								__( 'Site failed to verify: %(error)s', {
-									args: {
-										error: errorMessage,
-									},
-								} ),
+								sprintf(
+									/* translators: placeholder is an error message. */
+									__( 'Site failed to verify: %s', 'jetpack' ),
+									errorMessage
+								),
 								{
 									id: 'verify-site-google-error',
 									duration: 5000,
@@ -184,7 +187,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 			return (
 				<div>
 					<FormLabel className="jp-form-input-with-prefix" key="verification_service_google">
-						<span>{ __( 'Google' ) }</span>
+						<span>{ __( 'Google', 'jetpack' ) }</span>
 						<TextInput
 							name="google"
 							value={ this.props.value }
@@ -203,7 +206,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 									disabled={ this.props.disabled }
 									onClick={ this.quickSave }
 								>
-									{ __( 'Save' ) }
+									{ __( 'Save', 'jetpack' ) }
 								</Button>
 								<Button
 									type="button"
@@ -211,7 +214,7 @@ class GoogleVerificationServiceComponent extends React.Component {
 									disabled={ this.props.disabled }
 									onClick={ this.handleClickCancel }
 								>
-									{ __( 'Cancel' ) }
+									{ __( 'Cancel', 'jetpack' ) }
 								</Button>
 							</div>
 						) }
@@ -224,17 +227,17 @@ class GoogleVerificationServiceComponent extends React.Component {
 			return (
 				<div>
 					<div className="jp-form-input-with-prefix" key="verification_service_google">
-						<span>{ __( 'Google' ) }</span>
+						<span>{ __( 'Google', 'jetpack' ) }</span>
 						<div className="jp-form-site-verification-verified">
 							<Gridicon icon="checkmark-circle" size={ 20 } />{ ' ' }
-							<span>{ __( 'Your site is verified with Google' ) }</span>
+							<span>{ __( 'Your site is verified with Google', 'jetpack' ) }</span>
 						</div>
 						<Button
 							type="button"
 							className="jp-form-site-verification-edit-button"
 							onClick={ this.handleClickEdit }
 						>
-							{ __( 'Edit' ) }
+							{ __( 'Edit', 'jetpack' ) }
 						</Button>
 					</div>
 
@@ -242,51 +245,50 @@ class GoogleVerificationServiceComponent extends React.Component {
 						<div className="jp-form-input-with-prefix-bottom-message">
 							<div className="jp-form-setting-explanation">
 								<p>
-									{ __(
-										"Monitor your site's traffic and performance from the {{a}}Google Search Console{{/a}}.",
+									{ jetpackCreateInterpolateElement(
+										__(
+											"Monitor your site's traffic and performance from the <a>Google Search Console</a>.",
+											'jetpack'
+										),
 										{
-											components: {
-												a: (
-													<ExternalLink
-														icon
-														iconSize={ 16 }
-														target="_blank"
-														rel="noopener noreferrer"
-														href={ this.props.googleSearchConsoleUrl }
-													/>
-												),
-											},
+											a: (
+												<ExternalLink
+													icon
+													iconSize={ 16 }
+													target="_blank"
+													rel="noopener noreferrer"
+													href={ this.props.googleSearchConsoleUrl }
+												/>
+											),
 										}
 									) }{ ' ' }
-									{ __(
-										'Google will email about certain events that occur with your site, ' +
-											'including indications that your website has been {{a1}}hacked{{/a1}}, ' +
-											'or problems {{a2}}crawling or indexing{{/a2}} your site.',
+									{ jetpackCreateInterpolateElement(
+										/* translators: placeholders are links to Google support documents. */
+										__(
+											'Google will email about certain events that occur with your site, including indications that your website has been <a1>hacked</a1>, or problems <a2>crawling or indexing</a2> your site.',
+											'jetpack'
+										),
 										{
-											components: {
-												a1: (
-													<ExternalLink
-														icon
-														iconSize={ 16 }
-														target="_blank"
-														rel="noopener noreferrer"
-														href={
-															'https://developers.google.com/web/fundamentals/security/hacked/'
-														}
-													/>
-												),
-												a2: (
-													<ExternalLink
-														icon
-														iconSize={ 16 }
-														target="_blank"
-														rel="noopener noreferrer"
-														href={
-															'https://www.google.com/insidesearch/howsearchworks/crawling-indexing.html'
-														}
-													/>
-												),
-											},
+											a1: (
+												<ExternalLink
+													icon
+													iconSize={ 16 }
+													target="_blank"
+													rel="noopener noreferrer"
+													href={ 'https://developers.google.com/web/fundamentals/security/hacked/' }
+												/>
+											),
+											a2: (
+												<ExternalLink
+													icon
+													iconSize={ 16 }
+													target="_blank"
+													rel="noopener noreferrer"
+													href={
+														'https://www.google.com/insidesearch/howsearchworks/crawling-indexing.html'
+													}
+												/>
+											),
 										}
 									) }
 								</p>
@@ -308,20 +310,32 @@ class GoogleVerificationServiceComponent extends React.Component {
 				className="jp-form-input-with-prefix jp-form-google-label-unverified"
 				key="verification_service_google"
 			>
-				<span>{ __( 'Google' ) }</span>
+				<span>{ __( 'Google', 'jetpack' ) }</span>
 				<div className="jp-form-google-label-unverified-actions">
-					<Button
-						primary
-						type="button"
-						disabled={ disabled }
-						onClick={ this.handleClickAutoVerify }
-					>
-						{ __( 'Verify with Google' ) }
-					</Button>
-					<span className="jp-form-google-separator">{ __( 'or' ) }</span>
-					<Button type="button" disabled={ disabled } onClick={ this.handleClickSetManually }>
-						{ __( 'Manually Verify ' ) }
-					</Button>
+					{ jetpackCreateInterpolateElement(
+						__(
+							'<button1>Verify with Google</button1><span>or</span><button2>Manually Verify</button2>',
+							'jetpack'
+						),
+						{
+							button1: (
+								<Button
+									primary
+									type="button"
+									disabled={ disabled }
+									onClick={ this.handleClickAutoVerify }
+								/>
+							),
+							span: <span className="jp-form-google-separator" />,
+							button2: (
+								<Button
+									type="button"
+									disabled={ disabled }
+									onClick={ this.handleClickSetManually }
+								/>
+							),
+						}
+					) }
 				</div>
 			</div>
 		);

--- a/_inc/client/writing/composing.jsx
+++ b/_inc/client/writing/composing.jsx
@@ -3,13 +3,13 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { FormFieldset } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { isModuleFound as _isModuleFound } from 'state/search';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
@@ -55,8 +55,8 @@ export class Composing extends React.Component {
 					module={ copyPost }
 					support={ {
 						text: __(
-							'Duplicate existing posts, pages, Testimonials, and Portfolios. ' +
-								'All the content will be copied including text, featured images, sharing settings, and more.'
+							'Duplicate existing posts, pages, Testimonials, and Portfolios. All the content will be copied including text, featured images, sharing settings, and more.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-copy-post' ),
 					} }
@@ -79,9 +79,8 @@ export class Composing extends React.Component {
 					module={ markdown }
 					support={ {
 						text: __(
-							'Use Markdown syntax to compose content with links, lists, and other styles. ' +
-								'This setting enables Markdown in the Classic Editor ' +
-								'as well as within a Classic Editor block.'
+							'Use Markdown syntax to compose content with links, lists, and other styles. This setting enables Markdown in the Classic Editor as well as within a Classic Editor block.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-markdown' ),
 					} }
@@ -112,7 +111,8 @@ export class Composing extends React.Component {
 					module={ latex }
 					support={ {
 						text: __(
-							'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.'
+							'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.',
+							'jetpack'
 						),
 						link: getRedirectUrl( 'jetpack-support-beautiful-math-with-latex' ),
 					} }
@@ -147,7 +147,7 @@ export class Composing extends React.Component {
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Compose using shortcodes to embed media from popular sites' ) }
+								{ __( 'Compose using shortcodes to embed media from popular sites', 'jetpack' ) }
 							</span>
 						</ModuleToggle>
 					</FormFieldset>
@@ -157,7 +157,7 @@ export class Composing extends React.Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Composing', { context: 'Settings header' } ) }
+				header={ _x( 'Composing', 'Settings header', 'jetpack' ) }
 				module="composing"
 				saveDisabled={ this.props.isSavingAnyOption( 'ignored_phrases' ) }
 			>

--- a/_inc/client/writing/custom-content-types.jsx
+++ b/_inc/client/writing/custom-content-types.jsx
@@ -6,15 +6,16 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import getRedirectUrl from 'lib/jp-redirect';
+import { jetpackCreateInterpolateElement } from 'components/create-interpolate-element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import CompactCard from 'components/card/compact';
 import { FormFieldset } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { getModule, getModuleOverride } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
@@ -65,7 +66,8 @@ export class CustomContentTypes extends React.Component {
 		const disabledByOverride =
 			'inactive' === this.props.getModuleOverride( 'custom-content-types' );
 		const disabledReason =
-			disabledByOverride && __( 'This feature has been disabled by a site administrator.' );
+			disabledByOverride &&
+			__( 'This feature has been disabled by a site administrator.', 'jetpack' );
 		return (
 			<SettingsCard { ...this.props } module="custom-content-types" hideButton>
 				<SettingsGroup
@@ -76,15 +78,13 @@ export class CustomContentTypes extends React.Component {
 					} }
 				>
 					<p>
-						{ __(
-							'Add {{testimonialLink}}testimonials{{/testimonialLink}} to ' +
-								'your website to attract new customers. If your theme doesn’t ' +
-								'support Jetpack Testimonials, you can still use a simple ' +
-								'shortcode to display them on your site.',
+						{ jetpackCreateInterpolateElement(
+							__(
+								'Add <testimonialLink>testimonials</testimonialLink> to your website to attract new customers. If your theme doesn’t support Jetpack Testimonials, you can still use a simple shortcode to display them on your site.',
+								'jetpack'
+							),
 							{
-								components: {
-									testimonialLink: this.linkIfActiveCPT( 'testimonial' ),
-								},
+								testimonialLink: this.linkIfActiveCPT( 'testimonial' ),
 							}
 						) }
 					</p>
@@ -94,11 +94,11 @@ export class CustomContentTypes extends React.Component {
 						onChange={ this.handleTestimonialToggleChange }
 						disabledReason={ disabledReason }
 					>
-						<span className="jp-form-toggle-explanation">{ __( 'Testimonials' ) }</span>
+						<span className="jp-form-toggle-explanation">{ __( 'Testimonials', 'jetpack' ) }</span>
 					</CompactFormToggle>
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
-							{ __( 'Testimonials shortcode: [testimonials]' ) }
+							{ __( 'Testimonials shortcode: [testimonials]', 'jetpack' ) }
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
@@ -107,7 +107,7 @@ export class CustomContentTypes extends React.Component {
 						className="jp-settings-card__configure-link"
 						href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-testimonial` }
 					>
-						{ __( 'Add a testimonial' ) }
+						{ __( 'Add a testimonial', 'jetpack' ) }
 					</CompactCard>
 				) }
 				<SettingsGroup
@@ -118,15 +118,13 @@ export class CustomContentTypes extends React.Component {
 					} }
 				>
 					<p>
-						{ __(
-							'Use {{portfolioLink}}portfolios{{/portfolioLink}} on your ' +
-								'site to showcase your best work. If your theme doesn’t support ' +
-								'Jetpack Portfolios, you can still use a simple shortcode to ' +
-								'display them on your site.',
+						{ jetpackCreateInterpolateElement(
+							__(
+								'Use <portfolioLink>portfolios</portfolioLink> on your site to showcase your best work. If your theme doesn’t support Jetpack Portfolios, you can still use a simple shortcode to display them on your site.',
+								'jetpack'
+							),
 							{
-								components: {
-									portfolioLink: this.linkIfActiveCPT( 'portfolio' ),
-								},
+								portfolioLink: this.linkIfActiveCPT( 'portfolio' ),
 							}
 						) }
 					</p>
@@ -136,11 +134,11 @@ export class CustomContentTypes extends React.Component {
 						onChange={ this.handlePortfolioToggleChange }
 						disabledReason={ disabledReason }
 					>
-						<span className="jp-form-toggle-explanation">{ __( 'Portfolios' ) }</span>
+						<span className="jp-form-toggle-explanation">{ __( 'Portfolios', 'jetpack' ) }</span>
 					</CompactFormToggle>
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
-							{ __( 'Portfolios shortcode: [portfolio]' ) }
+							{ __( 'Portfolios shortcode: [portfolio]', 'jetpack' ) }
 						</p>
 					</FormFieldset>
 				</SettingsGroup>
@@ -149,7 +147,7 @@ export class CustomContentTypes extends React.Component {
 						className="jp-settings-card__configure-link"
 						href={ `${ this.props.siteAdminUrl }post-new.php?post_type=jetpack-portfolio` }
 					>
-						{ __( 'Add a portfolio item' ) }
+						{ __( 'Add a portfolio item', 'jetpack' ) }
 					</CompactCard>
 				) }
 			</SettingsCard>

--- a/_inc/client/writing/index.jsx
+++ b/_inc/client/writing/index.jsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -75,9 +75,10 @@ export class Writing extends React.Component {
 				<Card
 					title={
 						this.props.searchTerm
-							? __( 'Writing' )
+							? __( 'Writing', 'jetpack' )
 							: __(
-									'Compose content the way you want to and streamline your publishing experience.'
+									'Compose content the way you want to and streamline your publishing experience.',
+									'jetpack'
 							  )
 					}
 					className="jp-settings-description"
@@ -105,7 +106,8 @@ export class Writing extends React.Component {
 				{ ! showComposing && ! showPostByEmail && (
 					<Card>
 						{ __(
-							'Writing tools available to you will be shown here when an administrator enables them.'
+							'Writing tools available to you will be shown here when an administrator enables them.',
+							'jetpack'
 						) }
 					</Card>
 				) }

--- a/_inc/client/writing/masterbar.jsx
+++ b/_inc/client/writing/masterbar.jsx
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import { translate as __ } from 'i18n-calypso';
-import Card from 'components/card';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import Card from 'components/card';
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
 import SettingsGroup from 'components/settings-group';
@@ -24,7 +24,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 			return (
 				<SettingsCard
 					{ ...this.props }
-					header={ __( 'WordPress.com toolbar', { context: 'Settings header' } ) }
+					header={ _x( 'WordPress.com toolbar', 'Settings header', 'jetpack' ) }
 					module="masterbar"
 					hideButton
 				>
@@ -33,17 +33,16 @@ export const Masterbar = withModuleSettingsFormHelpers(
 						module={ { module: 'masterbar' } }
 						support={ {
 							text: __(
-								'Adds a toolbar with links to all your sites, notifications, your WordPress.com profile, and the Reader.'
+								'Adds a toolbar with links to all your sites, notifications, your WordPress.com profile, and the Reader.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-masterbar' ),
 						} }
 					>
 						<p>
 							{ __(
-								'The WordPress.com toolbar replaces the default WordPress admin toolbar. ' +
-									'It offers one-click access to notifications, your WordPress.com ' +
-									'profile and your other Jetpack and WordPress.com websites. ' +
-									'You can also catch up on the sites you follow in the Reader.'
+								'The WordPress.com toolbar replaces the default WordPress admin toolbar. It offers one-click access to notifications, your WordPress.com profile and your other Jetpack and WordPress.com websites. You can also catch up on the sites you follow in the Reader.',
+								'jetpack'
 							) }
 						</p>
 						<ModuleToggle
@@ -53,7 +52,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 							toggling={ this.props.isSavingAnyOption( 'masterbar' ) }
 							toggleModule={ this.props.toggleModuleNow }
 						>
-							{ __( 'Enable the WordPress.com toolbar' ) }
+							{ __( 'Enable the WordPress.com toolbar', 'jetpack' ) }
 						</ModuleToggle>
 					</SettingsGroup>
 					{ ! this.props.isUnavailableInDevMode( 'masterbar' ) && ! this.props.isLinked && (
@@ -62,7 +61,7 @@ export const Masterbar = withModuleSettingsFormHelpers(
 							className="jp-settings-card__configure-link"
 							href={ `${ this.props.connectUrl }&from=unlinked-user-masterbar` }
 						>
-							{ __( 'Create a Jetpack account to use this feature' ) }
+							{ __( 'Create a Jetpack account to use this feature', 'jetpack' ) }
 						</Card>
 					) }
 				</SettingsCard>

--- a/_inc/client/writing/post-by-email.jsx
+++ b/_inc/client/writing/post-by-email.jsx
@@ -3,17 +3,17 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import Button from 'components/button';
-import ClipboardButtonInput from 'components/clipboard-button-input';
-import Card from 'components/card';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import Button from 'components/button';
+import ClipboardButtonInput from 'components/clipboard-button-input';
+import Card from 'components/card';
 import { FormFieldset, FormLegend, FormLabel } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
 import { getModule } from 'state/modules';
 import { isModuleFound as _isModuleFound } from 'state/search';
@@ -57,13 +57,17 @@ class PostByEmail extends React.Component {
 					disableInDevMode
 					module={ postByEmail }
 					support={ {
-						text: __( 'Allows you to publish new posts by sending an email to a special address.' ),
+						text: __(
+							'Allows you to publish new posts by sending an email to a special address.',
+							'jetpack'
+						),
 						link: getRedirectUrl( 'jetpack-support-post-by-email' ),
 					} }
 				>
 					<p>
 						{ __(
-							'Post by email is a quick way to publish new posts without visiting your site. We’ll generate a unique email address for you to send your content to, which will then appear on your site just like any other post.'
+							'Post by email is a quick way to publish new posts without visiting your site. We’ll generate a unique email address for you to send your content to, which will then appear on your site just like any other post.',
+							'jetpack'
 						) }
 					</p>
 					{ this.props.userCanManageModules ? (
@@ -86,20 +90,27 @@ class PostByEmail extends React.Component {
 					) }
 					<FormFieldset>
 						<FormLabel>
-							<FormLegend>{ __( 'Send your new posts to this email address:' ) }</FormLegend>
+							<FormLegend>
+								{ __( 'Send your new posts to this email address:', 'jetpack' ) }
+							</FormLegend>
 							<ClipboardButtonInput
 								value={ emailAddress }
 								disabled={ ! isPbeActive || disabledControls }
-								copy={ __( 'Copy', { context: 'verb' } ) }
-								copied={ __( 'Copied!' ) }
-								prompt={ __( 'Highlight and copy the following text to your clipboard:' ) }
+								copy={ _x( 'Copy', 'verb', 'jetpack' ) }
+								copied={ __( 'Copied!', 'jetpack' ) }
+								prompt={ __(
+									'Highlight and copy the following text to your clipboard:',
+									'jetpack'
+								) }
 							/>
 						</FormLabel>
 						<Button
 							disabled={ ! isPbeActive || disabledControls }
 							onClick={ this.regeneratePostByEmailAddress }
 						>
-							{ emailAddress ? __( 'Regenerate address' ) : __( 'Create address' ) }
+							{ emailAddress
+								? __( 'Regenerate address', 'jetpack' )
+								: __( 'Create address', 'jetpack' ) }
 						</Button>
 					</FormFieldset>
 				</SettingsGroup>
@@ -109,7 +120,7 @@ class PostByEmail extends React.Component {
 						className="jp-settings-card__configure-link"
 						href={ `${ this.props.connectUrl }&from=unlinked-user-pbe` }
 					>
-						{ __( 'Create a Jetpack account to use this feature' ) }
+						{ __( 'Create a Jetpack account to use this feature', 'jetpack' ) }
 					</Card>
 				) }
 			</SettingsCard>

--- a/_inc/client/writing/theme-enhancements.jsx
+++ b/_inc/client/writing/theme-enhancements.jsx
@@ -3,13 +3,13 @@
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import analytics from 'lib/analytics';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import analytics from 'lib/analytics';
+import getRedirectUrl from 'lib/jp-redirect';
 import { FormLabel, FormLegend } from 'components/forms';
 import { ModuleToggle } from 'components/module-toggle';
 import { getModule } from 'state/modules';
@@ -122,7 +122,7 @@ class ThemeEnhancements extends React.Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Theme enhancements' ) }
+				header={ __( 'Theme enhancements', 'jetpack' ) }
 				hideButton={ ! foundInfiniteScroll || ! this.props.isInfiniteScrollSupported }
 				module="theme-enhancements"
 			>
@@ -136,7 +136,8 @@ class ThemeEnhancements extends React.Component {
 						key={ `theme_enhancement_${ infScr.module }` }
 						support={ {
 							text: __(
-								'Loads the next posts automatically when the reader approaches the bottom of the page.'
+								'Loads the next posts automatically when the reader approaches the bottom of the page.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-infinite-scroll' ),
 						} }
@@ -144,22 +145,23 @@ class ThemeEnhancements extends React.Component {
 						<FormLegend className="jp-form-label-wide">{ infScr.name }</FormLegend>
 						<p>
 							{ __(
-								'Create a smooth, uninterrupted reading experience by loading more content as visitors scroll to the bottom of your archive pages.'
+								'Create a smooth, uninterrupted reading experience by loading more content as visitors scroll to the bottom of your archive pages.',
+								'jetpack'
 							) }
 						</p>
 						{ this.props.isInfiniteScrollSupported ? (
 							[
 								{
 									key: 'infinite_default',
-									label: __( 'Load more posts using the default theme behavior' ),
+									label: __( 'Load more posts using the default theme behavior', 'jetpack' ),
 								},
 								{
 									key: 'infinite_button',
-									label: __( 'Load more posts in page with a button' ),
+									label: __( 'Load more posts in page with a button', 'jetpack' ),
 								},
 								{
 									key: 'infinite_scroll',
-									label: __( 'Load more posts as the reader scrolls down' ),
+									label: __( 'Load more posts as the reader scrolls down', 'jetpack' ),
 								},
 							].map( radio => (
 								<FormLabel key={ `${ infScr.module }_${ radio.key }` }>
@@ -176,15 +178,16 @@ class ThemeEnhancements extends React.Component {
 							) )
 						) : (
 							<span>
-								{ __( 'Theme support required.' ) + ' ' }
+								{ __( 'Theme support required.', 'jetpack' ) + ' ' }
 								<a
 									onClick={ this.trackLearnMoreIS }
 									href={ infScr.learn_more_button + '#theme' }
 									title={ __(
-										'Learn more about adding support for Infinite Scroll to your theme.'
+										'Learn more about adding support for Infinite Scroll to your theme.',
+										'jetpack'
 									) }
 								>
-									{ __( 'Learn more' ) }
+									{ __( 'Learn more', 'jetpack' ) }
 								</a>
 							</span>
 						) }
@@ -206,7 +209,7 @@ class ThemeEnhancements extends React.Component {
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							<span className="jp-form-toggle-explanation">
-								{ __( 'Enhance CSS customization panel' ) }
+								{ __( 'Enhance CSS customization panel', 'jetpack' ) }
 							</span>
 						</ModuleToggle>
 					</SettingsGroup>

--- a/_inc/client/writing/widgets.jsx
+++ b/_inc/client/writing/widgets.jsx
@@ -3,11 +3,12 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __, _x } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
+import getRedirectUrl from 'lib/jp-redirect';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { getModule } from 'state/modules';
 import { isModuleFound } from 'state/search';
@@ -27,7 +28,7 @@ class Widgets extends Component {
 		return (
 			<SettingsCard
 				{ ...this.props }
-				header={ __( 'Widgets', { context: 'Settings header' } ) }
+				header={ _x( 'Widgets', 'Settings header', 'jetpack' ) }
 				module="widgets"
 				hideButton
 			>
@@ -46,7 +47,8 @@ class Widgets extends Component {
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							{ __(
-								'Make extra widgets available for use on your site including subscription forms and Twitter streams'
+								'Make extra widgets available for use on your site including subscription forms and Twitter streams',
+								'jetpack'
 							) }
 						</ModuleToggle>
 					</SettingsGroup>
@@ -56,7 +58,8 @@ class Widgets extends Component {
 						module={ { module: 'widget-visibility' } }
 						support={ {
 							text: __(
-								'Widget visibility lets you decide which widgets appear on which pages, so you can finely tailor widget content.'
+								'Widget visibility lets you decide which widgets appear on which pages, so you can finely tailor widget content.',
+								'jetpack'
 							),
 							link: getRedirectUrl( 'jetpack-support-widget-visibility' ),
 						} }
@@ -68,7 +71,8 @@ class Widgets extends Component {
 							toggleModule={ this.props.toggleModuleNow }
 						>
 							{ __(
-								'Enable widget visibility controls to display widgets only on particular posts or pages'
+								'Enable widget visibility controls to display widgets only on particular posts or pages',
+								'jetpack'
 							) }
 						</ModuleToggle>
 					</SettingsGroup>

--- a/_inc/client/writing/writing-media.jsx
+++ b/_inc/client/writing/writing-media.jsx
@@ -4,14 +4,14 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { translate as __ } from 'i18n-calypso';
-import CompactFormToggle from 'components/form/form-toggle/compact';
-import getRedirectUrl from 'lib/jp-redirect';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import CompactFormToggle from 'components/form/form-toggle/compact';
 import { FormFieldset, FormLegend, FormLabel, FormSelect } from 'components/forms';
+import getRedirectUrl from 'lib/jp-redirect';
 import { ModuleToggle } from 'components/module-toggle';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import SettingsCard from 'components/settings-card';
@@ -69,7 +69,7 @@ function WritingMedia( props ) {
 		<SettingsCard
 			{ ...props }
 			module="media"
-			header={ __( 'Media' ) }
+			header={ __( 'Media', 'jetpack' ) }
 			hideButton={ ! foundCarousel }
 			saveDisabled={ props.isSavingAnyOption( 'carousel_background_color' ) }
 		>
@@ -82,9 +82,8 @@ function WritingMedia( props ) {
 			>
 				<p>
 					{ __(
-						'Create full-screen carousel slideshows for the images in your ' +
-							'posts and pages. Carousel galleries are mobile-friendly and ' +
-							'encourage site visitors to interact with your photos.'
+						'Create full-screen carousel slideshows for the images in your posts and pages. Carousel galleries are mobile-friendly and encourage site visitors to interact with your photos.',
+						'jetpack'
 					) }
 				</p>
 				<ModuleToggle
@@ -94,7 +93,7 @@ function WritingMedia( props ) {
 					toggleModule={ props.toggleModuleNow }
 				>
 					<span className="jp-form-toggle-explanation">
-						{ __( 'Display images in a full-screen carousel gallery' ) }
+						{ __( 'Display images in a full-screen carousel gallery', 'jetpack' ) }
 					</span>
 				</ModuleToggle>
 				<FormFieldset>
@@ -102,24 +101,25 @@ function WritingMedia( props ) {
 						displayExif,
 						'carousel_display_exif',
 						handleCarouselDisplayExifChange,
-						__( 'Show photo Exif metadata in carousel (when available)' )
+						__( 'Show photo Exif metadata in carousel (when available)', 'jetpack' )
 					) }
 					{ renderToggle(
 						displayComments,
 						'carousel_display_comments',
 						handleCarouselDisplayCommentsChange,
-						__( 'Show comments area in carousel' )
+						__( 'Show comments area in carousel', 'jetpack' )
 					) }
 					<FormFieldset>
 						<p className="jp-form-setting-explanation">
 							{ __(
-								'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.'
+								'Exif data shows viewers additional technical details of a photo, like its focal length, aperture, and ISO.',
+								'jetpack'
 							) }
 						</p>
 					</FormFieldset>
 					<FormLabel>
 						<FormLegend className="jp-form-label-wide">
-							{ __( 'Carousel color scheme' ) }
+							{ __( 'Carousel color scheme', 'jetpack' ) }
 						</FormLegend>
 						<FormSelect
 							name={ 'carousel_background_color' }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This is part 6, follow-up of #13527. We're moving away from `translate` and using the `@wordpress/i18n` package instead.

This PR focusses on updating the last pieces of the dashboard:

- Sharing settings
- Traffic settings
- Writing settings
- State

**Note: this PR is open against the branch used for part 1 in #13527 for now, hence the "Do not merge" label. Once the other PR is merged I'll update the base branch for this PR.**

#### Jetpack product discussion

* p1HpG7-99c-p2
* Primary issue: #16481 

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

Nothing should change at first sight.

* Check the Sharing, Traffic, and Writing settings pages.
* Try turning modules on and off, changing feature settings.

#### Proposed changelog entry for your changes:

* TBD