### PR TITLE
Make Social Previews a gated feature on WPCom

### DIFF
--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -12,8 +12,8 @@ registerJetpackPlugin( name, settings );
 
 // TODO: remove in favour of `getJetpackExtensionAvailability()` call.
 // Testing purposes only to force reveal of upgrade nudge UI.
-const extensionAvailableOnPlan = false;
-// const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
+const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
+// const extensionAvailableOnPlan = false;
 
 // If the social previews extension is **not** available on this plan (WP.com only)
 // then manually register a near identical Plugin which shows the upgrade nudge.

--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -22,7 +22,7 @@ const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previe
  * extension availability so will not render the Plugin if the extension is not
  * availabile.
  */
-if ( !extensionAvailableOnPlan ) {
+if ( ! extensionAvailableOnPlan ) {
     registerPlugin( `jetpack-${name}-upgrade-nudge`, {
         render: () => {
             return (

--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -6,14 +6,11 @@ import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
 import { registerPlugin } from '@wordpress/plugins';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 
-// Register the main "social-previews" extension if the feature is available
-// on the current plan.
+/*
+ * Register the main "social-previews" extension if the feature is available
+ * on the current plan.
+ */
 registerJetpackPlugin( name, settings );
-
-// TODO: remove in favour of `getJetpackExtensionAvailability()` call.
-// Testing purposes only to force reveal of upgrade nudge UI.
-const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
-// const extensionAvailableOnPlan = false;
 
 /*
  * If the social previews extension is **not** available on this plan (WP.com only)
@@ -22,6 +19,8 @@ const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previe
  * extension availability so will not render the Plugin if the extension is not
  * availabile.
  */
+const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
+
 if ( ! extensionAvailableOnPlan ) {
     registerPlugin( `jetpack-${name}-upgrade-nudge`, {
         render: () => {

--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -4,21 +4,28 @@
 import { name, settings, SocialPreviews } from '.';
 import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
 import { registerPlugin } from '@wordpress/plugins';
+import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 
+// Register the main "social-previews" extension if the feature is available
+// on the current plan.
 registerJetpackPlugin( name, settings );
 
-// const blockAvailableOnPlan = Jetpack_Editor_Initial_State.available_blocks[ 'social-previews' ].available;
-const blockAvailableOnPlan = false;
+// TODO: remove in favour of `getJetpackExtensionAvailability()` call.
+// Testing purposes only to force reveal of upgrade nudge UI.
+const extensionAvailableOnPlan = false;
+// const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
 
-registerPlugin( `jetpack-${name}-upgrade-nudge`, {
-    render: () => {
-        if ( blockAvailableOnPlan ) {
-            return null;
+// If the social previews extension is **not** available on this plan (WP.com only)
+// then manually register a near identical Plugin which shows the upgrade nudge.
+// Note this is necessary because the official `registerJetpackPlugin` checks the
+// extension availability so will not render the Plugin if the extension is not
+// availabile.
+if ( !extensionAvailableOnPlan ) {
+    registerPlugin( `jetpack-${name}-upgrade-nudge`, {
+        render: () => {
+            return (
+                <SocialPreviews showUpgradeNudge={ true } />
+            );
         }
-
-        return (
-            <SocialPreviews showUpgradeNudge={ true } />
-        );
-    }
-
-} );
+    } );
+}

--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -1,7 +1,24 @@
 /**
  * Internal dependencies
  */
-import { name, settings } from '.';
+import { name, settings, SocialPreviews } from '.';
 import registerJetpackPlugin from '../../shared/register-jetpack-plugin';
+import { registerPlugin } from '@wordpress/plugins';
 
 registerJetpackPlugin( name, settings );
+
+// const blockAvailableOnPlan = Jetpack_Editor_Initial_State.available_blocks[ 'social-previews' ].available;
+const blockAvailableOnPlan = false;
+
+registerPlugin( `jetpack-${name}-upgrade-nudge`, {
+    render: () => {
+        if ( blockAvailableOnPlan ) {
+            return null;
+        }
+
+        return (
+            <SocialPreviews showUpgradeNudge={ true } />
+        );
+    }
+
+} );

--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -15,11 +15,13 @@ registerJetpackPlugin( name, settings );
 const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
 // const extensionAvailableOnPlan = false;
 
-// If the social previews extension is **not** available on this plan (WP.com only)
-// then manually register a near identical Plugin which shows the upgrade nudge.
-// Note this is necessary because the official `registerJetpackPlugin` checks the
-// extension availability so will not render the Plugin if the extension is not
-// availabile.
+/*
+ * If the social previews extension is **not** available on this plan (WP.com only)
+ * then manually register a near identical Plugin which shows the upgrade nudge.
+ * Note this is necessary because the official `registerJetpackPlugin` checks the
+ * extension availability so will not render the Plugin if the extension is not
+ * availabile.
+ */
 if ( !extensionAvailableOnPlan ) {
     registerPlugin( `jetpack-${name}-upgrade-nudge`, {
         render: () => {

--- a/extensions/blocks/social-previews/index.js
+++ b/extensions/blocks/social-previews/index.js
@@ -17,11 +17,11 @@ export const settings = {
 	render: () => <SocialPreviews />,
 };
 
-const SocialPreviews = function SocialPreviews() {
+export const SocialPreviews = function SocialPreviews( { showUpgradeNudge } ) {
 	return (
 		<JetpackPluginSidebar>
 			<PanelBody title={ __( 'Social Previews', 'jetpack' ) }>
-				<SocialPreviewsPanel />
+				<SocialPreviewsPanel showUpgradeNudge={ showUpgradeNudge } />
 			</PanelBody>
 		</JetpackPluginSidebar>
 	);

--- a/extensions/blocks/social-previews/panel.js
+++ b/extensions/blocks/social-previews/panel.js
@@ -16,7 +16,7 @@ import { Button } from '@wordpress/components';
 import { AVAILABLE_SERVICES } from './constants';
 import { SocialServiceIcon } from '../../shared/icons';
 
-const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal } ) {
+const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal, showUpgradeNudge } ) {
 	return (
 		<div className="jetpack-social-previews__panel">
 			<p>
@@ -25,6 +25,11 @@ const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal } ) {
 					'jetpack'
 				) }
 			</p>
+
+			{ showUpgradeNudge && (
+				<p>{ __( 'Business or eCommerce plan required.', 'jetpack' ) }</p>
+			)}
+
 			<div className="jetpack-gutenberg-social-icons">
 				{ AVAILABLE_SERVICES.map( service => (
 					<SocialServiceIcon
@@ -34,9 +39,16 @@ const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal } ) {
 					/>
 				) ) }
 			</div>
-			<Button isSecondary onClick={ openModal } label={ __( 'Open Social Previews', 'jetpack' ) }>
-				{ __( 'Preview', 'jetpack' ) }
-			</Button>
+
+			{ showUpgradeNudge ? (
+				<Button isSecondary label={ __( 'Learn more about paid plans', 'jetpack' ) }>
+					{ __( 'Learn more', 'jetpack' ) }
+				</Button>
+			) : (
+				<Button isSecondary onClick={ openModal } label={ __( 'Open Social Previews', 'jetpack' ) }>
+					{ __( 'Preview', 'jetpack' ) }
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/extensions/blocks/social-previews/panel.js
+++ b/extensions/blocks/social-previews/panel.js
@@ -17,6 +17,9 @@ import { AVAILABLE_SERVICES } from './constants';
 import { SocialServiceIcon } from '../../shared/icons';
 
 const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal, showUpgradeNudge } ) {
+	const buttonText = showUpgradeNudge ? __( 'Learn more', 'jetpack' ) : __( 'Preview', 'jetpack' );
+	const buttonLabel = showUpgradeNudge ? __( 'Learn more about paid plans', 'jetpack' ) : __( 'Open Social Previews', 'jetpack' );
+
 	return (
 		<div className="jetpack-social-previews__panel">
 			<p>
@@ -40,15 +43,9 @@ const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal, showUpgra
 				) ) }
 			</div>
 
-			{ showUpgradeNudge ? (
-				<Button isSecondary label={ __( 'Learn more about paid plans', 'jetpack' ) }>
-					{ __( 'Learn more', 'jetpack' ) }
-				</Button>
-			) : (
-				<Button isSecondary onClick={ openModal } label={ __( 'Open Social Previews', 'jetpack' ) }>
-					{ __( 'Preview', 'jetpack' ) }
-				</Button>
-			) }
+			<Button isSecondary onClick={ openModal } label={ buttonLabel }>
+				{ buttonText }
+			</Button>
 		</div>
 	);
 };


### PR DESCRIPTION
Builds on https://github.com/Automattic/jetpack/pull/16633 to address the need to make Social Previews a paid feature on WordPress.com.

This PR will address the frontend aspect of this by creating a new "Gutenberg Plugin" `social-previews-upgrade-nudge` (note this is _not_ a WordPress Plugin in the traditional sense - [see here](https://github.com/WordPress/gutenberg/tree/65258a077e4899ee4933c79077108f56f8b5ce6d/packages/plugins)) which will be registered _only_ when the `social-previews` feature is not available on the current plan. 

It will show the exact same UI as the main `social-previews` Plugin but include an upgrade prompt instead of a link to display the "Preview" modal.

Note: the reason this is required is because `registerJetpackPlugin` checks whether the `social-previews` feature is available on the current plan. If it is not available then the `social-previews` Gutenberg Plugin is never registered. Therefore in order to show our "Upgrade Nudge" we need to circumvent this check and ensure that our Plugin is always registered to the Jetpack sidebar, even if the current Plan does not support the `social-previews` feature.

As a complementary note, recall that Social Previews is to be:

- free for Jetpack users.
- require a paid plan for WPCom users.

This ensures it meets the WP Plugin guidelines as the Social Previews feature doesn't meet the definition of SaaS.

Fixes https://github.com/Automattic/jetpack/issues/16616

#### Changes proposed in this Pull Request:

* Adds a new Gutenberg Plugin to the Jetpack Sidebar which is identical to the `social-previews` Plugin bar the inclusion of an "Upgrade Nudge".
* Check to ensure that the above Plugin is only registered if the `social-previews` extension is not available on the current Plan.

#### Jetpack product discussion
See `84-gh-dotcom-manage`.

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:

Same setup as https://github.com/Automattic/jetpack/pull/16633 .

Note: a followup PR will work to allow you to switch between Plans to view the different variations of the extension. But for the purposes of this incremental PR we are having to manually flip a variable in the code to force show the version with the upgrade nudge.

* Create a new Post using the Block Editor.
* Toggle the Jetpack sidebar open using the Jetpack icon (top left of editor).
* See the Social Previews feature without any form of "upgrade" notice. 
* In the code in `extensions/blocks/social-previews/editor.js` set `extensionAvailableOnPlan = false` and rebuild using `yarn build-extensions`.
* Reload your Post in the Block Editor. You should now see x2 "Social Previews" panels in the Jetpack sidebar. The first is the one you've already seen. Then second is one which contains the upgrade nudge as per the design in https://github.com/Automattic/jetpack/issues/16616#issue-667156299 (note the modal is not being addressed in this PR only the addition of the sidebar with the nudge!).



#### Proposed changelog entry for your changes:

* Social Previews [beta] - adds a new Gutenberg Plugin to the Jetpack Sidebar which is identical to the `social-previews` Plugin bar the inclusion of an "Upgrade Nudge".
