### PR TITLE
Jetpack Debug Helper: Data Mocker

### DIFF
--- a/packages/debug-helper/modules/class-mocker.php
+++ b/packages/debug-helper/modules/class-mocker.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * The Mocker class creates mock data userful for testing.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Debug_Helper;
+
+use Automattic\Jetpack\Debug_Helper\Mocker\Runner_Interface;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+
+require_once __DIR__ . '/inc/mockers/interface-runner.php';
+
+/**
+ * REST_API_Tester to test REST API endpoints.
+ */
+class Mocker {
+
+	const REST_BASE = 'jetpack-debug';
+
+	/**
+	 * List of available runners.
+	 *
+	 * @var string[]
+	 */
+	private $runners = array(
+		'options' => 'Options',
+		'nonces'  => 'Nonces (stored in options)',
+	);
+
+	/**
+	 * Construction.
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_submenu_page' ), 1000 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'rest_api_init', array( $this, 'register_endpoints' ) );
+	}
+
+	/**
+	 * Register the REST endpoint.
+	 */
+	public function register_endpoints() {
+		register_rest_route(
+			self::REST_BASE,
+			'/mocker',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'run' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Add submenu item.
+	 */
+	public function register_submenu_page() {
+		add_submenu_page(
+			'jetpack-debug-tools',
+			'Mocker',
+			'Mocker',
+			'manage_options',
+			'mocker',
+			array( $this, 'render_ui' ),
+			99
+		);
+	}
+
+	/**
+	 * Enqueue scripts!
+	 *
+	 * @param string $hook Page hook.
+	 */
+	public function enqueue_scripts( $hook ) {
+		if ( strpos( $hook, 'jetpack-debug_page_mocker' ) === 0 ) {
+			wp_enqueue_style( 'mocker_style', plugin_dir_url( __FILE__ ) . 'inc/css/mocker.css', array(), JETPACK_DEBUG_HELPER_VERSION );
+			wp_enqueue_script( 'mocker_script', plugin_dir_url( __FILE__ ) . 'inc/js/mocker.js', array( 'wp-api' ), JETPACK_DEBUG_HELPER_VERSION, true );
+
+			add_filter(
+				'script_loader_tag',
+				function( $tag, $handle ) {
+					if ( 'mocker_script' === $handle ) {
+						$tag = str_replace( '<script ', '<script type="module" ', $tag );
+					}
+
+					return $tag;
+				},
+				10,
+				2
+			);
+		}
+	}
+
+	/**
+	 * Render UI.
+	 */
+	public function render_ui() {
+		wp_localize_script(
+			'wp-mocker',
+			'wpApiSettings',
+			array(
+				'root'  => esc_url_raw( rest_url() ),
+				'nonce' => wp_create_nonce( 'wp_mocker' ),
+			)
+		);
+
+		?>
+		<h1>Fastest Data Mocker in Town!</h1>
+
+		<div class="jetpack-debug-mocker">
+			<form method="post" id="jetpack-debug-mocker-form">
+				<div class="mocker-block">
+					<label for="mocker-data">Data:</label>
+					<div class="mocker-field">
+						<select name="data" id="mocker-data">
+							<?php foreach ( $this->runners as $key => $name ) : ?>
+								<option value="<?php echo esc_html( $key ); ?>"><?php echo esc_html( $name ); ?></option>
+							<?php endforeach ?>
+						</select>
+					</div>
+				</div>
+
+				<div class="mocker-block">
+					<label for="mocker-number">How Many:</label>
+					<div class="mocker-field">
+						<input type="number" name="number" class="input-number" id="mocker-number" value="50">
+					</div>
+				</div>
+
+				<div class="mocker-block align-right">
+					<button type="submit" class="button-right" id="mocker-submit">Run! 🚀</button>
+				</div>
+
+				<div id="mocker-response" class="block-hide"></div>
+			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Load the class.
+	 */
+	public static function register_mocker() {
+		new Mocker();
+	}
+
+	/**
+	 * Initialize the runner and run it.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public function run( WP_REST_Request $request ) {
+		$params = $request->get_query_params();
+
+		$runner = empty( $params['data'] ) ? null : $params['data'];
+		$number = empty( $params['number'] ) ? null : (int) $params['number'];
+
+		if ( ! $runner || ! array_key_exists( $runner, $this->runners ) ) {
+			return new WP_Error( 'unknown_runner' );
+		}
+
+		if ( ! $number ) {
+			return new WP_Error( 'invalid_number' );
+		}
+
+		$filename = __DIR__ . "/inc/mockers/class-{$runner}-runner.php";
+		if ( ! file_exists( $filename ) ) {
+			return new WP_Error( 'runner_not_found' );
+		}
+
+		require_once $filename;
+
+		$class_name = '\Automattic\Jetpack\Debug_Helper\Mocker\\' . ucfirst( $runner ) . '_Runner';
+
+		if ( ! class_exists( $class_name ) || ! is_a( $class_name, Runner_Interface::class, true ) ) {
+			return new WP_Error( 'invalid_runner' );
+		}
+
+		$runner = new $class_name();
+
+		$result = $runner->run( (int) $params['number'] );
+
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		if ( false === $result ) {
+			return new WP_Error( 'runner_error' );
+		}
+
+		return rest_ensure_response( array( 'success' => true ) );
+	}
+}
+
+add_action( 'plugins_loaded', array( Mocker::class, 'register_mocker' ), 1000 );

--- a/packages/debug-helper/modules/class-rest-api-tester.php
+++ b/packages/debug-helper/modules/class-rest-api-tester.php
@@ -44,6 +44,19 @@ class REST_API_Tester {
 		if ( strpos( $hook, 'jetpack-debug_page_rest-api-tester' ) === 0 ) {
 			wp_enqueue_style( 'rest_api_tester_style', plugin_dir_url( __FILE__ ) . 'inc/css/rest-api-tester.css', array(), JETPACK_DEBUG_HELPER_VERSION );
 			wp_enqueue_script( 'rest_api_tester_script', plugin_dir_url( __FILE__ ) . 'inc/js/rest-api-tester.js', array( 'wp-api' ), JETPACK_DEBUG_HELPER_VERSION, true );
+
+			add_filter(
+				'script_loader_tag',
+				function( $tag, $handle ) {
+					if ( 'rest_api_tester_script' === $handle ) {
+						$tag = str_replace( '<script ', '<script type="module" ', $tag );
+					}
+
+					return $tag;
+				},
+				10,
+				2
+			);
 		}
 	}
 

--- a/packages/debug-helper/modules/inc/css/mocker.css
+++ b/packages/debug-helper/modules/inc/css/mocker.css
@@ -1,0 +1,64 @@
+/**
+Slyling up the REST API Tester
+ */
+
+.jetpack-debug-mocker {
+	margin-top: 20px;
+	float: left;
+	clear: both;
+}
+
+.jetpack-debug-mocker .mocker-block {
+	margin-bottom: 20px;
+}
+
+.jetpack-debug-mocker .mocker-field {
+	position: relative;
+}
+
+.jetpack-debug-mocker .mocker-block label {
+	display: inline-block;
+	font-weight: bold;
+	width: 120px;
+	vertical-align: top;
+	margin-top: 5px;
+}
+
+.jetpack-debug-mocker .mocker-block .mocker-field {
+	display: inline-block;
+}
+
+.jetpack-debug-mocker .mocker-block select {
+	margin-top: -3px;
+}
+
+.jetpack-debug-mocker .mocker-block .input-number {
+	width: 100px;
+	height: 35px;
+	font-size: 15px;
+}
+
+.jetpack-debug-mocker .mocker-block.align-left {
+	text-align: left;
+}
+
+.jetpack-debug-mocker .mocker-block button {
+	height: 35px;
+	width: 80px;
+	cursor: pointer;
+}
+
+.jetpack-debug-mocker .mocker-block textarea {
+	width: 400px;
+	height: 200px;
+}
+
+.jetpack-debug-mocker .block-hide {
+	display: none;
+}
+
+.jetpack-debug-mocker #mocker-response {
+	margin-top: 30px;
+	border: 4px dashed grey;
+	padding: 10px;
+}

--- a/packages/debug-helper/modules/inc/js/loader.js
+++ b/packages/debug-helper/modules/inc/js/loader.js
@@ -1,0 +1,36 @@
+/**
+ * Initialize the loader object, and retrieve the `on()` and `off()` methods.
+ *
+ * @param button The button HTMLElement
+ * @returns {{off: function, on: function}}
+ */
+export default function loaderButton( button ) {
+	const label = button.innerHTML;
+	let interval = null;
+
+	return {
+		on: () => {
+			if ( null === interval ) {
+				button.setAttribute( 'disabled', 'disabled' );
+				button.innerHTML = '.';
+				let dotCount = 1;
+
+				interval = setInterval( () => {
+					if ( dotCount > 3 ) {
+						dotCount = 0;
+						button.innerHTML = '';
+					}
+
+					++dotCount;
+					button.innerHTML += '.';
+				}, 500 );
+			}
+		},
+		off: () => {
+			clearInterval( interval );
+			interval = null;
+			button.innerHTML = label;
+			button.removeAttribute( 'disabled' );
+		},
+	};
+}

--- a/packages/debug-helper/modules/inc/js/mocker.js
+++ b/packages/debug-helper/modules/inc/js/mocker.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import loaderButton from './loader.js';
+
+class Mocker {
+	constructor() {
+		this.formElement = document.getElementById( 'jetpack-debug-mocker-form' );
+		this.dataElement = this.formElement.querySelector( '#mocker-data' );
+		this.numberElement = this.formElement.querySelector( '#mocker-number' );
+		this.submitElement = this.formElement.querySelector( '#mocker-submit' );
+		this.responseElement = this.formElement.querySelector( '#mocker-response' );
+
+		if ( this.formElement ) {
+			this.formElement.addEventListener( 'submit', e => {
+				e.preventDefault();
+				this.submit();
+			} );
+		}
+	}
+
+	submit() {
+		const loader = loaderButton( this.submitElement );
+		loader.on();
+
+		const data = this.dataElement.value.toLowerCase();
+		const number = parseInt( this.numberElement.value );
+
+		fetch(
+			`${ window.wpApiSettings.root }jetpack-debug/mocker&data=${ encodeURIComponent(
+				data
+			) }&number=${ number }`,
+			{
+				headers: {
+					'X-WP-Nonce': window.wpApiSettings.nonce,
+				},
+			}
+		)
+			.then( response => response.json() )
+			.then( body => {
+				if ( ! body.success ) {
+					console.log( body );
+				}
+
+				loader.off();
+
+				this.responseElement.innerHTML = `<strong>Response: ${
+					body.success ? 'Success' : 'Failure (see console log for details)'
+				}</strong>`;
+
+				this.responseElement.classList.remove( 'block-hide' );
+			} );
+
+		this.responseElement.innerHTML = '';
+		this.responseElement.classList.add( 'block-hide' );
+	}
+}
+
+document.addEventListener( 'DOMContentLoaded', () => new Mocker() );

--- a/packages/debug-helper/modules/inc/js/mocker.js
+++ b/packages/debug-helper/modules/inc/js/mocker.js
@@ -65,9 +65,9 @@ class Mocker {
 		++this.runningBatches;
 		div.innerHTML = `Batch ${ batchKey } has started...`;
 
-		const url = `${ window.wpApiSettings.root }jetpack-debug/mocker&data=${ encodeURIComponent(
-			data
-		) }&number=${ number }`;
+		const url = `${ window.wpApiSettings.root }jetpack-debug/mocker${
+			-1 === window.wpApiSettings.root.indexOf( '?' ) ? '?' : '&'
+		}data=${ encodeURIComponent( data ) }&number=${ number }`;
 		const headers = { 'X-WP-Nonce': window.wpApiSettings.nonce };
 
 		const response = await fetch( url, { headers } );

--- a/packages/debug-helper/modules/inc/js/rest-api-tester.js
+++ b/packages/debug-helper/modules/inc/js/rest-api-tester.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import loaderButton from './loader.js';
+
 class Jetpack_Debug_REST_API_Tester {
 	interval = null;
 
@@ -48,6 +53,7 @@ class Jetpack_Debug_REST_API_Tester {
 	}
 
 	submit() {
+		const loader = loaderButton( this.submitElement );
 		const method = this.methodElement.value.toUpperCase();
 		let body = null;
 
@@ -65,14 +71,14 @@ class Jetpack_Debug_REST_API_Tester {
 
 		request.onreadystatechange = () => {
 			if ( request.readyState === XMLHttpRequest.DONE ) {
-				this.switchLoader( 'off' );
+				loader.off();
 				this.handleResponse( request );
 			}
 		};
 
 		request.send( body );
 
-		this.switchLoader( 'on' );
+		loader.on();
 
 		this.responseElement.innerHTML = '';
 		this.responseElement.classList.add( 'block-hide' );
@@ -98,34 +104,6 @@ ${ this.escapeHtml( request.getAllResponseHeaders() ) }
 ${ this.escapeHtml( responseText ) }</pre>`;
 
 		this.responseElement.classList.remove( 'block-hide' );
-	}
-
-	switchLoader( status ) {
-		switch ( status ) {
-			case 'on':
-				if ( null === this.interval ) {
-					this.submitElement.setAttribute( 'disabled', 'disabled' );
-					this.submitElement.innerHTML = '.';
-					let dotCount = 1;
-
-					this.interval = setInterval( () => {
-						if ( dotCount > 3 ) {
-							dotCount = 0;
-							this.submitElement.innerHTML = '';
-						}
-
-						++dotCount;
-						this.submitElement.innerHTML += '.';
-					}, 500 );
-				}
-				break;
-			case 'off':
-				clearInterval( this.interval );
-				this.interval = null;
-				this.submitElement.innerHTML = 'Send';
-				this.submitElement.removeAttribute( 'disabled' );
-				break;
-		}
 	}
 
 	escapeHtml( html ) {

--- a/packages/debug-helper/modules/inc/mockers/class-nonces-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/class-nonces-runner.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * The Mocker Runner that creates mock nonces.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Debug_Helper\Mocker;
+
+require_once __DIR__ . '/class-tools.php';
+
+/**
+ * Creating the mock nonces.
+ */
+class Nonces_Runner implements Runner_Interface {
+
+	/**
+	 * Generate random nonces.
+	 *
+	 * @param int $number Number of nonces to generate.
+	 *
+	 * @return bool
+	 */
+	public function run( $number ) {
+		for ( $i = $number, $per_batch = 100; $i > 0; $i -= $per_batch ) {
+			$this->run_batch( min( $per_batch, $i ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add a batch of mock options.
+	 *
+	 * @param int $limit How many options to add.
+	 *
+	 * @return bool
+	 */
+	private function run_batch( $limit ) {
+		global $wpdb;
+
+		if ( ! $limit ) {
+			return false;
+		}
+
+		$sql = "INSERT INTO {$wpdb->prefix}options (option_name, option_value, autoload) VALUES ";
+
+		for ( $i = 0; $i < $limit; ++$i ) {
+			list( $name, $value ) = $this->get_random_nonce();
+			$sql                 .= "('" . esc_sql( $name ) . "', '" . esc_sql( $value ) . "', 'no'), ";
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( substr( $sql, 0, -2 ) );
+
+		return true;
+	}
+
+	/**
+	 * Generate a random nonce
+	 *
+	 * @return array [ $option_key, $option_value ]
+	 */
+	private function get_random_nonce() {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$time = rand( 1000000000, time() );
+
+		return array(
+			'jetpack_nonce_' . $time . '_' . Tools::get_random_string( 10 ),
+			$time,
+		);
+	}
+
+}

--- a/packages/debug-helper/modules/inc/mockers/class-nonces-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/class-nonces-runner.php
@@ -22,7 +22,7 @@ class Nonces_Runner implements Runner_Interface {
 	 * @return bool
 	 */
 	public function run( $number ) {
-		for ( $i = $number, $per_batch = 100; $i > 0; $i -= $per_batch ) {
+		for ( $i = $number, $per_batch = 500; $i > 0; $i -= $per_batch ) {
 			$this->run_batch( min( $per_batch, $i ) );
 		}
 

--- a/packages/debug-helper/modules/inc/mockers/class-nonces-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/class-nonces-runner.php
@@ -43,15 +43,16 @@ class Nonces_Runner implements Runner_Interface {
 			return false;
 		}
 
-		$sql = "INSERT INTO {$wpdb->prefix}options (option_name, option_value, autoload) VALUES ";
+		$sql = "INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES "
+			. implode( ', ', array_fill( 0, $limit, '( %s, %s, "no" )' ) );
 
+		$values_to_insert = array();
 		for ( $i = 0; $i < $limit; ++$i ) {
-			list( $name, $value ) = $this->get_random_nonce();
-			$sql                 .= "('" . esc_sql( $name ) . "', '" . esc_sql( $value ) . "', 'no'), ";
+			$values_to_insert = array_merge( $values_to_insert, $this->get_random_nonce() );
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( substr( $sql, 0, -2 ) );
+		$wpdb->query( $wpdb->prepare( $sql, $values_to_insert ) );
 
 		return true;
 	}

--- a/packages/debug-helper/modules/inc/mockers/class-options-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/class-options-runner.php
@@ -40,14 +40,17 @@ class Options_Runner implements Runner_Interface {
 	private function run_batch( $limit ) {
 		global $wpdb;
 
-		$sql = "INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES ";
+		$sql = "INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES "
+			. implode( ', ', array_fill( 0, $limit, '( %s, %s, "no" )' ) );
 
+		$values_to_insert = array();
 		for ( $i = 0; $i < $limit; ++$i ) {
-			$sql .= "('" . esc_sql( $this->get_random_name() ) . "', '" . esc_sql( $this->get_random_value() ) . "', 'no'), ";
+			$values_to_insert[] = $this->get_random_name();
+			$values_to_insert[] = $this->get_random_value();
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( substr( $sql, 0, -2 ) );
+		$wpdb->query( $wpdb->prepare( $sql, $values_to_insert ) );
 
 		return true;
 	}

--- a/packages/debug-helper/modules/inc/mockers/class-options-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/class-options-runner.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * The Mocker Runner that creates mock options.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Debug_Helper\Mocker;
+
+require_once __DIR__ . '/interface-runner.php';
+require_once __DIR__ . '/class-tools.php';
+
+/**
+ * Creating the mock options.
+ */
+class Options_Runner implements Runner_Interface {
+
+	/**
+	 * Generate the random options.
+	 *
+	 * @param int $number Number of options to generate.
+	 *
+	 * @return bool
+	 */
+	public function run( $number ) {
+		for ( $i = $number, $per_batch = 100; $i > 0; $i -= $per_batch ) {
+			$this->run_batch( min( $per_batch, $i ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Add a batch of mock options.
+	 *
+	 * @param int $limit How many options to add.
+	 *
+	 * @return bool
+	 */
+	private function run_batch( $limit ) {
+		global $wpdb;
+
+		$sql = "INSERT INTO {$wpdb->options} (option_name, option_value, autoload) VALUES ";
+
+		for ( $i = 0; $i < $limit; ++$i ) {
+			$sql .= "('" . esc_sql( $this->get_random_name() ) . "', '" . esc_sql( $this->get_random_value() ) . "', 'no'), ";
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( substr( $sql, 0, -2 ) );
+
+		return true;
+	}
+
+	/**
+	 * Generate a random option name.
+	 *
+	 * @return string
+	 */
+	private function get_random_name() {
+		return 'mock_option_' . Tools::get_random_string() . '_' . microtime( true );
+	}
+
+	/**
+	 * Generate a random option value.
+	 *
+	 * @return string
+	 */
+	private function get_random_value() {
+		return 'mock_value_' . Tools::get_random_string();
+	}
+
+}

--- a/packages/debug-helper/modules/inc/mockers/class-options-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/class-options-runner.php
@@ -23,7 +23,7 @@ class Options_Runner implements Runner_Interface {
 	 * @return bool
 	 */
 	public function run( $number ) {
-		for ( $i = $number, $per_batch = 100; $i > 0; $i -= $per_batch ) {
+		for ( $i = $number, $per_batch = 500; $i > 0; $i -= $per_batch ) {
 			$this->run_batch( min( $per_batch, $i ) );
 		}
 

--- a/packages/debug-helper/modules/inc/mockers/class-tools.php
+++ b/packages/debug-helper/modules/inc/mockers/class-tools.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Mocking tools.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Debug_Helper\Mocker;
+
+/**
+ * Mocking Tools.
+ */
+class Tools {
+
+	const CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+	/**
+	 * Generate a random string.
+	 *
+	 * @param int      $length Fixed string length, or minimum string length if maximum is provided.
+	 * @param int|null $length_max Maximum string length, optional.
+	 *
+	 * @return string
+	 */
+	public static function get_random_string( $length = 15, $length_max = null ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+		$length = $length_max ? rand( $length, $length_max ) : $length;
+
+		$char_length = strlen( self::CHARS );
+
+		for ( $string = '', $i = 0; $i < $length; $i++ ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand
+			$string .= self::CHARS[ rand( 0, $char_length - 1 ) ];
+		}
+
+		return $string;
+	}
+
+}

--- a/packages/debug-helper/modules/inc/mockers/interface-runner.php
+++ b/packages/debug-helper/modules/inc/mockers/interface-runner.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * The Mocker Runner Interface.
+ *
+ * @package Jetpack
+ */
+
+namespace Automattic\Jetpack\Debug_Helper\Mocker;
+
+/**
+ * Mocker Runner Interface.
+ */
+interface Runner_Interface {
+
+	/**
+	 * Run the mocker functionality
+	 *
+	 * @param int $number How many mock options to create.
+	 *
+	 * @return bool
+	 */
+	public function run( $number );
+
+}

--- a/packages/debug-helper/plugin.php
+++ b/packages/debug-helper/plugin.php
@@ -38,6 +38,11 @@ $jetpack_dev_debug_modules = array(
 		'name'        => 'REST API Tester',
 		'description' => '',
 	),
+	'mocker'          => array(
+		'file'        => 'class-mocker.php',
+		'name'        => 'Mocker',
+		'description' => '',
+	),
 );
 
 require_once 'class-admin.php';

--- a/packages/debug-helper/plugin.php
+++ b/packages/debug-helper/plugin.php
@@ -17,7 +17,7 @@ define( 'JETPACK_DEBUG_HELPER_BASE_PLUGIN_FILE', __FILE__ );
  * The plugin version.
  * Increase that if you do any edits to ensure refreshing the cached assets.
  */
-define( 'JETPACK_DEBUG_HELPER_VERSION', '1.0' );
+define( 'JETPACK_DEBUG_HELPER_VERSION', '1.0.1' );
 
 /**
  * Include file names from the modules directory here.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The new "Mocker" debugger module creates mock data for testing purposes.
There are two mockers implemented:
- Options to generate random options.
- Nonces, to create nonces with different timestamps.

The mocker works asynchronously, sending 5 requests at a time, each batch inserts up to 10k records into the database.

The PR also includes the new `loaderButton` JavaScript component extracted from the REST API Tester UI.
It's been reused for the Mocker UI.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Disable WP Cron by defining the constant `define( 'DISABLE_WP_CRON', true );` so mocked data wouldn't be immediately removed.
2. Go to the Jetpack Debug (`/wp-admin/admin.php?page=jetpack-debug-tools`), activate Mocker.
3. Go to "Jetpack Debug -> Mocker", create 100000 mock "Options". Confirm that only 5 batches are running at a time, with 10 batches total.
4. Confirm that 100,000 mock options were inserted (`yarn docker:db` or `wp db cli`):
`select count(*) from wp_options where option_name like 'mock\_option\_%';`
5. Remove the options: `delete from wp_options where option_name like 'mock\_option\_%';`
6. Create 100000 mock "Nonces". Confirm that only 5 batches are running at a time, with 10 batches total.
7. Confirm that 100,000 mock nonces were inserted: `select count(*) from wp_options where option_name like 'jetpack\_nonce\_%';`
8. Remove the nonces: `delete from wp_options where option_name like 'jetpack\_nonce\_%';`
9. Don't forget to remove the `DISABLE_WP_CRON` constant 🙂 

#### Proposed changelog entry for your changes:
* Data mocking module for the Jetpack Debugger plugin.
