### PR TITLE
Allow invalid AMP in Jetpack using a filter

### DIFF
--- a/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
+++ b/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
@@ -16,7 +16,8 @@ class Jetpack_AMP_Feature_Assets_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var asset_xpaths.
 	 */
 	private static $asset_xpaths = array(
-		'//script[contains(@src,\'www.opentable.com/widget\')]',
+		'//script[contains(@src,\'//www.opentable.com/widget\')]',
+		'//script[contains(@src,\'//assets.pinterest.com/js/pinit.js\')]',
 	);
 
 	/**

--- a/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
+++ b/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
@@ -20,6 +20,10 @@ class Jetpack_AMP_Feature_Assets_Sanitizer extends AMP_Base_Sanitizer {
 		'//script[contains(@src,\'//assets.pinterest.com/js/pinit.js\')]',
 		'//script[ @id = \'eventbrite-widget-js\' ]',
 		'//script[ @id = \'eventbrite-widget-js-after\' ]',
+		'//script[ @id = \'jetpack-block-calendly-js-extra\' ]',
+		'//script[ @id = \'jetpack-block-calendly-js\' ]',
+		'//script[ @id = \'jetpack-calendly-external-js-js\' ]',
+		'//script[ @id = \'jetpack-calendly-external-js-js-after\' ]',
 	);
 
 	/**

--- a/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
+++ b/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Provides AMP validation carve-outs for Jetpack features
+ *
+ * @see https://github.com/Automattic/amp-wp
+ * @package Jetpack
+ */
+
+/**
+ * This sanitizer class sets AMP devmode on the html element and each other element to be ignored (and not stripped out) for validation purposes.
+ */
+class Jetpack_AMP_Feature_Assets_Sanitizer extends AMP_Base_Sanitizer {
+	/**
+	 * List of xpaths selecting assets to be ignored
+	 *
+	 * @var asset_xpaths.
+	 */
+	private static $asset_xpaths = array(
+		'//script[contains(@src,\'www.opentable.com/widget\')]',
+	);
+
+	/**
+	 * Sanitize document for dev mode.
+	 *
+	 * @since 1.3
+	 */
+	public function sanitize() {
+		$this->dom->documentElement->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
+
+		$xpath = new DOMXPath( $this->dom );
+		foreach ( self::$asset_xpaths as $element_xpath ) {
+			foreach ( $xpath->query( $element_xpath ) as $node ) {
+				if ( $node instanceof DOMElement ) {
+					$node->setAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, '' );
+				}
+			}
+		}
+	}
+}

