### PR TITLE
Config: Add connection status check

### DIFF
--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -4,7 +4,12 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"minimum-stability": "dev",
-	"require": {},
+	"require": {
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-jitm": "@dev",
+		"automattic/jetpack-tracking": "@dev",
+		"automattic/jetpack-sync": "@dev"
+	},
 	"autoload": {
 		"classmap": [
 			"src/"

--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -7,8 +7,8 @@
 	"require": {
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-jitm": "@dev",
-		"automattic/jetpack-tracking": "@dev",
-		"automattic/jetpack-sync": "@dev"
+		"automattic/jetpack-sync": "@dev",
+		"automattic/jetpack-tracking": "@dev"
 	},
 	"autoload": {
 		"classmap": [

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -170,16 +170,21 @@ class Config {
 	}
 
 	/**
-	 * Enables the tracking feature. Depends on the Terms of Service package, so enables it too.
+	 * Enables the tracking feature.
+	 * Depends on the Terms of Service package and the Connection package,
+	 * so enables them too.
 	 */
 	protected function enable_tracking() {
 
 		// Enabling dependencies.
 		$this->ensure_feature( 'tos' );
+		$this->ensure_feature( 'connection' );
 
 		$terms_of_service = new Terms_Of_Service();
-		$tracking         = new Plugin_Tracking();
-		if ( $terms_of_service->has_agreed() ) {
+		$connection       = new Manager();
+		$tracking         = new Plugin_Tracking( $connection );
+
+		if ( $terms_of_service->has_agreed() && $connection->is_user_connected() ) {
 			add_action( 'init', array( $tracking, 'init' ) );
 		} else {
 			/**


### PR DESCRIPTION
This is required now because the connection status check has been removed from the ToS package in #16967 . 
It adds the extra check for the current user's connection when checking whether to enable the tracking feature.

Update: See #16979 for explanation on why we are now using `is_user_connected` instead of `is_active` 

Part of #16973

Changes proposed in this Pull Request:
* Adds a method call that checks for the current user's connection in the Config conditional to enable the tracking feature.
* Instantiates the Tracking class by passing a Connection/Manager object as argument.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
* This pull request does not add, but may remove some instances of data, because is_user_connected may be more restrictive than is_active that we were using before.

#### Testing instructions:
* Make sure that the tracking feature is disabled when a user is not connected and becomes available after connected their WP.com account:
I was mostly testing by adding corresponding logs to the `enable_tracking` method of `Config` to check whether tracking was initialized on `init` (connected user) or `jetpack_agreed_to_terms_of_service` (not connected) and testing out flows with secondary users linking/unlinking their account.


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* N/A
