### PR TITLE
Config: Remove composer dependencies

### DIFF
--- a/packages/config/composer.json
+++ b/packages/config/composer.json
@@ -4,12 +4,7 @@
 	"type": "library",
 	"license": "GPL-2.0-or-later",
 	"minimum-stability": "dev",
-	"require": {
-		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-jitm": "@dev",
-		"automattic/jetpack-sync": "@dev",
-		"automattic/jetpack-tracking": "@dev"
-	},
+	"require": {},
 	"autoload": {
 		"classmap": [
 			"src/"


### PR DESCRIPTION
Reverts adding composer dependencies to the Config package.

#### Changes proposed in this Pull Request:
The change was part of [this PR](https://github.com/Automattic/jetpack/pull/16987).
Seems we shouldn't declare any composer dependencies in the Config package because consumer plugins use Config to configure whichever packages they want. 
Config checks that the package classes are available by calling ensure_class().


#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
N/A

#### Proposed changelog entry for your changes:
N/A
