### PR TITLE
External Media: Fix image not attaching or being recognized as "used" in a post

### DIFF
--- a/class.photon.php
+++ b/class.photon.php
@@ -1271,7 +1271,13 @@ class Jetpack_Photon {
 	private function should_rest_photon_image_downsize_override( WP_REST_Request $request ) {
 		$route = $request->get_route();
 
-		if ( false !== strpos( $route, 'wp/v2/media' ) && 'edit' === $request->get_param( 'context' ) ) {
+		if (
+			(
+				false !== strpos( $route, 'wp/v2/media' )
+				&& 'edit' === $request->get_param( 'context' )
+			)
+			|| false !== strpos( $route, 'wpcom/v2/external-media/copy' )
+		) {
 			// Don't use `__return_true()`: Use something unique. See ::_override_image_downsize_in_rest_edit_context()
 			// Late execution to avoid conflict with other plugins as we really don't want to run in this situation.
 			add_filter(

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -14,6 +14,7 @@ import { withNotices, Modal } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -193,6 +194,7 @@ export default function withMedia() {
 							title: item.title,
 						} ) ),
 						service: source, // WPCOM.
+						post_id: this.props.postId ?? 0,
 					},
 				} )
 					.then( result => {
@@ -287,6 +289,10 @@ export default function withMedia() {
 			}
 		}
 
-		return withNotices( WithMediaComponent );
+		return withSelect( select => {
+			return {
+				postId: select( 'core/editor' ).getCurrentPostId(),
+			};
+		} )( withNotices( WithMediaComponent ) );
 	} );
 }

--- a/tests/php/test_class.jetpack_photon.php
+++ b/tests/php/test_class.jetpack_photon.php
@@ -1315,8 +1315,13 @@ class WP_Test_Jetpack_Photon extends Jetpack_Attachment_Test_Case {
 		$response = rest_get_server()->dispatch( $request );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_mocked_download_url' ), 10, 2 );
 
+		$this->assertEquals( 200, $response->get_status() );
+
 		$data = $response->get_data();
 
+		$this->assertNotEmpty( $data );
+		$this->assertInternalType( 'array', $data[0] );
+		$this->assertArrayHasKey( 'url', $data[0] );
 		$this->assertStringNotContainsString( 'wp.com', $data[0]['url'] );
 	}
 


### PR DESCRIPTION
See #16425 

This is very similar to an issue that @kraftbj recently fixed in #16287 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Do not process images with Photon when inserting from external services like Pexels or Google Photos
* Properly attach the photo to the post when copying

#### Jetpack product discussion

This came from a request from Galactica via Slack.

#### Does this pull request change what data or activity we track or use?

No 

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Connect site
- Add post and insert an image from Pexels or Google Photos
- Go to Media library and select new image
- Ensure that image is properly attached to post

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes issue where images from Pexels or Google Photos weren't attached to posts
