### PR TITLE
Donations Block -- automatically save and redirect to Stripe connection

### DIFF
--- a/extensions/shared/components/block-nudge/index.jsx
+++ b/extensions/shared/components/block-nudge/index.jsx
@@ -41,7 +41,7 @@ export default compose( [
 		autosaveAndRedirect: async event => {
 			event.preventDefault(); // Don't follow the href before autosaving
 			onClick( blockName );
-			await dispatch( 'core/editor' ).autosave();
+			await dispatch( 'core/editor' ).savePost();
 			// Using window.top to escape from the editor iframe on WordPress.com
 			window.top.location.href = href;
 		},


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/15602

#### Changes proposed in this Pull Request:

Automatically saves the user's post progress when the Donations block prompts a user to connect to Stripe. Not that this is also going to change the experience for `UpgradeNudge` since that block reuses the `BlockNudge`

#### Jetpack product discussion

pbAPfg-k3-p2

#### Does this pull request change what data or activity we track or use?

No.

#### GIFs:
![2020-08-24 23 29 56](https://user-images.githubusercontent.com/66652282/91121447-cc2fee00-e665-11ea-8e04-f581747b0664.gif)


#### Testing instructions:

* Set up a test site:
  * [Create a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=fix/donation-stripe-save-navigation). 
  * Set up Jetpack and purchase a Premium or Professional plan.
* Go to Posts > New.
* Click the "+" symbol at the top left of the page.
* Search for the Donations block and click on it to insert it onto the page
* Once the prompt "Connect to Stripe to use this block on your site" shows up, click the "Connect" button.
* The site should save and redirect you to the Connect to Stripe page, without showing you a prompt.
* If you navigate back to your post, your changes should have been saved from the moment you clicked "Connect"

#### Proposed changelog entry for your changes:

Automatically save and direct to the Stripe connection page on the Donations block.