### PR TITLE
Contact Form: avoid deprecation notice in WP 5.5

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -651,11 +651,35 @@ class Grunion_Contact_Form_Plugin {
 	 * @return bool TRUE => spam, FALSE => not spam
 	 */
 	public function is_spam_blocklist( $is_spam, $form = array() ) {
+		global $wp_version;
+
 		if ( $is_spam ) {
 			return $is_spam;
 		}
 
-		if ( wp_blacklist_check( $form['comment_author'], $form['comment_author_email'], $form['comment_author_url'], $form['comment_content'], $form['user_ip'], $form['user_agent'] ) ) {
+		/*
+		 * wp_blacklist_check was deprecated in WP 5.5.
+		 * @todo: remove when WordPress 5.5 is the minimum required version.
+		 */
+		if ( version_compare( $wp_version, '5.5-alpha', '>=' ) ) {
+			$check_comment_disallowed_list = 'wp_check_comment_disallowed_list';
+		} else {
+			$check_comment_disallowed_list = 'wp_blacklist_check';
+		}
+
+		if (
+			call_user_func_array(
+				$check_comment_disallowed_list,
+				array(
+					$form['comment_author'],
+					$form['comment_author_email'],
+					$form['comment_author_url'],
+					$form['comment_content'],
+					$form['user_ip'],
+					$form['user_agent'],
+				)
+			)
+		) {
 			return true;
 		}
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Contact Form: avoid deprecated notices when submitting a form

See https://make.wordpress.org/core/2020/07/23/codebase-language-improvements-in-5-5/

Primary issue: #15388 

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:
From 2 sites, both running this branch, one running WP 5.4.2 and another WP 5.5:

* Activate contact form feature.
* Add a form to a post
* Under Settings > Discussion, add the word "jeremy" to the comment disallowed list.
* View the post with your form, and submit a form with that word.
* The form should be submitted successfully, with no notices in your log, and you should see the form submission in the Spam category in the Feedback menu in wp-admin.

#### Proposed changelog entry for your changes:

* Contact Form: updates based on language improvements in WordPress 5.5.
