### PR TITLE
Social Previews: Add upgrade path

### DIFF
--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -9,27 +9,24 @@ import { __ } from '@wordpress/i18n';
  */
 import analytics from '../../../_inc/client/lib/analytics';
 import upgradeImageUrl from './upgrade-illustration.svg';
-import { BUSINESS_PLAN } from '../../shared/components/upgrade-nudge/constants';
 import useUpgradeFlow from '../../shared/use-upgrade-flow';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 import { name } from './index';
 
-const trackClickEvent = () =>
-	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
-		plan: BUSINESS_PLAN,
-		block: name,
-	} );
-
 export default function SocialPreviewsUpgrade() {
-	const {
-		details: { required_plan },
-	} = getJetpackExtensionAvailability( name );
+	const required_plan = getJetpackExtensionAvailability( name )?.details?.required_plan;
+	const trackClickEvent = () =>
+		void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+			plan: required_plan,
+			block: name,
+		} );
+
 	const [ href, autosaveAndRedirect, isRedirecting ] = useUpgradeFlow(
 		required_plan,
 		trackClickEvent
 	);
 
-	const redirectingText = __( 'Redirecting…', 'jetpack' );
+	const buttonText = isRedirecting ? __( 'Redirecting…', 'jetpack' ) : __( 'Upgrade', 'jetpack' );
 
 	return (
 		<div className="jetpack-social-previews__modal-upgrade">
@@ -72,7 +69,7 @@ export default function SocialPreviewsUpgrade() {
 					target="_top"
 					isBusy={ isRedirecting }
 				>
-					{ isRedirecting ? redirectingText : __( 'Upgrade', 'jetpack' ) }
+					{ buttonText }
 				</Button>
 			</div>
 		</div>

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -11,22 +11,27 @@ import { useEffect } from '@wordpress/element';
 import analytics from '../../../_inc/client/lib/analytics';
 import upgradeImageUrl from './upgrade-illustration.svg';
 import { BUSINESS_PLAN } from '../../shared/components/upgrade-nudge/constants';
-import useUpgradeFlow from "../../shared/use-upgrade-flow";
+import useUpgradeFlow from '../../shared/use-upgrade-flow';
+import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
+import { name } from './index';
 
 const trackViewEvent = () =>
 	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
 		plan: BUSINESS_PLAN,
-		block: 'social-previews',
+		block: name,
 	} );
 
 const trackClickEvent = () =>
 	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
 		plan: BUSINESS_PLAN,
-		block: 'social-previews',
+		block: name,
 	} );
 
 export default function SocialPreviewsUpgrade() {
-	const [ href, autosaveAndRedirect ] = useUpgradeFlow( BUSINESS_PLAN, trackClickEvent );
+	const {
+		details: { required_plan },
+	} = getJetpackExtensionAvailability( name );
+	const [ href, autosaveAndRedirect ] = useUpgradeFlow( required_plan, trackClickEvent );
 
 	// Using the effect here so the tracking is only called once on component mount.
 	useEffect( trackViewEvent, [] );

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -11,20 +11,14 @@ import analytics from '../../../_inc/client/lib/analytics';
 import upgradeImageUrl from './upgrade-illustration.svg';
 import useUpgradeFlow from '../../shared/use-upgrade-flow';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
-import { name } from './index';
+import { name as block } from './index';
 
 export default function SocialPreviewsUpgrade() {
-	const required_plan = getJetpackExtensionAvailability( name )?.details?.required_plan;
+	const plan = getJetpackExtensionAvailability( block )?.details?.required_plan;
 	const trackClickEvent = () =>
-		void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
-			plan: required_plan,
-			block: name,
-		} );
+		void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', { plan, block } );
 
