### PR TITLE
Settings: Change copy to not imply backups have been successful

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -192,7 +192,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 						</div>
 					);
 				}
-				return __( 'Your site is backed up and threat-free.', 'jetpack' );
+				return __( 'Your site is being backed up and monitored for threats.', 'jetpack' );
 			}
 
 			// Only return here if backups enabled and site on on free/personal plan, or if Jetpack Backup is in use.
@@ -204,7 +204,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					planClass
 				)
 			) {
-				return __( 'Your site is backed up.', 'jetpack' );
+				return __( 'Your site is being backed up.', 'jetpack' );
 			}
 
 			// Nothing is enabled. We can show upgrade/setup text now.

--- a/_inc/client/security/jetpack-backup.jsx
+++ b/_inc/client/security/jetpack-backup.jsx
@@ -38,7 +38,7 @@ export class JetpackBackup extends Component {
 					link: getRedirectUrl( 'jetpack-support-backup' ),
 				} }
 			>
-				{ __( 'Your site is backed up.', 'jetpack' ) }
+				{ __( 'Your site is being backed up.', 'jetpack' ) }
 			</SettingsGroup>
 		);
 	};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

The wording for the **Backups and security scanning** card in **Settings** has caused some confusion in the past (see links in "Jetpack product discussion"), so this PR attempts to fix that. Overall, the goal is to reduce the implication that successful backups exist while still explaining that backup functionality is enabled/active.

Fixes `1164141197617539-as-1156835636217697`.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Change copy on the Security settings page for Jetpack Backup and VaultPress customers, so that we don't imply backups have been made.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

Original report: p6TEKc-2ZM-p2
Conversation on what copy to use: p1596726897175800-slack-C0D96691V

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:

* Test with sites that meet the following criteria:
  * Scan and Backup with VaultPress
  * Scan and Backup with Rewind
  * Backup only with VaultPress
  * Backup only with Rewind (unchanged in this PR)
* Verify that the copy for each case matches below screenshots.

#### Screenshots

##### Scan + Backup, with either VaultPress or Rewind

<img width="808" alt="Screen Shot 2020-08-06 at 13 02 42" src="https://user-images.githubusercontent.com/670067/89568458-f457ca00-d7e8-11ea-8902-90e58e7bbe8b.png">

##### Backup only with VaultPress

<img width="804" alt="Screen Shot 2020-08-06 at 13 13 07" src="https://user-images.githubusercontent.com/670067/89568575-21a47800-d7e9-11ea-8178-4997d1e73c35.png">

##### Backup only with Rewind

<img width="806" alt="Screen Shot 2020-08-06 at 13 08 00" src="https://user-images.githubusercontent.com/670067/89568625-3123c100-d7e9-11ea-9f00-12b3ecb95732.png">

#### Proposed changelog entry for your changes:

* Tweaked the wording for "Backups and security scanning" in Settings, to reflect that backups are enabled but not necessarily that they've succeeded.