### PR TITLE
Instant Search: Add sanitizers for Customizer checkbox controls

### DIFF
--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
 require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
 require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
 require_once dirname( __FILE__ ) . '/customize-controls/class-excluded-post-types-control.php';
@@ -227,10 +228,11 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default'           => '1',
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'transport'         => 'postMessage',
-				'type'              => 'option',
+				'default'              => '1',
+				'sanitize_callback'    => array( 'Jetpack_Search_Helpers', 'sanitize_checkbox_value' ),
+				'sanitize_js_callback' => array( 'Jetpack_Search_Helpers', 'sanitize_checkbox_value_for_js' ),
+				'transport'            => 'postMessage',
+				'type'                 => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -246,10 +248,11 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default'           => '1',
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'transport'         => 'postMessage',
-				'type'              => 'option',
+				'default'              => '1',
+				'sanitize_callback'    => array( 'Jetpack_Search_Helpers', 'sanitize_checkbox_value' ),
+				'sanitize_js_callback' => array( 'Jetpack_Search_Helpers', 'sanitize_checkbox_value_for_js' ),
+				'transport'            => 'postMessage',
+				'type'                 => 'option',
 			)
 		);
 		$wp_customize->add_control(
@@ -265,10 +268,11 @@ class Jetpack_Search_Customize {
 		$wp_customize->add_setting(
 			$id,
 			array(
-				'default'           => '1',
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'transport'         => 'postMessage',
-				'type'              => 'option',
+				'default'              => '1',
+				'sanitize_callback'    => array( 'Jetpack_Search_Helpers', 'sanitize_checkbox_value' ),
+				'sanitize_js_callback' => array( 'Jetpack_Search_Helpers', 'sanitize_checkbox_value_for_js' ),
+				'transport'            => 'postMessage',
+				'type'                 => 'option',
 			)
 		);
 		$wp_customize->add_control(

--- a/modules/search/class.jetpack-search-helpers.php
+++ b/modules/search/class.jetpack-search-helpers.php
@@ -738,4 +738,28 @@ class Jetpack_Search_Helpers {
 			get_post_types( array( 'exclude_from_search' => false ), 'objects' )
 		);
 	}
+
+	/**
+	 * Sanitizes a checkbox value for writing to the database.
+	 *
+	 * @since 8.9.0
+	 *
+	 * @param any $value from the customizer form.
+	 * @return string either '0' or '1'.
+	 */
+	public static function sanitize_checkbox_value( $value ) {
+		return true === $value ? '1' : '0';
+	}
+
+	/**
+	 * Sanitizes a checkbox value for rendering the Customizer.
+	 *
+	 * @since 8.9.0
+	 *
+	 * @param any $value from the database.
+	 * @return boolean
+	 */
+	public static function sanitize_checkbox_value_for_js( $value ) {
+		return '1' === $value;
+	}
 }


### PR DESCRIPTION
Fixes #16734 (and a handful of customer support issues).

#### Changes proposed in this Pull Request:
* Sanitizes what we write to the database for checkbox inputs. Instead of `true`/`false`, we now write `'1'`/`'0'`.
* Sanitizes what we return to the customizer for the initial render. It correctly interprets `'1'` as truthy and `'0'` as falsy. 

This fixes a bug where the user tries to save one of the checkbox settings to a falsy value before the said value exists in the database. See the aforementioned issue for details.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this patch to a new Jetpack installation; I recommend using Jurassic Ninja to spin up a new site.
2. Ensure that a Jetpack Search subscription exists for your site.
3. Navigate to the Customizer -> Jetpack Search.
4. Uncheck one (or all) of the checkboxes and press publish.
5. Refresh the page and return to the Jetpack Search section.
6. Ensure that your selection from step 4 has been properly persisted.

#### Proposed changelog entry for your changes:
* Fixes a bug where Jetpack Search changes wouldn't properly save in the Customizer.
