### PR TITLE
Protect: check for jetpack_protect_save_whitelist function before using it

### DIFF
--- a/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -715,7 +715,12 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					break;
 
 				case 'jetpack_protect_global_whitelist':
+					if ( ! function_exists( 'jetpack_protect_save_whitelist' ) ) {
+						require_once JETPACK__PLUGIN_DIR . 'modules/protect/shared-functions.php';
+					}
+
 					$updated = jetpack_protect_save_whitelist( explode( PHP_EOL, str_replace( array( ' ', ',' ), array( '', "\n" ), $value ) ) );
+
 					if ( is_wp_error( $updated ) ) {
 						$error = $updated->get_error_message();
 					}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Check for the `jetpack_protect_save_whitelist` function before calling it in `Jetpack_Core_API_Module_Toggle_Endpoint::update_data`. If it doesn't exist, require the file that contains it.

The endpoint is currently returning a 500 error and generating a fatal. For context, see p1597673240279600-slack-CDLH4C1UZ

#### Jetpack product discussion
* N/A

#### Does this pull request change what data or activity we track or use?
* No

#### Testing instructions:
##### Reproduce the problem
1. Install, activate, and connect Jetpack on your test site.
2. Using the developer console, send a post request to `/jetpack-blogs/$blog_id/rest-api` with:
path: `/jetpack/v4/settings`
body: 
`{ "jetpack_protect_global_whitelist":"", "protect":false}`
3. The request should return a 500 error. This PHP error should be in your debug.log:

`PHP Fatal error:  Uncaught Error: Call to undefined function jetpack_protect_save_whitelist() in .../wp-content/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php:718`


##### Test the Fix
1. Checkout this branch.
2. Repeat the request shown above.
3. The request should be successful, and no errors should be generated.


#### Proposed changelog entry for your changes:
* tbd