### PR TITLE
Sync - Allow blog token usage in sync related endpoints

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-sync-endpoint.php
@@ -10,7 +10,13 @@ use Automattic\Jetpack\Sync\Settings;
 
 // POST /sites/%s/sync
 class Jetpack_JSON_API_Sync_Endpoint extends Jetpack_JSON_API_Endpoint {
-	protected $needed_capabilities = 'manage_options';
+
+	/**
+	 * Sync endpoints allow authentication via a blog token therefore require no user capabilities.
+	 *
+	 * @var array
+	 */
+	protected $needed_capabilities = array();
 
 	protected function validate_call( $_blog_id, $capability, $check_manage_active = true ) {
 		return parent::validate_call( $_blog_id, $capability, false );

--- a/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
+++ b/json-endpoints/jetpack/class.wpcom-json-api-get-option-endpoint.php
@@ -3,8 +3,12 @@
 use Automattic\Jetpack\Sync\Defaults;
 
 class WPCOM_JSON_API_Get_Option_Endpoint extends Jetpack_JSON_API_Endpoint {
-
-	protected $needed_capabilities = 'manage_options';
+	/**
+	 * This endpoint allows authentication via a blog token therefore requires no user capabilities.
+	 *
+	 * @var array
+	 */
+	protected $needed_capabilities = array();
 
 	public $option_name;
 	public $site_option;


### PR DESCRIPTION
Jetpack Sync Manager (WP.com) utilizes the User Token to send sync actions to a remote Jetpack site. This PR updates the sync related endpoints to allow usage of the blog token that is user agnostic.

#### Changes proposed in this Pull Request:
* Remove any user related capabilities from sync endpoints

#### Jetpack product discussion
p9dueE-1KW-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
- See D48304-code

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A :: non functional change, hardening of Jetpack Connection and Sync.
