### PR TITLE
Premium Blocks: tracking events

### DIFF
--- a/extensions/extended-blocks/paid-blocks/edit.js
+++ b/extensions/extended-blocks/paid-blocks/edit.js
@@ -9,12 +9,14 @@ import { InspectorControls } from '@wordpress/block-editor';
  */
 import UpgradePlanBanner from './upgrade-plan-banner';
 import { getRequiredPlan } from '../../shared/plan-utils';
+import { trackUpgradeClickEvent } from './utils';
 
 export default OriginalBlockEdit => props => {
 	const requiredPlan = getRequiredPlan( props?.name );
 	if ( ! requiredPlan ) {
 		return <OriginalBlockEdit { ...props } />;
 	}
+	const bannerContext = 'sidebar';
 
 	return (
 		<Fragment>
@@ -22,7 +24,12 @@ export default OriginalBlockEdit => props => {
 				<UpgradePlanBanner
 					description={ null }
 					requiredPlan={ requiredPlan }
-					context="sidebar"
+					context={ bannerContext }
+					onRedirect={ () => trackUpgradeClickEvent( {
+						plan: requiredPlan,
+						blockName: props.name,
+						context: bannerContext,
+					} ) }
 				/>
 			</InspectorControls>
 

--- a/extensions/extended-blocks/paid-blocks/edit.js
+++ b/extensions/extended-blocks/paid-blocks/edit.js
@@ -25,11 +25,13 @@ export default OriginalBlockEdit => props => {
 					description={ null }
 					requiredPlan={ requiredPlan }
 					context={ bannerContext }
-					onRedirect={ () => trackUpgradeClickEvent( {
-						plan: requiredPlan,
-						blockName: props.name,
-						context: bannerContext,
-					} ) }
+					onRedirect={ () =>
+						trackUpgradeClickEvent( {
+							plan: requiredPlan,
+							blockName: props.name,
+							context: bannerContext,
+						} )
+					}
 				/>
 			</InspectorControls>
 

--- a/extensions/extended-blocks/paid-blocks/render-paid-icon.js
+++ b/extensions/extended-blocks/paid-blocks/render-paid-icon.js
@@ -7,7 +7,7 @@ import { cloneElement } from '@wordpress/element';
  * Internal dependencies
  */
 import PaidSymbol from './paid-symbol';
-import { isUpgradable } from "../../shared/plan-utils";
+import { isUpgradable } from '../../shared/plan-utils';
 
 /**
  * Enhance the default block icon with a paid indicator

--- a/extensions/extended-blocks/paid-blocks/upgrade-plan-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/upgrade-plan-banner.jsx
@@ -33,13 +33,10 @@ const UpgradePlanBanner = ( {
 		return null;
 	}
 
-	const cssClasses = classNames(
-		className,
-		'jetpack-upgrade-plan-banner', {
-			'wp-block': context === 'editor-canvas',
-			'block-editor-block-list__block': context === 'editor-canvas',
-		}
-	);
+	const cssClasses = classNames( className, 'jetpack-upgrade-plan-banner', {
+		'wp-block': context === 'editor-canvas',
+		'block-editor-block-list__block': context === 'editor-canvas',
+	} );
 
 	const redirectingText = __( 'Redirecting…', 'jetpack' );
 

--- a/extensions/extended-blocks/paid-blocks/utils.js
+++ b/extensions/extended-blocks/paid-blocks/utils.js
@@ -23,3 +23,20 @@ export const trackUpgradeClickEvent = ( { plan, blockName, context } ) =>
 		block: blockName,
 		context,
 	} );
+
+/**
+ * Record event helper.
+ * Use it when the banner shows up in the block editor canvas.
+ *
+ * @param { object } props - Event properties.
+ * @param { string } props.plan -      Plan slug.
+ * @param { string } props.blockName - Block name where the banner is mounted.
+ * @param { string } props.context -   Banner context: sidebar, editor.
+ * @returns { Function }               Rector event helper function.
+ */
+export const trackUpgradeBannerImpression = ( { plan, blockName, context } ) =>
+	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_banner_impression', {
+		plan,
+		block: blockName,
+		context,
+	} );

--- a/extensions/extended-blocks/paid-blocks/utils.js
+++ b/extensions/extended-blocks/paid-blocks/utils.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import analytics from '../../../_inc/client/lib/analytics';
+
+/**
+ * Record event helper.
+ * Use it when the user clicks on the upgrade banner button.
+ *
+ * @param { object } props - Event properties.
+ * @param { string } props.plan -      Plan slug.
+ * @param { string } props.blockName - Block name where the banner is mounted.
+ * @param { string } props.context -   Banner context: sidebar, editor.
+ * @returns { Function }               Rector event helper function.
+ */
+export const trackUpgradeClickEvent = ( { plan, blockName, context } ) =>
+	void analytics.tracks.recordEvent( 'jetpack_editor_block_upgrade_click', {
+		plan,
+		block: blockName,
+		context,
+	} );

--- a/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -20,6 +20,7 @@ import {
 } from '../../shared/plan-utils';
 import UpgradePlanBanner from './upgrade-plan-banner';
 import { PaidBlockProvider } from './components';
+import { trackUpgradeClickEvent } from './utils';
 
 export default createHigherOrderComponent(
 	BlockListBlock => props => {
@@ -48,6 +49,8 @@ export default createHigherOrderComponent(
 			'is-upgradable': isBannerVisible,
 		} );
 
+		const bannerContext = 'editor-canvas';
+
 		return (
 			<PaidBlockProvider onBannerVisibilityChange={ setIsVisible }>
 				<UpgradePlanBanner
@@ -57,7 +60,12 @@ export default createHigherOrderComponent(
 					visible={ isBannerVisible }
 					description={ usableBlocksProps?.description }
 					requiredPlan={ requiredPlan }
-					context="editor-canvas"
+					context={ bannerContext }
+					onRedirect={ () => trackUpgradeClickEvent( {
+						plan: requiredPlan,
+						blockName: props.name,
+						context: bannerContext,
+					} ) }
 				/>
 
 				<BlockListBlock { ...props } className={ listBlockCSSClass } />

--- a/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -58,7 +58,7 @@ export default createHigherOrderComponent(
 		}, [ isBannerVisible, setBannerAlreadyShown ] );
 
 		useEffect( () => {
-			if ( hasBannerAlreadyShown ) {
+			if ( ! hasBannerAlreadyShown ) {
 				return;
 			}
 			trackUpgradeBannerImpression( trackEventData );

--- a/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -33,6 +33,7 @@ export default createHigherOrderComponent(
 		const usableBlocksProps = getUsableBlockProps( props.name );
 
 		const [ isVisible, setIsVisible ] = useState( ! isDualMode );
+		const [ hasBannerAlreadyShown, setBannerAlreadyShown ] = useState( false );
 
 		const bannerContext = 'editor-canvas';
 		const hasChildrenSelected = useSelect(
@@ -47,13 +48,21 @@ export default createHigherOrderComponent(
 			context: bannerContext,
 		};
 
+		// Record event just once, the first time.
 		useEffect( () => {
 			if ( ! isBannerVisible ) {
 				return;
 			}
 
+			setBannerAlreadyShown( true );
+		}, [ isBannerVisible, setBannerAlreadyShown ] );
+
+		useEffect( () => {
+			if ( hasBannerAlreadyShown ) {
+				return;
+			}
 			trackUpgradeBannerImpression( trackEventData );
-		}, [ isBannerVisible, trackEventData ] );
+		}, [ hasBannerAlreadyShown, trackEventData ] );
 
 		// Hide Banner when block changes its attributes (dual Mode).
 		useEffect( () => setIsVisible( ! isDualMode ), [ props.attributes, setIsVisible, isDualMode ] );

--- a/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -20,7 +20,7 @@ import {
 } from '../../shared/plan-utils';
 import UpgradePlanBanner from './upgrade-plan-banner';
 import { PaidBlockProvider } from './components';
-import { trackUpgradeClickEvent } from './utils';
+import { trackUpgradeBannerImpression, trackUpgradeClickEvent } from './utils';
 
 export default createHigherOrderComponent(
 	BlockListBlock => props => {
@@ -33,6 +33,22 @@ export default createHigherOrderComponent(
 		const usableBlocksProps = getUsableBlockProps( props.name );
 
 		const [ isVisible, setIsVisible ] = useState( ! isDualMode );
+
+		const bannerContext = 'editor-canvas';
+
+		const trackEventData = {
+			plan: requiredPlan,
+			blockName: props.name,
+			context: bannerContext,
+		};
+
+		useEffect( () => {
+			if ( ! isVisible ) {
+				return;
+			}
+
+			trackUpgradeBannerImpression( trackEventData );
+		}, [ isVisible, trackEventData ] );
 
 		// Hide Banner when block changes its attributes (dual Mode).
 		useEffect( () => setIsVisible( ! isDualMode ), [ props.attributes, setIsVisible, isDualMode ] );
@@ -49,8 +65,6 @@ export default createHigherOrderComponent(
 			'is-upgradable': isBannerVisible,
 		} );
 
-		const bannerContext = 'editor-canvas';
-
 		return (
 			<PaidBlockProvider onBannerVisibilityChange={ setIsVisible }>
 				<UpgradePlanBanner
@@ -61,11 +75,7 @@ export default createHigherOrderComponent(
 					description={ usableBlocksProps?.description }
 					requiredPlan={ requiredPlan }
 					context={ bannerContext }
-					onRedirect={ () => trackUpgradeClickEvent( {
-						plan: requiredPlan,
-						blockName: props.name,
-						context: bannerContext,
-					} ) }
+					onRedirect={ () => trackUpgradeClickEvent( trackEventData ) }
 				/>
 
 				<BlockListBlock { ...props } className={ listBlockCSSClass } />

--- a/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -35,6 +35,11 @@ export default createHigherOrderComponent(
 		const [ isVisible, setIsVisible ] = useState( ! isDualMode );
 
 		const bannerContext = 'editor-canvas';
+		const hasChildrenSelected = useSelect(
+			select => select( 'core/block-editor' ).hasSelectedInnerBlock( props?.clientId ),
+			[]
+		);
+		const isBannerVisible = ( props?.isSelected || hasChildrenSelected ) && isVisible;
 
 		const trackEventData = {
 			plan: requiredPlan,
@@ -43,22 +48,15 @@ export default createHigherOrderComponent(
 		};
 
 		useEffect( () => {
-			if ( ! isVisible ) {
+			if ( ! isBannerVisible ) {
 				return;
 			}
 
 			trackUpgradeBannerImpression( trackEventData );
-		}, [ isVisible, trackEventData ] );
+		}, [ isBannerVisible, trackEventData ] );
 
 		// Hide Banner when block changes its attributes (dual Mode).
 		useEffect( () => setIsVisible( ! isDualMode ), [ props.attributes, setIsVisible, isDualMode ] );
-
-		const hasChildrenSelected = useSelect(
-			select => select( 'core/block-editor' ).hasSelectedInnerBlock( props?.clientId ),
-			[]
-		);
-
-		const isBannerVisible = ( props?.isSelected || hasChildrenSelected ) && isVisible;
 
 		// Set banner CSS classes depending on its visibility.
 		const listBlockCSSClass = classNames( props?.className, {

--- a/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/with-upgrade-banner.jsx
@@ -58,11 +58,11 @@ export default createHigherOrderComponent(
 		}, [ isBannerVisible, setBannerAlreadyShown ] );
 
 		useEffect( () => {
-			if ( ! hasBannerAlreadyShown ) {
+			if ( hasBannerAlreadyShown || ! isBannerVisible ) {
 				return;
 			}
 			trackUpgradeBannerImpression( trackEventData );
-		}, [ hasBannerAlreadyShown, trackEventData ] );
+		}, [ hasBannerAlreadyShown, trackEventData, isBannerVisible ] );
 
 		// Hide Banner when block changes its attributes (dual Mode).
 		useEffect( () => setIsVisible( ! isDualMode ), [ props.attributes, setIsVisible, isDualMode ] );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR records two new tracking events: `jetpack_editor_block_upgrade_click` and `jetpack_editor_block_upgrade_banner_impression`.

Fixes #16863 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Premium Blocks: record tracking events.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply D48278-code
* Get sandboxed
* Pick up a Simple site to test (Sandbox it!)
<img src="https://user-images.githubusercontent.com/77539/90570798-d98d3a00-e186-11ea-94f4-990ce840258f.png" width="400px" />


* set debug namespace:
`localStorage.setItem( 'debug', 'dops:analytics*' );`
* add a premium block, for instance `calendly`

<img src="https://user-images.githubusercontent.com/77539/90570848-f6297200-e186-11ea-9c25-540e29da0d73.png" width="600px">

* You should see the first event recorded `jetpack_editor_block_upgrade_banner_impression`
![image](https://user-images.githubusercontent.com/77539/90570906-10635000-e187-11ea-9331-d15c009873b6.png)

* Confirm you see the `context`, `block` and `plan`

* Click on the Upgrade button. Activate preserve logs in order to don't lose it.

<img width="893" alt="Screen Shot 2020-08-18 at 7 17 43 PM" src="https://user-images.githubusercontent.com/77539/90571133-8ff11f00-e187-11ea-862c-7769d058b16f.png">

![image](https://user-images.githubusercontent.com/77539/90571156-9a131d80-e187-11ea-9ee1-2fbd6433bc5d.png)

* Click on the sidebar banner, confirming that now the context is `sidebar`.

![image](https://user-images.githubusercontent.com/77539/90571245-c038bd80-e187-11ea-998d-a37ecbe88796.png)


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Premium Blocks: record tracking events.
