### PR TITLE
Admin Page: avoid blank dashboard when notice is not a string

### DIFF
--- a/_inc/client/components/notice/index.jsx
+++ b/_inc/client/components/notice/index.jsx
@@ -76,9 +76,12 @@ export default class SimpleNotice extends React.Component {
 		return icon;
 	};
 
-	clearText( text ) {
-		return text.replace( /(<([^>]+)>)/gi, '' );
-	}
+	clearText = text => {
+		if ( 'string' === typeof text ) {
+			return text.replace( /(<([^>]+)>)/gi, '' );
+		}
+		return text;
+	};
 
 	render() {
 		const {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Follow-up of #16690

The contents of the dashboard notices is not always a string. It can be a React element.
When that's the case, let's avoid any errors by not using the replace method which is only available for strings.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Activate [Jetpack's Offline mode](https://jetpack.com/support/development-mode/) on your site, to trigger this notice in your dashboard:
https://github.com/Automattic/jetpack/blob/4392a22d643eaf812f42c37739bf675ea3ef7f34/_inc/client/components/jetpack-notices/index.jsx#L155
* Visit Jetpack > Settings
* Notice a blank dashboard with the following error: `react-dom.min.js?ver=16.9.0:103 TypeError: e.replace is not a function`
* Switch to this branch.
* The dashboard should now load.
* Deactivate Offline mode and try the instructions in #16690; they should still work.

#### Proposed changelog entry for your changes:

* Admin Page: avoid blank dashboard when some specific notices (such as Offline mode) are displayed.
