### PR TITLE
avoid conflict with other plugins filtering edit url

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -942,12 +942,10 @@ class Jetpack {
 			return $default_url;
 		}
 
-		return esc_url(
-			Redirect::get_url(
-				'calypso-edit-' . $post_type,
-				array(
-					'path' => $post_id,
-				)
+		return Redirect::get_url(
+			'calypso-edit-' . $post_type,
+			array(
+				'path' => $post_id,
 			)
 		);
 	}
@@ -956,12 +954,10 @@ class Jetpack {
 		// Take the `query` key value from the URL, and parse its parts to the $query_args. `amp;c` matches the comment ID.
 		wp_parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
 
-		return esc_url(
-			Redirect::get_url(
-				'calypso-edit-comment',
-				array(
-					'path' => $query_args['amp;c'],
-				)
+		return Redirect::get_url(
+			'calypso-edit-comment',
+			array(
+				'path' => $query_args['amp;c'],
 			)
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR avoids conflicts in the public Edit Post link if other plugins are filtering it.

The problem occurs when the `jetpack_edit_links_calypso_redirect` option is set to `true` and Jetpack changes all the "Edit" links to calypso instead of wp-admin.

Since our filter returns an escaped url, filters that run later might end up breaking it. This was reported and was happening with the Classic Editor plugin.

There are 2 ways of fixing this:

1. Change the filter priority, and let it run later after any other filters. For some reason, the priority of this filter is 1.

2. Remove the `esc_url` call at the end of the function.

Looking at the alternatives, I decided to go with option 2. It makes sense not to escape the URL at this point, since the original [`get_edit_post_link`](https://developer.wordpress.org/reference/functions/get_edit_post_link/) function does not return an escaped URL and it will most likely be escaped when printed. 

For some reason, this escape function was there before the redirect refactor (see [this commit](https://github.com/Automattic/jetpack/commit/3010b47431d784ba4771188ca1da2637bb922d97#diff-9ba9fa5bb52bd6cf36c6c0bdd5ed4830L943)) but ir was harmless because there was nothing on the query string.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Avoids conflict with other plugins filtering the edit post link

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* `wp option set jetpack_edit_links_calypso_redirect 1`
* Install and activate the "Classic Editor" plugin
* Go to Settings > Writting and set the default editor to Classic and "Allow users to switch editors" to "Yes"
* Visit a post in the front end
* check the link in the "Edit" button. It should be something like this: `https://jetpack.com/redirect/?source=calypso-edit-post&site=site.com&path=16&classic-editor` (Note the `&classic-editor` at the end)
* Click the link and confirm it works - it should take you to edit the post in calypso. The `classic-editor` parameter is ignored.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix compatibility with Classic Editor plugin in the "Edit posts" links
