### PR TITLE
Customizer: Dont remove accepted cookie widget from display

### DIFF
--- a/modules/widgets/eu-cookie-law/eu-cookie-law.js
+++ b/modules/widgets/eu-cookie-law/eu-cookie-law.js
@@ -5,6 +5,7 @@
 		),
 		overlay = document.getElementById( 'eu-cookie-law' ),
 		widget = document.querySelector( '.widget_eu_cookie_law_widget' ),
+		inCustomizer = widget.hasAttribute( 'data-customize-widget-id' ),
 		getScrollTop,
 		initialScrollPosition,
 		scrollFunction;
@@ -27,10 +28,10 @@
 			/(?:(?:^|.*;\s*)personalized-ads-consent\s*\=\s*([^;]*).*$)|^.*$/,
 			'$1'
 		);
-		if ( '' !== cookieValue && '' !== adsCookieValue ) {
+		if ( '' !== cookieValue && '' !== adsCookieValue && ! inCustomizer ) {
 			overlay.parentNode.removeChild( overlay );
 		}
-	} else if ( '' !== cookieValue ) {
+	} else if ( '' !== cookieValue && ! inCustomizer ) {
 		overlay.parentNode.removeChild( overlay );
 	}
 


### PR DESCRIPTION
Fixes #16926

#### Changes proposed in this Pull Request:
* Prevents the removal of the cookie widget from display in the Customizer allowing the user to still see the effects of any customization they make to the widget's settings

#### Does this pull request change what data or activity we track or use?
No changes.

#### Testing instructions:
1. Ensure you have extra widgets turned on in Jetpack settings and clear any previous accept cookies cookie.
2. Add the "Cookies & Consent" widget to your site
3. Open the frontend and Customizer for the site in two tabs
4. Note that the widget appears in both.
5. On the frontend page accept the cookies and reload. The widget should not show.
6. Refresh the Customizer page and notice that its hidden (actually removed from DOM via JS).
7. Apply this PR branch
8. Refresh the frontend and ensure the cookie widget does not show
9. Refresh the Customizer and check that the cookie widget is no longer removed from the page.

#### Before
<img width="1397" alt="Screen Shot 2020-08-21 at 12 54 45 pm" src="https://user-images.githubusercontent.com/60436221/90847313-8a751e00-e3ad-11ea-9419-e5f1dad29a59.png">

#### After
<img width="1395" alt="Screen Shot 2020-08-21 at 12 54 27 pm" src="https://user-images.githubusercontent.com/60436221/90847316-8cd77800-e3ad-11ea-8aff-af4fa0827c9c.png">

#### Proposed changelog entry for your changes:
* Customizer: Do not hide accepted cookie widget to allow visual customization.
