### PR TITLE
Plan page redirect flow update

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -11,12 +11,14 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import getRedirectUrl from 'lib/jp-redirect';
 import { isCurrentUserLinked, isOfflineMode } from 'state/connection';
 import { isModuleActivated as _isModuleActivated } from 'state/modules';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
 import SectionNav from 'components/section-nav';
 import {
+	getSiteRawUrl,
 	userCanManageModules as _userCanManageModules,
 	userCanViewStats as _userCanViewStats,
 } from 'state/initial-state';
@@ -66,7 +68,7 @@ export class Navigation extends React.Component {
 					) }
 					{ ! this.props.isOfflineMode && this.props.isLinked && (
 						<NavItem
-							path="#/plans"
+							path={ getRedirectUrl( 'jetpack-plans', { site: this.props.siteUrl } ) }
 							onClick={ this.trackPlansClick }
 							selected={ this.props.location.pathname === '/plans' }
 						>
@@ -109,5 +111,6 @@ export default connect( state => {
 		isModuleActivated: module_name => _isModuleActivated( state, module_name ),
 		isOfflineMode: isOfflineMode( state ),
 		isLinked: isCurrentUserLinked( state ),
+		siteUrl: getSiteRawUrl( state ),
 	};
 } )( withRouter( Navigation ) );

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -147,13 +147,10 @@ jQuery( document ).ready( function ( $ ) {
 
 			if ( jetpackConnectButton.isPaidPlan ) {
 				window.location.assign( jpConnect.dashboardUrl );
+				// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
+				window.location.reload( true );
 			} else {
 				window.location.assign( jpConnect.plansPromptUrl );
-			}
-
-			// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
-			if ( -1 !== jpConnect.indexOf( '#' ) ) {
-				window.location.reload( true );
 			}
 		},
 		handleConnectionError: function ( error ) {

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -152,7 +152,7 @@ jQuery( document ).ready( function ( $ ) {
 			}
 
 			// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
-			if ( jpConnect.contains( '#' ) ) {
+			if ( -1 !== jpConnect.indexOf( '#' ) ) {
 				window.location.reload( true );
 			}
 		},

--- a/_inc/connect-button.js
+++ b/_inc/connect-button.js
@@ -152,7 +152,7 @@ jQuery( document ).ready( function ( $ ) {
 			}
 
 			// The Jetpack admin page has hashes in the URLs, so we need to reload the page after .assign()
-			if ( window.location.hash ) {
+			if ( jpConnect.contains( '#' ) ) {
 				window.location.reload( true );
 			}
 		},

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -3,6 +3,7 @@
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Assets\Logo;
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Redirect;
 
 class Jetpack_Connection_Banner {
 	/**
@@ -194,7 +195,7 @@ class Jetpack_Connection_Banner {
 				'forceVariation'        => $force_variation,
 				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
-				'plansPromptUrl'        => Jetpack::admin_url( 'page=jetpack#/plans-prompt' ),
+				'plansPromptUrl'        => Redirect::get_url( 'jetpack-connect-plans' ),
 				'identity'              => $identity,
 				'preFetchScript'        => plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ) . '?ver=' . JETPACK__VERSION,
 			)

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -86,6 +86,10 @@ export async function doInPlaceConnection() {
 	await jetpackPage.connect();
 
 	await ( await InPlaceAuthorizeFrame.init( page ) ).approve();
+	await ( await PickAPlanPage.init( page ) ).selectFreePlan();
+	await ( await ThankYouPage.init( page ) ).waitForSetupAndProceed();
+	await ( await MyPlanPage.init( page ) ).returnToWPAdmin();
+	await ( await Sidebar.init( page ) ).selectJetpack();
 }
 
 export async function syncJetpackPlanData( plan, mockPlanData = true ) {

--- a/tests/e2e/lib/flows/jetpack-connect.js
+++ b/tests/e2e/lib/flows/jetpack-connect.js
@@ -25,7 +25,6 @@ import PlansPage from '../pages/wpcom/plans';
 import { persistPlanData, syncPlanData } from '../plan-helper';
 import logger from '../logger';
 import InPlaceAuthorizeFrame from '../pages/wp-admin/in-place-authorize';
-import InPlacePlansPage from '../pages/wp-admin/in-place-plans';
 
 const cookie = config.get( 'storeSandboxCookieValue' );
 const cardCredentials = config.get( 'testCardCredentials' );
@@ -87,7 +86,6 @@ export async function doInPlaceConnection() {
 	await jetpackPage.connect();
 
 	await ( await InPlaceAuthorizeFrame.init( page ) ).approve();
-	await ( await InPlacePlansPage.init( page ) ).selectFreePlan();
 }
 
 export async function syncJetpackPlanData( plan, mockPlanData = true ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes 1169247016322522-as-1189559105816970 and 1169247016322522-as-1188504668471449.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* This redirects users to in Calypso from two spots:
  - With the in-place connection flow, it sends users to the Jetpack Connect plans page. Note TBD is allowing users who select Free to immediately go back to their site dashboard.
  - With the plans tab, it changes the tab URL to redirect to Calypso.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Ref: pbtFFM-oz-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
I do not believe so? It performs some redirects that have tracking, but nothing we don't already use elsewhere.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Create a fresh Jetpack site with this code that is not connected.
* Perform an in-place connection flow.
* Observe redirecting to Calypso for plan selection after site is connected.
* Go back to the site wp-admin.
* In the Jetpack admin, click the Plans tab.
* Observe redirecting to Calypso plans page.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Deprecating plan selection in the WordPress admin. 