### PR TITLE
Settings: check for subdirectory site before rendering Ads.txt section

### DIFF
--- a/_inc/client/traffic/ads.jsx
+++ b/_inc/client/traffic/ads.jsx
@@ -27,7 +27,7 @@ export const Ads = withModuleSettingsFormHelpers(
 		/**
 		 * Update state so preview is updated instantly and toggle options.
 		 *
-		 * @param {string} optionName the slug of the option to update
+		 * @param {string} optionName - the slug of the option to update
 		 */
 		updateOptions = optionName => {
 			this.props.updateFormStateModuleOption( 'wordads', optionName );
@@ -44,6 +44,84 @@ export const Ads = withModuleSettingsFormHelpers(
 		handleChange = setting => {
 			return () => this.updateOptions( setting );
 		};
+
+		renderAdsTxtSection() {
+			const { getOptionValue, isUnavailableInOfflineMode } = this.props;
+			const wordads_custom_adstxt_enabled = getOptionValue(
+				'wordads_custom_adstxt_enabled',
+				'wordads'
+			);
+			const wordads_custom_adstxt = getOptionValue( 'wordads_custom_adstxt', 'wordads' );
+			const isAdsActive = getOptionValue( 'wordads' );
+			const unavailableInOfflineMode = isUnavailableInOfflineMode( 'wordads' );
+
+			return <SettingsGroup
+						hasChild
+						support={ {
+							text: __(
+								'Ads.txt (Authorized Digital Sellers) is a mechanism that enables content owners to declare who is authorized to sell their ad inventory. It’s the formal list of advertising partners you support as a publisher.',
+								'jetpack'
+							),
+							link: 'https://jetpack.com/support/ads/',
+						} }
+					>
+						<CompactFormToggle
+								checked={ wordads_custom_adstxt_enabled }
+								disabled={
+									! isAdsActive ||
+									unavailableInOfflineMode ||
+									this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt_enabled' ] )
+								}
+								onChange={ this.handleChange( 'wordads_custom_adstxt_enabled' ) }
+							>
+								<span className="jp-form-toggle-explanation">
+									{ __( 'Customize your ads.txt file', 'jetpack' ) }
+								</span>
+							</CompactFormToggle>
+						{ wordads_custom_adstxt_enabled && (
+							<FormFieldset>
+								<br />
+								<p>
+									{ isAdsActive &&
+										jetpackCreateInterpolateElement(
+											__(
+												'Jetpack Ads automatically generates a custom <link1>ads.txt</link1> tailored for your site. If you need to add additional entries for other networks please add them in the space below, one per line. <link2>Check here for more details</link2>.',
+												'jetpack'
+											),
+											{
+												link1: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />,
+												link2: (
+													<a
+														href={ getRedirectUrl(
+															'jetpack-how-jetpack-ads-members-can-increase-their-earnings-with-ads-txt'
+														) }
+														target="_blank"
+														rel="noopener noreferrer"
+													/>
+												),
+											}
+										) }
+
+									{ ! isAdsActive &&
+										__(
+											'When ads are enabled, Jetpack automatically generates a custom ads.txt tailored for your site.',
+											'jetpack'
+										) }
+								</p>
+								<Textarea
+									name="wordads_custom_adstxt"
+									value={ wordads_custom_adstxt }
+									disabled={
+										! isAdsActive ||
+										unavailableInOfflineMode ||
+										this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt' ] )
+									}
+									onChange={ this.props.onOptionChange }
+								/>
+							</FormFieldset>
+						) }
+					</SettingsGroup>;
+		}
 
 		render() {
 			const isAdsActive = this.props.getOptionValue( 'wordads' );
@@ -63,11 +141,7 @@ export const Ads = withModuleSettingsFormHelpers(
 				'wordads_display_archive',
 				'wordads'
 			);
-			const wordads_custom_adstxt_enabled = this.props.getOptionValue(
-				'wordads_custom_adstxt_enabled',
-				'wordads'
-			);
-			const wordads_custom_adstxt = this.props.getOptionValue( 'wordads_custom_adstxt', 'wordads' );
+
 			const wordads_ccpa_enabled = this.props.getOptionValue( 'wordads_ccpa_enabled', 'wordads' );
 			const wordads_ccpa_privacy_policy_url = this.props.getOptionValue(
 				'wordads_ccpa_privacy_policy_url',
@@ -332,74 +406,7 @@ export const Ads = withModuleSettingsFormHelpers(
 							</FormFieldset>
 						) }
 					</SettingsGroup>
-					<SettingsGroup
-						hasChild
-						support={ {
-							text: __(
-								'Ads.txt (Authorized Digital Sellers) is a mechanism that enables content owners to declare who is authorized to sell their ad inventory. It’s the formal list of advertising partners you support as a publisher.',
-								'jetpack'
-							),
-							link: 'https://jetpack.com/support/ads/',
-						} }
-					>
-						{ ! isSubDirSite && (
-							<CompactFormToggle
-								checked={ wordads_custom_adstxt_enabled }
-								disabled={
-									! isAdsActive ||
-									unavailableInOfflineMode ||
-									this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt_enabled' ] )
-								}
-								onChange={ this.handleChange( 'wordads_custom_adstxt_enabled' ) }
-							>
-								<span className="jp-form-toggle-explanation">
-									{ __( 'Customize your ads.txt file', 'jetpack' ) }
-								</span>
-							</CompactFormToggle>
-						) }
-						{ ! isSubDirSite && wordads_custom_adstxt_enabled && (
-							<FormFieldset>
-								<br />
-								<p>
-									{ isAdsActive &&
-										jetpackCreateInterpolateElement(
-											__(
-												'Jetpack Ads automatically generates a custom <link1>ads.txt</link1> tailored for your site. If you need to add additional entries for other networks please add them in the space below, one per line. <link2>Check here for more details</link2>.',
-												'jetpack'
-											),
-											{
-												link1: <a href="/ads.txt" target="_blank" rel="noopener noreferrer" />,
-												link2: (
-													<a
-														href={ getRedirectUrl(
-															'jetpack-how-jetpack-ads-members-can-increase-their-earnings-with-ads-txt'
-														) }
-														target="_blank"
-														rel="noopener noreferrer"
-													/>
-												),
-											}
-										) }
-
-									{ ! isAdsActive &&
-										__(
-											'When ads are enabled, Jetpack automatically generates a custom ads.txt tailored for your site.',
-											'jetpack'
-										) }
-								</p>
-								<Textarea
-									name="wordads_custom_adstxt"
-									value={ wordads_custom_adstxt }
-									disabled={
-										! isAdsActive ||
-										unavailableInOfflineMode ||
-										this.props.isSavingAnyOption( [ 'wordads', 'wordads_custom_adstxt' ] )
-									}
-									onChange={ this.props.onOptionChange }
-								/>
-							</FormFieldset>
-						) }
-					</SettingsGroup>
+					{ ! isSubDirSite && this.renderAdsTxtSection() }
 					{ ! unavailableInOfflineMode && isAdsActive && (
 						<Card
 							compact


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16647

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide Ads.txt section completely for subdir sites

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Use subdir site
* Enable WordAds on your site
* Go to `/wp-admin/admin.php?page=jetpack#/traffic`
* Make sure that Ads.txt section **is not** present, and there are no placeholders is present.

* Use singlesite site (🤦 )
* Enable WordAds on your site
* Go to `/wp-admin/admin.php?page=jetpack#/traffic`
* Make sure that Ads.txt section **is** present, and there are no placeholders is present.

**Before:**
![image](https://user-images.githubusercontent.com/5654161/89042980-8165d380-d350-11ea-8310-ab716c8f8bc2.png)


**After:**
<img width="700" alt="Jetpack ‹ Testing Jetpack on GoDaddy (subdir) — WordPress 2020-07-31 16-57-59" src="https://user-images.githubusercontent.com/5654161/89042812-33e96680-d350-11ea-8e1a-6506078e0091.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Hide Ads.txt settings section for subdirectory sites 
