### PR TITLE
Jetpack Protect: Replace `user_token` with `blog_token`.

### DIFF
--- a/modules/protect.php
+++ b/modules/protect.php
@@ -249,9 +249,7 @@ class Jetpack_Protect_Module {
 		}
 
 		// Request the key
-		$xml = new Jetpack_IXR_Client( array (
-			'user_id' => get_current_user_id()
-		) );
+		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.protect.requestKey', $request );
 
 		// Hmm, can't talk to wordpress.com


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* The WP.com API endpoint `jetpack.protect.requestKey` does not use the user ID, and can be authenticated using `blog_token`.

#### Jetpack product discussion
Part of the #16709.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Go to "Jetpack Settings -> Security" and confirm that "Brute force attack protection" is disabled.
2. Delete the existing Protect key:
```
delete from wp_options where option_name = 'jetpack_protect_key';
```
3. Enable "Brute force attack protection".
4. Confirm that the key was created and saved into the database:
```
select * from wp_options where option_name = 'jetpack_protect_key';
```

#### Proposed changelog entry for your changes:
n/a
