### PR TITLE
Admin Page: switch Creative Mail recommendation to a free one

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -319,7 +319,6 @@ const features = {
 				details: __( 'Turn visitors into subscribers with email marketing.', 'jetpack' ),
 				checked: isCreativeMailActive,
 				isDisabled: true,
-				isPaid: true,
 				configureLink: isCreativeMailActive ? '/wp-admin/admin.php?page=creativemail' : null,
 				learnMoreLink:
 					'https://jetpack.com/support/jetpack-blocks/form-block/newsletter-sign-up-form/',


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* See my comment here:
https://github.com/Automattic/jetpack/pull/16828#discussion_r476261753

**Before**

![image](https://user-images.githubusercontent.com/426388/91152571-696b4080-e6bf-11ea-9ebc-c0a0d68d1377.png)

**After**

![image](https://user-images.githubusercontent.com/426388/91152508-55274380-e6bf-11ea-96aa-cdea00631f8e.png)


#### Jetpack product discussion

pbtFPC-Hb-p2

#### Does this pull request change what data or activity we track or use?

* No

#### Testing instructions:

1. On your Jetpack site add the following to then end of the wp-config.php file in order to make the Setup Wizard show:
```php
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/features` and scroll to the Marketing section.
3. Verify that the Creative Mail recommendation is there, but does not include any star in the top left corner.

#### Proposed changelog entry for your changes:

* N/A
