### PR TITLE
Remove deprecated jetpack_tos_agreed

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -7170,18 +7170,6 @@ endif;
 	}
 
 	/**
-	 * Checks whether or not TOS has been agreed upon.
-	 * Will return true if a user has clicked to register, or is already connected.
-	 */
-	public static function jetpack_tos_agreed() {
-		_deprecated_function( 'Jetpack::jetpack_tos_agreed', 'Jetpack 7.9.0', '\Automattic\Jetpack\Terms_Of_Service->has_agreed' );
-
-		$terms_of_service = new Terms_Of_Service();
-		return $terms_of_service->has_agreed();
-
-	}
-
-	/**
 	 * Handles activating default modules as well general cleanup for the new connection.
 	 *
 	 * @param boolean $activate_sso                 Whether to activate the SSO module when activating default modules.


### PR DESCRIPTION
This is required now because the connection status check has been removed from the ToS package in #16967 .
Instead of adding the extra check for the current user's connection when checking if the user has agreed to the ToS, it completely removes the deprecated function where this check occurred.

Part of #16973

#### Changes proposed in this Pull Request:

* Removes the `jetpack_tos_agreed` deprecated since 7.9.0 method 

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
N/A

#### Proposed changelog entry for your changes:
N/A