### PR TITLE
Depreacate xmlrpc async call

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5831,7 +5831,7 @@ endif;
 	 */
 	public static function xmlrpc_async_call( ...$args ) {
 
-		_deprecated_function( 'Jetpack::xmlrpc_async_call', 'jetpack-8.9.0', 'Jetpack_Xmlrpc_Async_Call::add_call' );
+		_deprecated_function( 'Jetpack::xmlrpc_async_call', 'jetpack-8.9.0', 'Automattic\\Jetpack\\Connection\\Xmlrpc_Async_Call::add_call' );
 
 		global $blog_id;
 		static $clients = array();

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5824,9 +5824,15 @@ endif;
 	/**
 	 * Helper method for multicall XMLRPC.
 	 *
+	 * @deprecated since 8.9.0
+	 * @see Jetpack_Xmlrpc_Async_Call::add_call()
+	 *
 	 * @param ...$args Args for the async_call.
 	 */
 	public static function xmlrpc_async_call( ...$args ) {
+
+		_deprecated_function( 'Jetpack::xmlrpc_async_call', 'jetpack-8.9.0', 'Jetpack_Xmlrpc_Async_Call::add_call' );
+
 		global $blog_id;
 		static $clients = array();
 

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5825,7 +5825,7 @@ endif;
 	 * Helper method for multicall XMLRPC.
 	 *
 	 * @deprecated since 8.9.0
-	 * @see Jetpack_Xmlrpc_Async_Call::add_call()
+	 * @see Automattic\\Jetpack\\Connection\\Xmlrpc_Async_Call::add_call()
 	 *
 	 * @param ...$args Args for the async_call.
 	 */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This method was replaced with a more complete class in https://github.com/Automattic/jetpack/pull/16674

Its usage was replaced in

* https://github.com/Automattic/jetpack/pull/16692
* https://github.com/Automattic/jetpack/pull/16698
* https://github.com/Automattic/jetpack/pull/16710

Now it's no longer used and should be deprecated, especially because we don't want to use `JETPACK_MASTER_USER` token anymore.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Deprecates Jetpack::xmlrpc_async_call which is no longer used

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing specific to test, just make sure there are no warnings or notices anywhere
* Any thoughts of external plugins/blocks that could be using it?

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Deprecates Jetpack::xmlrpc_async_call
