### PR TITLE
Premium Blocks: Add upgrade banner to block inspector

### DIFF
--- a/extensions/shared/components/upgrade-nudge/index.jsx
+++ b/extensions/shared/components/upgrade-nudge/index.jsx
@@ -3,8 +3,7 @@
  */
 import GridiconStar from 'gridicons/dist/star';
 import { __, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import { compact, get, startsWith } from 'lodash';
+import { get, startsWith } from 'lodash';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -14,10 +13,9 @@ import { useEffect } from '@wordpress/element';
  */
 import analytics from '../../../../_inc/client/lib/analytics';
 import BlockNudge from '../block-nudge';
-import getSiteFragment from '../../get-site-fragment';
-import { isSimpleSite } from '../../site-type-utils';
-import './store';
+import { getUpgradeUrl } from '../../plan-utils';
 
+import './store';
 import './style.scss';
 
 const getTitle = ( customTitle, planName ) => {
@@ -94,45 +92,16 @@ export const UpgradeNudge = ( {
 export default compose( [
 	withSelect( ( select, { plan: planSlug, blockName } ) => {
 		const plan = select( 'wordpress-com/plans' ).getPlan( planSlug );
+		const postId = select( 'core/editor' ).getCurrentPostId();
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		const upgradeUrl = getUpgradeUrl( { plan, planSlug, postId, postType } );
 
 		// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
 		// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
 		const planPathSlug = startsWith( planSlug, 'jetpack_' )
 			? planSlug.substr( 'jetpack_'.length )
 			: get( plan, [ 'path_slug' ] );
-
-		const postId = select( 'core/editor' ).getCurrentPostId();
-		const postType = select( 'core/editor' ).getCurrentPostType();
-
-		// The editor for CPTs has an `edit/` route fragment prefixed
-		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
-
-		// Post-checkout: redirect back here
-		const redirect_to = isSimpleSite()
-			? addQueryArgs(
-					'/' +
-						compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
-							'/'
-						),
-					{
-						plan_upgraded: 1,
-					}
-			  )
-			: addQueryArgs(
-					window.location.protocol +
-						`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
-					{
-						action: 'edit',
-						post: postId,
-						plan_upgraded: 1,
-					}
-			  );
-
-		const upgradeUrl =
-			planPathSlug &&
-			addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
-				redirect_to,
-			} );
 
 		const planName = get( plan, [ 'product_name' ] );
 		return {

--- a/extensions/shared/plan-utils.js
+++ b/extensions/shared/plan-utils.js
@@ -75,7 +75,8 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 }
 
 /**
- * Check if the block should is upgradable.
+ * Check if the block is upgradable, based on whether
+ * the block requires a paid plan.
  *
  * @param {string} name - Block name.
  * @returns {boolean} True if it should show the nudge. Otherwise, False.
@@ -85,14 +86,14 @@ export function isUpgradable( name ) {
 		return false;
 	}
 
-	// core/cover is handled in ./extensions/shared/blocks/cover
+	// core/cover is handled in ./extensions/shared/blocks/cover.
 	if ( name === 'core/cover' ) {
 		return false;
 	}
 
 	let blockName = /^jetpack\//.test( name ) ? name.substr( 8, name.length ) : name;
 
-	// hardcode core/video block;
+	// hardcode core/video block.
 	blockName = blockName === 'core/video' ? 'video' : blockName;
 
 	const { details, unavailableReason } = getJetpackExtensionAvailability( blockName );

--- a/extensions/shared/plan-utils.js
+++ b/extensions/shared/plan-utils.js
@@ -1,8 +1,19 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { compact, get, startsWith } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
 import getJetpackData from './get-jetpack-data';
+import { isSimpleSite } from './site-type-utils';
+import getSiteFragment from './get-site-fragment';
 
 /**
  * Return whether upgrade nudges are enabled or not.
@@ -11,4 +22,52 @@ import getJetpackData from './get-jetpack-data';
  */
 export function isUpgradeNudgeEnabled() {
 	return get( getJetpackData(), 'jetpack.enable_upgrade_nudge', false );
+}
+
+/**
+ * Return the checkout URL to upgrade the site plan,
+ * depending on the plan, postId, and postType site values.
+ *
+ * @param {object} siteParams -          Site params used to build the URL.
+ * @param {string} siteParams.planSlug - Plan slug.
+ * @param {string} siteParams.plan -     An object with details about the plan.
+ * @param {number} siteParams.postId -   Post id.
+ * @param {string} siteParams.postType - Post type.
+ * @returns {string}                     Upgrade URL.
+ */
+export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
+	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
+	// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
+	const planPathSlug = startsWith( planSlug, 'jetpack_' )
+		? planSlug.substr( 'jetpack_'.length )
+		: get( plan, [ 'path_slug' ] );
+
+	// The editor for CPTs has an `edit/` route fragment prefixed
+	const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
+
+	// Post-checkout: redirect back here
+	const redirect_to = isSimpleSite()
+		? addQueryArgs(
+			'/' +
+			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
+				'/'
+			),
+			{
+				plan_upgraded: 1,
+			}
+		)
+		: addQueryArgs(
+			window.location.protocol +
+			`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
+			{
+				action: 'edit',
+				post: postId,
+				plan_upgraded: 1,
+			}
+		);
+
+	return planPathSlug &&
+		addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
+			redirect_to,
+		} );
 }

--- a/extensions/shared/premium-blocks/edit.js
+++ b/extensions/shared/premium-blocks/edit.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import UpgradePlanBanner from './upgrade-plan-banner';
+import { isUpgradable } from '../plan-utils';
+
+export default OriginalBlockEdit => props => {
+	if ( ! isUpgradable( props?.name ) ) {
+		return <OriginalBlockEdit { ...props } />;
+	}
+
+	return (
+		<Fragment>
+			<InspectorControls>
+				<UpgradePlanBanner description={ null } blockName={ props.name } />
+			</InspectorControls>
+
+			<OriginalBlockEdit { ...props } />
+		</Fragment>
+	);
+};

--- a/extensions/shared/premium-blocks/editor.scss
+++ b/extensions/shared/premium-blocks/editor.scss
@@ -72,4 +72,4 @@ $icon-background-color: #fff;
 	.components-placeholder__label .jetpack-paid-block-symbol {
 		display: none;
 	}
-}	
+}

--- a/extensions/shared/premium-blocks/editor.scss
+++ b/extensions/shared/premium-blocks/editor.scss
@@ -1,3 +1,59 @@
+@import 'modules/calypsoify/_studio-wpcom.scss';
+
+$banner-height: 48px;
+$icon-size: 10px;
+$icon-background-color: #fff;
+
+// Upgrade Plan Banner.
+.block-editor-block-list__layout{
+	.jetpack-upgrade-plan-banner {
+		position: relative;
+		top: $banner-height + 5px;
+		z-index: 1000;
+	}
+}
+
+.jetpack-upgrade-plan-banner {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: 14px;
+	height: $banner-height;
+	line-height: 14px;
+	background: black;
+	color: white;
+	padding: 0 20px;
+	border-radius: 2px 2px 0 0;
+	margin-bottom: 10px;
+
+	.jetpack-upgrade-plan-banner__title,
+	.jetpack-upgrade-plan-banner__description {
+		margin-right: 10px;
+	}
+
+	.components-button {
+		flex-shrink: 0;
+		margin-left: auto;
+		height: 28px;
+
+		&.is-primary {
+			background: $studio-pink-40;
+
+			&:hover {
+				background: $studio-pink-30;
+			}
+		}
+	}
+}
+
+// Adjust banner in the InspectorControls
+.block-editor-block-inspector {
+	.jetpack-upgrade-plan-banner {
+		border-radius: 0;
+		margin: 0 20px 20px;
+	}
+}
+
 // Premium Icons. Hide by default.
 .jetpack-paid-block-symbol {
 	display: none;
@@ -16,4 +72,4 @@
 	.components-placeholder__label .jetpack-paid-block-symbol {
 		display: none;
 	}
-}
+}	

--- a/extensions/shared/premium-blocks/index.js
+++ b/extensions/shared/premium-blocks/index.js
@@ -1,12 +1,32 @@
 /**
+ * External dependencies
+ */
+import { uniq } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { isUpgradeNudgeEnabled } from '../plan-utils';
+import { isUpgradeNudgeEnabled, isUpgradable } from '../plan-utils';
+import premiumBlockEdit from './edit';
+
+import './editor.scss';
+
+const jetpackPaidBlock = ( settings, name ) => {
+	if ( isUpgradable( name ) ) {
+		settings.edit = premiumBlockEdit( settings.edit );
+	}
+
+	return settings;
+};
+
+addFilter( 'blocks.registerBlockType', 'jetpack/paid-block', jetpackPaidBlock );
 
 import './editor.scss';
 

--- a/extensions/shared/premium-blocks/index.js
+++ b/extensions/shared/premium-blocks/index.js
@@ -1,14 +1,12 @@
 /**
  * External dependencies
  */
-import { uniq } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
 import { addFilter } from '@wordpress/hooks';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -27,8 +25,6 @@ const jetpackPaidBlock = ( settings, name ) => {
 };
 
 addFilter( 'blocks.registerBlockType', 'jetpack/paid-block', jetpackPaidBlock );
-
-import './editor.scss';
 
 /*
  * Add the `jetpack-enable-upgrade-nudge` css Class

--- a/extensions/shared/premium-blocks/upgrade-plan-banner.jsx
+++ b/extensions/shared/premium-blocks/upgrade-plan-banner.jsx
@@ -50,9 +50,6 @@ const UpgradePlanBanner = ( {
 
 	// Do not render banner if there is not
 	// a valid URL to redirect.
-	if ( ! checkoutUrl ) {
-		return null;
-	}
 
 	// Alias. Save post by dispatch.
 	const savePost = dispatch( 'core/editor' ).savePost;
@@ -83,15 +80,17 @@ const UpgradePlanBanner = ( {
 		<div className={ cssClasses } data-align={ align }>
 			{ title && <strong className={ `${ className }__title` }>{ title }</strong> }
 			{ description && <span className={ `${ className }__description` }>{ description }</span> }
-			<Button
-				href={ checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
-				onClick={ goToCheckoutPage }
-				className="is-primary"
-				label={ buttonText }
-				title={ buttonText }
-			>
-				{ buttonText }
-			</Button>
+			{ checkoutUrl && (
+				<Button
+					href={ checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
+					onClick={ goToCheckoutPage }
+					className="is-primary"
+					label={ buttonText }
+					title={ buttonText }
+				>
+					{ buttonText }
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/extensions/shared/premium-blocks/upgrade-plan-banner.jsx
+++ b/extensions/shared/premium-blocks/upgrade-plan-banner.jsx
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getUpgradeUrl } from '../plan-utils';
+
+function redirect( url, callback ) {
+	if ( callback ) {
+		callback( url );
+	}
+	window.top.location.href = url;
+}
+
+const UpgradePlanBanner = ( {
+	checkoutUrl,
+	isAutosaveablePost,
+	isDirtyPost,
+	savePost,
+	onRedirect,
+	align,
+	className,
+	title = __( 'Premium Block' ),
+	description = __( 'Upgrade your plan to use this premium block' ),
+	buttonText = __( 'Upgrade' ),
+	visible = true,
+} ) => {
+	if ( ! visible ) {
+		return null;
+	}
+
+	const goToCheckoutPage = event => {
+		if ( ! window?.top?.location?.href ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		/*
+		 * If there are not unsaved values, redirect.
+		 * If the post is not autosaveable, redirect.
+		 */
+		if ( ! isDirtyPost || ! isAutosaveablePost ) {
+			// Using window.top to escape from the editor iframe on WordPress.com
+			return redirect( checkoutUrl, onRedirect );
+		}
+
+		// Save the post, then redirect.
+		savePost( event ).then( () => redirect( checkoutUrl, onRedirect ) );
+	};
+
+	const cssClasses = classNames( className, 'jetpack-upgrade-plan-banner', `wp-block` );
+
+	return (
+		<div className={ cssClasses } data-align={ align }>
+			{ title && <strong className={ `${ className }__title` }>{ title }</strong> }
+			{ description && <span className={ `${ className }__description` }>{ description }</span> }
+			<Button
+				href={ checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
+				onClick={ goToCheckoutPage }
+				className="is-primary"
+				label={ buttonText }
+				title={ buttonText }
+			>
+				{ buttonText }
+			</Button>
+		</div>
+	);
+};
+
+export default compose( [
+	withSelect( select => {
+		const editorSelector = select( 'core/editor' );
+		const { id: postId, type: postType } = editorSelector.getCurrentPost();
+		const PLAN_SLUG = 'value_bundle';
+		const plan = select( 'wordpress-com/plans' ).getPlan( PLAN_SLUG );
+
+		return {
+			checkoutUrl: getUpgradeUrl( { plan, PLAN_SLUG, postId, postType } ),
+			isAutosaveablePost: editorSelector.isEditedPostAutosaveable(),
+			isDirtyPost: editorSelector.isEditedPostDirty(),
+		};
+	} ),
+	withDispatch( dispatch => ( {
+		savePost: dispatch( 'core/editor' ).savePost,
+	} ) ),
+] )( UpgradePlanBanner );

