### PR TITLE
Woo Services: update to use existing Jetpack plugin install tools

### DIFF
--- a/3rd-party/woocommerce-services.php
+++ b/3rd-party/woocommerce-services.php
@@ -126,22 +126,14 @@ class WC_Services_Installer {
 	 * @return bool result of installation
 	 */
 	private function install() {
-		include_once ABSPATH . '/wp-admin/includes/admin.php';
-		include_once ABSPATH . '/wp-admin/includes/plugin-install.php';
-		include_once ABSPATH . '/wp-admin/includes/plugin.php';
-		include_once ABSPATH . '/wp-admin/includes/class-wp-upgrader.php';
-		include_once ABSPATH . '/wp-admin/includes/class-plugin-upgrader.php';
+		jetpack_require_lib( 'plugins' );
+		$result = Jetpack_Plugins::install_plugin( 'woocommerce-services' );
 
-		$api = plugins_api( 'plugin_information', array( 'slug' => 'woocommerce-services' ) );
-
-		if ( is_wp_error( $api ) ) {
+		if ( is_wp_error( $result ) ) {
 			return false;
+		} else {
+			return true;
 		}
-
-		$upgrader = new Plugin_Upgrader( new Automatic_Upgrader_Skin() );
-		$result   = $upgrader->install( $api->download_link );
-
-		return true === $result;
 	}
 
 	/**


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Since Jetpack comes with its own lib to install and activate plugins, let's use that instead of duplicating code.


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

This is a bit of a tricky one.

Start with a site:
- With this branch
- Connected to WordPress.com
- With Woo active and configured
- With at least one order
- Without the WooCommerce Services plugin installed.
- With the following code snippet (we want to force JITMs to show, they're hidden at the moment):
```php
function jeherve_show_woo_jitm() {
?>
<style>
.woocommerce-layout__notice-list-hide {
	display: block !important;
}
</style>
<?php
}
add_action( 'admin_head', 'jeherve_show_woo_jitm' );
```

* Then go to WooCommerce > Orders
* You should see the JITM inviting you to install the Woo Services plugin
* Click to install
* Verify that the installation went through, and that no errors appeared in your log.

#### Proposed changelog entry for your changes:

* N/A

