### PR TITLE
Update/update role use user token

### DIFF
--- a/packages/sync/src/class-users.php
+++ b/packages/sync/src/class-users.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Sync;
 
 use Automattic\Jetpack\Connection\Manager as Jetpack_Connection;
 use Automattic\Jetpack\Roles;
+use Automattic\Jetpack\Connection\XMLRPC_Async_Call;
 
 /**
  * Class Users.
@@ -106,7 +107,7 @@ class Users {
 	 */
 	public static function update_role_on_com( $user_id ) {
 		$signed_role = self::get_signed_role( $user_id );
-		\Jetpack::xmlrpc_async_call( 'jetpack.updateRole', $user_id, $signed_role );
+		XMLRPC_Async_Call::add_call( 'jetpack.updateRole', get_current_user_id(), $user_id, $signed_role );
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR changes the token used to hit the `jetpack.updateRole`. It used to use the "Master user" token and now uses the current user token. It assumes that the user changing the role must have the proper capabilities to do so.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* `jetpack.updateRole` now uses the current user token

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Dv-p2#comment-2838

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Set up a connected Jetpack site
* Create a second user and authorize it to a different WordPress.com account
* Back to the first administrator, edit the second user and change its role
* Check the WPCOM database to see if the change was applied. See 25ef5-pb/#plain

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* * `jetpack.updateRole` now uses the current user token