-	const [ href, autosaveAndRedirect, isRedirecting ] = useUpgradeFlow(
-		required_plan,
-		trackClickEvent
-	);
+	const [ href, autosaveAndRedirect, isRedirecting ] = useUpgradeFlow( plan, trackClickEvent );
 
 	const buttonText = isRedirecting ? __( 'Redirecting…', 'jetpack' ) : __( 'Upgrade', 'jetpack' );
 

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -31,10 +31,15 @@ export default function SocialPreviewsUpgrade() {
 	const {
 		details: { required_plan },
 	} = getJetpackExtensionAvailability( name );
-	const [ href, autosaveAndRedirect ] = useUpgradeFlow( required_plan, trackClickEvent );
+	const [ href, autosaveAndRedirect, isRedirecting ] = useUpgradeFlow(
+		required_plan,
+		trackClickEvent
+	);
 
 	// Using the effect here so the tracking is only called once on component mount.
 	useEffect( trackViewEvent, [] );
+
+	const redirectingText = __( 'Redirecting…', 'jetpack' );
 
 	return (
 		<div className="jetpack-social-previews__modal-upgrade">
@@ -69,15 +74,15 @@ export default function SocialPreviewsUpgrade() {
 						) }
 					</li>
 				</ul>
-
 				<Button
 					href={ href } // Only for server-side rendering, since onClick doesn't work there.
 					isPrimary
 					label={ __( 'Purchase a business plan to access social previews', 'jetpack' ) }
 					onClick={ autosaveAndRedirect }
 					target="_top"
+					isBusy={ isRedirecting }
 				>
-					{ __( 'Upgrade', 'jetpack' ) }
+					{ isRedirecting ? redirectingText : __( 'Upgrade', 'jetpack' ) }
 				</Button>
 			</div>
 		</div>

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -3,7 +3,6 @@
  */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,12 +13,6 @@ import { BUSINESS_PLAN } from '../../shared/components/upgrade-nudge/constants';
 import useUpgradeFlow from '../../shared/use-upgrade-flow';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 import { name } from './index';
-
-const trackViewEvent = () =>
-	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
-		plan: BUSINESS_PLAN,
-		block: name,
-	} );
 
 const trackClickEvent = () =>
 	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
@@ -35,9 +28,6 @@ export default function SocialPreviewsUpgrade() {
 		required_plan,
 		trackClickEvent
 	);
-
-	// Using the effect here so the tracking is only called once on component mount.
-	useEffect( trackViewEvent, [] );
 
 	const redirectingText = __( 'Redirecting…', 'jetpack' );
 

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -1,15 +1,28 @@
 /**
  * External dependencies
  */
+import { compact, get } from 'lodash';
+import { Button } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { Button } from '@wordpress/components';
+import analytics from '../../../_inc/client/lib/analytics';
+import { isSimpleSite } from '../../shared/site-type-utils';
+import getSiteFragment from '../../shared/get-site-fragment';
 import upgradeImageUrl from './upgrade-illustration.svg';
 
-const SocialPreviewsUpgrade = function SocialPreviewsUpgrade() {
+const SocialPreviewsUpgrade = function SocialPreviewsUpgrade( {
+	autosaveAndRedirect,
+	href,
+	trackViewEvent,
+} ) {
+	trackViewEvent();
+
 	return (
 		<div className="jetpack-social-previews__modal-upgrade">
 			<img
@@ -43,10 +56,82 @@ const SocialPreviewsUpgrade = function SocialPreviewsUpgrade() {
 						) }
 					</li>
 				</ul>
-				<Button isPrimary>{ __( 'Upgrade', 'jetpack' ) }</Button>
+
+				<Button
+					href={ href } // Only for server-side rendering, since onClick doesn't work there.
+					isPrimary
+					label={ __( 'Purchase a business plan to access social previews', 'jetpack' ) }
+					onClick={ autosaveAndRedirect }
+					target="_top"
+				>
+					{ __( 'Upgrade', 'jetpack' ) }
+				</Button>
 			</div>
 		</div>
 	);
 };
 
