### PR TITLE
Search: avoid fatals when merging to wp.com

### DIFF
--- a/modules/search/class-jetpack-search-customize.php
+++ b/modules/search/class-jetpack-search-customize.php
@@ -12,8 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once dirname( __FILE__ ) . '/class.jetpack-search-helpers.php';
 require_once dirname( __FILE__ ) . '/class-jetpack-search-options.php';
-require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
-require_once dirname( __FILE__ ) . '/customize-controls/class-excluded-post-types-control.php';
 
 /**
  * Class to customize search on the site.
@@ -39,6 +37,8 @@ class Jetpack_Search_Customize {
 	 * @param WP_Customize_Manager $wp_customize Customizer instance.
 	 */
 	public function customize_register( $wp_customize ) {
+		require_once dirname( __FILE__ ) . '/customize-controls/class-label-control.php';
+		require_once dirname( __FILE__ ) . '/customize-controls/class-excluded-post-types-control.php';
 		$section_id     = 'jetpack_search';
 		$setting_prefix = Jetpack_Search_Options::OPTION_PREFIX;
 


### PR DESCRIPTION
WP.com seems to load the Customizer in a different order or something. Move the requires to just before we really need the code.

Corresponds to D48045

