### PR TITLE
Media Library: show descriptive upload errors

### DIFF
--- a/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -108,7 +108,8 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 
 		// Normal WPCOM upload processing
 		if ( count( $other_media_files ) > 0 || count( $media_urls ) > 0 ) {
-			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_upload_size' ), 9 );
+			add_filter( 'wp_handle_upload_prefilter', array( $this, 'check_upload_size' ), 9 ); // used for direct media uploads.
+			add_filter( 'wp_handle_sideload_prefilter', array( $this, 'check_upload_size' ), 9 ); // used for uploading media via url.
 
 			$create_media = $this->handle_media_creation_v1_1( $other_media_files, $media_urls, $media_attrs );
 			$media_ids = $create_media['media_ids'];
@@ -173,7 +174,7 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return $file;
 		}
 
-		if ( '0' != $file['error'] ) { // There's already an error.
+		if ( isset( $file['error'] ) && $file['error'] > 0 ) { // There's already an error. Error Codes Reference: https://www.php.net/manual/en/features.file-upload.errors.php .
 			return $file;
 		}
 

--- a/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -198,10 +198,6 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			$file['error'] = 'rest_upload_user_quota_exceeded|' . __( 'You have used your space quota. Please delete files before uploading.', 'default' );
 		}
 
-		if ( '0' != $file['error'] && ! isset( $_POST['html-upload'] ) && ! wp_doing_ajax() ) {
-			wp_die( $file['error'] . ' <a href="javascript:history.go(-1)">' . __( 'Back', 'default' ) . '</a>' );
-		}
-
 		return $file;
 	}
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes https://github.com/Automattic/wp-calypso/issues/43783

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reinstate functionality of showing descriptive upload errors in the media library as discussed here https://github.com/Automattic/wp-calypso/issues/43783#issuecomment-680744494
* Add space allowed check for uploads through URL

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

**Automated Testing**
* `arc patch D48615` to your clean sandbox and run the following
* `cd /home/wpcom/public_html/bin/tests/isolated`
* `phpunit --testsuite=media`
* All tests should pass

**Manual Testing**
* `arc patch D48615` to your clean sandbox
* Go to /wp-admin/options.php of your sandbox
* Change the `blog_upload_space` value to 1 (1mb). Be careful to note down the previous value
* Go to https://wordpress.com/media/ of that site
* You should be seeing that you are over the limit (if not, try uploading something)
![](https://cln.sh/MsrMmR+)
* Upload a new image thus triggering the `rest_upload_user_quota_exceeded` error. Try:
a) adding from your computer 
b) via url 
c) via copying from pexels/google photos)
* You should get a descriptive error and the XHR response should have a message which doesn't contain the error code itself

Before | After
-------|------
![](https://cln.sh/XdYoxO+)|![](https://cln.sh/O6Wa9U+)

* Go to `/wp-admin/options.php` of your sandbox
* Change the `blog_upload_space` value to what you have noted before

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Media Library: Show descriptive errors when uploading media 
* Media Library: Check for allowed space when uploading media through URL