### PR TITLE
Premium Blocks: Remove Upgrade Nudges from editor

### DIFF
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -18,7 +18,6 @@ import withVideoPressEdit from './edit';
 import withVideoPressSave from './save';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 import deprecatedV1 from './deprecated/v1';
-import wrapPaidBlock from '../../shared/wrap-paid-block';
 import { isSimpleSite } from '../../shared/site-type-utils';
 import withHasWarningIsInteractiveClassNames from '../../shared/with-has-warning-is-interactive-class-names';
 import './editor.scss';
@@ -160,22 +159,7 @@ const addVideoPressSupport = ( settings, name ) => {
 				reusable: false,
 			},
 
-			edit:
-				isSimpleSite() && [ 'missing_plan', 'unknown' ].includes( unavailableReason )
-					? wrapPaidBlock( {
-							requiredPlan: 'value_bundle',
-							customTitle: {
-								knownPlan: __( 'Upgrade to %(planName)s to upload videos.', 'jetpack' ),
-								unknownPlan: __( 'Upgrade to a paid plan to upload videos.', 'jetpack' ),
-							},
-							customSubTitle: __(
-								'Upload unlimited videos to your website and \
-						display them using a fast, unbranded, \
-						customizable player.',
-								'jetpack'
-							),
-					  } )( withVideoPressEdit( edit ) )
-					: withVideoPressEdit( edit ),
+			edit: withVideoPressEdit( edit ),
 
 			save: withVideoPressSave( save ),
 

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -11,7 +11,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import extensionList from '../index.json';
 import getJetpackExtensionAvailability from './get-jetpack-extension-availability';
 import withHasWarningIsInteractiveClassNames from './with-has-warning-is-interactive-class-names';
-import wrapPaidBlock from './wrap-paid-block';
 
 const availableBlockTags = {
 	paid: _x( 'paid', 'Short label appearing near a block requiring a paid plan', 'jetpack' ),
@@ -95,7 +94,6 @@ export default function registerJetpackBlock( name, settings, childBlocks = [] )
 	const result = registerBlockType( `jetpack/${ name }`, {
 		...settings,
 		title: buildBlockTitle( settings.title, buildBlockTags( name, requiredPlan ) ),
-		edit: requiredPlan ? wrapPaidBlock( { requiredPlan } )( settings.edit ) : settings.edit,
 		example: requiredPlan ? undefined : settings.example,
 	} );
 


### PR DESCRIPTION
This PR removes the Upgrade Nudges from the editor.

Fixes https://github.com/Automattic/wp-calypso/issues/44168

### 🌱 Pointing to a Feature branch

This PR is referenced to the `feature/premium-blocks ` feature branch.

#### Changes proposed in this Pull Request:

* Remove Upgrade Nudge from the editor.

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Apply this changes in your sandbox (D47018-code)
* Test in a _Simple site_ with a _Free Plan_
* Sandbox the testing site.
* Confirm that upgrade nudges don't show anymore in the following paid (premium) blocks in the editor.
  - Pay with Paypal
  - Payments
  - Premium Content
  - Donations
  - Calendly
  - OpenTable
  - Video
  - Audio
  - WhatsApp

Before | After
-------|------
![image](https://user-images.githubusercontent.com/77539/88592165-edd09200-d033-11ea-8ac6-3d187d2c4969.png) | ![image](https://user-images.githubusercontent.com/77539/88592121-dabdc200-d033-11ea-8ee4-ad0a0047c2da.png) 


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove upgrade nudge of premium blocks from the editor.
