### PR TITLE
Autoloader: don't reset the autoloader version during plugin update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,9 +65,9 @@ _inc/jetpack-strings.php
 /vendor/autoload.php
 /vendor/autoload_packages.php
 /vendor/autoload_functions.php
-/vendor/autoloader_functions.php
 /vendor/class-autoloader-handler.php
 /vendor/class-classes-handler.php
 /vendor/class-files-handler.php
 /vendor/class-plugins-handler.php
 /vendor/class-version-selector.php
+/vendor/jetpack-autoloader

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ _inc/jetpack-strings.php
 /vendor/autoload.php
 /vendor/autoload_packages.php
 /vendor/autoload_functions.php
+/vendor/autoloader_functions.php
 /vendor/class-autoloader-handler.php
 /vendor/class-classes-handler.php
 /vendor/class-files-handler.php

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -91,6 +91,9 @@ AUTOLOADER_COMMENT;
 		$classMap = $this->getClassMap( $autoloads, $filesystem, $vendorPath, $basePath );
 		$fileMap  = $this->getFileMap( $autoloads, $filesystem, $vendorPath, $basePath );
 
+		// Remove a file that was generated in versions 2.0.0 to 2.1.0.
+		$filesystem->remove( $vendorPath . '/autoload_functions.php' );
+
 		// Generate the files.
 		file_put_contents( $targetDir . '/jetpack_autoload_classmap.php', $this->getAutoloadClassmapPackagesFile( $classMap ) );
 		$this->io->writeError( '<info>Generated ' . $targetDir . '/jetpack_autoload_classmap.php</info>', true );

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -101,8 +101,8 @@ AUTOLOADER_COMMENT;
 		file_put_contents( $vendorPath . '/autoload_packages.php', $this->getAutoloadPackageFile( 'autoload.php', $suffix ) );
 		$this->io->writeError( '<info>Generated ' . $vendorPath . '/autoload_packages.php</info>', true );
 
-		file_put_contents( $vendorPath . '/autoload_functions.php', $this->getAutoloadPackageFile( 'functions.php', $suffix ) );
-		$this->io->writeError( '<info>Generated ' . $vendorPath . '/autoload_functions.php</info>', true );
+		file_put_contents( $vendorPath . '/autoloader_functions.php', $this->getAutoloadPackageFile( 'functions.php', $suffix ) );
+		$this->io->writeError( '<info>Generated ' . $vendorPath . '/autoloader_functions.php</info>', true );
 
 		file_put_contents( $vendorPath . '/class-autoloader-handler.php', $this->getAutoloadPackageFile( 'class-autoloader-handler.php', $suffix ) );
 		$this->io->writeError( '<info>Generated ' . $vendorPath . '/class-autoloader-handler.php</info>', true );

--- a/packages/autoloader/src/AutoloadGenerator.php
+++ b/packages/autoloader/src/AutoloadGenerator.php
@@ -101,8 +101,10 @@ AUTOLOADER_COMMENT;
 		file_put_contents( $vendorPath . '/autoload_packages.php', $this->getAutoloadPackageFile( 'autoload.php', $suffix ) );
 		$this->io->writeError( '<info>Generated ' . $vendorPath . '/autoload_packages.php</info>', true );
 
-		file_put_contents( $vendorPath . '/autoloader_functions.php', $this->getAutoloadPackageFile( 'functions.php', $suffix ) );
-		$this->io->writeError( '<info>Generated ' . $vendorPath . '/autoloader_functions.php</info>', true );
+		$jetpackAutoloaderDir = $vendorPath . '/jetpack-autoloader';
+		$filesystem->ensureDirectoryExists( $jetpackAutoloaderDir );
+		file_put_contents( $jetpackAutoloaderDir . '/autoload_functions.php', $this->getAutoloadPackageFile( 'functions.php', $suffix ) );
+		$this->io->writeError( '<info>Generated ' . $jetpackAutoloaderDir . '/jetpack-autoloader/autoload_functions.php</info>', true );
 
 		file_put_contents( $vendorPath . '/class-autoloader-handler.php', $this->getAutoloadPackageFile( 'class-autoloader-handler.php', $suffix ) );
 		$this->io->writeError( '<info>Generated ' . $vendorPath . '/class-autoloader-handler.php</info>', true );

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -1,6 +1,6 @@
 <?php
 /* HEADER */ // phpcs:ignore
 
-require_once trailingslashit( dirname( __FILE__ ) ) . '/autoload_functions.php';
+require_once trailingslashit( dirname( __FILE__ ) ) . '/autoloader_functions.php';
 
 set_up_autoloader();

--- a/packages/autoloader/src/autoload.php
+++ b/packages/autoloader/src/autoload.php
@@ -1,6 +1,6 @@
 <?php
 /* HEADER */ // phpcs:ignore
 
-require_once trailingslashit( dirname( __FILE__ ) ) . '/autoloader_functions.php';
+require_once trailingslashit( dirname( __FILE__ ) ) . 'jetpack-autoloader/autoload_functions.php';
 
 set_up_autoloader();

