### PR TITLE
Core Cover: avoid nesting filters

### DIFF
--- a/extensions/shared/blocks/cover/cover-media-placeholder.js
+++ b/extensions/shared/blocks/cover/cover-media-placeholder.js
@@ -8,13 +8,13 @@ import { useContext, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { isVideoFile } from './utils';
+import { isUpgradable, isVideoFile } from './utils';
 import { CoverMediaContext } from './components';
 
 export default createHigherOrderComponent(
 	CoreMediaPlaceholder => props => {
 		const { name } = useBlockEditContext();
-		if ( 'core/cover' !== name ) {
+		if ( ! isUpgradable( name ) ) {
 			return <CoreMediaPlaceholder { ...props } />;
 		}
 

--- a/extensions/shared/blocks/cover/cover-replace-control-button.js
+++ b/extensions/shared/blocks/cover/cover-replace-control-button.js
@@ -14,12 +14,12 @@ import { useRef, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { CoverMediaContext } from './components';
-import { isVideoFile } from './utils';
+import { isUpgradable, isVideoFile } from './utils';
 
 export default createHigherOrderComponent( MediaReplaceFlow => props => {
 	const { name } = useBlockEditContext();
 	const preUploadFile = useRef();
-	if ( 'core/cover' !== name ) {
+	if ( ! isUpgradable( name ) ) {
 		return <MediaReplaceFlow { ...props } />;
 	}
 

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -15,10 +15,10 @@ import coverMediaReplaceFlow from './cover-replace-control-button';
 import jetpackCoverBlockEdit from './edit';
 import './editor.scss';
 
-// Take the control the Replace block button control.
+// Take control of Replace button.
 addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );
 
-// Take the control oMediaPlaceholder.
+// Take control of MediaPlaceholder.
 addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
 
 // Extend Core CoverEditBlock.

--- a/extensions/shared/blocks/cover/index.js
+++ b/extensions/shared/blocks/cover/index.js
@@ -13,29 +13,13 @@ import { addFilter } from '@wordpress/hooks';
 import coverEditMediaPlaceholder from './cover-media-placeholder';
 import coverMediaReplaceFlow from './cover-replace-control-button';
 import jetpackCoverBlockEdit from './edit';
-import { isUpgradable } from './utils';
 import './editor.scss';
 
-const addVideoUploadPlanCheck = ( settings, name ) => {
-	if ( ! settings.isDeprecation && isUpgradable( name ) ) {
-		// Take the control of MediaPlaceholder.
-		addFilter(
-			'editor.MediaPlaceholder',
-			'jetpack/cover-edit-media-placeholder',
-			coverEditMediaPlaceholder
-		);
+// Take the control the Replace block button control.
+addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );
 
-		// Take the control of the Replace block button control.
-		addFilter(
-			'editor.MediaReplaceFlow',
-			'jetpack/cover-media-replace-flow',
-			coverMediaReplaceFlow
-		);
+// Take the control oMediaPlaceholder.
+addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );
 
-		// Extend Core CoverEditBlock.
-		addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
-	}
-
-	return settings;
-};
-addFilter( 'blocks.registerBlockType', 'core/cover', addVideoUploadPlanCheck );
+// Extend Core CoverEditBlock.
+addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR changes how the `core/cover` block is extending avoiding nesting filters in order to fix the following issue:

### The issue:

In the current implementation, the block is extended nesting filters, something like the following:

```es6
const addVideoUploadPlanCheck = ( settings, name ) => {
	if ( isUpgradable( name ) ) {
		// Take the control of MediaPlaceholder.
		addFilter( 'editor.MediaPlaceholder', 'jetpack/cover-edit-media-placeholder', coverEditMediaPlaceholder );

		// Take control of the Replace block button control.
		addFilter( 'editor.MediaReplaceFlow', 'jetpack/cover-media-replace-flow', coverMediaReplaceFlow );

		// Extend Core CoverEditBlock.
		addFilter( 'editor.BlockEdit', 'jetpack/cover-block-edit', jetpackCoverBlockEdit );
	}

	return settings;
};
addFilter( 'blocks.registerBlockType', 'core/cover', addVideoUploadPlanCheck );
```

The thread calls the nested blocks many times (specifically six times). I've added a console.count out and in of the conditional to count them

```
blocks.registerBlockType: 265
```
```
extending block...: 6
```

It results that the `coverMediaReplaceFlow` function is hooked six times, producing, among other not desired results, the following markdown:

<img src="https://user-images.githubusercontent.com/77539/87978350-a5026180-caa6-11ea-9328-b4fb81b6d166.png" />

I think It even could bring performance issues with the uploading file handler.

### Solution

It moves the hooked functions outside of the wrapper filter trying to ensure do not bind them multiple times. It's applied to `editor.MediaReplaceFlow` and `editor.MediaPlaceholder` filters. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change the way that the `core/cover` block is extended changing how the functions are hooked to the filters.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Test with a Simple Site
* Get sandboxed
* Apply these changes (D46665)
* Start to edit a post
* Add a `core/cover` block.
* Inspect the dom tree. Confirm that the MediaPlaceholder element is not rendered multiple times

<img src="https://user-images.githubusercontent.com/77539/87989278-1f87ad00-cab8-11ea-89fc-c117171c0d63.png" width="400px" />


#### Functionallity - MediaPlaceholder

* Try to upload a video file dropping in the drop-zone area. Confirm that it shows the Upgrade Nudge.

<img src="https://user-images.githubusercontent.com/77539/87989354-47771080-cab8-11ea-9e42-723e838ed180.png" width="400px" />


* Try to upload an unsupported file in the same way ^ (`.pdf`, for instance). Confirm you see the error notice.
<img src="https://user-images.githubusercontent.com/77539/87989380-5067e200-cab8-11ea-82fa-08ef279328bb.png" width="400px" />

* Try to upload an image in the same way. It should upload and render the image there.

<img src="https://user-images.githubusercontent.com/77539/87989515-89a05200-cab8-11ea-8956-d1734347849c.png" width="400px" />

#### Functionallity - MediaReplaceFlow

* Once the block already has a background, try to replace it using the `Replace` button. Check same previous steps but using this button. Upload a video, upload an unsupported file, and upload a file.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
