### PR TITLE
Sync: Improve theme support syncing

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -301,6 +301,8 @@ class Defaults {
 		'available_jetpack_blocks'         => array( 'Jetpack_Gutenberg', 'get_availability' ), // Includes both Gutenberg blocks *and* plugins.
 		'paused_themes'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_paused_themes' ),
 		'paused_plugins'                   => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_paused_plugins' ),
+		'theme_support'                    => array( 'Automattic\\Jetpack\\Sync\\Functions', 'get_theme_support' ),
+
 	);
 
 

--- a/packages/sync/src/class-functions.php
+++ b/packages/sync/src/class-functions.php
@@ -625,4 +625,24 @@ class Functions {
 		}
 		return false;
 	}
+
+	/**
+	 * Return the theme's supported features.
+	 * Used for syncing the supported feature that we care about.
+	 *
+	 * @return array List of features that the theme supports.
+	 */
+	public static function get_theme_support() {
+		global $_wp_theme_features;
+
+		$theme_support = array();
+		foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
+			$has_support = current_theme_supports( $theme_feature );
+			if ( $has_support ) {
+				$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];
+			}
+		}
+
+		return $theme_support;
+	}
 }

--- a/packages/sync/src/modules/class-callables.php
+++ b/packages/sync/src/modules/class-callables.php
@@ -104,6 +104,7 @@ class Callables extends Module {
 		} else {
 			$this->callable_whitelist = Defaults::get_callable_whitelist();
 		}
+		$this->force_send_callables_on_next_tick = false; // Resets here as well mostly for tests.
 	}
 
 	/**

--- a/packages/sync/src/modules/class-callables.php
+++ b/packages/sync/src/modules/class-callables.php
@@ -53,7 +53,20 @@ class Callables extends Module {
 		'jetpack_sync_error_idc',
 		'paused_plugins',
 		'paused_themes',
+
 	);
+
+	const ALWAYS_SEND_UPDATES_TO_THESE_OPTIONS_NEXT_TICK = array(
+		'stylesheet',
+	);
+	/**
+	 * Setting this value to true will make it so that the callables will not be unlocked
+	 * but the lock will be removed after content is send so that callables will be
+	 * sent in the next request.
+	 *
+	 * @var bool
+	 */
+	private $force_send_callables_on_next_tick = false;
 
 	/**
 	 * For some options, the callable key differs from the option name/key
@@ -107,6 +120,12 @@ class Callables extends Module {
 		foreach ( self::ALWAYS_SEND_UPDATES_TO_THESE_OPTIONS as $option ) {
 			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable' ) );
 			add_action( "delete_option_{$option}", array( $this, 'unlock_sync_callable' ) );
+		}
+
+		foreach ( self::ALWAYS_SEND_UPDATES_TO_THESE_OPTIONS_NEXT_TICK as $option ) {
+
+			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable_next_tick' ) );
+			add_action( "delete_option_{$option}", array( $this, 'unlock_sync_callable_next_tick' ) );
 		}
 
 		// Provide a hook so that hosts can send changes to certain callables right away.
@@ -289,6 +308,17 @@ class Callables extends Module {
 	}
 
 	/**
+	 * Unlock callables on the next tick.
+	 * Sometime the true callable values are only present on the next tick.
+	 * When switching themes for example.
+	 *
+	 * @access public
+	 */
+	public function unlock_sync_callable_next_tick() {
+		$this->force_send_callables_on_next_tick = true;
+	}
+
+	/**
 	 * Unlock callables and plugin action links.
 	 *
 	 * @access public
@@ -411,7 +441,6 @@ class Callables extends Module {
 	 * @access public
 	 */
 	public function maybe_sync_callables() {
-
 		$callables = $this->get_all_callables();
 		if ( ! apply_filters( 'jetpack_check_and_send_callables', false ) ) {
 			if ( ! is_admin() ) {
@@ -423,6 +452,9 @@ class Callables extends Module {
 				$callables = $this->get_always_sent_callables();
 			}
 			if ( get_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME ) ) {
+				if ( $this->force_send_callables_on_next_tick ) {
+					$this->unlock_sync_callable();
+				}
 				return;
 			}
 		}
@@ -430,8 +462,10 @@ class Callables extends Module {
 		if ( empty( $callables ) ) {
 			return;
 		}
-
-		set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Defaults::$default_sync_callables_wait_time );
+		// No need to set the transiant we are trying to remove it anyways.
+		if ( ! $this->force_send_callables_on_next_tick ) {
+			set_transient( self::CALLABLES_AWAIT_TRANSIENT_NAME, microtime( true ), Defaults::$default_sync_callables_wait_time );
+		}
 
 		$callable_checksums = (array) \Jetpack_Options::get_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, array() );
 		$has_changed        = false;
