### PR TITLE
Instant Search: Tweak expanded result path styling

### DIFF
--- a/modules/search/instant-search/components/search-result-expanded.scss
+++ b/modules/search/instant-search/components/search-result-expanded.scss
@@ -27,6 +27,10 @@ $min-height: 190px;
 	overflow-x: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	max-width: 40em;
+	.jetpack-instant-search__result-expanded--no-image & {
+		max-width: 46em;
+	}
 }
 
 .jetpack-instant-search__result-expanded__path-link {


### PR DESCRIPTION
Fixes #16693.

#### Changes proposed in this Pull Request:
* Applies a `max-width` rule to the path element for expanded search results.
<img width="685" alt="Screen Shot 2020-08-07 at 4 37 18 PM" src="https://user-images.githubusercontent.com/4044428/89693658-59d0b700-d8cc-11ea-980e-13e330b87427.png">

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this change to your local Jetpack installation.
2. Ensure that you've selected the `Expanded` search result type in the Customizer.
3. Set your search target to `45916486` by overriding the `jetpack_instant_search_options` filter.
4. Search for anything; ensure that the results render as expected.
5. Change your search query to `cailiao`; ensure that the results render without causing layout thrashing as described in #16693.

#### Proposed changelog entry for your changes:
* Tweak styling for the new expanded search result format in Jetpack Search.
