### PR TITLE
Improve Story block media loading

### DIFF
--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -123,7 +123,7 @@ export default withNotices( function StoryEdit( {
 					playInFullscreen={ false }
 					tapToPlayPause={ false }
 					playOnNextSlide={ false }
-					showSlideCount={ false }
+					showSlideCount={ ! isSelected }
 				/>
 			</div>
 			<DropZone onFilesDrop={ addFiles } />

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -7,13 +7,12 @@ import { get, pick } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { createElement, Fragment, useState } from '@wordpress/element';
+import { createElement, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { isBlobURL } from '@wordpress/blob';
 import { useDispatch } from '@wordpress/data';
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
-import { mediaUpload } from '@wordpress/editor';
-import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
+import { withNotices } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -87,7 +86,6 @@ export default withNotices( function StoryEdit( {
 
 	const mediaPlaceholder = (
 		<MediaPlaceholder
-			addToGallery={ hasImages }
 			isAppender={ hasImages }
 			className={ className }
 			disableMediaButtons={ hasImages && ! isSelected }

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -123,6 +123,7 @@ export default withNotices( function StoryEdit( {
 					playInFullscreen={ false }
 					tapToPlayPause={ false }
 					playOnNextSlide={ false }
+					showSlideCount={ false }
 				/>
 			</div>
 			<DropZone onFilesDrop={ addFiles } />

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -44,6 +44,8 @@ export const pickRelevantMediaFiles = ( media, sizeSlug = 'large' ) => {
 		media.url;
 	mediaProps.type = media.media_type || media.type;
 	mediaProps.mime = media.mime_type || media.mime;
+	mediaProps.width = mediaProps.width || get( media, [ 'media_details', 'width' ] );
+	mediaProps.height = mediaProps.height || get( media, [ 'media_details', 'height' ] );
 	return mediaProps;
 };
 

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -86,6 +86,7 @@ export default withNotices( function StoryEdit( {
 
 	const mediaPlaceholder = (
 		<MediaPlaceholder
+			addToGallery={ hasImages }
 			isAppender={ hasImages }
 			className={ className }
 			disableMediaButtons={ hasImages && ! isSelected }

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -49,10 +49,11 @@ export default withNotices( function StoryEdit( {
 	const { mediaFiles } = attributes;
 	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' );
 
-	const mediaReadyFilter = files =>
-		files.map( file => pickRelevantMediaFiles( file ) ).filter( media => ! isBlobURL( media.url ) );
+	const mediaFilter = files => files.map( file => pickRelevantMediaFiles( file ) );
 	const onSelectMedia = newMediaFiles =>
-		setAttributes( { mediaFiles: mediaReadyFilter( newMediaFiles ) } );
+		setAttributes( {
+			mediaFiles: mediaFilter( newMediaFiles ).filter( media => ! isBlobURL( media.url ) ),
+		} );
 
 	const addFiles = files => {
 		const lockName = 'storyBlockLock';
@@ -61,7 +62,7 @@ export default withNotices( function StoryEdit( {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList: files,
 			onFileChange: newMediaFiles => {
-				const mediaUploaded = mediaReadyFilter( newMediaFiles );
+				const mediaUploaded = mediaFilter( newMediaFiles );
 				setAttributes( {
 					mediaFiles: [ ...mediaFiles, ...mediaUploaded ],
 				} );
@@ -114,13 +115,12 @@ export default withNotices( function StoryEdit( {
 				<StoryPlayer
 					slides={ mediaFiles }
 					disabled={ ! isSelected }
-					settings={ {
-						shadowDOM: {
-							enabled: false,
-						},
-						playInFullscreen: false,
-						tapToPlayPause: true,
+					shadowDOM={ {
+						enabled: false,
 					} }
+					playInFullscreen={ false }
+					tapToPlayPause={ false }
+					playOnNextSlide={ false }
 				/>
 			</div>
 			<DropZone onFilesDrop={ addFiles } />

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -26,7 +26,16 @@ import './editor.scss';
 const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 
 export const pickRelevantMediaFiles = ( media, sizeSlug = 'large' ) => {
-	const mediaProps = pick( media, [ 'alt', 'id', 'link', 'type', 'mime', 'caption' ] );
+	const mediaProps = pick( media, [
+		'alt',
+		'id',
+		'link',
+		'type',
+		'mime',
+		'caption',
+		'width',
+		'height',
+	] );
 	mediaProps.url =
 		get( media, [ 'sizes', sizeSlug, 'url' ] ) ||
 		get( media, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] ) ||

--- a/extensions/blocks/story/edit.js
+++ b/extensions/blocks/story/edit.js
@@ -73,18 +73,6 @@ export default withNotices( function StoryEdit( {
 		} );
 	};
 
-	const addFiles = files => {
-		lockPostSaving( lockName );
-		mediaUpload( {
-			allowedTypes: ALLOWED_MEDIA_TYPES,
-			filesList: files,
-			onFileChange: newMediaFiles => {
-				onSelectMedia( [ ...mediaFiles, ...newMediaFiles ] );
-			},
-			onError: noticeOperations.createErrorNotice,
-		} );
-	};
-
 	const controls = (
 		<Controls
 			allowedMediaTypes={ ALLOWED_MEDIA_TYPES }
@@ -93,27 +81,39 @@ export default withNotices( function StoryEdit( {
 		/>
 	);
 
-	if ( mediaFiles.length === 0 ) {
+	const hasImages = !! mediaFiles.length;
+
+	const mediaPlaceholder = (
+		<MediaPlaceholder
+			addToGallery={ hasImages }
+			isAppender={ hasImages }
+			className={ className }
+			disableMediaButtons={ hasImages && ! isSelected }
+			icon={ ! hasImages && <BlockIcon icon={ icon } /> }
+			labels={ {
+				title: ! hasImages && __( 'Story', 'jetpack' ),
+				instructions:
+					! hasImages &&
+					__(
+						'Drag images and videos, upload new ones or select files from your library.',
+						'jetpack'
+					),
+			} }
+			onSelect={ onSelectMedia }
+			accept={ ALLOWED_MEDIA_TYPES.map( type => type + '/*' ).join( ',' ) }
+			allowedTypes={ ALLOWED_MEDIA_TYPES }
+			multiple
+			value={ mediaFiles }
+			notices={ hasImages ? undefined : noticeUI }
+			onError={ noticeOperations.createErrorNotice }
+		/>
+	);
+
+	if ( ! hasImages ) {
 		return (
 			<Fragment>
 				{ controls }
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					className={ className }
-					labels={ {
-						title: __( 'Story', 'jetpack' ),
-						instructions: __(
-							'Drag images and videos, upload new ones or select files from your library.',
-							'jetpack'
-						),
-					} }
-					onSelect={ onSelectMedia }
-					accept={ ALLOWED_MEDIA_TYPES.map( type => type + '/*' ).join( ',' ) }
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					multiple
-					notices={ noticeUI }
-					onError={ noticeOperations.createErrorNotice }
-				/>
+				{ mediaPlaceholder }
 			</Fragment>
 		);
 	}
@@ -132,24 +132,9 @@ export default withNotices( function StoryEdit( {
 					playInFullscreen={ false }
 					tapToPlayPause={ false }
 					playOnNextSlide={ false }
-					showSlideCount={ ! isSelected }
 				/>
 			</div>
-			<DropZone onFilesDrop={ addFiles } />
-			{ isSelected && (
-				<div className="wp-block-jetpack-story__add-item">
-					<FormFileUpload
-						multiple
-						isLarge
-						className="wp-block-jetpack-story__add-item-button"
-						onChange={ event => addFiles( event.target.files ) }
-						accept={ ALLOWED_MEDIA_TYPES.map( type => type + '/*' ).join( ',' ) }
-						icon="insert"
-					>
-						{ __( 'Add slide', 'jetpack' ) }
-					</FormFileUpload>
-				</div>
-			) }
+			{ isSelected && mediaPlaceholder }
 		</Fragment>
 	);
 } );

--- a/extensions/blocks/story/icon.js
+++ b/extensions/blocks/story/icon.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/components';
+
+export default (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+		<Path d="M0 0h24v24H0z" fill="none" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"
+		/>
+	</SVG>
+);

--- a/extensions/blocks/story/index.js
+++ b/extensions/blocks/story/index.js
@@ -2,31 +2,19 @@
  * External dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { Path, SVG } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
 import save from './save';
+import icon from './icon';
 import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 
 /**
  * Example Images
  */
 import storyExample1 from './story_example-1.png';
-
-export const icon = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-		<Path d="M0 0h24v24H0z" fill="none" />
-		<Path
-			fillRule="evenodd"
-			clipRule="evenodd"
-			fill="#2C3338"
-			d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"
-		/>
-	</SVG>
-);
 
 const attributes = {
 	mediaFiles: {
@@ -48,6 +36,8 @@ const exampleAttributes = {
 		},
 	],
 };
+
+export { icon };
 
 export const name = 'story';
 

--- a/extensions/blocks/story/index.js
+++ b/extensions/blocks/story/index.js
@@ -17,6 +17,9 @@ import getCategoryWithFallbacks from '../../shared/get-category-with-fallbacks';
 import storyExample1 from './story_example-1.png';
 
 const attributes = {
+	settings: {
+		type: 'object',
+	},
 	mediaFiles: {
 		type: 'array',
 		default: [],
@@ -24,7 +27,6 @@ const attributes = {
 };
 
 const exampleAttributes = {
-	align: 'center',
 	mediaFiles: [
 		{
 			alt: '',

--- a/extensions/blocks/story/player/components/background.js
+++ b/extensions/blocks/story/player/components/background.js
@@ -13,7 +13,7 @@ import { SVG } from '@wordpress/components';
  */
 
 export default function Background( { currentMedia } ) {
-	const url = currentMedia.type === 'image' ? currentMedia.url : null;
+	const url = currentMedia && currentMedia.type === 'image' ? currentMedia.url : null;
 
 	return (
 		<div className="wp-story-background">

--- a/extensions/blocks/story/player/components/calypso-spinner.js
+++ b/extensions/blocks/story/player/components/calypso-spinner.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+const CalypsoSpinner = () => (
+	<div className="wp-story-loading-spinner">
+		<div className="wp-story-loading-spinner__outer">
+			<div className="wp-story-loading-spinner__inner" />
+		</div>
+	</div>
+);
+
+export default CalypsoSpinner;

--- a/extensions/blocks/story/player/components/controls.js
+++ b/extensions/blocks/story/player/components/controls.js
@@ -9,7 +9,7 @@ import { createElement } from '@wordpress/element';
 import { SimpleButton } from './button';
 import { __ } from '@wordpress/i18n';
 
-export default function Controls( { playing, muted, setPlaying, setMuted } ) {
+export default function Controls( { playing, muted, setPlaying, setMuted, showMute } ) {
 	return (
 		<div className="wp-story-controls">
 			<SimpleButton
@@ -17,11 +17,13 @@ export default function Controls( { playing, muted, setPlaying, setMuted } ) {
 				onClick={ () => setPlaying( ! playing ) }
 				icon={ playing ? 'pause' : 'play_arrow' }
 			/>
-			<SimpleButton
-				label={ __( 'Mute', 'jetpack' ) }
-				onClick={ () => setMuted( ! muted ) }
-				icon={ muted ? 'volume_off' : 'volume_up' }
-			/>
+			{ showMute && (
+				<SimpleButton
+					label={ __( 'Mute', 'jetpack' ) }
+					onClick={ () => setMuted( ! muted ) }
+					icon={ muted ? 'volume_off' : 'volume_up' }
+				/>
+			) }
 		</div>
 	);
 }

--- a/extensions/blocks/story/player/components/index.js
+++ b/extensions/blocks/story/player/components/index.js
@@ -3,5 +3,6 @@ export { default as Controls } from './controls';
 export { default as Header } from './header';
 export { default as Overlay } from './overlay';
 export { default as Background } from './background';
+export { default as CalypsoSpinner } from './calypso-spinner';
 export * from './media';
 export * from './button';

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classNames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -11,7 +12,7 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 
-export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes, style } ) => (
+export const Image = ( { alt, className, id, mediaRef, mime, sizes, srcset, url } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<img
 		ref={ mediaRef }
@@ -19,42 +20,40 @@ export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes, style } ) 
 		data-mime={ mime }
 		alt={ alt }
 		src={ url }
-		className={ `wp-story-image wp-image-${ id }` }
+		className={ classNames( 'wp-story-image', `wp-image-${ id }`, className ) }
 		srcSet={ srcset }
 		sizes={ sizes }
-		style={ style }
 	/>
 );
 
-export const Video = ( { alt, mime, url, id, mediaRef, style } ) => (
+export const Video = ( { alt, className, id, mediaRef, mime, url } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<video
-		className="wp-story-video intrinsic-ignore"
+		className={ classNames( 'wp-story-video', 'intrinsic-ignore'`wp-video-${ id }`, className ) }
 		ref={ mediaRef }
 		data-id={ id }
 		title={ alt }
 		type={ mime }
 		src={ url }
-		style={ style }
 		playsInline
 	></video>
 );
 
 export const Media = ( { targetAspectRatio, cropUpTo, type, width, height, ...props } ) => {
-	const cropStyles = {};
+	let className = null;
 	if ( width && height ) {
 		const mediaAspectRatio = width / height;
 		if ( mediaAspectRatio >= targetAspectRatio ) {
 			// image wider than canvas
 			const mediaTooWideToCrop = mediaAspectRatio > targetAspectRatio / ( 1 - cropUpTo );
 			if ( ! mediaTooWideToCrop ) {
-				cropStyles.maxWidth = 'revert';
+				className = 'wp-story-crop-wide';
 			}
 		} else {
 			// image narrower than canvas
 			const mediaTooNarrowToCrop = mediaAspectRatio < targetAspectRatio * ( 1 - cropUpTo );
 			if ( ! mediaTooNarrowToCrop ) {
-				cropStyles.maxHeight = 'revert';
+				className = 'wp-story-crop-narrow';
 			}
 		}
 	}
@@ -62,9 +61,9 @@ export const Media = ( { targetAspectRatio, cropUpTo, type, width, height, ...pr
 	return (
 		<figure>
 			{ isVideo ? (
-				<Video { ...props } style={ cropStyles } />
+				<Video { ...props } className={ className } />
 			) : (
-				<Image { ...props } style={ cropStyles } />
+				<Image { ...props } className={ className } />
 			) }
 		</figure>
 	);

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -11,7 +11,7 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 
-export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes } ) => (
+export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes, style } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<img
 		ref={ mediaRef }
@@ -22,6 +22,7 @@ export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes } ) => (
 		className={ `wp-story-image wp-image-${ id }` }
 		srcSet={ srcset }
 		sizes={ sizes }
+		style={ style }
 	/>
 );
 
@@ -38,7 +39,36 @@ export const Video = ( { alt, mime, url, id, mediaRef } ) => (
 	></video>
 );
 
-export const Media = props => {
-	const isVideo = 'video' === props.type || ( props.mime || '' ).startsWith( 'video/' );
-	return <figure>{ isVideo ? <Video { ...props } /> : <Image { ...props } /> }</figure>;
+export const Media = ( { targetAspectRatio, cropUpTo, type, width, height, ...props } ) => {
+	const cropStyles = {};
+	if ( 'image' === type && width && height ) {
+		const imageRatio = width / height;
+		// Let's define the target ratio: Rt = w / h
+		// Where w and h are the width and height of the canvas to display the image onto.
+		// - In the case of an image too wide (with a ratio of Rw), we want to crop the left and right up to cropUpTo%
+		// of w, meaning:
+		//     Rt >= Rw >= Rt / ( 1 - cropUpTo )
+		// - In the case of an image too narrow (with a ratio of Rn), we want to crop the top and bottom up to cropUpTo%
+		// of h, meaning:
+		//     Rt <= Rn <= Rt * ( 1 - cropUpTo )
+		if ( imageRatio >= targetAspectRatio ) {
+			// image wider than canvas
+			const imageTooWideToCrop = imageRatio > targetAspectRatio / ( 1 - cropUpTo );
+			if ( ! imageTooWideToCrop ) {
+				cropStyles.maxWidth = 'revert';
+			}
+		} else {
+			// image narrower than canvas
+			const imageTooNarrowToCrop = imageRatio < targetAspectRatio * ( 1 - cropUpTo );
+			if ( ! imageTooNarrowToCrop ) {
+				cropStyles.maxHeight = 'revert';
+			}
+		}
+	}
+	const isVideo = 'video' === type || ( props.mime || '' ).startsWith( 'video/' );
+	return (
+		<figure>
+			{ isVideo ? <Video { ...props } /> : <Image { ...props } style={ cropStyles } /> }
+		</figure>
+	);
 };

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -26,41 +26,42 @@ export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes, style } ) 
 	/>
 );
 
-export const Video = ( { alt, mime, url, id, mediaRef } ) => (
+export const Video = ( { alt, mime, url, id, mediaRef, style } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<video
+		className="wp-story-video intrinsic-ignore"
 		ref={ mediaRef }
 		data-id={ id }
 		title={ alt }
 		type={ mime }
 		src={ url }
-		className="wp-story-video intrinsic-ignore"
+		style={ style }
 		playsInline
 	></video>
 );
 
 export const Media = ( { targetAspectRatio, cropUpTo, type, width, height, ...props } ) => {
 	const cropStyles = {};
-	if ( 'image' === type && width && height ) {
-		const imageRatio = width / height;
+	if ( width && height ) {
+		const mediaAspectRatio = width / height;
 		// Let's define the target ratio: Rt = w / h
-		// Where w and h are the width and height of the canvas to display the image onto.
-		// - In the case of an image too wide (with a ratio of Rw), we want to crop the left and right up to cropUpTo%
+		// Where w and h are the width and height of the canvas to display the media onto.
+		// - In the case of a media too wide (with a ratio of Rw), we want to crop the left and right up to cropUpTo%
 		// of w, meaning:
 		//     Rt >= Rw >= Rt / ( 1 - cropUpTo )
-		// - In the case of an image too narrow (with a ratio of Rn), we want to crop the top and bottom up to cropUpTo%
+		// - In the case of a media too narrow (with a ratio of Rn), we want to crop the top and bottom up to cropUpTo%
 		// of h, meaning:
 		//     Rt <= Rn <= Rt * ( 1 - cropUpTo )
-		if ( imageRatio >= targetAspectRatio ) {
+		if ( mediaAspectRatio >= targetAspectRatio ) {
 			// image wider than canvas
-			const imageTooWideToCrop = imageRatio > targetAspectRatio / ( 1 - cropUpTo );
-			if ( ! imageTooWideToCrop ) {
+			const mediaTooWideToCrop = mediaAspectRatio > targetAspectRatio / ( 1 - cropUpTo );
+			if ( ! mediaTooWideToCrop ) {
 				cropStyles.maxWidth = 'revert';
 			}
 		} else {
 			// image narrower than canvas
-			const imageTooNarrowToCrop = imageRatio < targetAspectRatio * ( 1 - cropUpTo );
-			if ( ! imageTooNarrowToCrop ) {
+			const mediaTooNarrowToCrop = mediaAspectRatio < targetAspectRatio * ( 1 - cropUpTo );
+			if ( ! mediaTooNarrowToCrop ) {
 				cropStyles.maxHeight = 'revert';
 			}
 		}
@@ -68,7 +69,11 @@ export const Media = ( { targetAspectRatio, cropUpTo, type, width, height, ...pr
 	const isVideo = 'video' === type || ( props.mime || '' ).startsWith( 'video/' );
 	return (
 		<figure>
-			{ isVideo ? <Video { ...props } /> : <Image { ...props } style={ cropStyles } /> }
+			{ isVideo ? (
+				<Video { ...props } style={ cropStyles } />
+			) : (
+				<Image { ...props } style={ cropStyles } />
+			) }
 		</figure>
 	);
 };

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -29,7 +29,7 @@ export const Image = ( { alt, className, id, mediaRef, mime, sizes, srcset, url 
 export const Video = ( { alt, className, id, mediaRef, mime, url } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<video
-		className={ classNames( 'wp-story-video', 'intrinsic-ignore'`wp-video-${ id }`, className ) }
+		className={ classNames( 'wp-story-video', 'intrinsic-ignore', `wp-video-${ id }`, className ) }
 		ref={ mediaRef }
 		data-id={ id }
 		title={ alt }

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -11,7 +11,7 @@ import { createElement } from '@wordpress/element';
  * Internal dependencies
  */
 
-export const Image = ( { alt, url, id, mime, mediaRef } ) => (
+export const Image = ( { alt, url, id, mime, mediaRef, srcset, sizes } ) => (
 	// eslint-disable-next-line jsx-a11y/media-has-caption
 	<img
 		ref={ mediaRef }
@@ -20,6 +20,8 @@ export const Image = ( { alt, url, id, mime, mediaRef } ) => (
 		alt={ alt }
 		src={ url }
 		className={ `wp-story-image wp-image-${ id }` }
+		srcSet={ srcset }
+		sizes={ sizes }
 	/>
 );
 

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -36,6 +36,7 @@ export const Video = ( { alt, mime, url, id, mediaRef } ) => (
 	></video>
 );
 
-export const Media = props => (
-	<figure>{ 'image' === props.type ? <Image { ...props } /> : <Video { ...props } /> }</figure>
-);
+export const Media = props => {
+	const isVideo = 'video' === props.type || ( props.mime || '' ).startsWith( 'video/' );
+	return <figure>{ isVideo ? <Video { ...props } /> : <Image { ...props } /> }</figure>;
+};

--- a/extensions/blocks/story/player/components/media.js
+++ b/extensions/blocks/story/player/components/media.js
@@ -44,14 +44,6 @@ export const Media = ( { targetAspectRatio, cropUpTo, type, width, height, ...pr
 	const cropStyles = {};
 	if ( width && height ) {
 		const mediaAspectRatio = width / height;
-		// Let's define the target ratio: Rt = w / h
-		// Where w and h are the width and height of the canvas to display the media onto.
-		// - In the case of a media too wide (with a ratio of Rw), we want to crop the left and right up to cropUpTo%
-		// of w, meaning:
-		//     Rt >= Rw >= Rt / ( 1 - cropUpTo )
-		// - In the case of a media too narrow (with a ratio of Rn), we want to crop the top and bottom up to cropUpTo%
-		// of h, meaning:
-		//     Rt <= Rn <= Rt * ( 1 - cropUpTo )
 		if ( mediaAspectRatio >= targetAspectRatio ) {
 			// image wider than canvas
 			const mediaTooWideToCrop = mediaAspectRatio > targetAspectRatio / ( 1 - cropUpTo );

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -10,7 +10,6 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { createElement, useCallback } from '@wordpress/element';
-import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,40 +24,33 @@ export default function Overlay( {
 	hasNext,
 	onNextSlide,
 	onPreviousSlide,
-	tapToPlayPause,
 	icon,
 	slideCount,
 } ) {
 	const onOverlayPressed = () => {
-		! disabled && tapToPlayPause && onClick();
+		! disabled && onClick();
 	};
-
-	const onPlayPressed = useCallback(
-		event => {
-			if ( tapToPlayPause || disabled ) {
-				// let the event bubble
-				return;
-			}
-			event.stopPropagation();
-			onClick();
-		},
-		[ tapToPlayPause, onClick ]
-	);
 
 	const onPreviousSlideHandler = useCallback(
 		event => {
+			if ( ended ) {
+				return;
+			}
 			event.stopPropagation();
 			onPreviousSlide();
 		},
-		[ onPreviousSlide ]
+		[ onPreviousSlide, ended ]
 	);
 
 	const onNextSlideHandler = useCallback(
 		event => {
+			if ( ended ) {
+				return;
+			}
 			event.stopPropagation();
 			onNextSlide();
 		},
-		[ onNextSlide ]
+		[ onNextSlide, ended ]
 	);
 
 	return (
@@ -66,7 +58,7 @@ export default function Overlay( {
 			role={ disabled ? 'presentation' : 'button' }
 			className={ classNames( {
 				'wp-story-overlay': true,
-				'wp-story-clickable': tapToPlayPause,
+				'wp-story-clickable': ! disabled,
 			} ) }
 			onClick={ onOverlayPressed }
 		>
@@ -99,13 +91,7 @@ export default function Overlay( {
 				) }
 			</div>
 			{ ended && (
-				<DecoratedButton
-					size={ 80 }
-					iconSize={ 56 }
-					label="Replay Story"
-					icon="replay"
-					onClick={ onPlayPressed }
-				/>
+				<DecoratedButton size={ 80 } iconSize={ 56 } label="Replay Story" icon="replay" />
 			) }
 		</div>
 	);

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -10,6 +10,7 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { createElement, useCallback } from '@wordpress/element';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -17,7 +18,6 @@ import { createElement, useCallback } from '@wordpress/element';
 import { DecoratedButton } from './button';
 
 export default function Overlay( {
-	playing,
 	ended,
 	disabled,
 	onClick,
@@ -26,7 +26,8 @@ export default function Overlay( {
 	onNextSlide,
 	onPreviousSlide,
 	tapToPlayPause,
-	showPlayButton,
+	icon,
+	slideCount,
 } ) {
 	const onOverlayPressed = () => {
 		! disabled && tapToPlayPause && onClick();
@@ -62,12 +63,19 @@ export default function Overlay( {
 
 	return (
 		<div
+			role={ disabled ? 'presentation' : 'button' }
 			className={ classNames( {
 				'wp-story-overlay': true,
 				'wp-story-clickable': tapToPlayPause,
 			} ) }
 			onClick={ onOverlayPressed }
 		>
+			{ icon && (
+				<div className="wp-story-embed-icon">
+					{ icon }
+					<span>{ slideCount }</span>
+				</div>
+			) }
 			<div className="wp-story-prev-slide" onClick={ onPreviousSlideHandler }>
 				{ hasPrevious && (
 					<DecoratedButton
@@ -90,15 +98,6 @@ export default function Overlay( {
 					/>
 				) }
 			</div>
-			{ showPlayButton && tapToPlayPause && ! playing && ! ended && (
-				<DecoratedButton
-					size={ 80 }
-					iconSize={ 56 }
-					label="Play Story"
-					icon="play_arrow"
-					onClick={ onPlayPressed }
-				/>
-			) }
 			{ ended && (
 				<DecoratedButton
 					size={ 80 }

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -5,6 +5,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import GridiconFullscreen from 'gridicons/dist/fullscreen';
 
 /**
  * WordPress dependencies
@@ -66,6 +67,11 @@ export default function Overlay( {
 				<div className="wp-story-embed-icon">
 					{ icon }
 					<span>{ slideCount }</span>
+				</div>
+			) }
+			{ ! icon && (
+				<div className="wp-story-embed-icon-expand">
+					<GridiconFullscreen />
 				</div>
 			) }
 			<div className="wp-story-prev-slide" onClick={ onPreviousSlideHandler }>

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -26,6 +26,7 @@ export default function Overlay( {
 	onNextSlide,
 	onPreviousSlide,
 	tapToPlayPause,
+	showPlayButton,
 } ) {
 	const onOverlayPressed = () => {
 		! disabled && tapToPlayPause && onClick();
@@ -89,7 +90,7 @@ export default function Overlay( {
 					/>
 				) }
 			</div>
-			{ tapToPlayPause && ! playing && ! ended && (
+			{ showPlayButton && tapToPlayPause && ! playing && ! ended && (
 				<DecoratedButton
 					size={ 80 }
 					iconSize={ 56 }

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -60,8 +60,8 @@ export default function Overlay( {
 					<GridiconFullscreen />
 				</div>
 			) }
-			<div className="wp-story-prev-slide" onClick={ onPreviousSlideHandler }>
-				{ hasPrevious && (
+			{ hasPrevious && (
+				<div className="wp-story-prev-slide" onClick={ onPreviousSlideHandler }>
 					<DecoratedButton
 						size={ 44 }
 						iconSize={ 24 }
@@ -69,10 +69,10 @@ export default function Overlay( {
 						icon="navigate_before"
 						className="outlined-w"
 					/>
-				) }
-			</div>
-			<div className="wp-story-next-slide" onClick={ onNextSlideHandler }>
-				{ hasNext && (
+				</div>
+			) }
+			{ hasNext && (
+				<div className="wp-story-next-slide" onClick={ onNextSlideHandler }>
 					<DecoratedButton
 						size={ 44 }
 						iconSize={ 24 }
@@ -80,8 +80,8 @@ export default function Overlay( {
 						icon="navigate_next"
 						className="outlined-w"
 					/>
-				) }
-			</div>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -24,7 +24,6 @@ export default function Overlay( {
 	onPreviousSlide,
 	icon,
 	slideCount,
-	children,
 } ) {
 	const onPreviousSlideHandler = useCallback(
 		event => {
@@ -83,10 +82,6 @@ export default function Overlay( {
 					/>
 				) }
 			</div>
-			{ ended && (
-				<DecoratedButton size={ 80 } iconSize={ 56 } label="Replay Story" icon="replay" />
-			) }
-			{ children }
 		</div>
 	);
 }

--- a/extensions/blocks/story/player/components/overlay.js
+++ b/extensions/blocks/story/player/components/overlay.js
@@ -4,7 +4,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import GridiconFullscreen from 'gridicons/dist/fullscreen';
 
 /**
@@ -19,19 +18,14 @@ import { DecoratedButton } from './button';
 
 export default function Overlay( {
 	ended,
-	disabled,
-	onClick,
 	hasPrevious,
 	hasNext,
 	onNextSlide,
 	onPreviousSlide,
 	icon,
 	slideCount,
+	children,
 } ) {
-	const onOverlayPressed = () => {
-		! disabled && onClick();
-	};
-
 	const onPreviousSlideHandler = useCallback(
 		event => {
 			if ( ended ) {
@@ -55,14 +49,7 @@ export default function Overlay( {
 	);
 
 	return (
-		<div
-			role={ disabled ? 'presentation' : 'button' }
-			className={ classNames( {
-				'wp-story-overlay': true,
-				'wp-story-clickable': ! disabled,
-			} ) }
-			onClick={ onOverlayPressed }
-		>
+		<div className="wp-story-overlay">
 			{ icon && (
 				<div className="wp-story-embed-icon">
 					{ icon }
@@ -99,6 +86,7 @@ export default function Overlay( {
 			{ ended && (
 				<DecoratedButton size={ 80 } iconSize={ 56 } label="Replay Story" icon="replay" />
 			) }
+			{ children }
 		</div>
 	);
 }

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -40,7 +40,7 @@ const defaultSettings = {
 	volume: 0.5,
 };
 
-export default function StoryPlayer( { slides, metadata, disabled, settings } ) {
+export default function StoryPlayer( { slides, metadata, disabled, ...settings } ) {
 	const playerSettings = merge( {}, defaultSettings, settings );
 
 	const rootElementRef = useRef();

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -38,7 +38,7 @@ const defaultSettings = {
 			'#jetpack-block-story-css, link[href*="jetpack/_inc/blocks/story/view.css"]',
 	},
 	defaultAspectRatio: 720 / 1280,
-	cropUpTo: 0.1, // crop percentage allowed, after which media is displayed in letterbox
+	cropUpTo: 0.15, // crop percentage allowed, after which media is displayed in letterbox
 	volume: 0.5,
 };
 

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -38,6 +38,7 @@ const defaultSettings = {
 			'#jetpack-block-story-css, link[href*="jetpack/_inc/blocks/story/view.css"]',
 	},
 	defaultAspectRatio: 720 / 1280,
+	cropUpTo: 0.1, // crop percentage allowed, after which media is displayed in letterbox
 	volume: 0.5,
 };
 

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -38,7 +38,7 @@ const defaultSettings = {
 			'#jetpack-block-story-css, link[href*="jetpack/_inc/blocks/story/view.css"]',
 	},
 	defaultAspectRatio: 720 / 1280,
-	cropUpTo: 0.15, // crop percentage allowed, after which media is displayed in letterbox
+	cropUpTo: 0.2, // crop percentage allowed, after which media is displayed in letterbox
 	volume: 0.5,
 };
 

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -30,7 +30,7 @@ const defaultSettings = {
 	exitFullscreenOnEnd: true,
 	loadInFullscreen: false,
 	blurredBackground: true,
-	showSlideCount: true,
+	showSlideCount: false,
 	shadowDOM: {
 		enabled: true,
 		mode: 'open', // closed not supported right now

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -31,6 +31,7 @@ const defaultSettings = {
 	loadInFullscreen: false,
 	tapToPlayPause: true, // embed feature
 	blurredBackground: true,
+	showSlideCount: true,
 	shadowDOM: {
 		enabled: true,
 		mode: 'open', // closed not supported right now

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { createElement, render, useEffect, useRef, useState } from '@wordpress/element';
+import { createElement, render, useLayoutEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -48,7 +48,7 @@ export default function StoryPlayer( { slides, metadata, disabled, ...settings }
 	const [ fullscreen, setFullscreen ] = useState( false );
 	const [ lastScrollPosition, setLastScrollPosition ] = useState( null );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( fullscreen ) {
 			if ( isMobile && fullscreenAPI.enabled() && ! playerSettings.loadInFullscreen ) {
 				fullscreenAPI.launch( rootElementRef.current );

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -26,6 +26,7 @@ const defaultSettings = {
 	renderInterval: 50,
 	startMuted: false,
 	playInFullscreen: true,
+	playOnNextSlide: true,
 	exitFullscreenOnEnd: true,
 	loadInFullscreen: false,
 	tapToPlayPause: true, // embed feature

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -29,7 +29,6 @@ const defaultSettings = {
 	playOnNextSlide: true,
 	exitFullscreenOnEnd: true,
 	loadInFullscreen: false,
-	tapToPlayPause: true, // embed feature
 	blurredBackground: true,
 	showSlideCount: true,
 	shadowDOM: {

--- a/extensions/blocks/story/player/index.js
+++ b/extensions/blocks/story/player/index.js
@@ -27,6 +27,7 @@ const defaultSettings = {
 	startMuted: false,
 	playInFullscreen: true,
 	playOnNextSlide: true,
+	playOnLoad: false,
 	exitFullscreenOnEnd: true,
 	loadInFullscreen: false,
 	blurredBackground: true,

--- a/extensions/blocks/story/player/lib/wait-media-ready.js
+++ b/extensions/blocks/story/player/lib/wait-media-ready.js
@@ -8,8 +8,9 @@ export default async function waitMediaReady( mediaElement, fullLoad = false ) {
 			mediaElement.addEventListener( 'load', resolve, { once: true } );
 		} );
 	} else if ( 'video' === elementTag || 'audio' === elementTag ) {
-		if ( fullLoad ) {
-			const src = mediaElement.src;
+		const src = mediaElement.src;
+		// only load the full video if it's on the same origin
+		if ( fullLoad && src && src.startsWith( window.location.origin ) ) {
 			mediaElement.src = '';
 			const videoRequest = new Request( src );
 			const requestHeaders = new Headers();
@@ -19,7 +20,7 @@ export default async function waitMediaReady( mediaElement, fullLoad = false ) {
 			return fetch( videoRequest, {
 				method: 'GET',
 				headers: requestHeaders,
-				mode: 'cors',
+				mode: 'no-cors',
 				cache: 'default',
 			} )
 				.then( response => {

--- a/extensions/blocks/story/player/lib/wait-media-ready.js
+++ b/extensions/blocks/story/player/lib/wait-media-ready.js
@@ -1,4 +1,4 @@
-export default async function waitMediaReady( mediaElement ) {
+export default async function waitMediaReady( mediaElement, fullLoad = false ) {
 	const elementTag = mediaElement.tagName.toLowerCase();
 	if ( 'img' === elementTag ) {
 		if ( mediaElement.complete ) {
@@ -8,6 +8,27 @@ export default async function waitMediaReady( mediaElement ) {
 			mediaElement.addEventListener( 'load', resolve, { once: true } );
 		} );
 	} else if ( 'video' === elementTag || 'audio' === elementTag ) {
+		if ( fullLoad ) {
+			const src = mediaElement.src;
+			mediaElement.src = '';
+			const videoRequest = new Request( src );
+			const requestHeaders = new Headers();
+			if ( mediaElement.type ) {
+				requestHeaders.append( 'Content-Type', mediaElement.type );
+			}
+			return fetch( videoRequest, {
+				method: 'GET',
+				headers: requestHeaders,
+				mode: 'cors',
+				cache: 'default',
+			} )
+				.then( response => {
+					return response.blob();
+				} )
+				.then( blob => {
+					mediaElement.src = URL.createObjectURL( blob );
+				} );
+		}
 		if ( mediaElement.HAVE_ENOUGH_DATA === mediaElement.readyState ) {
 			return;
 		}

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -116,6 +116,9 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 		if ( settings.loadInFullscreen ) {
 			setFullscreen( true );
 		}
+		if ( settings.playOnLoad ) {
+			setPlaying( true );
+		}
 	}, [] );
 
 	useLayoutEffect( () => {

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -75,12 +75,6 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 		}
 	}, [ disabled, playing ] );
 
-	// reset player on slide change
-	useEffect( () => {
-		setPlaying( false );
-		showSlide( 0, false );
-	}, [ slides ] );
-
 	// track play/pause state and check ending
 	useLayoutEffect( () => {
 		if ( playing ) {

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -89,7 +89,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 				setFullscreen( false );
 			}
 		}
-	}, [ currentSlideIndex ] );
+	}, [ currentSlideIndex, slides ] );
 
 	const onExitFullscreen = useCallback( () => {
 		setFullscreen( false );

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -33,7 +33,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	const [ slideWidth, setSlideWidth ] = useState( 279 );
 	const [ resizeListener, { height } ] = useResizeObserver();
 
-	const showSlide = ( slideIndex, play = true ) => {
+	const showSlide = ( slideIndex, play = settings.playOnNextSlide ) => {
 		setCurrentSlideProgress( 0 );
 		updateSlideIndex( slideIndex );
 
@@ -140,6 +140,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					hasPrevious={ currentSlideIndex > 0 }
 					hasNext={ currentSlideIndex < slides.length - 1 }
 					disabled={ settings.disabled }
+					showPlayButton={ settings.playInFullscreen }
 					tapToPlayPause={ ! fullscreen && settings.tapToPlayPause }
 					onClick={ () => {
 						if ( ! fullscreen && ! playing && settings.playInFullscreen ) {

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -149,7 +149,9 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 						if ( ended && ! playing ) {
 							showSlide( 0 );
 						}
-						setPlaying( ! playing );
+						if ( ! playing ) {
+							setPlaying( true );
+						}
 					} }
 					onPreviousSlide={ tryPreviousSlide }
 					onNextSlide={ tryNextSlide }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -39,6 +39,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	const showProgressBar = fullscreen || ! settings.showSlideCount;
 
 	const showSlide = ( slideIndex, play = settings.playOnNextSlide ) => {
+		setEnded( false );
 		setCurrentSlideProgress( 0 );
 		updateSlideIndex( slideIndex );
 
@@ -140,17 +141,15 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					ended={ ended }
 					hasPrevious={ currentSlideIndex > 0 }
 					hasNext={ currentSlideIndex < slides.length - 1 }
-					disabled={ fullscreen || settings.disabled }
-					tapToPlayPause={ ! fullscreen && settings.tapToPlayPause }
+					disabled={ settings.disabled }
 					onClick={ () => {
 						if ( ! fullscreen && ! playing && settings.playInFullscreen ) {
 							setFullscreen( true );
 						}
 						if ( ended && ! playing ) {
 							showSlide( 0 );
-						} else {
-							setPlaying( ! playing );
 						}
+						setPlaying( ! playing );
 					} }
 					onPreviousSlide={ tryPreviousSlide }
 					onNextSlide={ tryNextSlide }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classNames from 'classnames';
+import { some } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,6 +15,7 @@ import {
 	useLayoutEffect,
 	useCallback,
 } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -32,6 +34,8 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 
 	const [ slideWidth, setSlideWidth ] = useState( 279 );
 	const [ resizeListener, { height } ] = useResizeObserver();
+
+	const uploading = some( slides, media => isBlobURL( media.url ) );
 
 	const showSlide = ( slideIndex, play = settings.playOnNextSlide ) => {
 		setCurrentSlideProgress( 0 );
@@ -120,6 +124,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 							index={ index }
 							currentSlideIndex={ currentSlideIndex }
 							playing={ playing }
+							uploading={ uploading }
 							muted={ muted }
 							ended={ ended }
 							onProgress={ setCurrentSlideProgress }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -119,11 +119,16 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	}, [] );
 
 	useLayoutEffect( () => {
-		const wrapperHeight = ( wrapperRef.current && wrapperRef.current.offsetHeight ) || height;
-		const ratioBasedWidth = Math.round( settings.defaultAspectRatio * wrapperHeight );
 		if ( ! fullscreen ) {
+			if ( ! wrapperRef.current ) {
+				return;
+			}
+			const wrapperHeight = wrapperRef.current.offsetHeight;
+			const ratioBasedWidth = Math.round( settings.defaultAspectRatio * wrapperHeight );
 			setMaxSlideWidth( ratioBasedWidth );
 		} else {
+			const wrapperHeight = ( wrapperRef.current && wrapperRef.current.offsetHeight ) || height;
+			const ratioBasedWidth = Math.round( settings.defaultAspectRatio * wrapperHeight );
 			const newMaxSlideWidth =
 				Math.abs( 1 - ratioBasedWidth / width ) < settings.cropUpTo ? width : ratioBasedWidth;
 			setMaxSlideWidth( newMaxSlideWidth );
@@ -131,7 +136,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	}, [ width, height, fullscreen ] );
 
 	useLayoutEffect( () => {
-		if ( wrapperRef.current ) {
+		if ( wrapperRef.current && wrapperRef.current.offsetHeight > 0 ) {
 			setTargetAspectRatio( wrapperRef.current.offsetWidth / wrapperRef.current.offsetHeight );
 		}
 	}, [ width, height ] );

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -40,6 +40,13 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 
 	const uploading = some( slides, media => isBlobURL( media.url ) );
 	const showProgressBar = fullscreen || ! settings.showSlideCount;
+	const isVideo = slideIndex => {
+		const media = slideIndex < slides.length ? slides[ slideIndex ] : null;
+		if ( ! media ) {
+			return false;
+		}
+		return 'video' === media.type || ( media.mime || '' ).startsWith( 'video/' );
+	};
 
 	const showSlide = ( slideIndex, play = settings.playOnNextSlide ) => {
 		setCurrentSlideProgress( 0 );
@@ -60,7 +67,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 		if ( ended && ! playing ) {
 			showSlide( 0 );
 		}
-		if ( ! playing ) {
+		if ( ! playing && ! fullscreen ) {
 			setPlaying( true );
 		}
 	}, [ playing, ended, fullscreen, disabled ] );
@@ -140,7 +147,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					'wp-story-fullscreen': fullscreen,
 					'wp-story-ended': ended,
 					'wp-story-disabled': disabled,
-					'wp-story-clickable': ! disabled,
+					'wp-story-clickable': ! disabled && ! fullscreen,
 				} ) }
 				style={ { maxWidth: `${ maxSlideWidth }px` } }
 				onClick={ onPress }
@@ -165,6 +172,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 							onEnd={ tryNextSlide }
 							settings={ settings }
 							targetAspectRatio={ targetAspectRatio }
+							isVideo={ isVideo( currentSlideIndex ) }
 						/>
 					) ) }
 				</div>
@@ -192,6 +200,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					muted={ muted }
 					setPlaying={ setPlaying }
 					setMuted={ setMuted }
+					showMute={ isVideo( currentSlideIndex ) }
 				/>
 			</div>
 			{ fullscreen && (

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -9,7 +9,6 @@ import { some } from 'lodash';
  */
 import {
 	createElement,
-	useRef,
 	useState,
 	useEffect,
 	useLayoutEffect,
@@ -33,7 +32,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	const [ muted, setMuted ] = useState( settings.startMuted );
 	const [ currentSlideProgress, setCurrentSlideProgress ] = useState( 0 );
 
-	const [ slideWidth, setSlideWidth ] = useState( 279 );
+	const [ slideWidth, setSlideWidth ] = useState( null );
 	const [ resizeListener, { height } ] = useResizeObserver();
 
 	const uploading = some( slides, media => isBlobURL( media.url ) );
@@ -94,7 +93,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 		}
 	}, [] );
 
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( height ) {
 			const width = Math.round( settings.defaultAspectRatio * height );
 			setSlideWidth( width );

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -21,6 +21,7 @@ import { isBlobURL } from '@wordpress/blob';
  * Internal dependencies
  */
 import Slide from './slide';
+import icon from '../icon';
 import ProgressBar from './progress-bar';
 import { Background, Controls, Header, Overlay } from './components';
 import useResizeObserver from './use-resize-observer';
@@ -36,6 +37,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	const [ resizeListener, { height } ] = useResizeObserver();
 
 	const uploading = some( slides, media => isBlobURL( media.url ) );
+	const showProgressBar = fullscreen || ! settings.showSlideCount;
 
 	const showSlide = ( slideIndex, play = settings.playOnNextSlide ) => {
 		setCurrentSlideProgress( 0 );
@@ -134,12 +136,12 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					) ) }
 				</div>
 				<Overlay
-					playing={ playing }
+					icon={ settings.showSlideCount && icon }
+					slideCount={ slides.length }
 					ended={ ended }
 					hasPrevious={ currentSlideIndex > 0 }
 					hasNext={ currentSlideIndex < slides.length - 1 }
-					disabled={ settings.disabled }
-					showPlayButton={ settings.playInFullscreen }
+					disabled={ fullscreen || settings.disabled }
 					tapToPlayPause={ ! fullscreen && settings.tapToPlayPause }
 					onClick={ () => {
 						if ( ! fullscreen && ! playing && settings.playInFullscreen ) {
@@ -154,13 +156,15 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					onPreviousSlide={ tryPreviousSlide }
 					onNextSlide={ tryNextSlide }
 				/>
-				<ProgressBar
-					slides={ slides }
-					fullscreen={ fullscreen }
-					currentSlideIndex={ currentSlideIndex }
-					currentSlideProgress={ currentSlideProgress }
-					onSlideSeek={ showSlide }
-				/>
+				{ showProgressBar && (
+					<ProgressBar
+						slides={ slides }
+						fullscreen={ fullscreen }
+						currentSlideIndex={ currentSlideIndex }
+						currentSlideProgress={ currentSlideProgress }
+						onSlideSeek={ showSlide }
+					/>
+				) }
 				<Controls
 					playing={ playing }
 					muted={ muted }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -50,6 +50,21 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 		}
 	};
 
+	const onPress = useCallback( () => {
+		if ( disabled ) {
+			return;
+		}
+		if ( ! fullscreen && ! playing && settings.playInFullscreen ) {
+			setFullscreen( true );
+		}
+		if ( ended && ! playing ) {
+			showSlide( 0 );
+		}
+		if ( ! playing ) {
+			setPlaying( true );
+		}
+	}, [ playing, ended, fullscreen, disabled ] );
+
 	const tryPreviousSlide = useCallback( () => {
 		if ( currentSlideIndex > 0 ) {
 			showSlide( currentSlideIndex - 1 );
@@ -115,16 +130,20 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	}, [ width, height ] );
 
 	return (
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		<>
 			{ resizeListener }
 			<div
+				role={ disabled ? 'presentation' : 'button' }
 				className={ classNames( 'wp-story-container', {
 					'wp-story-with-controls': ! disabled && ! fullscreen && ! settings.playInFullscreen,
 					'wp-story-fullscreen': fullscreen,
 					'wp-story-ended': ended,
 					'wp-story-disabled': disabled,
+					'wp-story-clickable': ! disabled,
 				} ) }
 				style={ { maxWidth: `${ maxSlideWidth }px` } }
+				onClick={ onPress }
 			>
 				<Header
 					{ ...settings.metadata }
@@ -155,18 +174,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					ended={ ended }
 					hasPrevious={ currentSlideIndex > 0 }
 					hasNext={ currentSlideIndex < slides.length - 1 }
-					disabled={ settings.disabled }
-					onClick={ () => {
-						if ( ! fullscreen && ! playing && settings.playInFullscreen ) {
-							setFullscreen( true );
-						}
-						if ( ended && ! playing ) {
-							showSlide( 0 );
-						}
-						if ( ! playing ) {
-							setPlaying( true );
-						}
-					} }
+					disabled={ disabled }
 					onPreviousSlide={ tryPreviousSlide }
 					onNextSlide={ tryNextSlide }
 				/>

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -39,7 +39,6 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	const showProgressBar = fullscreen || ! settings.showSlideCount;
 
 	const showSlide = ( slideIndex, play = settings.playOnNextSlide ) => {
-		setEnded( false );
 		setCurrentSlideProgress( 0 );
 		updateSlideIndex( slideIndex );
 

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -212,7 +212,13 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 				/>
 			</div>
 			{ fullscreen && (
-				<Background currentMedia={ settings.blurredBackground && slides[ currentSlideIndex ] } />
+				<Background
+					currentMedia={
+						settings.blurredBackground &&
+						slides.length > currentSlideIndex &&
+						slides[ currentSlideIndex ]
+					}
+				/>
 			) }
 		</>
 	);

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -125,7 +125,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 							media={ media }
 							index={ index }
 							currentSlideIndex={ currentSlideIndex }
-							playing={ currentSlideIndex === index && playing }
+							playing={ playing }
 							muted={ muted }
 							ended={ ended }
 							onProgress={ setCurrentSlideProgress }

--- a/extensions/blocks/story/player/player.js
+++ b/extensions/blocks/story/player/player.js
@@ -32,8 +32,9 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 	const [ muted, setMuted ] = useState( settings.startMuted );
 	const [ currentSlideProgress, setCurrentSlideProgress ] = useState( 0 );
 
-	const [ slideWidth, setSlideWidth ] = useState( null );
-	const [ resizeListener, { height } ] = useResizeObserver();
+	const [ maxSlideWidth, setMaxSlideWidth ] = useState( null );
+	const [ resizeListener, { width, height } ] = useResizeObserver();
+	const [ targetAspectRatio, setTargetAspectRatio ] = useState( null );
 
 	const uploading = some( slides, media => isBlobURL( media.url ) );
 	const showProgressBar = fullscreen || ! settings.showSlideCount;
@@ -95,10 +96,16 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 
 	useLayoutEffect( () => {
 		if ( height ) {
-			const width = Math.round( settings.defaultAspectRatio * height );
-			setSlideWidth( width );
+			setMaxSlideWidth(
+				Math.round( settings.defaultAspectRatio * height * ( 1 + settings.cropUpTo ) )
+			);
 		}
 	}, [ height ] );
+
+	useEffect( () => {
+		const aspectRatio = height > 0 ? width / height : settings.defaultAspectRatio;
+		setTargetAspectRatio( aspectRatio );
+	}, [ width, height ] );
 
 	return (
 		<>
@@ -109,7 +116,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 					'wp-story-ended': ended,
 					'wp-story-disabled': disabled,
 				} ) }
-				style={ { width: `${ slideWidth }px` } }
+				style={ { maxWidth: `${ maxSlideWidth }px` } }
 			>
 				<Header
 					{ ...settings.metadata }
@@ -131,6 +138,7 @@ export const Player = ( { slides, fullscreen, setFullscreen, disabled, ...settin
 							onProgress={ setCurrentSlideProgress }
 							onEnd={ tryNextSlide }
 							settings={ settings }
+							targetAspectRatio={ targetAspectRatio }
 						/>
 					) ) }
 				</div>

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -175,7 +175,15 @@ export const Slide = ( {
 				className="wp-story-slide"
 				style={ { display: visible && ! loading ? 'block' : 'none' } }
 			>
-				{ preload && <Media { ...media } index={ index } mediaRef={ mediaRef } /> }
+				{ preload && (
+					<Media
+						{ ...media }
+						targetAspectRatio={ settings.defaultAspectRatio }
+						cropUpTo={ settings.cropUpTo }
+						index={ index }
+						mediaRef={ mediaRef }
+					/>
+				) }
 			</div>
 		</>
 	);

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -25,6 +25,7 @@ export const Slide = ( {
 	onEnd,
 	onProgress,
 	settings,
+	targetAspectRatio,
 } ) => {
 	const visible = index === currentSlideIndex;
 	const currentSlidePlaying = visible && playing;
@@ -178,7 +179,7 @@ export const Slide = ( {
 				{ preload && (
 					<Media
 						{ ...media }
-						targetAspectRatio={ settings.defaultAspectRatio }
+						targetAspectRatio={ targetAspectRatio }
 						cropUpTo={ settings.cropUpTo }
 						index={ index }
 						mediaRef={ mediaRef }

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -165,7 +165,6 @@ export const Slide = ( {
 
 	return (
 		<>
-			{ /* spinner from wp-calypso components */ }
 			{ visible && ( loading || uploading ) && (
 				<div className={ classNames( 'wp-story-slide', 'is-loading', { transparent: uploading } ) }>
 					<CalypsoSpinner />

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -2,16 +2,18 @@
  * External dependencies
  */
 import waitMediaReady from './lib/wait-media-ready';
+import classNames from 'classnames';
 
 /**
  * WordPress dependencies
  */
 import { createElement, useLayoutEffect, useEffect, useState, useRef } from '@wordpress/element';
+import { isBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
  */
-import { Media } from './components';
+import { Media, CalypsoSpinner } from './components';
 
 export const Slide = ( {
 	media,
@@ -26,6 +28,7 @@ export const Slide = ( {
 } ) => {
 	const visible = index === currentSlideIndex;
 	const currentSlidePlaying = visible && playing;
+	const uploading = isBlobURL( media.url );
 	const mediaRef = useRef( null );
 	const [ preload, setPreload ] = useState( false );
 	const [ loading, setLoading ] = useState( true );
@@ -158,18 +161,14 @@ export const Slide = ( {
 		waitMediaReady( mediaRef.current ).then( () => {
 			setLoading( false );
 		} );
-	}, [ preload ] );
+	}, [ preload, uploading ] );
 
 	return (
 		<>
 			{ /* spinner from wp-calypso components */ }
-			{ visible && loading && (
-				<div className="wp-story-slide is-loading">
-					<div className="spinner">
-						<div className="spinner__outer">
-							<div className="spinner__inner" />
-						</div>
-					</div>
+			{ visible && ( loading || uploading ) && (
+				<div className={ classNames( 'wp-story-slide', 'is-loading', { transparent: uploading } ) }>
+					<CalypsoSpinner />
 				</div>
 			) }
 			<div

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -6,7 +6,7 @@ import waitMediaReady from './lib/wait-media-ready';
 /**
  * WordPress dependencies
  */
-import { createElement, useEffect, useState, useRef } from '@wordpress/element';
+import { createElement, useLayoutEffect, useEffect, useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,9 +25,11 @@ export const Slide = ( {
 	settings,
 } ) => {
 	const visible = index === currentSlideIndex;
+	const currentSlidePlaying = visible && playing;
 	const mediaRef = useRef( null );
+	const [ preload, setPreload ] = useState( false );
 	const [ loading, setLoading ] = useState( true );
-	const isVideo = () => mediaRef.current.tagName.toLowerCase() === 'video';
+	const isVideo = () => mediaRef.current && mediaRef.current.tagName.toLowerCase() === 'video';
 
 	const [ progressState, updateProgressState ] = useState( {
 		currentTime: 0,
@@ -38,16 +40,16 @@ export const Slide = ( {
 	// Sync playing state with underlying HTMLMediaElement
 	useEffect( () => {
 		if ( isVideo() ) {
-			if ( playing ) {
+			if ( currentSlidePlaying ) {
 				mediaRef.current.play();
 			} else {
 				mediaRef.current.pause();
 			}
 		}
-	}, [ playing ] );
+	}, [ currentSlidePlaying ] );
 
 	// Display end of video on last slide when story ends
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( isVideo() && ended && visible ) {
 			mediaRef.current.currentTime = mediaRef.current.duration;
 		}
@@ -81,7 +83,7 @@ export const Slide = ( {
 
 	// Reset progress on replay for stories with one slide
 	useEffect( () => {
-		if ( playing && ended && currentSlideIndex === index ) {
+		if ( currentSlidePlaying && ended ) {
 			updateProgressState( {
 				currentTime: 0,
 				duration: null,
@@ -92,15 +94,15 @@ export const Slide = ( {
 				mediaRef.current.currentTime = 0;
 			}
 		}
-	}, [ playing, ended, currentSlideIndex ] );
+	}, [ currentSlidePlaying, ended ] );
 
 	// Sync progressState with underlying media playback progress
-	useEffect( () => {
+	useLayoutEffect( () => {
 		clearTimeout( progressState.timeout );
 		if ( loading ) {
 			return;
 		}
-		if ( playing ) {
+		if ( playing && visible ) {
 			const video = isVideo() ? mediaRef.current : null;
 			const duration = video ? video.duration : settings.imageTime;
 			if ( progressState.currentTime >= duration ) {
@@ -126,11 +128,11 @@ export const Slide = ( {
 				lastUpdate: null,
 			} );
 		}
-	}, [ loading, playing, progressState ] );
+	}, [ loading, playing, visible, progressState ] );
 
 	// Watch progressState and trigger events using onProgress and onEnd callbacks
 	useEffect( () => {
-		if ( ! playing || ended || progressState.duration === null ) {
+		if ( ! currentSlidePlaying || ended || progressState.duration === null ) {
 			return;
 		}
 		const percentage = Math.round( ( 100 * progressState.currentTime ) / progressState.duration );
@@ -140,14 +142,23 @@ export const Slide = ( {
 		} else {
 			onProgress( percentage );
 		}
-	}, [ playing, progressState ] );
+	}, [ currentSlidePlaying, visible, progressState ] );
+
+	useEffect( () => {
+		if ( index <= currentSlideIndex + ( playing ? 1 : 0 ) ) {
+			setPreload( true );
+		}
+	}, [ playing, currentSlideIndex ] );
 
 	// Sync media loading
-	useEffect( () => {
+	useLayoutEffect( () => {
+		if ( ! mediaRef.current ) {
+			return;
+		}
 		waitMediaReady( mediaRef.current ).then( () => {
 			setLoading( false );
 		} );
-	}, [ mediaRef.current ] );
+	}, [ preload ] );
 
 	return (
 		<>
@@ -165,7 +176,7 @@ export const Slide = ( {
 				className="wp-story-slide"
 				style={ { display: visible && ! loading ? 'block' : 'none' } }
 			>
-				<Media { ...media } index={ index } mediaRef={ mediaRef } />
+				{ preload && <Media { ...media } index={ index } mediaRef={ mediaRef } /> }
 			</div>
 		</>
 	);

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -32,7 +32,8 @@ export const Slide = ( {
 	const mediaRef = useRef( null );
 	const [ preload, setPreload ] = useState( false );
 	const [ loading, setLoading ] = useState( true );
-	const isVideo = () => mediaRef.current && mediaRef.current.tagName.toLowerCase() === 'video';
+	const isVideo = () =>
+		mediaRef.current && mediaRef.current.src && mediaRef.current.tagName.toLowerCase() === 'video';
 
 	const [ progressState, updateProgressState ] = useState( {
 		currentTime: 0,
@@ -41,6 +42,7 @@ export const Slide = ( {
 	} );
 
 	// Sync playing state with underlying HTMLMediaElement
+	// AJAX loading will pause the video when the video src attribute is modified
 	useEffect( () => {
 		if ( isVideo() ) {
 			if ( currentSlidePlaying ) {
@@ -49,7 +51,7 @@ export const Slide = ( {
 				mediaRef.current.pause();
 			}
 		}
-	}, [ currentSlidePlaying ] );
+	}, [ currentSlidePlaying, loading ] );
 
 	// Display end of video on last slide when story ends
 	useLayoutEffect( () => {
@@ -158,7 +160,7 @@ export const Slide = ( {
 		if ( ! mediaRef.current ) {
 			return;
 		}
-		waitMediaReady( mediaRef.current ).then( () => {
+		waitMediaReady( mediaRef.current, true ).then( () => {
 			setLoading( false );
 		} );
 	}, [ preload, uploading ] );

--- a/extensions/blocks/story/player/slide.js
+++ b/extensions/blocks/story/player/slide.js
@@ -8,7 +8,6 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { createElement, useLayoutEffect, useEffect, useState, useRef } from '@wordpress/element';
-import { isBlobURL } from '@wordpress/blob';
 
 /**
  * Internal dependencies
@@ -20,6 +19,7 @@ export const Slide = ( {
 	index,
 	currentSlideIndex,
 	playing,
+	uploading,
 	ended,
 	muted,
 	onEnd,
@@ -28,7 +28,6 @@ export const Slide = ( {
 } ) => {
 	const visible = index === currentSlideIndex;
 	const currentSlidePlaying = visible && playing;
-	const uploading = isBlobURL( media.url );
 	const mediaRef = useRef( null );
 	const [ preload, setPreload ] = useState( false );
 	const [ loading, setLoading ] = useState( true );

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -115,6 +115,14 @@
 		max-width: 100%;
 		margin: 0;
 		border: 0;
+
+		&.wp-story-crop-wide {
+			max-width: revert;
+		}
+
+		&.wp-story-crop-narrow {
+			max-height: revert;
+		}
 	}
 
 	.wp-story-meta, .wp-story-controls {

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -364,7 +364,7 @@
 		left: 0;
 		right: 0;
 		margin: 0;
-		z-index: 99999;
+		z-index: 9999999999;
 		width: 100% !important;
 		max-width: 100% !important;
 		height: 100%;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -407,6 +407,16 @@
 			margin-top: 84px;
 			margin-bottom: 84px;
 			border-radius: 0;
+			box-shadow: none;
+
+			&:before {
+				box-shadow: none;
+
+				&:hover {
+					opacity: 0;
+					transition: none !important;
+				}
+			}
 
 			.wp-story-embed-icon {
 				display: none;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -213,7 +213,7 @@
 	&.wp-story-ended,
 	&.wp-story-disabled {
 		.wp-story-overlay {
-			background-color: rgba(0, 0, 0, 0.4);
+			background-color: rgba(255, 255, 255, 0.4);
 		}
 	}
 

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -16,27 +16,18 @@
 	overflow: hidden;
 	-webkit-tap-highlight-color: transparent;
 	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
-	transition: transform 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+	transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
 
-	&:after {
-		content: ' ';
-		position: absolute;
-		z-index: -1;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		border-radius: 15px;
-		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
-		opacity: 0;
-		transition: opacity 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+	figure {
+		transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
 	}
 
 	&:hover {
-		transform: scale(1.03, 1.03);
-		&:after {
-			opacity: 1;
+		figure {
+			transform: scale(1.10, 1.10);
 		}
+		transform: scale(1.05, 1.05);
+		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
 	}
 
 	&.wp-story-initialized {
@@ -376,6 +367,11 @@
 			margin-bottom: 84px;
 			border-radius: 0;
 			overflow: initial;
+
+			figure {
+				transform: none;
+				transition: none !important;
+			}
 
 			@media ( max-width: $break-medium ) {
 				margin-top: 0;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -137,6 +137,7 @@
 		border-radius: 15px;
 		cursor: pointer;
 		box-shadow: 0 3px 15px rgba( 0, 0, 0, 0.4 );
+		-webkit-tap-highlight-color: transparent;
 
 		&:before {
 			content: ' ';

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -30,6 +30,13 @@
 		}
 	}
 
+	button {
+		box-shadow: none;
+		text-shadow: none;
+		background-color: transparent;
+		border: 0;
+	}
+
 	&.wp-story-initialized {
 		opacity: 1;
 	}
@@ -251,12 +258,10 @@
 		.wp-story-pagination-bullet {
 			flex: 1;
 			justify-content: space-between;
-			background-color: transparent;
 			opacity: 1;
 			margin: 0 2px;
 			padding: 6px 0;
 			vertical-align: top;
-			border: 0;
 
 			&:focus {
 				outline: none;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -586,7 +586,6 @@
 	img {
 		width: 100%;
 		height: 100%;
-
 	}
 
 	.wp-story-background-dark {

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -308,6 +308,12 @@
 
 	.wp-story-controls {
 		display: flex;
+
+		// reapply initial styles
+		@media ( max-width: $break-medium ) {
+			bottom: 30px;
+			margin: 0 10px;
+		}
 	}
 }
 

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -41,17 +41,6 @@
 		border-radius: 15px;
 		overflow: hidden;
 		background-color: $wp-story-background-color;
-		box-shadow: 0 3px 15px rgba(0, 0, 0, 0.25);
-
-		&:after {
-			box-shadow: 0 5px 15px rgba( 0, 0, 0, 0.5 );
-			opacity: 0;
-			transition: opacity 0.3s ease-in-out;
-		}
-
-		&:hover:after {
-			opacity: 1;
-		}
 	}
 
 	.wp-story-slide {
@@ -147,6 +136,26 @@
 		left: 0;
 		border-radius: 15px;
 		cursor: pointer;
+		box-shadow: 0 3px 15px rgba( 0, 0, 0, 0.4 );
+
+		&:before {
+			content: ' ';
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			border-radius: 15px;
+			box-shadow: 0 5px 15px rgba( 0, 0, 0, 0.5 );
+			opacity: 0;
+			transition: opacity 0.3s ease-in-out;
+		}
+
+		&:hover {
+			&:before {
+				opacity: 1;
+			}
+		}
 
 		.wp-story-button-play,
 		.wp-story-button-replay {

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -4,8 +4,8 @@
 @import '~@wordpress/components/src/spinner/style';
 
 .wp-story-container {
-	height: 496px;
-	width: 279px;
+	height: 320px;
+	width: 180px;
 	margin-left: auto;
 	margin-right: auto;
 	position: relative;
@@ -38,9 +38,20 @@
 		left: 0;
 		right: 0;
 		z-index: -1;
-		border-radius: 8px;
+		border-radius: 15px;
 		overflow: hidden;
 		background-color: $wp-story-background-color;
+		box-shadow: 0 3px 15px rgba(0, 0, 0, 0.25);
+
+		&:after {
+			box-shadow: 0 5px 15px rgba( 0, 0, 0, 0.5 );
+			opacity: 0;
+			transition: opacity 0.3s ease-in-out;
+		}
+
+		&:hover:after {
+			opacity: 1;
+		}
 	}
 
 	.wp-story-slide {
@@ -134,11 +145,42 @@
 		bottom: 0;
 		right: 0;
 		left: 0;
-		border-radius: 8px;
+		border-radius: 15px;
+		cursor: pointer;
 
 		.wp-story-button-play,
 		.wp-story-button-replay {
 			cursor: pointer;
+		}
+
+		.wp-story-embed-icon {
+			position: absolute;
+			top: 0;
+			right: 0;
+			margin: 15px;
+			padding: 5px 3px;
+			display: flex;
+			align-items: center;
+			background-color: rgba(0, 0, 0, 0.5);
+			border-radius: 5px;
+
+			* {
+				margin: 0 2px;
+			}
+
+			svg {
+				fill: #fff;
+				width: 20px;
+				height: 20px;
+			}
+
+			span {
+				color: #fff;
+				line-height: 20px;
+				font-size: 16px;
+				font-weight: 600;
+				font-family: sans-serif;
+			}
 		}
 	}
 
@@ -356,6 +398,10 @@
 			margin-top: 84px;
 			margin-bottom: 84px;
 			border-radius: 0;
+
+			.wp-story-embed-icon {
+				display: none;
+			}
 
 			@media ( max-width: $break-medium ) {
 				margin-top: 0;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -359,6 +359,7 @@
 		box-shadow: none;
 		transform: none;
 		transition: none !important;
+		overflow: initial;
 
 		&:before {
 			box-shadow: none;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -336,6 +336,7 @@
 			margin-top: 84px;
 			margin-bottom: 84px;
 			border-radius: 0;
+			overflow: initial;
 
 			@media ( max-width: $break-medium ) {
 				margin-top: 0;
@@ -547,7 +548,7 @@
 		@supports not (backdrop-filter: none) {
 			filter: blur(18px);
 			filter: url(#gaussian-blur-18);
-			filter: progid:DXImageTransform.Microsoft.Blur(PixelRadius='3');
+			filter: progid:DXImageTransform.Microsoft.Blur(PixelRadius='18');
 		}
 	}
 

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -55,6 +55,8 @@
 			justify-content: center;
 			margin: 0;
 			position: relative;
+			overflow: hidden;
+			object-fit: contain;
 
 			video {
 				width: 100%;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -295,6 +295,10 @@
 		.wp-story-slide {
 			height: 100%;
 			width: auto;
+
+			&.is-loading {
+				width: 100%;
+			}
 		}
 
 		.wp-story-meta {

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -161,7 +161,8 @@
 			cursor: pointer;
 		}
 
-		.wp-story-embed-icon {
+		.wp-story-embed-icon,
+		.wp-story-embed-icon-expand {
 			position: absolute;
 			top: 0;
 			right: 0;
@@ -188,6 +189,14 @@
 				font-size: 16px;
 				font-weight: 600;
 				font-family: sans-serif;
+			}
+		}
+
+		.wp-story-embed-icon-expand {
+			background-color: transparent;
+
+			svg {
+				filter: drop-shadow( 0 0 2px rgba(0, 0, 0, .6) );
 			}
 		}
 	}
@@ -425,7 +434,8 @@
 				}
 			}
 
-			.wp-story-embed-icon {
+			.wp-story-embed-icon,
+			.wp-story-embed-icon-expand {
 				display: none;
 			}
 

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -431,6 +431,16 @@
 			}
 		}
 
+		&.wp-story-ended,
+		&.wp-story-disabled {
+			.wp-story-overlay {
+				@media ( max-width: $break-medium ) {
+					top: 0;
+					bottom: 0;
+				}
+			}
+		}
+
 		.wp-story-prev-slide,
 		.wp-story-next-slide {
 			display: block;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -16,18 +16,18 @@
 	overflow: hidden;
 	-webkit-tap-highlight-color: transparent;
 	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
-	transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+	transition: box-shadow 0.3s ease-in-out, transform 0.3s cubic-bezier(0.18, 0.14, 0.25, 1);
 
 	figure {
-		transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+		transition: transform 0.3s cubic-bezier(0.18, 0.14, 0.25, 1);
 	}
 
 	&:hover {
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+		transform: scale(1.03, 1.03);
 		figure {
-			transform: scale(1.10, 1.10);
+			transform: scale(1.07, 1.07);
 		}
-		transform: scale(1.05, 1.05);
-		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
 	}
 
 	&.wp-story-initialized {
@@ -353,6 +353,11 @@
 		transition: none !important;
 		overflow: initial;
 
+		figure {
+			transform: none;
+			transition: none !important;
+		}
+
 		&:before {
 			box-shadow: none;
 
@@ -367,11 +372,6 @@
 			margin-bottom: 84px;
 			border-radius: 0;
 			overflow: initial;
-
-			figure {
-				transform: none;
-				transition: none !important;
-			}
 
 			@media ( max-width: $break-medium ) {
 				margin-top: 0;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -57,10 +57,6 @@
 			position: relative;
 			overflow: hidden;
 			object-fit: contain;
-
-			video {
-				width: 100%;
-			}
 		}
 
 		&.is-loading {
@@ -338,6 +334,7 @@
 	&.wp-story-container {
 		margin: auto;
 		height: 100%;
+		width: 100%;
 		max-width: 100%;
 		max-height: 100%;
 

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -60,6 +60,53 @@
 				width: 100%;
 			}
 		}
+
+		&.is-loading {
+			position: absolute;
+			z-index: 1;
+			background-color: #484542;
+			align-items: center;
+			justify-content: center;
+
+			&.transparent {
+				background-color: #4845427f;
+			}
+
+			@keyframes rotate-spinner {
+				100% {
+					transform: rotate( 360deg );
+				}
+			}
+
+			.wp-story-loading-spinner {
+				display: flex;
+				align-items: center;
+			}
+
+			.wp-story-loading-spinner__outer, .wp-story-loading-spinner__inner {
+				margin: auto;
+				box-sizing: border-box;
+				border: 0.1em solid transparent;
+				border-radius: 50%;
+				animation: 3s linear infinite;
+				animation-name: rotate-spinner;
+			}
+
+			.wp-story-loading-spinner__outer {
+				width: 40px;
+				height: 40px;
+				font-size: 40px;
+				border-top-color: #FFF;
+			}
+
+			.wp-story-loading-spinner__inner {
+				width: 100%;
+				height: 100%;
+				border-top-color: #C4C4C4;
+				border-right-color: #C4C4C4;
+				opacity: 0.4;
+			}
+		}
 	}
 
 	.wp-story-image, .wp-story-video {
@@ -248,47 +295,6 @@
 		.wp-story-slide {
 			height: 100%;
 			width: auto;
-
-			&.is-loading {
-				background-color: #484542;
-				align-items: center;
-				justify-content: center;
-
-				@keyframes rotate-spinner {
-					100% {
-						transform: rotate( 360deg );
-					}
-				}
-
-				.spinner {
-					display: flex;
-					align-items: center;
-				}
-
-				.spinner__outer, .spinner__inner {
-					margin: auto;
-					box-sizing: border-box;
-					border: 0.1em solid transparent;
-					border-radius: 50%;
-					animation: 3s linear infinite;
-					animation-name: rotate-spinner;
-				}
-
-				.spinner__outer {
-					width: 40px;
-					height: 40px;
-					font-size: 40px;
-					border-top-color: #FFF;
-				}
-
-				.spinner__inner {
-					width: 100%;
-					height: 100%;
-					border-top-color: #C4C4C4;
-					border-right-color: #C4C4C4;
-					opacity: 0.4;
-				}
-			}
 		}
 
 		.wp-story-meta {

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -16,11 +16,12 @@
 	overflow: hidden;
 	-webkit-tap-highlight-color: transparent;
 	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
-	transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+	transition: transform 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
 
-	&:before {
+	&:after {
 		content: ' ';
 		position: absolute;
+		z-index: -1;
 		top: 0;
 		right: 0;
 		bottom: 0;
@@ -28,12 +29,12 @@
 		border-radius: 15px;
 		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
 		opacity: 0;
-		transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+		transition: opacity 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
 	}
 
 	&:hover {
 		transform: scale(1.03, 1.03);
-		&:before {
+		&:after {
 			opacity: 1;
 		}
 	}
@@ -63,7 +64,6 @@
 		left: 0;
 		right: 0;
 		z-index: -1;
-		overflow: hidden;
 		background-color: $wp-story-background-color;
 	}
 
@@ -71,6 +71,7 @@
 		display: flex;
 		height: 100%;
 		width: 100%;
+
 		figure {
 			align-items: center;
 			display: flex;

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -12,12 +12,37 @@
 	list-style: none;
 	padding: 0;
 	z-index: 1;
+	border-radius: 15px;
+	overflow: hidden;
+	-webkit-tap-highlight-color: transparent;
+	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+	transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+
+	&:before {
+		content: ' ';
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border-radius: 15px;
+		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+		opacity: 0;
+		transition: all 0.3s cubic-bezier(0.165, 0.84, 0.44, 1);
+	}
+
+	&:hover {
+		transform: scale(1.03, 1.03);
+		&:before {
+			opacity: 1;
+		}
+	}
 
 	&.wp-story-initialized {
 		opacity: 1;
 	}
 
-	.wp-story-clickable {
+	&.wp-story-clickable {
 		cursor: pointer;
 	}
 
@@ -38,7 +63,6 @@
 		left: 0;
 		right: 0;
 		z-index: -1;
-		border-radius: 15px;
 		overflow: hidden;
 		background-color: $wp-story-background-color;
 	}
@@ -140,29 +164,6 @@
 		bottom: 0;
 		right: 0;
 		left: 0;
-		border-radius: 15px;
-		cursor: pointer;
-		box-shadow: 0 3px 15px rgba( 0, 0, 0, 0.4 );
-		-webkit-tap-highlight-color: transparent;
-
-		&:before {
-			content: ' ';
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			border-radius: 15px;
-			box-shadow: 0 5px 15px rgba( 0, 0, 0, 0.5 );
-			opacity: 0;
-			transition: opacity 0.3s ease-in-out;
-		}
-
-		&:hover {
-			&:before {
-				opacity: 1;
-			}
-		}
 
 		.wp-story-button-play,
 		.wp-story-button-replay {
@@ -354,6 +355,19 @@
 		width: 100%;
 		max-width: 100%;
 		max-height: 100%;
+		border-radius: 0;
+		box-shadow: none;
+		transform: none;
+		transition: none !important;
+
+		&:before {
+			box-shadow: none;
+
+			&:hover {
+				opacity: 0;
+				transition: none !important;
+			}
+		}
 
 		.wp-story-wrapper {
 			margin-top: 84px;
@@ -430,17 +444,6 @@
 		.wp-story-overlay {
 			margin-top: 84px;
 			margin-bottom: 84px;
-			border-radius: 0;
-			box-shadow: none;
-
-			&:before {
-				box-shadow: none;
-
-				&:hover {
-					opacity: 0;
-					transition: none !important;
-				}
-			}
 
 			.wp-story-embed-icon,
 			.wp-story-embed-icon-expand {

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -55,6 +55,7 @@
 		left: 0;
 		right: 0;
 		z-index: -1;
+		border-radius: 15px;
 		background-color: $wp-story-background-color;
 	}
 
@@ -294,33 +295,56 @@
 			margin: 0 16px;
 		}
 	}
-}
 
-.wp-story-with-controls {
-	overflow: visible;
+	&.wp-story-with-controls {
+		overflow: visible;
+		border-radius: 0;
+		box-shadow: none !important;
+		transition: none !important;
+		margin-bottom: 20px;
 
-	.wp-story-prev-slide,
-	.wp-story-next-slide {
-		display: block;
-	}
+		.wp-story-wrapper {
+			border-radius: 15px;
+			box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+			overflow: hidden;
+		}
 
-	.wp-story-prev-slide {
-		margin: auto;
-		left: -48px;
-	}
+		figure {
+			transform: none !important;
+			transition: none !important;
+		}
 
-	.wp-story-next-slide {
-		margin: auto;
-		right: -48px;
-	}
+		&:hover {
+			transform: none !important;
+			box-shadow: none !important;
+			figure {
+				transform: none;
+			}
+		}
 
-	.wp-story-controls {
-		display: flex;
+		.wp-story-prev-slide,
+		.wp-story-next-slide {
+			display: block;
+		}
 
-		// reapply initial styles
-		@media ( max-width: $break-medium ) {
-			bottom: 30px;
-			margin: 0 10px;
+		.wp-story-prev-slide {
+			margin: auto;
+			left: -48px;
+		}
+
+		.wp-story-next-slide {
+			margin: auto;
+			right: -48px;
+		}
+
+		.wp-story-controls {
+			display: flex;
+
+			// reapply initial styles
+			@media ( max-width: $break-medium ) {
+				bottom: 30px;
+				margin: 0 10px;
+			}
 		}
 	}
 }

--- a/extensions/blocks/story/player/style.scss
+++ b/extensions/blocks/story/player/style.scss
@@ -622,8 +622,7 @@
 		right: 0;
 		top: 0;
 		bottom: 0;
-		opacity: 0.88;
-		background-color: $wp-story-background-color;
+		background-color: #0e1112e0;
 
 		@supports (backdrop-filter: none) {
 			backdrop-filter: blur(18px);

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -141,6 +141,14 @@ function render_block( $attributes ) {
 					<div class="wp-story-wrapper">
 						%6$s
 					</div>
+					<div role="button" class="wp-story-overlay wp-story-clickable">
+						<div class="wp-story-embed-icon">
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+								<path d="M0 0h24v24H0z" fill="none"></path>
+								<path fill-rule="evenodd" clip-rule="evenodd" d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"></path>
+							</svg>
+							<span>%7$s</span>
+						</div>
 				</div>
 			</div>
 		</div>',
@@ -149,6 +157,7 @@ function render_block( $attributes ) {
 		__( 'Site icon', 'jetpack' ),
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
-		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : ''
+		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
+		count( $media_files )
 	);
 }

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -192,6 +192,7 @@ function render_block( $attributes ) {
 							</svg>
 							<span>%7$s</span>
 						</div>
+					</div>
 				</div>
 			</div>
 		</div>',

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -46,7 +46,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 			}
 			$attachment_id = $media_file['id'];
 			if ( 'image' === $media_file['type'] ) {
-				$image = wp_get_attachment_image_src( $attachment_id, 'full', false );
+				$image = wp_get_attachment_image_src( $attachment_id, EMBED_SIZE, false );
 				if ( ! $image ) {
 					return $media_file;
 				}
@@ -94,7 +94,7 @@ function render_image( $media ) {
 	if ( empty( $media['id'] ) || empty( $media['url'] ) ) {
 		return __( 'Error retrieving media', 'jetpack' );
 	}
-	$image      = wp_get_attachment_image_src( $media['id'], EMBED_SIZE, false );
+	$image      = wp_get_attachment_image_src( $media['id'], 'full', false );
 	$crop_class = '';
 	if ( $image ) {
 		list( , $width, $height ) = $image;

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -43,25 +43,39 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 				return $media_file;
 			}
 			$attachment_id = $media_file['id'];
-			$image         = wp_get_attachment_image_src( $attachment_id, EMBED_SIZE, false );
-			if ( ! $image ) {
-				return $media_file;
+			if ( 'image' === $media_file['type'] ) {
+				$image = wp_get_attachment_image_src( $attachment_id, EMBED_SIZE, false );
+				if ( ! $image ) {
+					return $media_file;
+				}
+				list( $src, $width, $height ) = $image;
+				$image_meta                   = wp_get_attachment_metadata( $attachment_id );
+				if ( ! is_array( $image_meta ) ) {
+					return $media_file;
+				}
+				$size_array = array( absint( $width ), absint( $height ) );
+				return array_merge(
+					$media_file,
+					array(
+						'width'  => absint( $width ),
+						'height' => absint( $height ),
+						'srcset' => wp_calculate_image_srcset( $size_array, $src, $image_meta, $attachment_id ),
+						'sizes'  => '(max-width: 169px) 169w, (max-width: 576px) 576w, (max-width: 768px) 768w, 1080w',
+					)
+				);
+			} else {
+				$video_meta = wp_get_attachment_metadata( $attachment_id );
+				if ( ! isset( $video_meta['width'] ) || ! isset( $video_meta['width'] ) ) {
+					return $media_file;
+				}
+				return array_merge(
+					$media_file,
+					array(
+						'width'  => absint( $video_meta['width'] ),
+						'height' => absint( $video_meta['height'] ),
+					)
+				);
 			}
-			list( $src, $width, $height ) = $image;
-			$image_meta                   = wp_get_attachment_metadata( $attachment_id );
-			if ( ! is_array( $image_meta ) ) {
-				return $media_file;
-			}
-			$size_array = array( absint( $width ), absint( $height ) );
-			return array_merge(
-				$media_file,
-				array(
-					'width'  => absint( $width ),
-					'height' => absint( $height ),
-					'srcset' => wp_calculate_image_srcset( $size_array, $src, $image_meta, $attachment_id ),
-					'sizes'  => '(max-width: 169px) 169w, (max-width: 576px) 576w, (max-width: 768px) 768w, 1080w',
-				)
-			);
 		},
 		$media_files
 	);

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -332,10 +332,10 @@ function render_block( $attributes ) {
 					<div class="wp-story-wrapper">
 						%6$s
 					</div>
-					<div role="button" class="wp-story-overlay wp-story-clickable">
-						%7$s
-					</div>
-					%8$s
+					<a class="wp-story-overlay" href="%7$s">
+						%8$s
+					</a>
+					%9$s
 				</div>
 			</div>
 		</div>',
@@ -345,6 +345,7 @@ function render_block( $attributes ) {
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
 		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
+		get_permalink(),
 		render_top_right_icon( $settings ),
 		render_pagination( $settings )
 	);

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -141,11 +141,6 @@ function render_block( $attributes ) {
 					<div class="wp-story-wrapper">
 						%6$s
 					</div>
-					<div class="wp-story-overlay">
-						<button class="jetpack-mdc-icon-button circle-icon outlined bordered" aria-label="%7$s" aria-pressed="false" style="width: 80px; height: 80px;">
-							<i class="jetpack-material-icons play_arrow" style="font-size: 56px;"></i>
-						</button>
-					</div>
 				</div>
 			</div>
 		</div>',
@@ -154,7 +149,6 @@ function render_block( $attributes ) {
 		__( 'Site icon', 'jetpack' ),
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
-		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
-		__( 'Exit Fullscreen', 'jetpack' )
+		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : ''
 	);
 }

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -30,13 +30,13 @@ function register_block() {
 add_action( 'init', __NAMESPACE__ . '\register_block' );
 
 /**
- * Add missing srcset and sizes properties to images in the mediaFiles block attributes
+ * Add missing `width`, `height`, `srcset` and `sizes` properties to images of the mediaFiles block attributes
  *
  * @param array $media_files  List of media, each as an array containing the media attributes.
  *
  * @return array $media_files
  */
-function with_srcset_and_sizes( $media_files ) {
+function with_width_height_srcset_and_sizes( $media_files ) {
 	return array_map(
 		function( $media_file ) {
 			if ( ! isset( $media_file['id'] ) || ! empty( $media_file['srcset'] ) ) {
@@ -56,6 +56,8 @@ function with_srcset_and_sizes( $media_files ) {
 			return array_merge(
 				$media_file,
 				array(
+					'width'  => absint( $width ),
+					'height' => absint( $height ),
 					'srcset' => wp_calculate_image_srcset( $size_array, $src, $image_meta, $attachment_id ),
 					'sizes'  => '(max-width: 169px) 169w, (max-width: 576px) 576w, (max-width: 768px) 768w, 1080w',
 				)
@@ -159,7 +161,7 @@ function render_block( $attributes ) {
 	$media_files = isset( $attributes['mediaFiles'] ) ? $attributes['mediaFiles'] : array();
 
 	$settings = array(
-		'slides' => with_srcset_and_sizes( $media_files ),
+		'slides' => with_width_height_srcset_and_sizes( $media_files ),
 	);
 
 	return sprintf(

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -172,10 +172,14 @@ function render_slide( $media, $index = 0 ) {
 function render_block( $attributes ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	$media_files = isset( $attributes['mediaFiles'] ) ? $attributes['mediaFiles'] : array();
+	$media_files              = isset( $attributes['mediaFiles'] ) ? $attributes['mediaFiles'] : array();
+	$settings_from_attributes = isset( $attributes['settings'] ) ? $attributes['settings'] : array();
 
-	$settings = array(
-		'slides' => with_width_height_srcset_and_sizes( $media_files ),
+	$settings = array_merge(
+		$settings_from_attributes,
+		array(
+			'slides' => with_width_height_srcset_and_sizes( $media_files ),
+		)
 	);
 
 	return sprintf(

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -44,7 +44,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 			}
 			$attachment_id = $media_file['id'];
 			if ( 'image' === $media_file['type'] ) {
-				$image = wp_get_attachment_image_src( $attachment_id, EMBED_SIZE, false );
+				$image = wp_get_attachment_image_src( $attachment_id, 'full', false );
 				if ( ! $image ) {
 					return $media_file;
 				}
@@ -60,7 +60,7 @@ function with_width_height_srcset_and_sizes( $media_files ) {
 						'width'  => absint( $width ),
 						'height' => absint( $height ),
 						'srcset' => wp_calculate_image_srcset( $size_array, $src, $image_meta, $attachment_id ),
-						'sizes'  => '(max-width: 169px) 169w, (max-width: 576px) 576w, (max-width: 768px) 768w, 1080w',
+						'sizes'  => '(max-width: 460px) 576w, (max-width: 614px) 768w, 120vw', // 120vw to match the 20% upToCrop ratio
 					)
 				);
 			} else {

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -84,17 +84,24 @@ function render_video( $media ) {
  *
  * @return string
  */
-function render_slide( $media, $index ) {
+function render_slide( $media, $index = 0 ) {
+	$media_template = '';
+	switch ( ! empty( $media['type'] ) && $media['type'] ) {
+		case 'image':
+			$media_template = render_image( $media, $index );
+			break;
+		case 'video':
+			$media_template = render_video( $media, $index );
+			break;
+	}
 	return sprintf(
-		'<li class="wp-story-slide" style="display: %s;">
+		'<div class="wp-story-slide" style="display: %s;">
 			<figure>
 				%s
 			</figure>
-		</li>',
+		</div>',
 		0 === $index ? 'block' : 'none',
-		'image' === $media['type']
-			? render_image( $media, $index )
-			: render_video( $media, $index )
+		$media_template
 	);
 }
 
@@ -108,8 +115,11 @@ function render_slide( $media, $index ) {
 function render_block( $attributes ) {
 	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
 
-	$settings    = array();
 	$media_files = isset( $attributes['mediaFiles'] ) ? $attributes['mediaFiles'] : array();
+
+	$settings = array(
+		'slides' => $media_files,
+	);
 
 	return sprintf(
 		'<div class="%1$s" data-settings="%2$s">
@@ -128,11 +138,11 @@ function render_block( $attributes ) {
 							<i class="jetpack-material-icons close md-24"></i>
 						</button>
 					</div>
-					<ul class="wp-story-wrapper">
+					<div class="wp-story-wrapper">
 						%6$s
-					</ul>
+					</div>
 					<div class="wp-story-overlay">
-						<button class="jetpack-mdc-icon-button circle-icon outlined bordered" aria-label="%7$s" aria-pressed="false">
+						<button class="jetpack-mdc-icon-button circle-icon outlined bordered" aria-label="%7$s" aria-pressed="false" style="width: 80px; height: 80px;">
 							<i class="jetpack-material-icons play_arrow" style="font-size: 56px;"></i>
 						</button>
 					</div>
@@ -144,7 +154,7 @@ function render_block( $attributes ) {
 		__( 'Site icon', 'jetpack' ),
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
-		join( "\n", array_map( __NAMESPACE__ . '\render_slide', $media_files, array_keys( $media_files ) ) ),
+		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
 		__( 'Exit Fullscreen', 'jetpack' )
 	);
 }

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -185,6 +185,79 @@ function render_slide( $media, $index = 0 ) {
 }
 
 /**
+ * Render the top right icon on top of the story embed
+ *
+ * @param array $settings The block settings.
+ *
+ * @return string
+ */
+function render_top_right_icon( $settings ) {
+	$show_slide_count = isset( $settings['showSlideCount'] ) ? $settings['showSlideCount'] : false;
+	$slide_count      = isset( $settings['slides'] ) ? count( $settings['slides'] ) : 0;
+	if ( $show_slide_count ) {
+		// Render the story block icon along with the slide count.
+		return sprintf(
+			'<div class="wp-story-embed-icon">
+				<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
+					<path d="M0 0h24v24H0z" fill="none"></path>
+					<path fill-rule="evenodd" clip-rule="evenodd" d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"></path>
+				</svg>
+				<span>%s</span>
+			</div>',
+			$slide_count
+		);
+	} else {
+		// Render the Fullscreen Gridicon.
+		return (
+			'<div class="wp-story-embed-icon-expand">
+				<svg class="gridicon gridicons-fullscreen" height="24" width="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+					<g>
+						<path d="M21 3v6h-2V6.41l-3.29 3.3-1.42-1.42L17.59 5H15V3zM3 3v6h2V6.41l3.29 3.3 1.42-1.42L6.41 5H9V3zm18 18v-6h-2v2.59l-3.29-3.29-1.41 1.41L17.59 19H15v2zM9 21v-2H6.41l3.29-3.29-1.41-1.42L5 17.59V15H3v6z"></path>
+					</g>
+				</svg>
+			</div>'
+		);
+	}
+}
+
+/**
+ * Render a pagination bullet
+ *
+ * @param array $slide_index The slide index it corresponds to.
+ *
+ * @return string
+ */
+function render_pagination_bullet( $slide_index ) {
+	return sprintf(
+		'<button class="wp-story-pagination-bullet" aria-label="Go to slide %d">
+			<div class="wp-story-pagination-bullet-bar"></div>
+		</button>',
+		$slide_index
+	);
+}
+
+/**
+ * Render pagination on top of the story embed
+ *
+ * @param array $settings The block settings.
+ *
+ * @return string
+ */
+function render_pagination( $settings ) {
+	$show_slide_count = isset( $settings['showSlideCount'] ) ? $settings['showSlideCount'] : false;
+	if ( $show_slide_count ) {
+		return '';
+	}
+	$slide_count = isset( $settings['slides'] ) ? count( $settings['slides'] ) : 0;
+	return sprintf(
+		'<div class="wp-story-pagination wp-story-pagination-bullets">
+			%s
+		</div>',
+		join( "\n", array_map( __NAMESPACE__ . '\render_pagination_bullet', range( 1, $slide_count ) ) )
+	);
+}
+
+/**
  * Render story block
  *
  * @param array $attributes  Block attributes.
@@ -225,14 +298,9 @@ function render_block( $attributes ) {
 						%6$s
 					</div>
 					<div role="button" class="wp-story-overlay wp-story-clickable">
-						<div class="wp-story-embed-icon">
-							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false">
-								<path d="M0 0h24v24H0z" fill="none"></path>
-								<path fill-rule="evenodd" clip-rule="evenodd" d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"></path>
-							</svg>
-							<span>%7$s</span>
-						</div>
+						%7$s
 					</div>
+					%8$s
 				</div>
 			</div>
 		</div>',
@@ -242,6 +310,7 @@ function render_block( $attributes ) {
 		esc_attr( get_site_icon_url( 32, includes_url( 'images/w-logo-blue.png' ) ) ),
 		esc_html( get_the_title() ),
 		! empty( $media_files[0] ) ? render_slide( $media_files[0] ) : '',
-		count( $media_files )
+		render_top_right_icon( $settings ),
+		render_pagination( $settings )
 	);
 }

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -200,6 +200,9 @@ function render_video( $media ) {
 function render_slide( $media, $index = 0 ) {
 	$media_template = '';
 	$media_type     = ! empty( $media['type'] ) ? $media['type'] : null;
+	if ( ! $media_type ) {
+		return '';
+	}
 	switch ( $media_type ) {
 		case 'image':
 			$media_template = render_image( $media, $index );

--- a/extensions/blocks/story/story.php
+++ b/extensions/blocks/story/story.php
@@ -237,7 +237,7 @@ function render_top_right_icon( $settings ) {
 					<path d="M0 0h24v24H0z" fill="none"></path>
 					<path fill-rule="evenodd" clip-rule="evenodd" d="M6 3H14V17H6L6 3ZM4 3C4 1.89543 4.89543 1 6 1H14C15.1046 1 16 1.89543 16 3V17C16 18.1046 15.1046 19 14 19H6C4.89543 19 4 18.1046 4 17V3ZM18 5C19.1046 5 20 5.89543 20 7V21C20 22.1046 19.1046 23 18 23H10C8.89543 23 8 22.1046 8 21H18V5Z"></path>
 				</svg>
-				<span>%s</span>
+				<span>%d</span>
 			</div>',
 			$slide_count
 		);
@@ -264,10 +264,11 @@ function render_top_right_icon( $settings ) {
  */
 function render_pagination_bullet( $slide_index ) {
 	return sprintf(
-		'<button class="wp-story-pagination-bullet" aria-label="Go to slide %d">
+		'<a href="#" class="wp-story-pagination-bullet" aria-label="%s">
 			<div class="wp-story-pagination-bullet-bar"></div>
-		</button>',
-		$slide_index
+		</a>',
+		/* translators: %d is the slide number (1, 2, 3...) */
+		sprintf( __( 'Go to slide %d', 'jetpack' ), $slide_index )
 	);
 }
 
@@ -325,9 +326,9 @@ function render_block( $attributes ) {
 								%5$s
 							</div>
 						</div>
-						<button class="wp-story-exit-fullscreen jetpack-mdc-icon-button">
+						<a class="wp-story-exit-fullscreen jetpack-mdc-icon-button">
 							<i class="jetpack-material-icons close md-24"></i>
-						</button>
+						</a>
 					</div>
 					<div class="wp-story-wrapper">
 						%6$s

--- a/extensions/blocks/story/view.js
+++ b/extensions/blocks/story/view.js
@@ -32,12 +32,7 @@ function renderPlayer( rootElement, settings ) {
 	}
 
 	render(
-		<StoryPlayer
-			slides={ slides }
-			metadata={ metadata }
-			disabled={ false }
-			settings={ settings }
-		/>,
+		<StoryPlayer slides={ slides } metadata={ metadata } disabled={ false } { ...settings } />,
 		rootElement
 	);
 }

--- a/extensions/blocks/story/view.js
+++ b/extensions/blocks/story/view.js
@@ -45,6 +45,8 @@ function parseSlides( slidesWrapper ) {
 		url: element.getAttribute( 'src' ),
 		id: element.getAttribute( 'data-id' ),
 		type: element.tagName.toLowerCase() === 'img' ? 'image' : 'video',
+		srcset: element.getAttribute( 'srcset' ),
+		sizes: element.getAttribute( 'sizes' ),
 	} ) );
 }
 


### PR DESCRIPTION
Addresses part of https://github.com/Automattic/jetpack/issues/16591:
- Show a progress indicator when uploading media from the block editor, prevent story playback while its uploading
- Improve loading of media files
- Better fit media on the player, use heuristics to crop some part of the image to make it fit a user screen (for instance allow 10% cropping max, after which margins can be displayed)
- Refine UX
- Scale down story embeds (make it 50% smaller?)
 
With this change we stop rendering all the slides dynamically from the server. Instead we only render the first one and serialize the media into the markup so the client can retrieve it and load slides dynamically. Slides are rendered as the story is played, with a preload of the next slide.

It also applies the latest changes in design regarding stories:
- Smaller embeds
- Shadow and animation on hover
- Play and replay button removed, replaced with transparent overlay
- Displaying an expand icon on the top right

This doesn't update buttons to use `@wordpress/element` nor fixes accessibility issues, those are tackled in this PR https://github.com/Automattic/jetpack/pull/16852

Here is how it looks like:

Frontend:
<img width="639" alt="Screenshot 2020-08-10 at 15 27 37" src="https://user-images.githubusercontent.com/230230/89787621-13729680-db1e-11ea-9e4e-fe33052c3310.png">

Block Editor:
<img width="591" alt="Screenshot 2020-08-10 at 15 27 08" src="https://user-images.githubusercontent.com/230230/89787652-1ff6ef00-db1e-11ea-96e9-c61567e192f0.png">

#### Changes proposed in this Pull Request:
In this PR we lazy load media while stories are being played. This way, we improve the initial page load speed.
We also define a list of alternative images for each slide using srcset and force the browser to load the right image for the current viewport.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Load a page with a story in it. Notice in the network tab only the fist slide is loaded.
Disable JS and reload the page, notice the story looks almost identical as the version with JS

#### Proposed changelog entry for your changes:
-  Improve loading of media files for the Story block