### PR TITLE
Blocks: add Calypso Color Schemes back

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-build": "6.1.0",
+		"@automattic/calypso-color-schemes": "1.0.0",
 		"@automattic/custom-colors-loader": "automattic/custom-colors-loader",
 		"@automattic/format-currency": "1.0.0-alpha.0",
 		"@automattic/popup-monitor": "1.0.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = () => ( {
 	plugins: {
 		'postcss-custom-properties': {
-			importFrom: [ require.resolve( '@automattic/color-studio' ) ],
+			importFrom: [ require.resolve( '@automattic/calypso-color-schemes' ) ],
 			// @TODO: Drop `preserve: false` workaround if possible
 			// See https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168
 			preserve: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,11 @@
     webpack-cli "3.3.10"
     webpack-rtl-plugin "2.0.0"
 
+"@automattic/calypso-color-schemes@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@automattic/calypso-color-schemes/-/calypso-color-schemes-1.0.0.tgz#17a14e3257bd90b40e960d624cca4353d4d20c34"
+  integrity sha512-W7r4pgcBauLx65oTLbHKV84ScnfEKmW7T/sXkPfByHhuIE7+OpubmiiBsizWatk1I/puUTmj+SDqEOJMOyRdzA==
+
 "@automattic/color-studio@2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@automattic/color-studio/-/color-studio-2.3.1.tgz#961d9af4fbe2878bcf30c6ade4eec06537ec1fb6"


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* It was removed in #16312, but caused issues discussed in #16733.


#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* Connect your site to WordPress.com.
* Under Jetpack > Settings, enable Publicize
* Go to Posts > Add New
* See that the Jetpack logo looks good in the plugin sidebar.
* Insert a Mailchimp block, connect it to your Mailchimp account.
* Modify one of the Mailchimp processsing messages and ensure that the colors are applied:

![image](https://user-images.githubusercontent.com/426388/91166088-177fe600-e6d2-11ea-9afc-0ffcaff016f4.png)

#### Proposed changelog entry for your changes:
* N/A
