### PR TITLE
Use blog token to request the jetpack.updateBlog XMLRPC endpoint

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -16,6 +16,7 @@
 
 use Automattic\Jetpack\Tracking;
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 use Automattic\Jetpack\Redirect;
 
 if ( defined( 'STATS_VERSION' ) ) {
@@ -895,7 +896,7 @@ function stats_admin_bar_menu( &$wp_admin_bar ) {
  * @return void
  */
 function stats_update_blog() {
-	Jetpack::xmlrpc_async_call( 'jetpack.updateBlog', stats_get_blog() );
+	XMLRPC_Async_Call::add_call( 'jetpack.updateBlog', 0, stats_get_blog() );
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR changes the token used by the stats module to make a request to the `updateBlog` XMLRPC endpoint. It drops the use of the "Master user" token and uses the blog token instead.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Dv-p2#comment-2838

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Open `modules/stats.php` file
* At line 25 change the `STATS_VERSION`value to a higher number, for example:
`define( 'STATS_VERSION', '10' );`

* This will force a call to the `updateBlog` endpoint
* Browse the admin panel. Just viewing a page is enough

* Check the `stats_options` option on the cache site and confirm the value for the `version` option key was updated :) 

* Now revert the change.
* Undo the change to the constant value in the `stats.php` file.

* On your local environment:
```
wp shell
$options = get_option( 'stats_options' );
unset($options['version']);
update_option( 'stats_options', $options );
```

* Visit the dashboard
* Check tha value of the option in the cache site is back to normal

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Use blog token to request the jetpack.updateBlog XMLRPC endpoint