### PR TITLE
Instant Search: Streamline overlay trigger experience

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -129,7 +129,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 				'enableSort'      => get_option( $prefix . 'enable_sort', '1' ) === '1',
 				'highlightColor'  => get_option( $prefix . 'highlight_color', '#FFC' ),
 				'opacity'         => (int) get_option( $prefix . 'opacity', 97 ),
-				'overlayTrigger'  => get_option( $prefix . 'overlay_trigger', 'immediate' ),
 				'resultFormat'    => get_option( $prefix . 'result_format', 'minimal' ),
 				'showPoweredBy'   => get_option( $prefix . 'show_powered_by', '1' ) === '1',
 			),

--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -96,29 +96,6 @@ class Jetpack_Search_Customize {
 			)
 		);
 
-		$id = $setting_prefix . 'overlay_trigger';
-		$wp_customize->add_setting(
-			$id,
-			array(
-				'default'   => 'results',
-				'transport' => 'postMessage',
-				'type'      => 'option',
-			)
-		);
-		$wp_customize->add_control(
-			$id,
-			array(
-				'label'       => __( 'Search Overlay Trigger', 'jetpack' ),
-				'description' => __( 'Select when your overlay should appear.', 'jetpack' ),
-				'section'     => $section_id,
-				'type'        => 'select',
-				'choices'     => array(
-					'immediate' => __( 'Open immediately', 'jetpack' ),
-					'results'   => __( 'Open when results are available', 'jetpack' ),
-				),
-			)
-		);
-
 		$id = $setting_prefix . 'excluded_post_types';
 		$wp_customize->add_setting(
 			$id,

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -75,6 +75,8 @@ class SearchApp extends Component {
 			input.addEventListener( 'input', this.handleInput );
 		} );
 		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
+			// Prevent 2020 theme's search modal from appearing.
+			button.dataset.toggleTarget && delete button.dataset.toggleTarget;
 			button.addEventListener( 'click', this.handleOverlayTriggerClick, true );
 		} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -129,7 +129,7 @@ class SearchApp extends Component {
 			return;
 		}
 		this.getResults( { query: event.target.value } );
-	}, 200 );
+	}, 100 );
 
 	handleFilterInputClick = event => {
 		event.preventDefault();

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -147,7 +147,6 @@ class SearchApp extends Component {
 	};
 
 	handleOverlayTriggerClick = event => {
-		event.preventDefault();
 		event.stopImmediatePropagation();
 		this.showResults();
 	};

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -77,7 +77,7 @@ class SearchApp extends Component {
 		document
 			.querySelectorAll( this.props.themeOptions.openOverlayButtonSelector )
 			.forEach( button => {
-				button.addEventListener( 'click', this.showResults );
+				button.addEventListener( 'click', this.handleOverlayTriggerClick );
 			} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
@@ -95,7 +95,7 @@ class SearchApp extends Component {
 		document
 			.querySelectorAll( this.props.themeOptions.openOverlayButtonSelector )
 			.forEach( button => {
-				button.removeEventListener( 'click', this.showResults );
+				button.removeEventListener( 'click', this.handleOverlayTriggerClick );
 			} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
@@ -145,6 +145,12 @@ class SearchApp extends Component {
 				setFilterQuery( event.target.dataset.filterType, event.target.dataset.val );
 			}
 		}
+		this.showResults();
+	};
+
+	handleOverlayTriggerClick = event => {
+		event.preventDefault();
+		event.stopImmediatePropagation();
 		this.showResults();
 	};
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -75,7 +75,7 @@ class SearchApp extends Component {
 			input.addEventListener( 'input', this.handleInput );
 		} );
 		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
-			button.addEventListener( 'click', this.handleOverlayTriggerClick );
+			button.addEventListener( 'click', this.handleOverlayTriggerClick, true );
 		} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
@@ -91,7 +91,7 @@ class SearchApp extends Component {
 			input.removeEventListener( 'input', this.handleInput );
 		} );
 		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
-			button.removeEventListener( 'click', this.handleOverlayTriggerClick );
+			button.removeEventListener( 'click', this.handleOverlayTriggerClick, true );
 		} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -74,11 +74,9 @@ class SearchApp extends Component {
 			input.form.addEventListener( 'submit', this.handleSubmit );
 			input.addEventListener( 'input', this.handleInput );
 		} );
-		document
-			.querySelectorAll( this.props.themeOptions.openOverlayButtonSelector )
-			.forEach( button => {
-				button.addEventListener( 'click', this.handleOverlayTriggerClick );
-			} );
+		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
+			button.addEventListener( 'click', this.handleOverlayTriggerClick );
+		} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.addEventListener( 'click', this.handleFilterInputClick );
 		} );
@@ -92,11 +90,9 @@ class SearchApp extends Component {
 			input.form.removeEventListener( 'submit', this.handleSubmit );
 			input.removeEventListener( 'input', this.handleInput );
 		} );
-		document
-			.querySelectorAll( this.props.themeOptions.openOverlayButtonSelector )
-			.forEach( button => {
-				button.removeEventListener( 'click', this.handleOverlayTriggerClick );
-			} );
+		document.querySelectorAll( this.props.themeOptions.overlayTriggerSelector ).forEach( button => {
+			button.removeEventListener( 'click', this.handleOverlayTriggerClick );
+		} );
 		document.querySelectorAll( this.props.themeOptions.filterInputSelector ).forEach( element => {
 			element.removeEventListener( 'click', this.handleFilterInputClick );
 		} );

