### PR TITLE
Debug Data: Mark sensitive information as private

### DIFF
--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -266,7 +266,7 @@ class Jetpack_Debug_Data {
 				$debug_info[ $header ] = array(
 					'label'   => 'Server Variable ' . $header,
 					'value'   => ( $_SERVER[ $header ] ) ? $_SERVER[ $header ] : 'false',
-					'private' => false,
+					'private' => true, // This isn't really 'private' information, but we don't want folks to easily paste these into public forums.
 				);
 			}
 		}

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack Debug Data for the legacy Jetpack debugger page and the WP 5.2-era Site Health sections.
+ * Jetpack Debug Data for the Site Health sections.
  *
  * @package jetpack
  */

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Sync\Modules;
 use Automattic\Jetpack\Sync\Functions;
 use Automattic\Jetpack\Sync\Sender;
 use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 /**
  * Class Jetpack_Debug_Data
@@ -180,8 +181,9 @@ class Jetpack_Debug_Data {
 		 * If a token does not contain a period, then it is malformed and we report it as such.
 		 */
 		$user_id    = get_current_user_id();
-		$blog_token = Jetpack_Data::get_access_token();
-		$user_token = Jetpack_Data::get_access_token( $user_id );
+		$cxn_mgr    = new Connection_Manager();
+		$blog_token = $cxn_mgr->get_access_token();
+		$user_token = $cxn_mgr->get_access_token( $user_id );
 
 		$tokenset = '';
 		if ( $blog_token ) {

--- a/_inc/lib/debugger/class-jetpack-debug-data.php
+++ b/_inc/lib/debugger/class-jetpack-debug-data.php
@@ -166,7 +166,7 @@ class Jetpack_Debug_Data {
 		);
 		$debug_info['master_user']    = array(
 			'label'   => 'Jetpack Master User',
-			'value'   => self::human_readable_master_user(),
+			'value'   => self::human_readable_master_user(), // Only ID number and user name.
 			'private' => false,
 		);
 
@@ -393,6 +393,6 @@ class Jetpack_Debug_Data {
 	private static function human_readable_user( $user ) {
 		$user = new WP_User( $user );
 
-		return sprintf( '#%1$d %2$s (%3$s)', $user->ID, $user->user_login, $user->user_email ); // Format: "#1 username (user@example.com)".
+		return sprintf( '#%1$d %2$s', $user->ID, $user->user_login ); // Format: "#1 username".
 	}
 }


### PR DESCRIPTION
Fixes #17007

#### Changes proposed in this Pull Request:
* Removes the e-mail address from the Site Health Debug Data area for the primary/master user and the current user.
* Marks the server variable fields as private.

While this information isn't typically a security concern, it is still personally-identifible information that is usually not requested within the w.org forums. Since fields not marked as private are easily copied to the clipboard via Core's copy button, they are often included
in forum posts where that information isn't actually helpful.

The server variables that are included are from a specific list of ones that matter for either the Jetpack connection or Protect. By marking them as private, Happiness will need to tweak their instructions (will p2 to them post-merge).

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
n/a

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
n/a

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to Tools->Site Health->Info
* See the "Server Variable" fields under the Jetpack section.
* Click the "Copy site info to clipboard" button and paste into a text editor.
* Verify that the Server Variable fields are not part of the copy/pasted materials.

#### Proposed changelog entry for your changes:
* Site Health: refine information shared when using the "Copy site info to clipboard" button.
