### PR TITLE
Repo Gardening: only assign issues when necessary

### DIFF
--- a/.github/actions/repo-gardening/src/tasks/assign-issues/index.js
+++ b/.github/actions/repo-gardening/src/tasks/assign-issues/index.js
@@ -10,7 +10,7 @@ const debug = require( '../../debug' );
  * @param {GitHub}                    octokit Initialized Octokit REST client.
  */
 async function assignIssues( payload, octokit ) {
-	const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? +(?:\#?|https?:\/\/github\.com\/automattic\/jetpack\/issues\/)(\d+)/gi;
+	const regex = /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved):? +(?:\#{1}|https?:\/\/github\.com\/automattic\/jetpack\/issues\/)(\d+)/gi;
 
 	let match;
 	while ( ( match = regex.exec( payload.pull_request.body ) ) ) {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/16532

#### Changes proposed in this Pull Request:

This avoids assigning unrelated issues to folks who use number in their PRs.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* The associated issue (#16532) does not have a Progress label right now.
* In a minute, I'll add a comment on the issue to mark the time.
* I will then edit this PR to add `Fixes #theissuenumber` 
* The issue should be triggered and the label will be added.

![image](https://user-images.githubusercontent.com/426388/88024592-43d49f80-cb33-11ea-83fe-49c8b639e672.png)


#### Proposed changelog entry for your changes:

* N/A

