### PR TITLE
Signature Class: Adds support for nested query strings

### DIFF
--- a/packages/connection/legacy/class-jetpack-signature.php
+++ b/packages/connection/legacy/class-jetpack-signature.php
@@ -325,20 +325,40 @@ class Jetpack_Signature {
 
 	/**
 	 * Concatenates a parameter name and a parameter value with an equals sign between them.
-	 * Supports one-dimensional arrays as `$value`.
 	 *
-	 * @param string $name  Parameter name.
-	 * @param mixed  $value Parameter value.
-	 * @return string A pair with parameter name and value (e.g. `name=value`).
+	 * @param string       $name  Parameter name.
+	 * @param string|array $value Parameter value.
+	 * @return string|array A string pair (e.g. `name=value`) or an array of string pairs.
 	 */
 	public function join_with_equal_sign( $name, $value ) {
 		if ( is_array( $value ) ) {
-			$result = array();
-			foreach ( $value as $array_key => $array_value ) {
-				$result[] = $name . '[' . $array_key . ']=' . $array_value;
-			}
-			return $result;
+			return $this->join_array_with_equal_sign( $name, $value );
 		}
 		return "{$name}={$value}";
+	}
+
+	/**
+	 * Helper function for join_with_equal_sign for handling arrayed values.
+	 * Explicitly supports nested arrays.
+	 *
+	 * @param string $name  Parameter name.
+	 * @param array  $value Parameter value.
+	 * @return array An array of string pairs (e.g. `[ name[example]=value ]`).
+	 */
+	private function join_array_with_equal_sign( $name, $value ) {
+		$result = array();
+		foreach ( $value as $value_key => $value_value ) {
+			$joined_value = $this->join_with_equal_sign( $name . '[' . $value_key . ']', $value_value );
+			if ( is_array( $joined_value ) ) {
+				foreach ( array_values( $joined_value ) as $individual_joined_value ) {
+					$result[] = $individual_joined_value;
+				}
+			} elseif ( is_string( $joined_value ) ) {
+				$result[] = $joined_value;
+			}
+		}
+
+		sort( $result );
+		return $result;
 	}
 }

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -1,0 +1,93 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * The SignatureTest class file.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Provides unit tests for the methods in the Jetpack_Signature class.
+ */
+class SignatureTest extends TestCase {
+	/**
+	 * Tests the Jetpack_Signature->join_with_equal_sign() method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Jetpack_Signature->join_with_equal_sign
+	 * @dataProvider join_with_equal_sign_data_provider
+	 *
+	 * @param string       $name Query string key value.
+	 * @param string|array $value Associated value for query string key.
+	 * @param string|array $expected_output The expected output of $signature->join_with_equal_sign.
+	 */
+	public function test_join_with_equal_sign( $name, $value, $expected_output ) {
+		$signature = new \Jetpack_Signature( 'some-secret', 0 );
+		$this->assertEquals( $expected_output, $signature->join_with_equal_sign( $name, $value ) );
+	}
+
+	/**
+	 * Data provider for test_join_with_equal_sign.
+	 *
+	 * The test data arrays have the format:
+	 *    'name'            => The value that the constant will be set to. Null if the constant will not be set.
+	 *    'value'           => The name of the constant.
+	 *    'expected_output' => The expected output of Utils::jetpack_api_constant_filter().
+	 */
+	public function join_with_equal_sign_data_provider() {
+		return array(
+			'string_value'                   =>
+				array(
+					'name'            => 'street',
+					'value'           => '1600 Pennsylvania Ave',
+					'expected_output' => 'street=1600 Pennsylvania Ave',
+				),
+			'array_value'                    =>
+				array(
+					'name'            => 'first_names',
+					'value'           => array( 'Michael', 'Jim', 'Pam' ),
+					'expected_output' => array( 'first_names[0]=Michael', 'first_names[1]=Jim', 'first_names[2]=Pam' ),
+				),
+			'nested_array_value'             =>
+				array(
+					'name'            => 'numbers',
+					'value'           => array( array( 0, 1 ), array( 2, 3 ), array( 4, 5 ) ),
+					'expected_output' => array(
+						'numbers[0][0]=0',
+						'numbers[0][1]=1',
+						'numbers[1][0]=2',
+						'numbers[1][1]=3',
+						'numbers[2][0]=4',
+						'numbers[2][1]=5',
+					),
+				),
+			'nested_associative_array_value' =>
+				array(
+					'name'            => 'people',
+					'value'           => array(
+						array(
+							'last_name'  => 'Scott',
+							'first_name' => 'Michael',
+							'city'       => 'Boulder',
+						),
+						array(
+							'first_name' => 'Jim',
+							'state'      => 'Texas',
+							'last_name'  => 'Halpert',
+						),
+					),
+					// Note: Expected output is sorted.
+					'expected_output' => array(
+						'people[0][city]=Boulder',
+						'people[0][first_name]=Michael',
+						'people[0][last_name]=Scott',
+						'people[1][first_name]=Jim',
+						'people[1][last_name]=Halpert',
+						'people[1][state]=Texas',
+					),
+				),
+		);
+	}
+}

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -99,4 +99,60 @@ class SignatureTest extends TestCase {
 				),
 		);
 	}
