### PR TITLE
Admin Page: display content in plan grid for lower plans

### DIFF
--- a/_inc/client/plans/plan-grid.jsx
+++ b/_inc/client/plans/plan-grid.jsx
@@ -223,9 +223,14 @@ class PlanGrid extends React.Component {
 					</td>
 				);
 			}
-			// don't show prices for a lower plan
+			// don't show prices for a lower plan.
+			// Only show the plan's description.
 			if ( ! this.shouldRenderButton( type ) ) {
-				return <td key={ 'price-' + type } className={ className } />;
+				return (
+					<td key={ 'price-' + type } className={ className }>
+						{ plan.description }
+					</td>
+				);
 			}
 			// using dangerouslySetInnerHTML because formatting localized
 			// currencies is best left to our server and it includes the <abbr> element


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Following the conversation in p1598873611002000-slack-C0299DMPG, here is a PR to propose that we output some information in the header of lower plans in the Plans Grid page.

Noting that this is not super important right now as we're now redirecting people to WordPress.com when they navigate to the Plans.

**Before**

![image](https://user-images.githubusercontent.com/426388/91739195-dbf18a00-ebb1-11ea-8b7b-b68237659256.png)

**After** 

![image](https://user-images.githubusercontent.com/426388/91739220-e4e25b80-ebb1-11ea-8618-a9cc22c1aeb4.png)

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* On a site that's connected to WordPress.com, purchase a Professional plan.
* Go to `wp-admin/admin.php?page=jetpack#/plans`
* View the grid.

#### Proposed changelog entry for your changes:

* N/A