### PR TITLE
Instagram Widget: Enqueue CSS in Customizer

### DIFF
--- a/modules/widgets/class-jetpack-instagram-widget.php
+++ b/modules/widgets/class-jetpack-instagram-widget.php
@@ -74,7 +74,7 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 	 * Enqueues the widget's frontend CSS but only if the widget is currently in use.
 	 */
 	public function enqueue_css() {
-		if ( ! is_active_widget( false, false, self::ID_BASE ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+		if ( ! is_active_widget( false, false, self::ID_BASE ) || is_active_widget( false, false, 'monster' ) ) {
 			return;
 		}
 

--- a/modules/widgets/class-jetpack-instagram-widget.php
+++ b/modules/widgets/class-jetpack-instagram-widget.php
@@ -45,7 +45,10 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 			)
 		);
 
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_css' ) );
+		if ( is_active_widget( false, false, self::ID_BASE ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_css' ) );
+		}
+
 		add_action( 'wp_ajax_wpcom_instagram_widget_update_widget_token_id', array( $this, 'ajax_update_widget_token_id' ) );
 
 		$this->valid_options = array(
@@ -74,10 +77,6 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 	 * Enqueues the widget's frontend CSS but only if the widget is currently in use.
 	 */
 	public function enqueue_css() {
-		if ( ! is_active_widget( false, false, self::ID_BASE ) || is_active_widget( false, false, 'monster' ) ) {
-			return;
-		}
-
 		wp_enqueue_style( self::ID_BASE, plugins_url( 'instagram/instagram.css', __FILE__ ), array(), JETPACK__VERSION );
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
I noticed this when trying to get the widget working on WPCOM (D46749-code).

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* The CSS needs to be enqueued so that we get a preview of the widget in the customizer.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open the customizer
* Add an Instagram widget
* Check that you see a preview of the widget in the customizer like this:
<img width="958" alt="Screenshot 2020-07-31 at 14 26 04" src="https://user-images.githubusercontent.com/275961/89039647-583a4880-d33a-11ea-888b-71382b37bd29.png">



#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* no changelog
