### PR TITLE
Social Previews: Sidebar design updates

### DIFF
--- a/extensions/blocks/social-previews/editor.scss
+++ b/extensions/blocks/social-previews/editor.scss
@@ -4,6 +4,11 @@
 
 .jetpack-social-previews { }
 
-.jetpack-social-previews__icon {
-	margin-right: 5px;
+.jetpack-gutenberg-social-icons {
+	margin-bottom: 1em;
+
+	.jetpack-gutenberg-social-icon.jetpack-social-previews__icon {
+		margin-right: 5px;
+		fill: currentColor;
+	}
 }

--- a/extensions/blocks/social-previews/panel.js
+++ b/extensions/blocks/social-previews/panel.js
@@ -25,7 +25,7 @@ const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal } ) {
 					'jetpack'
 				) }
 			</p>
-			<div>
+			<div className="jetpack-gutenberg-social-icons">
 				{ AVAILABLE_SERVICES.map( service => (
 					<SocialServiceIcon
 						key={ service.icon }
@@ -34,7 +34,7 @@ const SocialPreviewsPanel = function SocialPreviewsPanel( { openModal } ) {
 					/>
 				) ) }
 			</div>
-			<Button isTertiary onClick={ openModal } label={ __( 'Open Social Previews', 'jetpack' ) }>
+			<Button isSecondary onClick={ openModal } label={ __( 'Open Social Previews', 'jetpack' ) }>
 				{ __( 'Preview', 'jetpack' ) }
 			</Button>
 		</div>


### PR DESCRIPTION
Fixes #16701

#### Changes proposed in this Pull Request:
* Sets the same color to all icons (same as the surrounding text)
* Adds margin below icons, same as the paragraph above to keep the rhytm
* Updates button to be secondary (has extra border and thus aligns better)

#### Screenshot of the new design:
<img width="276" alt="Screenshot 2020-08-05 at 14 52 00" src="https://user-images.githubusercontent.com/156676/89414779-41756680-d72b-11ea-9f86-96bfe68aa4c0.png">

#### Jetpack product discussion
—

#### Does this pull request change what data or activity we track or use?
nope

#### Testing instructions:
* same as #16615
* open panel and confirm how cute it is now

#### Proposed changelog entry for your changes:
none, feature WIP
