### PR TITLE
Form Block: do not display CRM integration on Simple sites

### DIFF
--- a/extensions/blocks/contact-form/components/jetpack-crm-connection-settings.js
+++ b/extensions/blocks/contact-form/components/jetpack-crm-connection-settings.js
@@ -5,7 +5,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { get } from 'lodash';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { BaseControl, ExternalLink, Spinner, ToggleControl } from '@wordpress/components';
+import {
+	BaseControl,
+	ExternalLink,
+	PanelBody,
+	Spinner,
+	ToggleControl,
+} from '@wordpress/components';
 import semver from 'semver';
 
 function CRMConnectionSettings( props ) {
@@ -114,24 +120,26 @@ function CRMConnectionSettings( props ) {
 	};
 
 	return (
-		<BaseControl>
-			{ isFetchingPlugins && <Spinner /> }
+		<PanelBody title={ __( 'CRM Integration', 'jetpack' ) } initialOpen={ false }>
+			<BaseControl>
+				{ isFetchingPlugins && <Spinner /> }
 
-			{ shouldDisplayToggle() && (
-				<ToggleControl
-					label={ __( 'CRM Connection', 'jetpack' ) }
-					checked={ jetpackCRM }
-					onChange={ value => setAttributes( { jetpackCRM: value } ) }
-					help={ __( 'Enable and disable Jetpack CRM integration for this form.', 'jetpack' ) }
-				/>
-			) }
+				{ shouldDisplayToggle() && (
+					<ToggleControl
+						label={ __( 'CRM Connection', 'jetpack' ) }
+						checked={ jetpackCRM }
+						onChange={ value => setAttributes( { jetpackCRM: value } ) }
+						help={ __( 'Enable and disable Jetpack CRM integration for this form.', 'jetpack' ) }
+					/>
+				) }
 
-			{ ! isFetchingPlugins && ! error && getText() }
+				{ ! isFetchingPlugins && ! error && getText() }
 
-			{ error && (
-				<p>{ __( "Couldn't access the plugins. Please try again later.", 'jetpack' ) }</p>
-			) }
-		</BaseControl>
+				{ error && (
+					<p>{ __( "Couldn't access the plugins. Please try again later.", 'jetpack' ) }</p>
+				) }
+			</BaseControl>
+		</PanelBody>
 	);
 }
 

--- a/extensions/blocks/contact-form/edit.js
+++ b/extensions/blocks/contact-form/edit.js
@@ -35,6 +35,7 @@ import {
 import HelpMessage from '../../shared/help-message';
 import defaultVariations from './variations';
 import CRMConnectionSettings from './components/jetpack-crm-connection-settings';
+import { isSimpleSite } from '../../shared/site-type-utils';
 
 const ALLOWED_BLOCKS = [
 	'jetpack/markdown',
@@ -319,9 +320,9 @@ function JetpackContactFormEdit( {
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Form Settings', 'jetpack' ) }>{ renderFormSettings() }</PanelBody>
-				<PanelBody title={ __( 'CRM Integration', 'jetpack' ) } initialOpen={ false }>
+				{ ! isSimpleSite() && (
 					<CRMConnectionSettings jetpackCRM={ jetpackCRM } setAttributes={ setAttributes } />
-				</PanelBody>
+				) }
 			</InspectorControls>
 
 			<div className={ formClassnames }>


### PR DESCRIPTION

Follow-up from #16519 

#### Changes proposed in this Pull Request:

* Plugins cannot be installed there.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Go to Pages > Add New and add a new form block on a Jetpack site
* You should still see the CRM option in the block sidebar.

#### Proposed changelog entry for your changes:

* N/A
