### PR TITLE
Site Scan & AMP: Include toolbar scripts for Site Scan have data-ampdevmode on AMP requests

### DIFF
--- a/modules/scan/class-admin-bar-notice.php
+++ b/modules/scan/class-admin-bar-notice.php
@@ -9,7 +9,6 @@ namespace Automattic\Jetpack\Scan;
 
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Redirect;
-use Jetpack_AMP_Support;
 
 /**
  * Class Main
@@ -100,7 +99,7 @@ class Admin_Bar_Notice {
 		}
 
 		// We don't know about threats in the cache lets load the JS that fetches the info and updates the admin bar.
-		Assets::enqueue_async_script( self::SCRIPT_NAME, '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js', array(), self::SCRIPT_VERSION, true );
+		Assets::enqueue_async_script( self::SCRIPT_NAME, '_inc/build/scan/admin-bar-notice.min.js', 'modules/scan/admin-bar-notice.js', array( 'admin-bar' ), self::SCRIPT_VERSION, true );
 
 		$script_data = array(
 			'nonce'              => wp_create_nonce( 'wp_rest' ),
@@ -112,21 +111,6 @@ class Admin_Bar_Notice {
 			'multiple'           => sprintf( esc_html__( '%s Threats found', 'jetpack' ), $this->get_icon() ),
 		);
 		wp_localize_script( self::SCRIPT_NAME, 'Jetpack_Scan', $script_data );
-
-		// Inject the data-ampdevmode attribute into the <script> tag for jetpack-scan-show-notice. To revisit after https://github.com/ampproject/amp-wp/issues/4598.
-		if ( Jetpack_AMP_Support::is_amp_request() ) {
-			add_filter(
-				'script_loader_tag',
-				static function ( $tag, $handle ) {
-					if ( self::SCRIPT_NAME === $handle ) {
-						$tag = preg_replace( '/(?<=<script\s)/', ' data-ampdevmode ', $tag );
-					}
-					return $tag;
-				},
-				10,
-				2
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
Since the Site Scan feature launched, I've very frequently seen the AMP menu item in the admin bar show validation errors:

![image](https://user-images.githubusercontent.com/134745/91754245-f14cc100-eb7d-11ea-9529-b9a864cf3f6b.png)

The validation errors are coming from Jetpack:

![image](https://user-images.githubusercontent.com/134745/91754292-03c6fa80-eb7e-11ea-8670-d034e22145da.png)

Specifically they are coming from the Site Scan feature:

![jetpack-site-scan-validation-errors cropped](https://user-images.githubusercontent.com/134745/91754511-5ef8ed00-eb7e-11ea-95b9-87ba35eba39a.png)

The issue can be fixed simply be flagging the scripts as being part of [AMP Dev Mode](https://weston.ruter.net/2019/09/24/integrating-with-amp-dev-mode-in-wordpress/).

This can be done for the `jetpack-scan-show-notice` script simply by making it dependent on the `admin-bar` script, which is itself already part of AMP Dev Mode by default. The only thing left is to ensure that the inline script (added via `wp_localize_script()`) to also be flagged for AMP Dev Mode via the `amp_dev_mode_element_xpaths` filter, which itself may be unnecessary after https://github.com/ampproject/amp-wp/issues/4598.

#### Changes proposed in this Pull Request:

* Add `data-ampdevmode` attributes to printed scripts for Site Scan toolbar.

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

1. Ensure Site Scan is active and enqueuing scripts on the frontend.
2. Enable Standard mode in the AMP plugin.
3. See validation errors caused by Jetpack.

#### Proposed changelog entry for your changes:

* Fix AMP compatibility for Site Scan module.
