### PR TITLE
Infinite Scroll: Fix bug condition where no wrapper is present

### DIFF
--- a/modules/infinite-scroll/infinity.js
+++ b/modules/infinite-scroll/infinity.js
@@ -486,12 +486,16 @@
 
 			// If 'click' type and there are still posts to fetch, add back the handle
 			if ( type == 'click' ) {
-				// add focus to new posts, only in button mode as we know where page focus currently is
-				document
-					.querySelector( '#infinite-view-' + ( self.page + self.offset - 1 ) + ' a:first-of-type' )
-					.focus( {
-						preventScroll: true,
-					} );
+				// add focus to new posts, only in button mode as we know where page focus currently is and only if we have a wrapper
+				if ( infiniteScroll.settings.wrapper ) {
+					document
+						.querySelector(
+							'#infinite-view-' + ( self.page + self.offset - 1 ) + ' a:first-of-type'
+						)
+						.focus( {
+							preventScroll: true,
+						} );
+				}
 
 				if ( response.lastbatch ) {
 					if ( self.click_handle ) {


### PR DESCRIPTION
Conditional check for wrapper before giving focus to new page.

Fixes #16807

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Bug fix, add small conditional

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

N/A

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Make sure Jetpack 8.8 or Jetpack 8.8.1 is installed and activated
* Activate a Theme with Support for Infinite Scroll with the following settings: `'type' => 'click', 'wrapper' => false,`
* Go to the Dashboard > Jetpack > Settings > Writing
* Scroll down to 'Theme enhancements' > 'Infinite Scroll'
* Check 'Load more posts in page with a button' and click 'Save settings'
* Switch to the front end of the site and go to the blog page
* Scroll down to and click the 'Load more' button ( Make sure the site has enough posts for the Infinite Scroll button to be visible )
* Check for JS errors and that the load more button continues to work

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
