### PR TITLE
External Media: Arrow keys navigation

### DIFF
--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -152,7 +152,8 @@ function MediaBrowser( props ) {
 		}
 	}, [ media ] );
 
-	const handleMediaItemClick = ( event, { item, index } ) => {
+	// Using _event to avoid eslint errors. Can change to event if it's in use again.
+	const handleMediaItemClick = ( _event, { item } ) => {
 		select( item );
 	};
 

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -79,8 +79,6 @@ function MediaBrowser( props ) {
 		[ className ]: true,
 	} );
 
-	const prevMediaCount = useRef( 0 );
-
 	const onLoadMoreClick = () => {
 		if ( media.length ) {
 			setFocused( media.length );

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { memo, useCallback, useState, useRef } from '@wordpress/element';
+import { memo, useCallback, useState, useRef, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { UP, DOWN, LEFT, RIGHT, SPACE, ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -37,8 +39,12 @@ function MediaBrowser( props ) {
 		onCopy,
 	} = props;
 	const [ selected, setSelected ] = useState( [] );
+	const [ focused, setFocused ] = useState( -1 );
 
-	const onSelectImage = useCallback(
+	const columns = useRef( -1 );
+	const gridEl = useRef( null );
+
+	const select = useCallback(
 		newlySelected => {
 			let newSelected = [ newlySelected ];
 
@@ -76,8 +82,93 @@ function MediaBrowser( props ) {
 	const prevMediaCount = useRef( 0 );
 
 	const onLoadMoreClick = () => {
-		prevMediaCount.current = media.length;
+		if ( media.length ) {
+			setFocused( media.length );
+		}
 		nextPage();
+	};
+
+	const navigate = ( keyCode, index ) => {
+		switch ( keyCode ) {
+			case LEFT:
+				if ( index >= 1 ) {
+					setFocused( index - 1 );
+				}
+				break;
+			case RIGHT:
+				if ( index < media.length ) {
+					setFocused( index + 1 );
+				}
+				break;
+			case UP:
+				if ( index >= columns.current ) {
+					setFocused( index - columns.current );
+				}
+				break;
+			case DOWN:
+				if ( index < media.length - columns.current ) {
+					setFocused( index + columns.current );
+				}
+				break;
+		}
+	};
+
+	/**
+	 * Counts how many items are in a row by checking how many of the grid's child
+	 * items have a matching offsetTop.
+	 */
+	const checkColumns = () => {
+		let perRow = 1;
+
+		const items = gridEl.current.children;
+
+		if ( items.length > 0 ) {
+			const firstOffset = items[ 0 ].offsetTop;
+
+			/**
+			 * Check how many items have a matching offsetTop. This will give us the
+			 * total number of items in a row.
+			 */
+			while ( perRow < items.length && items[ perRow ].offsetTop === firstOffset ) {
+				++perRow;
+			}
+		}
+
+		columns.current = perRow;
+	};
+
+	const checkColumnsDebounced = debounce( checkColumns, 400 );
+
+	useEffect( () => {
+		// Re-set columns on window resize:
+		window.addEventListener( 'resize', checkColumnsDebounced );
+		return () => {
+			window.removeEventListener( 'resize', checkColumnsDebounced );
+		};
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect( () => {
+		// Set columns value once when media are loaded.
+		if ( media.length && columns.current === -1 ) {
+			checkColumns();
+		}
+	}, [ media ] );
+
+	const handleMediaItemClick = ( event, { item, index } ) => {
+		select( item );
+	};
+
+	const handleMediaItemKeyDown = ( event, { item, index } ) => {
+		if ( [ LEFT, RIGHT, UP, DOWN ].includes( event.keyCode ) ) {
+			navigate( event.keyCode, index );
+		} else if ( SPACE === event.keyCode ) {
+			select( item );
+			event.preventDefault(); // Prevent space from scrolling the page down.
+		} else if ( ENTER === event.keyCode ) {
+			select( item );
+		}
+
+		event.stopPropagation();
 	};
 
 	const SelectButton = () => {
@@ -95,13 +186,15 @@ function MediaBrowser( props ) {
 
 	return (
 		<div className={ wrapper }>
-			<ul className={ classes }>
+			<ul ref={ gridEl } className={ classes }>
 				{ media.map( ( item, index ) => (
 					<MediaItem
 						item={ item }
+						index={ index }
 						key={ item.ID }
-						onClick={ onSelectImage }
-						focusOnMount={ !! prevMediaCount.current && index === prevMediaCount.current }
+						onClick={ handleMediaItemClick }
+						onKeyDown={ handleMediaItemKeyDown }
+						focus={ index === focused }
 						isSelected={ selected.find( toFind => toFind.ID === item.ID ) }
 						isCopying={ isCopying }
 					/>

--- a/extensions/shared/external-media/media-browser/index.js
+++ b/extensions/shared/external-media/media-browser/index.js
@@ -167,7 +167,9 @@ function MediaBrowser( props ) {
 			select( item );
 		}
 
-		event.stopPropagation();
+		if ( [ LEFT, RIGHT, UP, DOWN, SPACE, ENTER ].includes( event.keyCode ) ) {
+			event.stopPropagation();
+		}
 	};
 
 	const SelectButton = () => {

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/extensions/shared/external-media/media-browser/media-item.js
+++ b/extensions/shared/external-media/media-browser/media-item.js
@@ -8,26 +8,27 @@ import classnames from 'classnames';
  */
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
-import { ENTER, SPACE } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 
 function MediaItem( props ) {
-	const onClick = useCallback( () => {
-		if ( props.onClick ) {
-			props.onClick( props.item );
-		}
-	}, [ props.onClick ] );
+	const onClick = event => {
+		const { item, index } = props;
 
-	// Catch space and enter key presses.
-	const onKeyDown = event => {
-		if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
-			// Prevent spacebar from scrolling the page down.
-			event.preventDefault();
-			onClick( event );
+		if ( props.onClick ) {
+			props.onClick( event, { item, index } );
 		}
 	};
 
-	const { item, focusOnMount, isSelected, isCopying = false } = props;
+	// Catch space and enter key presses.
+	const onKeyDown = event => {
+		const { item, index } = props;
+
+		if ( props.onKeyDown ) {
+			props.onKeyDown( event, { item, index } );
+		}
+	};
+
+	const { item, focus, isSelected, isCopying = false } = props;
 	const { thumbnails, caption, name, title, type, children = 0 } = item;
 	const { medium = null, fmt_hd = null } = thumbnails;
 	const alt = title || caption || name;
@@ -41,12 +42,10 @@ function MediaItem( props ) {
 	const itemEl = useRef( null );
 
 	useEffect( () => {
-		if ( focusOnMount ) {
+		if ( focus ) {
 			itemEl.current.focus();
 		}
-		// Passing empty dependency array to focus on mount only.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	}, [ focus ] );
 
 	/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 	return (

--- a/extensions/shared/external-media/media-button/index.js
+++ b/extensions/shared/external-media/media-button/index.js
@@ -33,7 +33,9 @@ function MediaButton( props ) {
 	};
 
 	return (
-		<>
+		// No added functionality, just capping event propagation.
+		// eslint-disable-next-line  jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+		<div onClick={ event => event.stopPropagation() }>
 			<MediaButtonMenu
 				{ ...props }
 				setSelectedSource={ setSelectedSource }
@@ -42,7 +44,7 @@ function MediaButton( props ) {
 			/>
 
 			{ ExternalLibrary && <ExternalLibrary onClose={ closeLibrary } { ...mediaProps } /> }
-		</>
+		</div>
 	);
 }
 

--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -38,8 +38,10 @@ export default function withMedia() {
 				};
 			}
 
-			modalRef = el => {
+			contentRef = el => {
 				if ( el ) {
+					// Store modal content.
+					this.contentElement = el;
 					// Find the modal wrapper.
 					this.modalElement = el.closest( '.jetpack-external-media-browser' );
 
@@ -51,6 +53,7 @@ export default function withMedia() {
 					// Remove listeners when unmounting.
 					this.modalElement.removeEventListener( 'keydown', this.stopArrowKeysPropagation );
 					this.modalElement = null;
+					this.contentElement = null;
 				}
 			};
 
@@ -69,7 +72,10 @@ export default function withMedia() {
 				 * This can be removed once
 				 * https://github.com/WordPress/gutenberg/issues/22940 is fixed.
 				 */
-				if ( [ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) ) {
+				if (
+					[ UP, DOWN, LEFT, RIGHT ].includes( event.keyCode ) &&
+					! event.target.classList.contains( 'jetpack-external-media-browser__media__item' ) // Only let arrow key navigation on media grid items through. All others need to be stopped.
+				) {
 					event.stopPropagation();
 				}
 			};
@@ -262,7 +268,7 @@ export default function withMedia() {
 						aria={ { describedby } }
 						className={ classes }
 					>
-						<div ref={ this.modalRef }>
+						<div ref={ this.contentRef }>
 							{ noticeUI }
 
 							<p id={ describedby } className="jetpack-external-media-browser--visually-hidden">


### PR DESCRIPTION
Adds arrow key navigation on media items in the external media browser modal. This brings it to have parity with the core Media Library image grid navigation.

![arrow-key-media-grid](https://user-images.githubusercontent.com/967608/84435242-1a049080-abf7-11ea-9e93-0ebd863a8729.gif)

#### Changes proposed in this Pull Request:
* Adds a `onKeyDown` prop to `MediaItem`
* Adds a `columns` ref and window resize listener to count and store the number of grid image columns. This is used to know where to send focus to when the up/down arrow keys are pressed.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to a post and add an Image or Gallery block
* **Arrow key presses _should not close the modal_**. Focus different elements (search input, search button, etc) and press the arrow keys. It should never close the modal. Arrow keys should operate normally inside inputs (like the search input).
* **Media Grid image items should be able to navigate with arrow key presses**
* **Resize the browser to less than or greater than 600px so the images restack.** The `columns` number should be updated and up/down arrow keys should bring you to the correct image.
* **All other functionality should still work** (Selecting images via click, space, enter; load more, etc)

**Duplicate of a potentially messed up branch for easier review and work: https://github.com/Automattic/jetpack/pull/16118**