--- a/modules/search/instant-search/components/search-form.jsx
+++ b/modules/search/instant-search/components/search-form.jsx
@@ -64,7 +64,7 @@ class SearchForm extends Component {
 						onChangeQuery={ this.onChangeQuery }
 						onChangeSort={ this.onChangeSort }
 						query={ getSearchQuery() }
-						shouldRestoreFocus={ this.props.overlayTrigger !== 'immediate' }
+						shouldRestoreFocus
 						showFilters={ this.state.showFilters }
 						sort={ this.props.sort }
 						toggleFilters={ this.toggleFilters }

--- a/modules/search/instant-search/components/search-results.jsx
+++ b/modules/search/instant-search/components/search-results.jsx
@@ -75,7 +75,6 @@ class SearchResults extends Component {
 					locale={ this.props.locale }
 					postTypes={ this.props.postTypes }
 					onChangeSort={ this.props.onChangeSort }
-					overlayTrigger={ this.props.overlayTrigger }
 					response={ this.props.response }
 					sort={ this.props.sort }
 					widgets={ this.props.widgets }

--- a/modules/search/instant-search/lib/customize.js
+++ b/modules/search/instant-search/lib/customize.js
@@ -9,7 +9,6 @@ const SETTINGS_TO_STATE_MAP = new Map( [
 	[ 'jetpack_search_highlight_color', 'highlightColor' ],
 	[ 'jetpack_search_inf_scroll', 'enableInfScroll' ],
 	[ 'jetpack_search_opacity', 'opacity' ],
-	[ 'jetpack_search_overlay_trigger', 'overlayTrigger' ],
 	[ 'jetpack_search_show_powered_by', 'showPoweredBy' ],
 	[ 'jetpack_search_result_format', 'resultFormat' ],
 ] );

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -15,7 +15,7 @@ export function getThemeOptions( searchOptions ) {
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
 		overlayTriggerSelector: [
 			'.jetpack-instant-search__open-overlay-button',
-			'#site-header .header-navigation-wrapper .header-toggles .search-toggle',
+			'#site-header .header-navigation-wrapper .header-toggles .search-toggle', // TwentyTwenty theme's search button
 		].join( ',' ),
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -14,7 +14,7 @@ export function getThemeOptions( searchOptions ) {
 		].join( ', ' ),
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
 		openOverlayButtonSelector: [
-			'.jetpack-instant-search__open-overlay',
+			'.jetpack-instant-search__open-overlay-button',
 			'#site-header .header-navigation-wrapper .header-toggles .search-toggle',
 		].join( ',' ),
 	};

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -13,7 +13,7 @@ export function getThemeOptions( searchOptions ) {
 			'.searchform input.search-field:not(.jetpack-instant-search__box-input)',
 		].join( ', ' ),
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
-		openOverlayButtonSelector: [
+		overlayTriggerSelector: [
 			'.jetpack-instant-search__open-overlay-button',
 			'#site-header .header-navigation-wrapper .header-toggles .search-toggle',
 		].join( ',' ),

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -13,6 +13,10 @@ export function getThemeOptions( searchOptions ) {
 			'.searchform input.search-field:not(.jetpack-instant-search__box-input)',
 		].join( ', ' ),
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
+		openOverlayButtonSelector: [
+			'.jetpack-instant-search__open-overlay',
+			'#site-header .header-navigation-wrapper .header-toggles .search-toggle',
+		].join( ',' ),
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;
 }

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -15,7 +15,7 @@ export function getThemeOptions( searchOptions ) {
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
 		overlayTriggerSelector: [
 			'.jetpack-instant-search__open-overlay-button',
-			'#site-header .header-navigation-wrapper .header-toggles .search-toggle', // TwentyTwenty theme's search button
+			'.search-toggle[data-toggle-target]', // TwentyTwenty theme's search button
 		].join( ',' ),
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;

--- a/modules/search/instant-search/lib/dom.js
+++ b/modules/search/instant-search/lib/dom.js
@@ -15,7 +15,7 @@ export function getThemeOptions( searchOptions ) {
 		filterInputSelector: [ 'a.jetpack-search-filter__link' ],
 		overlayTriggerSelector: [
 			'.jetpack-instant-search__open-overlay-button',
-			'.search-toggle[data-toggle-target]', // TwentyTwenty theme's search button
+			'header#site-header .search-toggle[data-toggle-target]', // TwentyTwenty theme's search button
 		].join( ',' ),
 	};
 	return searchOptions.theme_options ? { ...options, ...searchOptions.theme_options } : options;


### PR DESCRIPTION
Fixes #15923, replaces #16291.

#### Changes proposed in this Pull Request:
* Removes configurable overlay trigger setting from the customizer.
* Overlay is now triggered by search form submission (e.g. user presses enter, in most browsers).
* Preserves result prefetching that occurs while the user is typing.
* Adds manual handling for the Search button in the Twenty Twenty theme.
* Adds handling click events for all elements with the class name `jetpack-instant-search__open-overlay-button`. This enables site owners to create custom overlay trigger buttons.


#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this change to your local Jetpack installation.
2. Navigate to the customizer -> Jetpack Search. Ensure that the Customizer no longer contains a `Search Overlay Trigger`.

> Before:
> <img width="318" alt="Screen Shot 2020-08-06 at 5 08 05 PM" src="https://user-images.githubusercontent.com/4044428/89591508-9686aa80-d807-11ea-9806-5e9431f617ee.png">

> Now:
> <img width="318" alt="Screen Shot 2020-08-06 at 5 09 11 PM" src="https://user-images.githubusercontent.com/4044428/89591531-a1d9d600-d807-11ea-9581-e0bdb388e324.png">

3. Navigate to your site and enter a search query into your search widget's input. 

4. Ensure that the overlay has not been spawned. You can also inspect your browser's network console to verify that search result prefetching is still occurring.

5. Press enter to submit the search form. Ensure that the overlay spawns with your search query prefilled in the overlay search input.

#### Proposed changelog entry for your changes:
* The search overlay is now triggered upon search form submission.
