### PR TITLE
Cover Block: Force notice text color so it is visible

### DIFF
--- a/extensions/shared/blocks/cover/editor.scss
+++ b/extensions/shared/blocks/cover/editor.scss
@@ -20,3 +20,7 @@
 		min-width: 100%;
 	}
 }
+
+.wp-block-cover .components-notice {
+	color: #191e23;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16157

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Forces visible text color for component notices within cover blocks

NOTE: This PR would just be to fix the issue in the short term prior to a change being merged into core.

#### Does this pull request change what data or activity we track or use?
No, it does not.

#### Testing instructions:
* Edit a post, adding a cover block and selecting a background color for it
* Insert OpenTable block within the cover block
* Select the "wide" style for the OpenTable block, then align that block to the center
* You should see a notice displayed above the OpenTable block within the cover block but the text's color will match the notice background.
* Save post
* Apply this PR
* The notice text should clearly be visible

#### Before

<img width="690" alt="Screen Shot 2020-08-11 at 2 10 37 pm" src="https://user-images.githubusercontent.com/60436221/89858975-3ca92a80-dbe3-11ea-9a2d-8ddebe5f7870.png">

#### After

<img width="690" alt="Screen Shot 2020-08-11 at 2 28 47 pm" src="https://user-images.githubusercontent.com/60436221/89858983-3e72ee00-dbe3-11ea-97b2-c7c05d7d41cf.png">


#### Proposed changelog entry for your changes:
* Improved visibility of notice text when displayed within cover block
