### PR TITLE
Premium Blocks: Add premium indicator to donations block icon

### DIFF
--- a/extensions/blocks/donations/icon.js
+++ b/extensions/blocks/donations/icon.js
@@ -3,6 +3,11 @@
  */
 import { SVG, Path, Circle } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import PaidSymbol from '../../../extensions/shared/premium-blocks/paid-symbol';
+
 export default (
 	<SVG width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Path
@@ -16,5 +21,6 @@ export default (
 			strokeWidth="1.5"
 			fill="none"
 		/>
+		<PaidSymbol />
 	</SVG>
 );


### PR DESCRIPTION
This PR sets premium icons for donations block in jetpack

### 🌱 Pointing to a Feature branch

This PR is referenced to the [`feature/premium-blocks ` feature branch](https://github.com/Automattic/jetpack/pull/16611).

Fixes #16628

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Set icon for Donations Block in Jetpack.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:

* Apply these changes in your sandbox
* Test in a Simple site with a Free Plan
* Sandbox the testing site.
* Check that the donations block show a little red circle indicating it is premium.

![](https://cln.sh/gSPkLO+)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Set premium icon indicator for Jetpack Donations Block.