### PR TITLE
Jetpack SSO: Cleaning up the `requestNonce` API request.

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -642,9 +642,7 @@ class Jetpack_SSO {
 			: false;
 
 		if ( ! $nonce ) {
-			$xml = new Jetpack_IXR_Client( array(
-				'user_id' => get_current_user_id(),
-			) );
+			$xml = new Jetpack_IXR_Client();
 			$xml->query( 'jetpack.sso.requestNonce' );
 
 			if ( $xml->isError() ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

By the nature of the authentication form, `user_id` is unknown when it's opened, and `blog_token` is always used for the request even though the code attempts to use the `user_token`.
So this commit is janitorial and doesn't really affect the functionality.

#### Jetpack product discussion
Part of the issue #16709

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Go to "Jetpack -> Settings -> Security" and enable the "WordPress.com login" feature.
2. Open a private browser window and go to the `wp-login.php` page.
3. Confirm that the cookie `jetpack_sso_nonce` was created and contains the actual nonce (e.g. `kps0dsn9fqmxbxlzbtd9`).
4. Refresh the page, confirm the nonce hasn't changed.
5. Remove the cookie, refresh the page, make sure it's regenerated.

#### Proposed changelog entry for your changes:
n/a.