### PR TITLE
Social Icons Widget: add rel attribute to links

### DIFF
--- a/modules/widgets/social-icons.php
+++ b/modules/widgets/social-icons.php
@@ -135,12 +135,6 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 			$social_icons = $this->get_supported_icons();
 			$default_icon = $this->get_svg_icon( array( 'icon' => 'chain' ) );
 
-			// Set target attribute for the link.
-			if ( true === $instance['new-tab'] ) {
-				$target = '_blank';
-			} else {
-				$target = '_self';
-			}
 			?>
 
 			<ul class="jetpack-social-widget-list size-<?php echo esc_attr( $instance['icon-size'] ); ?>">
@@ -149,33 +143,40 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 
 					<?php if ( ! empty( $icon['url'] ) ) : ?>
 						<li class="jetpack-social-widget-item">
-							<a href="<?php echo esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ); ?>" target="<?php echo esc_attr( $target ); ?>">
-								<?php
-									$found_icon = false;
+							<?php
+							printf(
+								'<a href="%1$s" %2$s>',
+								esc_url( $icon['url'], array( 'http', 'https', 'mailto', 'skype' ) ),
+								true === $instance['new-tab'] ?
+									'target="_blank" rel="noopener noreferrer"' :
+									'target="_self"'
+							);
 
-								foreach ( $social_icons as $social_icon ) {
-									foreach ( $social_icon['url'] as $url_fragment ) {
-										if ( false !== stripos( $icon['url'], $url_fragment ) ) {
-											printf(
-												'<span class="screen-reader-text">%1$s</span>%2$s',
-												esc_attr( $social_icon['label'] ),
-												// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-												$this->get_svg_icon(
-													array(
-														'icon' => esc_attr( $social_icon['icon'] ),
-													)
+							$found_icon = false;
+
+							foreach ( $social_icons as $social_icon ) {
+								foreach ( $social_icon['url'] as $url_fragment ) {
+									if ( false !== stripos( $icon['url'], $url_fragment ) ) {
+										printf(
+											'<span class="screen-reader-text">%1$s</span>%2$s',
+											esc_attr( $social_icon['label'] ),
+											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+											$this->get_svg_icon(
+												array(
+													'icon' => esc_attr( $social_icon['icon'] ),
 												)
-											);
-											$found_icon = true;
-											break;
-										}
+											)
+										);
+										$found_icon = true;
+										break;
 									}
 								}
+							}
 
-								if ( ! $found_icon ) {
-									echo $default_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-								}
-								?>
+							if ( ! $found_icon ) {
+								echo $default_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							}
+							?>
 							</a>
 						</li>
 					<?php endif; ?>
@@ -203,7 +204,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 	 *
 	 * @return array Updated safe values to be saved.
 	 */
-	public function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$instance = array();
 
 		$instance['title']     = sanitize_text_field( $new_instance['title'] );
@@ -304,7 +305,7 @@ class Jetpack_Widget_Social_Icons extends WP_Widget {
 		?>
 
 		<p>
-			<em><a href="<?php echo esc_url( $support ); ?>" target="_blank">
+			<em><a href="<?php echo esc_url( $support ); ?>" target="_blank" rel="noopener noreferrer">
 				<?php esc_html_e( 'View available icons', 'jetpack' ); ?>
 			</a></em>
 		</p>

--- a/tests/php/modules/widgets/test_social-icons-widget.php
+++ b/tests/php/modules/widgets/test_social-icons-widget.php
@@ -1,0 +1,81 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+
+require_jetpack_file( 'modules/widgets/social-icons.php' );
+
+/**
+ * Test class for the Social Icons Widget.
+ *
+ * @covers Jetpack_Widget_Social_Icons
+ */
+class WP_Test_Social_Icons_Widget extends WP_UnitTestCase {
+
+	/**
+	 * This method is called before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->social_icon_widget = new Jetpack_Widget_Social_Icons();
+	}
+
+	/**
+	 * Verifies that the target and url attributes in the icon urls are correct when the new tab setting
+	 * is enabled.
+	 *
+	 * @covers Jetpack_Widget_Social_Icons::widget
+	 */
+	public function test_widget_icon_urls_new_tab() {
+		$args = array(
+			'before_widget' => null,
+			'after_widget'  => null,
+			'before_title'  => null,
+			'after_title'   => null,
+		);
+
+		$instance = array(
+			'icons'   => array(
+				'test_icon_1' => array(
+					'url' => 'https://www.example.com',
+				),
+			),
+			'new-tab' => true,
+		);
+
+		ob_start();
+		$this->social_icon_widget->widget( $args, $instance );
+		$output_string = ob_get_clean();
+
+		$this->assertNotFalse( strpos( $output_string, 'target="_blank"' ), 'The expected attribute target="_blank" is missing.' );
+		$this->assertNotFalse( strpos( $output_string, 'rel="noopener noreferrer"' ), 'The expected attribute rel="noopener noreferrer" is missing.' );
+	}
+
+	/**
+	 * Verifies that the target and url attributes in the icon urls are correct when the new tab setting
+	 * is disabled.
+	 *
+	 * @covers Jetpack_Widget_Social_Icons::widget
+	 */
+	public function test_widget_icon_urls_same_tab() {
+		$args = array(
+			'before_widget' => null,
+			'after_widget'  => null,
+			'before_title'  => null,
+			'after_title'   => null,
+		);
+
+		$instance = array(
+			'icons'   => array(
+				'test_icon_1' => array(
+					'url' => 'https://www.example.com',
+				),
+			),
+			'new-tab' => false,
+		);
+
+		ob_start();
+		$this->social_icon_widget->widget( $args, $instance );
+		$output_string = ob_get_clean();
+
+		$this->assertNotFalse( strpos( $output_string, 'target="_self"' ), 'The expected attribute target="_self" is missing.' );
+		$this->assertFalse( strpos( $output_string, 'rel="noopener noreferrer"' ), 'The attribute rel="noopener noreferrer should not be present.' );
+	}
+}


### PR DESCRIPTION
Fixes #16484

#### Changes proposed in this Pull Request:
* Add the `rel="noopener noreferrer"` attribute to links in the Social Icons widget that have a `target="_blank"` attribute.
* Add a small unit test that covers the change in this PR.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:

1. The test site must have Jetpack active and connected.
2. The test site must have extra sidebar widgets enabled.
3. Navigate to wp-admin -> Appearance -> Widgets.
4. Add a Jetpack Social Icons widget to your test site and add a few URLs to the widget. Check the `Open link in a new tab` checkbox and save.
5. While still on the Widgets page, open your browser's inspector, and confirm that the `View available icons` link includes  the `target="_blank"` and `rel="noopener noreferrer"` attributes and that the link is properly formatted.
6. Click the `View available icons` link and confirm that it works correctly.
7. Navigate to a front-end page.
8. Open your browser's inspector. Confirm that the social icon links include the `target="_blank"` and `rel="noopener noreferrer"` attributes and the the elements are properly formatted.
9. Click the social icons and confirm that the links work correctly.
10. Return to the Widgets page.
11. Open the existing Social Icons widget. Uncheck the `Open link in a new tab` checkbox and save.
12. Navigate to a front-end page.
13. Open your browser's inspector. Confirm that the social icon links include the `target="_self"` attribute and that they do not include the `rel="noopener noreferrer"` attribute. Also confirm that the elements are properly formatted.
14. Click the social icons and confirm that the links work correctly.
15. Navigate to wp-admin -> Appearance -> Customize. Use the browser's inspector to confirm that the Social Icons widget link attributes are correct in the customizer.

#### Proposed changelog entry for your changes:
* Widgets: add the rel attribute to links with target=”_blank” in the Social Icons widget.
