### PR TITLE
Admin Page: Change settings copy for VaultPress/Rewind to only say they're connected

### DIFF
--- a/_inc/client/security/backups-scan.jsx
+++ b/_inc/client/security/backups-scan.jsx
@@ -90,10 +90,7 @@ class BackupsScanRewind extends Component {
 				return {
 					title: __( 'Active', 'jetpack' ),
 					icon: 'checkmark-circle',
-					description: __(
-						'Your site is being backed up in real time and regularly scanned for security threats.',
-						'jetpack'
-					),
+					description: __( 'Your site is connected to Jetpack Backup and Scan.', 'jetpack' ),
 					url: getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ),
 				};
 			default:
@@ -192,7 +189,10 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 						</div>
 					);
 				}
-				return __( 'Your site is being backed up and monitored for threats.', 'jetpack' );
+				return __(
+					'Your site is connected to VaultPress for backups and security scanning.',
+					'jetpack'
+				);
 			}
 
 			// Only return here if backups enabled and site on on free/personal plan, or if Jetpack Backup is in use.
@@ -204,7 +204,7 @@ export const BackupsScan = withModuleSettingsFormHelpers(
 					planClass
 				)
 			) {
-				return __( 'Your site is being backed up.', 'jetpack' );
+				return __( 'Your site is connected to VaultPress for backups.', 'jetpack' );
 			}
 
 			// Nothing is enabled. We can show upgrade/setup text now.

--- a/_inc/client/security/jetpack-backup.jsx
+++ b/_inc/client/security/jetpack-backup.jsx
@@ -38,7 +38,7 @@ export class JetpackBackup extends Component {
 					link: getRedirectUrl( 'jetpack-support-backup' ),
 				} }
 			>
-				{ __( 'Your site is being backed up.', 'jetpack' ) }
+				{ __( 'Your site is connected to VaultPress for backups.', 'jetpack' ) }
 			</SettingsGroup>
 		);
 	};
@@ -69,7 +69,7 @@ export class JetpackBackup extends Component {
 				return {
 					title: __( 'Active', 'jetpack' ),
 					icon: 'checkmark-circle',
-					description: __( 'Your site is being backed up.', 'jetpack' ),
+					description: __( 'Your site is connected to Jetpack Backup.', 'jetpack' ),
 					url: getRedirectUrl( 'calypso-activity-log', { site: siteRawUrl } ),
 				};
 			default:


### PR DESCRIPTION
This is a follow-up from #16751.

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes `4257-gh-jpop-issues`.

Support issues are still cropping up due to confusion over copy on the Settings page for Jetpack Backup and Scan. This PR seeks to make things clearer by saying explicitly that these services are _connected_, and not that any backups or scans have taken place.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Alter copy in Settings to explicitly say that Jetpack Backup/Scan or VaultPress are connected, to avoid confusing implications that any backups or scans may have taken place.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

See `4257-gh-jpop-issues` for more information.

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

Follow the same instructions as in #16751 (copied here for easy access):

* Test with sites that meet the following criteria:
  * Backup only with VaultPress
  * Backup only with Rewind
  * Scan and Backup with VaultPress
  * Scan and Backup with Rewind
* Verify that the copy for each case matches below screenshots.

#### Screenshots

##### Backup only with VaultPress

<img width="376" alt="Screen Shot 2020-08-26 at 14 35 12" src="https://user-images.githubusercontent.com/670067/91349881-8d0bb500-e7ab-11ea-9f99-1316b39b2fa3.png">

##### Backup only with Rewind

<img width="351" alt="Screen Shot 2020-08-26 at 14 36 00" src="https://user-images.githubusercontent.com/670067/91349883-8d0bb500-e7ab-11ea-9c02-a89169797cdc.png">

##### Scan and Backup with VaultPress

<img width="506" alt="Screen Shot 2020-08-26 at 14 39 52" src="https://user-images.githubusercontent.com/670067/91349887-8da44b80-e7ab-11ea-9a0d-85a5ae9e8a29.png">

##### Scan and Backup with Rewind

<img width="415" alt="Screen Shot 2020-08-26 at 14 37 50" src="https://user-images.githubusercontent.com/670067/91349884-8d0bb500-e7ab-11ea-8439-3823ea246294.png">


#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Made "Backups and security scanning" status in Settings clearer, to reflect that services are only connected, not that backups or scans have taken place for the site.