### PR TITLE
Beta Building: Normalize version number.

### DIFF
--- a/tools/get-version.sh
+++ b/tools/get-version.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/includes/normalize-version.sh"
+
 # Retrieving the version from jetpack.php file
-PHP_VERSION=`head -15 jetpack.php | grep '* Version' | cut -d ':' -f2`
+PHP_VERSION=$(head -15 jetpack.php | grep '* Version' | cut -d ':' -f2)
 
 # Getting a github prefix
-CLOSEST_TAG=`git describe --tags --abbrev=0`
+CLOSEST_TAG=$(git describe --tags --abbrev=0)
 
 # Getting a git full version with the prefix and stripping away the prefix
 GIT_SUFFIX=$(git describe --tags | awk -F "$CLOSEST_TAG" '{ print $2; }')
 
-echo $PHP_VERSION$GIT_SUFFIX
+normalize_version_number "$PHP_VERSION" 3
+
+echo $NORMALIZED_VERSION$GIT_SUFFIX

--- a/tools/includes/normalize-version.sh
+++ b/tools/includes/normalize-version.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Normalizes a version string to desired length.
+# First arg is input string, second is minimum number of points.
+function normalize_version_number {
+	TARGET_LENGTH="${2:-2}"
+	VERSION_ARRAY=()
+
+	# Break off dash content to append later.
+	if [[ $1 =~ "-" ]]; then
+		VERSION_SUFFIX=$(echo $1 | cut -d'-' -f 2)
+		VERSION_RAW=$(echo $1 | cut -d'-' -f 1)
+	else
+		VERSION_RAW=$1
+	fi
+
+	# Iterate over version string, and append them to array.
+	IFS='.' read -ra VERSION_PARTS <<< "$VERSION_RAW"
+	for i in "${VERSION_PARTS[@]}"; do
+		VERSION_ARRAY+=( "$i" )
+	done
+
+	# Add additional zeros until target length is reached.
+	while [ "${#VERSION_ARRAY[@]}" -lt "$TARGET_LENGTH" ]; do
+		VERSION_ARRAY+=( "0" )
+	done
+
+	# Join array by dots, then append suffix.
+	NORMALIZED_VERSION=$(IFS=. ; echo "${VERSION_ARRAY[*]}")
+	if [ $VERSION_SUFFIX ]; then
+		NORMALIZED_VERSION="${NORMALIZED_VERSION}-${VERSION_SUFFIX}"
+	fi
+}

--- a/tools/version-update.sh
+++ b/tools/version-update.sh
@@ -11,37 +11,9 @@ function usage {
 	exit 1
 }
 
-# Normalizes a version string to desired length.
-# First arg is input string, second is minimum number of points.
-function normalize_version_number {
-	TARGET_LENGTH="${2:-2}"
-	VERSION_ARRAY=()
-
-	# Break off dash content to append later.
-	if [[ $1 =~ "-" ]]; then
-		VERSION_SUFFIX=$(echo $1 | cut -d'-' -f 2)
-		VERSION_RAW=$(echo $1 | cut -d'-' -f 1)
-	else
-		VERSION_RAW=$1
-	fi
-
-	# Iterate over version string, and append them to array.
-	IFS='.' read -ra VERSION_PARTS <<< "$VERSION_RAW"
-	for i in "${VERSION_PARTS[@]}"; do
-		VERSION_ARRAY+=( "$i" )
-	done
-
-	# Add additional zeros until target length is reached.
-	while [ "${#VERSION_ARRAY[@]}" -lt "$TARGET_LENGTH" ]; do
-		VERSION_ARRAY+=( "0" )
-	done
-
-	# Join array by dots, then append suffix.
-	NORMALIZED_VERSION=$(IFS=. ; echo "${VERSION_ARRAY[*]}")
-	if [ $VERSION_SUFFIX ]; then
-		NORMALIZED_VERSION="${NORMALIZED_VERSION}-${VERSION_SUFFIX}"
-	fi
-}
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+. "$DIR/includes/normalize-version.sh"
 
 # Sets options.
 while getopts ":hv:n:N" opt; do


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack-beta/issues/100

We can cherry-pick to that branch to prevent the same type of issue having there. 8.9-beta < 8.9.0-beta, so it should be an improvement to that branch specifically.

Other branches wouldn't be impacted negatively, I don't believe, since they branch off master, which has `alpha` usually.

#### Changes proposed in this Pull Request:
* See https://github.com/Automattic/jetpack-beta/issues/100 for details.
* This will ensure that beta versions have a X.Y.Z version number to ensure that X.Y-### wouldn't appear greater than X.Y.Z-###.

#### Jetpack product discussion
p1HpG7-a13-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Run `./tools/get-version.sh` from the command line before and after patch to see in action.

#### Proposed changelog entry for your changes:
* n/a
