### PR TITLE
Form Block: add new variation allowing site email collection

### DIFF
--- a/extensions/blocks/contact-form/variations.js
+++ b/extensions/blocks/contact-form/variations.js
@@ -34,6 +34,27 @@ const variations = [
 		],
 	},
 	{
+		name: 'collect-emails',
+		title: __( 'Signup Form', 'jetpack' ),
+		description: __( 'Collect email addresses on your site', 'jetpack' ),
+		icon: renderMaterialIcon(
+			<Path d="M21.99 8c0-.72-.37-1.35-.94-1.7l-8.04-4.71c-.62-.37-1.4-.37-2.02 0L2.95 6.3C2.38 6.65 2 7.28 2 8v10c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2l-.01-10zm-11.05 4.34l-7.2-4.5 7.25-4.25c.62-.37 1.4-.37 2.02 0l7.25 4.25-7.2 4.5c-.65.4-1.47.4-2.12 0z" />,
+			48,
+			48,
+			'-4 -4 32 32'
+		),
+		innerBlocks: [
+			[ 'jetpack/field-email', { required: true } ],
+			[
+				'jetpack/button',
+				{
+					text: __( 'Subscribe', 'jetpack' ),
+					element: 'button',
+				},
+			],
+		],
+	},
+	{
 		name: 'rsvp-form',
 		title: __( 'RSVP Form', 'jetpack' ),
 		description: __( 'Add an RSVP form to your page', 'jetpack' ),


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Let's expand the form block to add a new option allowing folks to collect email addresses for their site.

#### Jetpack product discussion

* Internal reference: p1HpG7-9NB-p2

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Go to Posts > Add New
* Search for block.
* See the new form option:

<img width="764" alt="screenshot 2020-07-28 at 9 11 30" src="https://user-images.githubusercontent.com/426388/88631665-ce2c7e80-d0b2-11ea-986e-9e241ec947d2.png">

* Type `/form`
* See the new option

<img width="369" alt="screenshot 2020-07-28 at 9 15 15" src="https://user-images.githubusercontent.com/426388/88631718-e3091200-d0b2-11ea-9af4-c528969ac8b4.png">

#### Proposed changelog entry for your changes:

* N/A