-export default SocialPreviewsUpgrade;
+export default compose( [
+	withSelect( select => {
+		const plan = select( 'wordpress-com/plans' ).getPlan( 'business-bundle' );
+		const planPathSlug = get( plan, [ 'path_slug' ] );
+
+		const postId = select( 'core/editor' ).getCurrentPostId();
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		// The editor for CPTs has an `edit/` route fragment prefixed.
+		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
+
+		// Post-checkout: redirect back here.
+		const redirect_to = isSimpleSite()
+			? addQueryArgs(
+					'/' +
+						compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
+							'/'
+						),
+					{
+						plan_upgraded: 1,
+					}
+			  )
+			: addQueryArgs(
+					window.location.protocol +
+						`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
+					{
+						action: 'edit',
+						post: postId,
+						plan_upgraded: 1,
+					}
+			  );
+
+		const href =
+			planPathSlug &&
+			addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
+				redirect_to,
+			} );
+
+		return {
+			href,
+			trackViewEvent: () =>
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_nudge_impression', {
+					plan: planPathSlug,
+					block: 'social-previews',
+				} ),
+			trackClickEvent: () =>
+				void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+					plan: planPathSlug,
+					block: 'social-previews',
+				} ),
+		};
+	} ),
+	withDispatch( ( dispatch, { href, trackClickEvent } ) => ( {
+		autosaveAndRedirect: async event => {
+			event.preventDefault(); // Don't follow the href before auto-saving.
+
+			trackClickEvent();
+			await dispatch( 'core/editor' ).autosave();
+
+			// Using window.top to escape from the editor iframe on WordPress.com.
+			window.top.location.href = href;
+		},
+	} ) ),
+] )( SocialPreviewsUpgrade );

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -7,6 +7,7 @@ import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,7 +22,8 @@ const SocialPreviewsUpgrade = function SocialPreviewsUpgrade( {
 	href,
 	trackViewEvent,
 } ) {
-	trackViewEvent();
+	// Using the effect here so the tracking is only called once on component mount.
+	useEffect( trackViewEvent, [] );
 
 	return (
 		<div className="jetpack-social-previews__modal-upgrade">

--- a/extensions/blocks/social-previews/upgrade.js
+++ b/extensions/blocks/social-previews/upgrade.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { compact, get } from 'lodash';
+import { compact } from 'lodash';
 import { Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
@@ -16,6 +16,7 @@ import analytics from '../../../_inc/client/lib/analytics';
 import { isSimpleSite } from '../../shared/site-type-utils';
 import getSiteFragment from '../../shared/get-site-fragment';
 import upgradeImageUrl from './upgrade-illustration.svg';
+import { BUSINESS_PLAN } from '../../shared/components/upgrade-nudge/constants';
 
 const SocialPreviewsUpgrade = function SocialPreviewsUpgrade( {
 	autosaveAndRedirect,
@@ -75,11 +76,12 @@ const SocialPreviewsUpgrade = function SocialPreviewsUpgrade( {
 
 export default compose( [
 	withSelect( select => {
-		const plan = select( 'wordpress-com/plans' ).getPlan( 'business-bundle' );
-		const planPathSlug = get( plan, [ 'path_slug' ] );
-
+		const plan = select( 'wordpress-com/plans' ).getPlan( BUSINESS_PLAN );
 		const postId = select( 'core/editor' ).getCurrentPostId();
 		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		const planPathSlug = plan?.path_slug;
+		const domain = getSiteFragment();
 
 		// The editor for CPTs has an `edit/` route fragment prefixed.
 		const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
@@ -87,17 +89,13 @@ export default compose( [
 		// Post-checkout: redirect back here.
 		const redirect_to = isSimpleSite()
 			? addQueryArgs(
-					'/' +
-						compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join(
-							'/'
-						),
+					'/' + compact( [ postTypeEditorRoutePrefix, postType, domain, postId ] ).join( '/' ),
 					{
 						plan_upgraded: 1,
 					}
 			  )
 			: addQueryArgs(
-					window.location.protocol +
-						`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
+					window.location.protocol + `//${ domain.replace( '::', '/' ) }/wp-admin/post.php`,
 					{
 						action: 'edit',
 						post: postId,
@@ -107,7 +105,7 @@ export default compose( [
 
 		const href =
 			planPathSlug &&
-			addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
+			addQueryArgs( `https://wordpress.com/checkout/${ domain }/${ planPathSlug }`, {
 				redirect_to,
 			} );
 

--- a/extensions/shared/components/upgrade-nudge/constants.js
+++ b/extensions/shared/components/upgrade-nudge/constants.js
@@ -1,3 +1,0 @@
-export const FREE_PLAN = 'free_plan';
-export const PREMIUM_PLAN = 'value_bundle';
-export const BUSINESS_PLAN = 'business-bundle';

--- a/extensions/shared/components/upgrade-nudge/constants.js
+++ b/extensions/shared/components/upgrade-nudge/constants.js
@@ -1,0 +1,3 @@
+export const FREE_PLAN = 'free_plan';
+export const PREMIUM_PLAN = 'value_bundle';
+export const BUSINESS_PLAN = 'business-bundle';

--- a/extensions/shared/plan-utils.js
+++ b/extensions/shared/plan-utils.js
@@ -38,21 +38,21 @@ export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
 	// Post-checkout: redirect back here
 	const redirect_to = isSimpleSite()
 		? addQueryArgs(
-			'/' +
-			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' ),
-			{
-				plan_upgraded: 1,
-			}
-		)
+				'/' +
+					compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' ),
+				{
+					plan_upgraded: 1,
+				}
+		  )
 		: addQueryArgs(
-			window.location.protocol +
-			`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
-			{
-				action: 'edit',
-				post: postId,
-				plan_upgraded: 1,
-			}
-		);
+				window.location.protocol +
+					`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
+				{
+					action: 'edit',
+					post: postId,
+					plan_upgraded: 1,
+				}
+		  );
 
 	return (
 		planPathSlug &&

--- a/extensions/shared/plan-utils.js
+++ b/extensions/shared/plan-utils.js
@@ -20,7 +20,7 @@ import getSiteFragment from './get-site-fragment';
  *
  * @param {object} siteParams -          Site params used to build the URL.
  * @param {string} siteParams.planSlug - Plan slug.
- * @param {string} siteParams.plan -     An object with details about the plan.
+ * @param {object} siteParams.plan -     An object with details about the plan.
  * @param {number} siteParams.postId -   Post id.
  * @param {string} siteParams.postType - Post type.
  * @returns {string}                     Upgrade URL.

--- a/extensions/shared/plan-utils.js
+++ b/extensions/shared/plan-utils.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { compact, get, startsWith } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { isSimpleSite } from './site-type-utils';
+import getSiteFragment from './get-site-fragment';
+
+/**
+ * Return the checkout URL to upgrade the site plan,
+ * depending on the plan, postId, and postType site values.
+ *
+ * @param {object} siteParams -          Site params used to build the URL.
+ * @param {string} siteParams.planSlug - Plan slug.
+ * @param {string} siteParams.plan -     An object with details about the plan.
+ * @param {number} siteParams.postId -   Post id.
+ * @param {string} siteParams.postType - Post type.
+ * @returns {string}                     Upgrade URL.
+ */
+export function getUpgradeUrl( { planSlug, plan, postId, postType } ) {
+	// WP.com plan objects have a dedicated `path_slug` field, Jetpack plan objects don't
+	// For Jetpack, we thus use the plan slug with the 'jetpack_' prefix removed.
+	const planPathSlug = startsWith( planSlug, 'jetpack_' )
+		? planSlug.substr( 'jetpack_'.length )
+		: get( plan, [ 'path_slug' ] );
+
+	// The editor for CPTs has an `edit/` route fragment prefixed
+	const postTypeEditorRoutePrefix = [ 'page', 'post' ].includes( postType ) ? '' : 'edit';
+
+	// Post-checkout: redirect back here
+	const redirect_to = isSimpleSite()
+		? addQueryArgs(
+			'/' +
+			compact( [ postTypeEditorRoutePrefix, postType, getSiteFragment(), postId ] ).join( '/' ),
+			{
+				plan_upgraded: 1,
+			}
+		)
+		: addQueryArgs(
+			window.location.protocol +
+			`//${ getSiteFragment().replace( '::', '/' ) }/wp-admin/post.php`,
+			{
+				action: 'edit',
+				post: postId,
+				plan_upgraded: 1,
+			}
+		);
+
+	return (
+		planPathSlug &&
+		addQueryArgs( `https://wordpress.com/checkout/${ getSiteFragment() }/${ planPathSlug }`, {
+			redirect_to,
+		} )
+	);
+}

--- a/extensions/shared/use-upgrade-flow/README.md
+++ b/extensions/shared/use-upgrade-flow/README.md
@@ -1,0 +1,43 @@
+UseUpgradeFlow hook
+-------------------
+
+Use this hook when you need to implement a component that leads the user to the checkout page.
+
+### Usage
+
+```es6
+/**
+ * Internal dependencies
+ */
+import useUpgradeFlow from '../../shared/use-upgrade-flow/index';
+
+const myUPgradeComponent = () => {
+	const [ checkoutUrl, goToCheckoutPage ] = useUpgradeFlow( 'business-bundle' );
+	return (
+        <Button
+            href={ checkoutUrl }
+            onClick={ goToCheckoutPage }
+        >
+            CheckOut!
+        </Button>
+    );
+};
+```
+
+### API
+
+```es6
+const [ checkoutUrl, goToCheckoutPage ] = useUpgradeFlow( planSlug, onRedirect );
+```
+
+The hook returns an array with two items.
+
+
+The first one (checkoutUrl) is a string with the checkout URL.
+You can use this value to set the href of an anchor element, for instance.
+
+The second item (goToCheckoutPage) is a function that can be used as a callback in an onClick event.
+It redirects the user to the checkout URL, checking before whether the current post/page/etc has changes to save.
+If so, it saves them before to redirect.
+
+The hook accepts two argument. the planSug and an (optional) callback function that will be run when the redirect process triggers. 

--- a/extensions/shared/use-upgrade-flow/README.md
+++ b/extensions/shared/use-upgrade-flow/README.md
@@ -1,5 +1,4 @@
-UseUpgradeFlow hook
--------------------
+## UseUpgradeFlow hook
 
 Use this hook when you need to implement a component that leads the user to the checkout page.
 
@@ -12,32 +11,37 @@ Use this hook when you need to implement a component that leads the user to the 
 import useUpgradeFlow from '../../shared/use-upgrade-flow/index';
 
 const myUPgradeComponent = () => {
-	const [ checkoutUrl, goToCheckoutPage ] = useUpgradeFlow( 'business-bundle' );
+	const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( 'business-bundle' );
 	return (
-        <Button
-            href={ checkoutUrl }
-            onClick={ goToCheckoutPage }
-        >
-            CheckOut!
-        </Button>
-    );
+		<Button href={ checkoutUrl } onClick={ goToCheckoutPage } isBusy={ isRedirecting }>
+			CheckOut!
+		</Button>
+	);
 };
 ```
 
 ### API
 
-```es6
-const [ checkoutUrl, goToCheckoutPage ] = useUpgradeFlow( planSlug, onRedirect );
-```
+`const [ checkoutUrl, goToCheckoutPage, isRedirecting ] = useUpgradeFlow( planSlug, onRedirect );`
 
-The hook returns an array with two items.
+#### Arguments
 
+The hook accepts two arguments.
 
-The first one (checkoutUrl) is a string with the checkout URL.
-You can use this value to set the href of an anchor element, for instance.
+- `planSlug` (`string`) - Slug of plan to purchase
+- _(optional)_ `onRedirect` (`(string) => void`) - callback function that will
+  be run when the redirect process triggers. The new URL is passed.
 
-The second item (goToCheckoutPage) is a function that can be used as a callback in an onClick event.
-It redirects the user to the checkout URL, checking before whether the current post/page/etc has changes to save.
-If so, it saves them before to redirect.
+### Return Values
 
-The hook accepts two argument. the planSug and an (optional) callback function that will be run when the redirect process triggers. 
+The hook returns an array with three items.
+
+- `checkoutUrl` (`string`): The checkout URL. You can use this value to set the href of an anchor element.
+- `goToCheckoutPage` (`(event) => void`): Callback to be used in an onClick event.
+
+Redirects the user to the checkout URL, checking before whether the current
+post/page/etc has changes to save. If so, it saves them before to redirect.
+
+- `isRedirecting` (`bool`): If the component is in the process of redirecting the
+  user. It may be waiting for a save to complete before redirecting. Use
+  this to set a button as busy or in a loading state.

--- a/extensions/shared/use-upgrade-flow/index.js
+++ b/extensions/shared/use-upgrade-flow/index.js
@@ -1,4 +1,3 @@
-
 /**
  * External dependencies
  */
@@ -8,6 +7,7 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect, dispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,9 +23,11 @@ function redirect( url, callback ) {
 	window.top.location.href = url;
 }
 
-import { getUpgradeUrl } from "../plan-utils";
+import { getUpgradeUrl } from '../plan-utils';
 
-export default function useUpgradeFlow ( planSlug, onRedirect = noop ) {
+export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+
 	const { checkoutUrl, isAutosaveablePost, isDirtyPost } = useSelect( select => {
 		const editorSelector = select( 'core/editor' );
 		const planSelector = select( 'wordpress-com/plans' );
@@ -50,6 +52,13 @@ export default function useUpgradeFlow ( planSlug, onRedirect = noop ) {
 
 		event.preventDefault();
 
+		// Lock re-redirecting attempts.
+		if ( isRedirecting ) {
+			return;
+		}
+
+		setIsRedirecting( true );
+
 		/*
 		 * If there are not unsaved values, redirect.
 		 * If the post is not auto-savable, redirect.
@@ -63,5 +72,5 @@ export default function useUpgradeFlow ( planSlug, onRedirect = noop ) {
 		savePost( event ).then( () => redirect( checkoutUrl, onRedirect ) );
 	};
 
-	return [ checkoutUrl, goToCheckoutPage ];
+	return [ checkoutUrl, goToCheckoutPage, isRedirecting ];
 }

--- a/extensions/shared/use-upgrade-flow/index.js
+++ b/extensions/shared/use-upgrade-flow/index.js
@@ -45,7 +45,7 @@ export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
 	// Alias. Save post by dispatch.
 	const savePost = dispatch( 'core/editor' ).savePost;
 
-	const goToCheckoutPage = event => {
+	const goToCheckoutPage = async event => {
 		if ( ! window?.top?.location?.href ) {
 			return;
 		}
@@ -64,7 +64,6 @@ export default function useUpgradeFlow( planSlug, onRedirect = noop ) {
 		 * If the post is not auto-savable, redirect.
 		 */
 		if ( ! isDirtyPost || ! isAutosaveablePost ) {
-			// Using window.top to escape from the editor iframe on WordPress.com
 			return redirect( checkoutUrl, onRedirect );
 		}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Takes inspiration from `UpgradeNudge` and `BlockNudge` to save the post and redirect to the checkout flow of the Business plan.

Reuses the following event:`jetpack_editor_block_upgrade_click`. We'll do a follow up PR for view event tracking.

Fixes #16781.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds tracking for upgrade modal view and Upgrade link click
* Autosaves current post and redirects to plan checkout flow for a business plan. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Similar to `UpgradeNudge` tracking.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* follow setup steps from #16615.
* ~When testing on dotcom, make sure D48017-code is applied.~ No longer required as now in Production.
* ~this PR currently shows both paid and unpaid versions of the sidebar. Click the one with~ If tested on local Jetpack Plugin, you will need to comment out [`social-previews` here](https://github.com/Automattic/jetpack/blob/c95e5fdb82110b54cb5e18b89b1558e37caead50/class.jetpack-plan.php#L35) in order to activate the "upgrade nudge".
* Click the  "Learn More" button and it opens up this upgrade nudge
* Click on "Upgrade" to see the post being saved before being redirected to the checkout flow.

* Additionally, confirm that both events are recorded when you do this flow:

Set the debug with `localStorage.setItem( 'debug', 'dops:analytics*' );`

```
dops:analytics Record event "jetpack_editor_block_upgrade_nudge_impression" called with props {"plan":"business-bundle","block":"social-previews","blog_id":"60487750"} +1ms
```

```
dops:analytics Record event "jetpack_editor_block_upgrade_click" called with props {"plan":"business-bundle","block":"social-previews","blog_id":"60487750"} +0ms
```

ProTip: Preserv the log in order to see the second event when the redirect happens.

<img width="825" alt="Screen Shot 2020-08-14 at 9 34 35 AM" src="https://user-images.githubusercontent.com/77539/90249784-72cbf180-de11-11ea-8ea6-cb0dc74b91ed.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Not needed.
