### PR TITLE
Social Previews: fix previews overflowing (Responsive Updates)

### DIFF
--- a/extensions/blocks/social-previews/modal.scss
+++ b/extensions/blocks/social-previews/modal.scss
@@ -32,6 +32,7 @@
 			outline: 0;
 			margin: 3px 0;
 			font-size: 0;
+			white-space: nowrap;
 
 			svg {
 				display: block;
@@ -46,21 +47,29 @@
 				box-shadow: 0px 0px 0px 2px $blue-medium-focus;
 			}
 		}
-
 	}
 
 	.components-tab-panel__tab-content {
 		padding: 10px;
 		background-color: $light-gray-100;
 		flex: 1;
+
+		> div {
+			display: flex;
+			justify-content: center;
+		}
 	}
 
-	@media ( min-width: $break-medium ) {
+	@media ( min-width: $break-small ) {
+		width: calc( 100vw - 40px );
+	}
+
+	@media ( min-width: $break-large ) {
 		flex-direction: row;
-		width: 900px;
+		width: calc( #{$break-large} - 40px );
 		min-height: 500px;
 
-		.components-tab-panel__tabs { 
+		.components-tab-panel__tabs {
 			flex-direction: column;
 			justify-content: flex-start;
 			padding: 24px;
@@ -93,25 +102,25 @@
 	.jetpack-social-previews__upgrade-description {
 		margin-bottom: 1em;
 	}
-	
+
 	.jetpack-social-previews__upgrade-heading {
 		font-size: 2em;
 		line-height: 1.15;
 	}
-	
+
 	.jetpack-social-previews__upgrade-feature-list {
 		list-style: none;
 		margin-bottom: 2em;
 		padding-left: 1em;
 		font-size: 1.1em;
 		line-height: 1.4;
-	
+
 		li {
 			position: relative;
 			margin-bottom: 12px;
-	
+
 			&:before {
-				content:  "\2713 ";
+				content: '\2713 ';
 				position: absolute;
 				left: -20px;
 				color: $alert-green;
@@ -126,7 +135,7 @@
 		grid-gap: 3em;
 		grid-template-columns: 1fr 1fr;
 		padding-top: 4em;
-	
+
 		.jetpack-social-previews__upgrade-illustration {
 			grid-column: 2;
 			grid-row: 1;
@@ -144,7 +153,7 @@
 		.jetpack-social-previews__upgrade-heading {
 			margin-top: 0;
 		}
-	
+
 		.jetpack-social-previews__upgrade-feature-list {
 			padding-left: 0;
 		}
@@ -154,5 +163,5 @@
 		.jetpack-social-previews__upgrade-description {
 			padding: 0 2em 2em;
 		}
-	}	
+	}
 }

--- a/extensions/blocks/social-previews/modal.scss
+++ b/extensions/blocks/social-previews/modal.scss
@@ -60,6 +60,10 @@
 		}
 	}
 
+	.twitter-preview__summary {
+		max-width: 100%;
+	}
+
 	@media ( min-width: $break-small ) {
 		width: calc( 100vw - 40px );
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

This PR aims to fix an issue where we were cutting off some of the content in social previews in some device widths. 

Fixes p7DVsv-97x-p2#comment-30410


#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
Before | After
-------|------
![screen-recording-2020-08-19-at-10 55-am](https://user-images.githubusercontent.com/12430020/91029717-b12e9100-e607-11ea-88e3-a8b15d515aef.gif) | ![SS 2020-08-24 at 12 40 04](https://user-images.githubusercontent.com/12430020/91030107-c7d4e800-e607-11ea-95ff-8b6195928bdc.gif)


#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
-

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
-

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* apply `arc patch D48491` in your **clean** sandbox OR `yarn build-extensions` and sync to your sandbox 
* sandbox a **business** site
* navigate to the edit page of a post / page
* click the Jetpack Icon in Bar
* click `Preview` in Social Previews section of the sidebar
* try resizing the window

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Fixes social previews overflowing in some device widths