### PR TITLE
OpenTable: Implement block styles natively

### DIFF
--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -18,15 +18,17 @@ export const languageOptions = [
 ];
 export const languageValues = optionValues( languageOptions );
 
+export const buttonStyle = {
+	name: 'button',
+	label: __( 'Button (210 x 113 pixels)', 'jetpack' ),
+};
+
 export const getStyleOptions = rid =>
 	compact( [
 		{ name: 'standard', label: __( 'Standard (224 x 301 pixels)', 'jetpack' ), isDefault: true },
 		{ name: 'tall', label: __( 'Tall (288 x 490 pixels)', 'jetpack' ) },
 		{ name: 'wide', label: __( 'Wide (840 x 150 pixels)', 'jetpack' ) },
-		( ! rid || rid.length === 1 ) && {
-			name: 'button',
-			label: __( 'Button (210 x 113 pixels)', 'jetpack' ),
-		},
+		( ! rid || rid.length === 1 ) && buttonStyle,
 	] );
 
 export const getStyleValues = rid => getStyleOptions( rid ).map( option => option.name );

--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -29,7 +29,7 @@ export const getStyleOptions = rid =>
 		},
 	] );
 
-export const getStyleValues = rid => optionValues( getStyleOptions( rid ) );
+export const getStyleValues = rid => getStyleOptions( rid ).map( option => option.name );
 
 const { siteLocale } = select( 'core/block-editor' ).getSettings();
 const defaultLanguage =

--- a/extensions/blocks/opentable/attributes.js
+++ b/extensions/blocks/opentable/attributes.js
@@ -20,14 +20,15 @@ export const languageValues = optionValues( languageOptions );
 
 export const getStyleOptions = rid =>
 	compact( [
-		{ value: 'standard', label: __( 'Standard (224 x 301 pixels)', 'jetpack' ) },
-		{ value: 'tall', label: __( 'Tall (288 x 490 pixels)', 'jetpack' ) },
-		{ value: 'wide', label: __( 'Wide (840 x 150 pixels)', 'jetpack' ) },
+		{ name: 'standard', label: __( 'Standard (224 x 301 pixels)', 'jetpack' ), isDefault: true },
+		{ name: 'tall', label: __( 'Tall (288 x 490 pixels)', 'jetpack' ) },
+		{ name: 'wide', label: __( 'Wide (840 x 150 pixels)', 'jetpack' ) },
 		( ! rid || rid.length === 1 ) && {
-			value: 'button',
+			name: 'button',
 			label: __( 'Button (210 x 113 pixels)', 'jetpack' ),
 		},
 	] );
+
 export const getStyleValues = rid => optionValues( getStyleOptions( rid ) );
 
 const { siteLocale } = select( 'core/block-editor' ).getSettings();

