### PR TITLE
Error Notice: removing HTML code, adjusting maximum width.

### DIFF
--- a/_inc/client/components/global-notices/style.scss
+++ b/_inc/client/components/global-notices/style.scss
@@ -18,18 +18,24 @@
 		right: 16px;
 		bottom: auto;
 		left: auto;
-		max-width: calc( 100% - 32px );
+
+		/* `36px` being the width of the collapsed WP-admin sidebar */
+		max-width: calc( 100% - 32px - 36px );
 	}
 
 	@include breakpoint( ">960px" ) {
 		top: 47px + 24px;
 		right: 24px;
-		max-width: calc( 100% - 48px );
+
+		/* `160px` being the width of the WP-admin sidebar */
+		max-width: calc( 100% - 48px - 160px );
 	}
 
 	@include breakpoint( ">1040px" ) {
 		right: 32px;
-		max-width: calc( 100% - 64px );
+
+		/* `160px` being the width of the WP-admin sidebar */
+		max-width: calc( 100% - 64px - 160px );
 	}
 }
 

--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -76,6 +76,10 @@ export default class SimpleNotice extends React.Component {
 		return icon;
 	};
 
+	clearText( text ) {
+		return text.replace( /(<([^>]+)>)/gi, '' );
+	}
+
 	render() {
 		const {
 			children,
@@ -99,7 +103,7 @@ export default class SimpleNotice extends React.Component {
 					<Gridicon className="dops-notice__icon" icon={ icon || this.getIcon() } size={ 24 } />
 				</span>
 				<span className="dops-notice__content">
-					<span className="dops-notice__text">{ text ? text : children }</span>
+					<span className="dops-notice__text">{ text ? this.clearText( text ) : children }</span>
 				</span>
 				{ text ? children : null }
 				{ showDismiss && (


### PR DESCRIPTION
The notice content should not contain HTML. If it happens to have any, we clear out the tags before displaying the error.

#### Changes proposed in this Pull Request:
* Removing HTML tags from the error text.
* Limiting the maximum width of the notice.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Open your theme's `functions.php` and add following code to display the connection error notice:
```php
add_filter( 'react_connection_errors_initial_state', function( $errors ) {
	$errors[] = array(
		'message' => __('Connection Error'),
		'action' => 'reconnect',
		'code' => 'invalid_blog_token',
	);

	return $errors;
} );
```
2. Open file `packages/connection/src/class-rest-connector.php` and add this line into the beginning of the `connection_reconnect()` method:
```php
return rest_ensure_response( new WP_Error( 'some_error', str_repeat( ' something something <strong>HTML</strong> something something', 100 ) ) );
```
3. Open the Jetpack Dashboard, and click "Restore Connection" in the Connection Error notice. You should see the lots of repeated lines: `something something HTML something something`
4. Make sure there are no HTML tags in the notice text.
5. Confirm that the message has reasonable margin from the left sidebar, and doesn't hide behind it.


##### Before:
<img width="1341" alt="Screen Shot 2020-08-03 at 12 24 52 PM" src="https://user-images.githubusercontent.com/1341249/89210093-17823f80-d585-11ea-8fc0-b875a78619e4.png">

##### After:
<img width="1341" alt="Screen Shot 2020-08-03 at 12 29 36 PM" src="https://user-images.githubusercontent.com/1341249/89210123-223cd480-d585-11ea-9468-9a5eeafb9b8d.png">


#### Proposed changelog entry for your changes:
N/a.
