### PR TITLE
Config: add info about the package dependencies to the package docs

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -124,3 +124,9 @@ you need for the package to run is present, and then it adds the hook
 handlers that initialize your class. After that you can use the config
 package's interface in a Jetpack package consumer application and load
 your package as shown in the first section of this README.
+
+# Config Package Dependencies
+
+The Config package does not have any composer package dependencies. The consumer plugins must require the packages that they need.
+
+Before using a package class, the Config package will verify that the class exists using the `Config::ensure_class()` method. This allows the consumer plugins to use the Config package to enable and initialize Jetpack features while requiring only the packages that they need.

--- a/packages/config/src/class-config.php
+++ b/packages/config/src/class-config.php
@@ -7,6 +7,11 @@
 
 namespace Automattic\Jetpack;
 
+/*
+ * The Config package does not require the composer packages that
+ * contain the package classes shown below. The consumer plugin
+ * must require the corresponding packages to use these features.
+ */
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\JITMS\JITM as JITMS_JITM;
 use Automattic\Jetpack\JITM as JITM;


### PR DESCRIPTION
Fixes #16993

#### Changes proposed in this Pull Request:
* The Config package is unusual because it uses multiple package classes but does not require the composer packages. Add info about this to the readme and the Config class.

#### Jetpack product discussion
* n/a

#### Does this pull request change what data or activity we track or use?
* no

#### Testing instructions:
* Read the documentation changes and make suggestions if anything is unclear.


#### Proposed changelog entry for your changes:
* n/a
