### PR TITLE
Donations: Avoid using buttons elements in block output

### DIFF
--- a/extensions/blocks/donations/amount.js
+++ b/extensions/blocks/donations/amount.js
@@ -110,36 +110,34 @@ const Amount = ( {
 	}, [ currency, isFocused, isInvalid, setAmount, value ] );
 
 	return (
-		<div className={ classnames( 'wp-block-button', 'donations__amount', className ) }>
-			<div
-				className={ classnames( 'wp-block-button__link', {
-					'has-focus': isFocused,
-					'has-error': isInvalid,
-				} ) }
-				onClick={ setFocus }
-				onKeyDown={ setFocus }
-				role="button"
-				tabIndex={ 0 }
-			>
-				{ CURRENCIES[ currency ].symbol }
-				{ ! disabled ? (
-					<RichText
-						allowedFormats={ [] }
-						aria-label={ label }
-						keepPlaceholderOnFocus={ true }
-						multiline={ false }
-						onChange={ amount => setAmount( amount ) }
-						placeholder={ formatCurrency( defaultValue, currency, { symbol: '' } ) }
-						ref={ richTextRef }
-						value={ editedValue }
-						withoutInteractiveFormatting
-					/>
-				) : (
-					<span className="donations__amount-value">
-						{ formatCurrency( value ? value : defaultValue, currency, { symbol: '' } ) }
-					</span>
-				) }
-			</div>
+		<div
+			className={ classnames( 'donations__amount', 'wp-block-button__link', className, {
+				'has-focus': isFocused,
+				'has-error': isInvalid,
+			} ) }
+			role="button"
+			tabIndex={ 0 }
+			onClick={ setFocus }
+			onKeyDown={ setFocus }
+		>
+			{ CURRENCIES[ currency ].symbol }
+			{ disabled ? (
+				<span className="donations__amount-value">
+					{ formatCurrency( value ? value : defaultValue, currency, { symbol: '' } ) }
+				</span>
+			) : (
+				<RichText
+					allowedFormats={ [] }
+					aria-label={ label }
+					keepPlaceholderOnFocus={ true }
+					multiline={ false }
+					onChange={ amount => setAmount( amount ) }
+					placeholder={ formatCurrency( defaultValue, currency, { symbol: '' } ) }
+					ref={ richTextRef }
+					value={ editedValue }
+					withoutInteractiveFormatting
+				/>
+			) }
 		</div>
 	);
 };

