### PR TITLE
Calypsoify: Change the default link to Customer Home

### DIFF
--- a/modules/calypsoify/class.jetpack-calypsoify.php
+++ b/modules/calypsoify/class.jetpack-calypsoify.php
@@ -292,9 +292,9 @@ class Jetpack_Calypsoify {
 	 */
 	public function insert_sidebar_html() {
 		$heading       = ( isset( $_GET['post_type'] ) && 'feedback' === $_GET['post_type'] ) ? __( 'Feedback', 'jetpack' ) : __( 'Plugins', 'jetpack' );
-		$stats_day_url = Redirect::get_url( 'calypso-stats-day' );
+		$home_url = Redirect::get_url( 'calypso-home' );
 		?>
-		<a href="<?php echo esc_url( $stats_day_url ); ?>" id="calypso-sidebar-header">
+		<a href="<?php echo esc_url( $home_url ); ?>" id="calypso-sidebar-header">
 			<svg class="gridicon gridicons-chevron-left" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g><path d="M14 20l-8-8 8-8 1.414 1.414L8.828 12l6.586 6.586"></path></g></svg>
 
 			<ul>
@@ -310,7 +310,7 @@ class Jetpack_Calypsoify {
 
 		// Add proper links to masterbar top sections.
 		$my_sites_node       = (object) $wp_admin_bar->get_node( 'blog' );
-		$my_sites_node->href = Redirect::get_url( 'calypso-stats-day' );
+		$my_sites_node->href = Redirect::get_url( 'calypso-home' );
 		$wp_admin_bar->add_node( $my_sites_node );
 
 		$reader_node       = (object) $wp_admin_bar->get_node( 'newdash' );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes Automattic/wp-calypso#41858

#### Changes proposed in this Pull Request:
As reported in Automattic/wp-calypso#41858, the back link is still using the stats
page as the home page in Calypso. This change swaps that to `/home/` and
updates the 'My Sites' link also.

If the site can't view the Customer Home, then it will be redirected back to the stats page.

#### Testing instructions:

* On a Jetpack/Atomic test site load a wp-admin page with the `calypsoify` query parameter, such as `/wp-admin/plugins.php?calypsoify=1`
* With the Calypsoified view, click on the backlink in the top of the sidebar, and ensure that it takes you back to Customer Home or the stats page, as appropriate
* Similarly check the My Sites link in the master bar. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No, this doesn't make any changes to data.

#### Proposed changelog entry for your changes:
I don't think one is needed, as this is a bug fix that's probably not of interest to most Jetpack users.
