### PR TITLE
Jetpack Offer Reset: Remove the personal plan from the plans page

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -141,7 +141,7 @@ class PlanGrid extends React.Component {
 			return this.featuredPlans;
 		}
 		// reduce the .features member to only the highlighted features.
-		const plansWithHighlightedFeatures = reduce(
+		const featuredPlans = reduce(
 			this.props.plans,
 			( plans, plan, key ) => {
 				// ignore the free plan
@@ -168,17 +168,17 @@ class PlanGrid extends React.Component {
 		// Users on the personal plan should still see the personal plan, otherwise
 		// they should see a modified premium and professional plan.
 		if ( 'is-personal-plan' === getPlanClass( this.props.sitePlan.product_slug ) ) {
-			this.featuredPlans = plansWithHighlightedFeatures;
+			this.featuredPlans = featuredPlans;
 		} else {
-			const personalFeatures = plansWithHighlightedFeatures.personal.features;
-			const premiumFeatures = plansWithHighlightedFeatures.premium.features;
-			plansWithHighlightedFeatures.premium.features = [
+			const personalFeatures = featuredPlans.personal.features;
+			const premiumFeatures = featuredPlans.premium.features;
+			featuredPlans.premium.features = [
 				personalFeatures.find( feature => 'backups' === feature.id ),
 				personalFeatures.find( feature => 'spam' === feature.id ),
 				...premiumFeatures.filter( feature => 'all-from-previous' !== feature.id ),
 				personalFeatures.find( feature => 'all-from-previous' === feature.id ),
 			];
-			this.featuredPlans = pick( plansWithHighlightedFeatures, [ 'premium', 'business' ] );
+			this.featuredPlans = pick( featuredPlans, [ 'premium', 'business' ] );
 		}
 
 		return this.featuredPlans;

--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -144,8 +144,8 @@ class PlanGrid extends React.Component {
 		const featuredPlans = reduce(
 			this.props.plans,
 			( plans, plan, key ) => {
-				// ignore the free plan
-				if ( 'free' === key ) {
+				// ignore the free and personal plans
+				if ( [ 'free', 'personal' ].includes( key ) ) {
 					return plans;
 				}
 				const highlights = plan.highlight;

--- a/_inc/client/plans/style.scss
+++ b/_inc/client/plans/style.scss
@@ -7,7 +7,8 @@ $plan-features-sidebar-width: 272px;
 /* Breakpoints 1150px, */
 
 .plan-features__content {
-	margin: 0 -16px 16px;
+	max-width: 840px;
+	margin: auto;
 	padding-top: $plan-features-header-banner-height;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR removes the personal plan from the plans page.

Before:
<img width="1089" alt="image" src="https://user-images.githubusercontent.com/42627630/88084664-5b6b5280-cb4a-11ea-9f32-86a426305510.png">

After:
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/42627630/88225927-f0487b80-cc30-11ea-8770-60ddef1f928b.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

MT: p1HpG7-8PX-p2
Current scoping: pbtFFM-mr-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a site without a personal plan:
1. Visit `/wp-admin/admin.php?page=jetpack#/plans-prompt`. Verify that the personal plan does not display there.
2. Visit `/wp-admin/admin.php?page=jetpack#/plans`. Verify that the personal plan does not display there.

On a site with a personal plan:
1. Visit `/wp-admin/admin.php?page=jetpack#/plans`. Verify that the personal plan displays as the owned plan.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Removed personal plan from purchase options.
