### PR TITLE
WPCOM Block Editor: Check for the _GET var before use

### DIFF
--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -95,7 +95,7 @@ class Jetpack_WPCOM_Block_Editor {
 			return;
 		}
 
-		if ( ! isset( $_GET['calypsoify_cookie_check'] ) || ! $_GET['calypsoify_cookie_check'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( empty( $_GET['calypsoify_cookie_check'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			header( 'Location: ' . esc_url_raw( $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' ) );
 			exit;
 		}

--- a/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
+++ b/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php
@@ -95,7 +95,7 @@ class Jetpack_WPCOM_Block_Editor {
 			return;
 		}
 
-		if ( ! $_GET['calypsoify_cookie_check'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['calypsoify_cookie_check'] ) || ! $_GET['calypsoify_cookie_check'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			header( 'Location: ' . esc_url_raw( $_SERVER['REQUEST_URI'] . '&calypsoify_cookie_check=true' ) );
 			exit;
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes `Notice: Undefined index: calypsoify_cookie_check in /srv/users/user7272d637/apps/user7272d637/public/wp-content/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php on line 98`

Introduced in https://github.com/Automattic/jetpack/pull/16167

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Check the var before use.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:

* Open the desktop app
* Select Jetpack site (with SSO enabled)
* Open Gutenberg
* Wait ~1 min.
* Error without the patch.

See p1595360260179800-slack-jetpack-plugin for the initial report.

#### Proposed changelog entry for your changes:
* Fix: PHP notice emitted when using the WordPress.com Desktop App.
