### PR TITLE
JSDoc Comments: Fix eslint warnings

### DIFF
--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -23,8 +23,8 @@ const betaExtensions = extensionList.beta || [];
 /**
  * Checks whether the block requires a paid plan or not.
  *
- * @param {string} unavailableReason The reason why block is unavailable
- * @param {Object} details The block details
+ * @param {string} unavailableReason - The reason why block is unavailable
+ * @param {object} details - The block details
  * @returns {string|boolean} Either false if the block doesn't require a paid plan, or the actual plan name it requires.
  */
 function requiresPaidPlan( unavailableReason, details ) {
@@ -37,9 +37,9 @@ function requiresPaidPlan( unavailableReason, details ) {
 /**
  * Builds an array of tags associated with this block, such as ["paid", "beta"].
  *
- * @param {string} name The block's name.
- * @param {string|boolean} requiredPlan  Does this block require a paid plan?
- * @returns {array} Array of tags associated with this block
+ * @param {string} name - The block's name.
+ * @param {string|boolean} requiredPlan -  Does this block require a paid plan?
+ * @returns {Array} Array of tags associated with this block
  */
 function buildBlockTags( name, requiredPlan ) {
 	const blockTags = [];
@@ -57,8 +57,8 @@ function buildBlockTags( name, requiredPlan ) {
 /**
  * Takes a block title string and optionally appends comma separated block tags in parentheses.
  *
- * @param {string} blockTitle The block's title
- * @param {array} blockTags The tags you want appended in parentheses (tags, show, here)
+ * @param {string} blockTitle - The block's title
+ * @param {Array} blockTags - The tags you want appended in parentheses (tags, show, here)
  * @returns {string} Block title
  */
 function buildBlockTitle( blockTitle, blockTags = [] ) {
@@ -72,10 +72,10 @@ function buildBlockTitle( blockTitle, blockTags = [] ) {
 /**
  * Registers a gutenberg block if the availability requirements are met.
  *
- * @param {string} name The block's name.
- * @param {object} settings The block's settings.
- * @param {object} childBlocks The block's child blocks.
- * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
+ * @param {string} name - The block's name.
+ * @param {object} settings - The block's settings.
+ * @param {object} childBlocks - The block's child blocks.
+ * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
 	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );

--- a/extensions/shared/register-jetpack-block.native.js
+++ b/extensions/shared/register-jetpack-block.native.js
@@ -21,10 +21,10 @@ function requiresPlan( unavailableReason, details ) {
 /**
  * Registers a gutenberg block if the availability requirements are met.
  *
- * @param {string} name The block's name.
- * @param {object} settings The block's settings.
- * @param {object} childBlocks The block's child blocks.
- * @returns {object|false} Either false if the block is not available, or the results of `registerBlockType`
+ * @param {string} name - The block's name.
+ * @param {object} settings - The block's settings.
+ * @param {object} childBlocks - The block's child blocks.
+ * @returns {object|boolean} Either false if the block is not available, or the results of `registerBlockType`
  */
 export default function registerJetpackBlock( name, settings, childBlocks = [] ) {
 	const { available, details, unavailableReason } = getJetpackExtensionAvailability( name );

--- a/extensions/shared/register-jetpack-plugin.js
+++ b/extensions/shared/register-jetpack-plugin.js
@@ -11,9 +11,9 @@ import getJetpackExtensionAvailability from './get-jetpack-extension-availabilit
 /**
  * Registers a Gutenberg block if the availability requirements are met.
  *
- * @param {string} name The plugin's name
- * @param {object} settings The plugin's settings.
- * @returns {object|false} Either false if the plugin is not available, or the results of `registerPlugin`
+ * @param {string} name - The plugin's name
+ * @param {object} settings - The plugin's settings.
+ * @returns {object|boolean} Either false if the plugin is not available, or the results of `registerPlugin`
  */
 export default function registerJetpackPlugin( name, settings ) {
 	const { available, unavailableReason } = getJetpackExtensionAvailability( name );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Fixes 22 eslint warnings.
- All changes are within comments, so there are no functional changes.
- These fixes were made by `eslint --fix`, which automatically fixes errors.
- Exception: for jsdoc/no-undefined-types, the "false" type was changed
  to "boolean".  See https://github.com/gajus/eslint-plugin-jsdoc#eslint-plugin-jsdoc-rules-no-undefined-types

```
These warnings were present before this commit:

/home/matta8c/h20/dev/jetpack/extensions/shared/register-jetpack-block.js
  26:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  27:0  warning  Invalid JSDoc @param "details" type "Object"; prefer: "object"  jsdoc/check-types
  27:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  40:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  41:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  42:0  warning  Invalid JSDoc @returns type "array"; prefer: "Array"            jsdoc/check-types
  42:0  warning  The type 'array' is undefined                                   jsdoc/no-undefined-types
  60:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  61:0  warning  The type 'array' is undefined                                   jsdoc/no-undefined-types
  61:0  warning  Invalid JSDoc @param "blockTags" type "array"; prefer: "Array"  jsdoc/check-types
  61:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  75:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  76:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  77:0  warning  There must be a hyphen before @param description                jsdoc/require-hyphen-before-param-description
  78:0  warning  The type 'false' is undefined                                   jsdoc/no-undefined-types

/home/matta8c/h20/dev/jetpack/extensions/shared/register-jetpack-block.native.js
  24:0  warning  There must be a hyphen before @param description  jsdoc/require-hyphen-before-param-description
  25:0  warning  There must be a hyphen before @param description  jsdoc/require-hyphen-before-param-description
  26:0  warning  There must be a hyphen before @param description  jsdoc/require-hyphen-before-param-description
  27:0  warning  The type 'false' is undefined                     jsdoc/no-undefined-types

/home/matta8c/h20/dev/jetpack/extensions/shared/register-jetpack-plugin.js
  14:0  warning  There must be a hyphen before @param description  jsdoc/require-hyphen-before-param-description
  15:0  warning  There must be a hyphen before @param description  jsdoc/require-hyphen-before-param-description
  16:0  warning  The type 'false' is undefined                     jsdoc/no-undefined-types
```

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->



<!--- Explain what functional changes your PR includes -->


#### Jetpack product discussion

N/A

#### Does this pull request change what data or activity we track or use?

No

#### Testing instructions:

No functional changes.  No testing required.

#### Proposed changelog entry for your changes:

No changelog entry needed.