### PR TITLE
Site Scan: Short-circuit update_threats_link() if Admin Bar is not present

### DIFF
--- a/modules/scan/admin-bar-notice.js
+++ b/modules/scan/admin-bar-notice.js
@@ -36,6 +36,10 @@
 
 	function update_threats_link( numberOfThreats ) {
 		var element = document.getElementById( 'wp-admin-bar-jetpack-scan-notice' );
+		if ( ! element ) {
+			return;
+		}
+
 		if ( ! numberOfThreats ) {
 			element.parentNode.removeChild( element );
 			return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In testing the new onboarding wizard screen for the AMP plugin (coming in v2.0), I noticed that Jetpack is throwing a JS error the Admin Bar is not printed on the screen.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate the latest 2.0 beta of the AMP plugin.
2. Access the new onboarding wizard.
3. See error in the console.

#### Proposed changelog entry for your changes:

* Avoid JS error when Admin Bar not present and Site Scan's `update_threats_link()` is called.