### PR TITLE
E2E Tests: Fix locator for classic connection flow

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,7 @@
 {
 	"plugins": [ "./tests/e2e/plugins/e2e-plan-data-interceptor.php" ],
 	"config": {
+		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true,
 		"WP_DEBUG_DISPLAY": false,
 		"JETPACK_BETA_BLOCKS": true,

--- a/tests/e2e/lib/pages/wpcom/pick-a-plan.js
+++ b/tests/e2e/lib/pages/wpcom/pick-a-plan.js
@@ -6,7 +6,7 @@ import { waitAndClick, waitForSelector } from '../../page-helper';
 
 export default class PickAPlanPage extends Page {
 	constructor( page ) {
-		const expectedSelector = '.plan-features__table button.is-personal-plan:not([disabled])';
+		const expectedSelector = '.plan-features__table button.is-premium-plan:not([disabled])';
 		super( page, { expectedSelector } );
 	}
 


### PR DESCRIPTION
Since personal plan is removed, we need to update a locator to address that change


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Travis should be green again
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