+
+	/**
+	 * Tests the Jetpack_Signature->normalized_query_parameters() method.
+	 *
+	 * @covers Automattic\Jetpack\Connection\Jetpack_Signature->normalized_query_parameters
+	 * @dataProvider normalized_query_parameters_data_provider
+	 *
+	 * @param string       $query_string Query string key value.
+	 * @param string|array $expected_output The expected output of $signature->normalized_query_parameters.
+	 */
+	public function test_normalized_query_parameters( $query_string, $expected_output ) {
+		$signature = new \Jetpack_Signature( 'some-secret', 0 );
+		$this->assertEquals( $expected_output, $signature->normalized_query_parameters( $query_string ) );
+	}
+
+	/**
+	 * Data provider for test_join_with_equal_sign.
+	 *
+	 * The test data arrays have the format:
+	 *    'name'            => The value that the constant will be set to. Null if the constant will not be set.
+	 *    'value'           => The name of the constant.
+	 *    'expected_output' => The expected output of Utils::jetpack_api_constant_filter().
+	 */
+	public function normalized_query_parameters_data_provider() {
+		return array(
+			'signature_omitted' =>
+				array(
+					'query_string'    => 'size=10&signature=super-secret',
+					'expected_output' => array(
+						'size=10',
+					),
+				),
+			'query_key_sort'    =>
+				array(
+					'query_string'    => 'size=10&highlight_fields%5B0%5D=title&highlight_fields%5B1%5D=content&aggregations%5Btaxonomy_1%5D%5Bterms%5D%5Bfield%5D=taxonomy.xposts.slug_slash_name&aggregations%5Btaxonomy_1%5D%5Bterms%5D%5Bsize%5D=5&fields%5B0%5D=date&fields%5B1%5D=permalink.url.raw&query=journey',
+					'expected_output' => array(
+						'query=journey',
+						// Note that size has been sorted below query.
+						'size=10',
+						array(
+							'aggregations[taxonomy_1][terms][field]=taxonomy.xposts.slug_slash_name',
+							'aggregations[taxonomy_1][terms][size]=5',
+						),
+						array(
+							'fields[0]=date',
+							'fields[1]=permalink.url.raw',
+						),
+						// Note that aggregations has been sorted below aggregations and fields.
+						array(
+							'highlight_fields[0]=title',
+							'highlight_fields[1]=content',
+						),
+					),
+				),
+		);
+	}
 }

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -50,6 +50,15 @@ class SignatureTest extends TestCase {
 					'value'           => array( 'Michael', 'Jim', 'Pam' ),
 					'expected_output' => array( 'first_names[0]=Michael', 'first_names[1]=Jim', 'first_names[2]=Pam' ),
 				),
+			'associative_array_value'        =>
+				array(
+					'name'            => 'numbers',
+					'value'           => array(
+						'one' => 1,
+						'two' => 2,
+					),
+					'expected_output' => array( 'numbers[one]=1', 'numbers[two]=2' ),
+				),
 			'nested_array_value'             =>
 				array(
 					'name'            => 'numbers',

--- a/packages/connection/tests/php/test_Signature.php
+++ b/packages/connection/tests/php/test_Signature.php
@@ -34,7 +34,7 @@ class SignatureTest extends TestCase {
 	 * The test data arrays have the format:
 	 *    'name'            => The value that the constant will be set to. Null if the constant will not be set.
 	 *    'value'           => The name of the constant.
-	 *    'expected_output' => The expected output of Utils::jetpack_api_constant_filter().
+	 *    'expected_output' => The expected output of $signature->join_with_equal_sign.
 	 */
 	public function join_with_equal_sign_data_provider() {
 		return array(
@@ -120,7 +120,7 @@ class SignatureTest extends TestCase {
 	 * The test data arrays have the format:
 	 *    'name'            => The value that the constant will be set to. Null if the constant will not be set.
 	 *    'value'           => The name of the constant.
-	 *    'expected_output' => The expected output of Utils::jetpack_api_constant_filter().
+	 *    'expected_output' => The expected output of $signature->normalized_query_parameters().
 	 */
 	public function normalized_query_parameters_data_provider() {
 		return array(
@@ -146,7 +146,7 @@ class SignatureTest extends TestCase {
 							'fields[0]=date',
 							'fields[1]=permalink.url.raw',
 						),
-						// Note that aggregations has been sorted below aggregations and fields.
+						// Note that highlight_fields has been sorted below aggregations and fields.
 						array(
 							'highlight_fields[0]=title',
 							'highlight_fields[1]=content',


### PR DESCRIPTION
Spun-off from #16938, which requires sending blog-token authenticated requests with nested query strings.

Our focus with this PR is to ensure backward compatibility with previous versions of Jetpack Signatures; we intend to ship these changes to the WPCOM API.

#### Changes proposed in this Pull Request:
* Adds support for nested query string support.
* Adds unit tests for `join_with_equal_sign` and `normalized_query_parameters`.

#### Jetpack product discussion
See p9dueE-1Nq-p2.

#### Does this pull request change what data or activity we track or use?
No.

#### Testing instructions:
1. Apply this patch to your Jetpack installation.
2. Perform a task that fires an API request signed using the Jetpack_Signature class (e.g. any invocation of `wpcom_json_api_request_as_user` or `wpcom_json_api_request_as_blog`; `/wp-admin/admin.php?page=jetpack#/dashboard` should kick off several).
3. Ensure that the API request succeeds; if you receive a `signature_mismatch` error, let us know below.

You can also run the new tests by running `bash ./tests/package-runner.sh connection`.

#### Proposed changelog entry for your changes:
* None.
