### PR TITLE
Slideshow Block: Hide Swiper next and previous button arrows

### DIFF
--- a/extensions/blocks/slideshow/style.scss
+++ b/extensions/blocks/slideshow/style.scss
@@ -109,6 +109,17 @@
 		display: none;
 	}
 
+	// Prevent swiper button pseudo-element content displaying duplicate arrows.
+	.swiper-button-prev:after,
+	.swiper-container-rtl .swiper-button-next:after {
+		content: "";
+	}
+
+	.swiper-button-next:after,
+	.swiper-container-rtl .swiper-button-prev:after {
+		content: "";
+	}
+
 	&.swiper-container-rtl .swiper-button-prev.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-prev,
 	.swiper-button-next.swiper-button-white,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16719

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Hide duplicate slideshow control arrows introduced via Swiper dependency update

Note: This just applies the CSS fix suggested in the [linked issue](https://github.com/Automattic/jetpack/issues/16719). Any issues with build artifacts can be addressed in a separate PR. This just aims to get this fixed visually as quickly as possible for users.

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
* Apply this PR branch
* Edit a post adding a Slideshow block with images
* There should be no duplicate arrows within the slideshow next/prev buttons
* Save post and confirm the frontend displays correctly as well

#### Before
<img width="659" alt="Screen Shot 2020-08-11 at 4 47 08 pm" src="https://user-images.githubusercontent.com/60436221/89866652-420e7100-dbf3-11ea-89a7-9facfb862add.png">

#### After
<img width="669" alt="Screen Shot 2020-08-11 at 4 46 37 pm" src="https://user-images.githubusercontent.com/60436221/89866661-463a8e80-dbf3-11ea-8730-197b682b762c.png">

#### Proposed changelog entry for your changes:
* Slideshow Block: Fix duplicate control arrows.
