### PR TITLE
Jetpack_IXR_ClientMulticall: Fix sort_calls() producing undefined relative order between equal items

### DIFF
--- a/packages/connection/legacy/class-jetpack-ixr-clientmulticall.php
+++ b/packages/connection/legacy/class-jetpack-ixr-clientmulticall.php
@@ -43,7 +43,7 @@ class Jetpack_IXR_ClientMulticall extends Jetpack_IXR_Client {
 	 * @return bool True if request succeeded, false otherwise.
 	 */
 	public function query( ...$args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		usort( $this->calls, array( $this, 'sort_calls' ) );
+		$this->calls = $this->sort_calls( $this->calls );
 
 		// Prepare multicall, then call the parent::query() method.
 		return parent::query( 'system.multicall', $this->calls );
@@ -53,19 +53,29 @@ class Jetpack_IXR_ClientMulticall extends Jetpack_IXR_Client {
 	 * Sort the IXR calls.
 	 * Make sure syncs are always done first.
 	 *
-	 * @param array $a First call in the sorting iteration.
-	 * @param array $b Second call in the sorting iteration.
-	 * @return int Result of the sorting iteration.
+	 * @param array $calls Calls to sort.
+	 * @return array Sorted calls.
 	 */
-	public function sort_calls( $a, $b ) {
-		if ( 'jetpack.syncContent' === $a['methodName'] ) {
-			return -1;
-		}
+	public function sort_calls( $calls ) {
+		usort(
+			$calls,
+			function ( $a, $b ) use ( $calls ) {
+				if ( 'jetpack.syncContent' === $a['methodName'] && 'jetpack.syncContent' !== $b['methodName'] ) {
+					return -1;
+				}
 
-		if ( 'jetpack.syncContent' === $b['methodName'] ) {
-			return 1;
-		}
+				if ( 'jetpack.syncContent' === $b['methodName'] && 'jetpack.syncContent' !== $a['methodName'] ) {
+					return 1;
+				}
 
-		return 0;
+				// The following will put equal values next to each other based on the index of the first one.
+				$a_index = array_search( $a, $calls, true );
+				$b_index = array_search( $b, $calls, true );
+
+				return $a_index - $b_index;
+			}
+		);
+
+		return $calls;
 	}
 }

--- a/packages/connection/legacy/class-jetpack-ixr-clientmulticall.php
+++ b/packages/connection/legacy/class-jetpack-ixr-clientmulticall.php
@@ -51,31 +51,23 @@ class Jetpack_IXR_ClientMulticall extends Jetpack_IXR_Client {
 
 	/**
 	 * Sort the IXR calls.
-	 * Make sure syncs are always done first.
+	 * Make sure syncs are always done first preserving relative order.
 	 *
 	 * @param array $calls Calls to sort.
 	 * @return array Sorted calls.
 	 */
 	public function sort_calls( $calls ) {
-		usort(
-			$calls,
-			function ( $a, $b ) use ( $calls ) {
-				if ( 'jetpack.syncContent' === $a['methodName'] && 'jetpack.syncContent' !== $b['methodName'] ) {
-					return -1;
-				}
+		$sync_calls  = array();
+		$other_calls = array();
 
-				if ( 'jetpack.syncContent' === $b['methodName'] && 'jetpack.syncContent' !== $a['methodName'] ) {
-					return 1;
-				}
-
-				// The following will put equal values next to each other based on the index of the first one.
-				$a_index = array_search( $a, $calls, true );
-				$b_index = array_search( $b, $calls, true );
-
-				return $a_index - $b_index;
+		foreach ( $calls as $call ) {
+			if ( 'jetpack.syncContent' === $call['methodName'] ) {
+				$sync_calls[] = $call;
+			} else {
+				$other_calls[] = $call;
 			}
-		);
+		}
 
-		return $calls;
+		return array_merge( $sync_calls, $other_calls );
 	}
 }

--- a/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
+++ b/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
@@ -1,0 +1,182 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotHyphenatedLowercase
+/**
+ * Connection Manager functionality testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Jetpack_IXR_ClientMulticall;
+use WorDBless\BaseTestCase;
+
+require_once ABSPATH . WPINC . '/IXR/class-IXR-client.php';
+require_once ABSPATH . WPINC . '/IXR/class-IXR-clientmulticall.php';
+
+/**
+ * Class Jetpack_IXR_ClientMulticall_Test.
+ *
+ * @package Automattic\Jetpack\Connection
+ */
+class Jetpack_IXR_ClientMulticall_Test extends BaseTestCase {
+	/**
+	 * Test ::sort_calls() preserves the relative order of equal items.
+	 */
+	public function test_sort_calls_preserves_relative_order_on_equal_items() {
+		$original = array(
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 1 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 2 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 3 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 4 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 5 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 6 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 7 ),
+			),
+			array(
+				'methodName' => 'jetpack.syncContent',
+				'params'     => array( 8 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 9 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 10 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 11 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 12 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 13 ),
+			),
+			array(
+				'methodName' => 'jetpack.syncContent',
+				'params'     => array( 14 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 15 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 16 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 17 ),
+			),
+			// Intentional duplicate.
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 12 ),
+			),
+		);
+
+		$expected = array(
+			array(
+				'methodName' => 'jetpack.syncContent',
+				'params'     => array( 8 ),
+			),
+			array(
+				'methodName' => 'jetpack.syncContent',
+				'params'     => array( 14 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 1 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 2 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 3 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 4 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 5 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 6 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 7 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 9 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 10 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 11 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 12 ),
+			),
+			// Intentional duplicate gets moved up next to the other one.
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 12 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 13 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 15 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 16 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 17 ),
+			),
+		);
+
+		$ixr = new Jetpack_IXR_ClientMulticall();
+
+		$this->assertSame( $expected, $ixr->sort_calls( $original ) );
+	}
+}

