### PR TITLE
Setup Wizard: Add Creative Mail Recommendation

### DIFF
--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -169,6 +169,20 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 
+		installPlugin: ( slug, source ) => {
+			const props = { slug, status: 'active' };
+
+			if ( source ) {
+				props.source = source;
+			}
+
+			return postRequest( `${ apiRoot }jetpack/v4/plugins`, postParams, {
+				body: JSON.stringify( props ),
+			} )
+				.then( checkStatus )
+				.then( parseJsonResponse );
+		},
+
 		activateAkismet: () =>
 			postRequest( `${ apiRoot }jetpack/v4/plugins`, postParams, {
 				body: JSON.stringify( { slug: 'akismet', status: 'active' } ),

--- a/_inc/client/setup-wizard/feature-toggle/index.jsx
+++ b/_inc/client/setup-wizard/feature-toggle/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import Gridicon from 'components/gridicon';
+import Spinner from 'components/spinner';
 import analytics from 'lib/analytics';
 
 import {
@@ -41,6 +42,7 @@ let FeatureToggle = props => {
 	} = props;
 
 	const [ windowWidth, setWindowWidth ] = useState( false );
+	const [ installing, setInstalling ] = useState( false );
 
 	const handleResize = useCallback( () => {
 		setWindowWidth( window.innerWidth <= 660 ? 'small' : 'large' );
@@ -88,6 +90,13 @@ let FeatureToggle = props => {
 		} );
 	}, [ feature ] );
 
+	const handleOnInstallClick = useCallback( () => {
+		setInstalling( true );
+		onInstallClick().then( () => {
+			setInstalling( false );
+		} );
+	} );
+
 	let buttonContent;
 	if ( ! checked && upgradeLink ) {
 		buttonContent = (
@@ -121,7 +130,21 @@ let FeatureToggle = props => {
 			</Button>
 		);
 	} else if ( ! checked && onInstallClick ) {
-		buttonContent = <Button onClick={ onInstallClick }>{ __( 'Install now', 'jetpack' ) }</Button>;
+		if ( installing ) {
+			buttonContent = (
+				<Button disabled>
+					{
+						<div className="jp-setup-wizard-install-spinner-container">
+							<Spinner />
+						</div>
+					}
+				</Button>
+			);
+		} else {
+			buttonContent = (
+				<Button onClick={ handleOnInstallClick }>{ __( 'Install now', 'jetpack' ) }</Button>
+			);
+		}
 	}
 
 	const largeWindow = 'large' === windowWidth;

--- a/_inc/client/setup-wizard/feature-toggle/index.jsx
+++ b/_inc/client/setup-wizard/feature-toggle/index.jsx
@@ -32,6 +32,7 @@ let FeatureToggle = props => {
 		configureLink,
 		upgradeLink,
 		optionsLink,
+		onInstallClick,
 		isPaid = false,
 		isButtonLinkExternal = false,
 		isOptionsLinkExternal = false,
@@ -111,6 +112,8 @@ let FeatureToggle = props => {
 				) }
 			</Button>
 		);
+	} else if ( ! checked && onInstallClick ) {
+		buttonContent = <Button onClick={ onInstallClick }>{ __( 'Install now', 'jetpack' ) }</Button>;
 	}
 
 	const largeWindow = 'large' === windowWidth;
@@ -187,6 +190,7 @@ FeatureToggle.propTypes = {
 	info: PropTypes.string,
 	checked: PropTypes.bool.isRequired,
 	onToggleChange: PropTypes.func,
+	onInstallClick: PropTypes.func,
 	configureLink: PropTypes.string,
 	upgradeLink: PropTypes.string,
 	optionsLink: PropTypes.string,

--- a/_inc/client/setup-wizard/feature-toggle/index.jsx
+++ b/_inc/client/setup-wizard/feature-toggle/index.jsx
@@ -42,7 +42,7 @@ let FeatureToggle = props => {
 	} = props;
 
 	const [ windowWidth, setWindowWidth ] = useState( false );
-	const [ installing, setInstalling ] = useState( false );
+	const [ isInstalling, setIsInstalling ] = useState( false );
 
 	const handleResize = useCallback( () => {
 		setWindowWidth( window.innerWidth <= 660 ? 'small' : 'large' );
@@ -91,9 +91,9 @@ let FeatureToggle = props => {
 	}, [ feature ] );
 
 	const handleOnInstallClick = useCallback( () => {
-		setInstalling( true );
+		setIsInstalling( true );
 		onInstallClick().then( () => {
-			setInstalling( false );
+			setIsInstalling( false );
 		} );
 	} );
 
@@ -130,7 +130,7 @@ let FeatureToggle = props => {
 			</Button>
 		);
 	} else if ( ! checked && onInstallClick ) {
-		if ( installing ) {
+		if ( isInstalling ) {
 			buttonContent = (
 				<Button disabled>
 					{

--- a/_inc/client/setup-wizard/feature-toggle/index.jsx
+++ b/_inc/client/setup-wizard/feature-toggle/index.jsx
@@ -32,10 +32,12 @@ let FeatureToggle = props => {
 		configureLink,
 		upgradeLink,
 		optionsLink,
+		learnMoreLink,
 		onInstallClick,
 		isPaid = false,
 		isButtonLinkExternal = false,
 		isOptionsLinkExternal = false,
+		isLearnMoreLinkExternal = false,
 	} = props;
 
 	const [ windowWidth, setWindowWidth ] = useState( false );
@@ -76,6 +78,12 @@ let FeatureToggle = props => {
 
 	const onViewOptionsClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_wizard_feature_view_options', {
+			feature,
+		} );
+	}, [ feature ] );
+
+	const onLearnMoreClick = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_wizard_feature_learn_more', {
 			feature,
 		} );
 	}, [ feature ] );
