### PR TITLE
Search: Use wpcom-proxy-request when on private WPCOM sites

### DIFF
--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Proxy endpoint for Jetpack Search
+ *
+ * @package Jetpack
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Jetpack Search: Makes authenticated requests to the site search API using blog tokens.
+ * This endpoint will only be used when trying to search private Jetpack and WordPress.com sites.
+ *
+ * @since 8.10
+ */
+class WPCOM_REST_API_V2_Endpoint_Search extends WP_REST_Controller {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'wpcom/v2';
+		$this->rest_base = 'search';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Called automatically on `rest_api_init()`.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_search_results' ),
+					'permission_callback' => 'is_user_logged_in',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Returns search results for the current blog.
+	 *
+	 * @param WP_REST_Request $request The REST API request data.
+	 * @return mixed The REST API response from public-api.
+	 */
+	public function get_search_results( $request ) {
+		$is_wpcom = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
+		$site_id  = $is_wpcom ? get_current_blog_id() : Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return new WP_Error(
+				'unavailable_site_id',
+				__( 'Sorry, something is wrong with your Jetpack connection.', 'jetpack' ),
+				403
+			);
+		}
+
+		$path    = add_query_arg(
+			$request->get_query_params(),
+			sprintf( '/sites/%d/search', absint( $site_id ) )
+		);
+		$request = Client::wpcom_json_api_request_as_blog( $path, '1.3' );
+		$body    = wp_remote_retrieve_body( $request );
+		return json_decode( $body );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Search' );

--- a/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
+++ b/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php
@@ -63,8 +63,16 @@ class WPCOM_REST_API_V2_Endpoint_Search extends WP_REST_Controller {
 			sprintf( '/sites/%d/search', absint( $site_id ) )
 		);
 		$request = Client::wpcom_json_api_request_as_blog( $path, '1.3' );
-		$body    = wp_remote_retrieve_body( $request );
-		return json_decode( $body );
+		$body    = json_decode( wp_remote_retrieve_body( $request ) );
+		if ( 200 === wp_remote_retrieve_response_code( $request ) ) {
+			return $body;
+		}
+
+		return new WP_Error(
+			$body->error,
+			$body->message,
+			array( 'status' => wp_remote_retrieve_response_code( $request ) )
+		);
 	}
 }
 

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -34,6 +34,7 @@ module.exports = [
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-instagram-gallery.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-podcast-player.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-resolve-redirect.php',
+	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-search.php',
 	'_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-tweetstorm-gather.php',
 	'_inc/lib/core-api/wpcom-endpoints/memberships.php',
 	'_inc/lib/debugger/',

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -140,6 +140,8 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'postsPerPage'          => $posts_per_page,
 			'siteId'                => $this->jetpack_blog_id,
 			'postTypes'             => $post_type_labels,
+			'isPrivateWpcom'        => '-1' === get_option( 'blog_public' ),
+			'webpackPublicPath'     => plugins_url( '_inc/build/instant-search/', JETPACK__PLUGIN_FILE ),
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -57,7 +57,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 	 */
 	public function load_assets() {
 		$script_relative_path = '_inc/build/instant-search/jp-search.bundle.js';
-		$style_relative_path  = '_inc/build/instant-search/instant-search.min.css';
+		$style_relative_path  = '_inc/build/instant-search/jp-search.bundle.css';
 		if ( ! file_exists( JETPACK__PLUGIN_DIR . $script_relative_path ) || ! file_exists( JETPACK__PLUGIN_DIR . $style_relative_path ) ) {
 			return;
 		}

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -140,8 +140,13 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			'postsPerPage'          => $posts_per_page,
 			'siteId'                => $this->jetpack_blog_id,
 			'postTypes'             => $post_type_labels,
-			'isPrivateWpcom'        => '-1' === get_option( 'blog_public' ),
 			'webpackPublicPath'     => plugins_url( '_inc/build/instant-search/', JETPACK__PLUGIN_FILE ),
+
+			// config values related to private site support.
+			'apiRoot'               => esc_url_raw( rest_url() ),
+			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
+			'isPrivateWpcom'        => '-1' === get_option( 'blog_public' ),
+			'isAtomic'              => jetpack_is_atomic_site(),
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -145,8 +145,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			// config values related to private site support.
 			'apiRoot'               => esc_url_raw( rest_url() ),
 			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-			'isPrivateWpcom'        => '-1' === get_option( 'blog_public' ),
-			'isAtomic'              => jetpack_is_atomic_site(),
+			'isAtomicSite'          => jetpack_is_atomic_site(),
+			'isPrivateSite'         => '-1' === get_option( 'blog_public' ),
+			'isWpcom'               => defined( 'IS_WPCOM' ) && IS_WPCOM,
 
 			// search options.
 			'defaultSort'           => get_option( $prefix . 'default_sort', 'relevance' ),

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -163,7 +163,7 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$options = apply_filters( 'jetpack_instant_search_options', $options );
 
 		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
-		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $options ) ) . '"));' );
+		wp_add_inline_script( 'jetpack-instant-search', 'var JetpackInstantSearchOptions=JSON.parse(decodeURIComponent("' . rawurlencode( wp_json_encode( $options ) ) . '"));', 'before' );
 	}
 
 	/**

--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -145,7 +145,6 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			// config values related to private site support.
 			'apiRoot'               => esc_url_raw( rest_url() ),
 			'apiNonce'              => wp_create_nonce( 'wp_rest' ),
-			'isAtomicSite'          => jetpack_is_atomic_site(),
 			'isPrivateSite'         => '-1' === get_option( 'blog_public' ),
 			'isWpcom'               => defined( 'IS_WPCOM' ) && IS_WPCOM,
 

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -224,6 +224,7 @@ class SearchApp extends Component {
 			sort,
 			postsPerPage: this.props.options.postsPerPage,
 			adminQueryFilter: this.props.options.adminQueryFilter,
+			isPrivateWpcom: this.props.options.isPrivateWpcom,
 		} )
 			.then( newResponse => {
 				if ( this.state.requestId === requestId ) {

--- a/modules/search/instant-search/components/search-app.jsx
+++ b/modules/search/instant-search/components/search-app.jsx
@@ -224,7 +224,6 @@ class SearchApp extends Component {
 			sort,
 			postsPerPage: this.props.options.postsPerPage,
 			adminQueryFilter: this.props.options.adminQueryFilter,
-			isPrivateWpcom: this.props.options.isPrivateWpcom,
 		} )
 			.then( newResponse => {
 				if ( this.state.requestId === requestId ) {

--- a/modules/search/instant-search/index.jsx
+++ b/modules/search/instant-search/index.jsx
@@ -1,5 +1,9 @@
 /** @jsx h */
 
