### PR TITLE
avoid warning on wp cli

### DIFF
--- a/docker/mu-plugins/avoid-plugin-deletion.php
+++ b/docker/mu-plugins/avoid-plugin-deletion.php
@@ -65,6 +65,9 @@ add_action( 'delete_plugin', 'jetpack_docker_disable_delete_plugin', 10, 2 );
  */
 function jetpack_docker_disable_plugin_update( $plugins ) {
 	global $jetpack_docker_avoided_plugins;
+	if ( ! is_array( $jetpack_docker_avoided_plugins ) ) {
+		return $plugins;
+	}
 	foreach ( $jetpack_docker_avoided_plugins as $avoided_plugin ) {
 		if ( isset( $plugins->response[ $avoided_plugin ] ) ) {
 			unset( $plugins->response[ $avoided_plugin ] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Removes Warning that happens sometimes when using `wp cli` in our docker env.

```
[07-Aug-2020 18:16:21 UTC] PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/wp-content/mu-plugins/avoid-plugin-deletion.php on line 68
```

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
do not apply

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

I didn't dig to find the reasons and a way to reproduce this warning. I can tell that for me, right now, if I

* check out https://github.com/Automattic/jetpack/pull/16758
* `wp option get jetpack_protect_key`

I get this Warning on the error log. But I'm not sure what are the conditions to trigger this. Anyway I think this is a safe fix.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No need
