### PR TITLE
Customizer: Disable display of accept cookie banner

### DIFF
--- a/modules/widgets/eu-cookie-law.php
+++ b/modules/widgets/eu-cookie-law.php
@@ -308,4 +308,17 @@ if ( ! class_exists( 'Jetpack_EU_Cookie_Law_Widget' ) ) {
 	};
 
 	add_action( 'widgets_init', 'jetpack_register_eu_cookie_law_widget' );
+
+	/**
+	 * Disable display of the EU Cookie Banner within Customizer.
+	 */
+	function jetpack_disable_eu_cookie_law_widget_for_customizer() {
+		global $wp_customize;
+
+		if ( $wp_customize ) {
+			add_filter( 'jetpack_disable_eu_cookie_law_widget', '__return_true', 1 );
+		}
+	}
+
+	add_action( 'widgets_init', 'jetpack_disable_eu_cookie_law_widget_for_customizer' );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes Automattic/wp-calypso#44126

#### Changes proposed in this Pull Request:
* Disable display of "Cookies & Consent" banner widget when in Customizer.

#### Does this pull request change what data or activity we track or use?
No changes. 

_While the cookies banner won't be displayed in Customizer anymore, if the user visits the frontend they'll still get the banner._

#### Testing instructions:
1. Apply this PR branch
2. Ensure you have a theme selected that can add widgets via the Customizer
3. Navigate to the Customizer
4. Either confirm "Cookies & Consent" widget has added or add it now 
  (May need to turn on extra widgets in Jetpack settings if not available)
5. Confirm that the accept cookies banner is not displayed within Customizer
6. Switch to the frontend and confirm that the cookies banner is shown

#### Customizer
<img width="1245" alt="Screen Shot 2020-08-14 at 10 24 34 am" src="https://user-images.githubusercontent.com/60436221/90200856-8cbf0180-de1c-11ea-8aa3-9163c22f2e5e.png">

#### Frontend
<img width="1245" alt="Screen Shot 2020-08-14 at 10 24 39 am" src="https://user-images.githubusercontent.com/60436221/90200850-8af53e00-de1c-11ea-8381-c639ca5b5cdd.png">

#### Proposed changelog entry for your changes:
* Customizer: Disable display of accept cookies banner widget
