### PR TITLE
New class to handle async XML-RPC requests

### DIFF
--- a/packages/connection/README.md
+++ b/packages/connection/README.md
@@ -19,3 +19,7 @@ Package is published in [Packagist](https://packagist.org/packages/automattic/je
 2. [Authorize the user](docs/authorize-user.md)
 3. In-place user auth @todo
 4. Disconnecting @todo
+
+## Tools
+
+1. [Making Authenticated async XML-RPC calls](docs/xmlrpc-async-calls.md)

--- a/packages/connection/docs/xmlrpc-async-calls.md
+++ b/packages/connection/docs/xmlrpc-async-calls.md
@@ -1,0 +1,15 @@
+# Making Authenticated async XML-RPC calls
+
+The Connection package comes with the `XMLRPC_Async_Call` class which helps you to make authenticated requests to WordPress.com.
+
+It's async because the calls are enqueued and dispatched all at once, in a multiCall request at `shutdown`.
+
+## Usage
+
+```PHP
+XMLRPC_Async_Call::add_call( 'methodName', get_current_user_id(), $arg1, $arg2, etc... )
+```
+
+* First argument is the method name. Example: `jetpack.updateBlog`
+* Second argument is the user ID of the connected user. Zero means it will use the blog token to authenticate
+* This method accepts a variable number of parameters. Any additional parameters will be passed as arguments in the request call

--- a/packages/connection/src/class-xmlrpc-async-call.php
+++ b/packages/connection/src/class-xmlrpc-async-call.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * XMLRPC Async Call class.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Jetpack_IXR_ClientMulticall;
+
+/**
+ * Make XMLRPC async calls to WordPress.com
+ *
+ * This class allows you to enqueue XMLRPC calls that will be grouped and sent
+ * at once in a multi-call request at shutdown.
+ *
+ * Usage:
+ *
+ * XMLRPC_Async_Call::add_call( 'methodName', get_current_user_id(), $arg1, $arg2, etc... )
+ *
+ * See XMLRPC_Async_Call::add_call for details
+ */
+class XMLRPC_Async_Call {
+
+	/**
+	 * Hold the IXR Clients that will be dispatched at shutdown
+	 *
+	 * Clients are stored in the following schema:
+	 * [
+	 *  $blog_id => [
+	 *    $user_id => [
+	 *      arrat of Jetpack_IXR_ClientMulticall
+	 *    ]
+	 *  ]
+	 * ]
+	 *
+	 * @var array
+	 */
+	public static $clients = array();
+
+	/**
+	 * Adds a new XMLRPC call to the queue to be processed on shutdown
+	 *
+	 * @param string  $method The XML-RPC method.
+	 * @param integer $user_id The user ID used to make the request (will use this user's token); Use 0 for the blog token.
+	 * @param mixed   ...$args This function accepts any number of additional arguments, that will be passed to the call.
+	 * @return void
+	 */
+	public static function add_call( $method, $user_id = 0, ...$args ) {
+		global $blog_id;
+
+		$client_blog_id = is_multisite() ? $blog_id : 0;
+
+		if ( ! isset( self::$clients[ $client_blog_id ] ) ) {
+			self::$clients[ $client_blog_id ] = array();
+		}
+
+		if ( ! isset( self::$clients[ $client_blog_id ][ $user_id ] ) ) {
+			self::$clients[ $client_blog_id ][ $user_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => $user_id ) );
+		}
+
+		if ( function_exists( 'ignore_user_abort' ) ) {
+			ignore_user_abort( true );
+		}
+
+		array_unshift( $args, $method );
+
+		call_user_func_array( array( self::$clients[ $client_blog_id ][ $user_id ], 'addCall' ), $args );
+
+		if ( false === has_action( 'shutdown', array( 'Automattic\Jetpack\Connection\XMLRPC_Async_Call', 'do_calls' ) ) ) {
+			add_action( 'shutdown', array( 'Automattic\Jetpack\Connection\XMLRPC_Async_Call', 'do_calls' ) );
+		}
+	}
+
+	/**
+	 * Trigger the calls at shutdown
+	 *
+	 * @return void
+	 */
+	public static function do_calls() {
+		if ( is_multisite() ) {
+			self::do_calls_multisite();
+		} else {
+			self::do_calls_single_site();
+		}
+	}
+
+	/**
+	 * Trigger the calls when in a multi-site environment
+	 *
+	 * @return void
+	 */
+	private static function do_calls_multisite() {
+		foreach ( self::$clients as $client_blog_id => $blog_clients ) {
+			if ( 0 === $client_blog_id ) {
+				continue;
+			}
+
+			foreach ( $blog_clients as $client ) {
+				if ( empty( $client->calls ) ) {
+					continue;
+				}
+
+				$switch_success = switch_to_blog( $client_blog_id, true );
+
+				if ( ! $switch_success ) {
+					continue;
+				}
+
+				flush();
+				$client->query();
+
+				restore_current_blog();
+			}
+		}
+	}
+
+	/**
+	 * Trigger the calls in a single site environment
+	 *
+	 * @return void
+	 */
+	private static function do_calls_single_site() {
+		if ( ! isset( self::$clients[0] ) ) {
+			return;
+		}
+
+		foreach ( self::$clients[0] as $client ) {
+			if ( empty( $client->calls ) ) {
+				continue;
+			}
+
+			flush();
+			$client->query();
+
+		}
+	}
+}

