### PR TITLE
Tracks the Reconnect dialog display

### DIFF
--- a/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
@@ -41,8 +41,11 @@ class NoticeActionReconnect extends React.Component {
 		this.props.reconnectSite( this.props.action );
 	};
 
-	render() {
+	componentDidMount() {
 		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_view', this.getEventProps() );
+	}
+
+	render() {
 		return (
 			<NoticeAction icon={ this.props.icon } onClick={ this.handleDisconnectClick }>
 				{ this.props.children }

--- a/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
+++ b/_inc/client/components/jetpack-notices/notice-action-reconnect.jsx
@@ -19,11 +19,7 @@ class NoticeActionReconnect extends React.Component {
 		action: PropTypes.string,
 	};
 
-	handleDisconnectClick = () => {
-		// Reconnection already in progress
-		if ( this.props.isReconnectingSite ) {
-			return;
-		}
+	getEventProps = () => {
 		const eventProps = {
 			location: 'dashboard',
 			purpose: 'reconnect',
@@ -32,13 +28,21 @@ class NoticeActionReconnect extends React.Component {
 		if ( this.props.errorCode ) {
 			eventProps.error_code = this.props.errorCode;
 		}
+		return eventProps;
+	};
 
-		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_click', eventProps );
+	handleDisconnectClick = () => {
+		// Reconnection already in progress
+		if ( this.props.isReconnectingSite ) {
+			return;
+		}
 
+		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_click', this.getEventProps() );
 		this.props.reconnectSite( this.props.action );
 	};
 
 	render() {
+		analytics.tracks.recordEvent( 'jetpack_termination_error_notice_view', this.getEventProps() );
 		return (
 			<NoticeAction icon={ this.props.icon } onClick={ this.handleDisconnectClick }>
 				{ this.props.children }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds tracking to the when the "Reconnect" dialog is displayed to the user

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Yes, it tracks when the "Reconnect Jetpack" error dialog is displayed to the user

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a connected jetpack site
* Use the Jetpack debug helper plugin
* Go to Broken Token and clik "Set invalid blog token"
* Visit the Jetpack Dashboard
* Open the console and type `localStorage.setItem('debug', 'dops:analytics');`
* Refresh the window
* Confirm you see the error dialog (like the image below)
* Confirm you see the tracking debug in the console: `dops:analytics Record event "jetpack_termination_error_notice_view"  ... `
* Confirm this debug message appears only once.

<img width="1076" alt="Captura de Tela 2020-07-29 às 17 02 30" src="https://user-images.githubusercontent.com/971483/88847369-5434ec00-d1bd-11ea-922b-8cc979c93848.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Tracks the number of times the "Reconnect" dialog is displayed
