### PR TITLE
Color Studio: update to bring back missing colors

### DIFF
--- a/extensions/blocks/repeat-visitor/editor.scss
+++ b/extensions/blocks/repeat-visitor/editor.scss
@@ -1,3 +1,5 @@
+@import "~@automattic/color-studio/dist/color-variables";
+
 .wp-block-jetpack-repeat-visitor {
 	.components-notice {
 		margin: 1em 0 0;
@@ -40,7 +42,7 @@
 	}
 
 	.components-base-control__help {
-		color: var( --muriel-hot-red-500 );
+		color: $studio-red-50;
 		font-size: 13px;
 	}
 }

--- a/extensions/shared/icons.scss
+++ b/extensions/shared/icons.scss
@@ -4,18 +4,18 @@
 	fill: $dark-gray-500;
 
 	&.is-facebook {
-		fill: var( --color-facebook );
+		fill: #39579a;
 	}
 	&.is-twitter {
-		fill: var( --color-twitter );
+		fill: #55acee;
 	}
 	&.is-linkedin {
-		fill: var( --color-linkedin );
+		fill: #0976b4;
 	}
 	&.is-tumblr {
-		fill: var( --color-tumblr );
+		fill: #35465c;
 	}
 	&.is-google {
-		fill: var( --color-gplus );
+		fill: #4285f4;
 	}
 }

--- a/extensions/shared/jetpack-plugin-sidebar.scss
+++ b/extensions/shared/jetpack-plugin-sidebar.scss
@@ -33,7 +33,7 @@
 			}
 
 			.jetpack-logo__icon-circle {
-				fill: var( --color-jetpack ) !important;
+				fill: var( --studio-jetpack-green ) !important;
 			}
 
 			.jetpack-logo__icon-triangle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

In #16312, we removed the `@automattic/calypso-color-schemes` package. That package was still in use fo a few things though, like Social Media icons used in Social Previews and Publicize.

This PR updates `yarn.lock` to finish removing the old package, and brings the Social Media Colors into Jetpack as hardcoded values so we do not have to rely on a full package just for those.

**To do**

This is not quite working. 

1. It looks like the Jetpack icon is still broken:

![image](https://user-images.githubusercontent.com/426388/89448120-6a135580-d757-11ea-9714-94e88dff8bb7.png)

3. There are other missing colors across blocks.


**Previous discussion about this**

https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168

#### Jetpack product discussion

* Internal reference: p1596629787307200-slack-CBG1CP4EN


#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Go to Jetpack > Settings > Sharing, and enable Publicize
* Go to Settings > Jetpack Constants, and enable Beta blocks
* Go to WordPress.com > Marketing > Connections, and connect a Facebook Page and Twitter profile.
* Go to Posts > Add New, and check that the Jetpack logo in the Jetpack sidebar looks good.
* Check that the Social Icons in both Social Previews and Publicize look good.

#### Proposed changelog entry for your changes:

* N/A