### PR TITLE
Allow pure Gutenberg extensions to be registered with Jetpack (with plan gate).

### DIFF
--- a/extensions/blocks/social-previews/editor.js
+++ b/extensions/blocks/social-previews/editor.js
@@ -19,7 +19,7 @@ registerJetpackPlugin( name, settings );
  * extension availability so will not render the Plugin if the extension is not
  * availabile.
  */
-const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' );
+const extensionAvailableOnPlan = getJetpackExtensionAvailability( 'social-previews' )?.available;
 
 if ( ! extensionAvailableOnPlan ) {
     registerPlugin( `jetpack-${name}-upgrade-nudge`, {

--- a/extensions/blocks/social-previews/social-previews.php
+++ b/extensions/blocks/social-previews/social-previews.php
@@ -12,17 +12,17 @@ namespace Automattic\Jetpack\Extensions\Social_Previews;
 use Jetpack_Gutenberg;
 
 const FEATURE_NAME = 'social-previews';
-const BLOCK_NAME   = 'jetpack/' . FEATURE_NAME;
+const EXTENSION_NAME   = 'jetpack/' . FEATURE_NAME;
 
 /**
  * Registers the Social Previews feature with the block editor.
  */
-function register_block() {
-	jetpack_register_block(
-		BLOCK_NAME,
+function register_extension() {
+	jetpack_register_extension(
+		EXTENSION_NAME,
 		array(
 			'plan_check' => true,
 		)
 	);
 }
-add_action( 'init', __NAMESPACE__ . '\register_block' );
+add_action( 'init', __NAMESPACE__ . '\register_extension' );


### PR DESCRIPTION
Alternative approach to https://github.com/Automattic/jetpack/pull/16746.

Enables registering a Gutenberg extension with Jetpack _without_ registering a block **but** _including_ a plan check. New the API is:

```php
function register_extension() {
	jetpack_register_extension(
		EXTENSION_NAME,
		array(
			'plan_check' => true,
		)
	);
}
add_action( 'init', __NAMESPACE__ . '\register_extension' );
```

## Why do this?
Some extensions for the Gutenberg editor in Jetpack are not strictly blocks. However, there is no way to register an extension with _Jetpack_ which is gated by a plan without either:

- manually setting the extension to be available using [`set_extension_available`](https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L257-L259).
- calling [`register_jetpack_block`](https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L24).

Moreover, if you need to gate your extension to a particular plan on either Jetpack or WPCom then you are forced to either:

- use `register_jetpack_block` with the `plan_check` argument - this is odd because the nomenclature of `extension` and `block` is jarring and confusing.
- manually call [`set_extension_available`](https://github.com/Automattic/jetpack/blob/11f81f14bb3df0b8c561981574106a1c2646206a/class.jetpack-gutenberg.php#L257-L259) and perform the plan checks yourself manually.

This PR attempts to normalise the situation by creating a new helper `register_jetpack_extension` which essential captures the functionality of `register_jetpack_block` (including the ability to do plan checks), but avoids registering a block with Gutenberg via `register_block`. The original `register_jetpack_block` is left in place, but now simply delegates the bulk of its functionality to the aforementioned `register_jetpack_extension`, and then simply calls `register_block` if extension registration is successful. 

## Use Cases

The `social-previews` extension needs to be gated for WPCom but not for Jetpack. Currently, in order to do this we are forced to register a _block_ which doesn't do anything (because it isn't a block!). This is confusing because the `social-previews` feature is not a block - it is purely adding to the Jetpack sidebar.

Using the new approach in this PR we are able to register the `social-previews` extension and gate it to WPCom plans.

## Changes proposed in this Pull Request:

This change allows us to:

- register Gutenberg extensions within Jetpack without registering a block.
- gate an extension to a WPCom or Jetpack plan in a central location.
- avoid spreading gating logic for Jetpack extensions within individual files (or indeed within the WPCom codebase as per this diff D46955-code).
- continue to register Jetpack blocks "as was" - this PR should preserve existing functionality.

## Jetpack product discussion
See 84-gh-dotcom-manage.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions:

Same as https://github.com/Automattic/jetpack/pull/16746.

We should also check that all existing Jetpack blocks continue to be register "as was".

#### Proposed changelog entry for your changes:

* Allow Gutenberg extensions which need to be gated by plan to be registered via Jetpack without registering a corresponding block.