### PR TITLE
Shortcodes: Add support for proxying Instagram embeds via WP.com API

### DIFF
--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -100,6 +100,10 @@ wp_embed_register_handler(
  * @param string $url     The original URL that was matched by the regex.
  */
 function jetpack_instagram_handler( $matches, $atts, $url ) {
+	if ( ! Jetpack::is_active_and_not_offline_mode() ) {
+		return jetpack_instagram_output_errored_embed( $url );
+	}
+
 	global $content_width;
 
 	// keep a copy of the passed-in URL since it's modified below.
@@ -174,8 +178,7 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
 	}
 
 	if ( is_wp_error( $response_body ) || empty( $response_body->html ) ) {
-		jetpack_instagram_output_errored_embed( $url );
-		return;
+		return jetpack_instagram_output_errored_embed( $url );
 	}
 
 	if ( $use_cache ) {
@@ -202,12 +205,15 @@ function jetpack_instagram_handler( $matches, $atts, $url ) {
  * Given a URL, will output an HTML comment and the linked URL.
  *
  * @param string $url The URL that was attempted to embed.
+ *
+ * @return string The linked URL to the Instagram item.
  */
 function jetpack_instagram_output_errored_embed( $url ) {
-	?>
-		<!-- Jetpack Instagram Embed: Failed to fetch from API -->
-		<a href="<?php echo esc_url( $url ); ?>"><?php echo esc_url_raw( $url ); ?></a>
-	<?php
+	return sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( $url ),
+		esc_url_raw( $url )
+	);
 }
 
 /**

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -264,7 +264,7 @@ function jetpack_instagram_fetch_embed( $args ) {
 		if ( ! Jetpack::is_active() ) {
 			return new WP_Error(
 				'jetpack_not_active',
-				'Jetpack must be active to fetch Instagram embed'
+				esc_html__( 'Jetpack must be active to fetch Instagram embed', 'jetpack' )
 			);
 		}
 
@@ -285,7 +285,7 @@ function jetpack_instagram_fetch_embed( $args ) {
 	) {
 		return new WP_Error(
 			'instagram_error',
-			'Invalid Instagram resource'
+			esc_html__( 'Invalid Instagram resource', 'jetpack' )
 		);
 	}
 

--- a/modules/shortcodes/instagram.php
+++ b/modules/shortcodes/instagram.php
@@ -100,10 +100,6 @@ wp_embed_register_handler(
  * @param string $url     The original URL that was matched by the regex.
  */
 function jetpack_instagram_handler( $matches, $atts, $url ) {
-	if ( ! Jetpack::is_active_and_not_offline_mode() ) {
-		return jetpack_instagram_output_errored_embed( $url );
-	}
-
 	global $content_width;
 
 	// keep a copy of the passed-in URL since it's modified below.
@@ -261,7 +257,7 @@ function jetpack_instagram_fetch_embed( $args ) {
 		);
 		$response = wp_remote_get( $url, array( 'redirection' => 0 ) );
 	} else {
-		if ( ! Jetpack::is_active() ) {
+		if ( ! Jetpack::is_active_and_not_offline_mode() ) {
 			return new WP_Error(
 				'jetpack_not_active',
 				esc_html__( 'Jetpack must be active to fetch Instagram embed', 'jetpack' )

--- a/tests/php/modules/shortcodes/test-class.instagram.php
+++ b/tests/php/modules/shortcodes/test-class.instagram.php
@@ -1,9 +1,16 @@
 <?php
 
+use Automattic\Jetpack\Constants;
+
 class WP_Test_Jetpack_Shortcodes_Instagram extends WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
+
+		// Note: This forces the tests below to use the WPCOM/legacy flow. This means that
+		// the call to the /oembed-proxy endpoint isn't covered with tests. We should create
+		// at least one test below that specifically covers that.
+		Constants::set_constant( 'IS_WPCOM', true );
 
 		// Back compat for PHPUnit 3!
 		// @todo Remove this when WP's PHP version bumps.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds some logic for conditionally proxying embed requests through a new `/oembed-proxy/instagram` endpoint which will then make an authenticated request to Facebook's API to get embed information for a given Instagram URL.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See p7H4VZ-2DU-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes. 

This PR will begin making authenticated requests to the WordPress.com API to get embed information for Instagram URLs which will create logs for those requests. These logs have the standard retention policy as other API request logs.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- In WPCOM sandbox, checkout D47837-code
- Be sure to sandbox Jetpack site with `JETPACK__SANDBOX_DOMAIN` constant
- Create new post with Instagram URL embedded
- View post on frontend
- Ensure that Instagram URL is embedded (this should cover the standard Jetpack flow)
- Ensure that unit tests pass (this should cover the WP.com flow)

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Begins proxying requests for Instagram embeds through WordPress.com in preparation for Facebook requiring authentication on all of their endpoints on October 24th.

#### Known issues

At the moment, there is one known issue where the embed doesn't properly preview in Gutenberg. I'm posting a screenshot below. If you happen to review this, and are interested, I'd definitely appreciate any debug assistance. 😄 

<img width="803" alt="Screen Shot 2020-08-11 at 9 18 38 PM" src="https://user-images.githubusercontent.com/1126811/89968179-cd4e2d80-dc18-11ea-991f-1caf769f1f9b.png">

