### PR TITLE
Sidebar: Point Jetpack sidebar link to the dashboard instead of WordPress.com

### DIFF
--- a/modules/scan/class-admin-sidebar-link.php
+++ b/modules/scan/class-admin-sidebar-link.php
@@ -112,10 +112,12 @@ class Admin_Sidebar_Link {
 		$offset = 0;
 		foreach ( $submenu['jetpack'] as $link ) {
 			if ( 'jetpack_admin_page' !== $link[1] ) {
-				return $offset;
+				break;
 			}
 			$offset++;
 		}
+
+		return $offset;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #16905.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Ensure the Jetpack sidebar menu link still points to the dashboard for non-admin users, by way of guaranteeing an integer return value from `get_link_offset()`.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* See #16905 for instructions to reproduce the issue. Verify the issue still occurs.
* Apply this PR's version of the Jetpack plugin on your site (e.g, by using the Jetpack Beta plugin).
* Try again to reproduce the issue. Verify the issue no longer occurs.
* Regression testing: verify that sidebar links still work for admin users, and for sites without a Jetpack plan or product.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fix the Jetpack sidebar menu link for non-administrators on sites with Jetpack Backup and/or Scan.