### PR TITLE
deprecates JETPACK_MASTER_USER and adds linter

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -8,6 +8,7 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-Extra" />
 	<rule ref="VariableAnalysis" />
+	<rule ref="bin/PHPCSSniffs" />
 
 	<!-- Elevate undefined variables to an Error instead of a Warning. -->
 	<rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable">

--- a/bin/PHPCSSniffs/Sniffs/MasterUserConstantSniff.php
+++ b/bin/PHPCSSniffs/Sniffs/MasterUserConstantSniff.php
@@ -1,0 +1,36 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Sniffer that looks for JETPACK_MASTER_USER constant usage
+ */
+class Jetpack_Sniffs_MasterUserConstantSniff implements PHP_CodeSniffer_Sniff {
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return array( T_STRING );
+	}
+
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file where the token was found.
+	 * @param int                  $stack_ptr The position in the stack where the token was found.
+	 */
+	public function process( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+
+		$tokens = $phpcs_file->getTokens();
+
+		if ( 'JETPACK_MASTER_USER' === $tokens[ $stack_ptr ]['content'] ) {
+			$phpcs_file->addWarning(
+				'JETPACK_MASTER_USER constant should not be used. Use the blog token to make requests instead, or use the current user token when needed.',
+				$stack_ptr,
+				'ShouldNotBeUsed'
+			);
+		}
+
+	}
+
+}

--- a/bin/PHPCSSniffs/ruleset.xml
+++ b/bin/PHPCSSniffs/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset name="Jetpack">
+	<description>Jetpack Specific lint rules.</description>
+</ruleset>

