### PR TITLE
Extensions: make `render_callback` optional when checking block registration against plan

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -40,10 +40,12 @@ function jetpack_register_block( $slug, $args = array() ) {
 	$feature_name = Jetpack_Gutenberg::remove_extension_prefix( $slug );
 	// If the block is dynamic, and a Jetpack block, wrap the render_callback to check availability.
 	if (
-		isset( $args['plan_check'], $args['render_callback'] )
+		isset( $args['plan_check'] )
 		&& true === $args['plan_check']
 	) {
-		$args['render_callback'] = Jetpack_Gutenberg::get_render_callback_with_availability_check( $feature_name, $args['render_callback'] );
+		if ( isset( $args['render_callback'] ) ) {
+			$args['render_callback'] = Jetpack_Gutenberg::get_render_callback_with_availability_check( $feature_name, $args['render_callback'] );
+		}
 		$method_name             = 'set_availability_for_plan';
 	} else {
 		$method_name = 'set_extension_available';

--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -19,7 +19,7 @@ registerJetpackPlugin( name, settings );
  * extension availability so will not render the Plugin if the extension is not
  * availabile.
  */
-const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
+const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' )?.available;
 
 if ( ! extensionAvailableOnPlan ) {
     registerPlugin( `jetpack-${name}-upgrade-nudge`, {


### PR DESCRIPTION
Certain blocks and extensions in Jetpack are gated by plan. Depending on where the code is being run (ie: in the Plugin or on WordPress.com) the plan being checked against might be either:

- Jetpack plan
- WordPress.com plan

https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L1088-L1096

Currently when registering a Jetpack extension/block using [`jetpack_register_block`](https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L24) you can use the `plan_check` arg in the settings array to choose to check if the feature should be enabled on the current plan. If it isn't the the block/extension won't be registered.

However, `jetpack_register_block` currently requires the developer to pass `render_callback` _as well as_ `plan_check` in order for the plan checking function to be activated.

https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L42-L47

Note: from PHP manual for `isset()`:

> If multiple parameters are supplied then isset() will return TRUE only if all of the parameters are considered set. 

This should not be in the case as there are times where you would want to gate the block registration by plan without having a render callback. You might assume this is simply to handle dynamic blocks to avoid them rendering on the front of the website if they aren't available on the given plan. However, recall that many blocks rely on the localized JS variable `window.Jetpack_Editor_Initial_State.available_blocks` in order to determine whether a block should be registered _within the Block Editor_. 

https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L764-L778

This variable is populated via `self::get_availability()` which ultimately depends on the same plan gating as the PHP code.

Therefore we shouldn't require a `render_callback` to be provided in order to gate the block to a plan.

Works towards addressing https://github.com/Automattic/jetpack/issues/16616

#### Changes proposed in this Pull Request:

* Allow non-dynamic blocks to be gated (ie: even without a `render_callback`).
* Make `render_callback` an optional settings argument to `jetpack_register_block` when the `plan_check` arg is provided as a setting.

#### Jetpack product discussion
Relates to `84-gh-dotcom-manage`.

#### Does this pull request change what data or activity we track or use?
Nope

#### Testing instructions:

First it's important we check that all other Jetpack blocks to not use `plan_check` without also providing `render_callback` - if all the blocks provide both arguments then we can safely assume that we won't be causing them any problems because they would already be opting into the plan gating functionality (because they already provided `render_callback` which we're now making optional). To do this search the entire `extensions` dir for `plan_check` and ensure that in all cases it is passed alongside a `render_callback` arg.

Note that Social Previews is passing `plan_check` but not passing `render_callback
https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/extensions/blocks/social-previews/social-previews.php#L20-L27.

The key to testing this PR is to check whether WordPress.com will effectively gate the feature by plan. This is easiest using the Phab Fusion sync diff. 

* Apply the Fusion sync diff to your SB - it is D47698-code.
* This should update the Jetpack class to match what's in this PR.
* Note that Social Previews is passing `plan_check` but not passing `render_callback
* Now _manually apply_ the changes from D47637-code to your sandbox. This will gate `social-previews` by Business or eCommerce plan only on WordPress.com.
* On a WP.com Business plan go to WPAdmin and create a new Post. 
* You should see the Social Previews panel in the Jetpack sidebar.
* You should be able to access `window.Jetpack_Editor_Initial_State.available_blocks["social-previews"].available` and see that it is `true`.
* On a WP.com plan that is _not_  Business or eCommerce go to WPAdmin and create a new Post. 
* You should _not_ see the Social Previews panel in the Jetpack sidebar.
* You should be able to access `window.Jetpack_Editor_Initial_State.available_blocks["social-previews"].available` but you should see that it is `false`.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*