### PR TITLE
Donations block: Remove "import-docblock" rule exceptions

### DIFF
--- a/extensions/blocks/donations/attributes.js
+++ b/extensions/blocks/donations/attributes.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
 import { __ } from '@wordpress/i18n';
 
 export default {

--- a/extensions/blocks/donations/context.js
+++ b/extensions/blocks/donations/context.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
 import { createContext } from '@wordpress/element';
 
 const Context = createContext( {

--- a/extensions/blocks/donations/controls.js
+++ b/extensions/blocks/donations/controls.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
 import { ExternalLink, PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';

--- a/extensions/blocks/donations/fetch-default-products.js
+++ b/extensions/blocks/donations/fetch-default-products.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
 import apiFetch from '@wordpress/api-fetch';
 
 const fetchDefaultProducts = async currency => {

--- a/extensions/blocks/donations/fetch-status.js
+++ b/extensions/blocks/donations/fetch-status.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
 import apiFetch from '@wordpress/api-fetch';
 
 const fetchStatus = async ( type = null ) => {

--- a/extensions/blocks/donations/loading-error.js
+++ b/extensions/blocks/donations/loading-error.js
@@ -1,4 +1,3 @@
-/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */

--- a/extensions/blocks/donations/loading-status.js
+++ b/extensions/blocks/donations/loading-status.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line wpcalypso/import-docblock
 import { __ } from '@wordpress/i18n';
 import { Placeholder, Spinner } from '@wordpress/components';
 


### PR DESCRIPTION
Follows up #16545.

#### Changes proposed in this Pull Request:
Remove the eslint exceptions disabling the `wpcalypso/import-docblock` from the donations block now that `eslint-plugin-wpcalypso` has been updated in #16566.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
Make sure CI builds pass.

#### Proposed changelog entry for your changes:
N/A
