### PR TITLE
OpenTable Block: Add mobile fallback when using wide style

### DIFF
--- a/extensions/blocks/opentable/editor.scss
+++ b/extensions/blocks/opentable/editor.scss
@@ -128,6 +128,13 @@
 		padding: 0;
 		margin: 0;
 	}
+
+	.wp-block > &.is-style-wide {
+		&.alignright {
+			left: auto;
+			right: 0;
+		}
+	}
 }
 
 .wp-block[data-type="jetpack/opentable"] {

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -60,7 +60,7 @@ function load_assets( $attributes ) {
 		$attributes = array_merge( $attributes, array( 'style' => 'standard' ) );
 		$classes[]  = 'is-style-mobile';
 	}
-	
+
 	// Handles case of deprecated version using theme instead of block styles.
 	if ( ! $class_name || strpos( $class_name, 'is-style-' ) === false ) {
 		$classes[] = sprintf( 'is-style-%s', $style );
@@ -74,7 +74,7 @@ function load_assets( $attributes ) {
 	}
 	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $classes );
 	$content = '<div class="' . esc_attr( $classes ) . '">';
-	
+
 	// The OpenTable script uses multiple `rid` paramters,
 	// so we can't use WordPress to output it, as WordPress attempts to validate it and removes them.
 	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -54,10 +54,11 @@ function load_assets( $attributes ) {
 
 	$classes    = array();
 	$class_name = get_attribute( $attributes, 'className' );
+	$style      = get_attribute( $attributes, 'style' );
 
 	// Handles case of deprecated version using theme instead of block styles.
 	if ( ! $class_name || strpos( $class_name, 'is-style-' ) === false ) {
-		$classes[] = sprintf( 'is-style-%s', get_attribute( $attributes, 'style' ) );
+		$classes[] = sprintf( 'is-style-%s', $style );
 	}
 
 	if ( array_key_exists( 'rid', $attributes ) && is_array( $attributes['rid'] ) && count( $attributes['rid'] ) > 1 ) {
@@ -72,6 +73,19 @@ function load_assets( $attributes ) {
 		$classes
 	);
 	$content = '<div class="' . esc_attr( $classes ) . '">';
+
+	// OpenTable's wide style has fixed widths within the embedded iframe.
+	// To improve the mobile experience we'll add a standard style widget as
+	// well and use CSS to switch display between the wide style and it.
+	if ( 'wide' === $style ) {
+		$fallback_attributes = array_merge( $attributes, array( 'style' => 'standard' ) );
+		$fallback_url        = build_embed_url( $fallback_attributes );
+		$content            .= '<div class="mobile-fallback">';
+		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$content .= '<script type="text/javascript" src="' . esc_url( $fallback_url ) . '"></script>';
+		$content .= '</div>';
+	}
+
 	// The OpenTable script uses multiple `rid` paramters,
 	// so we can't use WordPress to output it, as WordPress attempts to validate it and removes them.
 	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript

--- a/extensions/blocks/opentable/opentable.php
+++ b/extensions/blocks/opentable/opentable.php
@@ -56,6 +56,11 @@ function load_assets( $attributes ) {
 	$class_name = get_attribute( $attributes, 'className' );
 	$style      = get_attribute( $attributes, 'style' );
 
+	if ( 'wide' === $style && jetpack_is_mobile() ) {
+		$attributes = array_merge( $attributes, array( 'style' => 'standard' ) );
+		$classes[]  = 'is-style-mobile';
+	}
+	
 	// Handles case of deprecated version using theme instead of block styles.
 	if ( ! $class_name || strpos( $class_name, 'is-style-' ) === false ) {
 		$classes[] = sprintf( 'is-style-%s', $style );
@@ -67,30 +72,15 @@ function load_assets( $attributes ) {
 	if ( array_key_exists( 'negativeMargin', $attributes ) && $attributes['negativeMargin'] ) {
 		$classes[] = 'has-no-margin';
 	}
-	$classes = Jetpack_Gutenberg::block_classes(
-		FEATURE_NAME,
-		$attributes,
-		$classes
-	);
+	$classes = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attributes, $classes );
 	$content = '<div class="' . esc_attr( $classes ) . '">';
-
-	// OpenTable's wide style has fixed widths within the embedded iframe.
-	// To improve the mobile experience we'll add a standard style widget as
-	// well and use CSS to switch display between the wide style and it.
-	if ( 'wide' === $style ) {
-		$fallback_attributes = array_merge( $attributes, array( 'style' => 'standard' ) );
-		$fallback_url        = build_embed_url( $fallback_attributes );
-		$content            .= '<div class="mobile-fallback">';
-		// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$content .= '<script type="text/javascript" src="' . esc_url( $fallback_url ) . '"></script>';
-		$content .= '</div>';
-	}
-
+	
 	// The OpenTable script uses multiple `rid` paramters,
 	// so we can't use WordPress to output it, as WordPress attempts to validate it and removes them.
 	// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	$content .= '<script type="text/javascript" src="' . esc_url( build_embed_url( $attributes ) ) . '"></script>';
 	$content .= '</div>';
+
 	return $content;
 }
 

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -30,8 +30,19 @@
 
 	&.is-style-wide {
 		height: 150px;
-		&.aligncenter iframe {
+		iframe {
 			width: 840px !important;
+		}
+
+		&.alignleft {
+			max-width: 840px;
+			right: auto;
+			margin-left: 2rem;
+		}
+
+		&.alignright {
+			max-width: 840px;
+			left: calc( 100% - 840px - 2rem );
 		}
 	}
 
@@ -64,6 +75,60 @@
 			padding: 0;
 			&:hover {
 				text-decoration: none;
+			}
+		}
+	}
+
+	.mobile-fallback {
+		display: none;
+	}
+
+	@media screen and (max-width: 899px) {
+		.mobile-fallback {
+			display: flex;
+			height: 100%;
+			justify-content: center;
+
+			& + div {
+				display: none;
+			}
+		}
+
+		&.aligncenter {
+			.mobile-fallback {
+				justify-content: center;
+			}
+		}
+
+		&.alignright {
+			.mobile-fallback {
+				justify-content: flex-end;
+			}
+		}
+		
+		&.is-style-wide {
+			height: 301px;
+
+			&.is-multi {
+				height: 361px;
+			}
+
+			&.aligncenter iframe {
+				width: 224px !important;
+			}
+
+			&.alignleft {
+				max-width: 224px;
+				margin-left: 2rem;
+			}
+
+			&.alignright {
+				max-width: 224px;
+				left: calc( 100% - 224px - 2rem );
+			}
+
+			&.alignfull {
+				margin-left: 2rem;
 			}
 		}
 	}

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -4,7 +4,7 @@
 		margin: 0 auto;
 	}
 
-	&.is-style-standard {
+	&.is-style-standard, &.is-style-wide.is-style-mobile {
 		height: 301px;
 
 		&.is-multi {
@@ -75,60 +75,6 @@
 			padding: 0;
 			&:hover {
 				text-decoration: none;
-			}
-		}
-	}
-
-	.mobile-fallback {
-		display: none;
-	}
-
-	@media screen and (max-width: 899px) {
-		.mobile-fallback {
-			display: flex;
-			height: 100%;
-			justify-content: center;
-
-			& + div {
-				display: none;
-			}
-		}
-
-		&.aligncenter {
-			.mobile-fallback {
-				justify-content: center;
-			}
-		}
-
-		&.alignright {
-			.mobile-fallback {
-				justify-content: flex-end;
-			}
-		}
-		
-		.entry-content &.is-style-wide {
-			height: 301px;
-
-			&.is-multi {
-				height: 361px;
-			}
-
-			&.aligncenter iframe {
-				width: 224px !important;
-			}
-
-			&.alignleft {
-				max-width: 224px;
-				margin-left: 2rem;
-			}
-
-			&.alignright {
-				max-width: 224px;
-				left: calc( 100% - 224px - 2rem );
-			}
-
-			&.alignfull {
-				margin-left: 2rem;
 			}
 		}
 	}

--- a/extensions/blocks/opentable/view.scss
+++ b/extensions/blocks/opentable/view.scss
@@ -106,7 +106,7 @@
 			}
 		}
 		
-		&.is-style-wide {
+		.entry-content &.is-style-wide {
 			height: 301px;
 
 			&.is-multi {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16156

#### Changes proposed in this Pull Request:
* When the page is being loaded via mobile and the current style is `wide`, the embed URL is switched to the standard theme and an `is-style-mobile` CSS class added. This results in widget more easily being fit on smaller viewports. 
* The choice to switch the widget entirely was made to avoid duplicating markup and scripts for the block. The trade-off being this approach will not help desktop users who resize their browser window smaller than the `wide` style.

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
1. Apply this PR branch
2. Create a post and add an OpenTable block to it
3. Select the wide style for the block and save the post
4. Visit the post on the frontend.
5. Spoof the user agent in your browser to some kind of mobile device and reload the page. 
6. Ensure that the standard theme widget is displayed instead of the wide style.

| Before | After |
| --- | --- |
| <img width="446" alt="Screen Shot 2020-09-04 at 7 58 25 pm" src="https://user-images.githubusercontent.com/60436221/92227124-23955000-eee9-11ea-9d12-e2caad8c8de6.png"> | <img width="445" alt="Screen Shot 2020-09-04 at 7 57 54 pm" src="https://user-images.githubusercontent.com/60436221/92227135-285a0400-eee9-11ea-9a4f-035d33a20acd.png"> |


#### Proposed changelog entry for your changes:
* OpenTable Block: Display wide style widget as standard on mobile
