### PR TITLE
Increase the `editor.MediaUpload` hook priority

### DIFF
--- a/extensions/shared/external-media/index.js
+++ b/extensions/shared/external-media/index.js
@@ -56,7 +56,7 @@ if ( isCurrentUserConnected() && 'function' === typeof useBlockEditContext ) {
 
 			return <OriginalComponent { ...props } render={ render } />;
 		},
-		11
+		100
 	);
 
 	// Register the individual external media blocks.


### PR DESCRIPTION
Fixes #16668

#### Changes proposed in this Pull Request:

* Let's change the priority at which we hook our External Media implementation into the existing media library. That will avoid conflicts with other plugins that do the same.

#### Jetpack product discussion

* N/A


#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

* Go to Posts > Add New
* Add an image block
* Select Google Photos or Pexels in the options to pick an existing image
* It should still work

#### Proposed changelog entry for your changes:

* Block Editor: ensure our External Media option is compatible with other plugins that also make changes to the Media Library options in the block editor.
