### PR TITLE
Extend sync_status endpoint with optional debug_details field 

### DIFF
--- a/json-endpoints/jetpack/json-api-jetpack-endpoints.php
+++ b/json-endpoints/jetpack/json-api-jetpack-endpoints.php
@@ -489,6 +489,7 @@ new Jetpack_JSON_API_Sync_Status_Endpoint(
 			'cron_size'             => '(int) Size of the current cron array',
 			'next_cron'             => '(int) The number of seconds till the next item in cron.',
 			'progress'              => '(array) Full Sync status by module',
+			'debug_details'         => '(array) Details as to why Sync is disabled.',
 		),
 		'example_request'  => 'https://public-api.wordpress.com/rest/v1.1/sites/example.wordpress.org/sync/status',
 	)

--- a/packages/sync/src/class-actions.php
+++ b/packages/sync/src/class-actions.php
@@ -225,6 +225,42 @@ class Actions {
 	}
 
 	/**
+	 * Helper function to get details as to why sync is not allowed, if it is not allowed.
+	 *
+	 * @return array
+	 */
+	public static function get_debug_details() {
+		$debug                                  = array();
+		$debug['debug_details']['sync_allowed'] = self::sync_allowed();
+		$debug['debug_details']['sync_health']  = Health::get_status();
+		if ( false === $debug['debug_details']['sync_allowed'] ) {
+			if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+				$debug['debug_details']['is_wpcom'] = true;
+			}
+			if ( defined( 'PHPUNIT_JETPACK_TESTSUITE' ) ) {
+				$debug['debug_details']['PHPUNIT_JETPACK_TESTSUITE'] = true;
+			}
+			if ( ! Settings::is_sync_enabled() ) {
+				$debug['debug_details']['is_sync_enabled']              = false;
+				$debug['debug_details']['jetpack_sync_disable']         = Settings::get_setting( 'disable' );
+				$debug['debug_details']['jetpack_sync_network_disable'] = Settings::get_setting( 'network_disable' );
+			}
+			if ( ( new Status() )->is_offline_mode() ) {
+				$debug['debug_details']['is_offline_mode'] = true;
+			}
+			if ( ( new Status() )->is_staging_site() ) {
+				$debug['debug_details']['is_staging_site'] = true;
+			}
+			$connection = new Jetpack_Connection();
+			if ( ! $connection->is_active() ) {
+				$debug['debug_details']['active_connection'] = false;
+			}
+		}
+		return $debug;
+
+	}
+
+	/**
 	 * Determines if syncing during a cron job is allowed.
 	 *
 	 * @access public
@@ -281,6 +317,7 @@ class Actions {
 	 * @return Jetpack_Error|mixed|WP_Error  The result of the sending request.
 	 */
 	public static function send_data( $data, $codec_name, $sent_timestamp, $queue_id, $checkout_duration, $preprocess_duration, $queue_size = null, $buffer_id = null ) {
+
 		$query_args = array(
 			'sync'       => '1',             // Add an extra parameter to the URL so we can tell it's a sync action.
 			'codec'      => $codec_name,
@@ -768,6 +805,7 @@ class Actions {
 		$next_cron       = ( ! empty( $cron_timestamps ) ) ? $cron_timestamps[0] - time() : '';
 
 		$checksums = array();
+		$debug     = array();
 
 		if ( ! empty( $fields ) ) {
 			$store         = new Replicastore();
@@ -785,6 +823,10 @@ class Actions {
 			if ( in_array( 'comment_meta_checksum', $fields_params, true ) ) {
 				$checksums['comment_meta_checksum'] = $store->comment_meta_checksum();
 			}
+
+			if ( in_array( 'debug_details', $fields_params, true ) ) {
+				$debug = self::get_debug_details();
+			}
 		}
 
 		$full_sync_status = ( $sync_module ) ? $sync_module->get_status() : array();
@@ -794,6 +836,7 @@ class Actions {
 		$result = array_merge(
 			$full_sync_status,
 			$checksums,
+			$debug,
 			array(
 				'cron_size'            => count( $cron_timestamps ),
 				'next_cron'            => $next_cron,


### PR DESCRIPTION
By including the state of various settings in the sync_status endpoint, we can notify support of which checks are failing that would stop Sync from sending data to WP.com

#### Changes proposed in this Pull Request:
* Adds debug_details field to sync_status endpoint

#### Jetpack product discussion
* P2 forthcoming :)

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No this data is also available in various settings, this simply compiles it for direct access.

#### Testing instructions:

* Simplest method of testing is from a WP.com Sandbox
* Run `wp shell`
* `$jsm = new Jetpack_Sync_Manager(172156119 );`
* `$jsm->get_sync_status( false, true );`
* Verify debug_details are returned 
* `$jsm->get_sync_status( true );`
* Verify debug_details are not returned but checksum fields (4 of them) are.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Extend sync_status endpoint with debug_details optional field.
