### PR TITLE
Upgrade Banner: Improve alignment.

### DIFF
--- a/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/extensions/extended-blocks/paid-blocks/editor.scss
@@ -7,42 +7,46 @@ $icon-background-color: #fff;
 
 // Upgrade Banner.
 .jetpack-upgrade-plan-banner {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	font-size: 14px;
-	height: $banner-height;
-	background: black;
-	padding: 0 20px;
-	border-radius: 2px;
-	box-shadow: 0 0 1px inset $studio-white;
+	$banner-height: 48px;
 
-	.banner-title,
-	.banner-description {
-		color: $studio-white;
-	}
+	.jetpack-upgrade-plan-banner__wrapper {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		font-size: 14px;
+		height: $banner-height;
+		background: black;
+		padding: 0 20px;
+		border-radius: 2px;
+		box-shadow: 0 0 1px inset $studio-white;
 
-	.jetpack-upgrade-plan-banner__title,
-	.jetpack-upgrade-plan-banner__description {
-		margin-right: 10px;
-	}
-
-	.components-button {
-		flex-shrink: 0;
-		line-height: 1;
-		margin-left: auto;
-		height: 28px;
-
-		&.is-primary {
-			background: $studio-pink-40;
+		.banner-title,
+		.banner-description {
 			color: $studio-white;
+		}
 
-			&:hover {
-				background: $studio-pink-30;
-			}
-			&.is-busy {
-				background-size: 100px 100%;
-				background-image: linear-gradient(-45deg, $studio-pink-40 28%, $studio-pink-60 28%, $studio-pink-60 72%, $studio-pink-40 72%);
+		.jetpack-upgrade-plan-banner__title,
+		.jetpack-upgrade-plan-banner__description {
+			margin-right: 10px;
+		}
+
+		.components-button {
+			flex-shrink: 0;
+			line-height: 1;
+			margin-left: auto;
+			height: 28px;
+
+			&.is-primary {
+				background: $studio-pink-40;
+				color: $studio-white;
+
+				&:hover {
+					background: $studio-pink-30;
+				}
+				&.is-busy {
+					background-size: 100px 100%;
+					background-image: linear-gradient(-45deg, $studio-pink-40 28%, $studio-pink-60 28%, $studio-pink-60 72%, $studio-pink-40 72%);
+				}
 			}
 		}
 	}
@@ -56,6 +60,10 @@ $icon-background-color: #fff;
 	&.wp-block[data-align=right],
 	&.wp-block[data-align=left] {
 		height: $banner-height;
+		.jetpack-upgrade-plan-banner__wrapper {
+			max-width: $content-width;
+			width: 100%;
+		}
 	}
 }
 

--- a/extensions/extended-blocks/paid-blocks/editor.scss
+++ b/extensions/extended-blocks/paid-blocks/editor.scss
@@ -52,6 +52,11 @@ $icon-background-color: #fff;
 		margin-top: 0;
 		margin-bottom: 0;
 	}
+
+	&.wp-block[data-align=right],
+	&.wp-block[data-align=left] {
+		height: $banner-height;
+	}
 }
 
 // Tweak Banner depending on the context.

--- a/extensions/extended-blocks/paid-blocks/upgrade-plan-banner.jsx
+++ b/extensions/extended-blocks/paid-blocks/upgrade-plan-banner.jsx
@@ -42,27 +42,29 @@ const UpgradePlanBanner = ( {
 
 	return (
 		<div className={ cssClasses } data-align={ align }>
-			{ title && (
-				<strong
-					className={ classNames( 'banner-title', { [ `${ className }__title` ]: className } ) }
-				>
-					{ title }
-				</strong>
-			) }
-			{ description && (
-				<span className={ `${ className }__description banner-description` }>{ description }</span>
-			) }
-			{ checkoutUrl && (
-				<Button
-					href={ isRedirecting ? null : checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
-					onClick={ goToCheckoutPage }
-					target="_top"
-					className="is-primary"
-					isBusy={ isRedirecting }
-				>
-					{ isRedirecting ? redirectingText : buttonText }
-				</Button>
-			) }
+			<div className="jetpack-upgrade-plan-banner__wrapper">
+				{ title && (
+					<strong
+						className={ classNames( 'banner-title', { [ `${ className }__title` ]: className } ) }
+					>
+						{ title }
+					</strong>
+				) }
+				{ description && (
+					<span className={ `${ className }__description banner-description` }>{ description }</span>
+				) }
+				{ checkoutUrl && (
+					<Button
+						href={ isRedirecting ? null : checkoutUrl } // Only for server-side rendering, since onClick doesn't work there.
+						onClick={ goToCheckoutPage }
+						target="_top"
+						className="is-primary"
+						isBusy={ isRedirecting }
+					>
+						{ isRedirecting ? redirectingText : buttonText }
+					</Button>
+				) }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR improves the banner alignment defined indirectly when the block changes the alignment. The banner component is not part of the block component rather a sibling of it. 

Fixes #16912

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Improve Upgrade banner alignment.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Get sandboxed
* Apply **D48425-code**
* Start to edit a post
* Test with a premium block that allows changing its alignment, for instance, `opentable`
* Change all alignments. Confirm that the banner is shown as expected:

![image](https://user-images.githubusercontent.com/77539/90826484-e2aa1280-e310-11ea-962f-58b89e7ddf9b.png)

_Left alignment._

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Improve Upgrade banner alignment.
