### PR TITLE
Jetpack Monitor: Switch from `user_token` to `blog_token`.

### DIFF
--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -31,7 +31,16 @@ class Jetpack_Monitor {
 		Jetpack::enable_module_configurable( $this->module );
 	}
 
+	/**
+	 * Send an API request to check if the monitor is active.
+	 *
+	 * @return mixed
+	 *
+	 * @deprecated 4.2.0 The method is not being used, to be removed.
+	 */
 	public function is_active() {
+		_deprecated_function( __METHOD__, 'jetpack-4.2.0' );
+
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
 		) );
@@ -42,6 +51,13 @@ class Jetpack_Monitor {
 		return $xml->getResponse();
 	}
 
+	/**
+	 * Whether to receive the notifications.
+	 *
+	 * @param bool $value `true` to enable notifications, `false` to disable them.
+	 *
+	 * @return bool
+	 */
 	public function update_option_receive_jetpack_monitor_notification( $value ) {
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
@@ -84,7 +100,16 @@ class Jetpack_Monitor {
 		return $xml->getResponse();
 	}
 
+	/**
+	 * Send an API request to activate the monitor.
+	 *
+	 * @return bool
+	 *
+	 * @deprecated 4.2.0 The method is not being used, to be removed.
+	 */
 	public function activate_monitor() {
+		_deprecated_function( __METHOD__, 'jetpack-4.2.0' );
+
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
 		) );
@@ -97,7 +122,16 @@ class Jetpack_Monitor {
 		return true;
 	}
 
+	/**
+	 * Send an API request to deactivate the monitor.
+	 *
+	 * @return bool
+	 *
+	 * @deprecated 4.2.0 The method is not being used, to be removed.
+	 */
 	public function deactivate_monitor() {
+		_deprecated_function( __METHOD__, 'jetpack-4.2.0' );
+
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
 		) );
@@ -117,10 +151,6 @@ class Jetpack_Monitor {
 	 * @return date in YYYY-MM-DD HH:mm:ss format
 	 */
 	public function monitor_get_last_downtime() {
-//		if ( $last_down = get_transient( 'monitor_last_downtime' ) ) {
-//			return $last_down;
-//		}
-
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
 		) );

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -151,9 +151,7 @@ class Jetpack_Monitor {
 	 * @return date in YYYY-MM-DD HH:mm:ss format
 	 */
 	public function monitor_get_last_downtime() {
-		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id()
-		) );
+		$xml = new Jetpack_IXR_Client();
 
 		$xml->query( 'jetpack.monitor.getLastDowntime' );
 

--- a/modules/monitor.php
+++ b/modules/monitor.php
@@ -36,10 +36,10 @@ class Jetpack_Monitor {
 	 *
 	 * @return mixed
 	 *
-	 * @deprecated 4.2.0 The method is not being used, to be removed.
+	 * @deprecated 8.9.0 The method is not being used since Jetpack 4.2.0, to be removed.
 	 */
 	public function is_active() {
-		_deprecated_function( __METHOD__, 'jetpack-4.2.0' );
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0' );
 
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
@@ -105,10 +105,10 @@ class Jetpack_Monitor {
 	 *
 	 * @return bool
 	 *
-	 * @deprecated 4.2.0 The method is not being used, to be removed.
+	 * @deprecated 8.9.0 The method is not being used since Jetpack 4.2.0, to be removed.
 	 */
 	public function activate_monitor() {
-		_deprecated_function( __METHOD__, 'jetpack-4.2.0' );
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0' );
 
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()
@@ -127,10 +127,10 @@ class Jetpack_Monitor {
 	 *
 	 * @return bool
 	 *
-	 * @deprecated 4.2.0 The method is not being used, to be removed.
+	 * @deprecated 8.9.0 The method is not being used since Jetpack 4.2.0, to be removed.
 	 */
 	public function deactivate_monitor() {
-		_deprecated_function( __METHOD__, 'jetpack-4.2.0' );
+		_deprecated_function( __METHOD__, 'jetpack-8.9.0' );
 
 		$xml = new Jetpack_IXR_Client( array(
 			'user_id' => get_current_user_id()


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Methods `is_active()`, `activate_monitor()`, and `deactivate_monitor()` have not been used since Jetpack 4.2. Marking them as deprecated now.
* Using `blog_token` instead of the `user_token` for the `getLastDowntime` API request.

#### Jetpack product discussion
Part of the #16709.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Go to "Jetpack -> Settings -> Security", and activate the "Downtime Monitoring".
2. Go to "Jetpack Debug" and enable "REST API Tester".
3. In the "REST API Tester" send a GET request to `module/monitor/data`.
4. Make sure that you receive the correct response, such as:
```
{
    "code": "success",
    "date": "9 mins"
}
```

#### Proposed changelog entry for your changes:
n/a.