@@ -459,6 +493,9 @@ class Callables extends Module {
 			\Jetpack_Options::update_raw_option( self::CALLABLES_CHECKSUM_OPTION_NAME, $callable_checksums );
 		}
 
+		if ( $this->force_send_callables_on_next_tick ) {
+			$this->unlock_sync_callable();
+		}
 	}
 
 	/**

--- a/packages/sync/src/modules/class-callables.php
+++ b/packages/sync/src/modules/class-callables.php
@@ -124,7 +124,6 @@ class Callables extends Module {
 		}
 
 		foreach ( self::ALWAYS_SEND_UPDATES_TO_THESE_OPTIONS_NEXT_TICK as $option ) {
-
 			add_action( "update_option_{$option}", array( $this, 'unlock_sync_callable_next_tick' ) );
 			add_action( "delete_option_{$option}", array( $this, 'unlock_sync_callable_next_tick' ) );
 		}

--- a/packages/sync/src/modules/class-themes.php
+++ b/packages/sync/src/modules/class-themes.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Sync\Modules;
 
 use Automattic\Jetpack\Sync\Defaults;
+use Automattic\Jetpack\Sync\Functions;
 
 /**
  * Class to handle sync for themes.
@@ -109,7 +110,7 @@ class Themes extends Module {
 	 * @param mixed  $old_value  Old value of the network option.
 	 * @param int    $network_id ID of the network.
 	 */
