### PR TITLE
Remove usages of removed HTTP_RAW_POST_DATA

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -49,8 +49,6 @@ class Jetpack {
 
 	private $rest_authentication_status = null;
 
-	public $HTTP_RAW_POST_DATA = null; // copy of $GLOBALS['HTTP_RAW_POST_DATA']
-
 	/**
 	 * @var array The handles of styles that are concatenated into jetpack.css.
 	 *
@@ -5510,18 +5508,6 @@ endif;
 			return null;
 		}
 
-		// Ensure that we always have the request body available.  At this
-		// point, the WP REST API code to determine the request body has not
-		// run yet.  That code may try to read from 'php://input' later, but
-		// this can only be done once per request in PHP versions prior to 5.6.
-		// So we will go ahead and perform this read now if needed, and save
-		// the request body where both the Jetpack signature verification code
-		// and the WP REST API code can see it.
-		if ( ! isset( $GLOBALS['HTTP_RAW_POST_DATA'] ) ) {
-			$GLOBALS['HTTP_RAW_POST_DATA'] = file_get_contents( 'php://input' );
-		}
-		$this->HTTP_RAW_POST_DATA = $GLOBALS['HTTP_RAW_POST_DATA'];
-
 		// Only support specific request parameters that have been tested and
 		// are known to work with signature verification.  A different method
 		// can be passed to the WP REST API via the '?_method=' parameter if
@@ -5534,7 +5520,7 @@ endif;
 			);
 			return null;
 		}
-		if ( $_SERVER['REQUEST_METHOD'] !== 'POST' && ! empty( $this->HTTP_RAW_POST_DATA ) ) {
+		if ( 'POST' !== $_SERVER['REQUEST_METHOD'] && ! empty( file_get_contents( 'php://input' ) ) ) {
 			$this->rest_authentication_status = new WP_Error(
 				'rest_invalid_request',
 				__( 'This request method does not support body parameters.', 'jetpack' ),

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -205,19 +205,8 @@ class Manager {
 	 * @todo Tighten $wp_xmlrpc_server_class a bit to make sure it doesn't do bad things.
 	 */
 	public function alternate_xmlrpc() {
-		// phpcs:disable PHPCompatibility.Variables.RemovedPredefinedGlobalVariables.http_raw_post_dataDeprecatedRemoved
-		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
-		global $HTTP_RAW_POST_DATA;
-
 		// Some browser-embedded clients send cookies. We don't want them.
 		$_COOKIE = array();
-
-		// A fix for mozBlog and other cases where '<?xml' isn't on the very first line.
-		if ( isset( $HTTP_RAW_POST_DATA ) ) {
-			$HTTP_RAW_POST_DATA = trim( $HTTP_RAW_POST_DATA );
-		}
-
-		// phpcs:enable
 
 		include_once ABSPATH . 'wp-admin/includes/admin.php';
 		include_once ABSPATH . WPINC . '/class-IXR.php';

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -56,9 +56,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 		remove_filter( 'rest_pre_dispatch', array( $this, 'rest_pre_dispatch' ), 100, 2 );
 		remove_filter( 'pre_option_jetpack_private_options', array( $this, 'mock_jetpack_private_options' ), 10, 2 );
 		wp_set_current_user( 0 );
-		unset( $GLOBALS['HTTP_RAW_POST_DATA'] );
 		$jetpack = Jetpack::init();
-		$jetpack->HTTP_RAW_POST_DATA = null;
 	}
 
 	/**

--- a/tests/php/modules/post-by-email/test-class.post-by-email-api.php
+++ b/tests/php/modules/post-by-email/test-class.post-by-email-api.php
@@ -120,9 +120,6 @@ class WP_Test_Post_By_Email_API extends WP_Test_Jetpack_REST_Testcase {
 		}
 
 		wp_set_current_user( 0 );
-
-		unset( $GLOBALS['HTTP_RAW_POST_DATA'] );
-		Jetpack::init()->HTTP_RAW_POST_DATA = null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #16488
See #15388

#### Changes proposed in this Pull Request:
* Removes last mentions of `HTTP_RAW_POST_DATA`.
* class.jetpack.php -- Removes a usage that could be replaced with `php://input`. It was used for pre-PHP5.6 that couldn't read the input multiple times.
* connection package -- removes a trim for mozblog. We never specifically used this, it was part of a copy/paste from Core's xmlrpc.php that was added into our alt xmlrpc endpoint.
* Tests -- remove references that were there to reset after a test.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* verify unit tests pass.
*

#### Proposed changelog entry for your changes:
* Cleaner Code: removes reference to pre-PHP 5.6 code.
