### PR TITLE
Tracking: Add the connection check.

### DIFF
--- a/packages/tracking/src/class-tracking.php
+++ b/packages/tracking/src/class-tracking.php
@@ -104,7 +104,10 @@ class Tracking {
 		}
 		$terms_of_service = new Terms_Of_Service();
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
-		if ( ! $terms_of_service->has_agreed() ) {
+		if (
+			$this->connection->is_active()
+			&& ! $terms_of_service->has_agreed()
+		) {
 			return false;
 		}
 

--- a/packages/tracking/src/class-tracking.php
+++ b/packages/tracking/src/class-tracking.php
@@ -105,8 +105,8 @@ class Tracking {
 		$terms_of_service = new Terms_Of_Service();
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
 		if (
-			$this->connection->is_active()
-			&& ! $terms_of_service->has_agreed()
+			! $this->connection->is_user_connected()
+			|| ! $terms_of_service->has_agreed()
 		) {
 			return false;
 		}

--- a/packages/tracking/src/class-tracking.php
+++ b/packages/tracking/src/class-tracking.php
@@ -105,8 +105,8 @@ class Tracking {
 		$terms_of_service = new Terms_Of_Service();
 		// Don't track users who have opted out or not agreed to our TOS, or are not running an active Jetpack.
 		if (
-			! $this->connection->is_user_connected()
-			|| ! $terms_of_service->has_agreed()
+			! $terms_of_service->has_agreed()
+			|| ! $this->connection->is_user_connected()
 		) {
 			return false;
 		}


### PR DESCRIPTION
This is required now because the connection status check has been removed from the ToS package in #16967 . This is a minimal change, but we should also take a look at how we are passing the Connection Manager object to the constructor of this class and remove the optional direct instantiation.

**Update:** The change between `is_active` and `is_user_connected` requires some explanation. I have made this change first because in my testing I have seen that `is_active` can return true when a user is not connected, but a master user token check returns true anyway. So

- the use of `is_active` is not working as expected in case of Tracking - we need to actually check whether the active user is connected;
- the `is_active` method is going to be deprecated soon, and we might just as well start using a more appropriate method now.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Part of #16973 

#### Changes proposed in this Pull Request:
* Adds a method call in the tracking conditional that checks for the current user's connection.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
* This pull request does not add, but may remove some instances of data, because `is_user_connected` may be more restrictive than `is_active` that we were using before.

#### Testing instructions:
* To force tracking events and log the result you can use the following script:
```
add_action( 'plugins_loaded', function() {
  $tracking = new Tracking( 'jetpack', new Manager() );
  $result = $tracking->record_user_event( 'some_bogus_type', array() );

  error_log( 'Tracking result' );
  error_log( print_r( $result, true ) );
}, 1000 );
```
* In the error log you will either see a `1` for a successful tracking submission, or an empty string when there's no submission.
* See that tracking happens fine with a connected user, but doesn't happen when you disconnect Jetpack.
* Bonus points for testing secondary users, as well as unauthenticated flows.

#### Proposed changelog entry for your changes:
* N/A
