### PR TITLE
Premium Blocks: populate blocks keywords with Premium

### DIFF
--- a/extensions/shared/premium-blocks/index.js
+++ b/extensions/shared/premium-blocks/index.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { uniq } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
 import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -19,6 +21,9 @@ import './editor.scss';
 
 const jetpackPremiumBlock = ( settings, name ) => {
 	if ( isUpgradable( name ) ) {
+		// Populate block keywords.
+		settings.keywords = uniq( [ ...settings.keywords, 'premium', __( 'premium' ) ] );
+
 		// Extend BlockEdit function.
 		settings.edit = premiumBlockEdit( settings.edit );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR populates the blocks keywords with the`premium` word when they are premium blocks.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Populate block keywords with `premium` when the block is premium.

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes in your sandbox
* Test in a Simple site with a Free Plan
* Sandbox the testing site.
* Confirm that typing `premium` word the blocks inserter shows all premium blocks

**before** | **after**
-----------|----------
<img src="https://user-images.githubusercontent.com/77539/88936189-0241a400-d259-11ea-998e-196be9e384d6.png" /> | ![image](https://user-images.githubusercontent.com/77539/88936365-35843300-d259-11ea-92da-cff517e2b0e0.png)



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
