### PR TITLE
Calendly Block: Add edit button to block toolbar

### DIFF
--- a/extensions/blocks/calendly/edit.js
+++ b/extensions/blocks/calendly/edit.js
@@ -8,7 +8,7 @@ import queryString from 'query-string';
 /**
  * WordPress dependencies
  */
-import { BlockIcon, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls, BlockIcon, InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	ExternalLink,
@@ -17,6 +17,7 @@ import {
 	Placeholder,
 	Spinner,
 	ToggleControl,
+	Toolbar,
 	withNotices,
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
@@ -63,7 +64,8 @@ function CalendlyEdit( props ) {
 		style,
 		url,
 	} = validatedAttributes;
-	const [ embedCode, setEmbedCode ] = useState( '' );
+	const [ embedCode, setEmbedCode ] = useState( url );
+	const [ isEditingUrl, setIsEditingUrl ] = useState( false );
 	const [ isResolvingUrl, setIsResolvingUrl ] = useState( false );
 	const [ embedButtonAttributes, setEmbedButtonAttributes ] = useState( {} );
 
@@ -116,6 +118,7 @@ function CalendlyEdit( props ) {
 			.then( () => {
 				const newValidatedAttributes = getValidatedAttributes( attributeDetails, newAttributes );
 				setAttributes( newValidatedAttributes );
+				setIsEditingUrl( false );
 				noticeOperations.removeAllNotices();
 			} )
 			.catch( () => {
@@ -237,6 +240,13 @@ function CalendlyEdit( props ) {
 
 	const inspectorControls = (
 		<>
+			{ url && ! isEditingUrl && (
+				<BlockControls>
+					<Toolbar>
+						<Button onClick={ () => setIsEditingUrl( true ) }>{ __( 'Edit', 'jetpack' ) }</Button>
+					</Toolbar>
+				</BlockControls>
+			) }
 			{ url && (
 				<BlockStylesSelector
 					clientId={ clientId }
@@ -294,7 +304,7 @@ function CalendlyEdit( props ) {
 	return (
 		<div className={ classes }>
 			{ inspectorControls }
-			{ url ? blockPreview( style ) : blockPlaceholder }
+			{ url && ! isEditingUrl ? blockPreview( style ) : blockPlaceholder }
 		</div>
 	);
 }

--- a/extensions/blocks/calendly/editor.scss
+++ b/extensions/blocks/calendly/editor.scss
@@ -32,4 +32,8 @@
 	div[data-align=center] > & {
 		text-align: center;
 	}
+
+	.components-placeholder__fieldset input {
+		flex: 1;
+	}
 }


### PR DESCRIPTION
Fixes #15357

#### Changes proposed in this Pull Request:
* Adds an Edit button to the Calendly block toolbar
* Fixes width of form field in Calendly block's placeholder form

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
* Edit a post adding a Calendly block
* Apply this PR
* Confirm existing Calendly block functions as expected and toolbar has new Edit button
* Add a new Calendly block and then edit that block's Calendly URL or embed code
* Ensure block updates appropriately

#### Before

<img width="669" alt="Screen Shot 2020-08-11 at 1 36 13 pm" src="https://user-images.githubusercontent.com/60436221/89854658-c8b55500-dbd7-11ea-8fb3-dfb330a0ca65.png">

#### After

![Calendly-EditButton](https://user-images.githubusercontent.com/60436221/89854680-d2d75380-dbd7-11ea-8e0f-b90e7d8262aa.gif)


#### Proposed changelog entry for your changes:
* Calendly Block: Add edit button to toolbar
