### PR TITLE
Packages: Update filenames after #16810

### DIFF
--- a/packages/assets/.gitattributes
+++ b/packages/assets/.gitattributes
@@ -1,4 +1,4 @@
 # Files not needed to be distributed in the package.
-.gitattributes export-ignore
-phpunit.xml    export-ignore
-tests/         export-ignore
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/connection/.gitattributes
+++ b/packages/connection/.gitattributes
@@ -1,4 +1,4 @@
 # Files not needed to be distributed in the package.
-.gitattributes export-ignore
-phpunit.xml    export-ignore
-tests/         export-ignore
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/jitm/.gitattributes
+++ b/packages/jitm/.gitattributes
@@ -1,4 +1,4 @@
 # Files not needed to be distributed in the package.
-.gitattributes  export-ignore
-phpunit.xml     export-ignore
-tests/          export-ignore
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/partner/.gitattributes
+++ b/packages/partner/.gitattributes
@@ -1,4 +1,4 @@
 # Files not needed to be distributed in the package.
-.gitattributes export-ignore
-phpunit.xml    export-ignore
-tests/         export-ignore
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore

--- a/packages/redirect/.gitattributes
+++ b/packages/redirect/.gitattributes
@@ -1,4 +1,4 @@
 # Files not needed to be distributed in the package.
-.gitattributes export-ignore
-phpunit.xml    export-ignore
-tests/         export-ignore
+.gitattributes   export-ignore
+phpunit.xml.dist export-ignore
+tests/           export-ignore


### PR DESCRIPTION
Our testing now uses `phpunit.xml.dist` which was not updated in package's `.gitattributes` files.

Fixes issue introduced in #16810

#### Changes proposed in this Pull Request:
* n/a

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* Done pre-release. After a new version of a package has this update, should be able to do `composer install --no-dev` on a project with one of these packages and not see `phpunit.xml.dist` in the distributed copy.

#### Proposed changelog entry for your changes:
* n/a