--- a/extensions/blocks/opentable/deprecated/v2/index.js
+++ b/extensions/blocks/opentable/deprecated/v2/index.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import { defaultAttributes } from '../../attributes';
+
+export default {
+	attributes: defaultAttributes,
+	migrate: ( attributes ) => {
+		const { style, className } = attributes;
+		const styleClassName = 'standard' === style ? '' : `is-style-${ style }`;
+
+		return {
+			...attributes,
+			className: className ? `${ className } ${ styleClassName }` : styleClassName,
+		};
+	},
+	isEligible: ( { style, className } ) => {
+		if ( style && 'standard' !== style ) {
+			return ! className || className.indexOf( 'is-style-' ) === -1;
+		}
+
+		return false;
+	},
+	save: ( { attributes: { rid } } ) => (
+		<div>
+			{ rid.map( ( restaurantId ) => (
+				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` } >
+					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
+				</a>
+			) ) }
+		</div>
+	),
+};

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -28,7 +28,6 @@ import './editor.scss';
 import icon from './icon';
 import { isAtomicSite, isSimpleSite } from '../../shared/site-type-utils';
 import RestaurantPicker from './restaurant-picker';
-import BlockStylesSelector from '../../shared/components/block-styles-selector';
 
 import {
 	getStyleOptions,
@@ -38,6 +37,7 @@ import {
 	defaultAttributes,
 } from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
+import { getActiveStyleName } from '../../shared/block-styles';
 import { getAttributesFromEmbedCode } from './utils';
 
 function OpenTableEdit( {
@@ -56,17 +56,8 @@ function OpenTableEdit( {
 		setAttributes( validatedAttributes );
 	}
 
-	const {
-		align,
-		rid,
-		style,
-		iframe,
-		domain,
-		lang,
-		newtab,
-		negativeMargin,
-		__isBlockPreview,
-	} = attributes;
+	const { align, rid, iframe, domain, lang, newtab, negativeMargin, __isBlockPreview } = attributes;
+	const style = getActiveStyleName( getStyleOptions(), attributes.className );
 	const isPlaceholder = isEmpty( rid );
 
 	useEffect( () => {
@@ -184,14 +175,6 @@ function OpenTableEdit( {
 					/>
 				) }
 			</InspectorAdvancedControls>
-			<BlockStylesSelector
-				clientId={ clientId }
-				styleOptions={ styleOptions }
-				onSelectStyle={ updateStyle }
-				activeStyle={ style }
-				attributes={ attributes }
-				viewportWidth={ 150 }
-			/>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings', 'jetpack' ) }>
 					<RestaurantPicker rids={ rid } onChange={ onPickerSubmit } />

--- a/extensions/blocks/opentable/edit.js
+++ b/extensions/blocks/opentable/edit.js
@@ -18,7 +18,7 @@ import {
 	withNotices,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { getBlockDefaultClassName } from '@wordpress/blocks';
+import { getBlockDefaultClassName, registerBlockStyle, unregisterBlockStyle } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -31,11 +31,12 @@ import RestaurantPicker from './restaurant-picker';
 import usePrevious from './use-previous';
 
 import {
+	buttonStyle,
+	defaultAttributes,
 	getStyleOptions,
 	getStyleValues,
 	languageOptions,
 	languageValues,
-	defaultAttributes,
 } from './attributes';
 import { getValidatedAttributes } from '../../shared/get-validated-attributes';
 import { getActiveStyleName } from '../../shared/block-styles';
@@ -45,6 +46,7 @@ function OpenTableEdit( {
 	attributes,
 	className,
 	clientId,
+	isSelected,
 	name,
 	noticeOperations,
 	noticeUI,
@@ -106,6 +108,19 @@ function OpenTableEdit( {
 			setAttributes( { align: 'wide' } );
 		}
 	}, [ __isBlockPreview, isPlaceholder, rid, style, setAttributes, align, prevStyle, selectedStyle ] );
+
+	// Temporarily remove button block style if multiple restaurants are present.
+	useEffect( () => {
+		if ( ! isSelected ) {
+			return;
+		}
+
+		if ( Array.isArray( rid ) && rid.length > 1 ) {
+			unregisterBlockStyle( 'jetpack/opentable', [ 'button' ] );
+		} else {
+			registerBlockStyle( 'jetpack/opentable', buttonStyle );
+		}
+	}, [ isSelected, rid ] );
 
 	const parseEmbedCode = embedCode => {
 		const newAttributes = getAttributesFromEmbedCode( embedCode );

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -9,7 +9,7 @@
 	display: inline-block;
 	position: relative;
 
-	&-theme-wide,
+	&.is-style-wide,
 	&.is-placeholder {
 		display: block;
 	}
@@ -114,7 +114,7 @@
 		}
 	}
 
-	&-theme-button {
+	&.is-style-button {
 		&.has-no-margin {
 			iframe {
 				margin: -14px;

--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -42,25 +42,30 @@
 				width: 100%;
 				@media screen and ( min-width: 480px ) {
 					width: 327px;
+
+					input[type=text].components-form-token-field__input {
+						min-height: 32px;
+					}
 				}
 			}
 
-			.components-button.is-large {
-				// Used to emulate the new Gutenberg styles
-				// TODO: remove once support for < 7.2 is removed
+			> .components-button {
 				padding-bottom: 0px;
 				padding-top: 0px;
 				padding-right: 8px;
 				padding-left: 8px;
-				height: 36px;
+				height: 42px;
 				align-items: center;
 				line-height: normal;
-				// End copied styles
 
 				@media screen and ( min-width: 480px ) {
-					margin: 1px 0 0 4px;
+					margin: 0 0 0 4px;
 					position: relative;
 				}
+			}
+
+			.components-form-token-field__remove-token {
+				padding: 2px 6px;
 			}
 		}
 	}
@@ -81,6 +86,11 @@
 		margin-bottom: 1em;
 		position: relative;
 		width: 100%;
+
+		.components-form-token-field__token-text {
+			display: inline-flex;
+			align-items: center;
+		}
 	}
 
 	&-placeholder-links {
@@ -91,6 +101,11 @@
 		}
 
 		a {
+			@media screen and ( min-width: 480px ) {
+				form > button {
+					height: 50px;
+				}
+			}
 			padding: 0.25em 1em 0.25em 0;
 			&:last-child {
 				padding-right: 0;

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -9,6 +9,7 @@ import { createBlock } from '@wordpress/blocks';
  */
 import { defaultAttributes, getStyleOptions } from './attributes';
 import deprecatedV1 from './deprecated/v1';
+import deprecatedV2 from './deprecated/v2';
 import edit from './edit';
 import icon from './icon';
 
@@ -74,5 +75,5 @@ export const settings = {
 			},
 		],
 	},
-	deprecated: [ deprecatedV1 ],
+	deprecated: [ deprecatedV1, deprecatedV2 ],
 };

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -39,8 +39,8 @@ export const settings = {
 	edit,
 	save: ( { attributes: { rid } } ) => (
 		<div>
-			{ rid.map( restaurantId => (
-				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }>
+			{ rid.map( ( restaurantId, restaurantIndex ) => (
+				<a href={ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` } key={ `${ restaurantId }-${ restaurantIndex }` } >
 					{ `https://www.opentable.com/restref/client/?rid=${ restaurantId }` }
 				</a>
 			) ) }

--- a/extensions/blocks/opentable/index.js
+++ b/extensions/blocks/opentable/index.js
@@ -7,7 +7,7 @@ import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { defaultAttributes } from './attributes';
+import { defaultAttributes, getStyleOptions } from './attributes';
 import deprecatedV1 from './deprecated/v1';
 import edit from './edit';
 import icon from './icon';
@@ -47,6 +47,7 @@ export const settings = {
 		</div>
 	),
 	attributes: defaultAttributes,
+	styles: getStyleOptions(),
 	example: {
 		attributes: {
 			rid: [ '1' ],

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -52,7 +52,14 @@ function load_assets( $attributes ) {
 
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	$classes = array( sprintf( 'wp-block-jetpack-%s-theme-%s', FEATURE_NAME, get_attribute( $attributes, 'style' ) ) );
+	$classes    = array();
+	$class_name = get_attribute( $attributes, 'className' );
+
+	// Handles case of deprecated version using theme instead of block styles.
+	if ( ! $class_name || strpos( $class_name, 'is-style-' ) === false ) {
+		$classes[] = sprintf( 'is-style-%s', get_attribute( $attributes, 'style' ) );
+	}
+
 	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
 		$classes[] = 'is-multi';
 	}

--- a/extensions/blocks/opentable/restaurant-picker.js
+++ b/extensions/blocks/opentable/restaurant-picker.js
@@ -62,7 +62,7 @@ export default function RestaurantPicker( props ) {
 			{ props.onSubmit ? (
 				<form onSubmit={ onSubmit }>
 					{ formInput }
-					<Button isSecondary isLarge type="submit">
+					<Button isSecondary type="submit">
 						{ __( 'Embed', 'jetpack' ) }
 					</Button>
 				</form>

--- a/extensions/blocks/opentable/restaurant-picker.js
+++ b/extensions/blocks/opentable/restaurant-picker.js
@@ -36,7 +36,7 @@ export default function RestaurantPicker( props ) {
 	};
 
 	const restaurantNames = restaurants
-		.filter( restaurant => selectedRestaurants.indexOf( restaurant.rid.toString() ) )
+		.filter( restaurant => selectedRestaurants.indexOf( restaurant.rid.toString() ) < 0 )
 		.map( restaurant => restaurant.name + ` (#${ restaurant.rid })` );
 
 	const onSubmit = event => {

--- a/extensions/blocks/opentable/use-previous.js
+++ b/extensions/blocks/opentable/use-previous.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+export default function usePrevious( value ) {
+	const ref = useRef();
+
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] );
+
+	return ref.current;
+}

--- a/extensions/blocks/opentable/utils.js
+++ b/extensions/blocks/opentable/utils.js
@@ -3,6 +3,10 @@ export const restRefRegex = /restref=([0-9]+)&/;
 export const ridRegex = /rid=([0-9]+)&/;
 
 const getAttributesFromUrl = url => {
+	if ( ! url ) {
+		return;
+	}
+
 	let src = '';
 	if ( url.indexOf( 'http' ) === 0 ) {
 		src = new URL( url );

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -4,7 +4,7 @@
 		margin: 0 auto;
 	}
 
-	&-theme-standard {
+	&.is-style-standard {
 		height: 301px;
 
 		&.is-multi {
@@ -16,7 +16,7 @@
 		}
 	}
 
-	&-theme-tall {
+	&.is-style-tall {
 		height: 490px;
 
 		&.is-multi {
@@ -28,14 +28,14 @@
 		}
 	}
 
-	&-theme-wide {
+	&.is-style-wide {
 		height: 150px;
 		&.aligncenter iframe {
 			width: 840px !important;
 		}
 	}
 
-	&-theme-button {
+	&.is-style-button {
 		height: 113px;
 		&.aligncenter iframe {
 			width: 210px !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #15064

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Update implementation of block styles in the OpenTable block to be consistent with other blocks
* Improve form field and button alignments in OpenTable placeholder embed form
* Fix minor bugs causing console errors (isLarge and missing keys)
* Fix filtering of duplicate restaurants from suggestions

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Create new post
2. Add OpenTable blocks for each block style (standard, tall, wide & button)
3. Add new OpenTable block and add two restaurant IDs via placeholder form, then try and add the second again.
  (note that it is not filtered from suggestions)
4. Save post and view on frontend for reference
5. Checkout this PR branch
6. Refresh frontend page and confirm each block has new styles e.g. `is-style-tall`
7. Open post in the editor and confirm blocks are still valid and that they have the correct block styles
8. Confirm OpenTable blocks each have appropriate block style's CSS class in the Additional CSS field e.g. `is-style-button`
9. Attempt to add a duplicate restaurant again as per step # 3, it should not appear in the suggestions list
10. Save post and refresh frontend view
11. Confirm each block has correct style.

#### Before
![OpenTable-Styles-Before](https://user-images.githubusercontent.com/60436221/89238250-c3389780-d638-11ea-9a7b-f45486c534a2.gif)

#### After
![OpenTable-Styles-After](https://user-images.githubusercontent.com/60436221/89269403-319f4900-d67d-11ea-94d6-f01186679053.gif)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* OpenTable Block: Minor bug fixes and improvement of consistency of block style implementation
