### PR TITLE
Donations: Remove feature from Personal plans

### DIFF
--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -45,7 +45,6 @@ class Jetpack_Plan {
 			),
 			'supports' => array(
 				'akismet',
-				'donations',
 				'recurring-payments',
 			),
 		),
@@ -58,6 +57,7 @@ class Jetpack_Plan {
 				'value_bundle-2y',
 			),
 			'supports' => array(
+				'donations',
 				'simple-payments',
 				'vaultpress',
 				'videopress',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Remove the donations feature from Jetpack Personal since we're removing that plan. Donations now require a Jetpack Premium plan.

#### Jetpack product discussion
p1HpG7-9NV-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* With a WordPress instance of your choice, install Jetpack Beta and activate this branch. Or visit https://jurassic.ninja/create/?jetpack-beta&branch=update/donations-required-plan.
* Connect Jetpack to WordPress.com with a free plan.
* Make sure Jetpack beta blocks are visible by going to /wp-admin/options-general.php?page=companion_settings and activating `JETPACK_BETA_BLOCKS`. 
* Note that if folks are using the sandbox store method (PCYsg-lW4-p2) to also set the `JETPACK__SANDBOX_DOMAIN` value.
* Go to Posts > New
* Make sure the Donations block doesn't show up in the inserter.
* Upgrade to Jetpack Premium (ideally we should test that the block does not appear on a Personal plan, but seems it is no longer possible to upgrade to Jetpack Personal).
* Make sure the Donations block shows up now in the inserter.

#### Proposed changelog entry for your changes:
N/A.