--- a/packages/connection/src/class-xmlrpc-async-call.php
+++ b/packages/connection/src/class-xmlrpc-async-call.php
@@ -79,22 +79,13 @@ class XMLRPC_Async_Call {
 	 * @return void
 	 */
 	public static function do_calls() {
-		if ( is_multisite() ) {
-			self::do_calls_multisite();
-		} else {
-			self::do_calls_single_site();
-		}
-	}
-
-	/**
-	 * Trigger the calls when in a multi-site environment
-	 *
-	 * @return void
-	 */
-	private static function do_calls_multisite() {
 		foreach ( self::$clients as $client_blog_id => $blog_clients ) {
-			if ( 0 === $client_blog_id ) {
-				continue;
+			if ( $client_blog_id > 0 ) {
+				$switch_success = switch_to_blog( $client_blog_id, true );
+
+				if ( ! $switch_success ) {
+					continue;
+				}
 			}
 
 			foreach ( $blog_clients as $client ) {
@@ -102,38 +93,13 @@ class XMLRPC_Async_Call {
 					continue;
 				}
 
-				$switch_success = switch_to_blog( $client_blog_id, true );
-
-				if ( ! $switch_success ) {
-					continue;
-				}
-
 				flush();
 				$client->query();
+			}
 
+			if ( $client_blog_id > 0 ) {
 				restore_current_blog();
 			}
-		}
-	}
-
-	/**
-	 * Trigger the calls in a single site environment
-	 *
-	 * @return void
-	 */
-	private static function do_calls_single_site() {
-		if ( ! isset( self::$clients[0] ) ) {
-			return;
-		}
-
-		foreach ( self::$clients[0] as $client ) {
-			if ( empty( $client->calls ) ) {
-				continue;
-			}
-
-			flush();
-			$client->query();
-
 		}
 	}
 }

--- a/packages/connection/tests/php/test_XMLPC_Async_Call.php
+++ b/packages/connection/tests/php/test_XMLPC_Async_Call.php
@@ -1,0 +1,38 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Connection Manager functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use WorDBless\BaseTestCase;
+
+require_once ABSPATH . WPINC . '/IXR/class-IXR-client.php';
+/**
+ * Connection Manager functionality testing.
+ */
+class XMLRPC_Async_Call_Test extends BaseTestCase {
+
+	/**
+	 * Test add call
+	 */
+	public function test_add_call() {
+		XMLRPC_Async_Call::add_call( 'test', 0, 'test_arg', 'test_arg2' );
+		XMLRPC_Async_Call::add_call( 'test', 1, 'test_arg', 'test_arg2' );
+
+		$client_blog_id = is_multisite() ? get_current_blog_id() : 0;
+
+		$this->assertArrayHasKey( $client_blog_id, XMLRPC_Async_Call::$clients );
+		$this->assertInstanceOf( 'Jetpack_IXR_ClientMulticall', XMLRPC_Async_Call::$clients[ $client_blog_id ][0] );
+		$this->assertInstanceOf( 'Jetpack_IXR_ClientMulticall', XMLRPC_Async_Call::$clients[ $client_blog_id ][1] );
+
+		$this->assertNotEmpty( XMLRPC_Async_Call::$clients[ $client_blog_id ][0]->calls );
+		$this->assertEquals( 'test', XMLRPC_Async_Call::$clients[ $client_blog_id ][0]->calls[0]['methodName'] );
+		$this->assertEquals( array( 'test_arg', 'test_arg2' ), XMLRPC_Async_Call::$clients[ $client_blog_id ][0]->calls[0]['params'] );
+
+		$this->assertEquals( 10, has_action( 'shutdown', array( 'Automattic\Jetpack\Connection\XMLRPC_Async_Call', 'do_calls' ) ) );
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Introduces a new class to handle async XML-RPC requests and replace `Jetpack::xmlrpc_async_call()`

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Currently, `Jetpack::xmlrpc_async_call()` is used to enqueue few XML-RPC requests that are sent all at once, as a MultiCall request, at shutdown. This method forces the requests to use the "Master user" token.

As we are moving to give preference to the blog token everywhere we can, and the current user token where we are performing a user action, we needed a more flexible method that allowed us to choose which token we wanted to use.

To modify this method while keeping backward compatibility would result in a not very elegant solution, polluting the Jetpack class even more and adding complexity to an untested method. So I decided to create a new class to handle this, removing the responsibility from the `Jetpack` class and start writing simple tests for it.

This PR only adds the class but don't use it yet. Following PRs will replace the use of the deprecated method in favor of this class.

Note: I've first added a deprecation notice to the old method, but it breaks the tests, so I will first replace all the calls to it, and then we can review [this PR to add the notice](https://github.com/Automattic/jetpack/pull/16691).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* There is a simple PHPUnit test there that needs to pass
* At this point, just review the code. Following PRs will test its functionality

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
