### PR TITLE
Premium Blocks: Remove Upgrade Nudges from frontend

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -1130,8 +1130,6 @@ class Jetpack_Gutenberg {
 			$bare_slug    = self::remove_extension_prefix( $slug );
 			if ( isset( $availability[ $bare_slug ] ) && $availability[ $bare_slug ]['available'] ) {
 				return call_user_func( $render_callback, $prepared_attributes, $block_content );
-			} elseif ( isset( $availability[ $bare_slug ]['details']['required_plan'] ) ) {
-				return self::upgrade_nudge( $availability[ $bare_slug ]['details']['required_plan'] );
 			}
 
 			return null;


### PR DESCRIPTION
This PR removes the Upgrade Nudges from the **frontend**.
I decided not to remove all the code regarding the upgrade nudge in case we might need it again in the future. I just removed the call to rendering it.

Fixes https://github.com/Automattic/wp-calypso/issues/44168

### 🌱 Pointing to a Feature branch

This PR is referenced to the `feature/premium-blocks ` feature branch.

#### Changes proposed in this Pull Request:

* Remove Upgrade Nudge from the frontend.

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* Apply this changes in your sandbox D47071-code
* Test in a _Simple site_ with a _Free Plan_
* Sandbox the testing site.
* Confirm that upgrade nudges don't show anymore in the following paid (premium) blocks in the frontend.
  - Pay with Paypal
  - Payments
  - Premium Content
  - Donations
  - Calendly
  - OpenTable
  - Video
  - Audio
  - WhatsApp

Before | After
-------|------
![image](https://cln.sh/OpvJ9Z+) | ![image](https://cln.sh/ofYq62+) 


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove upgrade nudge of premium blocks from the frontend.