-	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) {
+	public function sync_network_allowed_themes_change( $option, $value, $old_value, $network_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$all_enabled_theme_slugs = array_keys( $value );
 
 		if ( count( $old_value ) > count( $value ) ) {
@@ -786,20 +787,11 @@ class Themes extends Module {
 	 * @return array Theme data.
 	 */
 	private function get_theme_support_info( $theme = null ) {
-		global $_wp_theme_features;
-
 		$theme_support = array();
 
 		// We are trying to get the current theme info.
 		if ( null === $theme ) {
 			$theme = wp_get_theme();
-
-			foreach ( Defaults::$default_theme_support_whitelist as $theme_feature ) {
-				$has_support = current_theme_supports( $theme_feature );
-				if ( $has_support ) {
-					$theme_support[ $theme_feature ] = $_wp_theme_features[ $theme_feature ];
-				}
-			}
 		}
 
 		$theme_support['name']    = $theme->get( 'Name' );

--- a/packages/sync/src/modules/class-themes.php
+++ b/packages/sync/src/modules/class-themes.php
@@ -556,7 +556,7 @@ class Themes extends Module {
 	 * @return array Theme data.
 	 */
 	public function expand_theme_data() {
-		return array( $this->get_theme_support_info() );
+		return array( $this->get_theme_support_info( null, true ) );
 	}
 
 	/**
@@ -784,9 +784,10 @@ class Themes extends Module {
 	 * @access private
 	 *
 	 * @param \WP_Theme $theme Theme object. Optional, will default to the current theme.
+	 * @param boolean   $send_full_theme_data Should send additional theme data.
 	 * @return array Theme data.
 	 */
-	private function get_theme_support_info( $theme = null ) {
+	private function get_theme_support_info( $theme = null, $send_full_theme_data = false ) {
 		$theme_support = array();
 
 		// We are trying to get the current theme info.
@@ -798,7 +799,9 @@ class Themes extends Module {
 		$theme_support['version'] = $theme->get( 'Version' );
 		$theme_support['slug']    = $theme->get_stylesheet();
 		$theme_support['uri']     = $theme->get( 'ThemeURI' );
-
+		if ( $send_full_theme_data ) {
+			return array_merge( Functions::get_theme_support(), $theme_support );
+		}
 		return $theme_support;
 	}
 

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -167,6 +167,47 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$this->assertEquals( null, $this->server_replica_storage->get_callable( 'jetpack_foo' ) );
 	}
 
+	/**
+	 * Tests that calling unlock_sync_callable_next_tick works as expected.
+	 *
+	 * Return null
+	 */
+	public function test_white_listed_callable_sync_on_next_tick() {
+		// Setup...
+		$this->callable_module->set_callable_whitelist( array( 'jetpack_foo' => 'jetpack_foo_is_callable_random' ) );
+		$this->sender->do_sync();
+		$initial_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+
+		// Action happends that should has the correct data only on the next page load.
+		$this->callable_module->unlock_sync_callable_next_tick(); // Calling this should have no effect on this sync.
+		$this->sender->do_sync();
+		$should_be_initial_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		$this->assertEquals( $initial_value, $should_be_initial_value );
+
+		// Next tick...
+		$this->sender->do_sync(); // This sync sends the updated data...
+		$new_value = $this->server_replica_storage->get_callable( 'jetpack_foo' );
+		$this->assertNotEquals( $initial_value, $new_value );
+	}
+
+	/**
+	 * Tests that updating the theme should result in the no callabled transient being set.
+	 *
+	 * Return null
+	 */
+	public function test_updating_stylesheet_sends_the_theme_data() {
+
+		// Make sure we don't already use this theme.
+		$this->assertNotEquals( 'twentythirteen', get_option( 'stylesheet' ) );
+
+		switch_theme( 'twentythirteen' );
+		$this->sender->do_sync();
+
+		// Since we can load up the data to see if new data will get send
+		// this tests if we remove the transiant so that the data can get synced on the next tick.
+		$this->assertFalse( get_transient( Callables::CALLABLES_AWAIT_TRANSIENT_NAME ) );
+	}
+
 	function test_sync_always_sync_changes_to_modules_right_away() {
 		Jetpack::update_active_modules( array( 'stats' ) );
 
@@ -1165,6 +1206,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$functions = new Functions();
 		$this->assertEquals( $main_network_wpcom_id, $functions->main_network_site_wpcom_id() );
 	}
+
 }
 
 function jetpack_recursive_banana() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -99,6 +99,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'paused_themes'                    => Functions::get_paused_themes(),
 			'paused_plugins'                   => Functions::get_paused_plugins(),
 			'main_network_site_wpcom_id'       => Functions::main_network_site_wpcom_id(),
+			'get_theme_support'                => Functions::get_theme_support(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {
@@ -1164,7 +1165,6 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		$functions = new Functions();
 		$this->assertEquals( $main_network_wpcom_id, $functions->main_network_site_wpcom_id() );
 	}
-
 }
 
 function jetpack_recursive_banana() {

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -99,7 +99,7 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 			'paused_themes'                    => Functions::get_paused_themes(),
 			'paused_plugins'                   => Functions::get_paused_plugins(),
 			'main_network_site_wpcom_id'       => Functions::main_network_site_wpcom_id(),
-			'get_theme_support'                => Functions::get_theme_support(),
+			'theme_support'                    => Functions::get_theme_support(),
 		);
 
 		if ( function_exists( 'wp_cache_is_enabled' ) ) {

--- a/tests/php/sync/test_class.jetpack-sync-themes.php
+++ b/tests/php/sync/test_class.jetpack-sync-themes.php
@@ -42,26 +42,6 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 	}
 
 	public function test_changed_theme_is_synced() {
-		$theme_features = array(
-			'post-thumbnails',
-			'post-formats',
-			'custom-header',
-			'custom-background',
-			'custom-logo',
-			'menus',
-			'automatic-feed-links',
-			'editor-style',
-			'widgets',
-			'html5',
-			'title-tag',
-			'jetpack-social-menu',
-			'jetpack-responsive-videos',
-			'infinite-scroll',
-			'site-logo',
-			'editor-color-palette',
-			'editor-gradient-presets',
-		);
-
 		// this forces theme mods to be saved as an option so that this test is valid
 		set_theme_mod( 'foo', 'bar' );
 		$this->sender->do_sync();
@@ -75,11 +55,6 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		$this->assertTrue( isset( $switch_data->args[1]['version'] ) );
 		$this->assertTrue( isset( $switch_data->args[1]['slug'] ) );
 		$this->assertTrue( isset( $switch_data->args[1]['uri'] ) );
-
-		foreach ( $theme_features as $theme_feature ) {
-			$synced_theme_support_value = $this->server_replica_storage->current_theme_supports( $theme_feature );
-			$this->assertEquals( current_theme_supports( $theme_feature ), $synced_theme_support_value, 'Feature(s) not synced' . $theme_feature );
-		}
 
 		// TODO: content_width - this has traditionally been synced as if it was a theme-specific
 		// value, but in fact it's a per-page/post value defined via Jetpack's Custom CSS module
@@ -101,6 +76,42 @@ class WP_Test_Jetpack_Sync_Themes extends WP_Test_Jetpack_Sync_Base {
 		}
 
 		$this->assertEquals( $local_value, $this->server_replica_storage->get_option( 'theme_mods_' . $this->theme ) );
+	}
+
+	/**
+	 * Test that we support syncing all the different theme features still.
+	 */
+	public function test_theme_callable_syncs_theme_supports_data() {
+		$this->sender->do_sync();
+		$theme_supports = $this->server_replica_storage->get_callable( 'theme_support' );
+
+		$theme_features = array(
+			'post-thumbnails',
+			'post-formats',
+			'custom-header',
+			'custom-background',
+			'custom-logo',
+			'menus',
+			'automatic-feed-links',
+			'editor-style',
+			'widgets',
+			'html5',
+			'title-tag',
+			'jetpack-social-menu',
+			'jetpack-responsive-videos',
+			'infinite-scroll',
+			'site-logo',
+			'editor-color-palette',
+			'editor-gradient-presets',
+		);
+
+		foreach ( $theme_features as $theme_feature ) {
+			$this->assertEquals(
+				current_theme_supports( $theme_feature ),
+				isset( $theme_supports[ $theme_feature ] ),
+				'Feature(s) not synced' . $theme_feature
+			);
+		}
 	}
 
 	public function test_network_enable_disable_theme_sync() {


### PR DESCRIPTION
Currently we are experiencing problems syncing theme features. 

The main problem is when theme switch occurs we don't actually have the theme features on the global variable yet. 
So they can't be accessed and synced in order to fix this, this PR provides a way to unlock callables and lets them be synced on the next tick. (Page load) 

The solution remove the locking transient so that on the next tick (page load we are able to send the data to .com as expected.) 

related D48095-code

#### Changes proposed in this Pull Request:
* This PR provides a way to reset the callabled transient so that the more accurate data can be send on the next request.


#### Does this pull request change what data or activity we track or use?
No it just tried to sync more accurate data. 

#### Testing instructions:
Apply this branch. 
Build it. 
Notice that when you switch theme you are seeing the correct data on .com side of things. 
The data should be send on the next tick page load.

#### Proposed changelog entry for your changes:
* Fix: Improves syncing of the theme data.
