### PR TITLE
SSO: Getting rid of the user token.

### DIFF
--- a/modules/sso.php
+++ b/modules/sso.php
@@ -475,7 +475,7 @@ class Jetpack_SSO {
 				 * @since 8.6.0
 				 */
 				do_action( 'jetpack_sso_login_form_above_wpcom' );
-				
+
 				if ( $display_name && $gravatar ) : ?>
 				<div id="jetpack-sso-wrap__user">
 					<img width="72" height="72" src="<?php echo esc_html( $gravatar ); ?>" />
@@ -523,7 +523,7 @@ class Jetpack_SSO {
 				 * @since 8.6.0
 				 */
 				do_action( 'jetpack_sso_login_form_below_wpcom' );
-				
+
 				if ( ! Jetpack_SSO_Helpers::should_hide_login_form() ) : ?>
 					<div class="jetpack-sso-or">
 						<span><?php esc_html_e( 'Or', 'jetpack' ); ?></span>
@@ -671,9 +671,7 @@ class Jetpack_SSO {
 		$wpcom_nonce   = sanitize_key( $_GET['sso_nonce'] );
 		$wpcom_user_id = (int) $_GET['user_id'];
 
-		$xml = new Jetpack_IXR_Client( array(
-			'user_id' => get_current_user_id(),
-		) );
+		$xml = new Jetpack_IXR_Client();
 		$xml->query( 'jetpack.sso.validateResult', $wpcom_nonce, $wpcom_user_id );
 
 		$user_data = $xml->isError() ? false : $xml->getResponse();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The SSO login process performs an API request to WP.com (`jetpack.sso.validateResult` endpoint) to validate the authentication the results and get user information.

Jetpack tries to use `user_token` for that request, but at that point the user is not authenticated in WP, so `user_id` equals `0`, thus `blog_token` is used for authorization anyway.

That makes the commit janitorial with no functional changes.

#### Jetpack product discussion
Part of the issue #16709.
Related to #16830.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Go to "Jetpack -> Settings -> Security" and enable the "WordPress.com login" feature.
2. Log out of WordPress.
3. Try to login using WordPress.com account.
4. Confirm you're logged in.

#### Proposed changelog entry for your changes:
n/a.
