### PR TITLE
Improve a11y of amp-social-share

### DIFF
--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -275,11 +275,11 @@ abstract class Sharing_Source {
 
 		$attrs        = array_merge(
 			array(
-				'type'			=> $this->get_id(),
-				'height'		=> '32px',
-				'width'			=> '32px',
-				'aria-label'	=> $title,
-				'title'			=> $title,
+				'type'       => $this->get_id(),
+				'height'     => '32px',
+				'width'      => '32px',
+				'aria-label' => $title,
+				'title'      => $title,
 			),
 			$attrs
 		);

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -1781,6 +1781,8 @@ class Share_Pocket extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'data-share-endpoint' => esc_url_raw( 'https://getpocket.com/save/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&title=' . rawurlencode( $this->get_share_title( $post->ID ) ) ),
+			'aria-label' => __( 'Click to share on Pocket', 'jetpack' ),
+			'title' => __( 'Click to share on Pocket', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -266,11 +266,20 @@ abstract class Sharing_Source {
 	 * @param array $attrs Custom attributes for rendering the social icon.
 	 */
 	protected function build_amp_markup( $attrs = array() ) {
+
+		$title = sprintf(
+			/* translators: placeholder is a service name, such as "Twitter" or "Facebook". */
+			__( 'Click to share on %s', 'jetpack' ),
+			$this->get_name()
+		);
+
 		$attrs        = array_merge(
 			array(
-				'type'   => $this->get_id(),
-				'height' => '32px',
-				'width'  => '32px',
+				'type'			=> $this->get_id(),
+				'height'		=> '32px',
+				'width'			=> '32px',
+				'aria-label'	=> $title,
+				'title'			=> $title,
 			),
 			$attrs
 		);
@@ -835,20 +844,6 @@ class Share_Twitter extends Sharing_Source {
 		}
 	}
 
-	/**
-	 * AMP display for Twitter.
-	 *
-	 * @param \WP_Post $post The current post being viewed.
-	 */
-	public function get_amp_display( $post ) {
-		$attrs = array(
-			'aria-label' => __( 'Click to share on Twitter', 'jetpack' ),
-			'title' => __( 'Click to share on Twitter', 'jetpack' ),
-		);
-
-		return $this->build_amp_markup( $attrs );
-	}
-
 	public function process_request( $post, array $post_data ) {
 		$post_title = $this->get_share_title( $post->ID );
 		$post_link = $this->get_share_url( $post->ID );
@@ -946,8 +941,6 @@ class Share_Reddit extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'data-share-endpoint' => esc_url_raw( 'https://reddit.com/submit?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&title=' . rawurlencode( $this->get_share_title( $post->ID ) ) ),
-			'aria-label' => __( 'Click to share on Reddit', 'jetpack' ),
-			'title' => __( 'Click to share on Reddit', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1140,8 +1133,6 @@ class Share_Facebook extends Sharing_Source {
 		$attrs = array(
 			/** This filter is documented in modules/sharedaddy/sharing-sources.php */
 			'data-param-app_id' => apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ),
-			'aria-label' => __( 'Click to share on Facebook', 'jetpack' ),
-			'title' => __( 'Click to share on Facebook', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1780,8 +1771,6 @@ class Share_Pocket extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'data-share-endpoint' => esc_url_raw( 'https://getpocket.com/save/?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&title=' . rawurlencode( $this->get_share_title( $post->ID ) ) ),
-			'aria-label' => __( 'Click to share on Pocket', 'jetpack' ),
-			'title' => __( 'Click to share on Pocket', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1837,8 +1826,6 @@ class Share_Telegram extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'data-share-endpoint' => esc_url_raw( 'https://telegram.me/share/url?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&text=' . rawurlencode( $this->get_share_title( $post->ID ) ) ),
-			'aria-label' => __( 'Click to share on Telegram', 'jetpack' ),
-			'title' => __( 'Click to share on Telegram', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1872,8 +1859,6 @@ class Jetpack_Share_WhatsApp extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'type' => 'whatsapp',
-			'aria-label' => __( 'Click to share on WhatsApp', 'jetpack' ),
-			'title' => __( 'Click to share on WhatsApp', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1950,8 +1935,6 @@ class Share_Skype extends Sharing_Source {
 				rawurlencode( $this->get_share_url( $post->ID ) ),
 				'en-US'
 			),
-			'aria-label' => __( 'Click to share on Skype', 'jetpack' ),
-			'title' => __( 'Click to share on Skype', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -842,7 +842,6 @@ class Share_Twitter extends Sharing_Source {
 	 */
 	public function get_amp_display( $post ) {
 		$attrs = array(
-			/** This filter is documented in modules/sharedaddy/sharing-sources.php */
 			'aria-label' => __( 'Click to share on Twitter', 'jetpack' ),
 			'title' => __( 'Click to share on Twitter', 'jetpack' ),
 		);

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -273,8 +273,8 @@ abstract class Sharing_Source {
 				'type'   => $this->get_id(),
 				'height' => '32px',
 				'width'  => '32px',
-				'aria-label' => esc_html( $global['sharing_label'] ) .' '. ucfirst($this->shortname),
-				'title' => esc_html( $global['sharing_label'] ) .' '. ucfirst( $this->shortname),
+				'aria-label' => $global['sharing_label'] .' '. ucfirst($this->shortname),
+				'title' => $global['sharing_label'] .' '. ucfirst( $this->shortname),
 			),
 			$attrs
 		);

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -266,15 +266,11 @@ abstract class Sharing_Source {
 	 * @param array $attrs Custom attributes for rendering the social icon.
 	 */
 	protected function build_amp_markup( $attrs = array() ) {
-		$sharer	 = new Sharing_Service();
-		$global	 = $sharer->get_global_options();
 		$attrs        = array_merge(
 			array(
 				'type'   => $this->get_id(),
 				'height' => '32px',
 				'width'  => '32px',
-				'aria-label' => $global['sharing_label'] .' '. ucfirst($this->shortname),
-				'title' => $global['sharing_label'] .' '. ucfirst( $this->shortname),
 			),
 			$attrs
 		);
@@ -839,6 +835,21 @@ class Share_Twitter extends Sharing_Source {
 		}
 	}
 
+	/**
+	 * AMP display for Twitter.
+	 *
+	 * @param \WP_Post $post The current post being viewed.
+	 */
+	public function get_amp_display( $post ) {
+		$attrs = array(
+			/** This filter is documented in modules/sharedaddy/sharing-sources.php */
+			'aria-label' => __( 'Click to share on Twitter', 'jetpack' ),
+			'title' => __( 'Click to share on Twitter', 'jetpack' ),
+		);
+
+		return $this->build_amp_markup( $attrs );
+	}
+
 	public function process_request( $post, array $post_data ) {
 		$post_title = $this->get_share_title( $post->ID );
 		$post_link = $this->get_share_url( $post->ID );
@@ -936,6 +947,8 @@ class Share_Reddit extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'data-share-endpoint' => esc_url_raw( 'https://reddit.com/submit?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&title=' . rawurlencode( $this->get_share_title( $post->ID ) ) ),
+			'aria-label' => __( 'Click to share on Reddit', 'jetpack' ),
+			'title' => __( 'Click to share on Reddit', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1128,6 +1141,8 @@ class Share_Facebook extends Sharing_Source {
 		$attrs = array(
 			/** This filter is documented in modules/sharedaddy/sharing-sources.php */
 			'data-param-app_id' => apply_filters( 'jetpack_sharing_facebook_app_id', '249643311490' ),
+			'aria-label' => __( 'Click to share on Facebook', 'jetpack' ),
+			'title' => __( 'Click to share on Facebook', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1821,6 +1836,8 @@ class Share_Telegram extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'data-share-endpoint' => esc_url_raw( 'https://telegram.me/share/url?url=' . rawurlencode( $this->get_share_url( $post->ID ) ) . '&text=' . rawurlencode( $this->get_share_title( $post->ID ) ) ),
+			'aria-label' => __( 'Click to share on Telegram', 'jetpack' ),
+			'title' => __( 'Click to share on Telegram', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1854,6 +1871,8 @@ class Jetpack_Share_WhatsApp extends Sharing_Source {
 	public function get_amp_display( $post ) {
 		$attrs = array(
 			'type' => 'whatsapp',
+			'aria-label' => __( 'Click to share on WhatsApp', 'jetpack' ),
+			'title' => __( 'Click to share on WhatsApp', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );
@@ -1930,6 +1949,8 @@ class Share_Skype extends Sharing_Source {
 				rawurlencode( $this->get_share_url( $post->ID ) ),
 				'en-US'
 			),
+			'aria-label' => __( 'Click to share on Skype', 'jetpack' ),
+			'title' => __( 'Click to share on Skype', 'jetpack' ),
 		);
 
 		return $this->build_amp_markup( $attrs );

--- a/modules/sharedaddy/sharing-sources.php
+++ b/modules/sharedaddy/sharing-sources.php
@@ -266,11 +266,15 @@ abstract class Sharing_Source {
 	 * @param array $attrs Custom attributes for rendering the social icon.
 	 */
 	protected function build_amp_markup( $attrs = array() ) {
+		$sharer	 = new Sharing_Service();
+		$global	 = $sharer->get_global_options();
 		$attrs        = array_merge(
 			array(
 				'type'   => $this->get_id(),
 				'height' => '32px',
 				'width'  => '32px',
+				'aria-label' => esc_html( $global['sharing_label'] ) .' '. ucfirst($this->shortname),
+				'title' => esc_html( $global['sharing_label'] ) .' '. ucfirst( $this->shortname),
 			),
 			$attrs
 		);

--- a/tests/php/3rd-party/test_class.jetpack-amp-support.php
+++ b/tests/php/3rd-party/test_class.jetpack-amp-support.php
@@ -38,7 +38,7 @@ class WP_Test_Jetpack_AMP_Support extends WP_UnitTestCase {
 
 		$social_icons = Jetpack_AMP_Support::render_sharing_html( '<div class="sd-content"><ul><li>Facebook</li></ul></div>', $services );
 
-		$this->assertEquals( '<div class="sd-content"><amp-social-share type="facebook" height="32px" width="32px" data-param-app_id="249643311490"></amp-social-share></div>', $social_icons );
+		$this->assertEquals( '<div class="sd-content"><amp-social-share type="facebook" height="32px" width="32px" data-param-app_id="249643311490" aria-label="Click to share on Facebook" title="Click to share on Facebook"></amp-social-share></div>', $social_icons );
 
 		// Print.
 		$services = array(
@@ -60,7 +60,7 @@ class WP_Test_Jetpack_AMP_Support extends WP_UnitTestCase {
 
 		$social_icons = Jetpack_AMP_Support::render_sharing_html( '<div class="sd-content"><ul><li>Whatsapp</li></ul></div>', $services );
 
-		$this->assertEquals( '<div class="sd-content"><amp-social-share type="whatsapp" height="32px" width="32px"></amp-social-share></div>', $social_icons );
+		$this->assertEquals( '<div class="sd-content"><amp-social-share type="whatsapp" height="32px" width="32px" aria-label="Click to share on WhatsApp" title="Click to share on WhatsApp"></amp-social-share></div>', $social_icons );
 
 		// Pocket.
 		$services = array(
@@ -71,7 +71,7 @@ class WP_Test_Jetpack_AMP_Support extends WP_UnitTestCase {
 
 		$social_icons = Jetpack_AMP_Support::render_sharing_html( '<div class="sd-content"><ul><li>Pocket</li></ul></div>', $services );
 
-		$this->assertEquals( '<div class="sd-content"><amp-social-share type="pocket" height="32px" width="32px" data-share-endpoint="https://getpocket.com/save/?url=http%3A%2F%2Fexample.org%2F%3Fp%3D' . $post->ID . '&amp;title=Test%20post"></amp-social-share></div>', $social_icons );
+		$this->assertEquals( '<div class="sd-content"><amp-social-share type="pocket" height="32px" width="32px" data-share-endpoint="https://getpocket.com/save/?url=http%3A%2F%2Fexample.org%2F%3Fp%3D' . $post->ID . '&amp;title=Test%20post" aria-label="Click to share on Pocket" title="Click to share on Pocket"></amp-social-share></div>', $social_icons );
 
 		// Reset global post.
 		$post = null;

--- a/tests/php/3rd-party/test_class.jetpack-amp-support.php
+++ b/tests/php/3rd-party/test_class.jetpack-amp-support.php
@@ -38,7 +38,7 @@ class WP_Test_Jetpack_AMP_Support extends WP_UnitTestCase {
 
 		$social_icons = Jetpack_AMP_Support::render_sharing_html( '<div class="sd-content"><ul><li>Facebook</li></ul></div>', $services );
 
-		$this->assertEquals( '<div class="sd-content"><amp-social-share type="facebook" height="32px" width="32px" data-param-app_id="249643311490" aria-label="Click to share on Facebook" title="Click to share on Facebook"></amp-social-share></div>', $social_icons );
+		$this->assertEquals( '<div class="sd-content"><amp-social-share type="facebook" height="32px" width="32px" aria-label="Click to share on Facebook" title="Click to share on Facebook" data-param-app_id="249643311490"></amp-social-share></div>', $social_icons );
 
 		// Print.
 		$services = array(
@@ -71,7 +71,7 @@ class WP_Test_Jetpack_AMP_Support extends WP_UnitTestCase {
 
 		$social_icons = Jetpack_AMP_Support::render_sharing_html( '<div class="sd-content"><ul><li>Pocket</li></ul></div>', $services );
 
-		$this->assertEquals( '<div class="sd-content"><amp-social-share type="pocket" height="32px" width="32px" data-share-endpoint="https://getpocket.com/save/?url=http%3A%2F%2Fexample.org%2F%3Fp%3D' . $post->ID . '&amp;title=Test%20post" aria-label="Click to share on Pocket" title="Click to share on Pocket"></amp-social-share></div>', $social_icons );
+		$this->assertEquals( '<div class="sd-content"><amp-social-share type="pocket" height="32px" width="32px" aria-label="Click to share on Pocket" title="Click to share on Pocket" data-share-endpoint="https://getpocket.com/save/?url=http%3A%2F%2Fexample.org%2F%3Fp%3D' . $post->ID . '&amp;title=Test%20post"></amp-social-share></div>', $social_icons );
 
 		// Reset global post.
 		$post = null;


### PR DESCRIPTION
Fix at Jetpack side: ampproject/amphtml#29563 and Automattic/newspack-theme#1014

When a button doesn't have an accessible name, screen readers announce it as "button", making it unusable for users who rely on screen readers.

I think this should be fixed when writing amp-social-share tag on HTML template.


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Add `aria-label` and `title` using a translated string to `$attrs` on `get_amp_display` method 

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
When you hover over a share button, it will display a tooltip
![image](https://user-images.githubusercontent.com/4308648/89456988-b0a28900-d732-11ea-92c0-d15ecc5b162f.png)

#### Proposed changelog entry for your changes:
* Improve accessibility (a11y) of amp-social-share buttons


