### PR TITLE
VideoPress: Prevent jetpack/videopress block removing align attribute from core/video block.

### DIFF
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -86,41 +86,8 @@ const addVideoPressSupport = ( settings, name ) => {
 			...settings,
 
 			attributes: {
-				autoplay: {
-					type: 'boolean',
-				},
-				caption: {
-					type: 'string',
-					source: 'html',
-					selector: 'figcaption',
-				},
-				controls: {
-					type: 'boolean',
-					default: true,
-				},
+				...settings.attributes,
 				guid: {
-					type: 'string',
-				},
-				id: {
-					type: 'number',
-				},
-				loop: {
-					type: 'boolean',
-				},
-				muted: {
-					type: 'boolean',
-				},
-				playsInline: {
-					type: 'boolean',
-				},
-				poster: {
-					type: 'string',
-				},
-				preload: {
-					type: 'string',
-					default: 'metadata',
-				},
-				src: {
 					type: 'string',
 				},
 			},


### PR DESCRIPTION
This PR fixes `core/video` block losing `align` attribute when editor is reloaded.

This is happening because `jetpack/videopress` block is recreating the `core/video`'s block attributes (when it should inherit them). The `align` attribute was introduced in `core/video`'s block which was not recreated by `jetpack/videopress`'s hook.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Inherit `core/video`'s block attributes instead of recreating them.

Before: https://www.screencast.com/t/eGCIAAci4Q1l
After: https://www.screencast.com/t/fitMKygi

![image](https://user-images.githubusercontent.com/1287077/88801724-5f325100-d1aa-11ea-8dad-4df884592f26.png)

More debugging context here: https://github.com/Automattic/wp-calypso/issues/43252

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

* Open up the editor to create a new post.
* Insert some paragraphs of content.
* In the middle of the paragraph, insert a **Video** block.
* Align the video block to the left or right.
* Save the blog post.
* Refresh the editor page.
* The video block should still be aligned to the left in the editor.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix video alignment not respected in the block editor.

Fixes #16158
