### PR TITLE
Social Previews: Simplify featured image media size logic

### DIFF
--- a/extensions/blocks/social-previews/modal.js
+++ b/extensions/blocks/social-previews/modal.js
@@ -81,7 +81,7 @@ export default withSelect( ( select, props ) => {
 	}
 
 	const { getMedia, getUser } = select( 'core' );
-	const { getCurrentPost, getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
+	const { getCurrentPost, getEditedPostAttribute } = select( 'core/editor' );
 
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
 	const authorId = getEditedPostAttribute( 'author' );
@@ -97,7 +97,6 @@ export default withSelect( ( select, props ) => {
 			__( 'Visit the post for more.', 'jetpack' ),
 		url: getEditedPostAttribute( 'link' ),
 		author: user?.name,
-		image:
-			!! featuredImageId && getMediaSourceUrl( getMedia( featuredImageId ), getCurrentPostId() ),
+		image: !! featuredImageId && getMediaSourceUrl( getMedia( featuredImageId ) ),
 	};
 } )( SocialPreviewsModal );

--- a/extensions/blocks/social-previews/utils.js
+++ b/extensions/blocks/social-previews/utils.js
@@ -2,7 +2,6 @@
  * Gets the URL of the media. Tries loading a smaller size (1024px width) if available and falls back to the full size.
  *
  * @param {object} media
- * @param {number} currentPostId
  * @returns {?string} URL address
  */
 export function getMediaSourceUrl( media ) {

--- a/extensions/blocks/social-previews/utils.js
+++ b/extensions/blocks/social-previews/utils.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { applyFilters } from '@wordpress/hooks';
-
-/**
  * Gets the URL of the media. Tries loading a smaller size (1024px width) if available and falls back to the full size.
  *
  * @param {object} media

--- a/extensions/blocks/social-previews/utils.js
+++ b/extensions/blocks/social-previews/utils.js
@@ -4,45 +4,17 @@
 import { applyFilters } from '@wordpress/hooks';
 
 /**
- * Gets the URL of the media. Tries loading a smaller size available to be used as a thumbnail and falls back to the full size.
- *
- * Source: https://github.com/WordPress/gutenberg/blob/HEAD/packages/editor/src/components/post-featured-image/index.js
+ * Gets the URL of the media. Tries loading a smaller size (1024px width) if available and falls back to the full size.
  *
  * @param {object} media
  * @param {number} currentPostId
  * @returns {?string} URL address
  */
-export function getMediaSourceUrl( media, currentPostId ) {
+export function getMediaSourceUrl( media ) {
 	if ( ! media ) {
 		return null;
 	}
 
-	const sizes = media.media_details?.sizes;
-	if ( sizes ) {
-		const mediaSize = applyFilters(
-			'editor.PostFeaturedImage.imageSize',
-			'post-thumbnail',
-			media.id,
-			currentPostId
-		);
-		if ( sizes[ mediaSize ] ) {
-			// use mediaSize when available
-			return sizes[ mediaSize ].source_url;
-		}
-
-		// get fallbackMediaSize if mediaSize is not available
-		const fallbackMediaSize = applyFilters(
-			'editor.PostFeaturedImage.imageSize',
-			'thumbnail',
-			media.id,
-			currentPostId
-		);
-		if ( sizes[ fallbackMediaSize ] ) {
-			// use fallbackMediaSize when mediaSize is not available
-			return sizes[ fallbackMediaSize ].source_url;
-		}
-	}
-
-	// use full image size when mediaFallbackSize and mediaSize are not available
-	return media.source_url;
+	// Try getting the large size (1024px width) and fallback to the full size.
+	return media.media_details?.sizes?.large?.source_url || media.source_url;
 }


### PR DESCRIPTION
We've had reports of image size being too small and I have confirmed that when running on wpcom. The image size provided was 150px big, which is not enough for bigger previews that might be generated. 

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Switch the logic to look for the `large` named image size and use the full one as a fallback. 

#### Jetpack product discussion

#### Does this pull request change what data or activity we track or use?
no

#### Testing instructions:
* same setup as #16615
* set a featured image and try getting a preview. they should look good, not blurry

#### Proposed changelog entry for your changes:
*
