### PR TITLE
Cover: improve extending core/cover block implementation

### DIFF
--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -1,4 +1,3 @@
-
 /**
  * WordPress dependencies
  */
@@ -25,8 +24,8 @@ import UpgradeNudge from '../../components/upgrade-nudge';
  * @returns {*} Nudge component or Null.
  */
 export const JetpackCoverUpgradeNudge = ( { name, show, align } ) =>
-	show
-		? <div className="jetpack-upgrade-nudge-wrapper wp-block" data-align={ align }>
+	show ? (
+		<div className="jetpack-upgrade-nudge-wrapper wp-block" data-align={ align }>
 			<UpgradeNudge
 				plan="value_bundle"
 				blockName={ name }
@@ -37,7 +36,7 @@ export const JetpackCoverUpgradeNudge = ( { name, show, align } ) =>
 				subtitle={ false }
 			/>
 		</div>
-		: null;
+	) : null;
 
 /**
  * Cover Media context
@@ -56,7 +55,10 @@ export const CoverMediaContext = createContext();
  * @returns {*} Provider component.
  */
 export const CoverMediaProvider = ( { onFilesUpload, blockName, children } ) => {
-	const memoContextProperties = useMemo( () => ( { onFilesUpload, blockName } ), [ onFilesUpload, blockName ] );
+	const memoContextProperties = useMemo( () => ( { onFilesUpload, blockName } ), [
+		onFilesUpload,
+		blockName,
+	] );
 
 	return (
 		<CoverMediaContext.Provider value={ memoContextProperties }>

--- a/extensions/shared/blocks/cover/components.js
+++ b/extensions/shared/blocks/cover/components.js
@@ -3,7 +3,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createContext } from '@wordpress/element';
+import { createContext, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -55,9 +55,11 @@ export const CoverMediaContext = createContext();
  * @param {boolean} props.children - Provider Children.
  * @returns {*} Provider component.
  */
-export const CoverMediaProvider = ( { onFilesUpload, children } ) => {
+export const CoverMediaProvider = ( { onFilesUpload, blockName, children } ) => {
+	const memoContextProperties = useMemo( () => ( { onFilesUpload, blockName } ), [ onFilesUpload, blockName ] );
+
 	return (
-		<CoverMediaContext.Provider value={ onFilesUpload }>
+		<CoverMediaContext.Provider value={ memoContextProperties }>
 			{ children }
 		</CoverMediaContext.Provider>
 	);

--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -8,17 +8,26 @@ import { useContext, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isVideoFile } from './utils';
+import { isUpgradable, isVideoFile } from './utils';
 import { CoverMediaContext } from './components';
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
-		const { name } = useBlockEditContext();
-		if ( 'core/cover' !== name ) {
+		/*
+		 * Data provided by the cover media context could be undefined.
+		 * We need to check data exists before proceeding.
+		 */
+		const coverMediaProvidedData = useContext( CoverMediaContext );
+		if ( ! coverMediaProvidedData ) {
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 
-		const onFilesUpload = useContext( CoverMediaContext );
+		// Check if the block is upgradable before to proceeding.
+		const { onFilesUpload, blockName: name } = coverMediaProvidedData;
+		if ( ! isUpgradable( name ) ) {
+			return <CoreMediaPlaceholder { ...props } />;
+		}
+
 		const { onError } = props;
 
 		/**

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -14,39 +14,42 @@ import { useRef, useContext } from '@wordpress/element';
 import { CoverMediaContext } from './components';
 import { isUpgradable, isVideoFile } from './utils';
 
-export default createHigherOrderComponent( MediaReplaceFlow => props => {
-	const preUploadFile = useRef();
-	/*
-	 * Data provided by the cover media context could be undefined.
-	 * We need to check data exists before proceeding.
-	 */
-	const coverMediaProvidedData = useContext( CoverMediaContext );
-	if ( ! coverMediaProvidedData ) {
-		return <MediaReplaceFlow { ...props } />;
-	}
+export default createHigherOrderComponent(
+	MediaReplaceFlow => props => {
+		const preUploadFile = useRef();
+		/*
+		 * Data provided by the cover media context could be undefined.
+		 * We need to check data exists before proceeding.
+		 */
+		const coverMediaProvidedData = useContext( CoverMediaContext );
+		if ( ! coverMediaProvidedData ) {
+			return <MediaReplaceFlow { ...props } />;
+		}
 
-	// Check if the block is upgradable before to proceeding.
-	const { onFilesUpload, blockName: name } = coverMediaProvidedData;
-	if ( ! isUpgradable( name ) ) {
-		return <MediaReplaceFlow { ...props } />;
-	}
+		// Check if the block is upgradable before to proceeding.
+		const { onFilesUpload, blockName: name } = coverMediaProvidedData;
+		if ( ! isUpgradable( name ) ) {
+			return <MediaReplaceFlow { ...props } />;
+		}
 
-	return (
-		<MediaReplaceFlow
-			{ ...props }
-			onFilesUpload={ ( files ) => {
-				preUploadFile.current = files?.length ? files[ 0 ] : null;
-				onFilesUpload( files );
-			} }
-			createNotice={ ( status, msg, options ) => {
-				// Detect video file from callback and reference instance.
-				if ( isVideoFile( preUploadFile.current ) ) {
-					preUploadFile.current = null; // clean up the file reference.
-					return null;
-				}
+		return (
+			<MediaReplaceFlow
+				{ ...props }
+				onFilesUpload={ files => {
+					preUploadFile.current = files?.length ? files[ 0 ] : null;
+					onFilesUpload( files );
+				} }
+				createNotice={ ( status, msg, options ) => {
+					// Detect video file from callback and reference instance.
+					if ( isVideoFile( preUploadFile.current ) ) {
+						preUploadFile.current = null; // clean up the file reference.
+						return null;
+					}
 
-				props.createNotice( status, msg, options );
-			} }
-		/>
-	);
-}, 'JetpackCoverMediaReplaceFlow' );
+					props.createNotice( status, msg, options );
+				} }
+			/>
+		);
+	},
+	'JetpackCoverMediaReplaceFlow'
+);

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -6,7 +5,6 @@
 /**
  * WordPress dependencies
  */
-import { useBlockEditContext } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useRef, useContext } from '@wordpress/element';
 
@@ -14,16 +12,24 @@ import { useRef, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { CoverMediaContext } from './components';
-import { isVideoFile } from './utils';
+import { isUpgradable, isVideoFile } from './utils';
 
 export default createHigherOrderComponent( MediaReplaceFlow => props => {
-	const { name } = useBlockEditContext();
 	const preUploadFile = useRef();
-	if ( 'core/cover' !== name ) {
+	/*
+	 * Data provided by the cover media context could be undefined.
+	 * We need to check data exists before proceeding.
+	 */
+	const coverMediaProvidedData = useContext( CoverMediaContext );
+	if ( ! coverMediaProvidedData ) {
 		return <MediaReplaceFlow { ...props } />;
 	}
 
-	const onFilesUpload = useContext( CoverMediaContext );
+	// Check if the block is upgradable before to proceeding.
+	const { onFilesUpload, blockName: name } = coverMediaProvidedData;
+	if ( ! isUpgradable( name ) ) {
+		return <MediaReplaceFlow { ...props } />;
+	}
 
 	return (
 		<MediaReplaceFlow

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -10,33 +10,34 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { isUpgradable, isVideoFile } from './utils';
 import { CoverMediaProvider, JetpackCoverUpgradeNudge } from './components';
 
-export const JetpackCoverBlockEdit = ( blockName ) => createHigherOrderComponent(
-	BlockEdit => props => {
-		const [ showNudge, setShowNudge ] = useState( false );
+export const JetpackCoverBlockEdit = blockName =>
+	createHigherOrderComponent(
+		BlockEdit => props => {
+			const [ showNudge, setShowNudge ] = useState( false );
 
-		const { attributes } = props;
+			const { attributes } = props;
 
-		// Remove Nudge if the block changes its attributes.
-		useEffect( () => setShowNudge( false ), [ attributes ] );
+			// Remove Nudge if the block changes its attributes.
+			useEffect( () => setShowNudge( false ), [ attributes ] );
 
-		const handleFilesPreUpload = useCallback( ( files ) => {
-			if ( ! files?.length || ! isVideoFile( files[ 0 ] ) ) {
-				return;
-			}
-			setShowNudge( true );
-		} );
+			const handleFilesPreUpload = useCallback( files => {
+				if ( ! files?.length || ! isVideoFile( files[ 0 ] ) ) {
+					return;
+				}
+				setShowNudge( true );
+			} );
 
-		return (
-			<Fragment>
-				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload } blockName={ blockName }>
-					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ attributes.align } />
-					<BlockEdit { ...props } />
-				</CoverMediaProvider>
-			</Fragment>
-		);
-	},
-	'JetpackCoverBlockEdit'
-);
+			return (
+				<Fragment>
+					<CoverMediaProvider onFilesUpload={ handleFilesPreUpload } blockName={ blockName }>
+						<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ attributes.align } />
+						<BlockEdit { ...props } />
+					</CoverMediaProvider>
+				</Fragment>
+			);
+		},
+		'JetpackCoverBlockEdit'
+	);
 
 export default ( settings, name ) => ( {
 	...settings,

--- a/extensions/shared/blocks/cover/edit.js
+++ b/extensions/shared/blocks/cover/edit.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useBlockEditContext } from '@wordpress/block-editor';
 import { useEffect, useState, Fragment, useCallback } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
@@ -11,7 +10,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
 import { isUpgradable, isVideoFile } from './utils';
 import { CoverMediaProvider, JetpackCoverUpgradeNudge } from './components';
 
-export default createHigherOrderComponent(
+export const JetpackCoverBlockEdit = ( blockName ) => createHigherOrderComponent(
 	BlockEdit => props => {
 		const [ showNudge, setShowNudge ] = useState( false );
 
@@ -27,14 +26,9 @@ export default createHigherOrderComponent(
 			setShowNudge( true );
 		} );
 
-		const { name } = useBlockEditContext();
-		if ( ! isUpgradable( name ) ) {
-			return <BlockEdit { ...props } />;
-		}
-
 		return (
 			<Fragment>
-				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload }>
+				<CoverMediaProvider onFilesUpload={ handleFilesPreUpload } blockName={ blockName }>
 					<JetpackCoverUpgradeNudge show={ showNudge } name={ name } align={ attributes.align } />
 					<BlockEdit { ...props } />
 				</CoverMediaProvider>
@@ -43,3 +37,8 @@ export default createHigherOrderComponent(
 	},
 	'JetpackCoverBlockEdit'
 );
+
+export default ( settings, name ) => ( {
+	...settings,
+	edit: isUpgradable( name ) ? JetpackCoverBlockEdit( name )( settings.edit ) : settings.edit,
+} );

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -17,6 +17,9 @@ import './editor.scss';
 
 // Take the control of the Replace block button control.
 addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );
-addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+addFilter(
+	'editor.MediaPlaceholder',
+	'jetpack/cover-edit-media-placeholder',
+	coverEditMediaPlaceholder
+);
 addFilter( 'blocks.registerBlockType', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
-

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -13,29 +13,10 @@ import { addFilter } from '@wordpress/hooks';
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import coverMediaReplaceFlow from './cover-replace-control-button';
 import jetpackCoverBlockEdit from './edit';
-import { isUpgradable } from './utils';
 import './editor.scss';
 
-const addVideoUploadPlanCheck = ( settings, name ) => {
-	if ( ! settings.isDeprecation && isUpgradable( name ) ) {
-		// Take the control of MediaPlaceholder.
-		addFilter(
-			'editor.MediaPlaceholder',
-			'jetpack/cover-edit-media-placeholder',
-			coverEditMediaPlaceholder
-		);
+// Take the control of the Replace block button control.
+addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );
+addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
+addFilter( 'blocks.registerBlockType', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
 
-		// Take the control of the Replace block button control.
-		addFilter(
-			'editor.MediaReplaceFlow',
-			'jetpack/cover-media-replace-flow',
-			coverMediaReplaceFlow
-		);
-
-		// Extend Core CoverEditBlock.
-		addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
-	}
-
-	return settings;
-};
-addFilter( 'blocks.registerBlockType', 'core/cover', addVideoUploadPlanCheck );

--- a/extensions/shared/get-allowed-mime-types.js
+++ b/extensions/shared/get-allowed-mime-types.js
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -21,7 +20,7 @@ export function getAllowedVideoTypesByType( mimeType ) {
 	if ( ! mimeType ) {
 		return {};
 	}
-	return pickBy( getAllowedMimeTypesBySite(), ( type ) => startsWith( type, `${ mimeType }/` ) );
+	return pickBy( getAllowedMimeTypesBySite(), type => startsWith( type, `${ mimeType }/` ) );
 }
 
 /**
@@ -38,7 +37,7 @@ export function pickFileExtensionsFromMimeTypes( mimeTypesObject ) {
 	if ( ! mimeTypesObject ) {
 		return [];
 	}
-	return flatten( map( keys( mimeTypesObject ), ( ext ) => ext.split( '|' ) ) );
+	return flatten( map( keys( mimeTypesObject ), ext => ext.split( '|' ) ) );
 }
 
 /**
@@ -49,4 +48,3 @@ export function pickFileExtensionsFromMimeTypes( mimeTypesObject ) {
 export default function getAllowedMimeTypesBySite() {
 	return get( getJetpackData(), [ 'allowedMimeTypes' ], [] );
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR changes how the `core/cover` block is extending avoiding nesting filters in order to fix the following issue:

### The issue:

In the current implementation, the block is extended nesting filters, something like the following:

```es6
const addVideoUploadPlanCheck = ( settings, name ) => {
	if ( isUpgradable( name ) ) {
		// Take the control of MediaPlaceholder.
		addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );

		// Take control of the Replace block button control.
		addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );

		// Extend Core CoverEditBlock.
		addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
	}

	return settings;
};
addFilter( 'blocks.registerBlockType', 'core/cover', addVideoUploadPlanCheck );
```

The thread calls the nested blocks many times (specifically six times). I've added a console.count out and in of the conditional to count them

```
blocks.registerBlockType: 265
```
```
extending block...: 6
```

It results that the `coverMediaReplaceFlow` function is hooked six times, producing, among other not desired results, the following markdown:

<img src="https://user-images.githubusercontent.com/77539/87978350-a5026180-caa6-11ea-9328-b4fb81b6d166.png" />

I think It even could bring performance issues with the uploading file handler.

### Solution

It moves the hooked functions outside of the wrapper filter trying to ensure do not bind them multiple times. It's applied to `editor.MediaReplaceFlow` and `editor.MediaPlaceholder` filters. This solution was mentioned [in this comment](https://github.com/Automattic/jetpack/pull/16241#issuecomment-647789962), and initially implemented [on this PR](https://github.com/Automattic/jetpack/pull/16240).


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the way that the `core/cover` block is extended changing how the functions are hooked to the filters.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a Simple Site
* Get sandboxed
* Apply these changes (D46635)
* Start to edit a post
* Add a `core/cover` block.
* Inspect the dom tree. Confirm that the MediaPlaceholder element is not rendered multiple times

<img src="https://user-images.githubusercontent.com/77539/87989278-1f87ad00-cab8-11ea-89fc-c117171c0d63.png" width="400px" />


#### Functionallity - MediaPlaceholder

* Try to upload a video file dropping in the drop-zone area. Confirm that it shows the Upgrade Nudge.

<img src="https://user-images.githubusercontent.com/77539/87989354-47771080-cab8-11ea-9e42-723e838ed180.png" width="400px" />


* Try to upload an unsupported file in the same way ^ (`.pdf`, for instance). Confirm you see the error notice.
<img src="https://user-images.githubusercontent.com/77539/87989380-5067e200-cab8-11ea-82fa-08ef279328bb.png" width="400px" />

* Try to upload an image in the same way. It should upload and render the image there.

<img src="https://user-images.githubusercontent.com/77539/87989515-89a05200-cab8-11ea-8956-d1734347849c.png" width="400px" />

#### Functionallity - MediaReplaceFlow

* Once the block already has a background, try to replace it using the `Replace` button. Check same previous steps but using this button. Upload a video, upload an unsupported file, and upload a file.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
