### PR TITLE
Status: add new method to check for a local development site, and expand list of staging sites.

### DIFF
--- a/_inc/client/components/jetpack-notices/index.jsx
+++ b/_inc/client/components/jetpack-notices/index.jsx
@@ -122,7 +122,9 @@ export class OfflineModeNotice extends React.Component {
 				);
 			}
 			if ( offlineMode.url ) {
-				reasons.push( __( 'Your site URL lacks a dot (e.g. http://localhost)', 'jetpack' ) );
+				reasons.push(
+					__( 'Your site URL is a known local development environment URL', 'jetpack' )
+				);
 			}
 
 			const text = jetpackCreateInterpolateElement(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -1659,7 +1659,9 @@ class Jetpack {
 	 * Determines reason for Jetpack offline mode.
 	 */
 	public static function development_mode_trigger_text() {
-		if ( ! ( new Status() )->is_offline_mode() ) {
+		$status = new Status();
+
+		if ( ! $status->is_offline_mode() ) {
 			return __( 'Jetpack is not in Offline Mode.', 'jetpack' );
 		}
 
@@ -1667,8 +1669,8 @@ class Jetpack {
 			$notice = __( 'The JETPACK_DEV_DEBUG constant is defined in wp-config.php or elsewhere.', 'jetpack' );
 		} elseif ( defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV ) {
 			$notice = __( 'The WP_LOCAL_DEV constant is defined in wp-config.php or elsewhere.', 'jetpack' );
-		} elseif ( site_url() && false === strpos( site_url(), '.' ) ) {
-			$notice = __( 'The site URL lacking a dot (e.g. http://localhost).', 'jetpack' );
+		} elseif ( $status->is_local_site() ) {
+			$notice = __( 'The site URL is a known local development environment URL (e.g. http://localhost).', 'jetpack' );
 			/** This filter is documented in packages/status/src/class-status.php */
 		} elseif ( has_filter( 'jetpack_development_mode' ) && apply_filters( 'jetpack_development_mode', false ) ) { // This is a deprecated filter name.
 			$notice = __( 'The jetpack_development_mode filter is set to true.', 'jetpack' );

--- a/packages/connection/src/class-rest-connector.php
+++ b/packages/connection/src/class-rest-connector.php
@@ -148,7 +148,7 @@ class REST_Connector {
 			'offlineMode'  => array(
 				'isActive'        => $status->is_offline_mode(),
 				'constant'        => defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG,
-				'url'             => site_url() && false === strpos( site_url(), '.' ),
+				'url'             => $status->is_local_site(),
 				/** This filter is documented in packages/status/src/class-status.php */
 				'filter'          => ( apply_filters( 'jetpack_development_mode', false ) || apply_filters( 'jetpack_offline_mode', false ) ), // jetpack_development_mode is deprecated.
 				'wpLocalConstant' => defined( 'WP_LOCAL_DEV' ) && WP_LOCAL_DEV,

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -36,14 +36,13 @@ class Status {
 	 */
 	public function is_offline_mode() {
 		$offline_mode = false;
-		$site_url     = site_url();
 
 		if ( defined( '\\JETPACK_DEV_DEBUG' ) ) {
 			$offline_mode = constant( '\\JETPACK_DEV_DEBUG' );
 		} elseif ( defined( '\\WP_LOCAL_DEV' ) ) {
 			$offline_mode = constant( '\\WP_LOCAL_DEV' );
-		} elseif ( $site_url ) {
-			$offline_mode = false === strpos( $site_url, '.' );
+		} elseif ( $this->is_local_site() ) {
+			$offline_mode = true;
 		}
 
 		/**

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -134,10 +134,12 @@ class Status {
 			'#\.lndo\.site$#i',    // Lando.
 		);
 
-		foreach ( $known_local as $url ) {
-			if ( preg_match( $url, site_url() ) ) {
-				$is_local = true;
-				break;
+		if ( ! $is_local ) {
+			foreach ( $known_local as $url ) {
+				if ( preg_match( $url, site_url() ) ) {
+					$is_local = true;
+					break;
+				}
 			}
 		}
 

--- a/packages/status/src/class-status.php
+++ b/packages/status/src/class-status.php
@@ -114,6 +114,45 @@ class Status {
 	}
 
 	/**
+	 * If the site is a local site.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @return bool
+	 */
+	public function is_local_site() {
+		// Check for localhost and sites using an IP only first.
+		$is_local = site_url() && false === strpos( site_url(), '.' );
+
+		// Then check for usual usual domains used by local dev tools.
+		$known_local = array(
+			'#\.local$#i',
+			'#\.localhost$#i',
+			'#\.test$#i',
+			'#\.docksal$#i',      // Docksal.
+			'#\.docksal\.site$#i', // Docksal.
+			'#\.dev\.cc$#i',       // ServerPress.
+			'#\.lndo\.site$#i',    // Lando.
+		);
+
+		foreach ( $known_local as $url ) {
+			if ( preg_match( $url, site_url() ) ) {
+				$is_local = true;
+				break;
+			}
+		}
+
+		/**
+		 * Filters is_local_site check.
+		 *
+		 * @since 8.8.0
+		 *
+		 * @param bool $is_local If the current site is a local site.
+		 */
+		return apply_filters( 'jetpack_is_local_site', $is_local );
+	}
+
+	/**
 	 * If is a staging site.
 	 *
 	 * @todo Add IDC detection to a package.
@@ -129,9 +168,16 @@ class Status {
 			'urls'      => array(
 				'#\.staging\.wpengine\.com$#i', // WP Engine.
 				'#\.staging\.kinsta\.com$#i',   // Kinsta.com.
+				'#\.kinsta\.cloud$#i',          // Kinsta.com.
 				'#\.stage\.site$#i',            // DreamPress.
 				'#\.newspackstaging\.com$#i',   // Newspack.
+				'#\.pantheonsite\.io$#i',       // Pantheon.
+				'#\.flywheelsites\.com$#i',     // Flywheel.
 				'#\.flywheelstaging\.com$#i',   // Flywheel.
+				'#\.cloudwaysapps\.com$#i',     // Cloudways.
+				'#\.azurewebsites\.net$#i',     // Azure.
+				'#\.wpserveur\.net$#i',         // WPServeur.
+				'#\-liquidwebsites\.com$#i',    // Liquidweb.
 			),
 			'constants' => array(
 				'IS_WPE_SNAPSHOT',      // WP Engine.

--- a/packages/status/tests/php/test-status.php
+++ b/packages/status/tests/php/test-status.php
@@ -334,4 +334,60 @@ class Test_Status extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests known local development sites.
+	 *
+	 * @dataProvider get_is_local_site_known_tld
+	 *
+	 * @param string $site_url Site URL.
+	 * @param bool   $expected_response Expected response.
+	 */
+	public function test_is_local_site_for_known_tld( $site_url, $expected_response ) {
+		Functions\when( 'site_url' )->justReturn( $site_url );
+		$result = $this->status->is_local_site();
+		$this->assertEquals(
+			$expected_response,
+			$result,
+			sprintf(
+				'Expected %1$s to return %2$s for is_local_site()',
+				$site_url,
+				$expected_response
+			)
+		);
+	}
+
+	/**
+	 * Known hosting providers.
+	 *
+	 * @return array
+	 */
+	public function get_is_local_site_known_tld() {
+		return array(
+			'vvv'            => array(
+				'http://jetpack.test',
+				true,
+			),
+			'docksal'        => array(
+				'http://jetpack.docksal',
+				true,
+			),
+			'serverpress'    => array(
+				'http://jetpack.dev.cc',
+				true,
+			),
+			'lando'          => array(
+				'http://jetpack.lndo.site',
+				true,
+			),
+			'test_subdomain' => array(
+				'https://test.jetpack.com',
+				false,
+			),
+			'test_in_domain' => array(
+				'https://jetpack.test.jetpack.com',
+				false,
+			),
+		);
+	}
 }


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This PR builts on top of #16338. **It is open against that branch**.

It does 3 things:
- It expands our list of known staging sites to detect more hosting providers. @Automattic/jetpack-infinity I'm adding you as reviewers for this PR so you can review and maybe warn hosting providers if necessary?
- It adds a new method to the Status package, allowing us to better detect local sites, as discussed here:
https://github.com/Automattic/jetpack/issues/11798#issuecomment-651514631
- It uses that new method in the Admin dashboard and in Site Health checks.

**Before**

<img width="1185" alt="screenshot 2020-07-27 at 13 12 51" src="https://user-images.githubusercontent.com/426388/88540650-a20df080-d013-11ea-907b-b43356db075e.png">

**After**

<img width="1032" alt="screenshot 2020-07-27 at 14 05 29" src="https://user-images.githubusercontent.com/426388/88540625-9a4e4c00-d013-11ea-8f9c-4b410723dd99.png">
<img width="1135" alt="screenshot 2020-07-27 at 14 01 59" src="https://user-images.githubusercontent.com/426388/88540630-9c180f80-d013-11ea-8bf2-a76824d74ce8.png">

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* On a local site, go to Tools > Site Health and Jetpack > Dashboard, and check the messages as per the screenshots above.

#### Proposed changelog entry for your changes:

* Connnection Tools: improve local development environment detection.