### PR TITLE
Settings: Recognize valid Akismet keys from wp-config and restrict input

### DIFF
--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -104,7 +104,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 				this.props.getSettingCurrentValue( 'wordpress_api_key' ) === '' &&
 				this.props.isAkismetKeyValid
 			) {
-				textProps.value = __( "A valid key has been set in your site's configuration." );
+				textProps.value = __( "A valid key has been set in your site's configuration.", 'jetpack' );
 				textProps.isValid = true;
 				textProps.disabled = true;
 				foldableHeader = __( 'Your site is protected from spam.', 'jetpack' );

--- a/_inc/client/security/antispam.jsx
+++ b/_inc/client/security/antispam.jsx
@@ -37,9 +37,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 		}
 
 		checkApiKeyTyped = event => {
-			if ( 0 < event.currentTarget.value.length ) {
-				this.props.checkAkismetKey( event.currentTarget.value );
-			}
+			this.props.checkAkismetKey( event.currentTarget.value );
 			this.keyChanged = true;
 			this.setState( {
 				delayKeyCheck: false,
@@ -87,12 +85,33 @@ export const Antispam = withModuleSettingsFormHelpers(
 			};
 			let akismetStatus = '',
 				foldableHeader = __( 'Checking your spam protection…', 'jetpack' ),
-				explanation = true;
+				explanation = jetpackCreateInterpolateElement(
+					__(
+						"If you don't already have an API key, then <a>get your API key here</a>, and you'll be guided through the process of getting one.",
+						'jetpack'
+					),
+					{
+						a: <a href={ 'https://akismet.com/wordpress/' } />,
+					}
+				);
 
 			if ( null === this.props.isAkismetKeyValid ) {
 				textProps.value = __( 'Fetching key…', 'jetpack' );
 				textProps.disabled = true;
 				explanation = false;
+			} else if (
+				! this.props.isDirty() &&
+				this.props.getSettingCurrentValue( 'wordpress_api_key' ) === '' &&
+				this.props.isAkismetKeyValid
+			) {
+				textProps.value = __( "A valid key has been set in your site's configuration." );
+				textProps.isValid = true;
+				textProps.disabled = true;
+				foldableHeader = __( 'Your site is protected from spam.', 'jetpack' );
+				explanation = __( 'It looks like your API key has been set globally.', 'jetpack' );
+				akismetStatus = (
+					<FormInputValidation text={ __( 'Your Antispam key is valid.', 'jetpack' ) } />
+				);
 			} else if ( '' === this.state.apiKey ) {
 				textProps.value = '';
 				foldableHeader = __( 'Your site needs an Antispam key.', 'jetpack' );
@@ -151,19 +170,7 @@ export const Antispam = withModuleSettingsFormHelpers(
 									<TextInput { ...textProps } />
 									{ akismetStatus }
 								</FormLabel>
-								{ explanation && (
-									<p className="jp-form-setting-explanation">
-										{ jetpackCreateInterpolateElement(
-											__(
-												"If you don't already have an API key, then <a>get your API key here</a>, and you'll be guided through the process of getting one.",
-												'jetpack'
-											),
-											{
-												a: <a href={ 'https://akismet.com/wordpress/' } />,
-											}
-										) }
-									</p>
-								) }
+								{ explanation && <p className="jp-form-setting-explanation">{ explanation }</p> }
 							</FormFieldset>
 						</SettingsGroup>
 					</FoldableCard>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #8226.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add a check in the Antispam component to look for indications of a globally-set WPCOM_API_KEY for Akismet.
* If a globally-set API key is detected, inform the user and disable input.

#### Jetpack product discussion

See #8226.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

How to globally define an Akismet API key:

* In the **Jetpack > Akismet Anti-spam** menu, if an API key is already set, disconnect or remove it.
* In your site's `wp-config.php` file, add the following line: `define( 'WPCOM_API_KEY', 'your api key' );` where `your api key` is your desired API key.

To test changes in this PR:

* Globally define a **valid** Akismet API key for your site (see instructions above).
* Verify that in **Jetpack > Settings > Security**, the **Anti-spam** card shows *"Your site is protected from spam."* and the text input is disabled, like in the below screenshot.

To test for regressions:

* Globally define an **invalid** Akismet API key for your site (see instructions above).
* Verify that in **Jetpack > Settings > Security**, the **Anti-spam** card shows *"Your site is not protected from spam."* and all UI elements appear/behave as they did before this PR.
* Remove all global and UI-based API key definitions from your site.
* Verify that in **Jetpack > Settings > Security**, the **Anti-spam** card shows *"Your site needs an Antispam key."* and all UI elements appear/behave as they did before this PR.
* Verify that the state of the **Anti-spam** card changes correctly based on the state of the **Your API key** text input.

##### Screenshot (After)

<img width="1058" alt="Screen Shot 2020-07-21 at 10 27 36" src="https://user-images.githubusercontent.com/670067/88074891-a763ca80-cb3d-11ea-9d3c-c6a128fd86b4.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Settings: Globally-configured Akismet API keys (e.g., in wp-config.php) now show as valid and cannot be altered from the UI.
