### PR TITLE
REST API: Add permission callback to all that lack one.

### DIFF
--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -95,44 +95,48 @@ class Jetpack_Core_Json_Api_Endpoints {
 		) );
 
 		register_rest_route( 'jetpack/v4', '/jitm', array(
-			'methods'  => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::get_jitm_message',
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::get_jitm_message',
+			'permission_callback' => '__return_true',
 		) );
 
 		register_rest_route( 'jetpack/v4', '/jitm', array(
-			'methods'  => WP_REST_Server::CREATABLE,
-			'callback' => __CLASS__ . '::delete_jitm_message'
+			'methods'             => WP_REST_Server::CREATABLE,
+			'callback'            => __CLASS__ . '::delete_jitm_message',
+			'permission_callback' => '__return_true',
 		) );
 
 		// Authorize a remote user
 		register_rest_route( 'jetpack/v4', '/remote_authorize', array(
-			'methods' => WP_REST_Server::EDITABLE,
-			'callback' => __CLASS__ . '::remote_authorize',
+			'methods'             => WP_REST_Server::EDITABLE,
+			'callback'            => __CLASS__ . '::remote_authorize',
+			'permission_callback' => '__return_true',
 		) );
 
 		// Get current connection status of Jetpack
 		register_rest_route( 'jetpack/v4', '/connection', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::jetpack_connection_status',
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::jetpack_connection_status',
+			'permission_callback' => '__return_true',
 		) );
 
 		// Test current connection status of Jetpack
 		register_rest_route( 'jetpack/v4', '/connection/test', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::jetpack_connection_test',
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::jetpack_connection_test',
 			'permission_callback' => __CLASS__ . '::manage_modules_permission_check',
 		) );
 
 		// Endpoint specific for privileged servers to request detailed debug information.
 		register_rest_route( 'jetpack/v4', '/connection/test-wpcom/', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::jetpack_connection_test_for_external',
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::jetpack_connection_test_for_external',
 			'permission_callback' => __CLASS__ . '::view_jetpack_connection_test_check',
 		) );
 
 		register_rest_route( 'jetpack/v4', '/rewind', array(
-			'methods' => WP_REST_Server::READABLE,
-			'callback' => __CLASS__ . '::get_rewind_data',
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::get_rewind_data',
 			'permission_callback' => __CLASS__ . '::view_admin_page_permission_check',
 		) );
 
@@ -500,6 +504,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => __CLASS__ . '::get_service_api_key',
+					'permission_callback' => '__return_true',
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,

--- a/_inc/lib/class.core-rest-api-endpoints.php
+++ b/_inc/lib/class.core-rest-api-endpoints.php
@@ -294,7 +294,7 @@ class Jetpack_Core_Json_Api_Endpoints {
 		register_rest_route( 'jetpack/v4', 'identity-crisis/migrate', array(
 			'methods' => WP_REST_Server::EDITABLE,
 			'callback' => __CLASS__ . '::migrate_stats_and_subscribers',
-			'permissison_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
+			'permission_callback' => __CLASS__ . '::identity_crisis_mitigation_permission_check',
 		) );
 
 		// Return all modules

--- a/_inc/lib/core-api/wpcom-endpoints/business-hours.php
+++ b/_inc/lib/core-api/wpcom-endpoints/business-hours.php
@@ -17,8 +17,9 @@ class WPCOM_REST_API_V2_Endpoint_Business_Hours extends WP_REST_Controller {
 		// GET /sites/<blog_id>/business-hours/localized-week - Return the localized
 		register_rest_route( $this->namespace, '/' . $this->rest_base . '/localized-week', array(
 			array(
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'get_localized_week' ),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_localized_week' ),
+				'permission_callback' => '__return_true',
 			)
 		) );
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php
@@ -45,8 +45,9 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/connect-url',
 			array(
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'get_instagram_connect_url' ),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_instagram_connect_url' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 
@@ -54,8 +55,9 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/connections',
 			array(
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'get_instagram_connections' ),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_instagram_connections' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 
@@ -63,7 +65,7 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base . '/gallery',
 			array(
-				'args'     => array(
+				'args'                => array(
 					'access_token' => array(
 						'description' => __( 'An Instagram Keyring access token.', 'jetpack' ),
 						'type'        => 'string',
@@ -78,8 +80,9 @@ class WPCOM_REST_API_V2_Endpoint_Instagram_Gallery extends WP_REST_Controller {
 						},
 					),
 				),
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'get_instagram_gallery' ),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_instagram_gallery' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-mailchimp.php
@@ -29,8 +29,9 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 			$this->rest_base,
 			array(
 				array(
-					'methods'  => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_mailchimp_status' ),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_mailchimp_status' ),
+					'permission_callback' => '__return_true',
 				),
 			)
 		);
@@ -39,8 +40,9 @@ class WPCOM_REST_API_V2_Endpoint_Mailchimp extends WP_REST_Controller {
 			$this->rest_base . '/groups',
 			array(
 				array(
-					'methods'  => WP_REST_Server::READABLE,
-					'callback' => array( $this, 'get_mailchimp_groups' ),
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_mailchimp_groups' ),
+					'permission_callback' => '__return_true',
 				),
 			)
 		);

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -56,6 +56,7 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 				'methods'                               => WP_REST_Server::READABLE,
 				'callback'                              => array( $this, 'gather_tweetstorm' ),
 				'allow_blog_token_when_site_is_private' => true,
+				'permission_callback'                   => '__return_true',
 			)
 		);
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/hello.php
+++ b/_inc/lib/core-api/wpcom-endpoints/hello.php
@@ -8,8 +8,9 @@ class WPCOM_REST_API_V2_Endpoint_Hello {
 	public function register_routes() {
 		register_rest_route( 'wpcom/v2', '/hello', array(
 			array(
-				'methods'  => WP_REST_Server::READABLE,
-				'callback' => array( $this, 'get_data' ),
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_data' ),
+				'permission_callback' => '__return_true',
 			),
 		) );
 	}

--- a/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
+++ b/_inc/lib/core-api/wpcom-endpoints/service-api-keys.php
@@ -32,6 +32,7 @@ class WPCOM_REST_API_V2_Endpoint_Service_API_Keys extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( __CLASS__, 'get_service_api_key' ),
+					'permission_callback' => '__return_true',
 				),
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,

--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -545,9 +545,10 @@ class Error_Handler {
 			'jetpack/v4',
 			'/verify_xmlrpc_error',
 			array(
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => array( $this, 'verify_xml_rpc_error' ),
-				'args'     => array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'verify_xml_rpc_error' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'nonce' => array(
 						'required' => true,
 						'type'     => 'string',

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -31,8 +31,9 @@ class REST_Connector {
 			'jetpack/v4',
 			'/verify_registration',
 			array(
-				'methods'  => \WP_REST_Server::EDITABLE,
-				'callback' => array( $this, 'verify_registration' ),
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'verify_registration' ),
+				'permission_callback' => '__return_true',
 			)
 		);
 	}


### PR DESCRIPTION
See #16539

I consider this an incomplete fix to silence the errors and so our unit testing isn't blocked. But, the ones that I added, we should review to ensure it is intentional.

#### Changes proposed in this Pull Request:
* Adds a permission_callback for all endpoints that lacked one.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Run a connected Jetpack on WP trunk.
* Any notices?

#### Proposed changelog entry for your changes:
* n/a would make a part of a general WP 5.5 compat line.
