### PR TITLE
Jetpack Dashboard: More meaningful error notices.

### DIFF
--- a/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
+++ b/_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ErrorNoticeCycleConnection from './error-notice-cycle-connection';
+import SimpleNotice from 'components/notice';
 
 export default class JetpackConnectionErrors extends React.Component {
 	static propTypes = {
@@ -20,6 +21,15 @@ export default class JetpackConnectionErrors extends React.Component {
 			case 'refresh_blog_token':
 			case 'refresh_user_token':
 				return <ErrorNoticeCycleConnection text={ message } errorCode={ code } action={ action } />;
+			case 'display':
+				return (
+					<SimpleNotice
+						text={ message }
+						status={ 'is-error' }
+						icon={ 'link-break' }
+						showDismiss={ false }
+					/>
+				);
 		}
 
 		return null;

--- a/_inc/client/rest-api/index.js
+++ b/_inc/client/rest-api/index.js
@@ -380,11 +380,15 @@ function checkStatus( response ) {
 		} );
 	}
 
-	return response.json().then( json => {
-		const error = new Error( `${ json.message } (Status ${ response.status })` );
-		error.response = json;
-		throw error;
-	} );
+	return response
+		.json()
+		.catch( e => catchJsonParseError( e ) )
+		.then( json => {
+			const error = new Error( `${ json.message } (Status ${ response.status })` );
+			error.response = json;
+			error.name = 'ApiError';
+			throw error;
+		} );
 }
 
 function parseJsonResponse( response ) {


### PR DESCRIPTION
If Jetpack encounters a communication error, it suggest reconnecting.
That doesn't always help. In fact, there is a myriad of other reasons why the error might be thrown, and blindly suggesting to restore connection might only mislead users.

#### Changes proposed in this Pull Request:

This PR introduces different types of error:

- `ApiError` is clearly a connection error, and might be solved by reconnecting.
<img width="812" alt="Screen Shot 2020-08-19 at 9 53 47 AM" src="https://user-images.githubusercontent.com/1341249/90650800-e8fd9900-e201-11ea-9752-8b471fa20ace.png">

- `JsonParseError` is a JSON parsing issue. This usually means there's an error output included into the JSON response, so we suggest the user to check the error log, and don't show the "Restore Connection" button.
<img width="593" alt="Screen Shot 2020-08-18 at 4 14 38 PM" src="https://user-images.githubusercontent.com/1341249/90566350-efdacc00-e16d-11ea-892d-abb56b371e7a.png">

- Anything else: we do nothing, as we have no idea what's going on. Most likely it's a network issue, and we don't have an easy solution for that.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. If you don't run `yarn watch`, please rebuild the JS after checking out the branch.
2. Go to the Jetpack Dashboard, make sure no error notices appear.

##### Connection Error
3. Break your `blog_token`, refresh the dashboard and wait until it loads.
4. Confirm that you see the error notice (see example above), and the "Restore Connection" button.
5. Click on the "Restore Connection", the Dashboard should reload
6. The error notice should not appear, the `blog_token` should get restored.

##### JSON parsing error
7. Find the `Jetpack_Core_Json_Api_Endpoints::get_site_data()` API endpoint method: https://github.com/Automattic/jetpack/blob/de7438643c0d3c01176e6f7b31d1401aca0674d8/_inc/lib/class.core-rest-api-endpoints.php#L1755
8. Add some output into the first line of the method (e.g. `echo 'something';`) to break the output JSON.
9. Confirm that you see the error notice (see example above). The "Restore Connection" button **must not appear**.

##### Why not both?
This is a special use case that needed to be fixed separately, so we need to test it too.
10. Keep your `echo 'something';` in place, but in addition to that break the `blog_token`. So the connection will be broken, but the error response will also contain invalid JSON.
11. Reload the Dashboard, and confirm that you see the "update to communicate" error notice (see example above). The "Restore Connection" button **must not appear**, as it's pointless trying to restore the connection as we won't be able to parse the response anyway.
12. Fix the JSON by removing your `echo 'something';` line from the `Jetpack_Core_Json_Api_Endpoints::get_site_data()` method. Keep the token broken for now.
13. Reload the dashboard. You should see the "Restore Connection" error notice.
14. Click on the "Restore Connection", the page should reload, the error notice should no longer appear.

Thanks for testing! 🙂 

#### Proposed changelog entry for your changes:
* Improved error notices in the Jetpack Dashboard.
