### PR TITLE
Compat: add new Creative Mail compat file

### DIFF
--- a/3rd-party/3rd-party.php
+++ b/3rd-party/3rd-party.php
@@ -20,6 +20,7 @@ function load_3rd_party() {
 		'buddypress.php',
 		'class.jetpack-amp-support.php',
 		'class.jetpack-modules-overrides.php', // Special case. Tools to be used to override module settings.
+		'creative-mail.php',
 		'debug-bar.php',
 		'domain-mapping.php',
 		'polldaddy.php',

--- a/3rd-party/creative-mail.php
+++ b/3rd-party/creative-mail.php
@@ -32,7 +32,8 @@ function try_install() {
 
 	check_admin_referer( 'creative-mail-install' );
 
-	$result = false;
+	$result   = false;
+	$redirect = admin_url( 'edit.php?post_type=feedback' );
 
 	// Attempt to install and activate the plugin.
 	if ( current_user_can( 'activate_plugins' ) ) {

--- a/3rd-party/creative-mail.php
+++ b/3rd-party/creative-mail.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Compatibility functions for the Creative Mail plugin.
+ * https://wordpress.org/plugins/creative-mail-by-constant-contact/
+ *
+ * @since 8.9.0
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Creative_Mail;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+const PLUGIN_SLUG = 'creative-mail-by-constant-contact';
+const PLUGIN_FILE = 'creative-mail-by-constant-contact/creative-mail-plugin.php';
+
+add_action( 'admin_notices', __NAMESPACE__ . '\error_notice' );
+add_action( 'admin_init', __NAMESPACE__ . '\try_install' );
+
+/**
+ * Verify the intent to install Creative Mail, and kick off installation.
+ *
+ * This works in tandem with a JITM set up in the JITM package.
+ */
+function try_install() {
+	if ( ! isset( $_GET['creative-mail-action'] ) ) {
+		return;
+	}
+
+	check_admin_referer( 'creative-mail-install' );
+
+	$result = false;
+
+	// Attempt to install and activate the plugin.
+	if ( current_user_can( 'activate_plugins' ) ) {
+		switch ( $_GET['creative-mail-action'] ) {
+			case 'install':
+				$result = install_and_activate();
+				break;
+			case 'activate':
+				$result = activate();
+				break;
+		}
+	}
+
+	if ( $result ) {
+		$redirect = admin_url( 'admin.php?page=creativemail' );
+	} else {
+		$redirect = add_query_arg( 'creative-mail-install-error', true, $redirect );
+	}
+
+	wp_safe_redirect( $redirect );
+
+	exit;
+}
+
+/**
+ * Install and activate the Creative Mail plugin.
+ *
+ * @return bool result of installation
+ */
+function install_and_activate() {
+	jetpack_require_lib( 'plugins' );
+	$result = \Jetpack_Plugins::install_and_activate_plugin( PLUGIN_SLUG );
+
+	if ( is_wp_error( $result ) ) {
+		return false;
+	} else {
+		return true;
+	}
+}
+
+/**
+ * Activate the Creative Mail plugin.
+ *
+ * @return bool result of activation
+ */
+function activate() {
+	$result = activate_plugin( PLUGIN_FILE );
+
+	// Activate_plugin() returns null on success.
+	return is_null( $result );
+}
+
+/**
+ * Notify the user that the installation of Creative Mail failed.
+ */
+function error_notice() {
+	if ( empty( $_GET['creative-mail-install-error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return;
+	}
+
+	?>
+	<div class="notice notice-error is-dismissible">
+		<p><?php esc_html_e( 'There was an error installing Creative Mail.', 'jetpack' ); ?></p>
+	</div>
+	<?php
+}

--- a/3rd-party/creative-mail.php
+++ b/3rd-party/creative-mail.php
@@ -19,6 +19,7 @@ const PLUGIN_FILE = 'creative-mail-by-constant-contact/creative-mail-plugin.php'
 
 add_action( 'admin_notices', __NAMESPACE__ . '\error_notice' );
 add_action( 'admin_init', __NAMESPACE__ . '\try_install' );
+add_action( 'jetpack_activated_plugin', __NAMESPACE__ . '\configure_plugin', 10, 2 );
 
 /**
  * Verify the intent to install Creative Mail, and kick off installation.
@@ -48,6 +49,8 @@ function try_install() {
 	}
 
 	if ( $result ) {
+		/** This action is already documented in _inc/lib/class.core-rest-api-endpoints.php */
+		do_action( 'jetpack_activated_plugin', PLUGIN_FILE, 'jitm' );
 		$redirect = admin_url( 'admin.php?page=creativemail' );
 	} else {
 		$redirect = add_query_arg( 'creative-mail-install-error', true, $redirect );
@@ -99,4 +102,27 @@ function error_notice() {
 		<p><?php esc_html_e( 'There was an error installing Creative Mail.', 'jetpack' ); ?></p>
 	</div>
 	<?php
+}
+
+/**
+ * Set some options when first activating the plugin via Jetpack.
+ *
+ * @since 8.9.0
+ *
+ * @param string $plugin_file Plugin file.
+ * @param string $source      Where did the plugin installation originate.
+ */
+function configure_plugin( $plugin_file, $source ) {
+	if ( PLUGIN_FILE !== $plugin_file ) {
+		return;
+	}
+
+	$plugin_info = array(
+		'plugin'  => 'jetpack',
+		'version' => JETPACK__VERSION,
+		'time'    => time(),
+		'source'  => esc_attr( $source ),
+	);
+
+	update_option( 'CE4WP_REFERRED_BY', $plugin_info );
 }

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -6,6 +6,7 @@ module.exports = [
 	'3rd-party/bbpress.php',
 	'3rd-party/class.jetpack-amp-support.php',
 	'3rd-party/class-jetpack-bbpress-rest-api.php',
+	'3rd-party/creative-mail.php',
 	'3rd-party/woocommerce-services.php',
 	'class.jetpack-bbpress-json-api.compat.php',
 	'class.jetpack-gutenberg.php',

--- a/packages/jitm/src/class-post-connection-jitm.php
+++ b/packages/jitm/src/class-post-connection-jitm.php
@@ -124,6 +124,40 @@ class Post_Connection_JITM extends JITM {
 	}
 
 	/**
+	 * A special filter used in the CTA of a JITM offering to install the Creative Mail plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_creative_mail_install() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'creative-mail-action' => 'install',
+				),
+				admin_url( 'edit.php?post_type=feedback' )
+			),
+			'creative-mail-install'
+		);
+	}
+
+	/**
+	 * A special filter used in the CTA of a JITM offering to activate the Creative Mail plugin.
+	 *
+	 * @return string The new CTA
+	 */
+	public static function jitm_jetpack_creative_mail_activate() {
+		return wp_nonce_url(
+			add_query_arg(
+				array(
+					'creative-mail-action' => 'activate',
+				),
+				admin_url( 'edit.php?post_type=feedback' )
+			),
+			'creative-mail-install'
+		);
+	}
+
+	/**
 	 * This is an entire admin notice dedicated to messaging and handling of the case where a user is trying to delete
 	 * the connection owner.
 	 */
@@ -318,10 +352,14 @@ class Post_Connection_JITM extends JITM {
 	 * @return array The JITM's to show, or an empty array if there is nothing to show
 	 */
 	public function get_messages( $message_path, $query, $full_jp_logo_exists ) {
-		// Custom filters go here.
+		// WooCommerce Services.
 		add_filter( 'jitm_woocommerce_services_msg', array( $this, 'jitm_woocommerce_services_msg' ) );
 		add_filter( 'jitm_jetpack_woo_services_install', array( $this, 'jitm_jetpack_woo_services_install' ) );
 		add_filter( 'jitm_jetpack_woo_services_activate', array( $this, 'jitm_jetpack_woo_services_activate' ) );
+
+		// Creative Mail.
+		add_filter( 'jitm_jetpack_creative_mail_install', array( $this, 'jitm_jetpack_creative_mail_install' ) );
+		add_filter( 'jitm_jetpack_creative_mail_activate', array( $this, 'jitm_jetpack_creative_mail_activate' ) );
 
 		$user = wp_get_current_user();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This should facilitate the installation and the configuration of the plugin.
The installation tools in there are to be used in tandem with a JITM, introduced in D48025-code.

#### Jetpack product discussion

* Internal references:
    * pbtFPC-GX-p2
    * pbtFPC-HO-p2

#### Does this pull request change what data or activity we track or use?

* No 

#### Testing instructions:

* Apply D48025-code on your WordPress.com sandbox.
* Start on a Jetpack site with this branch checked out.
* The Jetpack site should point to your WordPress.com sandbox, with the `JETPACK__SANDBOX_DOMAIN` constant.
* I would recommend disabling the cache for JITM messages, with `add_filter( 'jetpack_just_in_time_msg_cache', '__return_false' );`
* The site must be connected to WordPress.com, and the Contact Form module must be active.
* The Creative Mail plugin should not be active on your site.
    * You can test this diff with both the plugin installed but not active, or not installed at all.
* Go to the Feedback menu in your dashboard.
* Try clicking the CTA in the banner that appears.
* Upon plugin activation, run `wp option get CE4WP_REFERRED_BY`
* You should see the following data being returned:
```
array (
  'plugin' => 'jetpack',
  'version' => '8.9-alpha',
  'time' => 1597304061,
  'source' => 'jitm',
)
```

#### Proposed changelog entry for your changes:

* Compatibility: add new Creative Mail compatiblity file.
