### PR TITLE
Instant Search: Fix search query decoding

### DIFF
--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -7,17 +7,9 @@ import { encode } from 'qss';
 /**
  * Internal dependencies
  */
-import {
-	SERVER_OBJECT_NAME,
-	SORT_DIRECTION_ASC,
-	RESULT_FORMAT_MINIMAL,
-	RESULT_FORMAT_PRODUCT,
-	VALID_SORT_KEYS,
-} from './constants';
+import { SERVER_OBJECT_NAME, SORT_DIRECTION_ASC, VALID_SORT_KEYS } from './constants';
 import { getFilterKeys, getUnselectableFilterKeys, mapFilterToFilterKey } from './filters';
 import { decode } from './query-string-decode';
-
-const knownResultFormats = [ RESULT_FORMAT_MINIMAL, RESULT_FORMAT_PRODUCT ];
 
 function getQuery() {
 	return decode( window.location.search.substring( 1 ), false, false );
@@ -48,7 +40,6 @@ export function setSearchQuery( searchValue ) {
 	} else {
 		query.s = searchValue;
 	}
-
 	pushQueryString( encode( query ) );
 }
 

--- a/modules/search/instant-search/lib/query-string.js
+++ b/modules/search/instant-search/lib/query-string.js
@@ -38,7 +38,7 @@ function pushQueryString( queryString, shouldEmitEvent = true ) {
 export function getSearchQuery() {
 	const query = getQuery();
 	// Cast query.s as string since it can be a number
-	return 's' in query ? decodeURIComponent( String( query.s ) ) : '';
+	return 's' in query ? String( query.s ) : '';
 }
 
 export function setSearchQuery( searchValue ) {


### PR DESCRIPTION
Fixes #16919, a critical bug that breaks the search interface when the user enters `%` into the search input.

#### Changes proposed in this Pull Request:
* Prevents decoding an already decoded search query string.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply these changes to your Jetpack site with Instant Search enabled.
2. Enter a random search query. Ensure that the results appear as expected.
3. Append a percentage symbol to your query (e.g. "what 100%"). Ensure that no errors are logged in the browser console; ensure that results appear as expected. 

#### Proposed changelog entry for your changes:
* Fixes a critical bug with the Jetpack Search interface.
