### PR TITLE
In-Place Connection: Fallback for disabled third-party cookies.

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -125,12 +125,21 @@ jQuery( document ).ready( function ( $ ) {
 		},
 		receiveData: function ( event ) {
 			if (
-				event.origin === jpConnect.jetpackApiDomain &&
-				event.source === jetpackConnectIframe.get( 0 ).contentWindow &&
-				event.data === 'close'
+				event.origin !== jpConnect.jetpackApiDomain ||
+				event.source !== jetpackConnectIframe.get( 0 ).contentWindow
 			) {
-				window.removeEventListener( 'message', this.receiveData );
-				jetpackConnectButton.handleAuthorizationComplete();
+				return;
+			}
+
+			switch ( event.data ) {
+				case 'close':
+					window.removeEventListener( 'message', this.receiveData );
+					jetpackConnectButton.handleAuthorizationComplete();
+					break;
+				case 'wpcom_nocookie':
+					jetpackConnectIframe.hide();
+					jetpackConnectButton.handleConnectionError();
+					break;
 			}
 		},
 		handleAuthorizationComplete: function () {


### PR DESCRIPTION
If third-party cookies are disabled, we fallback from in-place connection to Calypso.

#### Changes proposed in this Pull Request:
* Catch the `message` sent from WP.com indicating that 3rd-party cookies are disabled.
* Fallback to the Calypso connection flow.

#### Jetpack product discussion
`p9dueE-1Fs-p2`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Disable third-party cookies in your browser (don't use Safari, it skips the in-place connection altogether).
2. Disconnect Jetpack (if connected).
3. Go to the Jetpack page and click "Set Up Jetpack".
4. After the iframe content gets loaded, you should be redirected to the Calypso flow.
5. Follow the Calypso auth flow to the end and make sure you get connected properly.
6. Enable the third-party cookies, disconnect Jetpack, and make sure that regular in-place flow works fine.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Connection to WordPress.com: fallback for disabled third-party cookies.
