### PR TITLE
Revert the backend changes for the Expert Guidance experiment.

### DIFF
--- a/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -56,7 +56,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'is_fse_active'               => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
-		'is_white_glove'              => '(bool) If the product being purchased is coming from the white glove offer, check pau2Xa-13X-p2',
 	);
 
 	protected static $no_member_fields = array(
@@ -412,9 +411,6 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'is_core_site_editor_enabled':
 				$response[ $key ] = $this->site->is_core_site_editor_enabled();
-				break;
-			case 'is_white_glove':
-				$response[ $key ] = $this->site->is_white_glove();
 				break;
 		}
 

--- a/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
@@ -53,7 +53,6 @@ class WPCOM_JSON_API_GET_Site_V1_2_Endpoint extends WPCOM_JSON_API_GET_Site_Endp
 		'is_fse_active'               => '(bool) If the site has Full Site Editing active or not.',
 		'is_fse_eligible'             => '(bool) If the site is capable of Full Site Editing or not',
 		'is_core_site_editor_enabled' => '(bool) If the site has the core site editor enabled.',
-		'is_white_glove'              => '(bool) If this is a white glove offer, as part of the ab test defined in pau2Xa-13X-p2',
 	);
 
 

--- a/sal/class.json-api-site-jetpack.php
+++ b/sal/class.json-api-site-jetpack.php
@@ -286,16 +286,6 @@ class Jetpack_Site extends Abstract_Jetpack_Site {
 	}
 
 	/**
-	 * Check if a site is eligible for the White Glove offer.
-	 * pau2Xa-13X-p2
-	 *
-	 * @return bool true if site is eligible for the White Glove offer.
-	 */
-	public function is_white_glove() {
-		return false;
-	}
-
-	/**
 	 * Return the last engine used for an import on the site.
 	 *
 	 * This option is not used in Jetpack.


### PR DESCRIPTION
Differential Revision: D46165-code

This commit syncs r210825-wpcom.

#### Changes proposed in this Pull Request:

Since we've decided to stop and roll back the Expert Guidance upsell experiment as described here: pbxNRc-gv-p2#comment-485,
this patch aims to roll back the changes introduced in r208548-wpcom (in Jetpack in #16089).

It is made by as the following:

1. Create a direct revert by running the command
1. There are simple merge conflicts in public.api/rest/json-endpoints/class.wpcom-json-api-get-site-endpoint.php and public.api/rest/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php. Resolving them by keeping the current trunk version while removing `is_white_glove` references.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

1. Review and confirm it's just a direct revert of r208548-wpcom, plus removing `is_white_glove` from public.api/rest/json-endpoints/class.wpcom-json-api-get-site-endpoint.php and public.api/rest/json-endpoints/class.wpcom-json-api-get-site-v1-2-endpoint.php
1. Run a few purchasing flows to see if the payment works as expected. Running the `wp-plan-purchase-spec` locally against it is a good check.

#### Proposed changelog entry for your changes:

* N/A
