### PR TITLE
Debugger: Add token health check test

### DIFF
--- a/_inc/lib/debugger/class-jetpack-cxn-tests.php
+++ b/_inc/lib/debugger/class-jetpack-cxn-tests.php
@@ -200,11 +200,11 @@ class Jetpack_Cxn_Tests extends Jetpack_Cxn_Test_Base {
 		} else {
 			$result = self::failing_test(
 				array(
-					'name'             => $name,
-					'label'            => __( 'Your site is not connected to Jetpack', 'jetpack' ),
-					'action'           => admin_url( 'admin.php?page=jetpack#/dashboard' ),
-					'action_label'     => __( 'Reconnect your site now', 'jetpack' ),
-					'long_description' => sprintf(
+					'name'              => $name,
+					'short_description' => __( 'Your site is not connected to Jetpack', 'jetpack' ),
+					'action'            => admin_url( 'admin.php?page=jetpack#/dashboard' ),
+					'action_label'      => __( 'Reconnect your site now', 'jetpack' ),
+					'long_description'  => sprintf(
 						'<p>%1$s</p>' .
 						'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s<strong> %4$s</strong></p>',
 						__( 'A healthy connection ensures Jetpack essential services are provided to your WordPress site, such as Stats and Site Security.', 'jetpack' ),


### PR DESCRIPTION
Jetpack Debugger: Add new test for testing blog and current user's token against WP.com's check-token-health endpoint

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adds a new `test__token_health` method in `Jetpack_Cxn_Tests` for checking both the blog and current user's token by making a REST API call to WP.com's `check-token-health` endpoint
* If for any reason the remote request fails, the test is marked as `skipped`.

**Note:** Since the local debugger is meant to be used by our end users, we are not displaying specific error codes or detailed info for any token related errors.

#### Jetpack product discussion
p9dueE-1NT-p2

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
* Go to your site's local debugger page (`/admin.php?page=jetpack-debugger`)
* Make sure all tests pass
* Using the "Broken Token" plugin (available via Jetpack Debug) invalidate the blog token. Also make sure to store your current connection options before.
* Go to the debugger page again and verify you are seeing the following error: "Connection test failed: Invalid Jetpack tokens"
* Using the "Broken Token" plugin restore your correct connection options
* Go to the debugger page again and make sure all tests pass
* Using the "Broken Token" plugin (available via Jetpack Debug) invalidate the current user's token.
* Go to the debugger page again and verify you are seeing the following error: "Connection test failed: Invalid Jetpack tokens"

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Jetpack Debugger: Add new test for testing blog and current user's token health.
