### PR TITLE
Ensure stats are output on AMP legacy post templates

### DIFF
--- a/modules/stats.php
+++ b/modules/stats.php
@@ -187,7 +187,7 @@ function stats_template_redirect() {
 	}
 
 	add_action( 'wp_footer', 'stats_footer', 101 );
-
+	add_action( 'amp_post_template_footer', 'stats_footer' );
 }
 
 


### PR DESCRIPTION
As [reported](https://wordpress.org/support/topic/amp-loading-in-development-mode/#post-13313733) on the AMP plugin forum, it appears the Jetpack stats are not being printed on legacy AMP templates:

> the main issue that I have is the fact that jetpack pixels are not functioning effectively on the website because the website is fully AMP, AMP keeps removing the script needed for start
> Jetpack stats tracking pixel are not working on the AMP
>
>Its function is missing called wp_footer(), stats tracking code is missing on our website, naijanews.com

#### Changes proposed in this Pull Request:

* Ensure that Jetpack stats are printed at `amp_post_template_footer` in addition to `wp_footer` when in legacy Reader mode.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Activate stats module.
2. Activate AMP plugin, set template mode to Reader and select the Legacy Reader theme (which is the default)
3. Look at an AMP page to see if you can see the `amp-pixel` component.

#### Proposed changelog entry for your changes:

* Ensure that Jetpack stats are printed at `amp_post_template_footer` in addition to `wp_footer` when in legacy Reader mode.
