### PR TITLE
Plugins: avoid including network-activated plugins in responses

### DIFF
--- a/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
+++ b/json-endpoints/jetpack/class.jetpack-json-api-plugins-endpoint.php
@@ -152,6 +152,10 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 
 		$plugin['uninstallable']   = is_uninstallable_plugin( $plugin_file );
 
+		if ( is_multisite() ) {
+			$plugin['network_active'] = is_plugin_active_for_network( $plugin_file );
+		}
+
 		if ( ! empty ( $this->log[ $plugin_file ] ) ) {
 			$plugin['log'] = $this->log[ $plugin_file ];
 		}
@@ -182,6 +186,10 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		$autoupdate_translation = $this->plugin_has_translations_autoupdates_enabled( $plugin_file );
 		$plugin['autoupdate_translation'] = $autoupdate || $autoupdate_translation || Jetpack_Options::get_option( 'autoupdate_translations', false );
 		$plugin['uninstallable']   = is_uninstallable_plugin( $plugin_file );
+
+		if ( is_multisite() ) {
+			$plugin['network_active'] = is_plugin_active_for_network( $plugin_file );
+		}
 
 		if ( ! empty ( $this->log[ $plugin_file ] ) ) {
 			$plugin['log'] = $this->log[ $plugin_file ];
@@ -248,10 +256,27 @@ abstract class Jetpack_JSON_API_Plugins_Endpoint extends Jetpack_JSON_API_Endpoi
 		$plugins = array();
 		/** This filter is documented in wp-admin/includes/class-wp-plugins-list-table.php */
 		$installed_plugins = apply_filters( 'all_plugins', get_plugins() );
-		foreach( $this->plugins as $plugin ) {
-			if ( ! isset( $installed_plugins[ $plugin ] ) )
+		foreach ( $this->plugins as $plugin ) {
+			if ( ! isset( $installed_plugins[ $plugin ] ) ) {
 				continue;
-			$plugins[] = $this->format_plugin( $plugin, $installed_plugins[ $plugin ] );
+			}
+
+			$formatted_plugin = $this->format_plugin( $plugin, $installed_plugins[ $plugin ] );
+
+			/*
+			 * Do not show network-active plugins
+			 * to folks who do not have the permission to see them.
+			 */
+			if (
+				/** This filter is documented in src/wp-admin/includes/class-wp-plugins-list-table.php */
+				! apply_filters( 'show_network_active_plugins', current_user_can( 'manage_network_plugins' ) )
+				&& ! empty( $formatted_plugin['network_active'] )
+				&& true === $formatted_plugin['network_active']
+			) {
+				continue;
+			}
+
+			$plugins[] = $formatted_plugin;
 		}
 		$args = $this->query_args();
 


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

When a site admin checks installed plugins on a site that's part of a Multisite network,
they should see similar results in the WordPress.com plugins interface and in the Plugins menu (if activated by the super admin) in wp-admin.

Reference: p8oabR-xs-p2#comment-4502

#### Jetpack product discussion

* N/A

#### Does this pull request change what data or activity we track or use?

* N/A

#### Testing instructions:

* See p8oabR-xs-p2#comment-4502

#### Proposed changelog entry for your changes:

* N/A

