### PR TITLE
blog token self-healing

### DIFF
--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -86,7 +86,9 @@ class Manager {
 		$manager->setup_xmlrpc_handlers(
 			$_GET, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$manager->is_active(),
-			$manager->verify_xml_rpc_signature()
+			$manager->verify_xml_rpc_signature(),
+			null,
+			$manager->is_registered()
 		);
 
 		$manager->error_handler = Error_Handler::get_instance();
@@ -114,12 +116,14 @@ class Manager {
 	 * @param Boolean                $is_active whether the connection is currently active.
 	 * @param Boolean                $is_signed whether the signature check has been successful.
 	 * @param \Jetpack_XMLRPC_Server $xmlrpc_server (optional) an instance of the server to use instead of instantiating a new one.
+	 * @param Boolean                $is_registered whether the connection is currently registered (has a blog token).
 	 */
 	public function setup_xmlrpc_handlers(
 		$request_params,
 		$is_active,
 		$is_signed,
-		\Jetpack_XMLRPC_Server $xmlrpc_server = null
+		\Jetpack_XMLRPC_Server $xmlrpc_server = null,
+		$is_registered = false
 	) {
 		add_filter( 'xmlrpc_blog_options', array( $this, 'xmlrpc_options' ), 1000, 2 );
 
@@ -159,7 +163,7 @@ class Manager {
 
 		$this->require_jetpack_authentication();
 
-		if ( $is_active ) {
+		if ( $is_active && $is_registered ) {
 			// Hack to preserve $HTTP_RAW_POST_DATA.
 			add_filter( 'xmlrpc_methods', array( $this, 'xmlrpc_methods' ) );
 

--- a/packages/connection/src/error-handlers/class-invalid-blog-token.php
+++ b/packages/connection/src/error-handlers/class-invalid-blog-token.php
@@ -12,7 +12,7 @@ use Automattic\Jetpack\Connection\Error_Handler;
 
 /**
  * This class handles all the error codes that indicates a broken blog token and
- * tries to self-heal and display an error message to the suer suggesting to reconnect.
+ * tries to self-heal and display an error message to the user suggesting to reconnect.
  *
  * @since 8.7.0
  */

--- a/packages/connection/src/error-handlers/class-invalid-blog-token.php
+++ b/packages/connection/src/error-handlers/class-invalid-blog-token.php
@@ -124,19 +124,6 @@ class Invalid_Blog_Token {
 	}
 
 	/**
-	 * Gets the number of times this blog attempted to regenerate the blog token
-	 * and updates it in the database
-	 *
-	 * @return integer
-	 */
-	public function get_heal_attempts() {
-		$attempts = (int) get_option( $this->attempts_option_name );
-		$attempts ++;
-		update_option( $this->attempts_option_name, $attempts );
-		return $attempts;
-	}
-
-	/**
 	 * Lock attempts
 	 *
 	 * @return void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Attempts to regenerate the blog token after the site triggered an XML-RPC error indicating that its token is missing or invalid.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

After #16194 and Jetpack 8.7 we are able to confirm that the user is having problems with its connection. More specifically, we are able to know that the blog token is missing or invalid.

Since registering the site doesn't require any user interaction, assuming the user has accepted TOS before, we can attempt to self-heal and refresh the blog token.

This PR will try to re-register the site 3 times after an error is confirmed.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a new connected site
* Activate the Jetpack Debug helper plugin (available by default in the docker env) 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. --> (https://github.com/automattic/jetpack-debug-helper)
* Go to Jetpack > Debug tools and activate the "Broken token module"
* Go to Jetpack > Broken token
* Click the "Clear blog token" button
* Go to Jetpack > XML-RPC errors
* Click the "Jetpack Debugger" link to open the jetpack debugger for your site
* Refresh any admin page
* Go to Jetpack > Broken token
* Confirm that the blog token stored in the database has been restored.
