### PR TITLE
add new features to debug helper

### DIFF
--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -420,7 +420,7 @@ class Error_Handler {
 	public function get_user_id_from_token( $token ) {
 		$parsed_token = explode( ':', wp_unslash( $token ) );
 
-		if ( isset( $parsed_token[2] ) && ! empty( $parsed_token[2] ) && ctype_digit( $parsed_token[2] ) ) {
+		if ( isset( $parsed_token[2] ) && ctype_digit( $parsed_token[2] ) ) {
 			$user_id = $parsed_token[2];
 		} else {
 			$user_id = 'invalid';


### PR DESCRIPTION
Adds two new features to the XML-RPC errors page in the Debug helper plugin

* create fake errors - help creating errors in the database without the need to actually breaking the site
* Clear all errors (both verified and unverified)

It also does a small fix in the error reporting, where all blog token errors (user id = 0) were being logged as "invalid_user" intead of user 0 (zero)

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Debug helper -> XMLRPC errors
* Play with the Create Fake Errors form

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*
