### PR TITLE
WordPress.com API: take new option names into account

### DIFF
--- a/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -245,6 +245,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 	 * @return array
 	 */
 	public function get_settings_response() {
+		global $wp_version;
 
 		// Allow update in later versions
 		/**
@@ -362,10 +363,16 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					'social_notifications_reblog' => ( "on" == get_option( 'social_notifications_reblog' ) ),
 					'social_notifications_subscribe' => ( "on" == get_option( 'social_notifications_subscribe' ) ),
 					'comment_moderation'      => (bool) get_option( 'comment_moderation' ),
-					'comment_whitelist'       => (bool) get_option( 'comment_whitelist' ),
+					'comment_whitelist'                => ( version_compare( $wp_version, '5.5-alpha', '>=' ) )
+						? (bool) get_option( 'comment_previously_approved' )
+						: (bool) get_option( 'comment_whitelist' ),
+					'comment_previously_approved'       => (bool) get_option( 'comment_previously_approved' ),
 					'comment_max_links'       => (int) get_option( 'comment_max_links' ),
 					'moderation_keys'         => get_option( 'moderation_keys' ),
-					'blacklist_keys'          => get_option( 'blacklist_keys' ),
+					'blacklist_keys'                   => ( version_compare( $wp_version, '5.5-alpha', '>=' ) )
+						? get_option( 'disallowed_keys' )
+						: get_option( 'blacklist_keys' ),
+					'disallowed_keys'          => get_option( 'disallowed_keys' ),
 					'lang_id'                 => defined( 'IS_WPCOM' ) && IS_WPCOM
 						? get_lang_id_by_code( wpcom_l10n_get_blog_locale_variant( $blog_id, true ) )
 						: get_option( 'lang_id' ),

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-2-endpoint.php
@@ -64,10 +64,12 @@ new WPCOM_JSON_API_Site_Settings_V1_2_Endpoint( array(
 		'social_notifications_reblog'          => '(bool) Email me when someone reblogs my post?',
 		'social_notifications_subscribe'       => '(bool) Email me when someone follows my blog?',
 		'comment_moderation'                   => '(bool) Moderate comments for manual approval?',
-		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?',
+		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?', // Now deprecated. Replaced by comment_previously_approved https://wp.me/p2AvED-lv6 Remove when minimum required is WordPress 5.5.
+		'comment_previously_approved'          => '(bool) Moderate comments unless author has a previously-approved comment?',
 		'comment_max_links'                    => '(int) Moderate comments that contain X or more links',
 		'moderation_keys'                      => '(string) Words or phrases that trigger comment moderation, one per line',
-		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line',
+		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line', // Now deprecated. Replaced by disallowed_keys https://wp.me/p2AvED-lv6 Remove when minimum required is WordPress 5.5.
+		'disallowed_keys'                      => '(string) Words or phrases that mark comment spam, one per line',
 		'lang_id'                              => '(int) ID for language blog is written in',
 		'locale'                               => '(string) locale code for language blog is written in',
 		'wga'                                  => '(array) Google Analytics Settings',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-3-endpoint.php
@@ -64,10 +64,12 @@ new WPCOM_JSON_API_Site_Settings_V1_3_Endpoint( array(
 		'social_notifications_reblog'          => '(bool) Email me when someone reblogs my post?',
 		'social_notifications_subscribe'       => '(bool) Email me when someone follows my blog?',
 		'comment_moderation'                   => '(bool) Moderate comments for manual approval?',
-		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?',
+		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?', // Now deprecated. Replaced by comment_previously_approved https://wp.me/p2AvED-lv6 Remove when minimum required is WordPress 5.5.
+		'comment_previously_approved'          => '(bool) Moderate comments unless author has a previously-approved comment?',
 		'comment_max_links'                    => '(int) Moderate comments that contain X or more links',
 		'moderation_keys'                      => '(string) Words or phrases that trigger comment moderation, one per line',
-		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line',
+		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line', // Now deprecated. Replaced by disallowed_keys https://wp.me/p2AvED-lv6 Remove when minimum required is WordPress 5.5.
+		'disallowed_keys'                      => '(string) Words or phrases that mark comment spam, one per line',
 		'lang_id'                              => '(int) ID for language blog is written in',
 		'locale'                               => '(string) locale code for language blog is written in',
 		'wga'                                  => '(array) Google Analytics Settings',

--- a/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-site-settings-v1-4-endpoint.php
@@ -64,10 +64,12 @@ new WPCOM_JSON_API_Site_Settings_V1_4_Endpoint( array(
 		'social_notifications_reblog'          => '(bool) Email me when someone reblogs my post?',
 		'social_notifications_subscribe'       => '(bool) Email me when someone follows my blog?',
 		'comment_moderation'                   => '(bool) Moderate comments for manual approval?',
-		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?',
+		'comment_whitelist'                    => '(bool) Moderate comments unless author has a previously-approved comment?', // Now deprecated. Replaced by comment_previously_approved https://wp.me/p2AvED-lv6 Remove when minimum required is WordPress 5.5.
+		'comment_previously_approved'          => '(bool) Moderate comments unless author has a previously-approved comment?',
 		'comment_max_links'                    => '(int) Moderate comments that contain X or more links',
 		'moderation_keys'                      => '(string) Words or phrases that trigger comment moderation, one per line',
-		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line',
+		'blacklist_keys'                       => '(string) Words or phrases that mark comment spam, one per line', // Now deprecated. Replaced by disallowed_keys https://wp.me/p2AvED-lv6 Remove when minimum required is WordPress 5.5.
+		'disallowed_keys'                      => '(string) Words or phrases that mark comment spam, one per line',
 		'lang_id'                              => '(int) ID for language blog is written in',
 		'locale'                               => '(string) locale code for language blog is written in',
 		'wga'                                  => '(array) Google Analytics Settings',


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* WordPress.com REST API: query the right option depending on WordPress version.
* See https://core.trac.wordpress.org/changeset/48575

Primary issues: #15388 and #16099 

* Note: indenting is off in some of those files. In a separate PR I'll aim to fix all indenting in these big arrays.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:

From 2 sites, both running this branch, one running WP 5.4.2 and another WP 5.5:

* Go to https://developer.wordpress.com/docs/api/console/
* Query the `/sites/%s/settings` endpoint for your site.
* You should see the 4 fields concerned by this PR return the right values, and no notices on your site.

#### Proposed changelog entry for your changes:
* WordPress.com REST API: adjust API response based on language improvements in WordPress 5.5.