--- a/extensions/blocks/donations/amount.js
+++ b/extensions/blocks/donations/amount.js
@@ -122,9 +122,9 @@ const Amount = ( {
 		>
 			{ CURRENCIES[ currency ].symbol }
 			{ disabled ? (
-				<span className="donations__amount-value">
+				<div className="donations__amount-value">
 					{ formatCurrency( value ? value : defaultValue, currency, { symbol: '' } ) }
-				</span>
+				</div>
 			) : (
 				<RichText
 					allowedFormats={ [] }

--- a/extensions/blocks/donations/common.scss
+++ b/extensions/blocks/donations/common.scss
@@ -77,6 +77,8 @@
 	}
 
 	.donations__custom-amount .donations__amount-value {
+		display: inline-block;
+		text-align: left;
 		margin-left: 4px;
 		min-width: 60px;
 	}

--- a/extensions/blocks/donations/common.scss
+++ b/extensions/blocks/donations/common.scss
@@ -16,38 +16,30 @@
 		flex-grow: 1;
 		text-align: center;
 		font-size: 16px;
-		padding: 16px;
-		height: auto;
-		border-radius: 0;
+		padding: 16px 24px;
+		border: none;
 		border-left: 1px solid $light-gray-700;
-		background-color: $white;
+		background: $white;
 		color: $dark-gray-800;
-		box-shadow: none;
+		cursor: pointer;
+		border-radius: 0;
 		text-transform: none;
 		text-decoration: none;
 		outline: none;
-
-		&:focus,
-		&:active {
-			border-radius: 0;
-		}
 
 		&:first-child {
 			border-left: none;
 		}
 
-		// Complex selector needed to override specificity.
-		&:not(:disabled):not([aria-disabled=true]):not(.is-secondary):not(.is-primary):not(.is-tertiary):not(.is-link):hover {
-			background-color: $light-gray-100;
-			box-shadow: none;
+		&:hover {
+			background: $light-gray-100;
+			color: $dark-gray-800;
 		}
 
-		// Complex selector needed to override specificity.
-		&.is-active,
-		&.is-active:not(:disabled):not([aria-disabled=true]):not(.is-secondary):not(.is-primary):not(.is-tertiary):not(.is-link):hover {
-			background-color: $blue-wordpress-700;
-			box-shadow: none;
+		&.is-active {
+			background: $blue-wordpress-700;
 			color: $white;
+			cursor: default;
 		}
 	}
 
@@ -58,21 +50,18 @@
 	.donations__amounts {
 		margin-top: 30px;
 		margin-bottom: 30px;
+		display: flex;
 	}
 
 	.donations__amount {
 		display: inline-block;
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-
-	.donations__amount .wp-block-button__link {
+		padding: 16px 24px;
 		background-color: $white;
 		color: $dark-gray-800;
 		border: 1px solid $light-gray-700;
-		cursor: text;
-		text-decoration: none;
-		text-transform: none;
+		margin-right: 8px;
+		font-weight: 600;
+		font-size: 16px;
 
 		&.has-focus {
 			box-shadow: 0 0 0 1px $white, 0 0 0 3px $blue-wordpress-700;
@@ -87,7 +76,7 @@
 		}
 	}
 
-	.donations__custom-amount  .donations__amount-value {
+	.donations__custom-amount .donations__amount-value {
 		margin-left: 4px;
 		min-width: 60px;
 	}

--- a/extensions/blocks/donations/editor.scss
+++ b/extensions/blocks/donations/editor.scss
@@ -21,8 +21,9 @@
 		}
 	}
 
-	.donations__amount.wp-block-button:not(.has-text-color):not(.is-style-outline) [data-rich-text-placeholder]:after {
+	.donations__amount [data-rich-text-placeholder]:after {
 		color: $light-gray-700;
+		opacity: 1;
 	}
 
 	.donations__custom-amount .donations__amount-value {

--- a/extensions/blocks/donations/editor.scss
+++ b/extensions/blocks/donations/editor.scss
@@ -2,6 +2,14 @@
 @import './common';
 
 .wp-block-jetpack-donations {
+	.donations__amount {
+		cursor: text;
+	}
+
+	.donations__custom-amount {
+		cursor: default;
+	}
+
 	.donations__amount .block-editor-rich-text__editable {
 		display: inline-block;
 		text-align: left;
@@ -15,10 +23,6 @@
 
 	.donations__amount.wp-block-button:not(.has-text-color):not(.is-style-outline) [data-rich-text-placeholder]:after {
 		color: $light-gray-700;
-	}
-
-	.donations__custom-amount .wp-block-button__link {
-		cursor: default;
 	}
 
 	.donations__custom-amount .donations__amount-value {

--- a/extensions/blocks/donations/save.js
+++ b/extensions/blocks/donations/save.js
@@ -7,7 +7,6 @@ import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -42,13 +41,15 @@ const Save = ( { attributes } ) => {
 				{ Object.keys( tabs ).length > 1 && (
 					<div className="donations__nav">
 						{ Object.entries( tabs ).map( ( [ interval, { title } ] ) => (
-							<Button
-								className="donations__nav-item"
+							<div
+								role="button"
+								tabIndex={ 0 }
+								className="donations__nav-item wp-block-button__link"
 								key={ `jetpack-donations-nav-item-${ interval } ` }
 								data-interval={ interval }
 							>
 								{ title }
-							</Button>
+							</div>
 						) ) }
 					</div>
 				) }
@@ -74,54 +75,39 @@ const Save = ( { attributes } ) => {
 							/>
 						) }
 						<RichText.Content tagName="p" value={ chooseAmountText } />
-						<div className="wp-block-buttons donations__amounts donations__one-time-item">
+						<div className="donations__amounts donations__one-time-item">
 							{ oneTimeDonation.amounts.map( amount => (
 								<div
-									className="wp-block-button donations__amount"
+									className="donations__amount wp-block-button__link"
 									data-interval="one-time"
 									data-amount={ amount }
 								>
-									<div className="wp-block-button__link">
-										{ CURRENCIES[ currency ].symbol }
-										<span className="donations__amount-value">
-											{ formatCurrency( amount, currency, { symbol: '' } ) }
-										</span>
-									</div>
+									{ formatCurrency( amount, currency ) }
 								</div>
 							) ) }
 						</div>
 						{ monthlyDonation.show && (
-							<div className="wp-block-buttons donations__amounts donations__monthly-item">
+							<div className="donations__amounts donations__monthly-item">
 								{ monthlyDonation.amounts.map( amount => (
 									<div
-										className="wp-block-button donations__amount"
+										className="donations__amount wp-block-button__link"
 										data-interval="1 month"
 										data-amount={ amount }
 									>
-										<div className="wp-block-button__link">
-											{ CURRENCIES[ currency ].symbol }
-											<span className="donations__amount-value">
-												{ formatCurrency( amount, currency, { symbol: '' } ) }
-											</span>
-										</div>
+										{ formatCurrency( amount, currency ) }
 									</div>
 								) ) }
 							</div>
 						) }
 						{ annualDonation.show && (
-							<div className="wp-block-buttons donations__amounts donations__annual-item">
+							<div className="donations__amounts donations__annual-item">
 								{ annualDonation.amounts.map( amount => (
 									<div
-										className="wp-block-button donations__amount"
+										className="donations__amount wp-block-button__link"
 										data-interval="1 year"
 										data-amount={ amount }
 									>
-										<div className="wp-block-button__link">
-											{ CURRENCIES[ currency ].symbol }
-											<span className="donations__amount-value">
-												{ formatCurrency( amount, currency, { symbol: '' } ) }
-											</span>
-										</div>
+										{ formatCurrency( amount, currency ) }
 									</div>
 								) ) }
 							</div>
@@ -129,20 +115,18 @@ const Save = ( { attributes } ) => {
 						{ showCustomAmount && (
 							<>
 								<RichText.Content tagName="p" value={ customAmountText } />
-								<div className="wp-block-button donations__amount donations__custom-amount">
-									<div className="wp-block-button__link">
-										{ CURRENCIES[ currency ].symbol }
-										<span
-											className="donations__amount-value"
-											contentEditable
-											data-currency={ currency }
-											data-placeholder={ formatCurrency(
-												minimumTransactionAmountForCurrency( currency ) * 100,
-												currency,
-												{ symbol: '' }
-											) }
-										/>
-									</div>
+								<div className="donations__amount donations__custom-amount wp-block-button__link">
+									{ CURRENCIES[ currency ].symbol }
+									<span
+										className="donations__amount-value"
+										contentEditable
+										data-currency={ currency }
+										data-placeholder={ formatCurrency(
+											minimumTransactionAmountForCurrency( currency ) * 100,
+											currency,
+											{ symbol: '' }
+										) }
+									/>
 								</div>
 							</>
 						) }
@@ -168,7 +152,8 @@ const Save = ( { attributes } ) => {
 						) }
 						<div className="wp-block-button donations__donate-button donations__one-time-item">
 							<RichText.Content
-								tagName="button"
+								tagName="div"
+								role="button"
 								className="wp-block-button__link"
 								value={ oneTimeDonation.buttonText }
 							/>
@@ -176,7 +161,8 @@ const Save = ( { attributes } ) => {
 						{ monthlyDonation.show && (
 							<div className="wp-block-button donations__donate-button donations__monthly-item">
 								<RichText.Content
-									tagName="button"
+									tagName="div"
+									role="button"
 									className="wp-block-button__link"
 									value={ monthlyDonation.buttonText }
 								/>
@@ -185,7 +171,8 @@ const Save = ( { attributes } ) => {
 						{ annualDonation.show && (
 							<div className="wp-block-button donations__donate-button donations__annual-item">
 								<RichText.Content
-									tagName="button"
+									tagName="div"
+									role="button"
 									className="wp-block-button__link"
 									value={ annualDonation.buttonText }
 								/>

--- a/extensions/blocks/donations/save.js
+++ b/extensions/blocks/donations/save.js
@@ -119,7 +119,6 @@ const Save = ( { attributes } ) => {
 									{ CURRENCIES[ currency ].symbol }
 									<div
 										className="donations__amount-value"
-										contentEditable
 										data-currency={ currency }
 										data-empty-text={ formatCurrency(
 											minimumTransactionAmountForCurrency( currency ) * 100,

--- a/extensions/blocks/donations/save.js
+++ b/extensions/blocks/donations/save.js
@@ -77,11 +77,7 @@ const Save = ( { attributes } ) => {
 						<RichText.Content tagName="p" value={ chooseAmountText } />
 						<div className="donations__amounts donations__one-time-item">
 							{ oneTimeDonation.amounts.map( amount => (
-								<div
-									className="donations__amount wp-block-button__link"
-									data-interval="one-time"
-									data-amount={ amount }
-								>
+								<div className="donations__amount wp-block-button__link" data-amount={ amount }>
 									{ formatCurrency( amount, currency ) }
 								</div>
 							) ) }
@@ -89,11 +85,7 @@ const Save = ( { attributes } ) => {
 						{ monthlyDonation.show && (
 							<div className="donations__amounts donations__monthly-item">
 								{ monthlyDonation.amounts.map( amount => (
-									<div
-										className="donations__amount wp-block-button__link"
-										data-interval="1 month"
-										data-amount={ amount }
-									>
+									<div className="donations__amount wp-block-button__link" data-amount={ amount }>
 										{ formatCurrency( amount, currency ) }
 									</div>
 								) ) }
@@ -102,11 +94,7 @@ const Save = ( { attributes } ) => {
 						{ annualDonation.show && (
 							<div className="donations__amounts donations__annual-item">
 								{ annualDonation.amounts.map( amount => (
-									<div
-										className="donations__amount wp-block-button__link"
-										data-interval="1 year"
-										data-amount={ amount }
-									>
+									<div className="donations__amount wp-block-button__link" data-amount={ amount }>
 										{ formatCurrency( amount, currency ) }
 									</div>
 								) ) }

--- a/extensions/blocks/donations/save.js
+++ b/extensions/blocks/donations/save.js
@@ -121,7 +121,7 @@ const Save = ( { attributes } ) => {
 										className="donations__amount-value"
 										contentEditable
 										data-currency={ currency }
-										data-placeholder={ formatCurrency(
+										data-empty-text={ formatCurrency(
 											minimumTransactionAmountForCurrency( currency ) * 100,
 											currency,
 											{ symbol: '' }

--- a/extensions/blocks/donations/save.js
+++ b/extensions/blocks/donations/save.js
@@ -117,7 +117,7 @@ const Save = ( { attributes } ) => {
 								<RichText.Content tagName="p" value={ customAmountText } />
 								<div className="donations__amount donations__custom-amount wp-block-button__link">
 									{ CURRENCIES[ currency ].symbol }
-									<span
+									<div
 										className="donations__amount-value"
 										contentEditable
 										data-currency={ currency }

--- a/extensions/blocks/donations/tab.js
+++ b/extensions/blocks/donations/tab.js
@@ -101,7 +101,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 				value={ chooseAmountText }
 				onChange={ value => setAttributes( { chooseAmountText: value } ) }
 			/>
-			<div className="wp-block-buttons donations__amounts">
+			<div className="donations__amounts">
 				{ amounts.map( ( amount, index ) => (
 					<Amount
 						currency={ currency }

--- a/extensions/blocks/donations/tabs.js
+++ b/extensions/blocks/donations/tabs.js
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -82,15 +81,18 @@ const Tabs = props => {
 				{ Object.keys( tabs ).length > 1 && (
 					<div className="donations__nav">
 						{ Object.entries( tabs ).map( ( [ interval, { title } ] ) => (
-							<Button
-								className={ classNames( 'donations__nav-item', {
+							<div
+								role="button"
+								tabIndex={ 0 }
+								className={ classNames( 'donations__nav-item', 'wp-block-button__link', {
 									'is-active': isTabActive( interval ),
 								} ) }
 								onClick={ () => setActiveTab( interval ) }
+								onKeyDown={ () => setActiveTab( interval ) }
 								key={ `jetpack-donations-nav-item-${ interval } ` }
 							>
 								{ title }
-							</Button>
+							</div>
 						) ) }
 					</div>
 				) }

--- a/extensions/blocks/donations/view.js
+++ b/extensions/blocks/donations/view.js
@@ -26,19 +26,22 @@ const initNavigation = () => {
 	const navItems = document.querySelectorAll( '.wp-block-jetpack-donations .donations__nav-item' );
 	const tabContent = document.querySelector( '.wp-block-jetpack-donations .donations__tab' );
 
-	navItems.forEach( navItem => {
-		navItem.addEventListener( 'click', event => {
-			// Toggle nav item.
-			document
-				.querySelector( '.wp-block-jetpack-donations .donations__nav-item.is-active' )
-				.classList.remove( 'is-active' );
-			event.target.classList.add( 'is-active' );
+	const handleClick = event => {
+		// Toggle nav item.
+		document
+			.querySelector( '.wp-block-jetpack-donations .donations__nav-item.is-active' )
+			.classList.remove( 'is-active' );
+		event.target.classList.add( 'is-active' );
 
-			// Toggle tab.
-			tabContent.classList.remove( tabClasses[ activeTab ] );
-			activeTab = event.target.dataset.interval;
-			tabContent.classList.add( tabClasses[ activeTab ] );
-		} );
+		// Toggle tab.
+		tabContent.classList.remove( tabClasses[ activeTab ] );
+		activeTab = event.target.dataset.interval;
+		tabContent.classList.add( tabClasses[ activeTab ] );
+	};
+
+	navItems.forEach( navItem => {
+		navItem.addEventListener( 'click', handleClick );
+		navItem.addEventListener( 'keydown', handleClick );
 	} );
 
 	// Activates the default tab on first execution.
@@ -58,9 +61,7 @@ const handleCustomAmount = () => {
 		return;
 	}
 
-	const wrapper = document.querySelector(
-		'.wp-block-jetpack-donations .donations__custom-amount .wp-block-button__link'
-	);
+	const wrapper = document.querySelector( '.wp-block-jetpack-donations .donations__custom-amount' );
 
 	// Prevent new lines.
 	input.addEventListener( 'keydown', event => {

--- a/extensions/blocks/donations/view.js
+++ b/extensions/blocks/donations/view.js
@@ -63,6 +63,9 @@ const handleCustomAmount = () => {
 
 	const wrapper = document.querySelector( '.wp-block-jetpack-donations .donations__custom-amount' );
 
+	// Make input editable.
+	input.setAttribute( 'contenteditable', '' );
+
 	// Prevent new lines.
 	input.addEventListener( 'keydown', event => {
 		if ( event.keyCode === 13 ) {

--- a/extensions/blocks/donations/view.scss
+++ b/extensions/blocks/donations/view.scss
@@ -22,20 +22,20 @@
 
 	.donations__custom-amount {
 		cursor: text;
-	}
 
-	.donations__amount-value {
-		white-space: pre-wrap;
-		display: inline-block;
-		text-align: left;
+		.donations__amount-value {
+			white-space: pre-wrap;
+			display: inline-block;
+			text-align: left;
 
-		&:empty:after {
-			content: attr(data-placeholder);
-			color: $light-gray-700;
-		}
+			&:empty:after {
+				content: attr(data-placeholder);
+				color: $light-gray-700;
+			}
 
-		&:focus {
-			outline: none;
+			&:focus {
+				outline: none;
+			}
 		}
 	}
 }

--- a/extensions/blocks/donations/view.scss
+++ b/extensions/blocks/donations/view.scss
@@ -16,8 +16,12 @@
 		}
 	}
 
-	.donations__amount:not( .donations__custom-amount ) .wp-block-button__link {
+	.donations__amount {
 		cursor: pointer;
+	}
+
+	.donations__custom-amount {
+		cursor: text;
 	}
 
 	.donations__amount-value {

--- a/extensions/blocks/donations/view.scss
+++ b/extensions/blocks/donations/view.scss
@@ -29,7 +29,7 @@
 			text-align: left;
 
 			&:empty:after {
-				content: attr(data-placeholder);
+				content: attr(data-empty-text);
 				color: $light-gray-700;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Some sites such as any WP.com simple site might have a more restricted KSES logic that doesn't allow `<button>` elements in a post content. 

To work around that, this PR modifies the output of the Donations block so all `<button>` elements are replaced with semantically equivalent `<div role="button">` elements, which are allowed in WP.com. We still need to allow the `data-*` attributes in WP.com KSES, but that will be handled in separate WP.com patch. The `contenteditable` attribute has been also removed from the post content and it's set not dynamically with JS so it doesn't need to be allowed by KSES.

It also simplifies the general markup by removing all `wp-block-buttons` and `wp-block-button` classes, so we need to override less styles.

#### Jetpack product discussion
p1HpG7-9NV-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
- On a WP.com sandbox, apply D47697-code and D47694-code (if D47694-code cannot be applied cleanly, it'll likely need a "rebase". See PCYsg-iiu-p2 #committing-block-changes-to-wordpress-com for instructions).
- Sandbox a simple test site, the API and the store (PCYsg-lW4-p2).
- Make sure your test site has a paid plan.
- Go to wordpress.com/block-editor and select your test site.
- Insert a donations block (you'd need to set up the connection to Stripe if it's not set yet).
- Edit the block at your wish and publish the post.
- Make sure the block is displayed correctly in the published post (so far you can only navigate through the tabs).

#### Proposed changelog entry for your changes:
N/A.