### PR TITLE
Settings: Hide auto-update plugins module for Atomic sites

### DIFF
--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -129,7 +129,7 @@ export class Security extends Component {
 						<QueryAkismetKeyCheck />
 					</>
 				) }
-				{ ! isAtomicSite && ! isSearchTerm && <ManagePlugins { ...commonProps } /> }
+				{ ! this.props.isAtomicSite && ! isSearchTerm && <ManagePlugins { ...commonProps } /> }
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ foundSso && <SSO { ...commonProps } /> }
 			</div>
@@ -149,5 +149,6 @@ export default connect( state => {
 		isPluginActive: plugin_slug => isPluginActive( state, plugin_slug ),
 		isPluginInstalled: plugin_slug => isPluginInstalled( state, plugin_slug ),
 		vaultPressData: getVaultPressData( state ),
+		isAtomicSite: isAtomicSite( state ),
 	};
 } )( Security );

--- a/_inc/client/security/index.jsx
+++ b/_inc/client/security/index.jsx
@@ -20,6 +20,7 @@ import QuerySite from 'components/data/query-site';
 import QueryAkismetKeyCheck from 'components/data/query-akismet-key-check';
 import { getPlanClass } from 'lib/plans/constants';
 import { getActiveSitePurchases, getSitePlan } from 'state/site';
+import { isAtomicSite } from 'state/initial-state';
 import BackupsScan from './backups-scan';
 import Antispam from './antispam';
 import { JetpackBackup } from './jetpack-backup';
@@ -128,7 +129,7 @@ export class Security extends Component {
 						<QueryAkismetKeyCheck />
 					</>
 				) }
-				{ ! isSearchTerm && <ManagePlugins { ...commonProps } /> }
+				{ ! isAtomicSite && ! isSearchTerm && <ManagePlugins { ...commonProps } /> }
 				{ foundProtect && <Protect { ...commonProps } /> }
 				{ foundSso && <SSO { ...commonProps } /> }
 			</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/dotcom-manage/issues/128

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Only show the auto-updates module if the site is NOT an Atomic site

Non-Atomic Sites | Atomic Sites
--- | ---
<img width="1065" alt="Screen Shot 2020-08-21 at 1 33 28 PM" src="https://user-images.githubusercontent.com/1689238/90919172-f5c1ee80-e3b3-11ea-803d-60e2a6150763.png"> | <img width="1060" alt="Screen Shot 2020-08-21 at 1 32 57 PM" src="https://user-images.githubusercontent.com/1689238/90919190-ffe3ed00-e3b3-11ea-9b5a-e4d8cf319a0e.png">


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
Atomic discussion: p9F6qB-5uo-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No changes.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Go to /wp-admin/admin.php?page=jetpack#/settings on an Atomic site
- [ ] There's no auto-update module and you can't click on “Choose which plugins to auto-update”
2. Go to /wp-admin/admin.php?page=jetpack#/settings on a self-hosted site
- [ ] There's an auto-update module and you can click on “Choose which plugins to auto-update”

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Hide the auto-updates module for Atomic sites
