### PR TITLE
Connect-in-place: hide new heading during connection process

### DIFF
--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -5,7 +5,7 @@ jQuery( document ).ready( function ( $ ) {
 	var tosText = $( '.jp-connect-full__tos-blurb' );
 	var jetpackConnectIframe = $( '<iframe class="jp-jetpack-connect__iframe" />' );
 	var connectionHelpSections = $(
-		'#jetpack-connection-cards, .jp-connect-full__dismiss-paragraph'
+		'#jetpack-connection-cards, .jp-connect-full__dismiss-paragraph, .jp-connect-full__testimonial'
 	);
 	var connectButtonFrom = '';
 
@@ -30,7 +30,7 @@ jQuery( document ).ready( function ( $ ) {
 		isRegistering: false,
 		isPaidPlan: false,
 		selectAndStartConnectionFlow: function () {
-			var connectionHelpSections = $( '#jetpack-connection-cards' );
+			var connectionHelpSections = $( '#jetpack-connection-cards, .jp-connect-full__testimonial' );
 			if ( connectionHelpSections.length ) {
 				connectionHelpSections.fadeOut( 600 );
 			}

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -383,7 +383,7 @@ class Jetpack_Connection_Banner {
 					</div>
 				</div>
 
-				<h2><?php esc_html_e( 'More than 5 million WordPress sites trust Jetpack for their website security and performance.', 'jetpack' ); ?></h2>
+				<h2 class="jp-connect-full__testimonial"><?php esc_html_e( 'More than 5 million WordPress sites trust Jetpack for their website security and performance.', 'jetpack' ); ?></h2>
 
 				<?php if ( 'plugins' === $current_screen->base ) : ?>
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

In #16643, we updated the design of the connection panel and added a new heading at the bottom of the page.

Let's ensure that heading disappears with the rest of the content when you start the connection process.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* On a brand new site running this branch, go to Jetpack > Dashboard
* Click on the button to setup Jetpack.
* The images, their descriptions, the ToS text, and the new heading at the bottom of the page ("More than 5 million..." should fade out. Only the connection iFrame and the main heading should remain.

#### Proposed changelog entry for your changes:

* N/A

