### PR TITLE
Docs: Reference one location for minimum version of Yarn needed

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ _**All commands mentioned in this document should be run from the base Jetpack d
 
 * [Docker](https://hub.docker.com/search/?type=edition&offering=community)
 * [NodeJS](https://nodejs.org)
-* [Yarn](https://yarnpkg.com/) — please make sure your version is higher than v1.3: `yarn --version`
+* [Yarn](https://yarnpkg.com/) — please make sure your version is higher than what is noted in ../docs/development-environment.md: `yarn --version`
 * Optionally [Ngrok](https://ngrok.com) client and account or some other service for creating a local HTTP tunnel. It’s fine to stay on the free pricing tier with Ngrok.
 
 Install prerequisites; you will need to open up Docker to install its dependencies.

--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ _**All commands mentioned in this document should be run from the base Jetpack d
 
 * [Docker](https://hub.docker.com/search/?type=edition&offering=community)
 * [NodeJS](https://nodejs.org)
-* [Yarn](https://yarnpkg.com/) — please make sure your version is higher than what is noted in ../docs/development-environment.md: `yarn --version`
+* [Yarn](https://yarnpkg.com/) — please make sure your version is higher than what is noted in the [development environment documentation](../docs/development-environment.md#minimum-required-versions): `yarn --version`
 * Optionally [Ngrok](https://ngrok.com) client and account or some other service for creating a local HTTP tunnel. It’s fine to stay on the free pricing tier with Ngrok.
 
 Install prerequisites; you will need to open up Docker to install its dependencies.

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -66,8 +66,8 @@ To get a local WordPress site up and running you need a web server (Apache, Ngin
 ## Installing development tools
 
 ### Minimum required versions
- * Node.js - LTS
- * Yarn - 1.7
+ * Node.js - LTS (Currently 10, see engines section of package.json)
+ * Yarn - 1.3 (See engines section of package.json)
  * PHP - 7.4 (in case you're running WordPress locally)
 
 ---


### PR DESCRIPTION
To ease how many places to update, let's only mention things once in the docs and reference the technical requirement location.

#### Changes proposed in this Pull Request:
* Updating docs.

#### Jetpack product discussion
n/a

#### Does this pull request change what data or activity we track or use?
n/a

#### Testing instructions:
n/a

#### Proposed changelog entry for your changes:
n/a
