### PR TITLE
Connection: move the rest authentication methods to the connection package

### DIFF
--- a/packages/connection/src/class-rest-authentication.php
+++ b/packages/connection/src/class-rest-authentication.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * The Jetpack Connection Rest Authentication file.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * The Jetpack Connection Rest Authentication class.
+ */
+class Rest_Authentication {
+
+	/**
+	 * The rest authentication status.
+	 *
+	 * @since 8.9.0
+	 * @var boolean
+	 */
+	private $rest_authentication_status = null;
+
+	/**
+	 * The Manager object.
+	 *
+	 * @since 8.9.0
+	 * @var Object
+	 */
+	private $connection_manager = null;
+
+	/**
+	 * Holds the singleton instance of this class
+	 *
+	 * @since 8.9.0
+	 * @var Object
+	 */
+	private static $instance = false;
+
+	/**
+	 * The constructor.
+	 */
+	private function __construct() {
+		$this->connection_manager = new Manager();
+	}
+
+	/**
+	 * Controls the single instance of this class.
+	 *
+	 * @static
+	 */
+	public static function init() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+
+			add_filter( 'determine_current_user', array( self::$instance, 'wp_rest_authenticate' ) );
+			add_filter( 'rest_authentication_errors', array( self::$instance, 'wp_rest_authentication_errors' ) );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Authenticates requests from Jetpack server to WP REST API endpoints.
+	 * Uses the existing XMLRPC request signing implementation.
+	 *
+	 * @param int|bool $user User ID if one has been determined, false otherwise.
+	 *
+	 * @return int|null The user id or null if the request was not authenticated.
+	 */
+	public function wp_rest_authenticate( $user ) {
+		if ( ! empty( $user ) ) {
+			// Another authentication method is in effect.
+			return $user;
+		}
+
+		if ( ! isset( $_GET['_for'] ) || 'jetpack' !== $_GET['_for'] ) {
+			// Nothing to do for this authentication method.
+			return null;
+		}
+
+		if ( ! isset( $_GET['token'] ) && ! isset( $_GET['signature'] ) ) {
+			// Nothing to do for this authentication method.
+			return null;
+		}
+
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
+			$this->rest_authentication_status = new \WP_Error(
+				'rest_invalid_request',
+				__( 'The request method is missing.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+			return null;
+		}
+
+		// Only support specific request parameters that have been tested and
+		// are known to work with signature verification.  A different method
+		// can be passed to the WP REST API via the '?_method=' parameter if
+		// needed.
+		if ( 'GET' !== $_SERVER['REQUEST_METHOD'] && 'POST' !== $_SERVER['REQUEST_METHOD'] ) {
+			$this->rest_authentication_status = new \WP_Error(
+				'rest_invalid_request',
+				__( 'This request method is not supported.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+			return null;
+		}
+		if ( 'POST' !== $_SERVER['REQUEST_METHOD'] && ! empty( file_get_contents( 'php://input' ) ) ) {
+			$this->rest_authentication_status = new \WP_Error(
+				'rest_invalid_request',
+				__( 'This request method does not support body parameters.', 'jetpack' ),
+				array( 'status' => 400 )
+			);
+			return null;
+		}
+
+		$verified = $this->connection_manager->verify_xml_rpc_signature();
+
+		if (
+			$verified &&
+			isset( $verified['type'] ) &&
+			'user' === $verified['type'] &&
+			! empty( $verified['user_id'] )
+		) {
+			// Authentication successful.
+			$this->rest_authentication_status = true;
+			return $verified['user_id'];
+		}
+
+		// Something else went wrong.  Probably a signature error.
+		$this->rest_authentication_status = new \WP_Error(
+			'rest_invalid_signature',
+			__( 'The request is not signed correctly.', 'jetpack' ),
+			array( 'status' => 400 )
+		);
+		return null;
+	}
+
+	/**
+	 * Report authentication status to the WP REST API.
+	 *
+	 * @param  WP_Error|mixed $value Error from another authentication handler, null if we should handle it, or another value if not.
+	 * @return WP_Error|boolean|null {@see WP_JSON_Server::check_authentication}
+	 */
+	public function wp_rest_authentication_errors( $value ) {
+		if ( null !== $value ) {
+			return $value;
+		}
+		return $this->rest_authentication_status;
+	}
+
+	/**
+	 * Resets the saved authentication state in between testing requests.
+	 */
+	public function reset_saved_auth_state() {
+		$this->rest_authentication_status = null;
+		$this->connection_manager->reset_saved_auth_state();
+	}
+}

--- a/packages/connection/tests/php/test_Rest_Authentication.php
+++ b/packages/connection/tests/php/test_Rest_Authentication.php
@@ -1,0 +1,239 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * REST Authentication functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * REST Authentication functionality testing.
+ */
+class REST_Authentication_Test extends TestCase {
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->rest_authentication = Rest_Authentication::init();
+
+		$this->manager = $this->getMockBuilder( 'Manager' )
+			->setMethods( array( 'verify_xml_rpc_signature', 'reset_saved_auth_state' ) )
+			->getMock();
+
+		$reflection_class = new \ReflectionClass( get_class( $this->rest_authentication ) );
+		$manager_property = $reflection_class->getProperty( 'connection_manager' );
+		$manager_property->setAccessible( true );
+		$manager_property->setValue( $this->rest_authentication, $this->manager );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$_GET = null;
+		unset( $_SERVER['REQUEST_METHOD'] );
+		$this->rest_authentication->reset_saved_auth_state();
+	}
+
+	/**
+	 * Tests wp_rest_authentication_errors with an incoming error.
+	 *
+	 * @covers REST_Authentication::wp_rest_authentication_errors
+	 */
+	public function test_wp_rest_authentication_errors_existing_error() {
+		$error = new \WP_Error( 'test_error', 'This is a test error' );
+		$this->assertEquals( $error, $this->rest_authentication->wp_rest_authentication_errors( $error ) );
+	}
+
+	/**
+	 * Tests wp_rest_authentication with an incoming user id.
+	 *
+	 * @covers REST_Authentication::wp_rest_authentication
+	 */
+	public function test_wp_rest_authentication_existing_user() {
+		$user_id = 123;
+		$this->assertEquals( $user_id, $this->rest_authentication->wp_rest_authenticate( $user_id ) );
+	}
+
+	/**
+	 * Tests wp_rest_authentication with an incoming user id.
+	 *
+	 * @param array $test_inputs      The array containing the test inputs.
+	 * @param array $expected_outputs The array containg the expected test outputs.
+	 *
+	 * @covers REST_Authentication::wp_rest_authentication
+	 * @dataProvider wp_rest_authenticate_data_provider
+	 */
+	public function test_wp_rest_authenticate( $test_inputs, $expected_outputs ) {
+		$_GET = $test_inputs['get_params'];
+		if ( isset( $test_inputs['request_method'] ) ) {
+			$_SERVER['REQUEST_METHOD'] = $test_inputs['request_method'];
+		}
+
+		$this->manager->expects( $this->any() )
+			->method( 'verify_xml_rpc_signature' )
+			->will( $this->returnValue( $test_inputs['verified'] ) );
+
+		$this->assertEquals( $expected_outputs['authenticate'], $this->rest_authentication->wp_rest_authenticate( '' ) );
+
+		if ( is_string( $expected_outputs['errors'] ) ) {
+			$this->assertInstanceOf( $expected_outputs['errors'], $this->rest_authentication->wp_rest_authentication_errors( null ) );
+		} else {
+			$this->assertEquals( $expected_outputs['errors'], $this->rest_authentication->wp_rest_authentication_errors( null ) );
+		}
+	}
+
+	/**
+	 * The data provider for test_wp_rest_authenticate.
+	 *
+	 * @return array An array containg the test inputs and expected outputs. Each test array has the format:
+	 *     ['test_inputs'] => [
+	 *         ['get'] =>
+	 *             ['_for'] => (string) The _for parameter value. Optional.
+	 *             ['token'] => (string) The token parameter value. Optional.
+	 *             ['signature'] => (string) The signature parameter value. Optional.
+	 *         ['request_method'] => (string) The request method. Optional.
+	 *         ['verified'] => (false|array) The mocked return value of Manager::verify_xml_rpc_signature. Required.
+	 *     ],
+	 *     ['test_outputs'] => [
+	 *         ['authenticate'] (int|null) The expected return value of wp_rest_authenticate. Required.
+	 *         ['errors'] (null|string|true) The expected return value of wp_rest_authenticate_errors. If the value is
+	 *                                       a string, this is the expected class of the object returned by
+	 *                                       wp_rest_authenticate_errors. Required.
+	 *     ]
+	 */
+	public function wp_rest_authenticate_data_provider() {
+		$token_data = array(
+			'type'      => 'user',
+			'token_key' => '123abc',
+			'user_id'   => 123,
+		);
+
+		return array(
+			'no for parameter'                => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'request_method' => 'GET',
+					'verified'       => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => null,
+					'errors'       => null,
+				),
+			),
+			'for parameter is not jetpack'    => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'_for'      => 'not_jetpack',
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'request_method' => 'GET',
+					'verified'       => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => null,
+					'errors'       => null,
+				),
+			),
+			'no token or signature parameter' => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'_for' => 'jetpack',
+					),
+					'request_method' => 'GET',
+					'verified'       => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => null,
+					'errors'       => null,
+				),
+			),
+			'no request method'               => array(
+				'test_inputs'  => array(
+					'get_params' => array(
+						'_for'      => 'jetpack',
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'verified'   => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => null,
+					'errors'       => 'WP_Error',
+				),
+			),
+			'invalid request method'          => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'_for'      => 'jetpack',
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'request_method' => 'DELETE',
+					'verified'       => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => null,
+					'errors'       => 'WP_Error',
+				),
+			),
+			'successful GET request'          => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'_for'      => 'jetpack',
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'request_method' => 'GET',
+					'verified'       => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => $token_data['user_id'],
+					'errors'       => true,
+				),
+			),
+			'successful POST request'         => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'_for'      => 'jetpack',
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'request_method' => 'POST',
+					'verified'       => $token_data,
+				),
+				'test_outputs' => array(
+					'authenticate' => $token_data['user_id'],
+					'errors'       => true,
+				),
+			),
+			'signature verification failed'   => array(
+				'test_inputs'  => array(
+					'get_params'     => array(
+						'_for'      => 'jetpack',
+						'token'     => 'token',
+						'signature' => 'signature',
+					),
+					'request_method' => 'GET',
+					'verified'       => false,
+				),
+				'test_outputs' => array(
+					'authenticate' => null,
+					'errors'       => 'WP_Error',
+				),
+			),
+		);
+	}
+}

