### PR TITLE
Update optin comment to say default is true

### DIFF
--- a/class.jetpack.php
+++ b/class.jetpack.php
@@ -6261,8 +6261,8 @@ endif;
 		}
 
 		/**
-		 * Allows sites to opt in to IDC mitigation which blocks the site from syncing to WordPress.com when the home
-		 * URL or site URL do not match what WordPress.com expects. The default value is either false, or the value of
+		 * Allows sites to opt in for IDC mitigation which blocks the site from syncing to WordPress.com when the home
+		 * URL or site URL do not match what WordPress.com expects. The default value is either true, or the value of
 		 * JETPACK_SYNC_IDC_OPTIN constant if set.
 		 *
 		 * @since 4.3.2


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
* Updates comment to state the default value is `true` not false. All sites are by default opted in to IDC mitigation.

#### Jetpack product discussion
N/A

#### Does this pull request change what data or activity we track or use?
No

#### Testing instructions:
N/A verify comment text makes sense.

#### Proposed changelog entry for your changes:
N/A
