### PR TITLE
Flickr: avoid Fatal errors when receiving unexpected response

### DIFF
--- a/modules/shortcodes/flickr.php
+++ b/modules/shortcodes/flickr.php
@@ -190,6 +190,11 @@ function flickr_shortcode_video_markup( $atts, $id, $video_param ) {
 			// Get the URL of the video from the page of the video.
 			$video_page_content = wp_remote_get( "http://flickr.com/photo.gne?id=$video_param" );
 
+			// Bail if we do not get any info from Flickr.
+			if ( is_wp_error( $video_page_content ) ) {
+				return '';
+			}
+
 			// Extract the URL from the og:url meta tag.
 			preg_match( '/property=\"og:url\"\scontent=\"([^\"]+)\"/', $video_page_content['body'], $matches );
 			if ( empty( $matches[1] ) ) {


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* In some cases Flickr may not return the expected response, thus causing the following error:

```
Fatal error .../shortcodes/flickr.php:194 - Uncaught Error: Cannot use object of type WP_Error as array in .../shortcodes/flickr.php:194
```

This avoids that.

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Try using a shortcode like `[flickr video=49931239842 autoplay="yes" controls="no"]` 
* It should still work.

#### Proposed changelog entry for your changes:

* Shortcodes: avoid Fatal errors when receiving unexpected response from Flickr.