--- a/tests/php/_inc/lib/test_class.rest-api-authentication.php
+++ b/tests/php/_inc/lib/test_class.rest-api-authentication.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-jetpack-rest-testcase.php';
 require_once JETPACK__PLUGIN_DIR . '/tests/php/lib/class-wp-test-spy-rest-server.php';
 
@@ -372,7 +374,7 @@ class WP_Test_Jetpack_REST_API_Authentication extends WP_Test_Jetpack_REST_Testc
 	public function rest_pre_dispatch( $result, $server ) {
 		// Reset Jetpack::xmlrpc_verification saved state
 		$jetpack = Jetpack::init();
-		$jetpack->reset_saved_auth_state();
+		Connection_Rest_Authentication::init()->reset_saved_auth_state();
 		// Set POST body for Jetpack::verify_xml_rpc_signature
 		$GLOBALS['HTTP_RAW_POST_DATA'] = $this->request->get_body();
 		// Set host and URL for Jetpack_Signature::sign_current_request

--- a/tests/php/modules/post-by-email/test-class.post-by-email-api.php
+++ b/tests/php/modules/post-by-email/test-class.post-by-email-api.php
@@ -1,4 +1,7 @@
 <?php
+
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+
 /**
  * Automated testing of the post-by-email REST API.
  *
@@ -195,8 +198,7 @@ class WP_Test_Post_By_Email_API extends WP_Test_Jetpack_REST_Testcase {
 	 */
 	public function rest_pre_dispatch( $result, $server ) {
 		// Reset Jetpack::xmlrpc_verification saved state.
-		$jetpack = Jetpack::init();
-		$jetpack->reset_saved_auth_state();
+		Connection_Rest_Authentication::init()->reset_saved_auth_state();
 
 		// Set POST body for Jetpack::verify_xml_rpc_signature.
 		$GLOBALS['HTTP_RAW_POST_DATA'] = $this->request->get_body(); // phpcs:ignore

--- a/tests/php/sync/test_class.jetpack-sync-callables.php
+++ b/tests/php/sync/test_class.jetpack-sync-callables.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Sync\Defaults;
 use Automattic\Jetpack\Sync\Functions;
@@ -1001,8 +1002,8 @@ class WP_Test_Jetpack_Sync_Functions extends WP_Test_Jetpack_Sync_Base {
 		unset( $_GET['body-hash'] ) ;
 		unset( $GLOBALS['HTTP_RAW_POST_DATA'] );
 		unset( $_SERVER['REQUEST_METHOD'] );
-		$jetpack = Jetpack::init();
-		$jetpack->reset_saved_auth_state();
+
+		Connection_Rest_Authentication::init()->reset_saved_auth_state();
 		Jetpack::connection()->reset_raw_post_data();
 		wp_set_current_user( $user_id );
 		self::$admin_id = null;


### PR DESCRIPTION
Fixes #16747

#### Changes proposed in this Pull Request:
* Move the rest authentication methods to the connection package so that they're
available to consuming plugins.
* The "wp_rest_authenticate' method hooks to the `determine_current_user` filter which is fired in `wp_get_current_user`. It looks like the expectation is that hooks will be set as the plugins are loaded that plugins can call `wp_get_current_user` during the `plugins_loaded` action, at any priority. Therefore, the consuming plugin needs to set up the filter hooks when it loads:

```
use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;

// Set up the Jetpack REST authentication hooks.
Connection_Rest_Authentication::init();
```

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Make authenticated requests to the Jetpack REST API, for example by loading Calypso. The requests should be successful.
* Send requests to the Jetpack REST API that should fail authentication (for example, missing token, missing signature, incorrect token, incorrect signature, etc.) and verify that the request fails.

#### Proposed changelog entry for your changes:
* tbd
