### PR TITLE
Premium Blocks: add CSS class to body when Upgrade Nudge is enabled

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -769,6 +769,7 @@ class Jetpack_Gutenberg {
 				'jetpack'          => array(
 					'is_active'                 => Jetpack::is_active(),
 					'is_current_user_connected' => $is_current_user_connected,
+					'enable_upgrade_nudge'      => apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ),
 				),
 				'siteFragment'     => $site_fragment,
 				'tracksUserData'   => $user_data,

--- a/extensions/editor.js
+++ b/extensions/editor.js
@@ -7,6 +7,7 @@ import './shared/plan-upgrade-notification';
 import './shared/stripe-connection-notification';
 import './shared/external-media';
 import './shared/blocks/cover';
+import './shared/premium-blocks';
 import analytics from '../_inc/client/lib/analytics';
 
 // @TODO Please make a shared analytics solution and remove this!

--- a/extensions/shared/plan-utils.js
+++ b/extensions/shared/plan-utils.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import getJetpackData from './get-jetpack-data';
+
+/**
+ * Return whether upgrade nudges are enabled or not.
+ *
+ * @returns {boolean} True if the Upgrade Nudge is enable. Otherwise, False.
+ */
+export function isUpgradeNudgeEnabled() {
+	return get( getJetpackData(), 'jetpack.enable_upgrade_nudge', false );
+}

--- a/extensions/shared/premium-blocks/index.js
+++ b/extensions/shared/premium-blocks/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
+ * Internal dependencies
+ */
+import { isUpgradeNudgeEnabled } from '../plan-utils';
+
+/*
+ * Add the `jetpack-enable-upgrade-nudge` css Class
+ * to the document body if the feature is enabled.
+ */
+domReady( function() {
+	if ( isUpgradeNudgeEnabled() ) {
+		document.body.classList.add( 'jetpack-enable-upgrade-nudge' );
+	}
+} );


### PR DESCRIPTION

This PR adds the `jetpack-enable-upgrade-nudge` CSS class to the document body when the site has enabled the Upgrade Nudge feature.
This class will be used in the next PRs to deal with some visual adjustments needed to implement the new Banner upgrade design. You'd like to take a look at [this commit](https://github.com/Automattic/jetpack/pull/16495/commits/15233684e431a8fd195f490049fd7ea936f80644) to see how it's used to add custom icons to the premium blocks.

### 🌱 Pointing to a Feature branch

This PR is referenced to the `feature/premium-blocks ` feature branch.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add CSS class to body when upgrade-nudge is enabled.


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Apply this changes in your sandbox (D47020-code)
* Test in a _Simple site_ with a _Free Plan_
* Sandbox the testing site.
* ✔️ Confirm the `enable_upgrade_nudge` is true in the global Jetpack object in the client using your dev console.
`Jetpack_Editor_Initial_State.jetpack`

<img width="300" alt="Screen Shot 2020-07-27 at 7 42 08 PM" src="https://user-images.githubusercontent.com/77539/88599097-52461e00-d041-11ea-866f-5f8fa61ffc85.png">

* ✔️ Confirm the `jetpack-enable-upgrade-nudge` CSS is added in the document body for a Simple site with a Free plan.

<img width="481" alt="Screen Shot 2020-07-27 at 7 50 17 PM" src="https://user-images.githubusercontent.com/77539/88599565-76562f00-d042-11ea-9e8a-6857fe136d36.png">

~Test with a paid plan. Either the `enable_upgrade_nudge` jetpack property, as well as the CSS class, shouldn't exist.~

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add CSS class to body when upgrade-nudge is enabled.
