### PR TITLE
VideoPress Block: Retain alignment support

### DIFF
--- a/extensions/blocks/videopress/editor.js
+++ b/extensions/blocks/videopress/editor.js
@@ -196,4 +196,11 @@ const addVideoPressSupport = ( settings, name ) => {
 	return settings;
 };
 
-addFilter( 'blocks.registerBlockType', 'jetpack/videopress', addVideoPressSupport );
+/**
+ * Assign higher-than-default priority to make our modifications before the more generic
+ * Gutenberg filters are run (that e.g. inject an extra `align` attribute based on the
+ * corresponding `supports` field).
+ *
+ * @see packages/block-editor/src/hooks/align.js
+ */
+addFilter( 'blocks.registerBlockType', 'jetpack/videopress', addVideoPressSupport, 5 );


### PR DESCRIPTION
The VideoPress block wraps around the `core/video` block. The `core/video` block sets the `align` `supports` field to `true` (rather than adding the attribute explicitly): https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-library/src/video/block.json#L66

The VideoPress block [inherits the `supports` field](https://github.com/Automattic/jetpack/blob/2ec6da0446c15fd0c87ac1c799c4075063db5598/extensions/blocks/videopress/editor.js#L158-L161) from the `core/video` block, but somehow in the process, the alignment support is lost -- that is issue #16158.

It turns out that handling of that `align` `supports` field is implemented in https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-editor/src/hooks/align.js, mostly through a number of filters that

1. [add](https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-editor/src/hooks/align.js#L228-L232) the [`align` attribute](https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-editor/src/hooks/align.js#L80-L102) to the block
2. [inject](https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-editor/src/hooks/align.js#L243-L247) the [`align{left|right|center}` class name into the saved HTML](https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-editor/src/hooks/align.js#L200-L226).

The reason for alignment support not carrying over to the VideoPress block is that we're [attaching](https://github.com/Automattic/jetpack/blob/2ec6da0446c15fd0c87ac1c799c4075063db5598/extensions/blocks/videopress/editor.js#L199) the VideoPress wrapper to the same filter that Gutenberg's [`addAttribute`]((https://github.com/WordPress/gutenberg/blob/6cce6e0fdbb27d496370d48305913523e3251ea1/packages/block-editor/src/hooks/align.js#L228-L232)) filter uses to automatically inject the `align` attribute -- they're just called in the wrong order. 

Fixes #16158
Supersedes #16627

props @yansern for the original PR #16627 and underlying research (https://github.com/Automattic/wp-calypso/issues/43252).

#### Changes proposed in this Pull Request:

This PR fixes the issue by assigning a higher priority to the VideoPress block's `blocks.registerBlockType` filter  -- arguably, our block-level modifications should run before the more generic modifiers that insert extra class names. Furthermore, this solution will also cover other `supports` fields that use the same mechanism (e.g. `anchor`) without requiring adding those attributes explicitly in the VideoPress block.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:

* Open up the editor to create a new post.
* Insert some paragraphs of content.
* In the middle of the paragraph, insert a **Video** block.
* Publish the blog post.
* Refresh the editor page.
* Verify that there is no block validation error.
* Align the video block to the left or right.
* Save the blog post.
* Refresh the editor page.
* The video block should still be aligned to the left in the editor.

#### Proposed changelog entry for your changes:
Fix VideoPress block alignment not respected in the block editor.