### PR TITLE
Autoloader: try to detect when both v1.x and v2.x files are present

### DIFF
--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -114,14 +114,14 @@ class Autoloader_Handler {
 			// The autoload_package.php file is a v1.x, so try to delete v2.x files.
 			$vendor_dir = trailingslashit( dirname( $autoload_packages_path ) );
 
-			$v1_files_to_delete = array(
+			$v2_files_to_delete = array(
 				$vendor_dir . 'autoload_functions.php',
 				$vendor_dir . 'jetpack-autoloader/autoload_functions.php',
 				$vendor_dir . 'composer/jetpack_autoload_classmap.php',
 				$vendor_dir . 'composer/jetpack_autoload_filemap.php',
 			);
 
-			foreach ( $v1_files_to_delete as $file ) {
+			foreach ( $v2_files_to_delete as $file ) {
 				if ( file_exists( $file ) ) {
 					@unlink( $file ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 				}

--- a/packages/autoloader/src/class-autoloader-handler.php
+++ b/packages/autoloader/src/class-autoloader-handler.php
@@ -112,34 +112,26 @@ class Autoloader_Handler {
 		 */
 		if ( 2000 < filesize( $autoload_packages_path ) ) {
 			// The autoload_package.php file is a v1.x, so try to delete v2.x files.
-			$vendor_dir = dirname( $autoload_packages_path );
-			if ( file_exists( trailingslashit( $vendor_dir ) . 'autoload_functions.php' )
-				&& is_writable( $vendor_dir )
-				&& is_executable( $vendor_dir ) ) {
-				unlink( trailingslashit( $vendor_dir ) . 'autoload_functions.php' );
-			}
+			$vendor_dir = trailingslashit( dirname( $autoload_packages_path ) );
 
-			$jetpack_autoloader_dir = trailingslashit( $vendor_dir ) . 'jetpack-autoloader';
-			if ( file_exists( trailingslashit( $jetpack_autoloader_dir ) . 'autoload_functions.php' )
-				&& is_writable( $jetpack_autoloader_dir )
-				&& is_executable( $jetpack_autoloader_dir ) ) {
-				unlink( trailingslashit( $jetpack_autoloader_dir ) . 'autoload_functions.php' );
-			}
+			$v1_files_to_delete = array(
+				$vendor_dir . 'autoload_functions.php',
+				$vendor_dir . 'jetpack-autoloader/autoload_functions.php',
+				$vendor_dir . 'composer/jetpack_autoload_classmap.php',
+				$vendor_dir . 'composer/jetpack_autoload_filemap.php',
+			);
 
-			$composer_dir = trailingslashit( $vendor_dir ) . 'composer';
-			if ( file_exists( trailingslashit( $composer_dir ) . 'jetpack_autoload_classmap.php' )
-				&& is_writable( $composer_dir )
-				&& is_executable( $composer_dir ) ) {
-				unlink( trailingslashit( $composer_dir ) . 'jetpack_autoload_classmap.php' );
+			foreach ( $v1_files_to_delete as $file ) {
+				if ( file_exists( $file ) ) {
+					@unlink( $file ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				}
 			}
 
 			return true;
 		}
 
 		// Try to delete v1.x classmap file.
-		if ( is_writable( dirname( $v1_classmap_path ) ) && is_executable( dirname( $v1_classmap_path ) ) ) {
-			unlink( $v1_classmap_path );
-		}
+		@unlink( $v1_classmap_path ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
 		return false;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The autoloader can end up with some v1.x files and some v2.x files in this situation:
1) At least two plugins on a site have v2.x autoloaders.
2) A backup is restored, and the backup contains a version of a plugin with a v1.x autoloader. Therefore, the backup downgrades the autoloader for that plugin from v2.x to v1.x.
3) The autoloader files that are exclusive to v2.x remain in the plugin's directory. The file that v1.x and 2.x have in common, `autoload_packages.php`, is replaced with the v1.x version.

When this occurs, v2.x autoloaders on the site think that this plugin has a v2.x autoloader, but the plugin actually runs a v1.x autoloader.

To fix this situation, detect that plugin has both v1.x and v2.x files by:
1) Checking for the existence of the v1 classmap file, `composer/autoload_classmap_package.php`.
2) If the v1 classmap file exists, check the file size of `vendor/autoload_packages.php` to determine if the plugin will run a v1 or v2 autoloader. This file is small for v2 autoloaders, less than 500 bytes. This file is much large for v1 autoloaders, greater than 6 KB.
3) Try to clean up the unneeded files. This is done for a few reasons:
 - It eliminates the need to do all of these checks for subsequent page loads.
 - It prevents the v2 autoloaders from using the v2 classmap, (`composer/jetpack_autoload_classmap.php`) that's left behind in the plugin folder. Since the plugin has been restored to a previous version, that classmap may no longer be valid.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
1. Install this branch and connect Jetpack.
2. Install and activate WooCommerce version 4.3.3.
3. Generate a backup.
4. Update WooCommerce to version 4.4.1.
5. Restore the backup generated in step 3, which contains WooCommerce 4.3.3.
6. Confirm that no errors are generated.


#### Proposed changelog entry for your changes:
* tbd
