### PR TITLE
Story Block: fallback to no shadow DOM if we cannot find the block styles in the page

### DIFF
--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -50,7 +50,7 @@ export default withNotices( function StoryEdit( {
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 
 	const mediaReadyFilter = files =>
-		files.map( pickRelevantMediaFiles ).filter( media => ! isBlobURL( media.url ) );
+		files.map( file => pickRelevantMediaFiles( file ) ).filter( media => ! isBlobURL( media.url ) );
 	const onSelectMedia = newMediaFiles =>
 		setAttributes( { mediaFiles: mediaReadyFilter( newMediaFiles ) } );
 

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -33,7 +33,8 @@ const defaultSettings = {
 	shadowDOM: {
 		enabled: true,
 		mode: 'open', // closed not supported right now
-		globalStyleElements: '#jetpack-block-story-css',
+		globalStyleElements:
+			'#jetpack-block-story-css, link[href*="jetpack/_inc/blocks/story/view.css"]',
 	},
 	defaultAspectRatio: 720 / 1280,
 	volume: 0.5,

--- a/extensions/blocks/story/player/lib/shadow-root.js
+++ b/extensions/blocks/story/player/lib/shadow-root.js
@@ -24,7 +24,11 @@ export default function ShadowRoot( {
 } ) {
 	const placeholder = useRef();
 	const [ shadowRoot, setShadowRoot ] = useState( false );
-	const useShadow = shadowRootSupported && enabled;
+	const styleElements =
+		typeof globalStyleElements === 'string'
+			? [ ...document.querySelectorAll( globalStyleElements ) ]
+			: globalStyleElements;
+	const useShadow = shadowRootSupported && enabled && styleElements.length > 0;
 
 	useEffect( () => {
 		if ( ! placeholder.current ) {
@@ -50,7 +54,7 @@ export default function ShadowRoot( {
 
 	const App = (
 		<>
-			{ useShadow && <Styles globalStyleElements={ globalStyleElements } /> }
+			{ useShadow && <Styles globalStyleElements={ styleElements } /> }
 			{ children }
 		</>
 	);
@@ -63,14 +67,9 @@ export default function ShadowRoot( {
 }
 
 function Styles( { globalStyleElements } ) {
-	const styleElements =
-		typeof globalStyleElements === 'string'
-			? [ ...document.querySelectorAll( globalStyleElements ) ]
-			: globalStyleElements;
-
 	return (
 		<>
-			{ styleElements.map( ( { id, tagName, attributes, innerHTML }, index ) => {
+			{ globalStyleElements.map( ( { id, tagName, attributes, innerHTML }, index ) => {
 				if ( tagName === 'LINK' ) {
 					return (
 						<link


### PR DESCRIPTION
This fixes the Story block on sites which replace the default CSS asset for the story block. This currently happens on WPCOM which groups the CSS of all blocks present on the page into one. This "optimization" prevents the Story block from finding the CSS/link element in the page and injecting it into each shadow dom so stories end up broken, without CSS.

Example of broken post containing a story on WPCOM: https://alexforcierbetablocks.wordpress.com/2020/07/24/story-post/

#### Changes proposed in this Pull Request:
- Make the CSS selector more flexible by matching on the href property as well
- Prevent using shadow DOM if no styles are found

#### Testing instructions
- Apply patch to a Jetpack site
- Make sure Story block are still functioning on the frontend and backend

#### Proposed changelog entry
No changelog if merged before the release

#### Privacy
No change