@@ -124,13 +132,15 @@ let FeatureToggle = props => {
 		infoContent = <p className="jp-setup-wizard-feature-toggle-info">{ info }</p>;
 	}
 
-	let optionsLinkElement;
+	// Note: if any more types of text links get added to this component then refactor these
+	// into a single set of textLink, isTextLinkExternal, and textLinkDisplayText props.
+	let textLinkContent;
 	if ( optionsLink ) {
 		const externalLinkProps = isOptionsLinkExternal
 			? { target: '_blank', rel: 'noopener noreferrer' }
 			: {};
 
-		optionsLinkElement = (
+		textLinkContent = (
 			<a
 				href={ optionsLink }
 				className="jp-setup-wizard-view-options-link"
@@ -139,6 +149,22 @@ let FeatureToggle = props => {
 			>
 				{ __( 'View options', 'jetpack' ) }
 				{ isOptionsLinkExternal && <Gridicon icon="external" size="18" /> }
+			</a>
+		);
+	} else if ( learnMoreLink ) {
+		const externalLinkProps = isLearnMoreLinkExternal
+			? { target: '_blank', rel: 'noopener noreferrer' }
+			: {};
+
+		textLinkContent = (
+			<a
+				href={ learnMoreLink }
+				className="jp-setup-wizard-view-options-link"
+				{ ...externalLinkProps }
+				onClick={ onLearnMoreClick }
+			>
+				{ __( 'Learn more', 'jetpack' ) }
+				{ isLearnMoreLinkExternal && <Gridicon icon="external" size="18" /> }
 			</a>
 		);
 	}
@@ -170,7 +196,7 @@ let FeatureToggle = props => {
 				<p className="jp-setup-wizard-feature-toggle-content">
 					{ largeWindow && <span>{ title }</span> }
 					{ details }
-					{ optionsLinkElement && <span>{ optionsLinkElement }</span> }
+					{ textLinkContent && <span>{ textLinkContent }</span> }
 				</p>
 			</div>
 			{ ( buttonContent || infoContent ) && (
@@ -194,10 +220,12 @@ FeatureToggle.propTypes = {
 	configureLink: PropTypes.string,
 	upgradeLink: PropTypes.string,
 	optionsLink: PropTypes.string,
+	learnMoreLink: PropTypes.string,
 	isPaid: PropTypes.bool,
 	isDisabled: PropTypes.bool,
 	isButtonLinkExternal: PropTypes.bool,
 	isOptionsLinkExternal: PropTypes.bool,
+	isLearnMoreLinkExternal: PropTypes.bool,
 };
 
 FeatureToggle = connect(

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -305,11 +305,14 @@ const features = {
 			return {
 				feature: 'creative-mail',
 				title: __( 'Creative Mail by Constant Contact', 'jetpack' ),
-				details: __( 'Send beautiful emails; grow followers.', 'jetpack' ),
+				details: __( 'Turn visitors into subscribers with email marketing.', 'jetpack' ),
 				checked: isCreativeMailActive,
 				isDisabled: true,
 				isPaid: true,
 				configureLink: isCreativeMailActive ? '/wp-admin/admin.php?page=creativemail' : null,
+				learnMoreLink:
+					'https://jetpack.com/support/jetpack-blocks/subscriber-form-block-and-field/',
+				isLearnMoreLinkExternal: true,
 			};
 		},
 		mapDispatchToProps: dispatch => {

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { get } from 'lodash';
+import { get, rest } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import getRedirectUrl from 'lib/jp-redirect';
 import { getPlanClass } from 'lib/plans/constants';
+import restApi from 'rest-api';
 import { getVaultPressData, isAkismetKeyValid } from 'state/at-a-glance';
 import { getSiteRawUrl } from 'state/initial-state';
 import { getRewindStatus } from 'state/rewind';
@@ -21,6 +22,7 @@ import {
 	hasActiveScanPurchase,
 	hasActiveSearchPurchase,
 } from 'state/site';
+import { isPluginActive } from 'state/site/plugins';
 
 function getInfoString( productName ) {
 	return sprintf(
@@ -299,13 +301,18 @@ const features = {
 				feature: 'creative-mail',
 				title: __( 'Creative Mail by Constant Contact', 'jetpack' ),
 				details: __( 'Send beautiful emails; grow followers.', 'jetpack' ),
-				checked: false,
+				checked: isPluginActive(
+					state,
+					'creative-mail-by-constant-contact/creative-mail-plugin.php'
+				),
 				optionsLink: '',
 			};
 		},
 		mapDispatchToProps: dispatch => {
 			return {
-				onToggleChange: currentCheckedValue => {},
+				onToggleChange: currentCheckedValue => {
+					restApi.installPlugin( 'creative-mail-by-constant-contact', 'setup-wizard' );
+				},
 			};
 		},
 	},

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -293,6 +293,23 @@ const features = {
 		},
 	},
 
+	'creative-mail': {
+		mapStateToProps: state => {
+			return {
+				feature: 'creative-mail',
+				title: __( 'Creative Mail by Constant Contact', 'jetpack' ),
+				details: __( 'Send beautiful emails; grow followers.', 'jetpack' ),
+				checked: false,
+				optionsLink: '',
+			};
+		},
+		mapDispatchToProps: dispatch => {
+			return {
+				onToggleChange: currentCheckedValue => {},
+			};
+		},
+	},
+
 	'custom-css': {
 		mapStateToProps: state => {
 			return {

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -311,7 +311,7 @@ const features = {
 				isPaid: true,
 				configureLink: isCreativeMailActive ? '/wp-admin/admin.php?page=creativemail' : null,
 				learnMoreLink:
-					'https://jetpack.com/support/jetpack-blocks/subscriber-form-block-and-field/',
+					'https://jetpack.com/support/jetpack-blocks/form-block/newsletter-sign-up-form/',
 				isLearnMoreLinkExternal: true,
 			};
 		},

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -308,6 +308,7 @@ const features = {
 				details: __( 'Send beautiful emails; grow followers.', 'jetpack' ),
 				checked: isCreativeMailActive,
 				isDisabled: isCreativeMailActive,
+				configureLink: isCreativeMailActive ? '/wp-admin/admin.php?page=creativemail' : null,
 			};
 		},
 		mapDispatchToProps: dispatch => {

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -307,7 +307,8 @@ const features = {
 				title: __( 'Creative Mail by Constant Contact', 'jetpack' ),
 				details: __( 'Send beautiful emails; grow followers.', 'jetpack' ),
 				checked: isCreativeMailActive,
-				isDisabled: isCreativeMailActive,
+				isDisabled: true,
+				isPaid: true,
 				configureLink: isCreativeMailActive ? '/wp-admin/admin.php?page=creativemail' : null,
 			};
 		},
@@ -319,11 +320,6 @@ const features = {
 			};
 
 			return {
-				onToggleChange: currentCheckedValue => {
-					if ( ! currentCheckedValue ) {
-						installAndRefreshPluginData();
-					}
-				},
 				onInstallClick: () => installAndRefreshPluginData(),
 			};
 		},

--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -22,7 +22,7 @@ import {
 	hasActiveScanPurchase,
 	hasActiveSearchPurchase,
 } from 'state/site';
-import { isPluginActive } from 'state/site/plugins';
+import { fetchPluginsData, isPluginActive } from 'state/site/plugins';
 
 function getInfoString( productName ) {
 	return sprintf(
@@ -297,22 +297,33 @@ const features = {
 
 	'creative-mail': {
 		mapStateToProps: state => {
+			const isCreativeMailActive = isPluginActive(
+				state,
+				'creative-mail-by-constant-contact/creative-mail-plugin.php'
+			);
+
 			return {
 				feature: 'creative-mail',
 				title: __( 'Creative Mail by Constant Contact', 'jetpack' ),
 				details: __( 'Send beautiful emails; grow followers.', 'jetpack' ),
-				checked: isPluginActive(
-					state,
-					'creative-mail-by-constant-contact/creative-mail-plugin.php'
-				),
-				optionsLink: '',
+				checked: isCreativeMailActive,
+				isDisabled: isCreativeMailActive,
 			};
 		},
 		mapDispatchToProps: dispatch => {
+			const installAndRefreshPluginData = () => {
+				restApi.installPlugin( 'creative-mail-by-constant-contact', 'setup-wizard' ).then( () => {
+					dispatch( fetchPluginsData() );
+				} );
+			};
+
 			return {
 				onToggleChange: currentCheckedValue => {
-					restApi.installPlugin( 'creative-mail-by-constant-contact', 'setup-wizard' );
+					if ( ! currentCheckedValue ) {
+						installAndRefreshPluginData();
+					}
 				},
+				onInstallClick: () => installAndRefreshPluginData(),
 			};
 		},
 	},

--- a/_inc/client/setup-wizard/feature-toggle/style.scss
+++ b/_inc/client/setup-wizard/feature-toggle/style.scss
@@ -168,3 +168,8 @@
 	font-weight: bold;
 	text-decoration: underline !important;
 }
+
+.jp-setup-wizard-install-spinner-container {
+	display: flex;
+	justify-content: center;
+}

--- a/_inc/client/setup-wizard/index.jsx
+++ b/_inc/client/setup-wizard/index.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import QuerySite from 'components/data/query-site';
+import QuerySitePlugins from 'components/data/query-site-plugins';
 import QueryRewindStatus from 'components/data/query-rewind-status';
 import QueryVaultPressData from 'components/data/query-vaultpress-data';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
@@ -47,6 +48,7 @@ const SetupWizardComponent = props => {
 	return (
 		<>
 			<QuerySite />
+			<QuerySitePlugins />
 			<QueryRewindStatus />
 			<QueryVaultPressData />
 			<QueryAkismetKeyCheck />

--- a/_inc/client/state/setup-wizard/feature-recommendations.js
+++ b/_inc/client/state/setup-wizard/feature-recommendations.js
@@ -11,6 +11,7 @@ export const featureGroups = {
 		'infinite-scroll',
 	],
 	marketing: [
+		'creative-mail',
 		'ads',
 		'comment-likes',
 		'contact-form',
@@ -61,6 +62,7 @@ export const featureRecommendations = {
 		'carousel',
 		'extra-sidebar-widgets',
 		'tiled-galleries',
+		'creative-mail',
 	],
 	'business-use': [ 'monitor', 'contact-form', 'notifications' ],
 	'advertising-revenue': [ 'ads' ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
This PR adds a recommendation to the Setup Wizard for Creative Mail.

When Creative Mail is not installed:
<img width="933" alt="image" src="https://user-images.githubusercontent.com/42627630/90672233-6f72a480-e21b-11ea-8ca4-5dabeb99b11f.png">

<img width="934" alt="image" src="https://user-images.githubusercontent.com/42627630/90672153-510ca900-e21b-11ea-9cc9-c5b337862160.png">

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
pbtFPC-Hb-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. On your Jetpack site add the following to then end of the wp-config.php file in order to make the Setup Wizard show:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/features` and scroll to the Marketing section.
3. Verify that the Creative Mail recommendation shows with a disabled toggle and an install button.
4. Click "Install Now" and verify that the Creative Mail plugin gets installed and activated.
5. Click "Configure" and verify that you are taken to the Creative Mail setup flow.
6. Click the "Learn more" link and verify that it navigates to a jetpack support page. (Note: this page does not yet exist but will before release)
7. Deactivate the Creative Mail plugin but leave it installed. Go to the recommendation in the Setup Wizard and click "Install Now". Verify that the Creative Mail plugin is activated.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Added Creative Mail recommendation to the Setup Wizard.