### PR TITLE
External Media: Handle space errors on upload

### DIFF
--- a/extensions/shared/external-media/sources/with-media.js
+++ b/extensions/shared/external-media/sources/with-media.js
@@ -127,6 +127,14 @@ export default function withMedia() {
 					return;
 				}
 
+				// Normalize upload errors.
+				if ( error.errors?.length ) {
+					error = {
+						code: error.errors[ 0 ].error,
+						message: error.errors[ 0 ].message,
+					};
+				}
+
 				const { noticeOperations } = this.props;
 
 				noticeOperations.createErrorNotice(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

See #16986.
Fixes #17010.

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Reshapes upload errors into the WP_Error format that the error handler was designed for.

Before | After
-- | --
![68747470733a2f2f636c6e2e73682f304c665967312b](https://user-images.githubusercontent.com/1398304/91601805-23141c80-e91f-11ea-9242-f07752a70d75.jpeg) | ![Screen Shot 2020-08-28 at 11 05 30 AM](https://user-images.githubusercontent.com/1398304/91601810-24454980-e91f-11ea-8e4a-7855a064df0f.png)



#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
Negative.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

On WP.com:
* Apply D48796-code and D48794-code to your sandbox.
* In an mu-plugin, add `add_filter( 'get_space_allowed', '__return_zero' )` to simulate your site running out of space.
* In the Editor, insert an image block or a gallery block.
* Select an external media provider and attempt to select one or more images to insert.
* Observe the error message to be contextually relevant.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* No changelog entry needed. This should not affect Jetpack sites.
