### PR TITLE
Instant Search: don't exclude any post types by default

### DIFF
--- a/modules/search/class-jetpack-instant-search.php
+++ b/modules/search/class-jetpack-instant-search.php
@@ -565,8 +565,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 		$enabled_post_types = array();
 		$widget_options     = get_option( Jetpack_Search_Helpers::get_widget_option_name(), array() );
 
-		// Iterate through each Jetpack Search widget configuration and append each enabled post type
-		// to $enabled_post_types.
+		// Prior to Jetpack 8.8, post types were enabled via Jetpack Search widgets rather than disabled via the Customizer.
+		// To continue supporting post types set up in the old way, we iterate through each Jetpack Search
+		// widget configuration and append each enabled post type to $enabled_post_types.
 		foreach ( $widget_options as $widget_option ) {
 			if ( isset( $widget_option['post_types'] ) && is_array( $widget_option['post_types'] ) ) {
 				foreach ( $widget_option['post_types'] as $enabled_post_type ) {
@@ -575,7 +576,9 @@ class Jetpack_Instant_Search extends Jetpack_Search {
 			}
 		}
 
-		$post_types_to_disable = array_diff( $post_types, $enabled_post_types );
-		update_option( Jetpack_Search_Options::OPTION_PREFIX . 'excluded_post_types', join( ',', $post_types_to_disable ) );
+		if ( ! empty( $enabled_post_types ) ) {
+			$post_types_to_disable = array_diff( $post_types, $enabled_post_types );
+			update_option( Jetpack_Search_Options::OPTION_PREFIX . 'excluded_post_types', join( ',', $post_types_to_disable ) );
+		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->
Fixes #16982.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
In #16364 we made two changes:
* Added a site-wide setting for excluding certain post types from search results in the Instant Search overlay.
* Removed per-widget setting for including only certain post types from the Jetpack Search widget when Instant Search is enabled.

In order to seamlessly support the older per-widget setting, we kept honouring post types set up in widgets (see https://github.com/Automattic/jetpack/commit/ffd7fe0021b5f327dc34c429cbadfe2429fc56f7). Unfortunately, this change also seems to disable all post types for brand new sites that don't have any widget settings. 

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On a test site with no Jetpack Search widgets set up, enable Jetpack Search and the instant search experience in `/wp-admin/admin.php?page=jetpack#/performance`.

<img width="1087" alt="Screen Shot 2020-08-26 at 15 19 18" src="https://user-images.githubusercontent.com/17325/91251421-88490000-e7af-11ea-938b-3238c921b2af.png">

Visit the Customizer and ensure that no post types have been disabled by default:

<img width="284" alt="Screen Shot 2020-08-26 at 15 15 21" src="https://user-images.githubusercontent.com/17325/91251403-7d8e6b00-e7af-11ea-8936-75ce65e7a490.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Ensure that all post types are enabled by default in Jetpack Instant Search.
