### PR TITLE
Jetpack Offer Reset: Add from parameter to plans redirect

### DIFF
--- a/_inc/client/components/navigation/index.jsx
+++ b/_inc/client/components/navigation/index.jsx
@@ -68,7 +68,10 @@ export class Navigation extends React.Component {
 					) }
 					{ ! this.props.isOfflineMode && this.props.isLinked && (
 						<NavItem
-							path={ getRedirectUrl( 'jetpack-plans', { site: this.props.siteUrl } ) }
+							path={ getRedirectUrl( 'jetpack-plans', {
+								site: this.props.siteUrl,
+								from: 'jetpack-plans',
+							} ) }
 							onClick={ this.trackPlansClick }
 							selected={ this.props.location.pathname === '/plans' }
 						>

--- a/_inc/client/lib/jp-redirect/index.js
+++ b/_inc/client/lib/jp-redirect/index.js
@@ -35,7 +35,7 @@ export default function getRedirectUrl( source, args = {} ) {
 		queryVars.source = encodeURIComponent( source );
 	}
 
-	const acceptedArgs = [ 'site', 'path', 'query', 'anchor' ];
+	const acceptedArgs = [ 'site', 'path', 'query', 'anchor', 'from' ];
 
 	Object.keys( args ).map( argName => {
 		if ( acceptedArgs.includes( argName ) ) {

--- a/class.jetpack-connection-banner.php
+++ b/class.jetpack-connection-banner.php
@@ -195,7 +195,7 @@ class Jetpack_Connection_Banner {
 				'forceVariation'        => $force_variation,
 				'connectInPlaceUrl'     => Jetpack::admin_url( 'page=jetpack#/setup' ),
 				'dashboardUrl'          => Jetpack::admin_url( 'page=jetpack#/dashboard' ),
-				'plansPromptUrl'        => Redirect::get_url( 'jetpack-connect-plans' ),
+				'plansPromptUrl'        => Redirect::get_url( 'jetpack-connect-plans', array( 'source' => 'jetpack-connect' ) ),
 				'identity'              => $identity,
 				'preFetchScript'        => plugins_url( '_inc/build/admin.js', JETPACK__PLUGIN_FILE ) . '?ver=' . JETPACK__VERSION,
 			)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

The Offer Reset plans page needs to know when a user navigated from wp-admin in the connect flow in order to display things correctly. This PR adds a `from` param to facilitate this.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p1HpG7-8PX-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
*