### PR TITLE
Make jetpack debug plugin work without Jetpack

### DIFF
--- a/packages/debug-helper/README.md
+++ b/packages/debug-helper/README.md
@@ -2,7 +2,7 @@
 
 This is a plugin to help developers debug some Jetpack features. 
 
-Once activated, visit `Jetpack > Debug tools` to activate the modules you want.
+Once activated, you will see a new Menu item in your admin dashboard called `Jetpack Debug`. Visit this page to activate the modules you want.
 
 ## Available Modules
 

--- a/packages/debug-helper/class-admin.php
+++ b/packages/debug-helper/class-admin.php
@@ -29,13 +29,13 @@ class Admin {
 	 * Register's submenu.
 	 */
 	public function register_submenu_page() {
-		add_submenu_page(
-			'jetpack',
-			'Debug tools',
-			'Debug tools',
+		add_menu_page(
+			'Jetpack Debug Helper',
+			'Jetpack Debug',
 			'manage_options',
-			'debug-tools',
+			'jetpack-debug-tools',
 			array( $this, 'render_ui' ),
+			'dashicons-hammer',
 			99
 		);
 	}

--- a/packages/debug-helper/modules/class-broken-token.php
+++ b/packages/debug-helper/modules/class-broken-token.php
@@ -124,7 +124,7 @@ class Broken_Token {
 	 */
 	public function broken_token_register_submenu_page() {
 		add_submenu_page(
-			'jetpack',
+			'jetpack-debug-tools',
 			'Broken Token',
 			'Broken Token',
 			'manage_options',
@@ -491,7 +491,7 @@ add_action( 'plugins_loaded', 'register_broken_token', 1000 );
  * Load the brokenness.
  */
 function register_broken_token() {
-	if ( class_exists( 'Jetpack' ) ) {
+	if ( class_exists( 'Jetpack_Options' ) ) {
 		new Broken_Token();
 		if ( class_exists( 'Automattic\Jetpack\Connection\Error_Handler' ) ) {
 			new Broken_Token_XmlRpc();
@@ -505,7 +505,7 @@ function register_broken_token() {
  * Notice for if Jetpack is not active.
  */
 function broken_token_jetpack_not_active() {
-	echo '<div class="notice info"><p>Jetpack needs to be active and installed for the Broken Token plugin.</p></div>';
+	echo '<div class="notice info"><p>Jetpack Debug tools: Jetpack_Options package must be present for the Broken Token to work.</p></div>';
 }
 
 // phpcs:enable

--- a/packages/debug-helper/modules/class-rest-api-tester.php
+++ b/packages/debug-helper/modules/class-rest-api-tester.php
@@ -25,7 +25,7 @@ class REST_API_Tester {
 	 */
 	public function register_submenu_page() {
 		add_submenu_page(
-			'jetpack',
+			'jetpack-debug-tools',
 			'REST API Tester',
 			'REST API Tester',
 			'manage_options',
@@ -41,7 +41,7 @@ class REST_API_Tester {
 	 * @param string $hook Page hook.
 	 */
 	public function enqueue_scripts( $hook ) {
-		if ( strpos( $hook, 'jetpack_page_rest-api-tester' ) === 0 ) {
+		if ( strpos( $hook, 'jetpack-debug_page_rest-api-tester' ) === 0 ) {
 			wp_enqueue_style( 'rest_api_tester_style', plugin_dir_url( __FILE__ ) . 'inc/css/rest-api-tester.css', array(), JETPACK_DEBUG_HELPER_VERSION );
 			wp_enqueue_script( 'rest_api_tester_script', plugin_dir_url( __FILE__ ) . 'inc/js/rest-api-tester.js', array( 'wp-api' ), JETPACK_DEBUG_HELPER_VERSION, true );
 		}
@@ -115,9 +115,7 @@ class REST_API_Tester {
 	 * Load the class.
 	 */
 	public static function register_rest_api_tester() {
-		if ( class_exists( 'Jetpack' ) ) {
-			new REST_API_Tester();
-		}
+		new REST_API_Tester();
 	}
 }
 

--- a/packages/debug-helper/modules/inc/class-broken-token-xmlrpc.php
+++ b/packages/debug-helper/modules/inc/class-broken-token-xmlrpc.php
@@ -37,7 +37,7 @@ class Broken_Token_XmlRpc {
 	 * @param string $hook Called hook.
 	 */
 	public function enqueue_scripts( $hook ) {
-		if ( 'jetpack_page_broken-token-xmlrpc-errors' === $hook ) {
+		if ( 'jetpack-debug_page_broken-token-xmlrpc-errors' === $hook ) {
 			wp_enqueue_script( 'broken_token_xmlrpc_errors', plugin_dir_url( __FILE__ ) . 'js/xmlrpc-errors.js', array( 'jquery' ), JETPACK_DEBUG_HELPER_VERSION, true );
 			wp_localize_script(
 				'broken_token_xmlrpc_errors',
@@ -56,7 +56,7 @@ class Broken_Token_XmlRpc {
 	 */
 	public function register_submenu_page() {
 		add_submenu_page(
-			'jetpack',
+			'jetpack-debug-tools',
 			'XML-RPC Errors',
 			'XML-RPC Errors',
 			'manage_options',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Jetpack debug helper is a plugin that brings some Debug tools to help you test things in Jetpack.

One of its main uses right now is to test the connection package, allowing us to break the tokens in many ways, inspect XML-RPC errors, and test local REST API endpoints.

Since we often want to make sure all the packages' features will work seamlessly when used by other plugins, without Jetpack, it makes sense for these debug tools to be available even when the Jetpack plugin is not active.

This PR moves all the Debug tools to its own top-level admin menu and makes sure that everything will work without Jetpack.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* First go to you admin Dashboard and visit "Jetpack Debug" menu
* Test activating and deactivating modules
* Test the features and make sure it works as before
* Deactivate Jetpack
* See that the "REST API Tester" is still working
* Activate the "Client Example" plugin
* Test the Broken token module and make sure it's still working

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
not necessary