### PR TITLE
Admin Page: lint all files for @wordpress/i18n errors

### DIFF
--- a/_inc/client/.eslintrc.js
+++ b/_inc/client/.eslintrc.js
@@ -2,5 +2,5 @@ module.exports = {
 	// Use root level ESlint configuration.
 	// JavaScript files inside this folder are meant to be transpiled by Webpack.
 	root: true,
-	extends: [ '../../.eslintrc.js' ],
+	extends: [ '../../.eslintrc.js', 'plugin:@wordpress/eslint-plugin/i18n' ],
 };

--- a/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
+++ b/_inc/client/at-a-glance/stats/dash-stats-bottom.jsx
@@ -74,6 +74,7 @@ class DashStatsBottom extends Component {
 							{ '-' === s.bestDay.count
 								? '-'
 								: sprintf(
+										/* Translators: placeholder is a number of views. */
 										_n( '%s View', '%s Views', s.bestDay.count, 'jetpack' ),
 										numberFormat( s.bestDay.count )
 								  ) }

--- a/_inc/client/components/footer/index.jsx
+++ b/_inc/client/components/footer/index.jsx
@@ -214,7 +214,13 @@ export class Footer extends React.Component {
 							className="jp-footer__link"
 							title={ __( 'Jetpack version', 'jetpack' ) }
 						>
-							{ version ? sprintf( __( 'Jetpack version %s', 'jetpack' ), version ) : 'Jetpack' }
+							{ version
+								? sprintf(
+										/* Translators: placeholder is a version number. */
+										__( 'Jetpack version %s', 'jetpack' ),
+										version
+								  )
+								: 'Jetpack' }
 						</a>
 					</li>
 					<li className="jp-footer__link-item">

--- a/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -117,7 +117,7 @@ class JetpackStateNotices extends React.Component {
 			case 'wpcom_bad_response':
 			case 'wpcom_outage':
 				message = __(
-					'WordPress.com is currently having problems and is unable to fuel up your Jetpack.  Please try again later.',
+					'WordPress.com is currently having problems and is unable to fuel up your Jetpack. Please try again later.',
 					'jetpack'
 				);
 				break;
@@ -126,7 +126,7 @@ class JetpackStateNotices extends React.Component {
 				message = sprintf(
 					/* translators: placeholder is an error code and message. */
 					__(
-						'Jetpack could not contact WordPress.com: %s.  This usually means something is incorrectly configured on your web host.',
+						'Jetpack could not contact WordPress.com: %s. This usually means something is incorrectly configured on your web host.',
 						'jetpack'
 					),
 					key
@@ -167,7 +167,7 @@ class JetpackStateNotices extends React.Component {
 					sprintf(
 						/* translators: placeholder is an error code and message. */
 						__(
-							'<s>Your Jetpack has a glitch.</s>  We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
+							'<s>Your Jetpack has a glitch.</s> We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
 							'jetpack'
 						),
 						key

--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -177,6 +177,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 						<div>
 							<strong>
 								{ sprintf(
+									/* Translators: placeholder is a number (of threats). */
 									_n( 'Uh oh, %s threat found.', 'Uh oh, %s threats found.', threats, 'jetpack' ),
 									numberFormat( threats )
 								) }

--- a/_inc/client/setup-wizard/updates-question/index.jsx
+++ b/_inc/client/setup-wizard/updates-question/index.jsx
@@ -57,6 +57,7 @@ let UpdatesQuestion = props => {
 			/>
 			<h1>
 				{ sprintf(
+					/* Translators: placeholder is the name of the site. */
 					__( 'Will %s have blog posts, news, or regular updates?', 'jetpack' ),
 					props.siteTitle
 				) }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

Now that we're using core WordPress translation functions, let's add linting to ensure that we use those functions properly.

* Primary issue: #16481 

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

* Does the linting test pass?

#### Proposed changelog entry for your changes:
* N/A
