### PR TITLE
Premium Blocks: set blocks availability

### DIFF
--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -46,7 +46,7 @@ function jetpack_register_block( $slug, $args = array() ) {
 		if ( isset( $args['render_callback'] ) ) {
 			$args['render_callback'] = Jetpack_Gutenberg::get_render_callback_with_availability_check( $feature_name, $args['render_callback'] );
 		}
-		$method_name             = 'set_availability_for_plan';
+		$method_name = 'set_availability_for_plan';
 	} else {
 		$method_name = 'set_extension_available';
 	}
@@ -803,6 +803,26 @@ class Jetpack_Gutenberg {
 				$extension_file_glob = glob( JETPACK__PLUGIN_DIR . 'extensions/*/' . $extension . '/' . $extension . '.php' );
 				if ( ! empty( $extension_file_glob ) ) {
 					include_once $extension_file_glob[0];
+				}
+			}
+		}
+	}
+
+	/**
+	 * Loads PHP components of extended-blocks.
+	 *
+	 * @since 8.9.0
+	 */
+	public static function load_extended_blocks() {
+		if ( self::should_load() ) {
+			$extended_blocks = glob( JETPACK__PLUGIN_DIR . 'extensions/extended-blocks/*' );
+
+			foreach ( $extended_blocks as $block ) {
+				$name = basename( $block );
+				$path = JETPACK__PLUGIN_DIR . 'extensions/extended-blocks/' . $name . '/' . $name . '.php';
+
+				if ( file_exists( $path ) ) {
+					include_once $path;
 				}
 			}
 		}

--- a/class.jetpack-plan.php
+++ b/class.jetpack-plan.php
@@ -33,6 +33,10 @@ class Jetpack_Plan {
 				'calendly',
 				'send-a-message',
 				'social-previews',
+
+				'core/video',
+				'core/cover',
+				'core/audio',
 			),
 		),
 		'personal' => array(

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -666,6 +666,7 @@ class Jetpack {
 		require_once JETPACK__PLUGIN_DIR . 'class.jetpack-gutenberg.php';
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'init' ) );
 		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_independent_blocks' ) );
+		add_action( 'plugins_loaded', array( 'Jetpack_Gutenberg', 'load_extended_blocks' ), 9 );
 		add_action( 'enqueue_block_editor_assets', array( 'Jetpack_Gutenberg', 'enqueue_block_editor_assets' ) );
 
 		add_action( 'set_user_role', array( $this, 'maybe_clear_other_linked_admins_transient' ), 10, 3 );

--- a/extensions/extended-blocks/core-audio/core-audio.php
+++ b/extensions/extended-blocks/core-audio/core-audio.php
@@ -1,0 +1,21 @@
+<?php
+// Populate the available extensions with core/audio.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge(
+			$extensions,
+			array(
+				'core/audio',
+			)
+		);
+	}
+);
+
+// Set the core/audio block availability, depending on the site plan.
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function() {
+		\Jetpack_Gutenberg::set_availability_for_plan( 'core/audio' );
+	}
+);

--- a/extensions/extended-blocks/core-audio/core-audio.php
+++ b/extensions/extended-blocks/core-audio/core-audio.php
@@ -1,5 +1,10 @@
 <?php
-// Populate the available extensions with core/audio.
+/**
+ * Populate the available extensions with core/audio.
+ *
+ * @package Jetpack
+ **/
+
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {

--- a/extensions/extended-blocks/core-audio/core-audio.php
+++ b/extensions/extended-blocks/core-audio/core-audio.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Populate the available extensions with core/audio.
+ * Plan checks for uploading audio files to core/audio.
  *
  * @package Jetpack
  **/
 
+// Populate the available extensions with core/audio.
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {

--- a/extensions/extended-blocks/core-cover/core-cover.php
+++ b/extensions/extended-blocks/core-cover/core-cover.php
@@ -1,5 +1,10 @@
 <?php
-// Populate the available extensions with core/cover.
+/**
+ * Populate the available extensions with core/cover.
+ *
+ * @package Jetpack
+ **/
+
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {

--- a/extensions/extended-blocks/core-cover/core-cover.php
+++ b/extensions/extended-blocks/core-cover/core-cover.php
@@ -1,0 +1,21 @@
+<?php
+// Populate the available extensions with core/cover.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge(
+			$extensions,
+			array(
+				'core/cover',
+			)
+		);
+	}
+);
+
+// Set the core/cover block availability, depending on the site plan.
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function() {
+		\Jetpack_Gutenberg::set_availability_for_plan( 'core/cover' );
+	}
+);

