### PR TITLE
Update/newsletter intergration subdirectory support

### DIFF
--- a/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
+++ b/_inc/client/setup-wizard/feature-toggle/map-feature-to-props.js
@@ -11,7 +11,7 @@ import getRedirectUrl from 'lib/jp-redirect';
 import { getPlanClass } from 'lib/plans/constants';
 import restApi from 'rest-api';
 import { getVaultPressData, isAkismetKeyValid } from 'state/at-a-glance';
-import { getSiteRawUrl } from 'state/initial-state';
+import { getSiteRawUrl, getSiteAdminUrl } from 'state/initial-state';
 import { getRewindStatus } from 'state/rewind';
 import { getSetting, updateSettings } from 'state/settings';
 import {
@@ -312,6 +312,8 @@ const features = {
 				state,
 				'creative-mail-by-constant-contact/creative-mail-plugin.php'
 			);
+			const siteAdminUrl = getSiteAdminUrl( state );
+			const creativeMailConfigureLink = siteAdminUrl + 'admin.php?page=creativemail';
 
 			return {
 				feature: 'creative-mail',
@@ -320,7 +322,7 @@ const features = {
 				checked: isCreativeMailActive,
 				isDisabled: true,
 				isPaid: true,
-				configureLink: isCreativeMailActive ? '/wp-admin/admin.php?page=creativemail' : null,
+				configureLink: isCreativeMailActive ? creativeMailConfigureLink : null,
 				learnMoreLink:
 					'https://jetpack.com/support/jetpack-blocks/form-block/newsletter-sign-up-form/',
 				isLearnMoreLinkExternal: true,

--- a/class.jetpack-gutenberg.php
+++ b/class.jetpack-gutenberg.php
@@ -775,6 +775,7 @@ class Jetpack_Gutenberg {
 					'enable_upgrade_nudge'      => apply_filters( 'jetpack_block_editor_enable_upgrade_nudge', false ),
 				),
 				'siteFragment'     => $site_fragment,
+				'adminUrl'         => esc_url( admin_url() ),
 				'tracksUserData'   => $user_data,
 				'wpcomBlogId'      => $blog_id,
 				'allowedMimeTypes' => wp_get_mime_types(),

--- a/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings.js
+++ b/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings.js
@@ -20,6 +20,7 @@ import {
 	activatePlugin,
 	getPlugins,
 } from './../../../shared/plugin-management';
+import getSiteFragment from './../../../shared/get-site-fragment';
 import { jetpackCreateInterpolateElement } from '../../../shared/create-interpolate-element';
 
 const pluginPathWithoutPhp = 'creative-mail-by-constant-contact/creative-mail-plugin';
@@ -146,6 +147,19 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 	);
 };
 
+function getCreativeMailPluginUrl () {
+	const siteFragment = getSiteFragment();
+
+	if ( undefined !== typeof window && window.location && siteFragment ) {
+		return `${ window.location.protocol }//${ siteFragment.replace(
+			'::',
+			'/'
+		) }/wp-admin/admin.php?page=creativemail`;
+	}
+
+	return null;
+}
+
 const CreativeMailPluginIsActive = () => {
 	return (
 		<p>
@@ -153,7 +167,7 @@ const CreativeMailPluginIsActive = () => {
 				{ __( 'You’re all setup for email marketing with Creative Mail.', 'jetpack' ) }
 				<br />
 				<br />
-				<ExternalLink href="/wp-admin/admin.php?page=creativemail">
+				<ExternalLink href={ getCreativeMailPluginUrl() }>
 					{ __( 'Open Creative Mail', 'jetpack' ) }
 				</ExternalLink>
 			</em>

--- a/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings.js
+++ b/extensions/blocks/contact-form/components/jetpack-newsletter-integration-settings.js
@@ -20,7 +20,7 @@ import {
 	activatePlugin,
 	getPlugins,
 } from './../../../shared/plugin-management';
-import getSiteFragment from './../../../shared/get-site-fragment';
+import getJetpackData from './../../../shared/get-jetpack-data';
 import { jetpackCreateInterpolateElement } from '../../../shared/create-interpolate-element';
 
 const pluginPathWithoutPhp = 'creative-mail-by-constant-contact/creative-mail-plugin';
@@ -147,18 +147,10 @@ const CreativeMailPluginIsInstalled = ( { activateCreativeMailPlugin, isInstalli
 	);
 };
 
-function getCreativeMailPluginUrl () {
-	const siteFragment = getSiteFragment();
-
-	if ( undefined !== typeof window && window.location && siteFragment ) {
-		return `${ window.location.protocol }//${ siteFragment.replace(
-			'::',
-			'/'
-		) }/wp-admin/admin.php?page=creativemail`;
-	}
-
-	return null;
-}
+const getCreativeMailPluginUrl = () => {
+	const adminUrl = get( getJetpackData(), 'adminUrl', false );
+	return `${ adminUrl }admin.php?page=creativemail`;
+};
 
 const CreativeMailPluginIsActive = () => {
 	return (


### PR DESCRIPTION
See #16808.
Fixes #17027.

#### Changes proposed in this Pull Request:
support subdirectory for wordpress

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
## test case 1
* Go to Posts > Add New
* Search for ‘Newsletter Sign-up’.
* Select the form block in the Gutenberg editor.
* collapse the "Newsletter Integration" on the right side
![image](https://user-images.githubusercontent.com/47211808/90694067-45030480-e278-11ea-9596-a52a964aa210.png)
* Click install plugin
![image](https://user-images.githubusercontent.com/47211808/90694105-577d3e00-e278-11ea-8672-0cd3f70452ae.png)
* click open creative mail, this should open the creative mail plugin in a new tab.

