### PR TITLE
Customizer: Tweak cookie widget edit button position

### DIFF
--- a/modules/widgets/eu-cookie-law/style.css
+++ b/modules/widgets/eu-cookie-law/style.css
@@ -124,3 +124,11 @@ amp-consent.widget_eu_cookie_law_widget.widget.top {
 		right: 8px;
 	}
 }
+
+/**
+ * Tweak position of the Customizer edit button to make it more obvious this
+ * is an editable widget rather than a normal accept cookies banner.
+ */
+.widget_eu_cookie_law_widget .customize-partial-edit-shortcut > button {
+	left: 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes Automattic/wp-calypso#44126

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Repositions the edit button that is added to the widget within the Customizer so it is more obvious the widget is editable and the button isn't partially hidden behind the Customizer sidebar.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes.

#### Testing instructions:
1. Ensure you have a theme selected that can add widgets via the Customizer
2. If you haven't already, turn on the extra widgets in Jetpack settings
3. Navigate to the Customizer and add the "Cookies & Consent" widget
4. Notice how the injected edit button for the widget is partially obscured
5. Apply this PR branch
6. Reload the Customizer and ensure the injected edit button now overlays the top left corner of the widget

#### Before
<img width="1379" alt="Screen Shot 2020-08-19 at 7 23 15 pm" src="https://user-images.githubusercontent.com/60436221/90618386-4837c980-e253-11ea-9c36-609c344dcd2e.png">

#### After
<img width="1377" alt="Screen Shot 2020-08-19 at 7 22 51 pm" src="https://user-images.githubusercontent.com/60436221/90618415-50900480-e253-11ea-8d08-87c1e453188e.png">

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Customizer: Make Cookies & Consent widget edit button more obvious.

