### PR TITLE
Blocks: add plugin management tools

### DIFF
--- a/extensions/shared/plugin-management.js
+++ b/extensions/shared/plugin-management.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { isSimpleSite } from './site-type-utils';
+
+/**
+ * Returns a list of all active plugins on the site.
+ *
+ * @returns {Promise} Resolves to a list of plugins, or reject if not retrievable (like on a wpcom simple site or a site running an older version of WP)
+ */
+export async function getPlugins() {
+	// Bail early on WordPress.com Simple sites.
+	if ( isSimpleSite() ) {
+		return Promise.reject();
+	}
+
+	try {
+		const plugins = await apiFetch( {
+			path: '/jetpack/v4/plugins',
+		} );
+		return plugins;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+}
+
+/**
+ * Install and activate a plugin from the WordPress.org plugin directory.
+ *
+ * @param {string} slug - The slug of the plugin we want to activate.
+ *
+ * @returns {Promise} Resolves to true if the plugin has been successfully activated, or reject.
+ */
+export async function installAndActivatePlugin( slug ) {
+	// Bail early on WordPress.com Simple sites.
+	if ( isSimpleSite() ) {
+		return Promise.reject();
+	}
+
+	try {
+		const attemptInstall = await apiFetch( {
+			path: '/jetpack/v4/plugins',
+			method: 'POST',
+			data: {
+				slug,
+				status: 'active',
+				source: 'block-editor',
+			},
+		} );
+		return attemptInstall;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+}
+
+/**
+ * Activate a plugin from the WordPress.org plugin directory.
+ *
+ * @param {string} pluginFile - The plugin long slug (slug/index-file, without the .php suffix) we want to activate.
+ *
+ * @returns {Promise} Resolves to true if the plugin has been successfully activated, or reject.
+ */
+export async function activatePlugin( pluginFile ) {
+	// Bail early on WordPress.com Simple sites.
+	if ( isSimpleSite() ) {
+		return Promise.reject();
+	}
+
+	try {
+		const attemptActivate = await apiFetch( {
+			path: `/jetpack/v4/plugins/${ pluginFile }`,
+			method: 'POST',
+			data: {
+				status: 'active',
+				source: 'block-editor',
+			},
+		} );
+		return attemptActivate;
+	} catch ( error ) {
+		return Promise.reject( error.message );
+	}
+}


### PR DESCRIPTION
This PR is built on top of #16821. It may be best to wait to merge it, and change the base branch once #16821 and #16713 are merged.

#### Changes proposed in this Pull Request:

This PR adds tools to install and activate plugins right from the block editor.

#### Jetpack product discussion

* Internal reference: p1HpG7-9NB-p2

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* This is not easy to tests on its own, but you could run the `apiFetch` calls in your browser console in the editor and see what comes up. It's going to be easier to test with something actually using it. You can switch to #16825 to be able to test those new functions with the Jetpack CRM integration.

#### Proposed changelog entry for your changes:

* N/A
