### PR TITLE
Donations block: Handle lack of tabs

### DIFF
--- a/extensions/blocks/donations/view.js
+++ b/extensions/blocks/donations/view.js
@@ -125,9 +125,13 @@ class JetpackDonations {
 
 			// Toggle nav item.
 			const prevNavItem = this.getNavItem( prevInterval );
-			prevNavItem.classList.remove( 'is-active' );
+			if ( prevNavItem ) {
+				prevNavItem.classList.remove( 'is-active' );
+			}
 			const newNavItem = this.getNavItem( newInterval );
-			newNavItem.classList.add( 'is-active' );
+			if ( newNavItem ) {
+				newNavItem.classList.add( 'is-active' );
+			}
 
 			// Toggle tab content.
 			tabContent.classList.remove( tabContentClasses[ prevInterval ] );
@@ -150,7 +154,9 @@ class JetpackDonations {
 
 		// Activates the default tab on first execution.
 		const navItem = this.getNavItem( this.interval );
-		navItem.classList.add( 'is-active' );
+		if ( navItem ) {
+			navItem.classList.add( 'is-active' );
+		}
 		tabContent.classList.add( tabContentClasses[ this.interval ] );
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

The logic that runs in the frontend view of a Donations block was assuming that the block will always show a tabbed interface, but this is not true when the monthly and annual donations options are disabled.

<img width="279" alt="Screen Shot 2020-08-28 at 09 55 32" src="https://user-images.githubusercontent.com/1233880/91536872-b47e9100-e915-11ea-90a0-a93b00e6c773.png">

That was causing the block to get stuck in a loading state. This PR modifies the frontend view logic so it can handle correctly the lack of tabs.

Before | After
--- | ---
<img width="791" alt="Screen Shot 2020-08-28 at 09 55 56" src="https://user-images.githubusercontent.com/1233880/91536849-aaf52900-e915-11ea-961d-9d5e5e45c469.png"> | <img width="784" alt="Screen Shot 2020-08-28 at 09 57 46" src="https://user-images.githubusercontent.com/1233880/91536857-acbeec80-e915-11ea-9a97-debecbd9b1cf.png">


#### Jetpack product discussion
p58i-9k2-p2#comment-47426.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Set up a test site:
  * [Create a JN site running this branch](https://jurassic.ninja/create/?jetpack-beta&branch=fix/donations-frontend-one-time-only). 
  * Go to WP Admin > Settings > Jetpack Constants.
  * Set `JETPACK__SANDBOX_DOMAIN` with your sandbox address.
  * Sandbox the API and the store (see PCYsg-lW4-p2 #sandbox-method for detailed instructions).
  * Set up Jetpack and purchase any paid plan.
* Go to WP Admin > Posts > New.
* Insert a Donations block and connect to Stripe.
* Back in the editor, open the settings panel and turn off the "Show monthly donations" and "Show annual donations" settings.
* Publish the post and visit it.
* Make sure the block is loaded correctly.

#### Proposed changelog entry for your changes:
N/A.