### PR TITLE
Tracks missing primary user via heartbeat

### DIFF
--- a/class.jetpack-heartbeat.php
+++ b/class.jetpack-heartbeat.php
@@ -137,6 +137,12 @@ class Jetpack_Heartbeat {
 			Jetpack_Options::delete_option( 'xmlrpc_errors' );
 		}
 
+		$master_user_error = Jetpack_Options::get_option( 'get_master_user_error', '' );
+		if ( $master_user_error ) {
+			$return[ "{$prefix}master-user-error" ] = $master_user_error;
+			Jetpack_Options::delete_option( 'get_master_user_error' );
+		}
+
 		// Missing the connection owner?
 		$connection_manager                 = new Manager();
 		$return[ "{$prefix}missing-owner" ] = $connection_manager->is_missing_connection_owner();

--- a/packages/options/legacy/class-jetpack-options.php
+++ b/packages/options/legacy/class-jetpack-options.php
@@ -72,6 +72,7 @@ class Jetpack_Options {
 					'mailchimp',                   // (string) Mailchimp keyring data, for mailchimp block.
 					'xmlrpc_errors',               // (array) Keys are XML-RPC signature error codes. Values are truthy.
 					'dismissed_wizard_banner',     // (int) True if the Wizard banner has been dismissed.
+					'get_master_user_error',       // (string) error triggered when master user is missing, used to send data via heartbeat.
 				);
 
 			case 'private':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Uses heartbeat to get stats on sites with broken Primary users.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

This will track specifically sites that have the `master_user` jetpack option pointing to an ID of a user that does not exist, but that still has a valid user token on the database.

This situation makes the site work and do not trigger any error. `is_active` also returns `true`. This PR doesn't change that, it only collects anonymous stats so we can have metrics on the number of sites in this situation.

Note: this would be cleaner if we had the [new Heartbeat package](https://github.com/Automattic/jetpack/pull/16285) :) 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Ei-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
It tracks anonymous stats on a very specific error

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a healthy connection
* Activate the Debug helper plugin 
* Go to Jetpack > Debug tools and activate the broken token module
* Go to Jetpack > Broken token
* Click on "Store these options" so you can heal recover your connection after the tests
* Click on "Randomize Primary User ID and move the user token together"
* Access any page in the admin
* `wp jetpack options get get_master_user_error` and confirm the error `user_not_found` is saved
* `wp jetpack options update last_heartbeat 0` - to trick Jetpack into running the heartbeat on command.
* `wp cron event run jetpack_v2_heartbeat` - to run the heartbeat on command.
* Visit MC Stats and check that the stats were bumped for `jetpack-v2-master-user-error` 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Tracks error on missing primary user
