### PR TITLE
Debugger: Add blog and master user token healtch checks

### DIFF
--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -168,6 +168,57 @@ class Client {
 	}
 
 	/**
+	 * Fetches a signed token.
+	 *
+	 * @param string $token the token.
+	 * @return string a signed token
+	 */
+	public static function get_signed_token( $token ) {
+		list( $token_key, $token_secret ) = explode( '.', $token->secret );
+
+		$token_key = sprintf(
+			'%s:%d:%d',
+			$token_key,
+			Constants::get_constant( 'JETPACK__API_VERSION' ),
+			$token->external_user_id
+		);
+
+		$timestamp = time();
+
+		if ( function_exists( 'wp_generate_password' ) ) {
+			$nonce = wp_generate_password( 10, false );
+		} else {
+			$nonce = substr( sha1( wp_rand( 0, 1000000 ) ), 0, 10 );
+		}
+
+		$normalized_request_string = join(
+			"\n",
+			array(
+				$token_key,
+				$timestamp,
+				$nonce,
+			)
+		) . "\n";
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		$signature = base64_encode( hash_hmac( 'sha1', $normalized_request_string, $token_secret, true ) );
+
+		$auth = array(
+			'token'     => $token_key,
+			'timestamp' => $timestamp,
+			'nonce'     => $nonce,
+			'signature' => $signature,
+		);
+
+		$header_pieces = array();
+		foreach ( $auth as $key => $value ) {
+			$header_pieces[] = sprintf( '%s="%s"', $key, $value );
+		}
+
+		return join( ' ', $header_pieces );
+	}
+
+	/**
 	 * Wrapper for wp_remote_request().  Turns off SSL verification for certain SSL errors.
 	 * This is lame, but many, many, many hosts have misconfigured SSL.
 	 *


### PR DESCRIPTION
IN PROGRESS

!! Needs D46648-code patch !!

#### Changes proposed in this Pull Request:
* Adds two new health checks in the jetpack Debugger for checking blog and master user token health.

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* In the master branch go to the Jetpack Debugger ( wp-admin/admin.php?page=jetpack-debugger ) and verify there are no errors
* Switch to this branch
* Go to the Jetpack Debugger page again and verify that there are still no errors
* Using the Broken Token plugin, invalidate the **user tokens**
* Go to the Jetpack Debugger page and verify the following error displays:
![Screenshot 2020-07-21 at 1 34 54 PM](https://user-images.githubusercontent.com/1758399/88045072-fbc77400-cb56-11ea-9c51-a426663a67ba.png)

* Using the Broken Token plugin, invalidate the **blog token**
* Go to the Jetpack Debugger page and verify the following error displays:
![Screenshot 2020-07-21 at 1 29 10 PM](https://user-images.githubusercontent.com/1758399/88043591-51e7e780-cb56-11ea-8950-5e6fc1506fb2.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Debugger: Add blog and master user token healtch checks
