### PR TITLE
Theme Tools: Use `genericons` if no option are set.

### DIFF
--- a/modules/theme-tools/social-menu.php
+++ b/modules/theme-tools/social-menu.php
@@ -60,10 +60,13 @@ add_action( 'restapi_theme_init', 'jetpack_social_menu_init' );
 function jetpack_social_menu_get_type() {
 	$options = get_theme_support( 'jetpack-social-menu' );
 
-	if ( ! $options || ! is_array( $options ) || ! isset( $options[0] ) ) {
+	if ( ! $options ) {
 		$menu_type = null;
 	} else {
-		$menu_type = ( in_array( $options[0], array( 'genericons', 'svg' ) ) ) ? $options[0] : 'genericons';
+		$menu_type = 'genericons';
+		if ( is_array( $options ) && isset( $options[0] ) ) {
+			$menu_type = ( in_array( $options[0], array( 'genericons', 'svg' ), true ) ) ? $options[0] : 'genericons';
+		}
 	}
 
 	return $menu_type;


### PR DESCRIPTION
Fixes https://github.com/Automattic/themes/issues/2353 (regression added in #16795 ).

#### Changes proposed in this Pull Request:
* If no options are set, it should use genericons, not null.

#### Jetpack product discussion
See pNEWy-8RI-p2

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Apply the dotcom diff and see https://nikaudemo.wordpress.com/
* Menu icons should appear on the right-hand side.

#### Proposed changelog entry for your changes:
* n/a fixes unreleased regession
