### PR TITLE
Rename `allow_blog_token_when_site_is_private` on tweetstorm endpoint 

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -55,7 +55,9 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 				),
 				'methods'                               => WP_REST_Server::READABLE,
 				'callback'                              => array( $this, 'gather_tweetstorm' ),
-				'allow_blog_token_when_site_is_private' => true,
+				'private_site_security_settings' => [
+					'allow_blog_token_access' => true,
+				],
 				'permission_callback'                   => '__return_true',
 			)
 		);

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php
@@ -46,19 +46,19 @@ class WPCOM_REST_API_V2_Endpoint_Tweetstorm_Gather extends WP_REST_Controller {
 			$this->namespace,
 			$this->rest_base,
 			array(
-				'args'                                  => array(
+				'args'                           => array(
 					'url' => array(
 						'description' => __( 'The tweet URL to gather from.', 'jetpack' ),
 						'type'        => 'string',
 						'required'    => true,
 					),
 				),
-				'methods'                               => WP_REST_Server::READABLE,
-				'callback'                              => array( $this, 'gather_tweetstorm' ),
-				'private_site_security_settings' => [
+				'methods'                        => WP_REST_Server::READABLE,
+				'callback'                       => array( $this, 'gather_tweetstorm' ),
+				'private_site_security_settings' => array(
 					'allow_blog_token_access' => true,
-				],
-				'permission_callback'                   => '__return_true',
+				),
+				'permission_callback'            => '__return_true',
 			)
 		);
 	}


### PR DESCRIPTION
Related to changes allowing backups to be made accessed for coming soon sites.

Differential Revision: D47231-code

This commit syncs r212027-wpcom.
