### PR TITLE
Autoloader: convert '\' directory separators to '/' in plugin paths

### DIFF
--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -50,6 +50,7 @@ class Autoloader_Handler {
 		global $jetpack_autoloader_latest_version;
 
 		$current_autoloader_path = trailingslashit( dirname( __FILE__ ) ) . 'autoload_packages.php';
+		$current_autoloader_path = str_replace( '\\', '/', $current_autoloader_path );
 
 		$selected_autoloader_version = null;
 		$selected_autoloader_path    = null;

--- a/packages/autoloader/src/class-plugins-handler.php
+++ b/packages/autoloader/src/class-plugins-handler.php
@@ -57,7 +57,8 @@ class Plugins_Handler {
 	 * @param string $plugin_slug The plugin slug.
 	 */
 	private function create_plugin_path( $plugin_slug ) {
-		return trailingslashit( WP_PLUGIN_DIR ) . substr( $plugin_slug, 0, strrpos( $plugin_slug, '/' ) );
+		$plugin_dir = str_replace( '\\', '/', WP_PLUGIN_DIR );
+		return trailingslashit( $plugin_dir ) . substr( $plugin_slug, 0, strrpos( $plugin_slug, '/' ) );
 	}
 
 	/**
@@ -142,7 +143,7 @@ class Plugins_Handler {
 	 * @return string The path of the current plugin.
 	 */
 	public function get_current_plugin_path() {
-		$vendor_path = dirname( __FILE__ );
+		$vendor_path = str_replace( '\\', '/', dirname( __FILE__ ) );
 		// Path to the plugin's folder (the parent of the vendor folder).
 		return substr( $vendor_path, 0, strrpos( $vendor_path, '/' ) );
 	}

--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -126,9 +126,9 @@ function reset_maps_after_update( $response, $hook_extra, $result ) {
 
 		/*
 		 * $plugin is the path to the plugin file relative to the plugins directory.
-		 * What if this plugin is not in the plugins directory, for example an mu plugin?
 		 */
-		$plugin_path = trailingslashit( WP_PLUGIN_DIR ) . trailingslashit( explode( '/', $plugin )[0] );
+		$plugin_dir  = str_replace( '\\', '/', WP_PLUGIN_DIR );
+		$plugin_path = trailingslashit( $plugin_dir ) . trailingslashit( explode( '/', $plugin )[0] );
 
 		if ( is_readable( $plugin_path . 'vendor/autoload_functions.php' ) ) {
 			// The plugin has a v2.x autoloader, so reset it.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* On Windows, the directory separator is a `\`. Normalize the plugin paths by converting `\` separators to `/`.

#### Jetpack product discussion
* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:

##### Cause a fatal error in a Windows environment.
1. Install and activate Jetpack using WP-CLI.
2. Observe the fatal error.

##### Test this PR.

If possible, test in both Linux and Windows environments.

1. Install Jetpack.
2. Activate Jetpack using wp-admin and confirm that no errors occur.
3. Deactivate Jetpack.
4. Activate Jetpack using WP-CLI and confirm that no errors occur.

#### Proposed changelog entry for your changes:
* Autoloader: normalize file paths so the autoloader will work properly in Windows environments.
