### PR TITLE
Donations block: Redirect users back to Calypso after connecting to Stripe

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -38,11 +38,18 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_status' ),
 					'permission_callback' => array( $this, 'get_status_permission_check' ),
 					'args'                => array(
-						'type' => array(
+						'type'   => array(
 							'type'              => 'string',
 							'required'          => false,
 							'validate_callback' => function( $param ) {
 								return in_array( $param, array( 'donation', 'all' ), true );
+							},
+						),
+						'source' => array(
+							'type'              => 'string',
+							'required'          => false,
+							'validate_callback' => function( $param ) {
+								return in_array( $param, array( 'calypso', 'earn', 'gutenberg', 'gutenberg-wpcom' ), true );
 							},
 						),
 					),

--- a/_inc/lib/core-api/wpcom-endpoints/memberships.php
+++ b/_inc/lib/core-api/wpcom-endpoints/memberships.php
@@ -219,6 +219,7 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 	 */
 	public function get_status( \WP_REST_Request $request ) {
 		$product_type = $request['type'];
+		$source       = $request['source'];
 		if ( ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
 			jetpack_require_lib( 'memberships' );
 			$blog_id = get_current_blog_id();
@@ -229,7 +230,8 @@ class WPCOM_REST_API_V2_Endpoint_Memberships extends WP_REST_Controller {
 			if ( $product_type ) {
 				$path = add_query_arg(
 					array(
-						'type' => $product_type,
+						'type'   => $product_type,
+						'source' => $source,
 					),
 					$path
 				);

--- a/extensions/blocks/donations/fetch-status.js
+++ b/extensions/blocks/donations/fetch-status.js
@@ -1,4 +1,7 @@
-/* global calypsoifyGutenberg */
+/**
+ * External dependencies
+ */
+import { parse as parseUrl } from 'url';
 
 /**
  * WordPress dependencies
@@ -7,9 +10,11 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 const fetchStatus = async ( type = null ) => {
+	const { query } = parseUrl( window.location.href, true );
+
 	const path = addQueryArgs( '/wpcom/v2/memberships/status', {
+		source: query.origin === 'https://wordpress.com' ? 'gutenberg-wpcom' : 'gutenberg',
 		...( type && { type } ),
-		...( typeof calypsoifyGutenberg !== 'undefined' && { source: 'gutenberg-calypso' } ),
 	} );
 	try {
 		const result = await apiFetch( {

--- a/extensions/blocks/donations/fetch-status.js
+++ b/extensions/blocks/donations/fetch-status.js
@@ -1,13 +1,16 @@
+/* global calypsoifyGutenberg */
+
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 const fetchStatus = async ( type = null ) => {
-	let path = '/wpcom/v2/memberships/status';
-	if ( type ) {
-		path += `?type=${ type }`;
-	}
+	const path = addQueryArgs( '/wpcom/v2/memberships/status', {
+		...( type && { type } ),
+		...( typeof calypsoifyGutenberg !== 'undefined' && { source: 'gutenberg-calypso' } ),
+	} );
 	try {
 		const result = await apiFetch( {
 			path,


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Ensure users are redirected back to the WordPress.com block editor if they connect to Stripe from a Donations block inserted in the WordPress.com block editor.

#### Jetpack product discussion
p58i-9k2-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Set up a test site:
  * [Create a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=fix/stripe-conection-redirect). 
  * Go to `/wp-admin/options-general.php?page=companion_settings`.
  * Set `JETPACK__SANDBOX_DOMAIN` with your sandbox address.
  * Sandbox the API and the store (see PCYsg-lW4-p2 #sandbox-method for detailed instructions).
  * Set up Jetpack and purchase a Premium or Professional plan.
* Apply D48460-code to your sandbox.
* Go to `wordpress.com/block-editor/post` and select the test site you created above.
* Insert a Donations block.
* The Stripe nudge should show up.
* Click on connect.
* Make sure you are sent back to the Calypso block editor after connecting to Stripe (note that the success notice will be missing, this is being implemented in https://github.com/Automattic/wp-calypso/pull/45108)

#### Proposed changelog entry for your changes:
Earn blocks: Redirect users back to WordPress.com after connecting to Stripe
