### PR TITLE
Premium Blocks: Add Upgrade banner to premium block in the editor canvas

### DIFF
--- a/extensions/shared/premium-blocks/editor.scss
+++ b/extensions/shared/premium-blocks/editor.scss
@@ -40,6 +40,7 @@ $icon-background-color: #fff;
 
 // Tweak Banner depending on the context.
 // Tweak Banner: Inspector Controls.
+.editor-styles-wrapper [data-block].is-upgradable,
 .block-editor-block-list__block.is-upgradable {
 	margin-top: 0;
 	padding-top: $banner-height;

--- a/extensions/shared/premium-blocks/editor.scss
+++ b/extensions/shared/premium-blocks/editor.scss
@@ -4,15 +4,7 @@ $banner-height: 48px;
 $icon-size: 10px;
 $icon-background-color: #fff;
 
-// Upgrade Plan Banner.
-.block-editor-block-list__layout{
-	.jetpack-upgrade-plan-banner {
-		position: relative;
-		top: $banner-height + 5px;
-		z-index: 1000;
-	}
-}
-
+// Upgrade Banner.
 .jetpack-upgrade-plan-banner {
 	display: flex;
 	justify-content: space-between;
@@ -46,7 +38,20 @@ $icon-background-color: #fff;
 	}
 }
 
-// Adjust banner in the InspectorControls
+// Tweak Banner depending on the context.
+// Tweak Banner: Inspector Controls.
+.block-editor-block-list__block.is-upgradable {
+	margin-top: 0;
+	padding-top: $banner-height;
+}
+
+// Tweak Banner: Editor Canvas.
+.block-editor-block-list__layout .jetpack-upgrade-plan-banner {
+	position: relative;
+	top: $banner-height + 5px;
+	z-index: 1000;
+}
+
 .block-editor-block-inspector {
 	.jetpack-upgrade-plan-banner {
 		border-radius: 0;
@@ -54,12 +59,12 @@ $icon-background-color: #fff;
 	}
 }
 
-// Premium Icons. Hide by default.
+// Premium Icons: Hide by default.
 .jetpack-paid-block-symbol {
 	display: none;
 }
 
-// Only show if upgrade is possible.
+// Premium Icons: Only show if upgrade is possible.
 .jetpack-enable-upgrade-nudge {
 	.block-editor-block-icon > svg {
 		overflow: visible;

--- a/extensions/shared/premium-blocks/index.js
+++ b/extensions/shared/premium-blocks/index.js
@@ -11,20 +11,26 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import withUpgradeBanner from './with-upgrade-banner';
 import { isUpgradeNudgeEnabled, isUpgradable } from '../plan-utils';
 import premiumBlockEdit from './edit';
 
 import './editor.scss';
 
-const jetpackPaidBlock = ( settings, name ) => {
+const jetpackPremiumBlock = ( settings, name ) => {
 	if ( isUpgradable( name ) ) {
+		// Extend BlockEdit function.
 		settings.edit = premiumBlockEdit( settings.edit );
 	}
 
 	return settings;
 };
 
-addFilter( 'blocks.registerBlockType', 'jetpack/paid-block', jetpackPaidBlock );
+// Extend BlockType.
+addFilter( 'blocks.registerBlockType', 'jetpack/paid-block', jetpackPremiumBlock );
+
+// Extend BlockListBlock.
+addFilter( 'editor.BlockListBlock', 'jetpack/premium-block-with-warning', withUpgradeBanner );
 
 /*
  * Add the `jetpack-enable-upgrade-nudge` css Class

--- a/extensions/shared/premium-blocks/upgrade-plan-banner.jsx
+++ b/extensions/shared/premium-blocks/upgrade-plan-banner.jsx
@@ -48,9 +48,6 @@ const UpgradePlanBanner = ( {
 		return null;
 	}
 
-	// Do not render banner if there is not
-	// a valid URL to redirect.
-
 	// Alias. Save post by dispatch.
 	const savePost = dispatch( 'core/editor' ).savePost;
 
@@ -70,11 +67,11 @@ const UpgradePlanBanner = ( {
 			return redirect( checkoutUrl, onRedirect );
 		}
 
-		// Save the post, then redirect.
+		// Save the post. Then redirect.
 		savePost( event ).then( () => redirect( checkoutUrl, onRedirect ) );
 	};
 
-	const cssClasses = classNames( className, 'jetpack-upgrade-plan-banner', `wp-block` );
+	const cssClasses = classNames( className, 'jetpack-upgrade-plan-banner', 'wp-block' );
 
 	return (
 		<div className={ cssClasses } data-align={ align }>

--- a/extensions/shared/premium-blocks/with-upgrade-banner.jsx
+++ b/extensions/shared/premium-blocks/with-upgrade-banner.jsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { Fragment } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { isUpgradable } from '../plan-utils';
+import UpgradePlanBanner from './upgrade-plan-banner';
+
+export default createHigherOrderComponent(
+	BlockListBlock => props => {
+		if ( ! isUpgradable( props?.name ) ) {
+			return <BlockListBlock { ...props } />;
+		}
+
+		const hasChildrenSelected = useSelect(
+			select => select( 'core/block-editor' ).hasSelectedInnerBlock( props.clientId ),
+			[]
+		);
+
+		const isVisible = props?.isSelected || hasChildrenSelected;
+
+		return (
+			<Fragment>
+				<UpgradePlanBanner
+					className={ `is-${ props.name.replace( /\//, '-' ) }-premium-block` }
+					title={ null }
+					align={ props?.attributes?.align }
+					visible={ isVisible }
+				/>
+
+				<BlockListBlock { ...props } className="is-interactive is-upgradable" />
+			</Fragment>
+		);
+	},
+	'withUpgradeBanner'
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds the Upgrade Banner to Premium Blocks in the editor canvas.
<img src="https://user-images.githubusercontent.com/77539/88691256-0348c900-d0d3-11ea-834b-2b9426cca7e7.png" width="600px" />

### 🌱 Pointing to a Feature branch

This PR is referenced to the [`feature/premium-blocks ` feature branch](https://github.com/Automattic/jetpack/pull/16611).

Also, let's hold on until https://github.com/Automattic/jetpack/pull/16603 merges with the feature branch.

Fixes https://github.com/Automattic/wp-calypso/issues/44056

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
*

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes in your sandbox ()
* Test in a Simple site with a Free Plan
* Sandbox the testing site.
* Add a Premium block to the editor.
* Confirm that you see the new Upgrade Plan banner there, only when the block is selected.

<img src="https://user-images.githubusercontent.com/77539/88691967-e6f95c00-d0d3-11ea-9508-7d80d1216f32.png" width="800px" />


#### Post with unsaved changes
This PR also handles saving post when the user clicks on the Upgrade button. Check that:

* If the post doesn't have changes, clicking on the Upgrade button leads to the checkout page immediately.
* If there are unsaved changes, confirm that when the user clicks on the Upgrade button, the app saves the post before to perform the redirect. Confirm that it doesn't show the alert modal:

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
