### PR TITLE
ToS: Remove dependency to Jetpack Connection

### DIFF
--- a/packages/terms-of-service/composer.json
+++ b/packages/terms-of-service/composer.json
@@ -5,8 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"automattic/jetpack-options": "@dev",
-		"automattic/jetpack-status": "@dev",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5",

--- a/packages/terms-of-service/src/class-terms-of-service.php
+++ b/packages/terms-of-service/src/class-terms-of-service.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack;
 
-use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Status;
 
 /**
@@ -53,9 +52,9 @@ class Terms_Of_Service {
 	 * Returns whether the master user has agreed to the terms of service.
 	 *
 	 * The following conditions have to be met in order to agree to the terms of service.
-	 * 1. The master user has gone though the connect flow.
+	 * 1. The master user has gone though the connect flow (deprecated @since 8.9.0).
 	 * 2. The site is not in dev mode.
-	 * 3. The master user of the site is still connected.
+	 * 3. The master user of the site is still connected (deprecated @since 8.9.0).
 	 *
 	 * @return bool
 	 */
@@ -63,8 +62,15 @@ class Terms_Of_Service {
 		if ( $this->is_offline_mode() ) {
 			return false;
 		}
-
-		return $this->get_raw_has_agreed() || $this->is_active();
+		/**
+		 * Before 8.9.0 we used to also check if the master user of the site is connected
+		 * by calling the Connection related `is_active` method.
+		 * As of 8.9.0 we have removed this check in order to resolve the
+		 * circular dependencies it was introducing to composer packages.
+		 *
+		 * @since 8.9.0
+		 */
+		return $this->get_raw_has_agreed();
 	}
 
 	/**
@@ -75,16 +81,6 @@ class Terms_Of_Service {
 	 */
 	protected function is_offline_mode() {
 		return ( new Status() )->is_offline_mode();
-	}
-
-	/**
-	 * Tells us if the site is connected.
-	 * Abstracted for testing purposes.
-	 *
-	 * @return bool
-	 */
-	protected function is_active() {
-		return ( new Manager() )->is_active();
 	}
 
 	/**

--- a/packages/terms-of-service/src/class-terms-of-service.php
+++ b/packages/terms-of-service/src/class-terms-of-service.php
@@ -52,7 +52,7 @@ class Terms_Of_Service {
 	 * Returns whether the master user has agreed to the terms of service.
 	 *
 	 * The following conditions have to be met in order to agree to the terms of service.
-	 * 1. The master user has gone though the connect flow (deprecated @since 8.9.0).
+	 * 1. The master user has gone though the connect flow.
 	 * 2. The site is not in dev mode.
 	 * 3. The master user of the site is still connected (deprecated @since 8.9.0).
 	 *

--- a/packages/terms-of-service/tests/php/test-terms-of-service.php
+++ b/packages/terms-of-service/tests/php/test-terms-of-service.php
@@ -24,7 +24,7 @@ class Test_Terms_Of_Service extends TestCase {
 	public function setUp() {
 		$this->terms_of_service = $this->createPartialMock(
 			__NAMESPACE__ . '\\Terms_Of_Service',
-			array( 'get_raw_has_agreed', 'is_offline_mode', 'set_agree', 'is_active', 'set_reject' )
+			array( 'get_raw_has_agreed', 'is_offline_mode', 'set_agree', 'set_reject' )
 		);
 	}
 
@@ -79,21 +79,6 @@ class Test_Terms_Of_Service extends TestCase {
 		$this->terms_of_service->method( 'get_raw_has_agreed' )->willReturn( true );
 		$this->terms_of_service->expects( $this->once() )->method( 'is_offline_mode' )->willReturn( true );
 		$this->assertFalse( $this->terms_of_service->has_agreed() );
-	}
-
-	/**
-	 * Tests has_agreed if active but not agreed.
-	 *
-	 * @covers Automattic\Jetpack\Terms_Of_Service
-	 */
-	public function test_returns_true_if_active_even_if_not_agreed() {
-		$this->terms_of_service->expects( $this->once() )->method( 'get_raw_has_agreed' )->willReturn( false );
-		$this->terms_of_service->expects( $this->once() )->method( 'is_offline_mode' )->willReturn( false );
-
-		// Jetpack is active.
-		$this->terms_of_service->expects( $this->once() )->method( 'is_active' )->willReturn( true );
-
-		$this->assertTrue( $this->terms_of_service->has_agreed() );
 	}
 
 	/**


### PR DESCRIPTION
This PR is part of an effort to remove the circular dependencies that were introduced by the connection, tracking and terms-of-service packages:
The connection package requires the tracking package.
The tracking package requires the terms-of-service package.
The terms-of-service package requires the connection package.

#### Changes proposed in this Pull Request:
Removes the terms-of-service package dependency to connection package, by:
* Removing the connection dependency from composer
* Removing the check for an active Jetpack Connection in the `has_agreed` public method. 

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
Since we are basically only removing the `is_active` check from the `has_agreed` method, successfully running the unit tests should probably be enough.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* ToS: Remove dependency to Jetpack Connection