--- a/extensions/shared/register-jetpack-block.js
+++ b/extensions/shared/register-jetpack-block.js
@@ -26,7 +26,7 @@ const betaExtensions = extensionList.beta || [];
  * @param {object} details - The block details
  * @returns {string|boolean} Either false if the block doesn't require a paid plan, or the actual plan name it requires.
  */
-function requiresPaidPlan( unavailableReason, details ) {
+export function requiresPaidPlan( unavailableReason, details ) {
 	if ( unavailableReason === 'missing_plan' ) {
 		return details.required_plan;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
**This PR depends on https://github.com/Automattic/jetpack/pull/16602 so review it before starting with this.**

This PR adds the Upgrade Plan Banner in the block inspector.

Fixes https://github.com/Automattic/wp-calypso/issues/44057

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add Upgrade Plan Banner to Block inspector.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Apply these changes in your sandbox ( D47027-code )
* Test in a Simple site with a Free Plan
* Sandbox the testing site.
* Add a Premium block to the editor.
* Confirm that you see the Upgrade button Block Inspector.

<img width="830" alt="Screen Shot 2020-07-27 at 10 51 32 PM" src="https://user-images.githubusercontent.com/77539/88609963-c55c8e00-d05b-11ea-9910-c4edd0a1c0d9.png">

* Confirm that clicking on the Upgrade button it leads to user to the checkout page.

#### Post with unsaved changes 

This PR also handles saving post when the user clicks on the Upgrade button. Check that:

* If the post doesn't have changes, clicking on the Upgrade button leads to the checkout page immediately.
* If there are unsaved changes, confirm that when the user clicks on the Upgrade button, the app saves the post before to perform the redirect. Confirm that it doesn't show the alert modal:



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Add Upgrade Plan Banner to Block inspector.
