### PR TITLE
Social Previews: improve preview description handling

### DIFF
--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -92,7 +92,6 @@ export default withSelect( ( select, props ) => {
 		title: getEditedPostAttribute( 'title' ),
 		description:
 			getEditedPostAttribute( 'excerpt' ) ||
-			getEditedPostAttribute( 'excerpt' ) ||
 			getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,

--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -93,7 +93,8 @@ export default withSelect( ( select, props ) => {
 		description:
 			getEditedPostAttribute( 'meta' )?.advanced_seo_description ||
 			getEditedPostAttribute( 'excerpt' ) ||
-			getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
+			getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ] ||
+			__( 'Visit the post for more.', 'jetpack' ),
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
 		image:

--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -92,7 +92,8 @@ export default withSelect( ( select, props ) => {
 		title: getEditedPostAttribute( 'title' ),
 		description:
 			getEditedPostAttribute( 'excerpt' ) ||
-			getEditedPostAttribute( 'content' ).split( '<!--more-->' )[ 0 ],
+			getEditedPostAttribute( 'excerpt' ) ||
+			getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
 		image:

--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -90,7 +90,9 @@ export default withSelect( ( select, props ) => {
 	return {
 		post: getCurrentPost(),
 		title: getEditedPostAttribute( 'title' ),
-		description: getEditedPostAttribute( 'excerpt' ) || getEditedPostAttribute( 'content' ),
+		description:
+			getEditedPostAttribute( 'excerpt' ) ||
+			getEditedPostAttribute( 'content' ).split( '<!--more-->' )[ 0 ],
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
 		image:

--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -91,6 +91,7 @@ export default withSelect( ( select, props ) => {
 		post: getCurrentPost(),
 		title: getEditedPostAttribute( 'title' ),
 		description:
+			getEditedPostAttribute( 'meta' )?.advanced_seo_description ||
 			getEditedPostAttribute( 'excerpt' ) ||
 			getEditedPostAttribute( 'content' ).split( '<!--more' )[ 0 ],
 		url: getEditedPostAttribute( 'link' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Similar to [its backend counterpart](https://github.com/Automattic/jetpack/blob/f9b5cdb92ffc1b8753db7f99b1697090bd886aa4/functions.opengraph.php#L137), the preview text can fall back to the post content if the perex is not present. In this case, we should respect the "more" block (represented as HTML comment) and only show content before it.
* I have also added support for the advanced seo that you can fill on wpcom in JP sidebar as well as the static text fallback

#### Jetpack product discussion


#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* follow setup steps from #16615
* go to the block editor
* check the social preview right away and you should see a static fallback there "Visit the post for more."
* now, don't write any excerpt but write some content into the post.
* use the "more" block and write some more text after it. feel free to edit the text of the more button
* open up the preview and confirm that nothing after the more tag makes it there
* open the Jetpack sidebar and update SEO description (testable on wpcom using the diff, or by altering some files )
* check the preview and confirm you can see the SEO description

| in master | this PR | 
| - | -
| <img width="578" alt="Screenshot 2020-08-19 at 11 25 11" src="https://user-images.githubusercontent.com/156676/90617192-aee6c400-e20e-11ea-8de0-f67feb98e9df.png"> |  <img width="531" alt="Screenshot 2020-08-19 at 11 20 00" src="https://user-images.githubusercontent.com/156676/90617082-8e1e6e80-e20e-11ea-8415-7892b48320f0.png">


#### Proposed changelog entry for your changes:
none