### PR TITLE
Fix recurring payments block disconnected from plan when page is reopened in block editor.

### DIFF
--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -355,7 +355,7 @@ class MembershipsButtonEdit extends Component {
 			} );
 		}
 
-		return setAttributes( { planId: id } );
+		return setAttributes( { planId: parseInt( id ) } );
 	};
 
 	renderMembershipAmounts = () => (


### PR DESCRIPTION
When a page that uses the recurring payments block is reopened in block editor, the plan is disconnected from the payments block.

This issue does not always happen but can be consistently reproduced on the site mentioned in p2EDhh-13q-p2.

See before & after video in: p2EDhh-13q-p2#comment-6488

#### Changes proposed in this Pull Request:

The recurring payment's block attribute schema says that `planId` should contain an integer. However, the `planId` that was set by `setMembershipAmount()` function is a string.

When the page is reopened for editing in block editor, the `planId` value is then invalidated, what used to contain the value of the planId becomes `undefined` when the block goes through Gutenberg's `getBlockAttributes()` function, causing the block to be disconnected from the plan.

More information about this can be seen in: p2EDhh-13q-p2#comment-6360

The fix is just to `parseInt` the `planId` in `setMembershipAmount()` function. This `parseInt` practice can be seen in other places in the same file as well.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

Test using the site mentioned in p2EDhh-13q-p2 via **Switch To User**.

* Build & sync Jetpack over to your sandbox (`_inc` to `_inc` folder will do).
* In your hosts file, point the user's site to the IP of your sandbox, along with `s0.wp.com` (as this is where the Jetpack script is loaded and you want to load this from the sandbox).
* Switch To User via Blog RC.
* Duplicate the "Homepage" page (and set it as a private draft page).
* Edit the duplicated page.
* Click on the payments block on the page and connect it with a plan through the sidebar.
* Update the page.
* Refresh the editor.
* The payments block should still be connected to the plan previously selected before editor refresh.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix recurring payments block may sometimes disconnect from the plan when reopened in block editor.

Fixes p2EDhh-13q-p2
