### PR TITLE
Connection: Fix broken connection for secondary users

### DIFF
--- a/_inc/client/components/auth-iframe/index.jsx
+++ b/_inc/client/components/auth-iframe/index.jsx
@@ -73,7 +73,9 @@ export class AuthIframe extends React.Component {
 	};
 
 	render = () => {
-		const src = this.props.connectUrl.replace( 'authorize', 'authorize_iframe' );
+		// The URL looks like https://jetpack.wordpress.com/jetpack.authorize_iframe/1/. We need to include the trailing
+		// slash below so that we don't end up with something like /jetpack.authorize_iframe_iframe/
+		const src = this.props.connectUrl.replace( 'authorize/', 'authorize_iframe/' );
 
 		return (
 			<div ref="iframeWrap" className="dops-card fade-in jp-iframe-wrap">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16906

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Fixes an issue where the connection iFrame didn't correctly load for secondary users.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. On Jetpack site set `add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );`
2. Connect Jetpack site with user A
3. Login to site as user B
4. Go to Jetpack dashboard
5. Click "Link to WordPress.com" button
6. Observe that iFrame loads properly

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes an issue where the connection screen would not load for secondary users.
