### PR TITLE
AAG: Display Backups card when Rewind API is loading or has error

### DIFF
--- a/_inc/client/at-a-glance/backups.jsx
+++ b/_inc/client/at-a-glance/backups.jsx
@@ -232,11 +232,14 @@ class DashBackups extends Component {
 		return (
 			<div>
 				<QueryVaultPressData />
-				{ 'unavailable' === this.props.rewindStatus ? (
-					this.getVPContent()
-				) : (
-					<div className="jp-dash-item">{ this.getRewindContent() }</div>
-				) }
+				{
+					// this.props.rewindStatus is empty string on API error.
+					'unavailable' === this.props.rewindStatus || '' === this.props.rewindStatus ? (
+						this.getVPContent()
+					) : (
+						<div className="jp-dash-item">{ this.getRewindContent() }</div>
+					)
+				}
 			</div>
 		);
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes the missing Backups card in the main dashboard when waiting for the response of the /rewind endpoint, as well as when that endpoint returns an error. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
The way this card works is quite confusing, since it needs to handle both VaultPress and Rewind statuses. 

Currently, this card relies on the /rewind endpoint to return one of a specific key before displaying any information. Unfortunately, there is no case for when the API errors. In this case, the value of `this.props.rewindStatus` is empty, therefore not falling back to the `getVPContent()` content that is used to show the loading/upgrade prompts. 

IMO this entire component could use a re-write. But for an immediate fix, this should at least solve the problem of the missing card in any case. 

Before: 
![image](https://user-images.githubusercontent.com/7129409/90431955-ca7b8e80-e097-11ea-95f2-1c3f28cad4a9.png)

After: 
![image](https://user-images.githubusercontent.com/7129409/90432008-e2531280-e097-11ea-99f8-24eb340133ea.png)
![image](https://user-images.githubusercontent.com/7129409/90432032-eb43e400-e097-11ea-8c40-ed66b6020a42.png)

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

- Connect Jetpack 
- Use the "Broken Token" plugin to "Set Invalid User Tokens". This will trigger an error in the /rewind API endpoint. 
- Navigate to /dashboard
- With this patch, the card should show both the loading state, and the final state based on the rewind response. 

Test it also on a paid plan to make sure the correct information shows, based on whether the site has VP or Rewind enabled. 

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
(Optional) General: Fix missing dashboard card for Backups in some error cases. 
