### PR TITLE
API Nonces: Runtime cleanup

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -508,9 +508,7 @@ class Jetpack {
 				}
 
 				// Upgrade to Jetpack 9.0.0, cleaning up nonces during runtime.
-				if ( wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
-					wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
-				}
+				wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
 			}
 		}
 	}
@@ -5570,21 +5568,6 @@ endif;
 	public function wp_rest_authentication_errors( $value ) {
 		_deprecated_function( __METHOD__, 'jetpack-8.9', 'Automattic\\Jetpack\\Connection\\Rest_Authentication::wp_rest_authenication_errors' );
 		return Connection_Rest_Authentication::init()->wp_rest_authentication_errors( $value );
-	}
-
-	/**
-	 * Add our nonce to this request.
-	 *
-	 * @deprecated since 7.7.0
-	 * @see Automattic\Jetpack\Connection\Manager::add_nonce()
-	 *
-	 * @param int    $timestamp Timestamp of the request.
-	 * @param string $nonce     Nonce string.
-	 */
-	public function add_nonce( $timestamp, $nonce ) {
-		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::add_nonce' );
-
-		return Nonce_Handler::add( $timestamp, $nonce );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -3304,8 +3304,11 @@ p {
 	 * @static
 	 */
 	public static function disconnect( $update_activated_state = true ) {
+		// The hook is not being set since Jetpack 9.0.0,
+		// but we're removing it just in case it wasn't properly cleaned up after the plugin update.
 		wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
-		Nonce_Handler::clean( true );
+
+		Nonce_Handler::clean_all();
 
 		$connection = self::connection();
 
@@ -5659,19 +5662,6 @@ endif;
 		}
 
 		return $this->connection_manager->xmlrpc_options( $options );
-	}
-
-	/**
-	 * Cleans nonces that were saved when calling ::add_nonce.
-	 *
-	 * @deprecated since 7.7.0
-	 * @see Automattic\Jetpack\Connection\Nonce_Handler::clean()
-	 *
-	 * @param bool $all whether to clean even non-expired nonces.
-	 */
-	public static function clean_nonces( $all = false ) {
-		_deprecated_function( __METHOD__, 'jetpack-7.7', 'Automattic\\Jetpack\\Connection\\Manager::clean_nonces' );
-		Nonce_Handler::clean( $all );
 	}
 
 	/**

--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -506,6 +506,11 @@ class Jetpack {
 						array( __CLASS__, 'upgrade_on_load' )
 					);
 				}
+
+				// Upgrade to Jetpack 9.0.0, cleaning up nonces during runtime.
+				if ( wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
+					wp_clear_scheduled_hook( 'jetpack_clean_nonces' );
+				}
 			}
 		}
 	}

--- a/composer.lock
+++ b/composer.lock
@@ -8,7 +8,7 @@
     "packages": [
         {
             "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/a8c-mc-stats",
@@ -39,7 +39,7 @@
         },
         {
             "name": "automattic/jetpack-abtest",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/abtest",
@@ -75,7 +75,7 @@
         },
         {
             "name": "automattic/jetpack-assets",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/assets",
@@ -111,11 +111,11 @@
         },
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/autoloader",
-                "reference": "b9eb7c8e38782d3715568382ea97462c5608bd92"
+                "reference": "557195e755ff951fe3f8544056c5696eecc4d2cb"
             },
             "require": {
                 "composer-plugin-api": "^1.1 || ^2.0"
@@ -151,7 +151,7 @@
         },
         {
             "name": "automattic/jetpack-backup",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/backup",
@@ -176,7 +176,7 @@
         },
         {
             "name": "automattic/jetpack-blocks",
-            "version": "dev-master",
+            "version": "dev-add/nonce-removal",
             "dist": {
                 "type": "path",
                 "url": "./packages/blocks",
@@ -211,7 +211,7 @@
         },
         {
             "name": "automattic/jetpack-compat",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/compat",
@@ -246,7 +246,7 @@
         },
         {
             "name": "automattic/jetpack-config",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/config",
@@ -268,15 +268,14 @@
         },
         {
             "name": "automattic/jetpack-connection",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/connection",
-                "reference": "ccbf1b70e17ee389082c8aaa1cf625582fd9b373"
+                "reference": "bb68aeb045a837fe2fe4784ca41ac667fe5b6fa5"
             },
             "require": {
                 "automattic/jetpack-constants": "@dev",
-                "automattic/jetpack-heartbeat": "@dev",
                 "automattic/jetpack-options": "@dev",
                 "automattic/jetpack-roles": "@dev",
                 "automattic/jetpack-status": "@dev",
@@ -316,7 +315,7 @@
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/constants",
@@ -348,7 +347,7 @@
         },
         {
             "name": "automattic/jetpack-device-detection",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/device-detection",
@@ -380,7 +379,7 @@
         },
         {
             "name": "automattic/jetpack-error",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/error",
@@ -411,7 +410,7 @@
         },
         {
             "name": "automattic/jetpack-heartbeat",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/heartbeat",
@@ -446,7 +445,7 @@
         },
         {
             "name": "automattic/jetpack-jitm",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/jitm",
@@ -490,14 +489,13 @@
         },
         {
             "name": "automattic/jetpack-lazy-images",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/lazy-images",
-                "reference": "b42d4c093ea12c89dd16c713c07e5a2c15c8ff5d"
+                "reference": "16409fc61cce65c8b914b08c80cae2cc0662ca2d"
             },
             "require": {
-                "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-constants": "@dev"
             },
             "require-dev": {
@@ -529,7 +527,7 @@
         },
         {
             "name": "automattic/jetpack-logo",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/logo",
@@ -561,7 +559,7 @@
         },
         {
             "name": "automattic/jetpack-options",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/options",
@@ -590,7 +588,7 @@
         },
         {
             "name": "automattic/jetpack-partner",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/partner",
@@ -624,7 +622,7 @@
         },
         {
             "name": "automattic/jetpack-redirect",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/redirect",
@@ -655,7 +653,7 @@
         },
         {
             "name": "automattic/jetpack-roles",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/roles",
@@ -687,7 +685,7 @@
         },
         {
             "name": "automattic/jetpack-status",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/status",
@@ -720,7 +718,7 @@
         },
         {
             "name": "automattic/jetpack-sync",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/sync",
@@ -749,13 +747,14 @@
         },
         {
             "name": "automattic/jetpack-terms-of-service",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/terms-of-service",
-                "reference": "723788a4aa7c508746f7c425f99c645c2a057598"
+                "reference": "f97241d09352c4ca44eab26520cac4c1903d08d3"
             },
             "require": {
+                "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-options": "@dev",
                 "automattic/jetpack-status": "@dev"
             },
@@ -785,7 +784,7 @@
         },
         {
             "name": "automattic/jetpack-tracking",
-            "version": "dev-master",
+            "version": "dev-add/jetpack-lazy-images-package",
             "dist": {
                 "type": "path",
                 "url": "./packages/tracking",

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -95,11 +95,6 @@ class Manager {
 
 		add_action( 'rest_api_init', array( $manager, 'initialize_rest_api_registration_connector' ) );
 
-		add_action( 'jetpack_clean_nonces', array( Nonce_Handler::class, 'clean' ) );
-		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
-			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
-		}
-
 		add_action( 'plugins_loaded', __NAMESPACE__ . '\Plugin_Storage::configure', 100 );
 
 		add_filter( 'map_meta_cap', array( $manager, 'jetpack_connection_custom_caps' ), 1, 4 );

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -1035,11 +1035,13 @@ class Manager {
 	 * @param bool $all whether to clean even non-expired nonces.
 	 *
 	 * @deprecated since 9.0.0
+	 *
+	 * @see Nonce_Handler::clean_all()
 	 */
 	public function clean_nonces( $all = false ) {
-		_deprecated_function( __METHOD__, 'jetpack-9.0.0', 'Automattic\\Jetpack\\Connection\\Nonce_Handler::clean' );
+		_deprecated_function( __METHOD__, 'jetpack-9.0.0', 'Automattic\\Jetpack\\Connection\\Nonce_Handler::clean_all' );
 
-		Nonce_Handler::clean( $all );
+		Nonce_Handler::clean_all( $all ? PHP_INT_MAX : time() - Nonce_Handler::LIFETIME );
 	}
 
 	/**

--- a/packages/connection/src/class-manager.php
+++ b/packages/connection/src/class-manager.php
@@ -95,7 +95,7 @@ class Manager {
 
 		add_action( 'rest_api_init', array( $manager, 'initialize_rest_api_registration_connector' ) );
 
-		add_action( 'jetpack_clean_nonces', array( $manager, 'clean_nonces' ) );
+		add_action( 'jetpack_clean_nonces', array( Nonce_Handler::class, 'clean' ) );
 		if ( ! wp_next_scheduled( 'jetpack_clean_nonces' ) ) {
 			wp_schedule_event( time(), 'hourly', 'jetpack_clean_nonces' );
 		}
@@ -451,7 +451,7 @@ class Manager {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Use up the nonce regardless of whether the signature matches.
-		if ( ! $this->add_nonce( $timestamp, $nonce ) ) {
+		if ( ! Nonce_Handler::add( $timestamp, $nonce ) ) {
 			return new \WP_Error(
 				'invalid_nonce',
 				'Could not add nonce',
@@ -1025,73 +1025,26 @@ class Manager {
 	 * @param int    $timestamp the current request timestamp.
 	 * @param string $nonce the nonce value.
 	 * @return bool whether the nonce is unique or not.
+	 *
+	 * @deprecated since 9.0.0
 	 */
 	public function add_nonce( $timestamp, $nonce ) {
-		global $wpdb;
-		static $nonces_used_this_request = array();
+		_deprecated_function( __METHOD__, 'jetpack-9.0.0', 'Automattic\\Jetpack\\Connection\\Nonce_Handler::add' );
 
-		if ( isset( $nonces_used_this_request[ "$timestamp:$nonce" ] ) ) {
-			return $nonces_used_this_request[ "$timestamp:$nonce" ];
-		}
-
-		// This should always have gone through Jetpack_Signature::sign_request() first to check $timestamp an $nonce.
-		$timestamp = (int) $timestamp;
-		$nonce     = esc_sql( $nonce );
-
-		// Raw query so we can avoid races: add_option will also update.
-		$show_errors = $wpdb->show_errors( false );
-
-		$old_nonce = $wpdb->get_row(
-			$wpdb->prepare( "SELECT * FROM `$wpdb->options` WHERE option_name = %s", "jetpack_nonce_{$timestamp}_{$nonce}" )
-		);
-
-		if ( is_null( $old_nonce ) ) {
-			$return = $wpdb->query(
-				$wpdb->prepare(
-					"INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s)",
-					"jetpack_nonce_{$timestamp}_{$nonce}",
-					time(),
-					'no'
-				)
-			);
-		} else {
-			$return = false;
-		}
-
-		$wpdb->show_errors( $show_errors );
-
-		$nonces_used_this_request[ "$timestamp:$nonce" ] = $return;
-
-		return $return;
+		return Nonce_Handler::add( $timestamp, $nonce );
 	}
 
 	/**
 	 * Cleans nonces that were saved when calling ::add_nonce.
 	 *
-	 * @todo Properly prepare the query before executing it.
-	 *
 	 * @param bool $all whether to clean even non-expired nonces.
+	 *
+	 * @deprecated since 9.0.0
 	 */
 	public function clean_nonces( $all = false ) {
-		global $wpdb;
+		_deprecated_function( __METHOD__, 'jetpack-9.0.0', 'Automattic\\Jetpack\\Connection\\Nonce_Handler::clean' );
 
-		$sql      = "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE %s";
-		$sql_args = array( $wpdb->esc_like( 'jetpack_nonce_' ) . '%' );
-
-		if ( true !== $all ) {
-			$sql       .= ' AND CAST( `option_value` AS UNSIGNED ) < %d';
-			$sql_args[] = time() - 3600;
-		}
-
-		$sql .= ' ORDER BY `option_id` LIMIT 100';
-
-		$sql = $wpdb->prepare( $sql, $sql_args ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-
-		for ( $i = 0; $i < 1000; $i++ ) {
-			if ( ! $wpdb->query( $sql ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-				break;
-			}
-		}
+		Nonce_Handler::clean( $all );
 	}
 
 	/**

--- a/packages/connection/src/class-nonce-handler.php
+++ b/packages/connection/src/class-nonce-handler.php
@@ -98,7 +98,7 @@ class Nonce_Handler {
 
 	/**
 	 * Removing [almost] all the nonces.
-	 * Capped at 1 million records to avoid breaking the site.
+	 * Capped at 20 seconds to avoid breaking the site.
 	 *
 	 * @param int $cutoff_timestamp All nonces added before this timestamp will be removed.
 	 *
@@ -106,7 +106,7 @@ class Nonce_Handler {
 	 */
 	public static function clean_all( $cutoff_timestamp = PHP_INT_MAX ) {
 		// phpcs:ignore Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed
-		for ( $start_time = time(), $i = 0; $i < 1000 && time() < $start_time + 20; ++$i ) {
+		for ( $end_time = time() + 20; time() < $end_time; ) {
 			$result = static::delete( static::CLEAN_ALL_LIMIT_PER_BATCH, $cutoff_timestamp );
 
 			if ( ! $result ) {

--- a/packages/connection/src/class-nonce-handler.php
+++ b/packages/connection/src/class-nonce-handler.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * The nonce handler.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+/**
+ * The nonce handler.
+ */
+class Nonce_Handler {
+
+	/**
+	 * The nonces used during the request are stored here to keep them valid.
+	 *
+	 * @var array
+	 */
+	private static $nonces_used_this_request = array();
+
+	/**
+	 * Adds a used nonce to a list of known nonces.
+	 *
+	 * @param int    $timestamp the current request timestamp.
+	 * @param string $nonce the nonce value.
+	 * @return bool whether the nonce is unique or not.
+	 */
+	public static function add( $timestamp, $nonce ) {
+		global $wpdb;
+
+		if ( isset( static::$nonces_used_this_request[ "$timestamp:$nonce" ] ) ) {
+			return static::$nonces_used_this_request[ "$timestamp:$nonce" ];
+		}
+
+		// This should always have gone through Jetpack_Signature::sign_request() first to check $timestamp an $nonce.
+		$timestamp = (int) $timestamp;
+		$nonce     = esc_sql( $nonce );
+
+		// Raw query so we can avoid races: add_option will also update.
+		$show_errors = $wpdb->show_errors( false );
+
+		$old_nonce = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM `$wpdb->options` WHERE option_name = %s", "jetpack_nonce_{$timestamp}_{$nonce}" )
+		);
+
+		if ( is_null( $old_nonce ) ) {
+			$return = (bool) $wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s)",
+					"jetpack_nonce_{$timestamp}_{$nonce}",
+					time(),
+					'no'
+				)
+			);
+		} else {
+			$return = false;
+		}
+
+		$wpdb->show_errors( $show_errors );
+
+		static::$nonces_used_this_request[ "$timestamp:$nonce" ] = $return;
+
+		return $return;
+	}
+
+	/**
+	 * Cleans nonces that were saved when calling ::add_nonce.
+	 *
+	 * @param bool $all whether to clean even non-expired nonces.
+	 */
+	public static function clean( $all = false ) {
+		global $wpdb;
+
+		$sql      = "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE %s";
+		$sql_args = array( $wpdb->esc_like( 'jetpack_nonce_' ) . '%' );
+
+		if ( true !== $all ) {
+			$sql       .= ' AND CAST( `option_value` AS UNSIGNED ) < %d';
+			$sql_args[] = time() - 3600;
+		}
+
+		$sql .= ' ORDER BY `option_id` LIMIT 100';
+
+		$sql = $wpdb->prepare( $sql, $sql_args ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		for ( $i = 0; $i < 1000; $i++ ) {
+			if ( ! $wpdb->query( $sql ) ) { // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Clean the cached nonces valid during the current request, therefore making them invalid.
+	 *
+	 * @return bool
+	 */
+	public static function invalidate_request_nonces() {
+		static::$nonces_used_this_request = array();
+
+		return true;
+	}
+
+}

--- a/packages/connection/src/class-nonce-handler.php
+++ b/packages/connection/src/class-nonce-handler.php
@@ -105,7 +105,8 @@ class Nonce_Handler {
 	 * @return true
 	 */
 	public static function clean_all( $cutoff_timestamp = PHP_INT_MAX ) {
-		for ( $i = 0; $i < 1000; ++$i ) {
+		// phpcs:ignore Generic.CodeAnalysis.ForLoopWithTestFunctionCall.NotAllowed
+		for ( $start_time = time(), $i = 0; $i < 1000 && time() < $start_time + 20; ++$i ) {
 			$result = static::delete( static::CLEAN_ALL_LIMIT_PER_BATCH, $cutoff_timestamp );
 
 			if ( ! $result ) {

--- a/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/packages/connection/tests/php/test-class-nonce-handler.php
@@ -1,0 +1,103 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * The nonce handler tests.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The nonce handler tests.
+ */
+class Test_Nonce_Handler extends TestCase {
+
+	/**
+	 * Reset the environment after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		Nonce_Handler::invalidate_request_nonces();
+	}
+
+	/**
+	 * Testing the nonce adding functionality.
+	 */
+	public function test_add() {
+		$time  = '1598639691';
+		$nonce = 'rAnDoM';
+
+		// Confirm that the nonce gets added.
+		self::assertTrue( Nonce_Handler::add( $time, $nonce ) );
+
+		// Confirm that the nonce is loaded from cache and still valid during the request.
+		self::assertTrue( Nonce_Handler::add( $time, $nonce ) );
+	}
+
+	/**
+	 * Trying to add an existing nonce, and making sure it's considered invalid (returns false).
+	 */
+	public function test_add_existing() {
+		$query_filter_run = false;
+
+		$time  = '1598639690';
+		$nonce = 'rAnDoM2';
+
+		$nonce_object = array(
+			'option_id'    => '12345',
+			'option_name'  => "jetpack_nonce_{$time}_{$nonce}",
+			'option_value' => $time,
+			'autoload'     => 'no',
+		);
+
+		$query_filter = function( $result, $query ) use ( &$query_filter_run, $nonce_object ) {
+			if ( ! $query_filter_run && false !== strpos( $query, 'jetpack_nonce_' ) ) {
+				$query_filter_run = true;
+				$this->assertEquals( "SELECT * FROM `options` WHERE option_name = '{$nonce_object['option_name']}'", $query );
+
+				return array( $nonce_object );
+			}
+
+			return $result;
+		};
+
+		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
+
+		$result = Nonce_Handler::add( $time, $nonce );
+
+		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
+
+		self::assertFalse( $result );
+		self::assertTrue( $query_filter_run, "The SQL query assertions haven't run." );
+	}
+
+	/**
+	 * Testing the nonce cleanup functionality.
+	 */
+	public function test_clean() {
+		$query_filter_run = false;
+
+		$query_filter = function( $result, $query ) use ( &$query_filter_run ) {
+			if ( ! $query_filter_run && false !== strpos( $query, 'jetpack\_nonce' ) ) {
+				global $wpdb;
+
+				$query_filter_run = true;
+				self::assertStringStartsWith( "DELETE FROM `{$wpdb->options}` WHERE `option_name` LIKE 'jetpack\_nonce\_", $query );
+			}
+
+			return $result;
+		};
+
+		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
+
+		Nonce_Handler::clean();
+
+		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
+
+		self::assertTrue( $query_filter_run, "The SQL query assertions haven't run." );
+	}
+
+}

--- a/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/packages/connection/tests/php/test-class-nonce-handler.php
@@ -76,19 +76,13 @@ class Test_Nonce_Handler extends TestCase {
 	public function test_add_existing() {
 		$query_filter_run = false;
 
-		$nonce_object = (object) array(
-			'option_id'    => '12345',
-			'option_name'  => 'jetpack_nonce_' . static::TIMESTAMP . '_' . static::NONCE,
-			'option_value' => static::TIMESTAMP,
-			'autoload'     => 'no',
-		);
-
-		$query_filter = function( $result, $query ) use ( &$query_filter_run, $nonce_object ) {
+		$query_filter = function( $result, $query ) use ( &$query_filter_run ) {
 			if ( ! $query_filter_run && false !== strpos( $query, 'jetpack_nonce_' ) ) {
 				$query_filter_run = true;
-				$this->assertEquals( "SELECT 1 FROM `options` WHERE option_name = '{$nonce_object->option_name}'", $query );
+				$nonce_name       = 'jetpack_nonce_' . static::TIMESTAMP . '_' . static::NONCE;
+				$this->assertEquals( "SELECT 1 FROM `options` WHERE option_name = '{$nonce_name}'", $query );
 
-				return array( $nonce_object );
+				return array( (object) array( 1 => '1' ) );
 			}
 
 			return $result;

--- a/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/packages/connection/tests/php/test-class-nonce-handler.php
@@ -151,4 +151,28 @@ class Test_Nonce_Handler extends TestCase {
 		self::assertTrue( $query_filter_delete_run, "The SQL query assertions haven't run." );
 	}
 
+	/**
+	 * Make sure the runtime cleanup doesn't get run when the table is locked, and gets run otherwise.
+	 */
+	public function test_cleanup_locked() {
+		$query_filter = function( $result, $query ) {
+			if ( 0 === strpos( $query, 'SHOW OPEN TABLES WHERE In_use > 0' ) ) {
+				return array( 'something' );
+			}
+
+			return $result;
+		};
+
+		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
+
+		$cleanup_skipped = ! Nonce_Handler::clean_runtime();
+
+		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
+
+		$cleanup_ran = Nonce_Handler::clean_runtime();
+
+		self::assertTrue( $cleanup_skipped, 'The cleanup was run over a locked table' );
+		self::assertTrue( $cleanup_ran, 'The cleanup was not run over an unlocked table' );
+	}
+
 }

--- a/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/packages/connection/tests/php/test-class-nonce-handler.php
@@ -15,26 +15,59 @@ use PHPUnit\Framework\TestCase;
 class Test_Nonce_Handler extends TestCase {
 
 	/**
+	 * The nonce timestamp.
+	 */
+	const TIMESTAMP = '1598639691';
+
+	/**
+	 * The nonce.
+	 */
+	const NONCE = 'rAnDoM';
+
+	/**
 	 * Reset the environment after each test.
 	 */
 	public function tearDown() {
 		parent::tearDown();
 
 		Nonce_Handler::invalidate_request_nonces();
+
+		remove_action( 'shutdown', array( Nonce_Handler::class, 'clean_runtime' ) );
 	}
 
 	/**
 	 * Testing the nonce adding functionality.
 	 */
 	public function test_add() {
-		$time  = '1598639691';
-		$nonce = 'rAnDoM';
-
 		// Confirm that the nonce gets added.
-		self::assertTrue( Nonce_Handler::add( $time, $nonce ) );
+		self::assertTrue( Nonce_Handler::add( static::TIMESTAMP, static::NONCE ) );
 
 		// Confirm that the nonce is loaded from cache and still valid during the request.
-		self::assertTrue( Nonce_Handler::add( $time, $nonce ) );
+		self::assertTrue( Nonce_Handler::add( static::TIMESTAMP, static::NONCE ) );
+	}
+
+	/**
+	 * Testing the shutdown cleanup hook.
+	 */
+	public function test_shutdown_cleanup() {
+		global $wp_filter;
+
+		// Using a custom function to avoid collisions with existing callbacks.
+		$return_false = function() {
+			return false;
+		};
+
+		add_filter( 'jetpack_connection_add_nonce_cleanup', $return_false );
+		Nonce_Handler::add( static::TIMESTAMP, static::NONCE );
+		$is_callback_missing = empty( $wp_filter['shutdown']->callbacks[10][ Nonce_Handler::class . '::clean_runtime' ] );
+		remove_filter( 'jetpack_connection_add_nonce_cleanup', $return_false );
+		Nonce_Handler::invalidate_request_nonces();
+
+		Nonce_Handler::add( static::TIMESTAMP, static::NONCE );
+		$is_callback_placed = ! empty( $wp_filter['shutdown']->callbacks[10][ Nonce_Handler::class . '::clean_runtime' ] );
+
+		self::assertTrue( $is_callback_missing, 'Cleanup callback is in place, it should not exist' );
+		self::assertTrue( $is_callback_placed, 'Cleanup callback is missing, it should have been added' );
 	}
 
 	/**
@@ -43,13 +76,10 @@ class Test_Nonce_Handler extends TestCase {
 	public function test_add_existing() {
 		$query_filter_run = false;
 
-		$time  = '1598639690';
-		$nonce = 'rAnDoM2';
-
 		$nonce_object = array(
 			'option_id'    => '12345',
-			'option_name'  => "jetpack_nonce_{$time}_{$nonce}",
-			'option_value' => $time,
+			'option_name'  => 'jetpack_nonce_' . static::TIMESTAMP . '_' . static::NONCE,
+			'option_value' => static::TIMESTAMP,
 			'autoload'     => 'no',
 		);
 
@@ -66,7 +96,7 @@ class Test_Nonce_Handler extends TestCase {
 
 		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
 
-		$result = Nonce_Handler::add( $time, $nonce );
+		$result = Nonce_Handler::add( static::TIMESTAMP, static::NONCE );
 
 		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
 
@@ -94,6 +124,32 @@ class Test_Nonce_Handler extends TestCase {
 		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
 
 		Nonce_Handler::clean();
+
+		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
+
+		self::assertTrue( $query_filter_run, "The SQL query assertions haven't run." );
+	}
+
+	/**
+	 * Testing the runtime nonce cleanup functionality.
+	 */
+	public function test_clean_runtime() {
+		$query_filter_run = false;
+
+		$query_filter = function( $result, $query ) use ( &$query_filter_run ) {
+			if ( ! $query_filter_run && false !== strpos( $query, 'jetpack_nonce_' ) ) {
+				global $wpdb;
+
+				$query_filter_run = true;
+				self::assertStringStartsWith( "DELETE FROM `{$wpdb->options}` WHERE `option_name` >= 'jetpack_nonce_' AND `option_name` < ", $query );
+			}
+
+			return $result;
+		};
+
+		add_filter( 'wordbless_wpdb_query_results', $query_filter, 10, 2 );
+
+		Nonce_Handler::clean_runtime();
 
 		remove_filter( 'wordbless_wpdb_query_results', $query_filter );
 

--- a/packages/connection/tests/php/test-class-nonce-handler.php
+++ b/packages/connection/tests/php/test-class-nonce-handler.php
@@ -76,7 +76,7 @@ class Test_Nonce_Handler extends TestCase {
 	public function test_add_existing() {
 		$query_filter_run = false;
 
-		$nonce_object = array(
+		$nonce_object = (object) array(
 			'option_id'    => '12345',
 			'option_name'  => 'jetpack_nonce_' . static::TIMESTAMP . '_' . static::NONCE,
 			'option_value' => static::TIMESTAMP,
@@ -86,7 +86,7 @@ class Test_Nonce_Handler extends TestCase {
 		$query_filter = function( $result, $query ) use ( &$query_filter_run, $nonce_object ) {
 			if ( ! $query_filter_run && false !== strpos( $query, 'jetpack_nonce_' ) ) {
 				$query_filter_run = true;
-				$this->assertEquals( "SELECT * FROM `options` WHERE option_name = '{$nonce_object['option_name']}'", $query );
+				$this->assertEquals( "SELECT 1 FROM `options` WHERE option_name = '{$nonce_object->option_name}'", $query );
 
 				return array( $nonce_object );
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- The Jetpack Nonce functionality is extracted from the Connection Manager, and moved into a separate class.
- The new class `Nonce_Handler` is covered with unit tests.
- The Jetpack Nonces are getting removed right after new nonce gets added, no longer requiring WP-cron to be working.

#### Jetpack product discussion
- `p1598036456118800-slack-CBG1CP4EN`
- `p9dueE-1Oi-p2`

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Connect Jetpack.
2. Run `composer install` to refresh the classmap.
3. Disable WP-cron to concentrate on testing the runtime cleanup: `define( 'DISABLE_WP_CRON', true );`
4. Use the Jetpack Debug's "Mocker" tool to create a bunch of old nonces (a few dozens would be enough, unless you want to test the performance too).
5. Count the nonces, write down how many are there:
```sql
SELECT COUNT(*) FROM wp_options WHERE option_name LIKE 'jetpack\_nonce\_%';
```
6. Go to the [Developer Console](https://developer.wordpress.com/docs/api/console/) and send an API request:
`WP.COM API`, `GET`, `v1.2`, `/sites/your-site.com`
7. Run the `COUNT` SQL query again and confirm that the number of nonces decreased by 9 (1 new nonce, 10 old removed).
8. Run the API requests until all the old nonces get removed. The new nonces will not get removed, because they are created less than an hour ago.
9. When the nonces will no longer get removed (and start to grow in number instead), fetch the oldest:
```sql
SELECT FROM_UNIXTIME(option_value, '%Y-%m-%d %H:%i:%s') FROM wp_options WHERE option_name LIKE 'jetpack\_nonce\_%' ORDER BY option_value LIMIT 1;
```
10. Convert the UTC date to your local timezone, and make sure that it's not older than an hour.
11. Disconnect Jetpack. Confirm that all existing nonces got removed, including the fresh ones:
```sql
SELECT COUNT(*) FROM wp_options WHERE option_name LIKE 'jetpack\_nonce\_%';
```

#### Proposed changelog entry for your changes:
- Switching Jetpack nonces cleanup from WP Cron to runtime.