### PR TITLE
Form Block: avoid breaking string into 2 because of link

### DIFF
--- a/extensions/blocks/contact-form/components/jetpack-crm-connection-settings.js
+++ b/extensions/blocks/contact-form/components/jetpack-crm-connection-settings.js
@@ -8,6 +8,11 @@ import { __ } from '@wordpress/i18n';
 import { BaseControl, ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
 import semver from 'semver';
 
+/**
+ * Internal dependencies
+ */
+import { jetpackCreateInterpolateElement } from '../../../shared/create-interpolate-element';
+
 function CRMConnectionSettings( props ) {
 	const pluginState = Object.freeze( {
 		ACTIVE: 1,
@@ -96,11 +101,15 @@ function CRMConnectionSettings( props ) {
 		// Either no valid version or Jetpack CRM is not installed.
 		return (
 			<p>
-				{ __(
-					'You can save contacts from Jetpack contact forms in Jetpack CRM. Learn more at ',
-					'jetpack'
+				{ jetpackCreateInterpolateElement(
+					__(
+						'You can save contacts from Jetpack contact forms in Jetpack CRM. Learn more at <a>jetpackcrm.com</a>',
+						'jetpack'
+					),
+					{
+						a: <ExternalLink href="https://jetpackcrm.com" />,
+					}
 				) }
-				<ExternalLink href="https://jetpackcrm.com">jetpackcrm.com</ExternalLink>
 			</p>
 		);
 	};


### PR DESCRIPTION
Follow-up from #16519 

#### Changes proposed in this Pull Request:

* This should make the sentence easier to translate for translators, as they know what the complete sentence is and how it ends.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?
* N/A
#### Testing instructions:
* Add a new Form block to a post.
* Check the CRM integration question in the block sidebar.

#### Proposed changelog entry for your changes:
* N/A
