### PR TITLE
Plans: Add Jetpack Anti-Spam to the Plans page

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7466,7 +7466,7 @@ endif;
 				),
 			),
 			'default_option'    => 'anti-spam',
-			'included_in_plans' => array( 'anti-spam-plan' ),
+			'included_in_plans' => array( 'personal-plan', 'premium-plan', 'business-plan', 'anti-spam-plan' ),
 		);
 
 		return $products;

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7454,7 +7454,7 @@ endif;
 		$products[] = array(
 			'key'               => 'anti-spam',
 			'title'             => __( 'Jetpack Anti-Spam', 'jetpack' ),
-			'short_description' => __( 'Automatically clear spam from comments and forms.', 'jetpack' ),
+			'short_description' => __( 'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.', 'jetpack' ),
 			'learn_more'        => __( 'Learn More', 'jetpack' ),
 			'description'       => __( 'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.', 'jetpack' ),
 			'options'           => array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7451,6 +7451,24 @@ endif;
 			'included_in_plans' => array( 'search-plan' ),
 		);
 
+		$products[] = array(
+			'key'               => 'anti-spam',
+			'title'             => __( 'Jetpack Anti-Spam', 'jetpack' ),
+			'short_description' => __( 'Automatically clear spam from comments and forms.', 'jetpack' ),
+			'learn_more'        => __( 'Learn More', 'jetpack' ),
+			'description'       => __( 'Automatically clear spam from comments and forms. Save time, get more responses, give your visitors a better experience – all without lifting a finger.', 'jetpack' ),
+			'options'           => array(
+				array(
+					'type'      => 'anti-spam',
+					'slug'      => 'jetpack-anti-spam',
+					'key'       => 'jetpack_anti_spam',
+					'name'      => __( 'Anti-Spam', 'jetpack' ),
+				),
+			),
+			'default_option'    => 'anti-spam',
+			'included_in_plans' => array( 'anti-spam-plan' ),
+		);
+
 		return $products;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add Jetpack Anti-Spam product as a new Jetpack product so users can purchase it from the Plans page.

#### Jetpack product discussion

* Ticket: 1181531115069428-as-1182646983386225

#### Does this pull request change what data or activity we track or use?

* No. It doesn't change what we currently track or use.

#### Testing instructions:

* Run this PR locally or use Jetpack Beta Tester plugin.
* Select a site that doesn't have Jetpack Anti-Spam.
* Go to Jetpack Dashboard -> Plans.
* Verify that you see Jetpack Anti-Spam card.
* Verify that you can purchase Jetpack Anti-Spam monthly and Jetpack Anti-Spam yearly subscriptions.

![image](https://user-images.githubusercontent.com/3418513/87962804-28fc1f80-ca8e-11ea-91fc-fb696c8f9a34.png)

#### Proposed changelog entry for your changes:
* Add Jetpack Anti-Spam to the Plans page so users can purchase it.
