### PR TITLE
Clear xmlrpc errors on site disconnect

### DIFF
--- a/packages/connection/src/class-error-handler.php
+++ b/packages/connection/src/class-error-handler.php
@@ -130,6 +130,9 @@ class Error_Handler {
 		// If the site gets reconnected, clear errors.
 		add_action( 'jetpack_site_registered', array( $this, 'delete_all_errors' ) );
 		add_action( 'jetpack_get_site_data_success', array( $this, 'delete_all_errors' ) );
+		add_filter( 'jetpack_connection_disconnect_site_wpcom', array( $this, 'delete_all_errors_and_return_unfiltered_value' ) );
+		add_filter( 'jetpack_connection_delete_all_tokens', array( $this, 'delete_all_errors_and_return_unfiltered_value' ) );
+		add_action( 'jetpack_unlinked_user', array( $this, 'delete_all_errors' ) );
 	}
 
 	/**
@@ -472,6 +475,21 @@ class Error_Handler {
 	public function delete_all_errors() {
 		$this->delete_stored_errors();
 		$this->delete_verified_errors();
+	}
+
+	/**
+	 * Delete all stored and verified errors from the database and returns unfiltered value
+	 *
+	 * This is used to hook into a couple of filters that expect true to not short circuit the disconnection flow
+	 *
+	 * @since 8.9.0
+	 *
+	 * @param mixed $check The input sent by the filter.
+	 * @return boolean
+	 */
+	public function delete_all_errors_and_return_unfiltered_value( $check ) {
+		$this->delete_all_errors();
+		return $check;
 	}
 
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

In our effort to avoid that errors are still displayed after they are fixed, this PR clears the XMLRPC errors in 3 new hooks that are triggered when the site is disconnected and/or the plugin is deactivated.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Clear xmlrpc errors on site disconnect

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

The easiest way to test it is by using wp-cli

* Start with a connected JP site
* Go to Debug tools -> XMLRPC errors and leave this window opened in the browser
* Open a terminal
* `yarn docker:wp shell`
* in the terminal: `$m = new \Automattic\Jetpack\Connection\Manager();`
* in the browser: click "Create error" under the Create Fake errors section
* a bunch o errors will appear
* in the terminal: `$m->disconnect_user(1,true);` (replace 1 with your user ID if needed)
* refresh the browser window and make sure the errors are gone

* Click "Create error" again
* `$m->delete_all_connection_tokens();`
* refresh the browser window and make sure the errors are gone

* Click "Create error" again
* `$m->disconnect_site_wpcom();`
* refresh the browser window and make sure the errors are gone

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Clear xmlrpc errors on site disconnect
