### PR TITLE
Remove jQuery from sharing.js

### DIFF
--- a/modules/sharedaddy/sharing-service.php
+++ b/modules/sharedaddy/sharing-service.php
@@ -950,7 +950,7 @@ function sharing_display( $text = '', $echo = false ) {
 					'_inc/build/sharedaddy/sharing.min.js',
 					'modules/sharedaddy/sharing.js'
 				),
-				array( 'jquery' ),
+				array(),
 				$ver,
 				false
 			);

--- a/modules/sharedaddy/sharing.js
+++ b/modules/sharedaddy/sharing.js
@@ -1,160 +1,400 @@
 /* global WPCOM_sharing_counts, grecaptcha */
-var sharing_js_options;
-if ( sharing_js_options && sharing_js_options.counts ) {
-	var WPCOMSharing = {
-		done_urls: [],
-		get_counts: function () {
-			var url, requests, id, service, service_request;
 
-			if ( 'undefined' === typeof WPCOM_sharing_counts ) {
-				return;
+// NOTE: This file intentionally does not make use of polyfills or libraries,
+// including jQuery. Please keep all code as IE11-compatible vanilla ES5, and
+// ensure everything is inside an IIFE to avoid global namespace pollution.
+// Code follows WordPress browser support guidelines. For an up to date list,
+// see https://make.wordpress.org/core/handbook/best-practices/browser-support/
+
+( function () {
+	var currentScript = document.currentScript;
+
+	// -------------------------- UTILITY FUNCTIONS -------------------------- //
+
+	// Helper function to load an external script.
+	function loadScript( url ) {
+		var script = document.createElement( 'script' );
+		var prev = currentScript || document.getElementsByTagName( 'script' )[ 0 ];
+		script.async = true;
+		script.src = url;
+		prev.parentNode.insertBefore( script, prev );
+	}
+
+	// Helper closest parent node function (not a polyfill) based on
+	// https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill
+	function closest( el, sel ) {
+		if ( el.closest ) {
+			return el.closest( sel );
+		}
+
+		var matcher =
+			Element.prototype.matches ||
+			Element.prototype.msMatchesSelector ||
+			Element.prototype.webkitMatchesSelector;
+		var current = el;
+
+		do {
+			var matches = matcher.bind( current );
+			if ( matches( sel ) ) {
+				return current;
 			}
+			current = current.parentElement || current.parentNode;
+		} while ( current !== null && current.nodeType === 1 );
 
-			for ( url in WPCOM_sharing_counts ) {
-				id = WPCOM_sharing_counts[ url ];
+		return null;
+	}
 
-				if ( 'undefined' !== typeof WPCOMSharing.done_urls[ id ] ) {
-					continue;
+	// Helper function to iterate over a NodeList
+	// (since IE 11 doesn't have NodeList.prototype.forEach)
+	function forEachNode( list, fn ) {
+		for ( var i = 0; i < list.length; i++ ) {
+			var node = list[ i ];
+			fn( node, i, list );
+		}
+	}
+
+	// Helper function to remove a node from the DOM.
+	function removeNode( node ) {
+		if ( node && node.parentNode ) {
+			node.parentNode.removeChild( node );
+		}
+	}
+
+	// Helper functions to show/hide a node, and check its status.
+	function hideNode( node ) {
+		if ( node ) {
+			node.style.display = 'none';
+		}
+	}
+
+	function showNode( node ) {
+		if ( node ) {
+			node.style.removeProperty( 'display' );
+		}
+	}
+
+	function isNodeHidden( node ) {
+		return ! node || node.style.display === 'none';
+	}
+
+	// ------------------------------- CLASSES ------------------------------- //
+
+	// Implements a MoreButton class, which controls the lifecycle and behavior
+	// of a "more" button and its dialog.
+	function MoreButton( buttonEl ) {
+		this.button = buttonEl;
+		this.pane = closest( buttonEl, 'div' ).querySelector( '.sharing-hidden .inner' );
+		this.openedBy = null;
+		this.recentlyOpenedByHover = false;
+
+		MoreButton.instances[ this.pane ] = this;
+
+		this.attachHandlers();
+	}
+
+	// Keep a reference to each instance, indexed by the pane DOM element,
+	// so we can get back to it from the DOM.
+	MoreButton.instances = {};
+
+	// Delay time configs.
+	MoreButton.hoverOpenDelay = 200;
+	MoreButton.recentOpenDelay = 400;
+	MoreButton.hoverCloseDelay = 300;
+
+	// Use this to avoid creating new instances for buttons which already have one.
+	MoreButton.instantiateOrReuse = function ( buttonEl ) {
+		var pane = buttonEl && closest( buttonEl, 'div' ).querySelector( '.sharing-hidden .inner' );
+
+		var existingInstance = pane && MoreButton.instances[ pane ];
+		if ( existingInstance ) {
+			return existingInstance;
+		}
+
+		return new MoreButton( buttonEl );
+	};
+
+	// Retrieve a button instance from the pane DOM element.
+	MoreButton.getButtonInstanceFromPane = function ( paneEl ) {
+		return MoreButton.instances[ paneEl ];
+	};
+
+	// Close all open More Button dialogs.
+	MoreButton.closeAll = function () {
+		for ( var key in MoreButton.instances ) {
+			MoreButton.instances[ key ].close();
+		}
+	};
+
+	MoreButton.prototype.open = function () {
+		this.pane.style.left = this.button.offsetLeft + 'px';
+		this.pane.style.top = this.button.offsetTop + this.button.offsetHeight + 'px';
+		showNode( this.pane );
+	};
+
+	MoreButton.prototype.close = function () {
+		hideNode( this.pane );
+		this.openedBy = null;
+	};
+
+	MoreButton.prototype.toggle = function () {
+		if ( isNodeHidden( this.pane ) ) {
+			this.open();
+		} else {
+			this.close();
+		}
+	};
+
+	MoreButton.prototype.resetCloseTimer = function () {
+		clearTimeout( this.closeTimer );
+		this.closeTimer = setTimeout( this.close.bind( this ), MoreButton.hoverCloseDelay );
+	};
+
+	MoreButton.prototype.attachHandlers = function () {
+		this.buttonClick = function ( event ) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			this.openedBy = 'click';
+			clearTimeout( this.openTimer );
+			clearTimeout( this.closeTimer );
+
+			closeEmailDialog();
+
+			if ( this.recentlyOpenedByHover ) {
+				this.recentlyOpenedByHover = false;
+				clearTimeout( this.hoverOpenTimer );
+				this.open();
+			} else {
+				this.toggle();
+			}
+		}.bind( this );
+
+		this.buttonEnter = function () {
+			if ( ! this.openedBy ) {
+				this.openTimer = setTimeout(
+					function () {
+						closeEmailDialog();
+						this.open();
+						this.openedBy = 'hover';
+						this.recentlyOpenedByHover = true;
+						this.hoverOpenTimer = setTimeout(
+							function () {
+								this.recentlyOpenedByHover = false;
+							}.bind( this ),
+							MoreButton.recentOpenDelay
+						);
+					}.bind( this ),
+					MoreButton.hoverOpenDelay
+				);
+			}
+			clearTimeout( this.closeTimer );
+		}.bind( this );
+
+		this.buttonLeave = function () {
+			if ( this.openedBy === 'hover' ) {
+				this.resetCloseTimer();
+			}
+			clearTimeout( this.openTimer );
+		}.bind( this );
+
+		this.paneEnter = function () {
+			clearTimeout( this.closeTimer );
+		}.bind( this );
+
+		this.paneLeave = function () {
+			if ( this.openedBy === 'hover' ) {
+				this.resetCloseTimer();
+			}
+		}.bind( this );
+
+		this.documentClick = function () {
+			this.close();
+		}.bind( this );
+
+		this.button.addEventListener( 'click', this.buttonClick );
+		document.addEventListener( 'click', this.documentClick );
+
+		if ( document.ontouchstart === undefined ) {
+			// Non-touchscreen device: use hover/mouseout with delay
+			this.button.addEventListener( 'mouseenter', this.buttonEnter );
+			this.button.addEventListener( 'mouseleave', this.buttonLeave );
+			this.pane.addEventListener( 'mouseenter', this.paneEnter );
+			this.pane.addEventListener( 'mouseleave', this.paneLeave );
+		}
+	};
+
+	// ---------------------------- SHARE COUNTS ---------------------------- //
+
+	if ( window.sharing_js_options && window.sharing_js_options.counts ) {
+		var WPCOMSharing = {
+			done_urls: [],
+			get_counts: function () {
+				var url, requests, id, service, service_request;
+
+				if ( 'undefined' === typeof WPCOM_sharing_counts ) {
+					return;
 				}
 
-				requests = {
-					// Pinterest handles share counts for both http and https
-					pinterest: [
-						window.location.protocol +
-							'//api.pinterest.com/v1/urls/count.json?callback=WPCOMSharing.update_pinterest_count&url=' +
-							encodeURIComponent( url ),
-					],
-					// Facebook protocol summing has been shown to falsely double counts, so we only request the current URL
-					facebook: [
-						window.location.protocol +
-							'//graph.facebook.com/?callback=WPCOMSharing.update_facebook_count&ids=' +
-							encodeURIComponent( url ),
-					],
-				};
+				for ( url in WPCOM_sharing_counts ) {
+					id = WPCOM_sharing_counts[ url ];
 
-				for ( service in requests ) {
-					if ( ! jQuery( 'a[data-shared=sharing-' + service + '-' + id + ']' ).length ) {
+					if ( 'undefined' !== typeof WPCOMSharing.done_urls[ id ] ) {
 						continue;
 					}
 
-					while ( ( service_request = requests[ service ].pop() ) ) {
-						jQuery.getScript( service_request );
+					requests = {
+						// Pinterest handles share counts for both http and https
+						pinterest: [
+							window.location.protocol +
+								'//api.pinterest.com/v1/urls/count.json?callback=WPCOMSharing.update_pinterest_count&url=' +
+								encodeURIComponent( url ),
+						],
+						// Facebook protocol summing has been shown to falsely double counts, so we only request the current URL
+						facebook: [
+							window.location.protocol +
+								'//graph.facebook.com/?callback=WPCOMSharing.update_facebook_count&ids=' +
+								encodeURIComponent( url ),
+						],
+					};
+
+					for ( service in requests ) {
+						if ( ! document.querySelector( 'a[data-shared=sharing-' + service + '-' + id + ']' ) ) {
+							continue;
+						}
+
+						while ( ( service_request = requests[ service ].pop() ) ) {
+							loadScript( service_request );
+						}
+
+						if ( window.sharing_js_options.is_stats_active ) {
+							WPCOMSharing.bump_sharing_count_stat( service );
+						}
 					}
 
-					if ( sharing_js_options.is_stats_active ) {
-						WPCOMSharing.bump_sharing_count_stat( service );
-					}
+					WPCOMSharing.done_urls[ id ] = true;
+				}
+			},
+
+			// get the version of the url that was stored in the dom
+			get_permalink: function ( url ) {
+				if ( 'https:' === window.location.protocol ) {
+					url = url.replace( /^http:\/\//i, 'https://' );
+				} else {
+					url = url.replace( /^https:\/\//i, 'http://' );
 				}
 
-				WPCOMSharing.done_urls[ id ] = true;
-			}
-		},
+				return url;
+			},
+			update_facebook_count: function ( data ) {
+				var url, permalink;
 
-		// get the version of the url that was stored in the dom (sharing-$service-URL)
-		get_permalink: function ( url ) {
-			if ( 'https:' === window.location.protocol ) {
-				url = url.replace( /^http:\/\//i, 'https://' );
-			} else {
-				url = url.replace( /^https:\/\//i, 'http://' );
-			}
+				if ( ! data ) {
+					return;
+				}
 
-			return url;
-		},
-		update_facebook_count: function ( data ) {
-			var url, permalink;
+				for ( url in data ) {
+					if (
+						! Object.prototype.hasOwnProperty.call( data, url ) ||
+						! data[ url ].share ||
+						! data[ url ].share.share_count
+					) {
+						continue;
+					}
 
-			if ( ! data ) {
-				return;
-			}
+					permalink = WPCOMSharing.get_permalink( url );
 
-			for ( url in data ) {
-				if (
-					! data.hasOwnProperty( url ) ||
-					! data[ url ].share ||
-					! data[ url ].share.share_count
+					if ( ! ( permalink in WPCOM_sharing_counts ) ) {
+						continue;
+					}
+
+					WPCOMSharing.inject_share_count(
+						'sharing-facebook-' + WPCOM_sharing_counts[ permalink ],
+						data[ url ].share.share_count
+					);
+				}
+			},
+			update_pinterest_count: function ( data ) {
+				if ( 'undefined' !== typeof data.count && data.count * 1 > 0 ) {
+					WPCOMSharing.inject_share_count(
+						'sharing-pinterest-' + WPCOM_sharing_counts[ data.url ],
+						data.count
+					);
+				}
+			},
+			inject_share_count: function ( id, count ) {
+				forEachNode( document.querySelectorAll( 'a[data-shared=' + id + '] > span' ), function (
+					span
 				) {
-					continue;
+					var countNode = span.querySelector( '.share-count' );
+					removeNode( countNode );
+					var newNode = document.createElement( 'span' );
+					newNode.className = 'share-count';
+					newNode.textContent = WPCOMSharing.format_count( count );
+					span.appendChild( newNode );
+				} );
+			},
+			format_count: function ( count ) {
+				if ( count < 1000 ) {
+					return count;
 				}
-
-				permalink = WPCOMSharing.get_permalink( url );
-
-				if ( ! ( permalink in WPCOM_sharing_counts ) ) {
-					continue;
+				if ( count >= 1000 && count < 10000 ) {
+					return String( count ).substring( 0, 1 ) + 'K+';
 				}
+				return '10K+';
+			},
+			bump_sharing_count_stat: function ( service ) {
+				new Image().src =
+					document.location.protocol +
+					'//pixel.wp.com/g.gif?v=wpcom-no-pv&x_sharing-count-request=' +
+					service +
+					'&r=' +
+					Math.random();
+			},
+		};
+		window.WPCOMSharing = WPCOMSharing;
+	}
 
-				WPCOMSharing.inject_share_count(
-					'sharing-facebook-' + WPCOM_sharing_counts[ permalink ],
-					data[ url ].share.share_count
-				);
-			}
-		},
-		update_pinterest_count: function ( data ) {
-			if ( 'undefined' !== typeof data.count && data.count * 1 > 0 ) {
-				WPCOMSharing.inject_share_count(
-					'sharing-pinterest-' + WPCOM_sharing_counts[ data.url ],
-					data.count
-				);
-			}
-		},
-		inject_share_count: function ( id, count ) {
-			var $share = jQuery( 'a[data-shared=' + id + '] > span' );
-			$share.find( '.share-count' ).remove();
-			$share.append(
-				'<span class="share-count">' + WPCOMSharing.format_count( count ) + '</span>'
-			);
-		},
-		format_count: function ( count ) {
-			if ( count < 1000 ) {
-				return count;
-			}
-			if ( count >= 1000 && count < 10000 ) {
-				return String( count ).substring( 0, 1 ) + 'K+';
-			}
-			return '10K+';
-		},
-		bump_sharing_count_stat: function ( service ) {
-			new Image().src =
-				document.location.protocol +
-				'//pixel.wp.com/g.gif?v=wpcom-no-pv&x_sharing-count-request=' +
-				service +
-				'&r=' +
-				Math.random();
-		},
-	};
-}
+	// ------------------------ BUTTON FUNCTIONALITY ------------------------ //
 
-( function ( $ ) {
-	var $body, $sharing_email;
+	function shareIsEmail( val ) {
+		return /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i.test(
+			val
+		);
+	}
 
-	$.fn.extend( {
-		share_is_email: function () {
-			return /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i.test(
-				this.val()
-			);
-		},
-	} );
+	function closeEmailDialog() {
+		var dialog = document.querySelector( '#sharing_email' );
+		hideNode( dialog );
+	}
 
-	$body = $( document.body ).on( 'post-load', WPCOMSharing_do );
-	$( document ).ready( function () {
-		$sharing_email = $( '#sharing_email' );
-		$body.append( $sharing_email );
+	// Sharing initialization.
+	// Will run immediately or on `DOMContentLoaded`, depending on current page status.
+	function init() {
+		// Move email dialog to end of body.
+		var emailDialog = document.querySelector( '#sharing_email' );
+		document.body.appendChild( emailDialog );
+
 		WPCOMSharing_do();
-	} );
+	}
+	if ( document.readyState !== 'loading' ) {
+		init();
+	} else {
+		document.addEventListener( 'DOMContentLoaded', init );
+	}
 
+	// Set up sharing again whenever a new post loads, to pick up any new buttons.
+	document.body.addEventListener( 'post-load', WPCOMSharing_do );
+
+	// Set up sharing, updating counts and adding all button functionality.
 	function WPCOMSharing_do() {
-		var $more_sharing_buttons;
-		if ( 'undefined' !== typeof WPCOMSharing ) {
-			WPCOMSharing.get_counts();
+		if ( window.WPCOMSharing ) {
+			window.WPCOMSharing.get_counts();
 		}
-		$more_sharing_buttons = $( '.sharedaddy a.sharing-anchor' );
 
-		$more_sharing_buttons.click( function () {
-			return false;
-		} );
-
-		$( '.sharedaddy a' ).each( function () {
-			if ( $( this ).attr( 'href' ) && $( this ).attr( 'href' ).indexOf( 'share=' ) !== -1 ) {
-				$( this ).attr( 'href', $( this ).attr( 'href' ) + '&nb=1' );
+		forEachNode( document.querySelectorAll( '.sharedaddy a' ), function ( anchor ) {
+			var href = anchor.getAttribute( 'href' );
+			if ( href && href.indexOf( 'share=' ) !== -1 && href.indexOf( '&nb=1' ) === -1 ) {
+				anchor.setAttribute( 'href', href + '&nb=1' );
 			}
 		} );
 
@@ -162,203 +402,73 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 
 		// Touchscreen device: use click.
 		// Non-touchscreen device: use click if not already appearing due to a hover event
-		$more_sharing_buttons.on( 'click', function () {
-			var $more_sharing_button = $( this ),
-				$more_sharing_pane = $more_sharing_button.parents( 'div:first' ).find( '.inner' );
 
-			if ( $more_sharing_pane.is( ':animated' ) ) {
-				// We're in the middle of some other event's animation
-				return;
-			}
-
-			if ( true === $more_sharing_pane.data( 'justSlid' ) ) {
-				// We just finished some other event's animation - don't process click event so that slow-to-react-clickers don't get confused
-				return;
-			}
-
-			$sharing_email.slideUp( 200 );
-
-			$more_sharing_pane
-				.css( {
-					left: $more_sharing_button.position().left + 'px',
-					top: $more_sharing_button.position().top + $more_sharing_button.height() + 3 + 'px',
-				} )
-				.slideToggle( 200 );
+		forEachNode( document.querySelectorAll( '.sharedaddy a.sharing-anchor' ), function (
+			buttonEl
+		) {
+			MoreButton.instantiateOrReuse( buttonEl );
 		} );
 
-		if ( document.ontouchstart === undefined ) {
-			// Non-touchscreen device: use hover/mouseout with delay
-			$more_sharing_buttons.hover(
-				function () {
-					var $more_sharing_button = $( this ),
-						$more_sharing_pane = $more_sharing_button.parents( 'div:first' ).find( '.inner' ),
-						timer;
-
-					if ( ! $more_sharing_pane.is( ':animated' ) ) {
-						// Create a timer to make the area appear if the mouse hovers for a period
-						timer = setTimeout( function () {
-							var handler_item_leave,
-								handler_item_enter,
-								handler_original_leave,
-								handler_original_enter,
-								close_it;
-
-							$sharing_email.slideUp( 200 );
-
-							$more_sharing_pane.data( 'justSlid', true );
-							$more_sharing_pane
-								.css( {
-									left: $more_sharing_button.position().left + 'px',
-									top:
-										$more_sharing_button.position().top + $more_sharing_button.height() + 3 + 'px',
-								} )
-								.slideDown( 200, function () {
-									// Mark the item as have being appeared by the hover
-									$more_sharing_button.data( 'hasoriginal', true ).data( 'hasitem', false );
-
-									setTimeout( function () {
-										$more_sharing_pane.data( 'justSlid', false );
-									}, 300 );
-
-									$more_sharing_pane
-										.mouseleave( handler_item_leave )
-										.mouseenter( handler_item_enter );
-									$more_sharing_button
-										.mouseleave( handler_original_leave )
-										.mouseenter( handler_original_enter );
-								} );
-
-							// The following handlers take care of the mouseenter/mouseleave for the share button and the share area - if both are left then we close the share area
-							handler_item_leave = function () {
-								$more_sharing_button.data( 'hasitem', false );
-
-								if ( $more_sharing_button.data( 'hasoriginal' ) === false ) {
-									var timer = setTimeout( close_it, 800 );
-									$more_sharing_button.data( 'timer2', timer );
-								}
-							};
-
-							handler_item_enter = function () {
-								$more_sharing_button.data( 'hasitem', true );
-								clearTimeout( $more_sharing_button.data( 'timer2' ) );
-							};
-
-							handler_original_leave = function () {
-								$more_sharing_button.data( 'hasoriginal', false );
-
-								if ( $more_sharing_button.data( 'hasitem' ) === false ) {
-									var timer = setTimeout( close_it, 800 );
-									$more_sharing_button.data( 'timer2', timer );
-								}
-							};
-
-							handler_original_enter = function () {
-								$more_sharing_button.data( 'hasoriginal', true );
-								clearTimeout( $more_sharing_button.data( 'timer2' ) );
-							};
-
-							close_it = function () {
-								$more_sharing_pane.data( 'justSlid', true );
-								$more_sharing_pane.slideUp( 200, function () {
-									setTimeout( function () {
-										$more_sharing_pane.data( 'justSlid', false );
-									}, 300 );
-								} );
-
-								// Clear all hooks
-								$more_sharing_button
-									.unbind( 'mouseleave', handler_original_leave )
-									.unbind( 'mouseenter', handler_original_enter );
-								$more_sharing_pane
-									.unbind( 'mouseleave', handler_item_leave )
-									.unbind( 'mouseenter', handler_item_leave );
-								return false;
-							};
-						}, 200 );
-
-						// Remember the timer so we can detect it on the mouseout
-						$more_sharing_button.data( 'timer', timer );
-					}
-				},
-				function () {
-					// Mouse out - remove any timer
-					$more_sharing_buttons.each( function () {
-						clearTimeout( $( this ).data( 'timer' ) );
-					} );
-					$more_sharing_buttons.data( 'timer', false );
-				}
-			);
-		} else {
-			$( document.body ).addClass( 'jp-sharing-input-touch' );
+		if ( document.ontouchstart !== undefined ) {
+			document.body.classList.add( 'jp-sharing-input-touch' );
 		}
 
-		$( document ).click( function () {
-			// Click outside
-			// remove any timer
-			$more_sharing_buttons.each( function () {
-				clearTimeout( $( this ).data( 'timer' ) );
-			} );
-			$more_sharing_buttons.data( 'timer', false );
-
-			// slide down forcibly
-			$( '.sharedaddy .inner' ).slideUp();
-		} );
-
 		// Add click functionality
-		$( '.sharedaddy ul' ).each( function () {
-			if ( 'yep' === $( this ).data( 'has-click-events' ) ) {
+		forEachNode( document.querySelectorAll( '.sharedaddy ul' ), function ( group ) {
+			if ( group.getAttribute( 'data-sharing-events-added' ) === 'true' ) {
 				return;
 			}
-			$( this ).data( 'has-click-events', 'yep' );
+			group.setAttribute( 'data-sharing-events-added', 'true' );
 
 			var printUrl = function ( uniqueId, urlToPrint ) {
-				$( 'body:first' ).append(
-					'<iframe style="position:fixed;top:100;left:100;height:1px;width:1px;border:none;" id="printFrame-' +
-						uniqueId +
-						'" name="printFrame-' +
-						uniqueId +
-						'" src="' +
-						urlToPrint +
-						'" onload="frames[\'printFrame-' +
-						uniqueId +
-						"'].focus();frames['printFrame-" +
-						uniqueId +
-						'\'].print();"></iframe>'
-				);
+				var iframe = document.createElement( 'iframe' );
+				iframe.style = 'position:fixed; top:100; left:100; height:1px; width:1px; border:none;';
+				iframe.id = 'printFrame-' + uniqueId;
+				iframe.name = iframe.id;
+				iframe.src = urlToPrint;
+				iframe.onload =
+					'frames["printFrame-' +
+					uniqueId +
+					'"].focus();frames["printFrame-' +
+					uniqueId +
+					'"].print();';
+				document.body.appendChild( iframe );
 			};
 
 			// Print button
-			$( this )
-				.find( 'a.share-print' )
-				.click( function () {
-					var ref = $( this ).attr( 'href' ),
-						do_print = function () {
-							if ( ref.indexOf( '#print' ) === -1 ) {
-								var uid = new Date().getTime();
-								printUrl( uid, ref );
-							} else {
-								print();
-							}
-						};
+			forEachNode( group.querySelectorAll( 'a.share-print' ), function ( printButton ) {
+				printButton.addEventListener( 'click', function ( event ) {
+					event.preventDefault();
+					event.stopPropagation();
+
+					var ref = printButton.getAttribute( 'href' ) || '';
+					var doPrint = function () {
+						if ( ref.indexOf( '#print' ) === -1 ) {
+							var uid = new Date().getTime();
+							printUrl( uid, ref );
+						} else {
+							window.print();
+						}
+					};
 
 					// Is the button in a dropdown?
-					if ( $( this ).parents( '.sharing-hidden' ).length > 0 ) {
-						$( this )
-							.parents( '.inner' )
-							.slideUp( 0, function () {
-								do_print();
-							} );
-					} else {
-						do_print();
+					var pane = closest( printButton, '.sharing-hidden .inner' );
+					if ( pane ) {
+						var moreButton = MoreButton.getButtonInstanceFromPane( pane );
+						if ( moreButton ) {
+							moreButton.close();
+							doPrint();
+						}
 					}
-
-					return false;
 				} );
+			} );
 
 			// Press This button
-			$( this )
-				.find( 'a.share-press-this' )
-				.click( function () {
+			forEachNode( group.querySelectorAll( 'a.share-press-this' ), function ( pressThisButton ) {
+				pressThisButton.addEventListener( 'click', function ( event ) {
+					event.preventDefault();
+					event.stopPropagation();
+
 					var s = '';
 
 					if ( window.getSelection ) {
@@ -370,39 +480,47 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 					}
 
 					if ( s ) {
-						$( this ).attr( 'href', $( this ).attr( 'href' ) + '&sel=' + encodeURI( s ) );
+						var href = pressThisButton.getAttribute( 'href' );
+						pressThisButton.setAttribute( 'href', href + '&sel=' + encodeURI( s ) );
 					}
 
 					if (
 						! window.open(
-							$( this ).attr( 'href' ),
+							pressThisButton.getAttribute( 'href' ),
 							't',
 							'toolbar=0,resizable=1,scrollbars=1,status=1,width=720,height=570'
 						)
 					) {
-						document.location.href = $( this ).attr( 'href' );
+						document.location.href = pressThisButton.getAttribute( 'href' );
 					}
-
-					return false;
 				} );
+			} );
 
 			// Email button
-			$( 'a.share-email', this ).on( 'click', function () {
-				var url = $( this ).attr( 'href' );
-				var currentDomain = window.location.protocol + '//' + window.location.hostname + '/';
-				if ( url.indexOf( currentDomain ) !== 0 ) {
-					return true;
-				}
+			forEachNode( group.querySelectorAll( 'a.share-email' ), function ( emailButton ) {
+				var dialog = document.querySelector( '#sharing_email' );
 
-				if ( $sharing_email.is( ':visible' ) ) {
-					$sharing_email.slideUp( 200 );
-				} else {
-					$( '.sharedaddy .inner' ).slideUp();
+				emailButton.addEventListener( 'click', function ( event ) {
+					event.preventDefault();
+					event.stopPropagation();
 
-					$( '#sharing_email .response' ).remove();
-					$( '#sharing_email form' ).show();
-					$( '#sharing_email form input[type=submit]' ).removeAttr( 'disabled' );
-					$( '#sharing_email form a.sharing_cancel' ).show();
+					var url = emailButton.getAttribute( 'href' );
+					var currentDomain = window.location.protocol + '//' + window.location.hostname + '/';
+					if ( url.indexOf( currentDomain ) !== 0 ) {
+						return true;
+					}
+
+					if ( ! isNodeHidden( dialog ) ) {
+						closeEmailDialog();
+						return;
+					}
+
+					removeNode( document.querySelector( '#sharing_email .response' ) );
+
+					var form = document.querySelector( '#sharing_email form' );
+					showNode( form );
+					form.querySelector( 'input[type=submit]' ).removeAttribute( 'disabled' );
+					showNode( form.querySelector( 'a.sharing_cancel' ) );
 
 					// Reset reCATPCHA if exists.
 					if (
@@ -414,95 +532,138 @@ if ( sharing_js_options && sharing_js_options.counts ) {
 					}
 
 					// Show dialog
-					$sharing_email
-						.css( {
-							left: $( this ).offset().left + 'px',
-							top: $( this ).offset().top + $( this ).height() + 'px',
-						} )
-						.slideDown( 200 );
+					var rect = emailButton.getBoundingClientRect();
+					var scrollLeft = window.pageXOffset || document.documentElement.scrollLeft || 0;
+					var scrollTop = window.pageYOffset || document.documentElement.scrollTop || 0;
+					dialog.style.left = scrollLeft + rect.left + 'px';
+					dialog.style.top = scrollTop + rect.top + rect.height + 'px';
+					showNode( dialog );
 
-					// Hook up other buttons
-					$( '#sharing_email a.sharing_cancel' )
-						.unbind( 'click' )
-						.click( function () {
-							$( '#sharing_email .errors' ).hide();
-							$sharing_email.slideUp( 200 );
-							$( '#sharing_background' ).fadeOut();
-							return false;
-						} );
+					// Close all open More Button dialogs.
+					MoreButton.closeAll();
+				} );
 
-					// Submit validation
-					$( '#sharing_email input[type=submit]' )
-						.unbind( 'click' )
-						.click( function () {
-							var form = $( this ).parents( 'form' );
-							var source_email_input = form.find( 'input[name=source_email]' );
-							var target_email_input = form.find( 'input[name=target_email]' );
+				// Hook up other buttons
+				dialog.querySelector( 'a.sharing_cancel' ).addEventListener( 'click', function ( event ) {
+					event.preventDefault();
+					event.stopPropagation();
 
-							// Disable buttons + enable loading icon
-							$( this ).prop( 'disabled', true );
-							form.find( 'a.sharing_cancel' ).hide();
-							form.find( 'img.loading' ).show();
+					hideNode( dialog.querySelector( '.errors' ) );
+					hideNode( dialog );
+					hideNode( document.querySelector( '#sharing_background' ) );
+				} );
 
-							$( '#sharing_email .errors' ).hide();
-							$( '#sharing_email .error' ).removeClass( 'error' );
+				var submitButton = dialog.querySelector( 'input[type=submit]' );
+				submitButton.addEventListener( 'click', function ( event ) {
+					event.preventDefault();
+					event.stopPropagation();
 
-							if ( ! source_email_input.share_is_email() ) {
-								source_email_input.addClass( 'error' );
+					var form = closest( submitButton, 'form' );
+					var source_email_input = form.querySelector( 'input[name=source_email]' );
+					var target_email_input = form.querySelector( 'input[name=target_email]' );
+
+					// Disable buttons + enable loading icon
+					submitButton.setAttribute( 'disabled', true );
+					hideNode( form.querySelector( 'a.sharing_cancel' ) );
+					forEachNode( form.querySelectorAll( 'img.loading' ), function ( img ) {
+						showNode( img );
+					} );
+
+					hideNode( form.querySelector( '.errors' ) );
+
+					forEachNode( form.querySelectorAll( '.error' ), function ( node ) {
+						node.classList.remove( 'error' );
+					} );
+
+					if ( ! shareIsEmail( source_email_input.value ) ) {
+						source_email_input.classList.add( 'error' );
+					}
+
+					if ( ! shareIsEmail( target_email_input.value ) ) {
+						target_email_input.classList.add( 'error' );
+					}
+
+					if ( ! form.querySelector( '.error' ) ) {
+						// Encode form data. This would be much easier if we could rely on URLSearchParams...
+						var params = [];
+						for ( var i = 0; i < form.elements.length; i++ ) {
+							if ( form.elements[ i ].name ) {
+								// Encode each form element into a URI-compatible string.
+								var encoded =
+									encodeURIComponent( form.elements[ i ].name ) +
+									'=' +
+									encodeURIComponent( form.elements[ i ].value );
+								// In x-www-form-urlencoded, spaces should be `+`, not `%20`.
+								params.push( encoded.replace( '%20', '+' ) );
 							}
+						}
+						var data = params.join( '&' );
 
-							if ( ! target_email_input.share_is_email() ) {
-								target_email_input.addClass( 'error' );
-							}
+						// AJAX send the form
+						var request = new XMLHttpRequest();
+						request.open( 'POST', emailButton.getAttribute( 'href' ), true );
+						request.setRequestHeader(
+							'Content-Type',
+							'application/x-www-form-urlencoded; charset=UTF-8'
+						);
+						request.setRequestHeader( 'x-requested-with', 'XMLHttpRequest' );
 
-							if ( $( '#sharing_email .error' ).length === 0 ) {
-								// AJAX send the form
-								$.ajax( {
-									url: url,
-									type: 'POST',
-									data: form.serialize(),
-									success: function ( response ) {
-										form.find( 'img.loading' ).hide();
-
-										if ( response === '1' || response === '2' || response === '3' ) {
-											$( '#sharing_email .errors-' + response ).show();
-											form.find( 'input[type=submit]' ).removeAttr( 'disabled' );
-											form.find( 'a.sharing_cancel' ).show();
-
-											if (
-												'object' === typeof grecaptcha &&
-												'function' === typeof grecaptcha.reset
-											) {
-												grecaptcha.reset();
-											}
-										} else {
-											$( '#sharing_email form' ).hide();
-											$sharing_email.append( response );
-											$( '#sharing_email a.sharing_cancel' ).click( function () {
-												$sharing_email.slideUp( 200 );
-												$( '#sharing_background' ).fadeOut();
-												return false;
-											} );
-										}
-									},
+						request.onreadystatechange = function () {
+							if ( this.readyState === XMLHttpRequest.DONE && this.status === 200 ) {
+								forEachNode( form.querySelectorAll( 'img.loading' ), function ( img ) {
+									hideNode( img );
 								} );
 
-								return false;
+								if ( this.response === '1' || this.response === '2' || this.response === '3' ) {
+									showNode( dialog.querySelector( '.errors-' + this.response ) );
+									dialog.querySelector( 'input[type=submit]' ).removeAttribute( 'disabled' );
+									showNode( dialog.querySelector( 'a.sharing_cancel' ) );
+
+									if ( typeof grecaptcha === 'object' && typeof grecaptcha.reset === 'function' ) {
+										grecaptcha.reset();
+									}
+								} else {
+									hideNode( form );
+									var temp = document.createElement( 'div' );
+									temp.innerHTML = this.response;
+									dialog.appendChild( temp.firstChild );
+									showNode( dialog.querySelector( 'a.sharing_cancel' ) );
+									var closeButton = dialog.querySelector( '.response a.sharing_cancel' );
+									if ( closeButton ) {
+										closeButton.addEventListener( 'click', function ( event ) {
+											event.preventDefault();
+											event.stopPropagation();
+
+											closeEmailDialog();
+											hideNode( document.querySelector( '#sharing_background' ) );
+										} );
+									}
+								}
 							}
+						};
 
-							form.find( 'img.loading' ).hide();
-							form.find( 'input[type=submit]' ).removeAttr( 'disabled' );
-							form.find( 'a.sharing_cancel' ).show();
-							$( '#sharing_email .errors-1' ).show();
+						request.send( data );
 
-							return false;
-						} );
-				}
+						return;
+					}
 
-				return false;
+					forEachNode( dialog.querySelectorAll( 'img.loading' ), function ( img ) {
+						hideNode( img );
+					} );
+					submitButton.removeAttribute( 'disabled' );
+					showNode( dialog.querySelector( 'a.sharing_cancel' ) );
+					forEachNode( dialog.querySelectorAll( '.errors-1' ), function ( error ) {
+						showNode( error );
+					} );
+				} );
 			} );
 		} );
 
-		$( 'li.share-email, li.share-custom a.sharing-anchor' ).addClass( 'share-service-visible' );
+		forEachNode(
+			document.querySelectorAll( 'li.share-email, li.share-custom a.sharing-anchor' ),
+			function ( node ) {
+				node.classList.add( 'share-service-visible' );
+			}
+		);
 	}
-} )( jQuery );
+} )();


### PR DESCRIPTION
Works towards #16409.

#### Changes proposed in this Pull Request:

* Reimplement `modules/sharedaddy/sharing.js` without jQuery.
* Remove dependency on `jQuery` when enqueuing

Note: I intentionally removed the slide animation on the dialogs. Slide animations are difficult to implement performantly on the web, and I felt like they didn't add enough here to justify the effort and the additional JS/CSS needed. If you feel it's important, however, please let me know and I'll be happy to go back and cook something up.

#### Does this pull request change what data or activity we track or use?

No.

#### Testing instructions:

* Ensure you're testing the new code (e.g. through a sandbox or Chrome's local overrides)
* Enable sharing buttons in the Jetpack options for your test site
* Configure the sharing buttons so that there's at least one button inside a "More" dialog
* Configure the sharing buttons so that the "Print" and "Email" buttons are enabled
* Go to the test site and open a blog post
* Ensure that share counts are displayed on the buttons that support them (e.g. Facebook)
* Ensure that the More button displays the dialog on hover
* Ensure that the More button displays the dialog on touch / click
* Ensure that the Print button works
* Ensure that the Email button works
* Ensure that all of the above works on IE 11 as well
* If possible, also test the functionality on a site that lazily loads posts as the user scrolls (or clicks on something like a "More posts" button), and ensure that newly loaded posts have their share buttons working correctly too

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Removed `jQuery` dependency from `modules/sharedaddy/sharing.js`
