### PR TITLE
Theme Tools: Resolve PHP 7.4 array offset notice.

### DIFF
--- a/modules/theme-tools/social-menu.php
+++ b/modules/theme-tools/social-menu.php
@@ -60,7 +60,7 @@ add_action( 'restapi_theme_init', 'jetpack_social_menu_init' );
 function jetpack_social_menu_get_type() {
 	$options = get_theme_support( 'jetpack-social-menu' );
 
-	if ( empty( $options ) ) {
+	if ( ! $options || ! is_array( $options ) || ! isset( $options[0] ) ) {
 		$menu_type = null;
 	} else {
 		$menu_type = ( in_array( $options[0], array( 'genericons', 'svg' ) ) ) ? $options[0] : 'genericons';


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/php-7-4-errors/

#### Changes proposed in this Pull Request:
* Ensure that the value used is an array with the applicable offset before use.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* n/a
*

#### Proposed changelog entry for your changes:
* Theme Tools: Resolve a PHP notice in PHP 7.4.