--- a/bin/phpcs-requirelist.js
+++ b/bin/phpcs-requirelist.js
@@ -83,4 +83,5 @@ module.exports = [
 	'tests/php/general/test-class.jetpack-network.php',
 	'tests/php/test_class.jetpack_photon.php',
 	'views/admin/deactivation-dialog.php',
+	'bin/PHPCSSniffs',
 ];

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5793,7 +5793,7 @@ endif;
 		$client_blog_id = is_multisite() ? $blog_id : 0;
 
 		if ( ! isset( $clients[ $client_blog_id ] ) ) {
-			$clients[ $client_blog_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => JETPACK_MASTER_USER ) ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+			$clients[ $client_blog_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => Connection_Manager::MASTER_USER ) );
 			if ( function_exists( 'ignore_user_abort' ) ) {
 				ignore_user_abort( true );
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5793,7 +5793,7 @@ endif;
 		$client_blog_id = is_multisite() ? $blog_id : 0;
 
 		if ( ! isset( $clients[ $client_blog_id ] ) ) {
-			$clients[ $client_blog_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => JETPACK_MASTER_USER ) );
+			$clients[ $client_blog_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => JETPACK_MASTER_USER ) ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 			if ( function_exists( 'ignore_user_abort' ) ) {
 				ignore_user_abort( true );
 			}

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -5793,7 +5793,7 @@ endif;
 		$client_blog_id = is_multisite() ? $blog_id : 0;
 
 		if ( ! isset( $clients[ $client_blog_id ] ) ) {
-			$clients[ $client_blog_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => Connection_Manager::MASTER_USER ) );
+			$clients[ $client_blog_id ] = new Jetpack_IXR_ClientMulticall( array( 'user_id' => Connection_Manager::CONNECTION_OWNER ) );
 			if ( function_exists( 'ignore_user_abort' ) ) {
 				ignore_user_abort( true );
 			}

--- a/jetpack.php
+++ b/jetpack.php
@@ -21,7 +21,7 @@ define( 'JETPACK__VERSION', '9.0-alpha' );
 /**
  * Constant used to fetch the connection owner token
  *
- * @deprecated 8.9.0
+ * @deprecated 9.0.0
  * @var boolean
  */
 define( 'JETPACK_MASTER_USER', true );

--- a/jetpack.php
+++ b/jetpack.php
@@ -17,7 +17,15 @@
 define( 'JETPACK__MINIMUM_WP_VERSION', '5.4' );
 define( 'JETPACK__MINIMUM_PHP_VERSION', '5.6' );
 define( 'JETPACK__VERSION', '9.0-alpha' );
+
+/**
+ * Constant used to fetch the connection owner token
+ *
+ * @deprecated 8.9.0
+ * @var boolean
+ */
 define( 'JETPACK_MASTER_USER', true );
+
 define( 'JETPACK__API_VERSION', 1 );
 define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK__PLUGIN_FILE', __FILE__ );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -26,7 +26,14 @@ class Manager {
 	const SECRETS_EXPIRED        = 'secrets_expired';
 	const SECRETS_OPTION_NAME    = 'jetpack_secrets';
 	const MAGIC_NORMAL_TOKEN_KEY = ';normal;';
-	const JETPACK_MASTER_USER    = true;
+
+	/**
+	 * For internal use only. If you need to get the connection owner, use the provided methods
+	 * get_connection_owner_id, get_connection_owner and is_get_connection_owner
+	 *
+	 * @var boolean
+	 */
+	const JETPACK_MASTER_USER = true; //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 
 	/**
 	 * The procedure that should be run to generate secrets.
@@ -494,7 +501,7 @@ class Manager {
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
-		return (bool) $this->get_access_token( self::JETPACK_MASTER_USER );
+		return (bool) $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 	}
 
 	/**
@@ -546,7 +553,7 @@ class Manager {
 	 * @return string|int Returns the ID of the connection owner or False if no connection owner found.
 	 */
 	public function get_connection_owner_id() {
-		$user_token       = $this->get_access_token( self::JETPACK_MASTER_USER );
+		$user_token       = $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
 			$connection_owner = $user_token->external_user_id;
@@ -621,7 +628,7 @@ class Manager {
 	 * @return object|false False if no connection owner found.
 	 */
 	public function get_connection_owner() {
-		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER );
+		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
@@ -643,7 +650,7 @@ class Manager {
 			$user_id = get_current_user_id();
 		}
 
-		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER );
+		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
 	}
@@ -2191,7 +2198,7 @@ class Manager {
 			if ( ! $user_tokens ) {
 				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack' ) );
 			}
-			if ( self::JETPACK_MASTER_USER === $user_id ) {
+			if ( self::JETPACK_MASTER_USER === $user_id ) { //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 				$user_id = \Jetpack_Options::get_option( 'master_user' );
 				if ( ! $user_id ) {
 					return $suppress_errors ? false : new \WP_Error( 'empty_master_user_option', __( 'No primary user defined', 'jetpack' ) );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -31,7 +31,7 @@ class Manager {
 	 * Constant used to fetch the master user token. Deprecated.
 	 *
 	 * @deprecated 9.0.0
-	 * @see Manager::MASTER_USER
+	 * @see Manager::CONNECTION_OWNER
 	 * @var boolean
 	 */
 	const JETPACK_MASTER_USER = true; //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
@@ -40,9 +40,11 @@ class Manager {
 	 * For internal use only. If you need to get the connection owner, use the provided methods
 	 * get_connection_owner_id, get_connection_owner and is_get_connection_owner
 	 *
+	 * @todo Add private visibility once PHP 7.1 is the minimum supported verion.
+	 *
 	 * @var boolean
 	 */
-	const MASTER_USER = true;
+	const CONNECTION_OWNER = true;
 
 	/**
 	 * The procedure that should be run to generate secrets.
@@ -510,7 +512,7 @@ class Manager {
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
-		return (bool) $this->get_access_token( self::MASTER_USER );
+		return (bool) $this->get_access_token( self::CONNECTION_OWNER );
 	}
 
 	/**
@@ -562,7 +564,7 @@ class Manager {
 	 * @return string|int Returns the ID of the connection owner or False if no connection owner found.
 	 */
 	public function get_connection_owner_id() {
-		$user_token       = $this->get_access_token( self::MASTER_USER );
+		$user_token       = $this->get_access_token( self::CONNECTION_OWNER );
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
 			$connection_owner = $user_token->external_user_id;
@@ -637,7 +639,7 @@ class Manager {
 	 * @return object|false False if no connection owner found.
 	 */
 	public function get_connection_owner() {
-		$user_token = $this->get_access_token( self::MASTER_USER );
+		$user_token = $this->get_access_token( self::CONNECTION_OWNER );
 
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
@@ -659,7 +661,7 @@ class Manager {
 			$user_id = get_current_user_id();
 		}
 
-		$user_token = $this->get_access_token( self::MASTER_USER );
+		$user_token = $this->get_access_token( self::CONNECTION_OWNER );
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
 	}
@@ -2207,7 +2209,7 @@ class Manager {
 			if ( ! $user_tokens ) {
 				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack' ) );
 			}
-			if ( self::MASTER_USER === $user_id ) {
+			if ( self::CONNECTION_OWNER === $user_id ) {
 				$user_id = \Jetpack_Options::get_option( 'master_user' );
 				if ( ! $user_id ) {
 					return $suppress_errors ? false : new \WP_Error( 'empty_master_user_option', __( 'No primary user defined', 'jetpack' ) );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -33,7 +33,7 @@ class Manager {
 	 *
 	 * @var boolean
 	 */
-	const JETPACK_MASTER_USER = true; //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+	const MASTER_USER = true;
 
 	/**
 	 * The procedure that should be run to generate secrets.
@@ -501,7 +501,7 @@ class Manager {
 	 * @return Boolean is the site connected?
 	 */
 	public function is_active() {
-		return (bool) $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+		return (bool) $this->get_access_token( self::MASTER_USER );
 	}
 
 	/**
@@ -553,7 +553,7 @@ class Manager {
 	 * @return string|int Returns the ID of the connection owner or False if no connection owner found.
 	 */
 	public function get_connection_owner_id() {
-		$user_token       = $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+		$user_token       = $this->get_access_token( self::MASTER_USER );
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
 			$connection_owner = $user_token->external_user_id;
@@ -628,7 +628,7 @@ class Manager {
 	 * @return object|false False if no connection owner found.
 	 */
 	public function get_connection_owner() {
-		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+		$user_token = $this->get_access_token( self::MASTER_USER );
 
 		$connection_owner = false;
 		if ( $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) ) {
@@ -650,7 +650,7 @@ class Manager {
 			$user_id = get_current_user_id();
 		}
 
-		$user_token = $this->get_access_token( self::JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+		$user_token = $this->get_access_token( self::MASTER_USER );
 
 		return $user_token && is_object( $user_token ) && isset( $user_token->external_user_id ) && $user_id === $user_token->external_user_id;
 	}
@@ -2198,7 +2198,7 @@ class Manager {
 			if ( ! $user_tokens ) {
 				return $suppress_errors ? false : new \WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack' ) );
 			}
-			if ( self::JETPACK_MASTER_USER === $user_id ) { //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+			if ( self::MASTER_USER === $user_id ) {
 				$user_id = \Jetpack_Options::get_option( 'master_user' );
 				if ( ! $user_id ) {
 					return $suppress_errors ? false : new \WP_Error( 'empty_master_user_option', __( 'No primary user defined', 'jetpack' ) );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -28,6 +28,15 @@ class Manager {
 	const MAGIC_NORMAL_TOKEN_KEY = ';normal;';
 
 	/**
+	 * Constant used to fetch the master user token. Deprecated.
+	 *
+	 * @deprecated 9.0.0
+	 * @see Manager::MASTER_USER
+	 * @var boolean
+	 */
+	const JETPACK_MASTER_USER = true; //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+
+	/**
 	 * For internal use only. If you need to get the connection owner, use the provided methods
 	 * get_connection_owner_id, get_connection_owner and is_get_connection_owner
 	 *

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -180,13 +180,13 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_master_user_returns_false_when_no_master_user() {
 		Jetpack_Options::delete_option( 'master_user' );
-		$token = $this->connection->get_access_token( JETPACK_MASTER_USER );
+		$token = $this->connection->get_access_token( JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 
 		$this->assertFalse( $token );
 	}
 
 	public function test_get_access_token_with_master_user() {
-		$token = $this->connection->get_access_token( JETPACK_MASTER_USER );
+		$token = $this->connection->get_access_token( JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
 
 		$this->assertEquals( 'user-two.dos', $token->secret );
 	}

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -180,13 +180,13 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_master_user_returns_false_when_no_master_user() {
 		Jetpack_Options::delete_option( 'master_user' );
-		$token = $this->connection->get_access_token( JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+		$token = $this->connection->get_access_token( Connection_Manager::MASTER_USER );
 
 		$this->assertFalse( $token );
 	}
 
 	public function test_get_access_token_with_master_user() {
-		$token = $this->connection->get_access_token( JETPACK_MASTER_USER ); //phpcs:ignore ..Jetpack_Sniffs_MasterUserConstant.ShouldNotBeUsed
+		$token = $this->connection->get_access_token( Connection_Manager::MASTER_USER );
 
 		$this->assertEquals( 'user-two.dos', $token->secret );
 	}

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -180,7 +180,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 
 	public function test_get_access_token_with_master_user_returns_false_when_no_master_user() {
 		Jetpack_Options::delete_option( 'master_user' );
-		$token = $this->connection->get_access_token( Connection_Manager::MASTER_USER );
+		$token = $this->connection->get_access_token( Connection_Manager::CONNECTION_OWNER );
 
 		$this->assertFalse( $token );
 	}

--- a/tests/php/general/test_class.jetpack-data.php
+++ b/tests/php/general/test_class.jetpack-data.php
@@ -186,7 +186,7 @@ class WP_Test_Jetpack_Data extends WP_UnitTestCase {
 	}
 
 	public function test_get_access_token_with_master_user() {
-		$token = $this->connection->get_access_token( Connection_Manager::MASTER_USER );
+		$token = $this->connection->get_access_token( Connection_Manager::CONNECTION_OWNER );
 
 		$this->assertEquals( 'user-two.dos', $token->secret );
 	}


### PR DESCRIPTION
Deprecates the JETPACK_MASTER_USER constant and add a linter rule to avoi it from being used again

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
p9dueE-1Gw-p2

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Nothing to test - just need general feedback, especially on the linter error message

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* deprecate JETPACK_MASTER_USER constant