### PR TITLE
Donations: Avoid setting a link in the donate button

### DIFF
--- a/extensions/blocks/donations/tab.js
+++ b/extensions/blocks/donations/tab.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { RichText } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -87,6 +88,11 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 		} );
 	};
 
+	const formatTypes = useSelect( select => select( 'core/rich-text' ).getFormatTypes(), [] );
+	const allowedFormatsForButton = formatTypes
+		.map( format => format.name )
+		.filter( format => format !== 'core/link' );
+
 	return (
 		<div className="donations__tab">
 			<RichText
@@ -147,6 +153,7 @@ const Tab = ( { activeTab, attributes, setAttributes } ) => {
 					placeholder={ __( 'Write a message…', 'jetpack' ) }
 					value={ getDonationValue( 'buttonText' ) }
 					onChange={ value => setButtonText( value ) }
+					allowedFormats={ allowedFormatsForButton }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/16887

#### Changes proposed in this Pull Request:
Prevent users from setting a link to the donate button, so it doesn't collide with the link we set for showing the payments dialog.

Before | After
--- | --- 
<img width="384" alt="Screen Shot 2020-08-20 at 18 04 45" src="https://user-images.githubusercontent.com/1233880/90796463-a629e700-e30f-11ea-9c91-0048c53f9f49.png"> | <img width="354" alt="Screen Shot 2020-08-20 at 18 00 09" src="https://user-images.githubusercontent.com/1233880/90796407-93171700-e30f-11ea-8d60-a6da408ba7ec.png">


#### Jetpack product discussion
p58i-9k2-p2

#### Does this pull request change what data or activity we track or use?
N/A

#### Testing instructions:
* Set up a test site:
  * [Create a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=update/donations-prevent-set-link). 
  * Go to `/wp-admin/options-general.php?page=companion_settings`.
    * Activate `JETPACK_BETA_BLOCKS`. 
    * Set `JETPACK__SANDBOX_DOMAIN` with your sandbox address (make sure you enter the short URL e.g. mysandbox.wordpress.com to avoid issues with the SSL certificate).
  * Sandbox the API, the store and `subscribe.wordpress.com` (see PCYsg-lW4-p2 #sandbox-method for detailed instructions).
  * Set up Jetpack and purchase a Premium or Professional plan.
* Go to Posts > New and insert a new Donations block.
* Focus the donate button at the end.
* Make sure the block toolbar does not contain an option for setting a link.


#### Proposed changelog entry for your changes:
N/A.