### PR TITLE
Use blog token to make the request to fetchSubscriberCount

### DIFF
--- a/modules/subscriptions/views.php
+++ b/modules/subscriptions/views.php
@@ -561,7 +561,7 @@ class Jetpack_Subscriptions_Widget extends WP_Widget {
 		if ( self::is_jetpack() ) {
 			$subs_count = get_transient( 'wpcom_subscribers_total' );
 			if ( false === $subs_count || 'failed' == $subs_count['status'] ) {
-				$xml = new Jetpack_IXR_Client( array( 'user_id' => JETPACK_MASTER_USER, ) );
+				$xml = new Jetpack_IXR_Client();
 
 				$xml->query( 'jetpack.fetchSubscriberCount' );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Changes the call to fetchSubscriberToken to use the blog token instead of primary user token, as it is not needed

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Dv-p2#comment-2838

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Test it first on the master branch:

* Set up a connected site
* Activate Subscriptions module
* Make sure you have at least one subscriber
* Add the "Blog Subscriptions (Jetpack)" widget to your site
* Visit the site and check the number of subscribers being displayed. "Join XX other subscribers"

Now checkout this branch
* clear the cache: `wp transient delete wpcom_subscribers_total`
* Visit the site again and confirm that you see the same number of subscribers

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Call to fetchSubscriberToken now uses the blog token
