### PR TITLE
Donations: Fix dependencies

### DIFF
--- a/extensions/blocks/donations/amount.js
+++ b/extensions/blocks/donations/amount.js
@@ -13,31 +13,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { minimumTransactionAmountForCurrency } from '../../shared/currencies';
-
-const parseAmount = ( amount, currency ) => {
-	if ( ! amount ) {
-		return null;
-	}
-
-	if ( typeof amount === 'number' ) {
-		return amount;
-	}
-
-	amount = parseFloat(
-		amount
-			// Remove any thousand grouping separator.
-			.replace( new RegExp( '\\' + CURRENCIES[ currency ].grouping, 'g' ), '' )
-			// Replace the localized decimal separator with a dot (the standard decimal separator in float numbers).
-			.replace( new RegExp( '\\' + CURRENCIES[ currency ].decimal, 'g' ), '.' )
-	);
-
-	if ( isNaN( amount ) ) {
-		return null;
-	}
-
-	return amount;
-};
+import { minimumTransactionAmountForCurrency, parseAmount } from '../../shared/currencies';
 
 const Amount = ( {
 	className = '',
@@ -143,4 +119,3 @@ const Amount = ( {
 };
 
 export default Amount;
-export { parseAmount };

--- a/extensions/blocks/donations/donations.php
+++ b/extensions/blocks/donations/donations.php
@@ -39,7 +39,7 @@ add_action( 'init', __NAMESPACE__ . '\register_block' );
  * @return string
  */
 function render_block( $attr, $content ) {
-	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME );
+	Jetpack_Gutenberg::load_assets_as_required( FEATURE_NAME, array( 'thickbox' ) );
 
 	require_once JETPACK__PLUGIN_DIR . '/modules/memberships/class-jetpack-memberships.php';
 	add_thickbox();

--- a/extensions/blocks/donations/view.js
+++ b/extensions/blocks/donations/view.js
@@ -1,21 +1,24 @@
 /**
  * External dependencies
  */
+import formatCurrency from '@automattic/format-currency';
+
+/**
+ * WordPress dependencies
+ */
 import domReady from '@wordpress/dom-ready';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { parseAmount } from './amount';
-import { minimumTransactionAmountForCurrency } from '../../shared/currencies';
+import { minimumTransactionAmountForCurrency, parseAmount } from '../../shared/currencies';
 import { initializeMembershipButtons } from '../../shared/memberships';
 
 /**
  * Style dependencies
  */
 import './view.scss';
-import formatCurrency from '@automattic/format-currency';
 
 let jetpackDonationsAmount = null;
 let jetpackDonationsIsCustomAmount = false;

--- a/extensions/index.json
+++ b/extensions/index.json
@@ -44,6 +44,7 @@
 		"calendly",
 		"contact-form",
 		"contact-info",
+		"donations",
 		"eventbrite",
 		"gif",
 		"google-calendar",

--- a/extensions/shared/currencies.js
+++ b/extensions/shared/currencies.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { CURRENCIES } from '@automattic/format-currency';
+
+/**
  * Currencies we support and Stripe's minimum amount for a transaction in that currency.
  *
  * @link https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts
@@ -33,9 +38,32 @@ export const SUPPORTED_CURRENCIES = {
  * known types it returns ...
  *
  * @param {string} currency_code three character currency code to get minimum charge for
- * @return {number} Minimum charge amount for the given currency_code
+ * @returns {number} Minimum charge amount for the given currency_code
  */
 export function minimumTransactionAmountForCurrency( currency_code ) {
-	const minimum = SUPPORTED_CURRENCIES[ currency_code ];
-	return minimum;
+	return SUPPORTED_CURRENCIES[ currency_code ];
+}
+
+export function parseAmount( amount, currency ) {
+	if ( ! amount ) {
+		return null;
+	}
+
+	if ( typeof amount === 'number' ) {
+		return amount;
+	}
+
+	amount = parseFloat(
+		amount
+			// Remove any thousand grouping separator.
+			.replace( new RegExp( '\\' + CURRENCIES[ currency ].grouping, 'g' ), '' )
+			// Replace the localized decimal separator with a dot (the standard decimal separator in float numbers).
+			.replace( new RegExp( '\\' + CURRENCIES[ currency ].decimal, 'g' ), '.' )
+	);
+
+	if ( isNaN( amount ) ) {
+		return null;
+	}
+
+	return amount;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Add `thickbox` as dependency when loading the view assets (Thickbox is required for the payments dialog).
- Add `donations` to the `no-post-editor` list of blocks (TBH, not sure what `no-post-editor` does, but I see `recurring-payments` is there, so we likely need the donations block there too given they both share the same architecture.
- Move the `parseAmount` function to a file that does not import anything from `@wordpress/block-editor`. That way, the `wp-block-editor` dep is not added to the `view.asset.php` file, which was causing the issue noted in p58i-9k2-p2#comment-47338.

#### Jetpack product discussion
p58i-9k2-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- Sandbox the API, `s0.wp.com` and `austineatworld.wordpress.com`.
- Add the code below to your `0-sandbox.php` file:
```
define( 'FORCE_CONCAT', TRUE );
add_filter( 'wpcom_sandbox_staticize_subdomain', '__return_true' );
```
- Make sure your `0-sandbox.php` file has not enabled the sandbox store (we need the production store for this).
- Visit https://austineatworld.wordpress.com/2020/08/19/donations-block-test/.
- Open the browser devtools and note the JS errors.
<img width="488" alt="Screen Shot 2020-08-19 at 13 10 12" src="https://user-images.githubusercontent.com/1233880/90629136-1b69bf00-e21f-11ea-8ffa-95a897ca14d5.png">

- Apply D48300-code.
- Reload https://austineatworld.wordpress.com/2020/08/19/donations-block-test/.
- Make sure the JS errors are gone.

#### Proposed changelog entry for your changes:
TBD