### PR TITLE
Instant Search: Fix photon integration

### DIFF
--- a/modules/search/instant-search/components/photon-image.jsx
+++ b/modules/search/instant-search/components/photon-image.jsx
@@ -6,8 +6,19 @@
 import { h } from 'preact';
 import photon from 'photon';
 
+/**
+ * Strips query string values from URLs; photon can't handle them.
+ *
+ * @param {string} url - Image URL
+ *
+ * @returns {string} - Image URL without any query strings.
+ */
+function stripQueryString( url ) {
+	return url.split( '?', 1 )[ 0 ];
+}
+
 const PhotonImage = ( { useDiv, src, maxWidth = 300, maxHeight = 300, alt, ...otherProps } ) => {
-	const photonSrc = photon( src, { resize: `${ maxWidth },${ maxHeight }` } );
+	const photonSrc = photon( stripQueryString( src ), { resize: `${ maxWidth },${ maxHeight }` } );
 
 	return useDiv ? (
 		<div style={ { backgroundImage: `url("${ src }")` } } title={ alt } { ...otherProps } />

--- a/modules/search/instant-search/components/photon-image.jsx
+++ b/modules/search/instant-search/components/photon-image.jsx
@@ -19,11 +19,16 @@ function stripQueryString( url ) {
 
 const PhotonImage = ( { useDiv, src, maxWidth = 300, maxHeight = 300, alt, ...otherProps } ) => {
 	const photonSrc = photon( stripQueryString( src ), { resize: `${ maxWidth },${ maxHeight }` } );
+	const srcToDisplay = photonSrc !== null ? photonSrc : src;
 
 	return useDiv ? (
-		<div style={ { backgroundImage: `url("${ src }")` } } title={ alt } { ...otherProps } />
+		<div
+			style={ { backgroundImage: `url("${ srcToDisplay }")` } }
+			title={ alt }
+			{ ...otherProps }
+		/>
 	) : (
-		<img src={ photonSrc !== null ? photonSrc : src } alt={ alt } { ...otherProps } />
+		<img src={ srcToDisplay } alt={ alt } { ...otherProps } />
 	);
 };
 


### PR DESCRIPTION
Fixes #17036.

#### Changes proposed in this Pull Request:
* Strips query string from the image source URL before sending it to the Photon service.
* Enabled Photon for images shown as div backgrounds.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Activate Jetpack Instant Search on your site.
2. Set your search result format to `Expanded`.
3. Perform a search containing results containing large images.
4. Ensure that the images are being served by `i*.wp.com` and have been resized to `300px x 300px`.

#### Proposed changelog entry for your changes:
* Improves compression for images returned by the new Jetpack Search experience.
