### PR TITLE
Add a filter to jetpack options

### DIFF
--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -176,6 +176,16 @@ class Jetpack_Options {
 	 * @return mixed
 	 */
 	public static function get_option( $name, $default = false ) {
+		/**
+		 * Filter Jetpack Options.
+		 * Can be useful in environments when Jetpack is running with a different setup
+		 *
+		 * @since 8.8.0
+		 *
+		 * @param string $value The value from the database.
+		 * @param string $name Option name, _without_ `jetpack_%` prefix.
+		 * @return string $value, unless the filters modify it.
+		 */
 		return apply_filters( 'jetpack_options', self::get_option_from_database( $name, $default ), $name );
 	}
 

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -167,7 +167,8 @@ class Jetpack_Options {
 	}
 
 	/**
-	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.
+	 * Filters the requested option.
+	 * This is a wrapper around `get_option_from_database` so that we can filter the option.
 	 *
 	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
 	 * @param mixed  $default (optional).
@@ -175,6 +176,18 @@ class Jetpack_Options {
 	 * @return mixed
 	 */
 	public static function get_option( $name, $default = false ) {
+		return apply_filters( 'jetpack_options', self::get_option_from_database( $name, $default ), $name );
+	}
+
+	/**
+	 * Returns the requested option.  Looks in jetpack_options or jetpack_$name as appropriate.
+	 *
+	 * @param string $name Option name. It must come _without_ `jetpack_%` prefix. The method will prefix the option name.
+	 * @param mixed  $default (optional).
+	 *
+	 * @return mixed
+	 */
+	private static function get_option_from_database( $name, $default = false ) {
 		if ( self::is_valid( $name, 'non_compact' ) ) {
 			if ( self::is_network_option( $name ) ) {
 				return get_site_option( "jetpack_$name", $default );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This makes it possible to filter the result of Jetpack_Options::get_option() so that in other contexts we can alter the result

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Ee-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Add a filter to a file that your site loads, for example:
```
function override_jetpack_option_id( $value, $name ) {
	if ( 'id' === $name ) {
		return '9999';
	}

	return $value;
}
```

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add a filter for Jetpack options.
