### PR TITLE
Docker: Clean out vendor and composer.lock before installing package deps

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -162,6 +162,16 @@ For a specific package's tests
 yarn docker:phpunit:package autoloader
 ```
 
+If you need to clear out a particular package's composer.lock
+```sh
+yarn docker:phpunit:package autoloader -c
+```
+
+To run all package unit tests and clear all composer.lock files within
+```sh
+yarn docker:phpunit:package -c
+```
+
 ### Starting over
 
 To remove all docker images, all MySQL data, and all docker-related files from your local machine run:

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -235,6 +235,26 @@ To get started, there are several ways to run the unit tests, depending on how y
 	```sh
 	yarn docker:phpunit:multisite --filter=Protect
 	```
+ 
+    For all package unit tests
+    ```sh
+    yarn docker:phpunit:package
+    ```
+    
+    For a specific package's tests
+    ```sh
+    yarn docker:phpunit:package autoloader
+    ```
+    
+    If you need to clear out a particular package's composer.lock
+    ```sh
+    yarn docker:phpunit:package autoloader -c
+    ```
+    
+    To run all package unit tests and clear all composer.lock files within
+    ```sh
+    yarn docker:phpunit:package -c
+    ```
 
 * ### VVV & Local Installs
 

--- a/modules/widgets/class-jetpack-instagram-widget.php
+++ b/modules/widgets/class-jetpack-instagram-widget.php
@@ -45,7 +45,10 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 			)
 		);
 
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_css' ) );
+		if ( is_active_widget( false, false, self::ID_BASE ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
+			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_css' ) );
+		}
+
 		add_action( 'wp_ajax_wpcom_instagram_widget_update_widget_token_id', array( $this, 'ajax_update_widget_token_id' ) );
 
 		$this->valid_options = array(
@@ -74,10 +77,6 @@ class Jetpack_Instagram_Widget extends WP_Widget {
 	 * Enqueues the widget's frontend CSS but only if the widget is currently in use.
 	 */
 	public function enqueue_css() {
-		if ( ! is_active_widget( false, false, self::ID_BASE ) || is_active_widget( false, false, 'monster' ) || is_customize_preview() ) {
-			return;
-		}
-
 		wp_enqueue_style( self::ID_BASE, plugins_url( 'instagram/instagram.css', __FILE__ ), array(), JETPACK__VERSION );
 	}
 

--- a/tests/package-runner.sh
+++ b/tests/package-runner.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+# Set defaults.
+CLEAN_LOCK=0 # Used to trigger if composer.lock and the vendor folder should be deleted.
+PACKAGE='' # Used to store the package name passed in the args.
+
+# This function fires if no package name is passed in the command line and will run all packages.
 function run_packages_tests {
 	echo "Running tests for all packages:"
 	export PACKAGES='./packages/**'
-	for PACKAGE in $PACKAGES
+	for P in $PACKAGES
 	do
-		if [ -d "$PACKAGE" ]; then
-			folder="$(basename $PACKAGE)"
+		if [ -d "$P" ]; then
+			folder="$(basename $P)"
 			result="run_package_test $folder"
 
 			if $result; then
@@ -19,14 +24,17 @@ function run_packages_tests {
 	done
 }
 
+# This function runs a particular package.
 function run_package_test {
 	package=$1;
 
 	if [ -f "./packages/$package/phpunit.xml.dist" ]; then
 			echo "Running tests for package \`$package\` "
 			cd "./packages/$package"
-			rm composer.lock
-			rm -rf vendor
+			if [ 1 == $CLEAN_LOCK ]; then
+				rm composer.lock
+				rm -rf vendor
+			fi
 			composer install
 			cd "../.."
 			result="yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/packages/$package/phpunit.xml.dist"
@@ -42,9 +50,24 @@ function run_package_test {
 
 }
 
+for arg in "$@"
+do
+	case $arg in
+		-c|--clean-lock)
+			CLEAN_LOCK=1
+			shift
+			;;
+		*)
+			PACKAGE="$1"
+			shift
+			;;
+	esac
+done
 
-if [ -f "./packages/$1/phpunit.xml.dist"  ]; then
-	run_package_test "$1"
+
+
+if [ -f "./packages/$PACKAGE/phpunit.xml.dist"  ]; then
+	run_package_test "$PACKAGE"
 else
 	echo "You did not specify a package. Running all of them can take a good amount of time."
 	echo "Do you wish to run tests for all packages?"

--- a/tests/package-runner.sh
+++ b/tests/package-runner.sh
@@ -25,6 +25,8 @@ function run_package_test {
 	if [ -f "./packages/$package/phpunit.xml.dist" ]; then
 			echo "Running tests for package \`$package\` "
 			cd "./packages/$package"
+			rm composer.lock
+			rm -rf vendor
 			composer install
 			cd "../.."
 			result="yarn docker:compose exec wordpress phpunit --configuration=/var/www/html/wp-content/plugins/jetpack/packages/$package/phpunit.xml.dist"


### PR DESCRIPTION
Before installing a package's deps for testing, clean out the vendor and the non-VCS'd composer.lock.

#### Changes proposed in this Pull Request:
*

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
* `yarn docker:phpunit:package connection` on master, make manual changes to composer.json
* Run again, see no change with master.
* Switch to this version and run. See that vendor and composre.lock are fixed.

#### Proposed changelog entry for your changes:
* n/a
