### PR TITLE
Remove CSS width on Account connection panel text

### DIFF
--- a/_inc/client/at-a-glance/style.scss
+++ b/_inc/client/at-a-glance/style.scss
@@ -326,7 +326,6 @@
 }
 
 .jp-connection-settings__text {
-	width: 70%;
 	margin-left: rem( 16px );
 	word-break: break-word;
 }


### PR DESCRIPTION
The `width: 70%` rule in the Account connection panel causes the email address to wrap when it's longer than the line above. Removing the width allows the email address to scale the entire width of the panel, and then `word-wrap` if necessary.

Fixes #16641 

#### Changes proposed in this Pull Request:
* Removes one line of CSS for the At a Glance dashboard to fix wrapping email addresses when they don't need to wrap

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to **Dashboard > At a Glance** on a connected Jetpack site
* Scroll down to the Account connection panel
* Note the screenshots below:

**Before:**
![image](https://user-images.githubusercontent.com/4297811/88965771-f77e1380-d246-11ea-80c9-b326ec0878eb.png)

**After:**
![image](https://user-images.githubusercontent.com/4297811/88965798-0238a880-d247-11ea-9204-6c180698051b.png)

**Edge Case (really long email address):**
![image](https://user-images.githubusercontent.com/4297811/88965958-4035cc80-d247-11ea-827a-b9db6dceeca9.png)

#### Proposed changelog entry for your changes:
* No changelog entry needed
