### PR TITLE
add tracking for deleted but active master users

### DIFF
--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -304,8 +304,46 @@ class Error_Handler {
 			'nonce'         => wp_generate_password( 10, false ),
 		);
 
+		if ( $this->track_lost_active_master_user( $error->get_error_code(), $data['token'], $user_id ) ) {
+			$error_array['error_message'] = 'Site has a deleted but active master user token';
+		}
+
 		return $error_array;
 
+	}
+
+	/**
+	 * This is been used to track blogs with deleted master user but whose tokens are still actively being used
+	 *
+	 * See p9dueE-1GB-p2
+	 *
+	 * This tracking should be removed as long as we no longer need, possibly in 8.9
+	 *
+	 * @since 8.8.1
+	 *
+	 * @param string  $error_code The error code.
+	 * @param string  $token The token that triggered the error.
+	 * @param integer $user_id The user ID used to make the request that triggered the error.
+	 * @return boolean
+	 */
+	private function track_lost_active_master_user( $error_code, $token, $user_id ) {
+		if ( 'unknown_user' === $error_code ) {
+			$manager = new Manager();
+			// If the Unknown user is the master user (master user has been deleted).
+			if ( $manager->is_missing_connection_owner() && (int) $user_id === (int) $manager->get_connection_owner_id() ) {
+				$user_token = $manager->get_access_token( JETPACK_MASTER_USER );
+				// If there's still a token stored for the deleted master user.
+				if ( $user_token && is_object( $user_token ) && isset( $user_token->secret ) ) {
+					$token_parts = explode( ':', wp_unslash( $token ) );
+					// If the token stored for the deleted master user matches the token user by wpcom to make the request.
+					// This means that requests FROM this site TO wpcom using the JETPACK_MASTER_USER constant are still working.
+					if ( isset( $token_parts[0] ) && ! empty( $token_parts[0] ) && false !== strpos( $user_token->secret, $token_parts[0] ) ) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR adds tracking of sites that have a orphan user token key for a deleted user who is still marked as the connection owner. This helps us understand what sites could be affected if we deleted these old tokens that trigger the `unknown_user` error from the wpcom's database.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1GB-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Not significantly. It just tracks a boolean indicating whether the site still has a valid token from a deleted user which is still being used to make requests to wpcom

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a connected jetpack site
* Create a secondary admin user
* Log in as the secondary admin user
* Move your master user away. Directly in your database: `UPDATE wp_users SET ID = 99 WHERE ID = 1` (Replace Ids as needed)
* Go to Jetpack Debug > XML-RPC Errors
* Click the link and visit the Jetpack debugger. Wait until it finishes
* Refresh Jetpack Debug > XML-RPC and confirm you've got a `unknown_user` error.
* Check that the `error_message` for this error is "Site has a deleted but active master user token"

This will test the case where the remote site still has a token that is present in wpcom and is still using it to communicate, even though the connection is technically broken. 

Now let's test if we are not catching false positives:

* add to your wp-config `define( 'JETPACK_DEV_DEBUG', true );`
* Still logged in as the secondary admin, Go to Jetpack Debug > Brolen token
* Click "Set invalid user tokens"
* Visit the Jetpack Debugger again
* Go to Jetpack Debug > XML-RPC Errors and confirm you've got a new `unknown_user` error.
* Check that the `error_message` for this error is  "User 1 does not exist" 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*