### PR TITLE
Sync: add Creative Mail configuration option to synced options

### DIFF
--- a/packages/sync/src/class-defaults.php
+++ b/packages/sync/src/class-defaults.php
@@ -165,6 +165,7 @@ class Defaults {
 		'jetpack_publicize_options',
 		'jetpack_connection_active_plugins',
 		'jetpack_sync_non_blocking', // is non-blocking Jetpack Sync flow enabled.
+		'ce4wp_referred_by',
 	);
 
 	/**

--- a/tests/php/sync/test_class.jetpack-sync-options.php
+++ b/tests/php/sync/test_class.jetpack-sync-options.php
@@ -212,6 +212,7 @@ class WP_Test_Jetpack_Sync_Options extends WP_Test_Jetpack_Sync_Base {
 			'jetpack_publicize_options'                => array(),
 			'jetpack_connection_active_plugins'        => array( 'jetpack' ),
 			'jetpack_sync_non_blocking'                => false,
+			'ce4wp_referred_by'                        => array(),
 		);
 
 		// Options Deprecated in WP 5.5.


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Follow-up from #16861 and #16818 

#### Jetpack product discussion

* Internal reference: pbtFPC-H5-p2

#### Does this pull request change what data or activity we track or use?

* Yes, we synchronize one additional option, but that option is set by Jetpack, so I do not think it requires a change in our privacy policy.

#### Testing instructions:

* Not much to test here just yet.

#### Proposed changelog entry for your changes:

* N/A
