### PR TITLE
Broken Token: Breaking user tokens improvement

### DIFF
--- a/packages/debug-helper/modules/class-broken-token.php
+++ b/packages/debug-helper/modules/class-broken-token.php
@@ -296,9 +296,14 @@ class Broken_Token {
 	public function admin_post_set_invalid_user_tokens() {
 		check_admin_referer( 'set-invalid-user-tokens' );
 		$this->notice_type = 'jetpack-broken';
-		foreach ( Jetpack_Options::get_option( 'user_tokens', array() ) as $id => $token ) {
-			Jetpack_Options::update_option( 'user_tokens', array( $id => sprintf( $this->invalid_user_token, $id ) ) );
+
+		$new_tokens = array();
+
+		foreach ( Jetpack_Options::get_option( 'user_tokens' ) as $id => $token ) {
+			$new_tokens[ $id ] = sprintf( $this->invalid_user_token, $id );
 		}
+
+		Jetpack_Options::update_option( 'user_tokens', $new_tokens );
 
 		$this->admin_post_redirect_referrer();
 	}

--- a/packages/debug-helper/modules/class-broken-token.php
+++ b/packages/debug-helper/modules/class-broken-token.php
@@ -88,6 +88,7 @@ class Broken_Token {
 		// Break stuff.
 		add_action( 'admin_post_set_invalid_blog_token', array( $this, 'admin_post_set_invalid_blog_token' ) );
 		add_action( 'admin_post_set_invalid_user_tokens', array( $this, 'admin_post_set_invalid_user_tokens' ) );
+		add_action( 'admin_post_set_invalid_current_user_token', array( $this, 'admin_post_set_invalid_current_user_token' ) );
 		add_action( 'admin_post_clear_blog_token', array( $this, 'admin_post_clear_blog_token' ) );
 		add_action( 'admin_post_clear_user_tokens', array( $this, 'admin_post_clear_user_tokens' ) );
 		add_action( 'admin_post_randomize_master_user', array( $this, 'admin_post_randomize_master_user' ) );
@@ -207,6 +208,12 @@ class Broken_Token {
 			<?php wp_nonce_field( 'set-invalid-user-tokens' ); ?>
 			<input type="submit" value="Set invalid user tokens" class="button button-primary button-break-it">
 		</form>
+		<br>
+		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
+			<input type="hidden" name="action" value="set_invalid_current_user_token">
+			<?php wp_nonce_field( 'set-invalid-current-user-token' ); ?>
+			<input type="submit" value="Set invalid user token (current user)" class="button button-primary button-break-it">
+		</form>
 
 		<p><strong>Break the Primary User:</strong></p>
 		<form action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post">
@@ -304,6 +311,23 @@ class Broken_Token {
 		}
 
 		Jetpack_Options::update_option( 'user_tokens', $new_tokens );
+
+		$this->admin_post_redirect_referrer();
+	}
+
+	/**
+	 * Set invalid current user token.
+	 */
+	public function admin_post_set_invalid_current_user_token() {
+		check_admin_referer( 'set-invalid-current-user-token' );
+		$this->notice_type = 'jetpack-broken';
+
+		$tokens = Jetpack_Options::get_option( 'user_tokens' );
+
+		$id            = get_current_user_id();
+		$tokens[ $id ] = sprintf( $this->invalid_user_token, $id );
+
+		Jetpack_Options::update_option( 'user_tokens', $tokens );
 
 		$this->admin_post_redirect_referrer();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
1. Adding a button to break the token for current user only, and leave the rest intact.
2. Currently if there are more than one user tokens, only last token gets "broken", the rest are removed. This commit fixes the issue, allowing "breaking" of all existing tokens instead of deleting them.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
This is a minor change in the internal debugging tool, no testing is necessary.

1. Login as a separate user (non-master), doesn't matter if it's connected to WordPress.com or not.
2. Go to "Jetpack -> Broken Token". Click on the button `Set invalid user token (current user)`.
3. Take a look at the user tokens dump, make sure that your user token has been broken (even if it didn't exist before).
4. Make sure that other tokens remain intact.

#### Proposed changelog entry for your changes:
n/a