--- a/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
+++ b/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php
@@ -18,6 +18,8 @@ class Jetpack_AMP_Feature_Assets_Sanitizer extends AMP_Base_Sanitizer {
 	private static $asset_xpaths = array(
 		'//script[contains(@src,\'//www.opentable.com/widget\')]',
 		'//script[contains(@src,\'//assets.pinterest.com/js/pinit.js\')]',
+		'//script[ @id = \'eventbrite-widget-js\' ]',
+		'//script[ @id = \'eventbrite-widget-js-after\' ]',
 	);
 
 	/**

--- a/3rd-party/class.jetpack-amp-support.php
+++ b/3rd-party/class.jetpack-amp-support.php
@@ -65,6 +65,24 @@ class Jetpack_AMP_Support {
 
 		// Sync the amp-options.
 		add_filter( 'jetpack_options_whitelist', array( 'Jetpack_AMP_Support', 'filter_jetpack_options_safelist' ) );
+
+		// Allow spec-violating AMP content.
+		add_filter( 'amp_content_sanitizers', array( 'Jetpack_AMP_Support', 'amp_content_sanitizers' ) );
+	}
+
+	/**
+	 * Selectively disable AMP validation errors for some Jetpack content
+	 *
+	 * @param array $sanitizers The array of sanitizers, 'MyClassName' => [] // array of constructor params for class.
+	 */
+	public static function amp_content_sanitizers( $sanitizers ) {
+		if ( ! apply_filters( 'jetpack_allow_unsanitary_amp_content', true ) ) { // @todo - make false by default before merging
+			return $sanitizers;
+		}
+
+		require_once JETPACK__PLUGIN_DIR . '/3rd-party/class-jetpack-amp-feature-assets-sanitizer.php';
+		$sanitizers['Jetpack_AMP_Feature_Assets_Sanitizer'] = array();
+		return $sanitizers;
 	}
 
 	/**

--- a/extensions/blocks/calendly/calendly.php
+++ b/extensions/blocks/calendly/calendly.php
@@ -63,9 +63,8 @@ function load_assets( $attr, $content ) {
 	$primary_color           = get_attribute( $attr, 'primaryColor' );
 	$classes                 = Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr, array( 'calendly-style-' . $style ) );
 	$block_id                = wp_unique_id( 'calendly-block-' );
-	$is_amp_request          = class_exists( 'Jetpack_AMP_Support' ) && \Jetpack_AMP_Support::is_amp_request();
 
-	if ( ! wp_script_is( 'jetpack-calendly-external-js' ) && ! $is_amp_request ) {
+	if ( ! wp_script_is( 'jetpack-calendly-external-js' ) ) {
 		enqueue_calendly_js();
 	}
 
@@ -93,36 +92,24 @@ function load_assets( $attr, $content ) {
 			$content = str_replace( $base_url, $url, $content );
 		}
 
-		if ( ! $is_amp_request ) {
-			wp_add_inline_script(
-				'jetpack-calendly-external-js',
-				sprintf( "calendly_attach_link_events( '%s' )", esc_js( $block_id ) )
-			);
-		}
+		wp_add_inline_script(
+			'jetpack-calendly-external-js',
+			sprintf( "calendly_attach_link_events( '%s' )", esc_js( $block_id ) )
+		);
 	} else { // Inline style.
-		if ( $is_amp_request ) {
-			$content = sprintf(
-				'<div class="%1$s" id="%2$s"><a href="%3$s" role="button" target="_blank">%4$s</a></div>',
-				esc_attr( Jetpack_Gutenberg::block_classes( FEATURE_NAME, $attr ) ),
-				esc_attr( $block_id ),
-				esc_js( $url ),
-				wp_kses_post( get_attribute( $attr, 'submitButtonText' ) )
-			);
-		} else {
-			$content = sprintf(
-				'<div class="%1$s" id="%2$s"></div>',
-				esc_attr( $classes ),
-				esc_attr( $block_id )
-			);
-			$script  = <<<JS_END
+		$content = sprintf(
+			'<div class="%1$s" id="%2$s"></div>',
+			esc_attr( $classes ),
+			esc_attr( $block_id )
+		);
+		$script  = <<<JS_END
 Calendly.initInlineWidget({
-	url: '%s',
-	parentElement: document.getElementById('%s'),
-	inlineStyles: false,
+url: '%s',
+parentElement: document.getElementById('%s'),
+inlineStyles: false,
 });
 JS_END;
-			wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
-		}
+		wp_add_inline_script( 'jetpack-calendly-external-js', sprintf( $script, esc_url( $url ), esc_js( $block_id ) ) );
 	}
 
 	return $content;


### PR DESCRIPTION
See: #14395 

A few widgets, such as OpenTable, don't work in AMP due to their reliance on external javascript.

However, in order to transition to AMP standard mode, sites would like the option of reaping the performance benefits of AMP without necessarily having every page be 100% strict AMP.

This PR provides a filter, `jetpack_allow_unsanitary_amp_content` (better names suggestions welcome) which - when set to true - allows various widgets to work at the expense of 100% AMP compatibility.

It does this by setting the ampdevmode attribute on the `html` element and also any matching invalid assets.

Repaired widgets:

- [x] OpenTable
- [x] Pinterest
- [x] Eventbrite
- [x] Calendly