--- a/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
+++ b/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
@@ -88,14 +88,14 @@ class Jetpack_IXR_ClientMulticall_Test extends BaseTestCase {
 				'methodName' => 'foo',
 				'params'     => array( 16 ),
 			),
-			array(
-				'methodName' => 'foo',
-				'params'     => array( 17 ),
-			),
 			// Intentional duplicate.
 			array(
 				'methodName' => 'foo',
 				'params'     => array( 12 ),
+			),
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 17 ),
 			),
 		);
 
@@ -152,11 +152,6 @@ class Jetpack_IXR_ClientMulticall_Test extends BaseTestCase {
 				'methodName' => 'foo',
 				'params'     => array( 12 ),
 			),
-			// Intentional duplicate gets moved up next to the other one.
-			array(
-				'methodName' => 'foo',
-				'params'     => array( 12 ),
-			),
 			array(
 				'methodName' => 'foo',
 				'params'     => array( 13 ),
@@ -168,6 +163,11 @@ class Jetpack_IXR_ClientMulticall_Test extends BaseTestCase {
 			array(
 				'methodName' => 'foo',
 				'params'     => array( 16 ),
+			),
+			// Intentional duplicate remains in the same place.
+			array(
+				'methodName' => 'foo',
+				'params'     => array( 12 ),
 			),
 			array(
 				'methodName' => 'foo',


### PR DESCRIPTION
Fixes #17008

#### Changes proposed in this Pull Request:
* Fix a `usort()` bug that will affect `add/license-support` once its merged.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
Running unit tests is sufficient. Since this PR introduces a method signature change you can use this variation of the unit test introduced in this PR to run on `master` in order to reproduce the issue:
https://gist.github.com/atanas-dev/ba31849fc39517df9deda659e8632953
The difference being:
```diff
diff --git a/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php b/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
index aaf742da1..60051d5fb 100644
--- a/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
+++ b/packages/connection/tests/php/test_Jetpack_IXR_ClientMulticall.php
@@ -177,6 +177,8 @@ class Jetpack_IXR_ClientMulticall_Test extends BaseTestCase {
 
 		$ixr = new Jetpack_IXR_ClientMulticall();
 
-		$this->assertSame( $expected, $ixr->sort_calls( $original ) );
+		usort( $original, array( $ixr, 'sort_calls' ) );
+
+		$this->assertSame( $expected, $original );
 	}
 }
```
Which results in:
https://gist.github.com/atanas-dev/5951a2a2263c20138f0760f0e7708ffa

#### Proposed changelog entry for your changes:
* No changelog entry needed.