--- a/extensions/extended-blocks/core-cover/core-cover.php
+++ b/extensions/extended-blocks/core-cover/core-cover.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Populate the available extensions with core/cover.
+ * Plan checks for uploading video files to core/cover.
  *
  * @package Jetpack
  **/
 
+// Populate the available extensions with core/cover.
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {

--- a/extensions/extended-blocks/core-video/core-video.php
+++ b/extensions/extended-blocks/core-video/core-video.php
@@ -1,10 +1,11 @@
 <?php
 /**
- * Populate the available extensions with core/video.
+ * Plan checks for uploading video files to core/video.
  *
  * @package Jetpack
  **/
 
+// Populate the available extensions with core/video.
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {

--- a/extensions/extended-blocks/core-video/core-video.php
+++ b/extensions/extended-blocks/core-video/core-video.php
@@ -1,5 +1,10 @@
 <?php
-// Populate the available extensions with core/video.
+/**
+ * Populate the available extensions with core/video.
+ *
+ * @package Jetpack
+ **/
+
 add_filter(
 	'jetpack_set_available_extensions',
 	function ( $extensions ) {

--- a/extensions/extended-blocks/core-video/core-video.php
+++ b/extensions/extended-blocks/core-video/core-video.php
@@ -1,0 +1,21 @@
+<?php
+// Populate the available extensions with core/video.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge(
+			$extensions,
+			array(
+				'core/video',
+			)
+		);
+	}
+);
+
+// Set the core/video block availability, depending on the site plan.
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function() {
+		\Jetpack_Gutenberg::set_availability_for_plan( 'core/video' );
+	}
+);

--- a/extensions/extended-blocks/premium-content-container/premium-content-container.php
+++ b/extensions/extended-blocks/premium-content-container/premium-content-container.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plan checks for uploading video files to premium-content/container.
+ *
+ * @package Jetpack
+ **/
+
+// Populate the available extensions with premium-content/container.
+add_filter(
+	'jetpack_set_available_extensions',
+	function ( $extensions ) {
+		return array_merge(
+			$extensions,
+			array(
+				'premium-content/container',
+			)
+		);
+	}
+);
+
+// Set the premium-content/container block availability, depending on the site plan.
+add_action(
+	'jetpack_register_gutenberg_extensions',
+	function() {
+		\Jetpack_Gutenberg::set_availability_for_plan( 'premium-content/container' );
+	}
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR is an alternative approach to https://github.com/Automattic/jetpack/pull/16870.

>  ... a way to set the availability of the block in terms of the current plan of the site. These blocks are not registered by Jetpack.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Set not-jetpack blocks availability according to the site plan.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->


#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

no

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Apply these changes in your testing site
* Inspect the Jetpack Initial Status and make sure that core/* blocks are available.
* Upload a video to a core/video block and make sure it works.
* Upload a video to a core/cover block and make sure it works.
* Upload an audio file to a core/audio block and make it works.

##### On WP.com
* Apply **D48329-code**
* Upload a video to a core/video block and make sure an upgrade banner appears that links you to the premium plan checkout.
* Upload a video to a core/cover block and make sure an upgrade banner appears that links you to the premium plan checkout.
* Upload an audio file to a core/audio block and make sure an upgrade banner appears that links you to the personal plan checkout.
#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->

* Set not-jetpack blocks availability according to the site plan.
