### PR TITLE
Setup Wizard: Switch order of performance and marketing categories

### DIFF
--- a/_inc/client/state/setup-wizard/reducer.js
+++ b/_inc/client/state/setup-wizard/reducer.js
@@ -92,7 +92,7 @@ export const getRecommendedFeatureGroups = state => {
 	);
 
 	// Note these are in a list here to guarantee order
-	return [ 'security', 'performance', 'marketing', 'publishing' ].map( featureGroupKey => ( {
+	return [ 'security', 'marketing', 'performance', 'publishing' ].map( featureGroupKey => ( {
 		...getFeatureGroupContent( featureGroupKey ),
 		features: intersection( featureGroups[ featureGroupKey ], recommendedFeatures ),
 	} ) );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Per request from @jessefriedman this PR switches the order of the performance and marketing categories in Jetpack.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->
N/A

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->
1. On your Jetpack site add the following to then end of the wp-config.php file in order to make the Setup Wizard show:
```
add_filter( 'jetpack_show_setup_wizard', '__return_true' );
add_filter( 'jetpack_pre_connection_prompt_helpers', '__return_true' );
```
2. Visit `/wp-admin/admin.php?page=jetpack#/setup/features`.
3. Verify that the order of the sections is security, marketing, performance, and design.

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* None needed