+// NOTE: This must be imported first before any other imports.
+// See: https://github.com/webpack/webpack/issues/2776#issuecomment-233208623
+import './set-webpack-public-path';
+
 /**
  * External dependencies
  */

--- a/modules/search/instant-search/lib/api.js
+++ b/modules/search/instant-search/lib/api.js
@@ -276,6 +276,12 @@ export function search( {
 	return fetch( url, {
 		headers: isApiColocated ? { 'X-WP-Nonce': window[ SERVER_OBJECT_NAME ].apiNonce } : {},
 	} )
+		.then( response => {
+			if ( ! response.ok || response.status !== 200 ) {
+				throw new Error( `Unexpected response from API with status code ${ response.status }.` );
+			}
+			return response;
+		} )
 		.catch( errorHandler )
 		.then( r => r.json() )
 		.then( responseHandler );

--- a/modules/search/instant-search/set-webpack-public-path.js
+++ b/modules/search/instant-search/set-webpack-public-path.js
@@ -1,0 +1,6 @@
+// NOTE: Setting this free variable allows us to modify Webpack's public path, enabling us to use
+//       dynamic imports. Also note that we don't import any other file to ensure that this operation is
+//       completed before any other module imports. See:
+//       https://github.com/webpack/webpack/issues/2776#issuecomment-233208623
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = window.JetpackInstantSearchOptions.webpackPublicPath;

--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
 		"unfetch": "4.1.0",
 		"url-polyfill": "1.1.10",
 		"webpack": "4.44.1",
-		"webpack-cli": "3.3.12"
+		"webpack-cli": "3.3.12",
+		"wpcom-proxy-request": "5.0.2"
 	},
 	"optionalDependencies": {
 		"react": "16.13.1",

--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -325,20 +325,13 @@ class Jetpack_Signature {
 
 	/**
 	 * Concatenates a parameter name and a parameter value with an equals sign between them.
-	 * Supports one-dimensional arrays as `$value`.
+	 * Supports nested array `$value`s.
 	 *
 	 * @param string $name  Parameter name.
 	 * @param mixed  $value Parameter value.
 	 * @return string A pair with parameter name and value (e.g. `name=value`).
 	 */
 	public function join_with_equal_sign( $name, $value ) {
-		if ( is_array( $value ) ) {
-			$result = array();
-			foreach ( $value as $array_key => $array_value ) {
-				$result[] = $name . '[' . $array_key . ']=' . $array_value;
-			}
-			return $result;
-		}
-		return "{$name}={$value}";
+		return substr( add_query_arg( $name, $value, '' ), 1 );
 	}
 }

--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -325,13 +325,40 @@ class Jetpack_Signature {
 
 	/**
 	 * Concatenates a parameter name and a parameter value with an equals sign between them.
-	 * Supports nested array `$value`s.
 	 *
-	 * @param string $name  Parameter name.
-	 * @param mixed  $value Parameter value.
-	 * @return string A pair with parameter name and value (e.g. `name=value`).
+	 * @param string       $name  Parameter name.
+	 * @param string|array $value Parameter value.
+	 * @return string|array A string pair (e.g. `name=value`) or an array of string pairs.
 	 */
 	public function join_with_equal_sign( $name, $value ) {
-		return substr( add_query_arg( $name, $value, '' ), 1 );
+		if ( is_array( $value ) ) {
+			return $this->join_array_with_equal_sign( $name, $value );
+		}
+		return "{$name}={$value}";
+	}
+
+	/**
+	 * Helper function for join_with_equal_sign for handling arrayed values.
+	 * Explicitly supports nested arrays.
+	 *
+	 * @param string $name  Parameter name.
+	 * @param array  $value Parameter value.
+	 * @return array An array of string pairs (e.g. `[ name[example]=value ]`).
+	 */
+	private function join_array_with_equal_sign( $name, $value ) {
+		$result = array();
+		foreach ( $value as $value_key => $value_value ) {
+			$joined_value = $this->join_with_equal_sign( $name . '[' . $value_key . ']', $value_value );
+			if ( is_array( $joined_value ) ) {
+				foreach ( array_values( $joined_value ) as $individual_joined_value ) {
+					$result[] = $individual_joined_value;
+				}
+			} elseif ( is_string( $joined_value ) ) {
+				$result[] = $joined_value;
+			}
+		}
+
+		sort( $result );
+		return $result;
 	}
 }

--- a/tools/builder/sass.js
+++ b/tools/builder/sass.js
@@ -62,7 +62,7 @@ gulp.task( 'sass:instant-search', function ( done ) {
 			prepend.prependText( '/* Do not modify this file directly.  It is compiled SASS code. */\n' )
 		)
 		.pipe( autoprefixer() )
-		.pipe( rename( { suffix: '.min' } ) )
+		.pipe( rename( { basename: 'jp-search.bundle' } ) )
 		.pipe( gulp.dest( './_inc/build/instant-search' ) )
 		.on( 'end', function () {
 			log( 'Instant Search CSS finished.' );

--- a/webpack.config.search.js
+++ b/webpack.config.search.js
@@ -35,8 +35,9 @@ module.exports = [
 		entry: { search: path.join( __dirname, './modules/search/instant-search/index.jsx' ) },
 		output: {
 			...sharedWebpackConfig.output,
-			path: path.join( __dirname, '_inc/build/instant-search' ),
+			chunkFilename: 'jp-search.chunk-[name]-[hash].js',
 			filename: 'jp-search.bundle.js',
+			path: path.join( __dirname, '_inc/build/instant-search' ),
 		},
 		performance: isDevelopment
 			? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4710,6 +4710,11 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+builtin-status-codes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz#6f22003baacf003ccd287afe6872151fddc58579"
+  integrity sha1-byIAO6rPADzNKHr+aHIVH93FhXk=
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -4842,6 +4847,11 @@ camelcase-keys@^2.0.0:
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
+
+camelcase@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 camelcase@^2.0.0:
   version "2.1.1"
@@ -5477,7 +5487,7 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
-component-event@^0.1.4:
+component-event@0.1.4, component-event@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/component-event/-/component-event-0.1.4.tgz#3de78fc28782381787e24bf2a7c536bf0142c9b4"
   integrity sha1-PeePwoeCOBeH4kvyp8U2vwFCybQ=
@@ -11945,12 +11955,12 @@ minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8, minimist@^0.2.1:
+minimist@0.0.8, minimist@^0.2.1, minimist@^1.2.5:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
   integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -14121,6 +14131,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
+progress-event@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/progress-event/-/progress-event-1.0.0.tgz#1146df4b61849ddbe93ee81f9365af91b8901c51"
+  integrity sha1-EUbfS2GEndvpPugfk2WvkbiQHFE=
 
 progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
@@ -17050,6 +17065,11 @@ uglify-save-license@0.4.1:
   resolved "https://registry.yarnpkg.com/uglify-save-license/-/uglify-save-license-0.4.1.tgz#95726c17cc6fd171c3617e3bf4d8d82aa8c4cce1"
   integrity sha1-lXJsF8xv0XHDYX479NjYKqjEzOE=
 
+uid@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/uid/-/uid-0.0.2.tgz#5e4a5d4b78138b4f70f89fd3c76fc59aa9d2f103"
+  integrity sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM=
+
 unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
@@ -17194,6 +17214,13 @@ upath@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
+
+uppercamelcase@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/uppercamelcase/-/uppercamelcase-1.1.0.tgz#324d98a6b3afc7e8a8953e10641509b0e4e23f97"
+  integrity sha1-Mk2YprOvx+iolT4QZBUJsOTiP5c=
+  dependencies:
+    camelcase "^1.2.1"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -17813,6 +17840,25 @@ workerpool@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.0.0.tgz#85aad67fa1a2c8ef9386a1b43539900f61d03d58"
   integrity sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==
+
+wp-error@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/wp-error/-/wp-error-1.3.0.tgz#720247aa326424991c58775cb2fedc9bfd885420"
+  integrity sha1-cgJHqjJkJJkcWHdcsv7cm/2IVCA=
+  dependencies:
+    builtin-status-codes "^2.0.0"
+    uppercamelcase "^1.1.0"
+
+wpcom-proxy-request@5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/wpcom-proxy-request/-/wpcom-proxy-request-5.0.2.tgz#7ee07001ae4d92f96692002e63038444c4cb8bc6"
+  integrity sha512-2MTJNiadTdZIaobhv9XJiPa/7eS1CIF4Zzp0HUKee27lhCfdoMktrjF/K+WSj7LkFZvWVR37Qh7DWfRDUiNGNQ==
+  dependencies:
+    uid "0.0.2"
+    component-event "0.1.4"
+    debug "^3.1.0"
+    progress-event "~1.0.0"
+    wp-error "^1.3.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Changes `Jetpack_Signature->join_with_equal_sign` to handle nested arrays while preserving backward compatibility. 
* Adjusts Webpack configuration for Jetpack Search to handle chunks generated by dynamic imports.
* Adjusts Jetpack Search to use `wpcom-proxy-request` when it detects that it's running on a private WPCOM site.
* Tweaks the name of the Search stylesheet for consistency (`instant-search.min.css` -> `jp-search.bundle.css`).

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
In order to test these changes, the corresponding D48473-code must be applied to `public-api`.

Testing on a Jetpack site:
  1. Apply these changes to a Jurassic Ninja site (or a Jetpack site of your choice).
  2. Ensure that the API requests work as expected.

To test these changes on an atomic WPCOM site, use the [Jetpack Beta](https://jetpack.com/download-jetpack-beta/) plugin and point it at this branch.
  1. Purchase Jetpack Search and ensure that instant search is enabled.
  2. Set the site privacy to `private` and perform a site search.
      * Ensure that a JavaScript file named `jp-search.chunk*.js` has been loaded in the network panel.
      * Ensure that you receive valid search results.
  3. Set the site privacy to `public` and perform another site search.
      * Ensure no JavaScript file named `jp-search.chunk*.js` have loaded.
      * Ensure that you receive valid search results.

To test these changes on a simple WPCOM site, follow these instructions:
  1. Apply these changes to your sandbox by D48473-code.
  2. Build a production version of the Jetpack Search bundle by running `yarn && NODE_ENV=production BABEL_ENV=production yarn build-search` in `wp-content/mu-plugins/jetpack`.
  3. Sandbox a private simple WPCOM site of your choice. 
  4. Purchase Jetpack Search and ensure that instant search is enabled.
  5. Set the site privacy to `private` and perform a site search.
      * Ensure that a JavaScript file named `jp-search.chunk*.js` has been loaded in the network panel.
      * Ensure that you receive valid search results.
  6. Set the site privacy to `public` and perform another site search.
      * Ensure no JavaScript file named `jp-search.chunk*.js` have loaded.
      * Ensure that you receive valid search results.

If you're receiving zero search results for your private sites, you might need to kick off an indexing step for your private site and add your private WPCOM site to the search whitelist. See p1597961809007100-slack-C82FZ5T4G for further context.

#### Proposed changelog entry for your changes:
* Not sure if necessary since this should only affect private WPCOM sites. 
* "Adds support for searching private WordPress.com sites."