### PR TITLE
Component auth-iframe: Add fallback flow for blocked 3rd-party cookies

### DIFF
--- a/_inc/client/components/auth-iframe/index.jsx
+++ b/_inc/client/components/auth-iframe/index.jsx
@@ -49,16 +49,26 @@ export class AuthIframe extends React.Component {
 	};
 
 	receiveData = e => {
-		if ( e.source === this.refs.iframe.contentWindow && e.data === 'close' ) {
-			// Remove listener, our job here is done.
-			window.removeEventListener( 'message', this.receiveData );
-			// Dispatch successful authorization.
-			this.props.authorizeUserInPlaceSuccess();
-			// Fetch user connection data after successful authorization to trigger state refresh
-			// for linked user.
-			this.props.fetchUserConnectionData();
-			// Trigger 'onAuthorized' callback, if provided
-			this.props.onAuthorized();
+		if ( e.source !== this.refs.iframe.contentWindow ) {
+			return;
+		}
+
+		switch ( e.data ) {
+			case 'close':
+				// Remove listener, our job here is done.
+				window.removeEventListener( 'message', this.receiveData );
+				// Dispatch successful authorization.
+				this.props.authorizeUserInPlaceSuccess();
+				// Fetch user connection data after successful authorization to trigger state refresh
+				// for linked user.
+				this.props.fetchUserConnectionData();
+				// Trigger 'onAuthorized' callback, if provided
+				this.props.onAuthorized();
+				break;
+			case 'wpcom_nocookie':
+				// Third-party cookies blocked. Let's redirect.
+				window.location.replace( this.props.connectUrl );
+				break;
 		}
 	};
 


### PR DESCRIPTION
If third-party cookies are disabled, we fallback from in-place connection to Calypso.

#### Changes proposed in this Pull Request:
* Catch the message sent from WP.com indicating that 3rd-party cookies are disabled.
* Fallback to the Calypso connection flow.

#### Jetpack product discussion
p9dueE-1CV-code

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Disable third-party cookies in your browser (don't use Safari, it skips the in-place connection altogether).
- Create a new user (secondary)
- Go to the Jetpack page as the secondary user and click "Link my account".
- After the iframe content gets loaded, you should be redirected to the Calypso flow.
- Follow the Calypso auth flow to the end and make sure you get connected properly.
- Enable the third-party cookies, create a new secondary user (or unlink the existing one), and make sure that regular in-place flow works fine.

#### Proposed changelog entry for your changes:
* Secondary Users In-place Connection: Fallback for disabled third-party cookies.