--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -42,8 +42,8 @@ function autoloader( $class_name ) {
  * @param Version_Selector $version_selector The Version_Selector object.
  */
 function enqueue_files( $plugins_handler, $version_selector ) {
-	require_once __DIR__ . '/class-classes-handler.php';
-	require_once __DIR__ . '/class-files-handler.php';
+	require_once __DIR__ . '/../class-classes-handler.php';
+	require_once __DIR__ . '/../class-files-handler.php';
 
 	$classes_handler = new Classes_Handler( $plugins_handler, $version_selector );
 	$classes_handler->set_class_paths();
@@ -62,9 +62,9 @@ function set_up_autoloader() {
 	global $jetpack_autoloader_latest_version;
 	global $jetpack_packages_classmap;
 
-	require_once __DIR__ . '/class-plugins-handler.php';
-	require_once __DIR__ . '/class-version-selector.php';
-	require_once __DIR__ . '/class-autoloader-handler.php';
+	require_once __DIR__ . '/../class-plugins-handler.php';
+	require_once __DIR__ . '/../class-version-selector.php';
+	require_once __DIR__ . '/../class-autoloader-handler.php';
 
 	$plugins_handler    = new Plugins_Handler();
 	$version_selector   = new Version_Selector();
@@ -129,7 +129,7 @@ function reset_maps_after_update( $response, $hook_extra, $result ) {
 		$plugin_dir  = str_replace( '\\', '/', WP_PLUGIN_DIR );
 		$plugin_path = trailingslashit( $plugin_dir ) . trailingslashit( explode( '/', $plugin )[0] );
 
-		if ( is_readable( $plugin_path . 'vendor/autoloader_functions.php' ) ) {
+		if ( is_readable( $plugin_path . 'vendor/jetpack-autoloader/autoload_functions.php' ) ) {
 			// The plugin has a >=v2.3 autoloader, so reset the classmap.
 			$jetpack_packages_classmap = array();
 

--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -104,7 +104,6 @@ function set_up_autoloader() {
  * @return bool The passed in $response param.
  */
 function reset_maps_after_update( $response, $hook_extra, $result ) {
-	global $jetpack_autoloader_latest_version;
 	global $jetpack_packages_classmap;
 
 	if ( isset( $hook_extra['plugin'] ) ) {
@@ -130,10 +129,9 @@ function reset_maps_after_update( $response, $hook_extra, $result ) {
 		$plugin_dir  = str_replace( '\\', '/', WP_PLUGIN_DIR );
 		$plugin_path = trailingslashit( $plugin_dir ) . trailingslashit( explode( '/', $plugin )[0] );
 
-		if ( is_readable( $plugin_path . 'vendor/autoload_functions.php' ) ) {
-			// The plugin has a v2.x autoloader, so reset it.
-			$jetpack_autoloader_latest_version = null;
-			$jetpack_packages_classmap         = array();
+		if ( is_readable( $plugin_path . 'vendor/autoloader_functions.php' ) ) {
+			// The plugin has a >=v2.3 autoloader, so reset the classmap.
+			$jetpack_packages_classmap = array();
 
 			set_up_autoloader();
 		}

--- a/packages/autoloader/src/functions.php
+++ b/packages/autoloader/src/functions.php
@@ -130,7 +130,7 @@ function reset_maps_after_update( $response, $hook_extra, $result ) {
 		$plugin_path = trailingslashit( $plugin_dir ) . trailingslashit( explode( '/', $plugin )[0] );
 
 		if ( is_readable( $plugin_path . 'vendor/jetpack-autoloader/autoload_functions.php' ) ) {
-			// The plugin has a >=v2.3 autoloader, so reset the classmap.
+			// The plugin has a >=v2.2 autoloader, so reset the classmap.
 			$jetpack_packages_classmap = array();
 
 			set_up_autoloader();
@@ -139,4 +139,3 @@ function reset_maps_after_update( $response, $hook_extra, $result ) {
 
 	return $response;
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
During a plugin update, an error can be caused by opcache holding the old version of the `autoload_packages.php` file when `find_latest_autoloader()` tries to load the newly installed autoloader. To prevent this, don't try to find the latest autoloader version; just continue using the current autoloader.

Also, change the path of the the `autoload_functions.php` file to `jetpack-autoloader/autoloader_functions.php`. This will help prevent errors caused by the previous versions of the autoloader that have already been released. This path matches the path being used in PR #16819, which is in-progress.

See p9dueE-1IA-p2 for more info about the errors and for a discussion about removing the `reset_maps_after_udpate` method. The method has not been removed in this PR, but it can be if we decide it's best to remove it.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Confirm that plugins that use the autoloader can be successfully updated.
* The changes in this PR should be tested in an updated version of a plugin. You will need to update from a current version of a plugin to a new version of the plugin with the changes in this PR. That will require manual changes to a plugin, and then updating to a plugin zip file that you create. The update should be tested while a plugin with the >2.0 autoloader is already active on a site.

#### Proposed changelog entry for your changes:
* tbd