### PR TITLE
Make Stats module use the blog token

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -669,7 +669,7 @@ function stats_reports_page( $main_chart_only = false ) {
 	$url = add_query_arg( $q, $url );
 	$method = 'GET';
 	$timeout = 90;
-	$user_id = JETPACK_MASTER_USER; // means send the wp.com user_id
+	$user_id = 0; // Means use the blog token.
 
 	$get = Client::remote_request( compact( 'url', 'method', 'timeout', 'user_id' ) );
 	$get_code = wp_remote_retrieve_response_code( $get );
@@ -1307,7 +1307,7 @@ function stats_dashboard_widget_content() {
 	$url = add_query_arg( $q, $url );
 	$method = 'GET';
 	$timeout = 90;
-	$user_id = JETPACK_MASTER_USER;
+	$user_id = 0; // Means use the blog token.
 
 	$get = Client::remote_request( compact( 'url', 'method', 'timeout', 'user_id' ) );
 	$get_code = wp_remote_retrieve_response_code( $get );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR drops the use of the `JETPACK_MASTER_USER` token and replaces it with the use of Blog token.

~PLEASE do not merge it before D47631-code is verified and deployed.~ deployed

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Dv-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a Jetpack connected site with some stats
* Checkout this branch
* ~Apply D47631-code~
* ~Sandbox `dashboard.wordpress.com`~
* Visit WordPress admin dashboard and confirm the Stats widget loads the graph properly (admin home, not the Jetpack dashboard)
* Visit Jetpack > Site Stats and confirm the page and the graphs load properly

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*