### PR TITLE
Disable xmlrpc errors out of JP dashboard

### DIFF
--- a/packages/connection/docs/error-handling.md
+++ b/packages/connection/docs/error-handling.md
@@ -2,23 +2,27 @@
 
 Whenever WordPress.com makes a request that fails to authenticate, the Connection package will store the error in the database and display a generic error message to the user.
 
-If you want to disable or customize this message, here is what you have to do.
+If you want to enable and customize this message, here is what you have to do.
 
 (Check [#16194](https://github.com/Automattic/jetpack/pull/16194) for more information on how errors are catched and validated.)
 
-## Disabling the default generic error message
+## Enabling the error message
 
-Return an empty value to the filter that defines the error message:
+If you want to enable the error message, you can use the `jetpack_connection_error_notice_message` filter. The second argument is an array with the details of all the errors (if more than one).
+
+This basic example show how to display a simple error message no matter the specific error type:
 
 ```PHP
-add_filter( 'jetpack_connection_error_notice_message', '__return_empty_string' );
+
+add_filter( 'jetpack_connection_error_notice_message', 'my_function', 10, 2 );
+
+function my_function( $message, $errors ) {
+	__( 'There is a problem with connection...', 'my_plugin' );
+}
+
 ```
 
-## Changing the error message
-
-If you want to change the error message, you can use the same filter. The second argument is an array with the details of all the errors (if more than one).
-
-The example below changes the error message only if there's a specific error with the current logged user.
+The example below enables the error message only if there's a specific error with the current logged user.
 
 ```PHP
 
@@ -45,11 +49,9 @@ function my_function( $message, $errors ) {
 
 ## Further customizing error notices
 
-If you want to completely change the admin notice, you can disable the default message and hook into an actino that will let you do whatever you want.
+If you want to completely change the admin notice, you can ignore the default message and hook into an actino that will let you do whatever you want.
 
 ```PHP
-// disable default message.
-add_filter( 'jetpack_connection_error_notice_message', '__return_empty_string' );
 
 add_action( 'jetpack_connection_error_notice', 'my_function' );
 
@@ -61,6 +63,7 @@ function my_function( $errors ) {
 	?>
 	<div class="notice notice-error is-dismissible jetpack-message jp-connect" style="display:block !important;">
 		<p><?php _e( 'my message', 'my_plugin' ); ?></p>
+		<a href="#" class="my-cta"><?php _e( 'Fix it!', 'my_plugin' ); ?></a>
 	</div>
 	<?php
 

--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -646,7 +646,9 @@ class Error_Handler {
 		}
 
 		/**
-		 * Filters the message to be displayed in the admin notices area when there's a xmlrpc error
+		 * Filters the message to be displayed in the admin notices area when there's a xmlrpc error.
+		 *
+		 * By default  we don't display any errors.
 		 *
 		 * Return an empty value to disable the message.
 		 *
@@ -655,7 +657,7 @@ class Error_Handler {
 		 * @param string $message The error message.
 		 * @param array  $errors The array of errors. See Automattic\Jetpack\Connection\Error_Handler for details on the array structure.
 		 */
-		$message = apply_filters( 'jetpack_connection_error_notice_message', __( 'Your connection with WordPress.com seems to be broken. If you\'re experiencing issues, please try reconnecting.', 'jetpack' ), $this->get_verified_errors() );
+		$message = apply_filters( 'jetpack_connection_error_notice_message', '', $this->get_verified_errors() );
 
 		/**
 		 * Fires inside the admin_notices hook just before displaying the error message for a broken connection.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

XML-RPC errors displayed outside the context of the Jetpack Dashboard are still a bit confusing:

* We need to add the context that this is related to Jetpack and a CTA to fix it
* We can't assure the error is still present in the moment the error. message is being displayed.

The purpose of displaying the error in the WP Dashboard is for them to be displayed by plugins using the connection package without the Jetpack plugin. However, there's still more work to do to better display these errors, so we are disabling it by default while leaving room for plugins to activate them if they want.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Disable XML-RPC errors in the WordPress admin

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1597856985219100-slack-CBG1CP4EN

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Start with a healthy jetpack site and the Debug Helper plugin
* Go to Broken token and break your connection
* Go to XMLRPC errors and click the link to visit the debugger
* Back in the XMLRPC errors make dure there are errors listed under the "Verified errors"
* If errors are only listed in the "Unverified" list, click the "Verify error (via API)" button
* Visit any page in the WordPress admin and confirm there is no error notice
* Visit the Jetpack Dashboard and confirm there's an error notice with the "Restore connection" CTA

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Disable XML-RPC errors in the WordPress admin