### PR TITLE
Donations / Payments: Use getSiteFragment for building Calypso links

### DIFF
--- a/extensions/blocks/donations/controls.js
+++ b/extensions/blocks/donations/controls.js
@@ -25,9 +25,10 @@ import { DOWN } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { SUPPORTED_CURRENCIES } from '../../shared/currencies';
+import getSiteFragment from '../../shared/get-site-fragment';
 
 const Controls = props => {
-	const { attributes, setAttributes, siteSlug } = props;
+	const { attributes, setAttributes } = props;
 	const { currency, monthlyDonation, annualDonation, showCustomAmount } = attributes;
 
 	const toggleDonation = ( interval, show ) => {
@@ -112,7 +113,7 @@ const Controls = props => {
 						onChange={ value => setAttributes( { showCustomAmount: value } ) }
 						label={ __( 'Show custom amount option', 'jetpack' ) }
 					/>
-					<ExternalLink href={ `https://wordpress.com/earn/payments/${ siteSlug }` }>
+					<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
 						{ __( 'View donation earnings', 'jetpack' ) }
 					</ExternalLink>
 				</PanelBody>

--- a/extensions/blocks/donations/edit.js
+++ b/extensions/blocks/donations/edit.js
@@ -20,7 +20,6 @@ const Edit = props => {
 	const [ shouldUpgrade, setShouldUpgrade ] = useState( false );
 	const [ stripeConnectUrl, setStripeConnectUrl ] = useState( false );
 	const [ products, setProducts ] = useState( [] );
-	const [ siteSlug, setSiteSlug ] = useState( '' );
 
 	const apiError = message => {
 		setLoadingError( message );
@@ -51,7 +50,6 @@ const Edit = props => {
 		}
 		setShouldUpgrade( result.should_upgrade_to_access_memberships );
 		setStripeConnectUrl( result.connect_url );
-		setSiteSlug( result.site_slug );
 
 		const filteredProducts = filterProducts( result.products );
 
@@ -91,7 +89,6 @@ const Edit = props => {
 			{ ...props }
 			products={ products }
 			shouldUpgrade={ shouldUpgrade }
-			siteSlug={ siteSlug }
 			stripeConnectUrl={ stripeConnectUrl }
 		/>
 	);

--- a/extensions/blocks/recurring-payments/edit.jsx
+++ b/extensions/blocks/recurring-payments/edit.jsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import formatCurrency from '@automattic/format-currency';
-import { addQueryArgs, getQueryArg, isURL } from '@wordpress/url';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import {
@@ -28,6 +27,7 @@ import { applyFilters } from '@wordpress/hooks';
 import getJetpackExtensionAvailability from '../../shared/get-jetpack-extension-availability';
 import StripeNudge from '../../shared/components/stripe-nudge';
 import { minimumTransactionAmountForCurrency } from '../../shared/currencies';
+import getSiteFragment from '../../shared/get-site-fragment';
 import { icon, isPriceValid, removeInvalidProducts, CURRENCY_OPTIONS } from '.';
 
 const API_STATE_LOADING = 0;
@@ -63,7 +63,6 @@ class MembershipsButtonEdit extends Component {
 			shouldUpgrade: false,
 			upgradeURL: '',
 			products: [],
-			siteSlug: '',
 			editedProductCurrency: 'USD',
 			editedProductPrice: formatPriceForNumberInputValue(
 				minimumTransactionAmountForCurrency( 'USD' ),
@@ -112,7 +111,6 @@ class MembershipsButtonEdit extends Component {
 					products,
 					should_upgrade_to_access_memberships: shouldUpgrade,
 					upgrade_url: upgradeURL,
-					site_slug: siteSlug,
 				} = result;
 				const connected = result.connected_account_id
 					? API_STATE_CONNECTED
@@ -122,7 +120,6 @@ class MembershipsButtonEdit extends Component {
 					connectURL,
 					shouldUpgrade,
 					upgradeURL,
-					siteSlug,
 					products: removeInvalidProducts( products ),
 				} );
 			},
@@ -415,7 +412,7 @@ class MembershipsButtonEdit extends Component {
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Management', 'jetpack' ) }>
-					<ExternalLink href={ `https://wordpress.com/earn/payments/${ this.state.siteSlug }` }>
+					<ExternalLink href={ `https://wordpress.com/earn/payments/${ getSiteFragment() }` }>
 						{ __( 'See your earnings, subscriber list, and payment plans.', 'jetpack' ) }
 					</ExternalLink>
 				</PanelBody>


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/17033

#### Changes proposed in this Pull Request:
The `site_slug` property returned in the response of the `wpcom/v2/memberships/status` API endpoint has a wrong value when [WordPress is installed in subdirectory](https://wordpress.org/support/article/giving-wordpress-its-own-directory/).

However, as noted by @jeherve in https://github.com/Automattic/jetpack/issues/17033#issue-689341871, we can actually rely on the shared `getSiteFragment` utility that is used across all blocks for building links to Calypso.

#### Jetpack product discussion
pbMlHh-dW-p2

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
* Spin up a JN sub-directory multisite by including the Beta plugin on this branch and clicking "Launch Multisite on subdirs".
* Network-activate both Jetpack and the Jetpack Beta plugin.
* Create a new sub-directory site in the Network Admin.
* Set up Jetpack and purchase any paid plan for the new sub-directory site.
* Go to WP Admin > Posts > New.
* Insert a Donations block.
* Open the block settings.
* Click on "View donation earnings".
* Make sure the link redirects to the right place in Calypso (the site slug format should be `root-domain::sub-slug` (eg. `https://high-hamsters.jurassic.ninja::test-site`).

#### Proposed changelog entry for your changes:
Donations / Payments: Fix link to WordPress.com on sites where WordPress is installed in a subdirectory.