### PR TITLE
Sync: Fix nonce action string in theme edit sync

### DIFF
--- a/packages/sync/src/modules/class-themes.php
+++ b/packages/sync/src/modules/class-themes.php
@@ -257,8 +257,7 @@ class Themes extends Module {
 			return;
 		}
 
-		$real_file = $theme->get_stylesheet_directory() . '/' . $file;
-		if ( ! wp_verify_nonce( $args['nonce'], 'edit-theme_' . $real_file . $stylesheet ) ) {
+		if ( ! wp_verify_nonce( $args['nonce'], 'edit-theme_' . $stylesheet . '_' . $file ) ) {
 			return;
 		}
 
@@ -285,6 +284,7 @@ class Themes extends Module {
 			}
 		}
 
+		$real_file = $theme->get_stylesheet_directory() . '/' . $file;
 		if ( 0 !== validate_file( $real_file, $allowed_files ) ) {
 			return;
 		}


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

This was ported from D47418-code.

There is currently a mistake in the edit theme jetpack sync functionality that is preventing theme edited events from reaching the Activity Log.

The nonce field is being created like this in the theme editor:
`wp_nonce_field( 'edit-theme_' . $stylesheet . '_' . $relative_file, 'nonce'  );`


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Apply this patch, edit a theme and check that there is a theme modified event in the Activity Log.


#### Proposed changelog entry for your changes:

* Activity Log: ensure that theme changes are mentioned in the Activity Log.
