### PR TITLE
Contact Form: add a CRM Connection setting

### DIFF
--- a/extensions/blocks/contact-form/attributes.js
+++ b/extensions/blocks/contact-form/attributes.js
@@ -23,4 +23,8 @@ export default {
 		type: 'string',
 		default: '',
 	},
+	jetpackCRM: {
+		type: 'boolean',
+		default: true,
+	},
 };

--- a/extensions/blocks/contact-form/components/jetpack-crm-connection-settings.js
+++ b/extensions/blocks/contact-form/components/jetpack-crm-connection-settings.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { get } from 'lodash';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { BaseControl, ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
+import semver from 'semver';
+
+function CRMConnectionSettings( props ) {
+	const pluginState = Object.freeze( {
+		ACTIVE: 1,
+		INSTALLED: 2,
+		NOT_INSTALLED: 3,
+	} );
+
+	const { jetpackCRM, setAttributes } = props;
+
+	const [ isFetchingPlugins, setIsFetchingPlugins ] = useState( false );
+	const [ plugins, setPlugins ] = useState( null );
+	const [ error, setError ] = useState( null );
+
+	useEffect( () => {
+		setIsFetchingPlugins( true );
+
+		apiFetch( {
+			path: '/jetpack/v4/plugins',
+		} )
+			.then( result => {
+				if ( result.error ) {
+					throw result.message;
+				}
+
+				setPlugins( result );
+			} )
+			.catch( () => setError( true ) )
+			.finally( () => setIsFetchingPlugins( false ) );
+	}, [] );
+
+	let jetpackCRMPlugin = pluginState.NOT_INSTALLED;
+	let jetpackCRMVersion = null;
+
+	if ( get( plugins, [ 'zero-bs-crm/ZeroBSCRM.php' ] ) ) {
+		jetpackCRMVersion = semver.coerce( get( plugins, [ 'zero-bs-crm/ZeroBSCRM.php', 'Version' ] ) );
+
+		if ( get( plugins, [ 'zero-bs-crm/ZeroBSCRM.php', 'active' ] ) ) {
+			jetpackCRMPlugin = pluginState.ACTIVE;
+		} else {
+			jetpackCRMPlugin = pluginState.INSTALLED;
+		}
+	}
+
+	const getText = () => {
+		if ( jetpackCRMVersion ) {
+			if ( semver.lt( jetpackCRMVersion, '3.0.19' ) ) {
+				return (
+					<p>
+						{ __(
+							'The Zero BS CRM plugin is now Jetpack CRM. Update to the latest version to integrate your contact form with your CRM.',
+							'jetpack'
+						) }
+					</p>
+				);
+			}
+
+			if ( pluginState.ACTIVE === jetpackCRMPlugin ) {
+				return (
+					<div>
+						<p>
+							{ __(
+								'You can save contacts from this contact form in your Jetpack CRM.',
+								'jetpack'
+							) }
+						</p>
+						<p>
+							{ __(
+								'Make sure the Jetpack Contact Form Extension is enabled in Jetpack CRM.',
+								'jetpack'
+							) }
+						</p>
+					</div>
+				);
+			} else if ( pluginState.INSTALLED === jetpackCRMPlugin ) {
+				return (
+					<p>
+						{ __(
+							'Activate Jetpack CRM to save contacts from this contact form in your Jetpack CRM.',
+							'jetpack'
+						) }
+					</p>
+				);
+			}
+		}
+
+		// Either no valid version or Jetpack CRM is not installed.
+		return (
+			<p>
+				{ __(
+					'You can save contacts from Jetpack contact forms in Jetpack CRM. Learn more at ',
+					'jetpack'
+				) }
+				<ExternalLink href="https://jetpackcrm.com">jetpackcrm.com</ExternalLink>
+			</p>
+		);
+	};
+
+	const shouldDisplayToggle = () => {
+		if ( pluginState.ACTIVE !== jetpackCRMPlugin || ! jetpackCRMVersion ) {
+			return false;
+		}
+
+		return semver.gt( jetpackCRMVersion, '4.0.0' );
+	};
+
+	return (
+		<BaseControl>
+			{ isFetchingPlugins && <Spinner /> }
+
+			{ shouldDisplayToggle() && (
+				<ToggleControl
+					label={ __( 'CRM Connection', 'jetpack' ) }
+					checked={ jetpackCRM }
+					onChange={ value => setAttributes( { jetpackCRM: value } ) }
+					help={ __( 'Enable and disable Jetpack CRM integration for this form.', 'jetpack' ) }
+				/>
+			) }
+
+			{ ! isFetchingPlugins && ! error && getText() }
+
+			{ error && (
+				<p>{ __( "Couldn't access the plugins. Please try again later.", 'jetpack' ) }</p>
+			) }
+		</BaseControl>
+	);
+}
+
+export default CRMConnectionSettings;

--- a/extensions/blocks/contact-form/edit.js
+++ b/extensions/blocks/contact-form/edit.js
@@ -34,6 +34,7 @@ import {
  */
 import HelpMessage from '../../shared/help-message';
 import defaultVariations from './variations';
+import CRMConnectionSettings from './components/jetpack-crm-connection-settings';
 
 const ALLOWED_BLOCKS = [
 	'jetpack/markdown',
@@ -71,7 +72,14 @@ function JetpackContactFormEdit( {
 	variations,
 	defaultVariation,
 } ) {
-	const { to, subject, customThankyou, customThankyouMessage, customThankyouRedirect } = attributes;
+	const {
+		to,
+		subject,
+		customThankyou,
+		customThankyouMessage,
+		customThankyouRedirect,
+		jetpackCRM,
+	} = attributes;
 
 	const [ emailErrors, setEmailErrors ] = useState( false );
 	const formClassnames = classnames( className, 'jetpack-contact-form' );
@@ -311,6 +319,9 @@ function JetpackContactFormEdit( {
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Form Settings', 'jetpack' ) }>{ renderFormSettings() }</PanelBody>
+				<PanelBody title={ __( 'CRM Integration', 'jetpack' ) } initialOpen={ false }>
+					<CRMConnectionSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
+				</PanelBody>
 			</InspectorControls>
 
 			<div className={ formClassnames }>

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -1844,7 +1844,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		$this->hash                 = sha1( json_encode( $attributes ) . $content );
 		self::$forms[ $this->hash ] = $this;
 
-		// Set up the default subject and recipient for this form
+		// Set up the default subject and recipient for this form.
 		$default_to      = '';
 		$default_subject = '[' . get_option( 'blogname' ) . ']';
 
@@ -1863,7 +1863,7 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$default_to      .= $post_author->user_email;
 		}
 
-		// Keep reference to $this for parsing form fields
+		// Keep reference to $this for parsing form fields.
 		self::$current_form = $this;
 
 		$this->defaults = array(
@@ -1877,18 +1877,19 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			'customThankyou'         => '', // Whether to show a custom thankyou response after submitting a form. '' for no, 'message' for a custom message, 'redirect' to redirect to a new URL.
 			'customThankyouMessage'  => __( 'Thank you for your submission!', 'jetpack' ), // The message to show when customThankyou is set to 'message'.
 			'customThankyouRedirect' => '', // The URL to redirect to when customThankyou is set to 'redirect'.
+			'jetpackCRM'             => true, // Whether Jetpack CRM should store the form submission.
 		);
 
 		$attributes = shortcode_atts( $this->defaults, $attributes, 'contact-form' );
 
-		// We only enable the contact-field shortcode temporarily while processing the contact-form shortcode
+		// We only enable the contact-field shortcode temporarily while processing the contact-form shortcode.
 		Grunion_Contact_Form_Plugin::$using_contact_form_field = true;
 
 		parent::__construct( $attributes, $content );
 
 		// There were no fields in the contact form. The form was probably just [contact-form /]. Build a default form.
 		if ( empty( $this->fields ) ) {
-			// same as the original Grunion v1 form
+			// same as the original Grunion v1 form.
 			$default_form = '
 				[contact-field label="' . __( 'Name', 'jetpack' ) . '" type="name"  required="true" /]
 				[contact-field label="' . __( 'Email', 'jetpack' ) . '" type="email" required="true" /]
@@ -1904,10 +1905,10 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 
 			$this->parse_content( $default_form );
 
-			// Store the shortcode
+			// Store the shortcode.
 			$this->store_shortcode( $default_form, $attributes, $this->hash );
 		} else {
-			// Store the shortcode
+			// Store the shortcode.
 			$this->store_shortcode( $content, $attributes, $this->hash );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Add a CRM Connection setting to the Advanced section in the Contact Form block sidebar. The setting will allow the user to enable and disable the form's integration with a CRM.

#### Jetpack product discussion
* pbhBOz-b7-p2

#### Does this pull request change what data or activity we track or use?
* No.

#### Testing instructions:
##### Test Site
1. Install, activate, and connect this branch.
2. Create a post, add a Jetpack form block, and publish the post. The form must have an email field.

##### Test with CRM <v3.0.19 (no form integration is available)
3. Install Jetpack CRM v3.0.18. (don't activate yet).
4. Navigate to the post created above. Navigate to the form sidebar and open the CRM Integration section. Confirm that it suggests that you update the CRM plugin.
5. Activate Jetpack CRM.
6. Navigate to CRM -> Manage Extensions. Activate the Jetpack Form extension, which is found at the bottom of the page, in the Core Modules section.
7. Navigate to the post created above. Navigate to the form sidebar and open the CRM Integration section. Confirm that it suggests that you update the CRM plugin.
8. Navigate to the form post. Fill out the form and submit it.
9. Navigate to wp-admin -> Feedback and confirm that the form submission is displayed.
10. Confirm that no errors were generated in the console and debug.log.

##### Test with CRM v4.0 (form integration is available)
11. Install Jetpack CRM v4.0. (don't activate yet)
12. Navigate to the post created above. Navigate to the form sidebar and open the CRM Integration section. Confirm that it suggests that you activate the CRM plugin.
13. Activate Jetpack CRM.
14. Navigate to CRM -> Manage Extensions. Activate the Jetpack Form extension, which is found at the bottom of the page, in the Core Modules section.
15. Navigate to the post created above. Navigate to the form sidebar and open the CRM Integration section. Confirm that it informs you that the form can be integrated with the CRM.
16. Navigate to the form post. Fill out the form and submit it.
17. Navigate to wp-admin -> Feedback and confirm that the form submission is displayed.
18. Navigate to CRM -> contacts. Confirm that a new contact was created with the email address that you submitted.
19. Confirm that no errors were generated in the console and debug.log.


##### Test with [Jetpack CRM PR 756](https://github.com/Automattic/zero-bs-crm/pull/756)
20. Install and activate the Jetpack CRM branch in PR 756.
21. Manually change the Jetpack CRM plugin version so something greater than 4.0.
21. Navigate to CRM -> Manage Extensions. Activate the Jetpack Form extension, which is found at the bottom of the page, in the Core Modules section.

###### Test with the toggle switch on.
23. Navigate to the post created above. Navigate to the form sidebar and open the CRM Integration section. Confirm that it informs you that the form can be integrated with the CRM. Also, a toggle switch should be displayed, and it should default to 'on'.
24. Navigate to the form post. Fill out the form and submit it.
25. Navigate to wp-admin -> Feedback and confirm that the form submission is displayed.
26. Navigate to CRM -> contacts. Confirm that a new contact was created with the email address that you submitted.

###### Test with the toggle switch off.
27. Navigate to the post created above. Navigate to the form sidebar and open the CRM Integration section. Turn the toggle switch off.
28. Navigate to the form post. Fill out the form and submit it.
29. Navigate to wp-admin -> Feedback and confirm that the form submission is displayed.
30. Navigate to CRM -> contacts. Confirm that a new contact was not created for the email address that you submitted.
31. Confirm that no errors were generated in the console and debug.log.

#### Proposed changelog entry for your changes:
* tbd
