### PR TITLE
Use blog token to add new comment subscriber

### DIFF
--- a/modules/subscriptions.php
+++ b/modules/subscriptions.php
@@ -12,6 +12,8 @@
  * Additional Search Queries: subscriptions, subscription, email, follow, followers, subscribers, signup
  */
 
+use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
+
 add_action( 'jetpack_modules_loaded', 'jetpack_subscriptions_load' );
 
 function jetpack_subscriptions_load() {
@@ -546,7 +548,7 @@ class Jetpack_Subscriptions {
 			}
 
 			if ( $async ) {
-				Jetpack::xmlrpc_async_call( 'jetpack.subscribeToSite', $email, $post_id, serialize( $extra_data ) );
+				XMLRPC_Async_Call::add_call( 'jetpack.subscribeToSite', 0, $email, $post_id, serialize( $extra_data ) ); //phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 			} else {
 				$xml->addCall( 'jetpack.subscribeToSite', $email, $post_id, serialize( $extra_data ) );
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR changes the token used to dispatch requests to subscribe to comments.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Use the blog token to submit subscription to comments

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Dv-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a connected Jetpack
* Activate the Subscription module
* Visit your site as an anonymous user
* Leave a comment on a post, enter a valid email and check the "Notify me of follow-up comments by email" box.

* verify the subscription worked. See 25ebc-pb/#plain

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Subscribe to comments now uses the blog token