### PR TITLE
Carousel: add jQuery script dependency

### DIFF
--- a/modules/carousel/jetpack-carousel.php
+++ b/modules/carousel/jetpack-carousel.php
@@ -234,7 +234,7 @@ class Jetpack_Carousel {
 					'_inc/build/carousel/jetpack-carousel.min.js',
 					'modules/carousel/jetpack-carousel.js'
 				),
-				array(),
+				array( 'jquery' ),
 				$this->asset_version( JETPACK__VERSION ),
 				true
 			);


### PR DESCRIPTION
Fixes #16550

#### Changes proposed in this Pull Request:

In 0507aa58fae1eca84e6115217da90d84cb1a0c93, we removed another dependency that itself depended on jQuery.
Since the Carousel script relies on jQuery, let's add it as a dependency.

**Note**: in the future we should be able to get rid of this dependency for good as we keep working on #16420.

#### Jetpack product discussion

* N/A 

#### Does this pull request change what data or activity we track or use?

* N/A 

#### Testing instructions:

Start with a site with no other plugin, no other Jetpack feature active, and the Twenty Twenty theme.

1. Enable Carousel.
2. Publish a post with a gallery.
3. It works when logged in.
4. Log out
5. Carousel should still work. You should see no errors in the console.

#### Proposed changelog entry for your changes:

* Carousel: ensure jQuery is loaded when using the Carousel feature.
