### PR TITLE
E2E tests: Add retry to .org login method

### DIFF
--- a/tests/e2e/lib/pages/wp-admin/login.js
+++ b/tests/e2e/lib/pages/wp-admin/login.js
@@ -7,8 +7,9 @@ import { createURL } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import Page from '../page';
-import { waitAndClick, waitAndType } from '../../page-helper';
+import { waitAndClick, waitAndType, waitForSelector } from '../../page-helper';
 import { WP_USERNAME, WP_PASSWORD } from '../../setup';
+import logger from '../../logger';
 
 export default class WPLoginPage extends Page {
 	constructor( page ) {
@@ -17,7 +18,7 @@ export default class WPLoginPage extends Page {
 		super( page, { expectedSelector, url } );
 	}
 
-	async login( username = WP_USERNAME, password = WP_PASSWORD ) {
+	async login( username = WP_USERNAME, password = WP_PASSWORD, { retry = true } = {} ) {
 		const ssoLoginButton = '.jetpack-sso.button';
 		if ( ( await this.page.$( ssoLoginButton ) ) !== null ) {
 			await this.toggleSSOLogin();
@@ -26,8 +27,22 @@ export default class WPLoginPage extends Page {
 		await waitAndType( this.page, '#user_login', username );
 		await waitAndType( this.page, '#user_pass', password );
 
-		// await Promise.all( [ this.page.waitForNavigation(), this.page.click( '#wp-submit' ) ] );
-		return await this.page.click( '#wp-submit' );
+		await this.page.click( '#wp-submit' );
+
+		if ( await waitForSelector( this.page, this.expectedSelector, { hidden: true } ) ) {
+		}
+
+		try {
+			await waitForSelector( this.page, this.expectedSelector, {
+				hidden: true,
+			} );
+		} catch ( e ) {
+			if ( retry === true ) {
+				logger.info( `The WPORG login didn't work as expected - retrying now: '${ e }'` );
+				return await this.login( username, password, { retry: false } );
+			}
+			throw e;
+		}
 	}
 
 	async loginSSO() {

--- a/tests/e2e/lib/pages/wp-admin/login.js
+++ b/tests/e2e/lib/pages/wp-admin/login.js
@@ -29,9 +29,6 @@ export default class WPLoginPage extends Page {
 
 		await this.page.click( '#wp-submit' );
 
-		if ( await waitForSelector( this.page, this.expectedSelector, { hidden: true } ) ) {
-		}
-
 		try {
 			await waitForSelector( this.page, this.expectedSelector, {
 				hidden: true,


### PR DESCRIPTION
.org login sometimes fails due to puppeteer failing to type in the credentials correctly. It's kinda hard to figure out why this is happening, so I added a retry attempt to the login method.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* add retry to .org login method

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a
#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a
#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Travis tests still should be green
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* n/a
