### PR TITLE
Reconnect Process: Partial Reconnect

### DIFF
--- a/_inc/client/state/connection/actions.js
+++ b/_inc/client/state/connection/actions.js
@@ -289,7 +289,7 @@ export const reconnectSite = ( action = 'reconnect' ) => {
 					dispatch( {
 						type: SITE_RECONNECT_SUCCESS,
 					} );
-					dispatch( removeNotice( 'reconnect-jetpack' ) );
+					window.location.reload();
 				}
 			} )
 			.catch( error => {

--- a/packages/connection/composer.json
+++ b/packages/connection/composer.json
@@ -7,7 +7,8 @@
 		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-options": "@dev",
 		"automattic/jetpack-roles": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-tracking": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/connection/src/class-client.php
+++ b/packages/connection/src/class-client.php
@@ -168,57 +168,6 @@ class Client {
 	}
 
 	/**
-	 * Fetches a signed token.
-	 *
-	 * @param string $token the token.
-	 * @return string a signed token
-	 */
-	public static function get_signed_token( $token ) {
-		list( $token_key, $token_secret ) = explode( '.', $token->secret );
-
-		$token_key = sprintf(
-			'%s:%d:%d',
-			$token_key,
-			Constants::get_constant( 'JETPACK__API_VERSION' ),
-			$token->external_user_id
-		);
-
-		$timestamp = time();
-
-		if ( function_exists( 'wp_generate_password' ) ) {
-			$nonce = wp_generate_password( 10, false );
-		} else {
-			$nonce = substr( sha1( wp_rand( 0, 1000000 ) ), 0, 10 );
-		}
-
-		$normalized_request_string = join(
-			"\n",
-			array(
-				$token_key,
-				$timestamp,
-				$nonce,
-			)
-		) . "\n";
-
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-		$signature = base64_encode( hash_hmac( 'sha1', $normalized_request_string, $token_secret, true ) );
-
-		$auth = array(
-			'token'     => $token_key,
-			'timestamp' => $timestamp,
-			'nonce'     => $nonce,
-			'signature' => $signature,
-		);
-
-		$header_pieces = array();
-		foreach ( $auth as $key => $value ) {
-			$header_pieces[] = sprintf( '%s="%s"', $key, $value );
-		}
-
-		return join( ' ', $header_pieces );
-	}
-
-	/**
 	 * Wrapper for wp_remote_request().  Turns off SSL verification for certain SSL errors.
 	 * This is lame, but many, many, many hosts have misconfigured SSL.
 	 *

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2584,7 +2584,7 @@ class Manager {
 			'2',
 			'sites/' . $blog_id . '/jetpack-refresh-blog-token'
 		);
-		$method  = 'GET';
+		$method  = 'POST';
 		$user_id = get_current_user_id();
 
 		$response = Client::remote_request( compact( 'url', 'method', 'user_id' ) );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2569,13 +2569,18 @@ class Manager {
 	 * @return WP_Error|bool The result of updating the blog_token option.
 	 */
 	public static function refresh_blog_token() {
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		if ( ! $blog_id ) {
+			return new WP_Error( 'site_not_registered', 'Site not registered.' );
+		}
+
 		$url     = sprintf(
 			'%s://%s/%s/v%s/%s',
 			Client::protocol(),
 			Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' ),
 			'wpcom',
 			'2',
-			'jetpack-refresh-blog-token'
+			'sites/' . $blog_id . '/jetpack-refresh-blog-token'
 		);
 		$method  = 'GET';
 		$user_id = get_current_user_id();

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -2578,7 +2578,7 @@ class Manager {
 			'jetpack-refresh-blog-token'
 		);
 		$method  = 'GET';
-		$user_id = JETPACK_MASTER_USER;
+		$user_id = get_current_user_id();
 
 		$response = Client::remote_request( compact( 'url', 'method', 'user_id' ) );
 
@@ -2595,15 +2595,15 @@ class Manager {
 			$json = false;
 		}
 
-		if ( 200 !== $code || ! empty( $json->error ) ) {
-			if ( empty( $json->error ) ) {
+		if ( 200 !== $code ) {
+			if ( empty( $json->code ) ) {
 				return new WP_Error( 'unknown', '', $code );
 			}
 
 			/* translators: Error description string. */
-			$error_description = isset( $json->error_description ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->error_description ) : '';
+			$error_description = isset( $json->message ) ? sprintf( __( 'Error Details: %s', 'jetpack' ), (string) $json->message ) : '';
 
-			return new WP_Error( (string) $json->error, $error_description, $code );
+			return new WP_Error( (string) $json->code, $error_description, $code );
 		}
 
 		if ( empty( $json->jetpack_secret ) || ! is_scalar( $json->jetpack_secret ) ) {

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -230,7 +230,7 @@ class REST_Connector {
 	 * @return bool|WP_Error Whether user has the capability 'jetpack_disconnect'.
 	 */
 	public static function jetpack_reconnect_permission_check() {
-		if ( current_user_can( 'jetpack_connect' ) && current_user_can( 'jetpack_disconnect' ) ) {
+		if ( current_user_can( 'jetpack_reconnect' ) ) {
 			return true;
 		}
 

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -105,7 +105,7 @@ class REST_Connector {
 						'required' => true,
 					),
 				),
-				'permission_callback' => __CLASS__ . '::jetpack_disconnect_permission_check',
+				'permission_callback' => __CLASS__ . '::jetpack_reconnect_permission_check',
 			)
 		);
 	}
@@ -229,8 +229,8 @@ class REST_Connector {
 	 *
 	 * @return bool|WP_Error Whether user has the capability 'jetpack_disconnect'.
 	 */
-	public static function jetpack_disconnect_permission_check() {
-		if ( current_user_can( 'jetpack_disconnect' ) ) {
+	public static function jetpack_reconnect_permission_check() {
+		if ( current_user_can( 'jetpack_connect' ) && current_user_can( 'jetpack_disconnect' ) ) {
 			return true;
 		}
 

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -264,7 +264,16 @@ class REST_Connector {
 
 		switch ( $params['action'] ) {
 			case 'reconnect':
-				$next = $this->connection->restore();
+				$result = $this->connection->restore();
+
+				if ( is_wp_error( $result ) ) {
+					$response = $result;
+				} elseif ( is_string( $result ) ) {
+					$next = $result;
+				} else {
+					$next = true === $result ? 'completed' : 'failed';
+				}
+
 				break;
 			case 'reconnect_force':
 				$result = $this->connection->reconnect();
@@ -284,6 +293,12 @@ class REST_Connector {
 			case 'authorize':
 				$response['status']       = 'in_progress';
 				$response['authorizeUrl'] = $this->connection->get_authorization_url();
+				break;
+			case 'completed':
+				$response['status'] = 'completed';
+				break;
+			case 'failed':
+				$response = new WP_Error( 'Reconnect failed' );
 				break;
 		}
 

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -260,19 +260,30 @@ class REST_Connector {
 
 		$response = array();
 
+		$next = null;
+
 		switch ( $params['action'] ) {
 			case 'reconnect':
+				$next = $this->connection->restore();
+				break;
+			case 'reconnect_force':
 				$result = $this->connection->reconnect();
 
 				if ( true === $result ) {
-					$response['status']       = 'in_progress';
-					$response['authorizeUrl'] = $this->connection->get_authorization_url();
+					$next = 'authorize';
 				} elseif ( is_wp_error( $result ) ) {
 					$response = $result;
 				}
 				break;
 			default:
 				$response = new WP_Error( 'Unknown action' );
+				break;
+		}
+
+		switch ( $next ) {
+			case 'authorize':
+				$response['status']       = 'in_progress';
+				$response['authorizeUrl'] = $this->connection->get_authorization_url();
 				break;
 		}
 

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -54,8 +54,7 @@ class Test_REST_Endpoints extends TestCase {
 		add_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
 
 		$user = wp_get_current_user();
-		$user->add_cap( 'jetpack_connect' );
-		$user->add_cap( 'jetpack_disconnect' );
+		$user->add_cap( 'jetpack_reconnect' );
 
 		$this->api_host_original                                  = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' );
 		Constants::$set_constants['JETPACK__WPCOM_JSON_API_HOST'] = 'public-api.wordpress.com';
@@ -72,8 +71,7 @@ class Test_REST_Endpoints extends TestCase {
 		remove_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
 
 		$user = wp_get_current_user();
-		$user->remove_cap( 'jetpack_disconnect' );
-		$user->remove_cap( 'jetpack_connect' );
+		$user->remove_cap( 'jetpack_reconnect' );
 
 		Constants::$set_constants['JETPACK__WPCOM_JSON_API_HOST'] = $this->api_host_original;
 

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -172,7 +172,7 @@ class Test_REST_Endpoints extends TestCase {
 		$this->assertSame( 0, strpos( $data['authorizeUrl'], 'https://jetpack.wordpress.com/jetpack.authorize/1' ) );
 
 		remove_filter( 'pre_http_request', array( $this, 'intercept_register_request' ), 10 );
-		$this->setup_reconnect_test( null );
+		$this->shutdown_reconnect_test( null );
 	}
 
 	/**

--- a/packages/connection/tests/php/test-rest-endpoints.php
+++ b/packages/connection/tests/php/test-rest-endpoints.php
@@ -6,6 +6,7 @@ require_once ABSPATH . WPINC . '/class-IXR.php';
 
 use Automattic\Jetpack\Connection\Plugin as Connection_Plugin;
 use Automattic\Jetpack\Connection\Plugin_Storage as Connection_Plugin_Storage;
+use Automattic\Jetpack\Constants;
 use phpmock\MockBuilder;
 use PHPUnit\Framework\TestCase;
 use WP_REST_Request;
@@ -20,12 +21,21 @@ use Requests_Utility_CaseInsensitiveDictionary;
  */
 class Test_REST_Endpoints extends TestCase {
 
+	const BLOG_TOKEN = 'new.blogtoken';
+
 	/**
 	 * REST Server object.
 	 *
 	 * @var WP_REST_Server
 	 */
 	private $server;
+
+	/**
+	 * The original hostname to restore after tests are finished.
+	 *
+	 * @var string
+	 */
+	private $api_host_original;
 
 	/**
 	 * Setting up the test.
@@ -42,6 +52,15 @@ class Test_REST_Endpoints extends TestCase {
 		new REST_Connector( new Manager() );
 
 		add_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
+
+		$user = wp_get_current_user();
+		$user->add_cap( 'jetpack_connect' );
+		$user->add_cap( 'jetpack_disconnect' );
+
+		$this->api_host_original                                  = Constants::get_constant( 'JETPACK__WPCOM_JSON_API_HOST' );
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_HOST'] = 'public-api.wordpress.com';
+
+		set_transient( 'jetpack_assumed_site_creation_date', '2020-02-28 01:13:27' );
 	}
 
 	/**
@@ -51,6 +70,14 @@ class Test_REST_Endpoints extends TestCase {
 		parent::tearDown();
 
 		remove_action( 'jetpack_disabled_raw_options', array( $this, 'bypass_raw_options' ) );
+
+		$user = wp_get_current_user();
+		$user->remove_cap( 'jetpack_disconnect' );
+		$user->remove_cap( 'jetpack_connect' );
+
+		Constants::$set_constants['JETPACK__WPCOM_JSON_API_HOST'] = $this->api_host_original;
+
+		delete_transient( 'jetpack_assumed_site_creation_date' );
 	}
 
 	/**
@@ -131,30 +158,71 @@ class Test_REST_Endpoints extends TestCase {
 	}
 
 	/**
-	 * Testing the `connection/reconnect` endpoint.
+	 * Testing the `connection/reconnect` endpoint, full reconnect.
 	 */
-	public function test_connection_reconnect() {
-		$user = wp_get_current_user();
-		$user->add_cap( 'jetpack_disconnect' );
-
-		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/reconnect' );
-		$this->request->set_header( 'Content-Type', 'application/json' );
-		$this->request->set_body( wp_json_encode( array( 'action' => 'reconnect' ) ) );
-
-		set_transient( 'jetpack_assumed_site_creation_date', '2020-02-28 01:13:27' );
+	public function test_connection_reconnect_full() {
+		$this->setup_reconnect_test( null );
 		add_filter( 'pre_http_request', array( $this, 'intercept_register_request' ), 10, 3 );
 
-		$response = $this->server->dispatch( $this->request );
+		$response = $this->server->dispatch( $this->build_reconnect_request() );
 		$this->assertEquals( 200, $response->get_status() );
 
 		$data = $response->get_data();
 		$this->assertEquals( 'in_progress', $data['status'] );
-		$this->assertEquals( 0, strpos( $data['authorizeUrl'], 'https://jetpack.wordpress.com/jetpack.authorize/1' ) );
+		$this->assertSame( 0, strpos( $data['authorizeUrl'], 'https://jetpack.wordpress.com/jetpack.authorize/1' ) );
 
 		remove_filter( 'pre_http_request', array( $this, 'intercept_register_request' ), 10 );
-		delete_transient( 'jetpack_assumed_site_creation_date' );
+		$this->setup_reconnect_test( null );
+	}
 
-		$user->remove_cap( 'jetpack_disconnect' );
+	/**
+	 * Testing the `connection/reconnect` endpoint, successful partial reconnect (blog token).
+	 */
+	public function test_connection_reconnect_partial_blog_token_success() {
+		$this->setup_reconnect_test( 'blog_token' );
+		add_filter( 'pre_http_request', array( $this, 'intercept_refresh_blog_token_request' ), 10, 3 );
+
+		$response = $this->server->dispatch( $this->build_reconnect_request() );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'completed', $data['status'] );
+
+		remove_filter( 'pre_http_request', array( $this, 'intercept_refresh_blog_token_request' ), 10 );
+		$this->shutdown_reconnect_test( 'blog_token' );
+	}
+
+	/**
+	 * Testing the `connection/reconnect` endpoint, failed partial reconnect (blog token).
+	 */
+	public function test_connection_reconnect_partial_blog_token_fail() {
+		$this->setup_reconnect_test( 'blog_token' );
+		add_filter( 'pre_http_request', array( $this, 'intercept_refresh_blog_token_request_fail' ), 10, 3 );
+
+		$response = $this->server->dispatch( $this->build_reconnect_request() );
+		$this->assertEquals( 500, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'jetpack_secret', $data['code'] );
+
+		remove_filter( 'pre_http_request', array( $this, 'intercept_refresh_blog_token_request_fail' ), 10 );
+		$this->shutdown_reconnect_test( 'blog_token' );
+	}
+
+	/**
+	 * Testing the `connection/reconnect` endpoint, successful partial reconnect (user token).
+	 */
+	public function test_connection_reconnect_partial_user_token_success() {
+		$this->setup_reconnect_test( 'user_token' );
+
+		$response = $this->server->dispatch( $this->build_reconnect_request() );
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'in_progress', $data['status'] );
+		$this->assertSame( 0, strpos( $data['authorizeUrl'], 'https://jetpack.wordpress.com/jetpack.authorize/1' ) );
+
+		$this->shutdown_reconnect_test( 'user_token' );
 	}
 
 	/**
@@ -197,6 +265,283 @@ class Test_REST_Endpoints extends TestCase {
 				'message' => 'OK',
 			),
 		);
+	}
+
+	/**
+	 * Intercept the `jetpack-token-health` API request sent to WP.com, and mock the "invalid blog token" response.
+	 *
+	 * @param bool|array $response The existing response.
+	 * @param array      $args The request arguments.
+	 * @param string     $url The request URL.
+	 *
+	 * @return array
+	 */
+	public function intercept_validate_tokens_request_invalid_blog_token( $response, $args, $url ) {
+		if ( false === strpos( $url, 'jetpack-token-health' ) ) {
+			return $response;
+		}
+
+		return $this->build_validate_tokens_response( 'blog_token' );
+	}
+
+	/**
+	 * Intercept the `jetpack-token-health` API request sent to WP.com, and mock the "invalid user token" response.
+	 *
+	 * @param bool|array $response The existing response.
+	 * @param array      $args The request arguments.
+	 * @param string     $url The request URL.
+	 *
+	 * @return array
+	 */
+	public function intercept_validate_tokens_request_invalid_user_token( $response, $args, $url ) {
+		if ( false === strpos( $url, 'jetpack-token-health' ) ) {
+			return $response;
+		}
+
+		return $this->build_validate_tokens_response( 'user_token' );
+	}
+
+	/**
+	 * Intercept the `jetpack-token-health` API request sent to WP.com, and mock the "valid tokens" response.
+	 *
+	 * @param bool|array $response The existing response.
+	 * @param array      $args The request arguments.
+	 * @param string     $url The request URL.
+	 *
+	 * @return array
+	 */
+	public function intercept_validate_tokens_request_valid_tokens( $response, $args, $url ) {
+		if ( false === strpos( $url, 'jetpack-token-health' ) ) {
+			return $response;
+		}
+
+		return $this->build_validate_tokens_response( null );
+	}
+
+	/**
+	 * Build the response for a tokens validation request
+	 *
+	 * @param string $invalid_token Accepted values: 'blog_token', 'user_token'.
+	 *
+	 * @return array
+	 */
+	private function build_validate_tokens_response( $invalid_token ) {
+		$body = array(
+			'blog_token' => array(
+				'is_healthy' => true,
+			),
+			'user_token' => array(
+				'is_healthy'     => true,
+				'is_master_user' => true,
+			),
+		);
+
+		switch ( $invalid_token ) {
+			case 'blog_token':
+				$body['blog_token'] = array(
+					'is_healthy' => false,
+					'code'       => 'unknown_token',
+				);
+				break;
+			case 'user_token':
+				$body['user_token'] = array(
+					'is_healthy' => false,
+					'code'       => 'unknown_token',
+				);
+				break;
+		}
+
+		return array(
+			'headers'  => new Requests_Utility_CaseInsensitiveDictionary( array( 'content-type' => 'application/json' ) ),
+			'body'     => wp_json_encode( $body ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Intercept the `jetpack-refresh-blog-token` API request sent to WP.com, and mock the success response.
+	 *
+	 * @param bool|array $response The existing response.
+	 * @param array      $args The request arguments.
+	 * @param string     $url The request URL.
+	 *
+	 * @return array
+	 */
+	public function intercept_refresh_blog_token_request( $response, $args, $url ) {
+		if ( false === strpos( $url, 'jetpack-refresh-blog-token' ) ) {
+			return $response;
+		}
+
+		return array(
+			'headers'  => new Requests_Utility_CaseInsensitiveDictionary( array( 'content-type' => 'application/json' ) ),
+			'body'     => wp_json_encode( array( 'jetpack_secret' => self::BLOG_TOKEN ) ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Intercept the `jetpack-refresh-blog-token` API request sent to WP.com, and mock the failure response.
+	 *
+	 * @param bool|array $response The existing response.
+	 * @param array      $args The request arguments.
+	 * @param string     $url The request URL.
+	 *
+	 * @return array
+	 */
+	public function intercept_refresh_blog_token_request_fail( $response, $args, $url ) {
+		if ( false === strpos( $url, 'jetpack-refresh-blog-token' ) ) {
+			return $response;
+		}
+
+		return array(
+			'headers'  => new Requests_Utility_CaseInsensitiveDictionary( array( 'content-type' => 'application/json' ) ),
+			'body'     => wp_json_encode( array( 'jetpack_secret_missing' => true ) ), // Meaningless body.
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Intercept the `Jetpack_Options` call to get `blog_id`, and set a random value.
+	 *
+	 * @param mixed  $value The current option value.
+	 * @param string $name Option name.
+	 *
+	 * @return int
+	 */
+	public function mock_blog_id( $value, $name ) {
+		if ( 'id' !== $name ) {
+			return $value;
+		}
+
+		return 42;
+	}
+
+	/**
+	 * Intercept the `Jetpack_Options` call to get `user_tokens`, and set a mock value.
+	 *
+	 * @param mixed  $value The current option value.
+	 * @param string $name Option name.
+	 *
+	 * @return int
+	 */
+	public function mock_access_tokens( $value, $name ) {
+		if ( 'blog_token' !== $name ) {
+			return $value;
+		}
+
+		return self::BLOG_TOKEN;
+	}
+
+	/**
+	 * Build the `connection/reconnect` request object.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function build_reconnect_request() {
+		$this->request = new WP_REST_Request( 'POST', '/jetpack/v4/connection/reconnect' );
+		$this->request->set_header( 'Content-Type', 'application/json' );
+		$this->request->set_body( wp_json_encode( array( 'action' => 'reconnect' ) ) );
+
+		return $this->request;
+	}
+
+	/**
+	 * Setup the environment to test the reconnection process.
+	 *
+	 * @param string|null $invalid_token The invalid token to be returned in the response. Null if the tokens should be valid.
+	 */
+	private function setup_reconnect_test( $invalid_token ) {
+		switch ( $invalid_token ) {
+			case 'blog_token':
+				add_filter(
+					'pre_http_request',
+					array(
+						$this,
+						'intercept_validate_tokens_request_invalid_blog_token',
+					),
+					10,
+					3
+				);
+				break;
+			case 'user_token':
+				add_filter(
+					'pre_http_request',
+					array(
+						$this,
+						'intercept_validate_tokens_request_invalid_user_token',
+					),
+					10,
+					3
+				);
+				break;
+			case null:
+				add_filter(
+					'pre_http_request',
+					array(
+						$this,
+						'intercept_validate_tokens_request_valid_tokens',
+					),
+					10,
+					3
+				);
+				break;
+		}
+
+		add_filter( 'jetpack_options', array( $this, 'mock_access_tokens' ), 10, 2 );
+		add_filter( 'jetpack_options', array( $this, 'mock_blog_id' ), 10, 2 );
+	}
+
+	/**
+	 * Restore the environment after the `reconnect` test has been run.
+	 *
+	 * @param string|null $invalid_token The invalid token to be returned in the response. Null if the tokens should be valid.
+	 */
+	private function shutdown_reconnect_test( $invalid_token ) {
+		switch ( $invalid_token ) {
+			case 'blog_token':
+				remove_filter(
+					'pre_http_request',
+					array(
+						$this,
+						'intercept_validate_tokens_request_invalid_blog_token',
+					),
+					10
+				);
+				break;
+			case 'user_token':
+				remove_filter(
+					'pre_http_request',
+					array(
+						$this,
+						'intercept_validate_tokens_request_invalid_user_token',
+					),
+					10
+				);
+				break;
+			case null:
+				remove_filter(
+					'pre_http_request',
+					array(
+						$this,
+						'intercept_validate_tokens_request_valid_tokens',
+					),
+					10
+				);
+				break;
+		}
+
+		remove_filter( 'jetpack_options', array( $this, 'mock_blog_id' ), 10 );
+		remove_filter( 'jetpack_options', array( $this, 'mock_access_tokens' ), 10 );
+		remove_filter( 'pre_http_request', array( $this, 'intercept_validate_tokens_request' ), 10 );
 	}
 
 }

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -423,6 +423,36 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
+	 * Test the `get_signed_token` functionality.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Manager::get_signed_token
+	 */
+	public function test_get_signed_token() {
+		$access_token = (object) array(
+			'external_user_id' => 1,
+		);
+
+		$manager = ( new Manager() );
+		// Missing secret.
+		$invalid_token_error = new WP_Error( 'invalid_token' );
+		$this->assertEquals( $invalid_token_error, $manager->get_signed_token( $access_token ) );
+		// Secret is null.
+		$access_token->secret = null;
+		$this->assertEquals( $invalid_token_error, $manager->get_signed_token( $access_token ) );
+		// Secret is empty.
+		$access_token->secret = '';
+		$this->assertEquals( $invalid_token_error, $manager->get_signed_token( $access_token ) );
+		// Valid secret.
+		$access_token->secret = 'abcd1234';
+
+		$signed_token = $manager->get_signed_token( $access_token );
+		$this->assertTrue( strpos( $signed_token, 'token' ) !== false );
+		$this->assertTrue( strpos( $signed_token, 'timestamp' ) !== false );
+		$this->assertTrue( strpos( $signed_token, 'nonce' ) !== false );
+		$this->assertTrue( strpos( $signed_token, 'signature' ) !== false );
+	}
+
+	/**
 	 * Mock a global function and make it return a certain value.
 	 *
 	 * @param string $function_name Name of the function.

--- a/packages/connection/tests/php/test_Manager.php
+++ b/packages/connection/tests/php/test_Manager.php
@@ -18,6 +18,7 @@ use phpmock\MockBuilder;
 use phpmock\MockEnabledException;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
+use WP_Error;
 
 /**
  * Connection Manager functionality testing.


### PR DESCRIPTION
~Requires `D46648-code` and `D47087-code`  patches to be applied.~ Patches deployed.

#### Changes proposed in this Pull Request:
- Blog and user tokens get validated via the `jetpack-token-health` WP.com endpoint.
- If the user token is invalid, it gets refreshed.
- If the blog token is invalid, it gets refreshed via the  `jetpack-refresh-blog-token` WP.com endpoint.

#### Jetpack product discussion
`p9dueE-1CV-p2`

#### Does this pull request change what data or activity we track or use?
Yes.
It adds three new events for the "Restore Connection" process:
- `restore_connection_reconnect` (full reconnect started)
- `restore_connection_refresh_blog_token` (blog token refresh initiated)
- `restore_connection_refresh_user_token` (user token refresh initiated)
Any of these events can only be triggered after Jetpack has already been connected, therefore TOS have been accepted.
Additionally, there's [TOS check](https://github.com/Automattic/jetpack/blob/master/packages/tracking/src/class-tracking.php#L107) in the code that doesn't allow the events to be tracked if TOS wasn't accepted.

#### Testing instructions:
1. Check out the branch, install the "Debug Tools", activate the "Broken Token".
2. Break the blog token.
3. Go to Jetpack Dashboard and confirm that you see the error notice.
4. Click "Restore Connection" button.
5. The dashboard should reload, the blog token should be restored. You *should not* have to click on the "Approve" button.
7. Break the user token, save somewhere existing blog token.
8. Add following code into your theme's `functions.php`:
```php
add_filter( 'react_connection_errors_initial_state', function( $errors ) {
	$errors[] = array(
		'message' => __('Connection Error'),
		'action' => 'reconnect',
		'code' => 'invalid_blog_token',
	);

	return $errors;
} );
```
9. Reload the Jetpack Dashboard, click "Restore Connection" in the error notice.
10. The authorization iframe should appear below the error notice, click "Approve".
11. Jetpack Dashboard should reload, the broken user token should be restored. The blog token _should not_ change.
12. **Do not** break any tokens, but open the "Broken Token" tab and save the current tokens somewhere.
13. Go to the Jetpack Dashboard, click "Restore Connection". Go through the authorization process.
14. Open another "Broken Token" tab and confirm that both blog and user tokens have changed.

#### Proposed changelog entry for your changes:
* Improved restoring connection to WordPress.com in case of connection errors.
