### PR TITLE
Contact Form: put feedback that matches the disallowed list in trash

### DIFF
--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -141,7 +141,7 @@ class Grunion_Contact_Form_Plugin {
 		}
 
 		add_filter( 'jetpack_contact_form_is_spam', array( $this, 'is_spam_blocklist' ), 10, 2 );
-
+		add_filter( 'jetpack_contact_form_in_comment_disallowed_list', array( $this, 'is_in_disallowed_list' ), 10, 2 );
 		// Akismet to the rescue
 		if ( defined( 'AKISMET_VERSION' ) || function_exists( 'akismet_http_post' ) ) {
 			add_filter( 'jetpack_contact_form_is_spam', array( $this, 'is_spam_akismet' ), 10, 2 );
@@ -678,10 +678,26 @@ class Grunion_Contact_Form_Plugin {
 	 * @return bool TRUE => spam, FALSE => not spam
 	 */
 	public function is_spam_blocklist( $is_spam, $form = array() ) {
-		global $wp_version;
-
 		if ( $is_spam ) {
 			return $is_spam;
+		}
+
+		return $this->is_in_disallowed_list( false, $form );
+	}
+
+	/**
+	 * Check if a submission matches the comment disallowed list.
+	 * Attached to `jetpack_contact_form_in_comment_disallowed_list`.
+	 *
+	 * @param boolean $in_disallowed_list Whether the feedback is in the disallowed list.
+	 * @param array   $form The form array.
+	 * @return bool Returns true if the form submission matches the disallowed list and false if it doesn't.
+	 */
+	public function is_in_disallowed_list( $in_disallowed_list, $form = array() ) {
+		global $wp_version;
+
+		if ( $in_disallowed_list ) {
+			return $in_disallowed_list;
 		}
 
 		/*
@@ -2725,6 +2741,8 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$spam = '***SPAM*** ';
 		}
 
+		$in_comment_disallowed_list = apply_filters( 'jetpack_contact_form_in_comment_disallowed_list', false, $akismet_values );
+
 		if ( ! $comment_author ) {
 			$comment_author = $comment_author_email;
 		}
@@ -2779,8 +2797,14 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 		$date_time_format = sprintf( $date_time_format, get_option( 'date_format' ), get_option( 'time_format' ) );
 		$time             = date_i18n( $date_time_format, current_time( 'timestamp' ) );
 
-		// keep a copy of the feedback as a custom post type
-		$feedback_status = $is_spam === true ? 'spam' : 'publish';
+		// Keep a copy of the feedback as a custom post type.
+		if ( $in_comment_disallowed_list ) {
+			$feedback_status = 'trash';
+		} elseif ( $is_spam ) {
+			$feedback_status = 'spam';
+		} else {
+			$feedback_status = 'publish';
+		}
 
 		foreach ( (array) $akismet_values as $av_key => $av_value ) {
 			$akismet_values[ $av_key ] = Grunion_Contact_Form_Plugin::strip_tags( $av_value );

--- a/modules/contact-form/grunion-contact-form.php
+++ b/modules/contact-form/grunion-contact-form.php
@@ -2741,6 +2741,16 @@ class Grunion_Contact_Form extends Crunion_Contact_Form_Shortcode {
 			$spam = '***SPAM*** ';
 		}
 
+		/**
+		 * Filter whether a submitted contact form is in the comment disallowed list.
+		 *
+		 * @module contact-form
+		 *
+		 * @since 8.9.0
+		 *
+		 * @param bool  $result         Is the submitted feedback in the disallowed list.
+		 * @param array $akismet_values Feedack values returned by the Akismet plugin.
+		 */
 		$in_comment_disallowed_list = apply_filters( 'jetpack_contact_form_in_comment_disallowed_list', false, $akismet_values );
 
 		if ( ! $comment_author ) {


### PR DESCRIPTION
Fixes #16513

#### Changes proposed in this Pull Request:
* If the contact form submission matches the user's disallowed list, put the feedback post in the Trash section.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install, activate, and connect Jetpack.
2. Create a post with a contact form.
3. Navigate to the contact form and submit it.
4. Navigate to wp-admin -> Feedback and confirm that the feedback post for the form submission is in the `All` section.
5. Navigate to the contact form and submit something that will be caught as spam. For example, use `akismet-guaranteed-spam@example.com` for the email address.
6.  Navigate to wp-admin -> Feedback and confirm that the feedback post for the form submission is in the `Spam` section.
7. Navigate to wp-admin -> Settings -> Discussion and add something to the Comment Blocklist.
8. Navigate to the contact form and submit something that will match the blocklist.
9.  Navigate to wp-admin -> Feedback and confirm that the feedback post for the form submission is in the `Trash` section.


NOTE: if the user set the `grunion_still_email_spam` filter to true, form submissions that match the blocklist will be sent to the form email address, and they will include `*** SPAM ***` in the email subject. 

#### Proposed changelog entry for your changes:
* Contact Form: put feedback that matches the disallowed list in trash
