### PR TITLE
External Media: Fix `speak` announcements

### DIFF
--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -11,8 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
 import { withNotices, Modal } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import { speak } from '@wordpress/a11y';
+import { __ } from '@wordpress/i18n';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
 import { withSelect } from '@wordpress/data';
 
@@ -170,18 +169,6 @@ export default function withMedia() {
 				if ( this.modalElement ) {
 					this.modalElement.focus();
 				}
-
-				// Announce the action with appended string of all the images' alt text.
-				speak(
-					sprintf(
-						__( 'Inserting: %s', 'jetpack' ),
-						items
-							.map( item => item.title )
-							.filter( item => item )
-							.join( ', ' )
-					),
-					'polite'
-				);
 
 				apiFetch( {
 					path: apiUrl,


### PR DESCRIPTION
The `speak` message is currently announced on insertion of the image. I have removed this `speak` message and did not replace it, as focus is moved to the top of the modal on insert, and it's best to not make an announcement while moving focus as one of the messages will get lost anyways. It's best to let the focus move handle the announcement.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/jetpack/issues/16695

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Removes `speak` announcement when image is being inserted into the editor.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to the block editor
* Insert an image block
* Turn on a screen reader
* Click Select Media > Pexels Free Photos 
* Select a photo
* Insert the photo
* There should be no "Inserting: [alt text]" announcement

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
I don't think a changelog entry is necessary here, as it's a minor change.
